### PR TITLE
Add local Telegram channel SDK driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This project used to be called `multipass`, but was renamed to `crabline` to avo
 The v1 shape is:
 
 - built-in `loopback` provider for local development and contract tests
+- deterministic local channel SDK provider, starting with `telegram-local-v1`
 - native `discord` provider backed by the Chat SDK Discord adapter
 - native `slack` provider backed by the Chat SDK Slack adapter
 - native community adapters for `matrix` and `imessage`
@@ -70,7 +71,7 @@ configVersion: 1
 userName: crabline
 providers:
   local:
-    adapter: loopback | script | slack | discord | matrix | imessage
+    adapter: channel | loopback | script | slack | discord | matrix | imessage
     platform: see support matrix below
 fixtures:
   - id: string
@@ -100,6 +101,7 @@ Credentials stay in env, never in fixtures.
 
 - `ready`: `loopback`, native `slack`, native `discord`, native-community `matrix`, native-community `imessage`
 - `bridge`: `bluebubbles`, `feishu`, `googlechat`, `irc`, `line`, `mattermost`, `msteams`, `nextcloudtalk`, `nostr`, `signal`, `synologychat`, `telegram`, `tlon`, `twitch`, `webchat`, `whatsapp`, `zalo`, `zalouser`
+- deterministic local channel driver: `telegram-local-v1` via `adapter: channel`, `platform: telegram`
 - Plugin-backed in OpenClaw, still supported through the bridge: `feishu`, `line`, `mattermost`, `msteams`, `nextcloudtalk`, `nostr`, `synologychat`, `tlon`, `twitch`, `zalo`, `zalouser`
 - Recommended bridge-only path today: `bluebubbles`, `googlechat`, `irc`, `signal`, `telegram`, `webchat`, `whatsapp`
 
@@ -109,6 +111,32 @@ Telegram bridge notes:
 - Do not model Telegram roundtrip as bot-to-bot; Telegram bots do not receive messages from other bots, and Bot API delivery is update-queue/webhook based rather than arbitrary history fetch.
 - Best operator path: DM-first, then group/topic once DM roundtrip is stable.
 - For unattended automation, drive the user side with MTProto (for example Telethon), not a second bot.
+
+Local Telegram channel SDK driver:
+
+```yaml
+providers:
+  telegram-local:
+    adapter: channel
+    platform: telegram
+    channel:
+      driver: telegram-local-v1
+      botUserName: multipass_telegram_bot
+      qaResponse:
+        mode: ack # QA-fixture response only; no model call is made
+```
+
+`telegram-local-v1` is a deterministic local upstream shim. It records Telegram-shaped
+inbound events, outbound actions, and transcript entries for DM, group mention,
+forum topic/thread, inline button action, media metadata, and reconnect assertions.
+It is not Canonical Multipass VM orchestration and does not route through OpenClaw's
+`qa-channel` normalized bus.
+
+Capability metadata is available for automation:
+
+```bash
+pnpm dev channel-matrix --json
+```
 
 Native Discord provider options:
 
@@ -287,6 +315,7 @@ pnpm dev providers --config fixtures/examples/openclaw-supported.yaml
 ```bash
 crabline providers
 crabline fixtures
+crabline channel-matrix
 crabline probe <fixture|provider>
 crabline send <fixture>
 crabline roundtrip <fixture>
@@ -363,6 +392,7 @@ or:
 
 ## Current scope
 
-- Real built-in providers: `loopback`, native `slack`
+- Real built-in providers: `loopback`, native `slack`, native `discord`, native-community `matrix`, native-community `imessage`
+- Deterministic local channel SDK drivers: `telegram-local-v1`
 - Real external bridge: `script` for the full OpenClaw channel matrix
-- Not implemented yet: native adapters beyond Slack, richer inbound event storage, rich media/cards, recorder compaction/query tooling
+- Not implemented yet: local channel drivers beyond Telegram, richer recorder compaction/query tooling, live-model response generation

--- a/fixtures/examples/crabline.example.yaml
+++ b/fixtures/examples/crabline.example.yaml
@@ -8,6 +8,15 @@ providers:
     loopback:
       delayMs: 0
 
+  telegram-local:
+    adapter: channel
+    platform: telegram
+    channel:
+      driver: telegram-local-v1
+      botUserName: multipass_telegram_bot
+      qaResponse:
+        mode: ack
+
   slack-native:
     adapter: slack
     platform: slack
@@ -86,6 +95,39 @@ fixtures:
     target:
       id: agent-bot
       behavior: agent
+
+  - id: telegram-local-dm
+    provider: telegram-local
+    mode: roundtrip
+    target:
+      id: "100000001"
+      metadata:
+        chatType: dm
+        userName: qa-user
+    inboundMatch:
+      author: assistant
+      strategy: contains
+      nonce: contains
+
+  - id: telegram-local-group-topic-action
+    provider: telegram-local
+    mode: roundtrip
+    target:
+      id: "-100000001"
+      channelId: telegram:group:-100000001
+      threadId: "42"
+      metadata:
+        actionId: approve-tool-1
+        actionPayload: approve:tool
+        actionType: button
+        chatType: group
+        mediaKind: image
+        mention: "true"
+        topicId: "42"
+    inboundMatch:
+      author: assistant
+      strategy: contains
+      nonce: contains
 
   - id: slack-openclaw-demo
     provider: slack-openclaw

--- a/package.json
+++ b/package.json
@@ -1,18 +1,25 @@
 {
   "name": "crabline",
   "version": "0.1.0",
-  "private": true,
   "description": "Standalone CLI for deterministic messaging provider E2E tests",
   "license": "MIT",
   "bin": {
     "crabline": "./dist/src/bin/crabline.js"
   },
   "files": [
-    "dist",
+    "dist/src",
     "README.md",
     "fixtures"
   ],
   "type": "module",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js"
+    }
+  },
   "scripts": {
     "build": "tsgo -p tsconfig.json",
     "clean": "rm -rf dist coverage",
@@ -22,6 +29,7 @@
     "format": "oxfmt --write .",
     "format:check": "oxfmt --check .",
     "lint": "pnpm format:check && pnpm typecheck && oxlint --deny-warnings --allow vitest/require-mock-type-parameters --type-aware --tsconfig tsconfig.json src test",
+    "prepare": "pnpm build",
     "run": "tsx src/bin/crabline.ts run",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
@@ -31,28 +39,55 @@
     "check": "pnpm verify"
   },
   "dependencies": {
-    "@beeper/chat-adapter-matrix": "^0.1.0",
-    "@chat-adapter/discord": "^4.30.0",
-    "@chat-adapter/shared": "^4.30.0",
-    "@chat-adapter/slack": "^4.30.0",
-    "@chat-adapter/state-memory": "^4.30.0",
-    "chat": "^4.30.0",
-    "chat-adapter-imessage": "^0.1.1",
     "commander": "^14.0.3",
     "picocolors": "^1.1.1",
     "yaml": "^2.9.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@beeper/chat-adapter-matrix": "^0.1.0",
+    "@chat-adapter/discord": "^4.30.0",
+    "@chat-adapter/slack": "^4.30.0",
+    "@chat-adapter/state-memory": "^4.30.0",
     "@types/node": "^25.9.2",
     "@typescript/native-preview": "7.0.0-dev.20260503.1",
     "@vitest/coverage-v8": "^4.1.8",
+    "chat": "^4.30.0",
+    "chat-adapter-imessage": "^0.1.1",
     "oxfmt": "^0.47.0",
     "oxlint": "^1.69.0",
     "oxlint-tsgolint": "^0.22.1",
     "tsx": "^4.22.4",
     "typescript": "^6.0.3",
     "vitest": "^4.1.8"
+  },
+  "peerDependencies": {
+    "@beeper/chat-adapter-matrix": "^0.1.0",
+    "@chat-adapter/discord": "^4.30.0",
+    "@chat-adapter/slack": "^4.30.0",
+    "@chat-adapter/state-memory": "^4.30.0",
+    "chat": "^4.30.0",
+    "chat-adapter-imessage": "^0.1.1"
+  },
+  "peerDependenciesMeta": {
+    "@beeper/chat-adapter-matrix": {
+      "optional": true
+    },
+    "@chat-adapter/discord": {
+      "optional": true
+    },
+    "@chat-adapter/slack": {
+      "optional": true
+    },
+    "@chat-adapter/state-memory": {
+      "optional": true
+    },
+    "chat": {
+      "optional": true
+    },
+    "chat-adapter-imessage": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=22"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,27 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@beeper/chat-adapter-matrix':
-        specifier: ^0.1.0
-        version: 0.1.0(zod@4.4.3)
-      '@chat-adapter/discord':
-        specifier: ^4.30.0
-        version: 4.30.0(zod@4.4.3)
-      '@chat-adapter/shared':
-        specifier: ^4.30.0
-        version: 4.30.0(zod@4.4.3)
-      '@chat-adapter/slack':
-        specifier: ^4.30.0
-        version: 4.30.0(zod@4.4.3)
-      '@chat-adapter/state-memory':
-        specifier: ^4.30.0
-        version: 4.30.0(zod@4.4.3)
-      chat:
-        specifier: ^4.30.0
-        version: 4.30.0(zod@4.4.3)
-      chat-adapter-imessage:
-        specifier: ^0.1.1
-        version: 0.1.1(chat@4.30.0(zod@4.4.3))(typescript@6.0.3)(zod@4.4.3)
       commander:
         specifier: ^14.0.3
         version: 14.0.3
@@ -42,6 +21,18 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@beeper/chat-adapter-matrix':
+        specifier: ^0.1.0
+        version: 0.1.0(zod@4.4.3)
+      '@chat-adapter/discord':
+        specifier: ^4.30.0
+        version: 4.30.0(zod@4.4.3)
+      '@chat-adapter/slack':
+        specifier: ^4.30.0
+        version: 4.30.0(zod@4.4.3)
+      '@chat-adapter/state-memory':
+        specifier: ^4.30.0
+        version: 4.30.0(zod@4.4.3)
       '@types/node':
         specifier: ^25.9.2
         version: 25.9.2
@@ -51,6 +42,12 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.8
         version: 4.1.8(vitest@4.1.8)
+      chat:
+        specifier: ^4.30.0
+        version: 4.30.0(zod@4.4.3)
+      chat-adapter-imessage:
+        specifier: ^0.1.1
+        version: 0.1.1(chat@4.30.0(zod@4.4.3))(typescript@6.0.3)(zod@4.4.3)
       oxfmt:
         specifier: ^0.47.0
         version: 0.47.0

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -1,0 +1,21 @@
+export { LOCAL_CHANNEL_DRIVER_MATRIX } from "./matrix.js";
+export {
+  TELEGRAM_LOCAL_DRIVER_ID,
+  TELEGRAM_LOCAL_DRIVER_METADATA,
+  TelegramLocalChannelDriver,
+} from "./telegram.js";
+export { LocalChannelUpstream } from "./local-upstream.js";
+export type {
+  ChannelActor,
+  ChannelAttachment,
+  ChannelCapability,
+  ChannelCapabilityMatrixRow,
+  ChannelConversation,
+  ChannelDirection,
+  ChannelDriverMetadata,
+  ChannelLiveMode,
+  ChannelNativeAction,
+  ChannelTranscriptEntry,
+  ChannelTranscriptKind,
+  LocalChannelDriverId,
+} from "./types.js";

--- a/src/channels/local-upstream.ts
+++ b/src/channels/local-upstream.ts
@@ -1,0 +1,109 @@
+import type {
+  ChannelActor,
+  ChannelAttachment,
+  ChannelConversation,
+  ChannelDriverMetadata,
+  ChannelNativeAction,
+  ChannelTranscriptEntry,
+  ChannelTranscriptKind,
+} from "./types.js";
+
+export type IngestChannelEventInput = {
+  action?: ChannelNativeAction | undefined;
+  actor: ChannelActor;
+  attachments?: ChannelAttachment[] | undefined;
+  conversation: ChannelConversation;
+  kind?: ChannelTranscriptKind | undefined;
+  raw?: Record<string, unknown> | undefined;
+  replyToId?: string | undefined;
+  sentAt?: string | undefined;
+  text?: string | undefined;
+};
+
+export type RecordChannelActionInput = {
+  action?: ChannelNativeAction | undefined;
+  actor: ChannelActor;
+  attachments?: ChannelAttachment[] | undefined;
+  conversation: ChannelConversation;
+  kind?: ChannelTranscriptKind | undefined;
+  raw?: Record<string, unknown> | undefined;
+  replyToId?: string | undefined;
+  sentAt?: string | undefined;
+  text?: string | undefined;
+};
+
+export class LocalChannelUpstream {
+  readonly metadata: ChannelDriverMetadata;
+
+  readonly #transcript: ChannelTranscriptEntry[] = [];
+  #sequence = 0;
+
+  constructor(metadata: ChannelDriverMetadata) {
+    this.metadata = metadata;
+  }
+
+  ingestEvent(input: IngestChannelEventInput): ChannelTranscriptEntry {
+    return this.#append("inbound", input);
+  }
+
+  recordAction(input: RecordChannelActionInput): ChannelTranscriptEntry {
+    return this.#append("outbound", input);
+  }
+
+  listTranscript(conversation?: ChannelConversation): ChannelTranscriptEntry[] {
+    if (!conversation) {
+      return [...this.#transcript];
+    }
+
+    return this.#transcript.filter(
+      (entry) =>
+        entry.conversation.id === conversation.id &&
+        entry.conversation.topicId === conversation.topicId,
+    );
+  }
+
+  listSince(params: {
+    conversation: ChannelConversation;
+    direction?: "inbound" | "outbound" | undefined;
+    since?: string | undefined;
+  }): ChannelTranscriptEntry[] {
+    const sinceTime = params.since ? new Date(params.since).getTime() : Number.NEGATIVE_INFINITY;
+    return this.listTranscript(params.conversation).filter((entry) => {
+      if (params.direction && entry.direction !== params.direction) {
+        return false;
+      }
+      return new Date(entry.sentAt).getTime() >= sinceTime;
+    });
+  }
+
+  #append(
+    direction: "inbound" | "outbound",
+    input: IngestChannelEventInput | RecordChannelActionInput,
+  ): ChannelTranscriptEntry {
+    this.#sequence += 1;
+    const id = `${this.metadata.driverId}:event:${this.#sequence}`;
+    const entry: ChannelTranscriptEntry = {
+      actor: input.actor,
+      attachments: input.attachments ?? [],
+      channel: this.metadata.channel,
+      conversation: input.conversation,
+      direction,
+      driverId: this.metadata.driverId,
+      id,
+      kind: input.kind ?? "message",
+      raw: input.raw ?? {},
+      sentAt: input.sentAt ?? new Date(1_767_225_600_000 + this.#sequence).toISOString(),
+      text: input.text ?? "",
+    };
+
+    if (input.action) {
+      entry.action = input.action;
+    }
+    if (input.replyToId) {
+      entry.replyToId = input.replyToId;
+    }
+
+    this.#transcript.push(entry);
+    return entry;
+  }
+}

--- a/src/channels/matrix.ts
+++ b/src/channels/matrix.ts
@@ -1,0 +1,32 @@
+import type { ChannelCapabilityMatrixRow } from "./types.js";
+import { TELEGRAM_LOCAL_DRIVER_ID, TELEGRAM_LOCAL_DRIVER_METADATA } from "./telegram.js";
+
+export const LOCAL_CHANNEL_DRIVER_MATRIX = [
+  ...TELEGRAM_LOCAL_DRIVER_METADATA.capabilities.map(
+    (capability): ChannelCapabilityMatrixRow => ({
+      capabilityId: capability.id,
+      channel: "telegram",
+      driverId: TELEGRAM_LOCAL_DRIVER_ID,
+      notes: capability.notes,
+      status: capability.status,
+    }),
+  ),
+  {
+    capabilityId: "discord.dm.text",
+    channel: "discord",
+    notes: "Planned local Discord upstream driver.",
+    status: "planned",
+  },
+  {
+    capabilityId: "slack.dm.text",
+    channel: "slack",
+    notes: "Planned local Slack upstream driver.",
+    status: "planned",
+  },
+  {
+    capabilityId: "whatsapp.dm.text",
+    channel: "whatsapp",
+    notes: "Planned local WhatsApp upstream driver.",
+    status: "planned",
+  },
+] as const satisfies readonly ChannelCapabilityMatrixRow[];

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -1,0 +1,156 @@
+import type { NormalizedTarget } from "../providers/types.js";
+import type {
+  ChannelActor,
+  ChannelAttachment,
+  ChannelConversation,
+  ChannelDriverMetadata,
+  ChannelNativeAction,
+} from "./types.js";
+import { LocalChannelUpstream } from "./local-upstream.js";
+
+export const TELEGRAM_LOCAL_DRIVER_ID = "telegram-local-v1" as const;
+
+export const TELEGRAM_LOCAL_DRIVER_METADATA = {
+  capabilities: [
+    {
+      assertions: [
+        "inbound user message is recorded with Telegram chat metadata",
+        "outbound assistant message is recorded in the same DM transcript",
+      ],
+      id: "telegram.dm.text",
+      notes: "Direct-message text turn with source-visible transcript assertions.",
+      status: "covered",
+    },
+    {
+      assertions: [
+        "group messages preserve chat id",
+        "mention metadata can be asserted without changing the target channel",
+      ],
+      id: "telegram.group.mention",
+      notes: "Group mention semantics for routing and reply isolation.",
+      status: "covered",
+    },
+    {
+      assertions: [
+        "forum topic id is preserved separately from group id",
+        "replies stay in the selected topic transcript",
+      ],
+      id: "telegram.group.topic",
+      notes: "Forum topic/thread identity for group conversations.",
+      status: "covered",
+    },
+    {
+      assertions: [
+        "inline button callback payload is represented as a native action",
+        "action acknowledgements can be asserted independently of model output",
+      ],
+      id: "telegram.action.inline_button",
+      notes: "Native approval/action event shape.",
+      status: "covered",
+    },
+    {
+      assertions: [
+        "media kind and provider file id are preserved",
+        "media assertions do not require downloading binary payloads",
+      ],
+      id: "telegram.media.metadata",
+      notes: "Media/location metadata placeholder coverage.",
+      status: "covered",
+    },
+    {
+      assertions: ["connection events appear in the transcript with Telegram driver metadata"],
+      id: "telegram.connection.reconnect",
+      notes: "Reconnect marker for future Gateway recovery assertions.",
+      status: "covered",
+    },
+  ],
+  channel: "telegram",
+  channelLive: false,
+  deterministic: true,
+  driverId: TELEGRAM_LOCAL_DRIVER_ID,
+  eventKinds: ["message", "action", "connection", "delivery"],
+  notes: "Deterministic local Telegram upstream shim for OpenClaw QA Lab channel assertions.",
+  status: "ready",
+} as const satisfies ChannelDriverMetadata;
+
+export class TelegramLocalChannelDriver extends LocalChannelUpstream {
+  constructor() {
+    super(TELEGRAM_LOCAL_DRIVER_METADATA);
+  }
+
+  conversationFromTarget(target: NormalizedTarget): ChannelConversation {
+    const kind = target.metadata.chatType === "group" ? "group" : "dm";
+    const id = target.channelId ?? `telegram:${kind}:${target.id}`;
+    const conversation: ChannelConversation = { id, kind };
+
+    const title = target.metadata.chatTitle;
+    if (title) {
+      conversation.title = title;
+    }
+
+    const topicId = target.threadId ?? target.metadata.topicId;
+    if (topicId) {
+      conversation.topicId = topicId;
+    }
+
+    return conversation;
+  }
+
+  createUserActor(target: NormalizedTarget): ChannelActor {
+    return {
+      displayName: target.metadata.userName ?? target.metadata.fromName,
+      id: target.metadata.userId ?? target.id,
+      isBot: false,
+      role: "user",
+    };
+  }
+
+  createAssistantActor(botUserName: string): ChannelActor {
+    return {
+      displayName: botUserName,
+      id: botUserName,
+      isBot: true,
+      role: "assistant",
+    };
+  }
+
+  createMediaAttachment(target: NormalizedTarget): ChannelAttachment | null {
+    const mediaKind = target.metadata.mediaKind;
+    if (!isTelegramMediaKind(mediaKind)) {
+      return null;
+    }
+
+    return {
+      id: target.metadata.fileId ?? "telegram-local-file",
+      kind: mediaKind,
+      metadata: {
+        fileId: target.metadata.fileId ?? "telegram-local-file",
+        mimeType: target.metadata.mimeType ?? "application/octet-stream",
+      },
+    };
+  }
+
+  createNativeAction(target: NormalizedTarget): ChannelNativeAction | null {
+    const actionType = target.metadata.actionType;
+    if (actionType !== "button" && actionType !== "command" && actionType !== "reaction") {
+      return null;
+    }
+
+    return {
+      id: target.metadata.actionId ?? `${TELEGRAM_LOCAL_DRIVER_ID}:action`,
+      label: target.metadata.actionLabel,
+      payload: target.metadata.actionPayload ?? "crabline:approval",
+      type: actionType,
+    };
+  }
+}
+
+function isTelegramMediaKind(value: string | undefined): value is ChannelAttachment["kind"] {
+  return (
+    value === "document" ||
+    value === "image" ||
+    value === "location" ||
+    value === "sticker" ||
+    value === "voice"
+  );
+}

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -1,0 +1,78 @@
+import type { ProviderPlatform } from "../config/schema.js";
+
+export type ChannelLiveMode = "local" | "live";
+export type ChannelDirection = "inbound" | "outbound";
+export type ChannelConversationKind = "dm" | "group";
+export type ChannelTranscriptKind = "action" | "connection" | "delivery" | "message";
+export type ChannelCapabilityStatus = "covered" | "planned" | "unsupported";
+
+export type LocalChannelDriverId = "telegram-local-v1";
+
+export type ChannelConversation = {
+  id: string;
+  kind: ChannelConversationKind;
+  title?: string | undefined;
+  topicId?: string | undefined;
+};
+
+export type ChannelActor = {
+  displayName?: string | undefined;
+  id: string;
+  isBot: boolean;
+  role: "assistant" | "system" | "user";
+};
+
+export type ChannelAttachment = {
+  id: string;
+  kind: "document" | "image" | "location" | "sticker" | "voice";
+  metadata: Record<string, string>;
+};
+
+export type ChannelNativeAction = {
+  id: string;
+  label?: string | undefined;
+  payload: string;
+  type: "button" | "command" | "reaction";
+};
+
+export type ChannelTranscriptEntry = {
+  action?: ChannelNativeAction | undefined;
+  actor: ChannelActor;
+  attachments: ChannelAttachment[];
+  channel: ProviderPlatform;
+  conversation: ChannelConversation;
+  direction: ChannelDirection;
+  driverId: LocalChannelDriverId;
+  id: string;
+  kind: ChannelTranscriptKind;
+  raw: Record<string, unknown>;
+  replyToId?: string | undefined;
+  sentAt: string;
+  text: string;
+};
+
+export type ChannelCapability = {
+  assertions: readonly string[];
+  id: string;
+  notes: string;
+  status: ChannelCapabilityStatus;
+};
+
+export type ChannelDriverMetadata = {
+  capabilities: readonly ChannelCapability[];
+  channel: ProviderPlatform;
+  channelLive: false;
+  deterministic: true;
+  driverId: LocalChannelDriverId;
+  eventKinds: readonly ChannelTranscriptKind[];
+  notes: string;
+  status: "ready";
+};
+
+export type ChannelCapabilityMatrixRow = {
+  capabilityId: string;
+  channel: ProviderPlatform;
+  driverId?: LocalChannelDriverId | undefined;
+  notes: string;
+  status: ChannelCapabilityStatus;
+};

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -1,4 +1,6 @@
 import { Command } from "commander";
+import { LOCAL_CHANNEL_DRIVER_MATRIX } from "../channels/matrix.js";
+import { TELEGRAM_LOCAL_DRIVER_METADATA } from "../channels/telegram.js";
 import { loadManifest } from "../config/load.js";
 import { createRegistry } from "../providers/registry.js";
 import { formatJson, formatRunResultText } from "../core/reporters.js";
@@ -49,6 +51,18 @@ export function createProgram(): Command {
         support: registry.catalog,
       };
       print(options.json ? formatJson(payload) : renderProvidersText(payload));
+    });
+
+  program
+    .command("channel-matrix")
+    .description("List deterministic local channel driver capabilities")
+    .action(() => {
+      const options = program.opts() as GlobalOptions;
+      const payload = {
+        drivers: [TELEGRAM_LOCAL_DRIVER_METADATA],
+        matrix: LOCAL_CHANNEL_DRIVER_MATRIX,
+      };
+      print(options.json ? formatJson(payload) : renderChannelMatrixText(payload));
     });
 
   program
@@ -216,6 +230,38 @@ function renderProvidersText(payload: {
     lines.push(
       `  ${entry.platform} status=${entry.status} supports=${entry.supports.join(",")} ${entry.notes}`,
     );
+  }
+
+  return lines.join("\n");
+}
+
+function renderChannelMatrixText(payload: {
+  drivers: ReadonlyArray<{
+    channel: string;
+    channelLive: false;
+    deterministic: true;
+    driverId: string;
+    status: string;
+  }>;
+  matrix: ReadonlyArray<{
+    capabilityId: string;
+    channel: string;
+    driverId?: string | undefined;
+    notes: string;
+    status: string;
+  }>;
+}): string {
+  const lines = ["local channel drivers:"];
+  for (const driver of payload.drivers) {
+    lines.push(
+      `  ${driver.driverId} channel=${driver.channel} live=${String(driver.channelLive)} deterministic=${String(driver.deterministic)} status=${driver.status}`,
+    );
+  }
+
+  lines.push("capability matrix:");
+  for (const row of payload.matrix) {
+    const driver = row.driverId ? ` driver=${row.driverId}` : "";
+    lines.push(`  ${row.channel} ${row.capabilityId} status=${row.status}${driver} ${row.notes}`);
   }
 
   return lines.join("\n");

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -5,6 +5,7 @@ export const INBOUND_AUTHORS = ["assistant", "user", "system", "any"] as const;
 export const INBOUND_STRATEGIES = ["contains", "exact", "regex"] as const;
 export const INBOUND_NONCE_MODES = ["contains", "exact", "ignore"] as const;
 export const BUILTIN_ADAPTERS = [
+  "channel",
   "discord",
   "imessage",
   "loopback",
@@ -145,10 +146,21 @@ const IMessageConfigSchema = z.object({
   serverUrl: z.string().url().optional(),
 });
 
+const ChannelConfigSchema = z.object({
+  botUserName: z.string().min(1).default("multipass_telegram_bot"),
+  driver: z.literal("telegram-local-v1").default("telegram-local-v1"),
+  qaResponse: z
+    .object({
+      mode: z.enum(["ack", "echo", "none"]).default("none"),
+    })
+    .default({ mode: "none" }),
+});
+
 export const ProviderConfigSchema = z
   .object({
     adapter: z.enum(BUILTIN_ADAPTERS),
     capabilities: z.array(z.enum(FIXTURE_MODES)).default(["probe", "send", "roundtrip", "agent"]),
+    channel: ChannelConfigSchema.optional(),
     discord: DiscordConfigSchema.optional(),
     env: z.array(z.string().min(1)).default([]),
     imessage: IMessageConfigSchema.optional(),
@@ -205,6 +217,14 @@ export const ProviderConfigSchema = z
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: "imessage adapter must use platform=imessage",
+        path: ["platform"],
+      });
+    }
+
+    if (value.adapter === "channel" && value.platform !== "telegram") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "channel adapter currently supports platform=telegram",
         path: ["platform"],
       });
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,15 @@
+export {
+  findLocalChannelDriver,
+  listLocalChannelDriverMatrix,
+  runLocalChannelDriverSmoke,
+  type LocalChannelDriverSmokeResult,
+} from "./local-channel-driver-api.js";
+export {
+  LOCAL_CHANNEL_DRIVER_MATRIX,
+  TELEGRAM_LOCAL_DRIVER_ID,
+  TELEGRAM_LOCAL_DRIVER_METADATA,
+  TelegramLocalChannelDriver,
+  type ChannelCapabilityMatrixRow,
+  type ChannelDriverMetadata,
+  type LocalChannelDriverId,
+} from "./channels/index.js";

--- a/src/local-channel-driver-api.ts
+++ b/src/local-channel-driver-api.ts
@@ -5,7 +5,6 @@ import { OPENCLAW_SUPPORT_CATALOG } from "./providers/catalog.js";
 import type { Registry } from "./providers/registry.js";
 import {
   LOCAL_CHANNEL_DRIVER_MATRIX,
-  TELEGRAM_LOCAL_DRIVER_ID,
   TELEGRAM_LOCAL_DRIVER_METADATA,
   type ChannelCapabilityMatrixRow,
   type ChannelDriverMetadata,
@@ -27,22 +26,25 @@ export function listLocalChannelDriverMatrix() {
 
 export function findLocalChannelDriver(params: {
   channel: ProviderPlatform;
-  driverId: LocalChannelDriverId;
+  driverId?: LocalChannelDriverId;
 }): ChannelDriverMetadata | null {
   return (
     listLocalChannelDriverMatrix().drivers.find(
-      (driver) => driver.channel === params.channel && driver.driverId === params.driverId,
+      (driver) =>
+        driver.channel === params.channel &&
+        (!params.driverId || driver.driverId === params.driverId),
     ) ?? null
   );
 }
 
 function buildLocalChannelSmokeManifest(params: {
-  channel: ProviderPlatform;
-  driverId: LocalChannelDriverId;
+  driver: ChannelDriverMetadata;
   userName?: string;
 }): ManifestDefinition {
-  if (params.channel !== "telegram" || params.driverId !== TELEGRAM_LOCAL_DRIVER_ID) {
-    throw new Error(`unsupported local channel driver: ${params.channel}/${params.driverId}`);
+  if (params.driver.channel !== "telegram") {
+    throw new Error(
+      `unsupported local channel driver: ${params.driver.channel}/${params.driver.driverId}`,
+    );
   }
 
   return ManifestSchema.parse({
@@ -53,7 +55,7 @@ function buildLocalChannelSmokeManifest(params: {
         adapter: "channel",
         platform: "telegram",
         channel: {
-          driver: TELEGRAM_LOCAL_DRIVER_ID,
+          driver: params.driver.driverId,
           botUserName: "crabline_telegram_bot",
           qaResponse: {
             mode: "ack",
@@ -107,19 +109,23 @@ function createLocalChannelDriverRegistry(manifest: ManifestDefinition): Registr
 
 export async function runLocalChannelDriverSmoke(params: {
   channel: ProviderPlatform;
-  driverId: LocalChannelDriverId;
+  driverId?: LocalChannelDriverId;
   manifestPath?: string;
   userName?: string;
 }): Promise<LocalChannelDriverSmokeResult> {
   const driver = findLocalChannelDriver({
     channel: params.channel,
-    driverId: params.driverId,
+    ...(params.driverId ? { driverId: params.driverId } : {}),
   });
   if (!driver) {
-    throw new Error(`local channel driver not found: ${params.channel}/${params.driverId}`);
+    const suffix = params.driverId ? `/${params.driverId}` : "";
+    throw new Error(`local channel driver not found: ${params.channel}${suffix}`);
   }
 
-  const manifest = buildLocalChannelSmokeManifest(params);
+  const manifest = buildLocalChannelSmokeManifest({
+    driver,
+    ...(params.userName ? { userName: params.userName } : {}),
+  });
   const manifestPath = params.manifestPath ?? "crabline-local-channel-driver-smoke.json";
   const registry = createLocalChannelDriverRegistry(manifest);
   const result = await runFixtureCommand({

--- a/src/local-channel-driver-api.ts
+++ b/src/local-channel-driver-api.ts
@@ -1,0 +1,142 @@
+import { ManifestSchema, type ManifestDefinition, type ProviderPlatform } from "./config/schema.js";
+import { runFixtureCommand, type CommandRunResult } from "./core/run.js";
+import { LocalChannelProviderAdapter } from "./providers/builtin/channel.js";
+import { OPENCLAW_SUPPORT_CATALOG } from "./providers/catalog.js";
+import type { Registry } from "./providers/registry.js";
+import {
+  LOCAL_CHANNEL_DRIVER_MATRIX,
+  TELEGRAM_LOCAL_DRIVER_ID,
+  TELEGRAM_LOCAL_DRIVER_METADATA,
+  type ChannelCapabilityMatrixRow,
+  type ChannelDriverMetadata,
+  type LocalChannelDriverId,
+} from "./channels/index.js";
+
+export type LocalChannelDriverSmokeResult = {
+  driver: ChannelDriverMetadata;
+  matrix: readonly ChannelCapabilityMatrixRow[];
+  result: CommandRunResult;
+};
+
+export function listLocalChannelDriverMatrix() {
+  return {
+    drivers: [TELEGRAM_LOCAL_DRIVER_METADATA],
+    matrix: LOCAL_CHANNEL_DRIVER_MATRIX,
+  };
+}
+
+export function findLocalChannelDriver(params: {
+  channel: ProviderPlatform;
+  driverId: LocalChannelDriverId;
+}): ChannelDriverMetadata | null {
+  return (
+    listLocalChannelDriverMatrix().drivers.find(
+      (driver) => driver.channel === params.channel && driver.driverId === params.driverId,
+    ) ?? null
+  );
+}
+
+function buildLocalChannelSmokeManifest(params: {
+  channel: ProviderPlatform;
+  driverId: LocalChannelDriverId;
+  userName?: string;
+}): ManifestDefinition {
+  if (params.channel !== "telegram" || params.driverId !== TELEGRAM_LOCAL_DRIVER_ID) {
+    throw new Error(`unsupported local channel driver: ${params.channel}/${params.driverId}`);
+  }
+
+  return ManifestSchema.parse({
+    configVersion: 1,
+    userName: params.userName ?? "crabline",
+    providers: {
+      "telegram-local": {
+        adapter: "channel",
+        platform: "telegram",
+        channel: {
+          driver: TELEGRAM_LOCAL_DRIVER_ID,
+          botUserName: "crabline_telegram_bot",
+          qaResponse: {
+            mode: "ack",
+          },
+        },
+      },
+    },
+    fixtures: [
+      {
+        id: "telegram-local-driver-smoke",
+        provider: "telegram-local",
+        mode: "roundtrip",
+        target: {
+          id: "100000001",
+          metadata: {
+            chatType: "dm",
+            userName: "qa-user",
+          },
+        },
+        inboundMatch: {
+          author: "assistant",
+          nonce: "contains",
+          strategy: "contains",
+        },
+        timeoutMs: 1_000,
+      },
+    ],
+  });
+}
+
+function createLocalChannelDriverRegistry(manifest: ManifestDefinition): Registry {
+  return {
+    catalog: OPENCLAW_SUPPORT_CATALOG,
+    resolve(providerId, fixtureId) {
+      const fixture = manifest.fixtures.find((entry) => entry.id === fixtureId);
+      if (!fixture) {
+        throw new Error(`Unknown fixture: ${fixtureId}`);
+      }
+      const config = manifest.providers[providerId];
+      if (!config) {
+        throw new Error(`Unknown provider: ${providerId}`);
+      }
+      if (config.adapter !== "channel") {
+        throw new Error(`Expected local channel provider: ${providerId}`);
+      }
+
+      return new LocalChannelProviderAdapter(providerId, config);
+    },
+  };
+}
+
+export async function runLocalChannelDriverSmoke(params: {
+  channel: ProviderPlatform;
+  driverId: LocalChannelDriverId;
+  manifestPath?: string;
+  userName?: string;
+}): Promise<LocalChannelDriverSmokeResult> {
+  const driver = findLocalChannelDriver({
+    channel: params.channel,
+    driverId: params.driverId,
+  });
+  if (!driver) {
+    throw new Error(`local channel driver not found: ${params.channel}/${params.driverId}`);
+  }
+
+  const manifest = buildLocalChannelSmokeManifest(params);
+  const manifestPath = params.manifestPath ?? "crabline-local-channel-driver-smoke.json";
+  const registry = createLocalChannelDriverRegistry(manifest);
+  const result = await runFixtureCommand({
+    fixtureId: "telegram-local-driver-smoke",
+    manifest,
+    manifestPath,
+    registry,
+  });
+  if (!result.ok) {
+    throw new Error(
+      `local channel driver smoke failed: ${result.diagnostics.join("; ") || "unknown failure"}`,
+    );
+  }
+
+  return {
+    driver,
+    matrix: LOCAL_CHANNEL_DRIVER_MATRIX,
+    result,
+  };
+}

--- a/src/providers/builtin/channel.ts
+++ b/src/providers/builtin/channel.ts
@@ -1,0 +1,222 @@
+import { extractNonce } from "../../core/nonces.js";
+import type { ProviderConfig } from "../../config/schema.js";
+import { TelegramLocalChannelDriver } from "../../channels/telegram.js";
+import type { ChannelTranscriptEntry } from "../../channels/types.js";
+import type {
+  InboundEnvelope,
+  NormalizedTarget,
+  ProbeResult,
+  ProviderAdapter,
+  ProviderContext,
+  SendContext,
+  SendResult,
+  WaitContext,
+  WatchContext,
+} from "../types.js";
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export class LocalChannelProviderAdapter implements ProviderAdapter {
+  readonly id;
+  readonly platform = "telegram" as const;
+  readonly status = "ready" as const;
+  readonly supports = ["probe", "send", "roundtrip", "agent"] as const;
+
+  readonly #botUserName: string;
+  readonly #driver = new TelegramLocalChannelDriver();
+  readonly #qaResponseMode: "ack" | "echo" | "none";
+
+  constructor(id: string, config: ProviderConfig) {
+    this.id = id;
+    this.#botUserName = config.channel?.botUserName ?? "multipass_telegram_bot";
+    this.#qaResponseMode = config.channel?.qaResponse?.mode ?? "none";
+  }
+
+  normalizeTarget(target: ProviderContext["fixture"]["target"]): NormalizedTarget {
+    const normalized: NormalizedTarget = { id: target.id, metadata: target.metadata };
+    if (target.channelId) {
+      normalized.channelId = target.channelId;
+    }
+    if (target.threadId) {
+      normalized.threadId = target.threadId;
+    }
+    return normalized;
+  }
+
+  probe(): Promise<ProbeResult> {
+    return Promise.resolve({
+      details: [
+        `channel driver ${this.#driver.metadata.driverId} ready`,
+        `channel=${this.#driver.metadata.channel} live=${String(this.#driver.metadata.channelLive)}`,
+        `capabilities=${this.#driver.metadata.capabilities.map((entry) => entry.id).join(",")}`,
+      ],
+      healthy: true,
+    });
+  }
+
+  async send(context: SendContext): Promise<SendResult> {
+    const target = this.normalizeTarget(context.fixture.target);
+    const conversation = this.#driver.conversationFromTarget(target);
+    const attachment = this.#driver.createMediaAttachment(target);
+    const action = this.#driver.createNativeAction(target);
+    const inbound = this.#driver.ingestEvent({
+      action: action ?? undefined,
+      actor: this.#driver.createUserActor(target),
+      attachments: attachment ? [attachment] : [],
+      conversation,
+      kind: action ? "action" : "message",
+      raw: createTelegramRawInbound(target, context.text, action),
+      sentAt: new Date().toISOString(),
+      text: context.text,
+    });
+
+    if (target.metadata.reconnect === "true") {
+      this.#driver.ingestEvent({
+        actor: { id: "telegram-local-upstream", isBot: true, role: "system" },
+        conversation,
+        kind: "connection",
+        raw: { event: "reconnect", ok: true },
+        sentAt: new Date().toISOString(),
+        text: "telegram reconnect",
+      });
+    }
+
+    const replyText = resolveQaReply(this.#qaResponseMode, context.text);
+    if (replyText) {
+      this.#driver.recordAction({
+        actor: this.#driver.createAssistantActor(this.#botUserName),
+        conversation,
+        kind: "message",
+        raw: {
+          chat: conversation.id,
+          driverId: this.#driver.metadata.driverId,
+          method: "sendMessage",
+          parse_mode: "Markdown",
+        },
+        replyToId: inbound.id,
+        sentAt: new Date().toISOString(),
+        text: replyText,
+      });
+    }
+
+    return {
+      accepted: true,
+      messageId: inbound.id,
+      threadId: encodeThreadId(conversation),
+    };
+  }
+
+  async waitForInbound(context: WaitContext): Promise<InboundEnvelope | null> {
+    const target = this.normalizeTarget(context.fixture.target);
+    const conversation = this.#driver.conversationFromTarget(target);
+    const started = Date.now();
+
+    while (Date.now() - started <= context.timeoutMs) {
+      const matches = this.#driver.listSince({
+        conversation,
+        direction: "outbound",
+        since: context.since,
+      });
+      if (matches.length > 0) {
+        return toEnvelope(this.id, matches.at(-1)!);
+      }
+
+      await sleep(Math.min(200, context.timeoutMs));
+    }
+
+    return null;
+  }
+
+  async *watch(context: WatchContext): AsyncIterable<InboundEnvelope> {
+    const target = this.normalizeTarget(context.fixture.target);
+    const conversation = this.#driver.conversationFromTarget(target);
+    const seen = new Set<string>();
+
+    while (true) {
+      const matches = this.#driver.listSince({
+        conversation,
+        direction: "inbound",
+        since: context.since,
+      });
+
+      for (const entry of matches) {
+        if (seen.has(entry.id)) {
+          continue;
+        }
+        seen.add(entry.id);
+        yield toEnvelope(this.id, entry);
+      }
+
+      await sleep(250);
+    }
+  }
+}
+
+function createTelegramRawInbound(
+  target: NormalizedTarget,
+  text: string,
+  action: ReturnType<TelegramLocalChannelDriver["createNativeAction"]>,
+): Record<string, unknown> {
+  const chatType = target.metadata.chatType ?? "private";
+  const raw: Record<string, unknown> = {
+    chat: {
+      id: target.channelId ?? target.id,
+      type: chatType === "group" ? "supergroup" : "private",
+    },
+    from: {
+      id: target.metadata.userId ?? target.id,
+      is_bot: false,
+      username: target.metadata.userName ?? "crabline-user",
+    },
+    text,
+  };
+
+  const topicId = target.threadId ?? target.metadata.topicId;
+  if (topicId) {
+    raw.message_thread_id = topicId;
+  }
+  if (target.metadata.mention === "true") {
+    raw.entities = [{ type: "mention", user: target.metadata.botUserName ?? "@crabline" }];
+  }
+  if (action) {
+    raw.callback_query = {
+      data: action.payload,
+      id: action.id,
+      message: { text },
+    };
+  }
+
+  return raw;
+}
+
+function encodeThreadId(conversation: { id: string; topicId?: string | undefined }): string {
+  return conversation.topicId
+    ? `${conversation.id}::topic:${conversation.topicId}`
+    : conversation.id;
+}
+
+function resolveQaReply(mode: "ack" | "echo" | "none", text: string): string | null {
+  if (mode === "none") {
+    return null;
+  }
+  if (mode === "echo") {
+    return text;
+  }
+
+  const nonce = extractNonce(text);
+  return nonce ? `ACK ${nonce}` : "ACK";
+}
+
+function toEnvelope(providerId: string, entry: ChannelTranscriptEntry): InboundEnvelope {
+  return {
+    author: entry.actor.role === "assistant" ? "assistant" : entry.actor.role,
+    id: entry.id,
+    provider: providerId,
+    raw: entry,
+    sentAt: entry.sentAt,
+    text: entry.text,
+    threadId: encodeThreadId(entry.conversation),
+  };
+}

--- a/src/providers/catalog.ts
+++ b/src/providers/catalog.ts
@@ -64,7 +64,10 @@ export const OPENCLAW_SUPPORT_CATALOG = [
     supports: COMMON_BRIDGE_SUPPORT,
   },
   createBridgeEntry("synologychat", "OpenClaw plugin channel via script bridge."),
-  createBridgeEntry("telegram", "OpenClaw channel via script bridge."),
+  createBridgeEntry(
+    "telegram",
+    "OpenClaw channel via script bridge; deterministic local driver available as telegram-local-v1.",
+  ),
   createBridgeEntry("tlon", "OpenClaw plugin channel via script bridge."),
   createBridgeEntry("twitch", "OpenClaw plugin channel via script bridge."),
   createBridgeEntry("webchat", "OpenClaw web channel via script bridge."),

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -1,5 +1,6 @@
 import { CrablineError } from "../core/errors.js";
 import type { ManifestDefinition } from "../config/schema.js";
+import { LocalChannelProviderAdapter } from "./builtin/channel.js";
 import { DiscordProviderAdapter } from "./builtin/discord.js";
 import { IMessageProviderAdapter } from "./builtin/imessage.js";
 import { LoopbackProviderAdapter } from "./builtin/loopback.js";
@@ -42,6 +43,10 @@ export function createRegistry(manifest: ManifestDefinition, manifestPath: strin
 
       if (config.adapter === "loopback") {
         return new LoopbackProviderAdapter(providerId, config, manifest.userName);
+      }
+
+      if (config.adapter === "channel") {
+        return new LocalChannelProviderAdapter(providerId, config);
       }
 
       if (config.adapter === "discord") {

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -1,19 +1,174 @@
 import { CrablineError } from "../core/errors.js";
-import type { ManifestDefinition } from "../config/schema.js";
+import type {
+  BuiltinAdapterId,
+  FixtureMode,
+  ManifestDefinition,
+  ProviderConfig,
+} from "../config/schema.js";
 import { LocalChannelProviderAdapter } from "./builtin/channel.js";
-import { DiscordProviderAdapter } from "./builtin/discord.js";
-import { IMessageProviderAdapter } from "./builtin/imessage.js";
-import { LoopbackProviderAdapter } from "./builtin/loopback.js";
-import { MatrixProviderAdapter } from "./builtin/matrix.js";
-import { SlackProviderAdapter } from "./builtin/slack.js";
 import { ScriptProviderAdapter } from "./builtin/script.js";
 import { OPENCLAW_SUPPORT_CATALOG } from "./catalog.js";
-import type { ProviderAdapter, ProviderContext } from "./types.js";
+import type {
+  InboundEnvelope,
+  NormalizedTarget,
+  ProbeResult,
+  ProviderAdapter,
+  ProviderContext,
+  ProviderSupportStatus,
+  SendContext,
+  SendResult,
+  WaitContext,
+  WatchContext,
+} from "./types.js";
 
 export type Registry = {
   catalog: typeof OPENCLAW_SUPPORT_CATALOG;
   resolve(providerId: string, fixtureId: string): ProviderAdapter;
 };
+
+const COMMON_PROVIDER_SUPPORT = [
+  "probe",
+  "send",
+  "roundtrip",
+  "agent",
+] as const satisfies readonly FixtureMode[];
+
+type LazyAdapterId = Exclude<BuiltinAdapterId, "channel" | "script">;
+type ProviderFactory = () => Promise<ProviderAdapter>;
+type LazyProviderFactory = (params: {
+  config: ProviderConfig;
+  providerId: string;
+  userName: string;
+}) => Promise<ProviderAdapter>;
+
+const LAZY_PROVIDER_FACTORIES = {
+  async discord({ config, providerId, userName }) {
+    const { DiscordProviderAdapter } = await import("./builtin/discord.js");
+    return new DiscordProviderAdapter(providerId, config, userName);
+  },
+  async imessage({ config, providerId, userName }) {
+    const { IMessageProviderAdapter } = await import("./builtin/imessage.js");
+    return new IMessageProviderAdapter(providerId, config, userName);
+  },
+  async loopback({ config, providerId, userName }) {
+    const { LoopbackProviderAdapter } = await import("./builtin/loopback.js");
+    return new LoopbackProviderAdapter(providerId, config, userName);
+  },
+  async matrix({ config, providerId, userName }) {
+    const { MatrixProviderAdapter } = await import("./builtin/matrix.js");
+    return new MatrixProviderAdapter(providerId, config, userName);
+  },
+  async slack({ config, providerId, userName }) {
+    const { SlackProviderAdapter } = await import("./builtin/slack.js");
+    return new SlackProviderAdapter(providerId, config, userName);
+  },
+} satisfies Record<LazyAdapterId, LazyProviderFactory>;
+
+function isLazyAdapter(adapter: BuiltinAdapterId): adapter is LazyAdapterId {
+  return adapter in LAZY_PROVIDER_FACTORIES;
+}
+
+function normalizeTarget(target: ProviderContext["fixture"]["target"]): NormalizedTarget {
+  const normalized: NormalizedTarget = { id: target.id, metadata: target.metadata };
+  if (target.channelId) {
+    normalized.channelId = target.channelId;
+  }
+  if (target.threadId) {
+    normalized.threadId = target.threadId;
+  }
+  return normalized;
+}
+
+function createLazyProvider(params: {
+  adapter: LazyAdapterId;
+  config: ProviderConfig;
+  providerId: string;
+  userName: string;
+}): ProviderAdapter {
+  return new LazyProviderAdapter({
+    adapterName: params.adapter,
+    factory: () => LAZY_PROVIDER_FACTORIES[params.adapter](params),
+    id: params.providerId,
+    platform: params.config.platform,
+    status: "ready",
+    supports: COMMON_PROVIDER_SUPPORT,
+  });
+}
+
+class LazyProviderAdapter implements ProviderAdapter {
+  readonly id;
+  readonly platform;
+  readonly status;
+  readonly supports;
+
+  readonly #adapterName: string;
+  readonly #factory: ProviderFactory;
+  #providerPromise: Promise<ProviderAdapter> | null = null;
+
+  constructor(params: {
+    adapterName: string;
+    factory: ProviderFactory;
+    id: string;
+    platform: ProviderAdapter["platform"];
+    status: ProviderSupportStatus;
+    supports: ProviderAdapter["supports"];
+  }) {
+    this.#adapterName = params.adapterName;
+    this.#factory = params.factory;
+    this.id = params.id;
+    this.platform = params.platform;
+    this.status = params.status;
+    this.supports = params.supports;
+  }
+
+  normalizeTarget(target: ProviderContext["fixture"]["target"]): NormalizedTarget {
+    return normalizeTarget(target);
+  }
+
+  async probe(context: ProviderContext): Promise<ProbeResult> {
+    return await (await this.#provider()).probe(context);
+  }
+
+  async send(context: SendContext): Promise<SendResult> {
+    return await (await this.#provider()).send(context);
+  }
+
+  async waitForInbound(context: WaitContext): Promise<InboundEnvelope | null> {
+    return await (await this.#provider()).waitForInbound(context);
+  }
+
+  watch(context: WatchContext): AsyncIterable<InboundEnvelope> {
+    return this.#watch(context);
+  }
+
+  async cleanup(): Promise<void> {
+    if (!this.#providerPromise) {
+      return;
+    }
+    await (await this.#providerPromise).cleanup?.();
+  }
+
+  async #provider(): Promise<ProviderAdapter> {
+    this.#providerPromise ??= this.#factory().catch((error: unknown) => {
+      this.#providerPromise = null;
+      throw new CrablineError(
+        `Provider adapter "${this.#adapterName}" could not load. Install its optional peer dependencies before using this adapter.`,
+        { cause: error, kind: "config" },
+      );
+    });
+    return await this.#providerPromise;
+  }
+
+  async *#watch(context: WatchContext): AsyncIterable<InboundEnvelope> {
+    const provider = await this.#provider();
+    if (!provider.watch) {
+      throw new CrablineError(`Provider "${this.id}" does not implement watch.`, {
+        kind: "config",
+      });
+    }
+    yield* provider.watch(context);
+  }
+}
 
 export function createRegistry(manifest: ManifestDefinition, manifestPath: string): Registry {
   return {
@@ -41,28 +196,17 @@ export function createRegistry(manifest: ManifestDefinition, manifestPath: strin
         userName: manifest.userName,
       };
 
-      if (config.adapter === "loopback") {
-        return new LoopbackProviderAdapter(providerId, config, manifest.userName);
+      if (isLazyAdapter(config.adapter)) {
+        return createLazyProvider({
+          adapter: config.adapter,
+          config,
+          providerId,
+          userName: manifest.userName,
+        });
       }
 
       if (config.adapter === "channel") {
         return new LocalChannelProviderAdapter(providerId, config);
-      }
-
-      if (config.adapter === "discord") {
-        return new DiscordProviderAdapter(providerId, config, manifest.userName);
-      }
-
-      if (config.adapter === "matrix") {
-        return new MatrixProviderAdapter(providerId, config, manifest.userName);
-      }
-
-      if (config.adapter === "imessage") {
-        return new IMessageProviderAdapter(providerId, config, manifest.userName);
-      }
-
-      if (config.adapter === "slack") {
-        return new SlackProviderAdapter(providerId, config, manifest.userName);
       }
 
       return new ScriptProviderAdapter(context);

--- a/test/channel-provider.test.ts
+++ b/test/channel-provider.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import { runFixtureCommand } from "../src/core/run.js";
+import { createRegistry } from "../src/providers/registry.js";
+import type { ManifestDefinition } from "../src/config/schema.js";
+import { LOCAL_CHANNEL_DRIVER_MATRIX, TelegramLocalChannelDriver } from "../src/channels/index.js";
+
+const manifest: ManifestDefinition = {
+  configVersion: 1,
+  fixtures: [
+    {
+      env: [],
+      id: "telegram-dm",
+      inboundMatch: { author: "assistant", nonce: "contains", strategy: "contains" },
+      mode: "roundtrip",
+      provider: "telegram-local",
+      retries: 0,
+      tags: [],
+      target: {
+        id: "user-123",
+        metadata: {
+          chatType: "dm",
+          userName: "qa-user",
+        },
+      },
+      timeoutMs: 1000,
+    },
+    {
+      env: [],
+      id: "telegram-group-topic-action",
+      inboundMatch: { author: "assistant", nonce: "contains", strategy: "contains" },
+      mode: "roundtrip",
+      provider: "telegram-local",
+      retries: 0,
+      tags: [],
+      target: {
+        channelId: "telegram:group:-100123",
+        id: "-100123",
+        metadata: {
+          actionId: "approve-1",
+          actionPayload: "approve:tool",
+          actionType: "button",
+          chatType: "group",
+          mediaKind: "image",
+          mention: "true",
+          topicId: "42",
+        },
+        threadId: "42",
+      },
+      timeoutMs: 1000,
+    },
+  ],
+  providers: {
+    "telegram-local": {
+      adapter: "channel",
+      capabilities: ["probe", "send", "roundtrip", "agent"],
+      channel: {
+        botUserName: "crabline_bot",
+        driver: "telegram-local-v1",
+        qaResponse: { mode: "ack" },
+      },
+      env: [],
+      platform: "telegram",
+      status: "active",
+    },
+  },
+  userName: "crabline",
+};
+
+describe("local channel provider", () => {
+  it("runs a deterministic Telegram DM roundtrip with transcript metadata", async () => {
+    const registry = createRegistry(manifest, "/tmp/crabline.yaml");
+    const result = await runFixtureCommand({
+      fixtureId: "telegram-dm",
+      manifest,
+      manifestPath: "/tmp/crabline.yaml",
+      registry,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("accepted message telegram-local-v1:event:1"),
+        expect.stringContaining("matched inbound telegram-local-v1:event:2"),
+      ]),
+    );
+  });
+
+  it("models Telegram group topic, media, and native action semantics", () => {
+    const driver = new TelegramLocalChannelDriver();
+    const target = {
+      channelId: "telegram:group:-100123",
+      id: "-100123",
+      metadata: {
+        actionId: "approve-1",
+        actionPayload: "approve:tool",
+        actionType: "button",
+        chatType: "group",
+        fileId: "file-123",
+        mediaKind: "image",
+        mention: "true",
+        topicId: "42",
+      },
+      threadId: "42",
+    };
+    const conversation = driver.conversationFromTarget(target);
+    const action = driver.createNativeAction(target);
+    const attachment = driver.createMediaAttachment(target);
+    const inbound = driver.ingestEvent({
+      action: action ?? undefined,
+      actor: driver.createUserActor(target),
+      attachments: attachment ? [attachment] : [],
+      conversation,
+      kind: "action",
+      raw: { callback_query: { data: action?.payload } },
+      text: "@crabline approve",
+    });
+
+    expect(conversation).toMatchObject({
+      id: "telegram:group:-100123",
+      kind: "group",
+      topicId: "42",
+    });
+    expect(inbound.action).toMatchObject({ id: "approve-1", payload: "approve:tool" });
+    expect(inbound.attachments[0]).toMatchObject({ id: "file-123", kind: "image" });
+    expect(inbound.channel).toBe("telegram");
+    expect(inbound.driverId).toBe("telegram-local-v1");
+  });
+
+  it("keeps local capability gaps visible for future channels", () => {
+    expect(LOCAL_CHANNEL_DRIVER_MATRIX).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          capabilityId: "telegram.dm.text",
+          channel: "telegram",
+          status: "covered",
+        }),
+        expect.objectContaining({
+          capabilityId: "discord.dm.text",
+          channel: "discord",
+          status: "planned",
+        }),
+      ]),
+    );
+  });
+});

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -61,6 +61,24 @@ describe("cli", () => {
     expect(captured.stdout.join("")).toContain("roundtrip-fixture");
   });
 
+  it("lists local channel driver metadata", async () => {
+    const captured = captureWrites();
+
+    try {
+      expect(await runCli(["node", "crabline", "channel-matrix"])).toBe(0);
+      expect(await runCli(["node", "crabline", "--json", "channel-matrix"])).toBe(0);
+    } finally {
+      captured.restore();
+    }
+
+    const stdout = captured.stdout.join("");
+    expect(stdout).toContain("telegram-local-v1");
+    expect(stdout).toContain("telegram.dm.text");
+    expect(JSON.parse(stdout.slice(stdout.indexOf("{")))).toMatchObject({
+      drivers: [expect.objectContaining({ driverId: "telegram-local-v1" })],
+    });
+  });
+
   it("runs doctor, probe, send, roundtrip, and suite commands", async () => {
     const configPath = await createConfig();
     const captured = captureWrites();

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -164,4 +164,45 @@ describe("manifest schema", () => {
       }),
     ).toThrow(/discord adapter must use platform=discord/u);
   });
+
+  it("parses the local Telegram channel driver config", () => {
+    const manifest = ManifestSchema.parse({
+      configVersion: 1,
+      fixtures: [
+        {
+          id: "telegram-local-dm",
+          mode: "roundtrip",
+          provider: "telegram-local",
+          target: { id: "user-123" },
+        },
+      ],
+      providers: {
+        "telegram-local": {
+          adapter: "channel",
+          channel: {
+            qaResponse: { mode: "ack" },
+          },
+          platform: "telegram",
+        },
+      },
+    });
+
+    expect(manifest.providers["telegram-local"]?.channel?.driver).toBe("telegram-local-v1");
+    expect(manifest.providers["telegram-local"]?.channel?.qaResponse.mode).toBe("ack");
+  });
+
+  it("rejects channel adapters on non-Telegram platforms until a driver exists", () => {
+    expect(() =>
+      ManifestSchema.parse({
+        configVersion: 1,
+        fixtures: [],
+        providers: {
+          discord: {
+            adapter: "channel",
+            platform: "discord",
+          },
+        },
+      }),
+    ).toThrow(/channel adapter currently supports platform=telegram/u);
+  });
 });

--- a/test/local-channel-driver-api.test.ts
+++ b/test/local-channel-driver-api.test.ts
@@ -10,7 +10,6 @@ describe("local channel driver API", () => {
     expect(
       findLocalChannelDriver({
         channel: "telegram",
-        driverId: "telegram-local-v1",
       }),
     ).toMatchObject({
       channel: "telegram",
@@ -35,7 +34,6 @@ describe("local channel driver API", () => {
     await expect(
       runLocalChannelDriverSmoke({
         channel: "telegram",
-        driverId: "telegram-local-v1",
       }),
     ).resolves.toMatchObject({
       driver: {

--- a/test/local-channel-driver-api.test.ts
+++ b/test/local-channel-driver-api.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  findLocalChannelDriver,
+  listLocalChannelDriverMatrix,
+  runLocalChannelDriverSmoke,
+} from "../src/index.js";
+
+describe("local channel driver API", () => {
+  it("exposes deterministic local channel driver metadata", () => {
+    expect(
+      findLocalChannelDriver({
+        channel: "telegram",
+        driverId: "telegram-local-v1",
+      }),
+    ).toMatchObject({
+      channel: "telegram",
+      channelLive: false,
+      deterministic: true,
+      driverId: "telegram-local-v1",
+      status: "ready",
+    });
+    expect(listLocalChannelDriverMatrix().matrix).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          capabilityId: "telegram.dm.text",
+          channel: "telegram",
+          driverId: "telegram-local-v1",
+          status: "covered",
+        }),
+      ]),
+    );
+  });
+
+  it("runs a deterministic smoke fixture for the selected local driver", async () => {
+    await expect(
+      runLocalChannelDriverSmoke({
+        channel: "telegram",
+        driverId: "telegram-local-v1",
+      }),
+    ).resolves.toMatchObject({
+      driver: {
+        channel: "telegram",
+        driverId: "telegram-local-v1",
+      },
+      result: {
+        fixtureId: "telegram-local-driver-smoke",
+        ok: true,
+        providerId: "telegram-local",
+      },
+    });
+  });
+});

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -100,6 +100,40 @@ describe("registry", () => {
     expect(provider.status).toBe("ready");
   });
 
+  it("resolves local channel providers", () => {
+    const channelManifest: ManifestDefinition = {
+      ...manifest,
+      fixtures: [
+        {
+          ...manifest.fixtures[0]!,
+          id: "telegram-fixture",
+          provider: "telegram",
+          target: { id: "user-123", metadata: {} },
+        },
+      ],
+      providers: {
+        telegram: {
+          adapter: "channel",
+          capabilities: ["probe", "send", "roundtrip", "agent"],
+          channel: {
+            botUserName: "crabline_bot",
+            driver: "telegram-local-v1",
+            qaResponse: { mode: "ack" },
+          },
+          env: [],
+          platform: "telegram",
+          status: "active",
+        },
+      },
+    };
+
+    const registry = createRegistry(channelManifest, "/tmp/crabline.yaml");
+    const provider = registry.resolve("telegram", "telegram-fixture");
+    expect(provider.id).toBe("telegram");
+    expect(provider.platform).toBe("telegram");
+    expect(provider.status).toBe("ready");
+  });
+
   it("resolves native discord, matrix, and imessage providers", () => {
     const nativeManifest: ManifestDefinition = {
       ...manifest,


### PR DESCRIPTION
POSTE MERGE EDIT: This has more or less been reverted since should have used chat sdk

## Summary

- Add SDK-level local channel driver types, transcript semantics, and capability metadata.
- Expose `adapter: channel` for deterministic Telegram local upstream runs without live credentials or VM orchestration.
- Add `crabline channel-matrix --json` plus example Telegram local fixtures for future OpenClaw QA Lab `smoke-ci` evidence mapping.
- Export a root package API for QA Lab integration: `listLocalChannelDriverMatrix()`, `findLocalChannelDriver()`, and `runLocalChannelDriverSmoke()`.
- Let `runLocalChannelDriverSmoke({ channel: "telegram" })` resolve the concrete local driver inside Crabline, so OpenClaw does not hardcode Crabline driver IDs.
- Keep the exported local-driver smoke path on the local channel provider, not the full native adapter registry, so OpenClaw can import it without pulling Slack/Discord/Matrix/iMessage runtime adapters.
- Lazy-load optional native/loopback provider adapters so a Git-installed Crabline package can run local channel commands without installing optional native adapter peer packages.

## Scope notes

- Model responses stay out of scope except deterministic QA fixture replies needed by the channel driver (`ack`, `echo`, or `none`); no model calls are made.
- Capability IDs are intended as stable mapping keys for OpenClaw QA Lab evidence, starting with `telegram.dm.text`, `telegram.group.mention`, `telegram.group.topic`, `telegram.action.inline_button`, `telegram.media.metadata`, and `telegram.connection.reconnect`.
- The matrix uses concrete coverage status only (`covered` / `planned` / `unsupported` in the SDK type surface); it does not introduce `extended`, `soak`, `manual`, or `advisory` profiles.
- PR openclaw/openclaw#91487 was used only for shape ideas: per-channel selection, metadata, and matrix visibility.

## Testing

- `pnpm --ignore-workspace exec vitest run test/local-channel-driver-api.test.ts test/channel-provider.test.ts test/registry.test.ts`
- `pnpm --ignore-workspace exec vitest run test/registry.test.ts test/channel-provider.test.ts test/local-channel-driver-api.test.ts test/cli.test.ts`
- `pnpm --ignore-workspace typecheck`
- `pnpm --ignore-workspace verify`
- Packed-install smoke: pack Crabline, install the tarball into a temp app, import and run `runLocalChannelDriverSmoke({ channel: "telegram" })` from `crabline`.
- Packed-install smoke: import `listLocalChannelDriverMatrix` from `crabline`, run `crabline --json channel-matrix`, and run `crabline --json run local-roundtrip` with `adapter: channel`.
- `pnpm dev channel-matrix --json`
- `pnpm dev roundtrip telegram-local-dm --config fixtures/examples/crabline.example.yaml --json`
