### PR TITLE
simpler local channel driver selection/naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This project used to be called `multipass`, but was renamed to `crabline` to avo
 The v1 shape is:
 
 - built-in `loopback` provider for local development and contract tests
-- deterministic local channel SDK provider, starting with `telegram-local-v1`
+- deterministic local channel SDK provider, starting with Telegram
 - native `discord` provider backed by the Chat SDK Discord adapter
 - native `slack` provider backed by the Chat SDK Slack adapter
 - native community adapters for `matrix` and `imessage`
@@ -101,7 +101,7 @@ Credentials stay in env, never in fixtures.
 
 - `ready`: `loopback`, native `slack`, native `discord`, native-community `matrix`, native-community `imessage`
 - `bridge`: `bluebubbles`, `feishu`, `googlechat`, `irc`, `line`, `mattermost`, `msteams`, `nextcloudtalk`, `nostr`, `signal`, `synologychat`, `telegram`, `tlon`, `twitch`, `webchat`, `whatsapp`, `zalo`, `zalouser`
-- deterministic local channel driver: `telegram-local-v1` via `adapter: channel`, `platform: telegram`
+- deterministic local channel driver: `adapter: channel`, `platform: telegram`
 - Plugin-backed in OpenClaw, still supported through the bridge: `feishu`, `line`, `mattermost`, `msteams`, `nextcloudtalk`, `nostr`, `synologychat`, `tlon`, `twitch`, `zalo`, `zalouser`
 - Recommended bridge-only path today: `bluebubbles`, `googlechat`, `irc`, `signal`, `telegram`, `webchat`, `whatsapp`
 
@@ -120,15 +120,15 @@ providers:
     adapter: channel
     platform: telegram
     channel:
-      driver: telegram-local-v1
-      botUserName: multipass_telegram_bot
+      botUserName: crabline_telegram_bot
       qaResponse:
         mode: ack # QA-fixture response only; no model call is made
 ```
 
-`telegram-local-v1` is a deterministic local upstream shim. It records Telegram-shaped
+The Telegram local driver is a deterministic local upstream shim. It records Telegram-shaped
 inbound events, outbound actions, and transcript entries for DM, group mention,
 forum topic/thread, inline button action, media metadata, and reconnect assertions.
+Its in-code driver metadata carries `driverId: "telegram"` and `driverVersion: 1`.
 It is not Canonical Multipass VM orchestration and does not route through OpenClaw's
 `qa-channel` normalized bus.
 
@@ -393,6 +393,6 @@ or:
 ## Current scope
 
 - Real built-in providers: `loopback`, native `slack`, native `discord`, native-community `matrix`, native-community `imessage`
-- Deterministic local channel SDK drivers: `telegram-local-v1`
+- Deterministic local channel SDK drivers: Telegram
 - Real external bridge: `script` for the full OpenClaw channel matrix
 - Not implemented yet: local channel drivers beyond Telegram, richer recorder compaction/query tooling, live-model response generation

--- a/fixtures/examples/crabline.example.yaml
+++ b/fixtures/examples/crabline.example.yaml
@@ -12,8 +12,7 @@ providers:
     adapter: channel
     platform: telegram
     channel:
-      driver: telegram-local-v1
-      botUserName: multipass_telegram_bot
+      botUserName: crabline_telegram_bot
       qaResponse:
         mode: ack
 

--- a/src/channels/driver-registry.ts
+++ b/src/channels/driver-registry.ts
@@ -1,0 +1,32 @@
+import type { ProviderPlatform } from "../config/schema.js";
+import { LocalChannelUpstream } from "./local-upstream.js";
+import { TelegramLocalChannelDriver } from "./telegram.js";
+import type {
+  ChannelActor,
+  ChannelAttachment,
+  ChannelConversation,
+  ChannelDriverMetadata,
+  ChannelNativeAction,
+} from "./types.js";
+import type { NormalizedTarget } from "../providers/types.js";
+
+export type LocalChannelDriver = {
+  readonly metadata: ChannelDriverMetadata;
+  conversationFromTarget(target: NormalizedTarget): ChannelConversation;
+  createAssistantActor(botUserName: string): ChannelActor;
+  createMediaAttachment(target: NormalizedTarget): ChannelAttachment | null;
+  createNativeAction(target: NormalizedTarget): ChannelNativeAction | null;
+  createUserActor(target: NormalizedTarget): ChannelActor;
+  ingestEvent: LocalChannelUpstream["ingestEvent"];
+  listSince: LocalChannelUpstream["listSince"];
+  recordAction: LocalChannelUpstream["recordAction"];
+};
+
+export const LOCAL_CHANNEL_DRIVER_METADATA = [TelegramLocalChannelDriver.metadata] as const;
+
+export function createLocalChannelDriver(platform: ProviderPlatform): LocalChannelDriver | null {
+  if (platform === "telegram") {
+    return new TelegramLocalChannelDriver();
+  }
+  return null;
+}

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -1,7 +1,9 @@
+export { LOCAL_CHANNEL_DRIVER_METADATA, createLocalChannelDriver } from "./driver-registry.js";
 export { LOCAL_CHANNEL_DRIVER_MATRIX } from "./matrix.js";
 export {
   TELEGRAM_LOCAL_DRIVER_ID,
   TELEGRAM_LOCAL_DRIVER_METADATA,
+  TELEGRAM_LOCAL_DRIVER_VERSION,
   TelegramLocalChannelDriver,
 } from "./telegram.js";
 export { LocalChannelUpstream } from "./local-upstream.js";

--- a/src/channels/matrix.ts
+++ b/src/channels/matrix.ts
@@ -1,15 +1,17 @@
 import type { ChannelCapabilityMatrixRow } from "./types.js";
-import { TELEGRAM_LOCAL_DRIVER_ID, TELEGRAM_LOCAL_DRIVER_METADATA } from "./telegram.js";
+import { LOCAL_CHANNEL_DRIVER_METADATA } from "./driver-registry.js";
 
 export const LOCAL_CHANNEL_DRIVER_MATRIX = [
-  ...TELEGRAM_LOCAL_DRIVER_METADATA.capabilities.map(
-    (capability): ChannelCapabilityMatrixRow => ({
-      capabilityId: capability.id,
-      channel: "telegram",
-      driverId: TELEGRAM_LOCAL_DRIVER_ID,
-      notes: capability.notes,
-      status: capability.status,
-    }),
+  ...LOCAL_CHANNEL_DRIVER_METADATA.flatMap((driver) =>
+    driver.capabilities.map(
+      (capability): ChannelCapabilityMatrixRow => ({
+        capabilityId: capability.id,
+        channel: driver.channel,
+        driverId: driver.driverId,
+        notes: capability.notes,
+        status: capability.status,
+      }),
+    ),
   ),
   {
     capabilityId: "discord.dm.text",

--- a/src/channels/telegram.ts
+++ b/src/channels/telegram.ts
@@ -8,7 +8,8 @@ import type {
 } from "./types.js";
 import { LocalChannelUpstream } from "./local-upstream.js";
 
-export const TELEGRAM_LOCAL_DRIVER_ID = "telegram-local-v1" as const;
+export const TELEGRAM_LOCAL_DRIVER_ID = "telegram" as const;
+export const TELEGRAM_LOCAL_DRIVER_VERSION = 1;
 
 export const TELEGRAM_LOCAL_DRIVER_METADATA = {
   capabilities: [
@@ -68,12 +69,15 @@ export const TELEGRAM_LOCAL_DRIVER_METADATA = {
   channelLive: false,
   deterministic: true,
   driverId: TELEGRAM_LOCAL_DRIVER_ID,
+  driverVersion: TELEGRAM_LOCAL_DRIVER_VERSION,
   eventKinds: ["message", "action", "connection", "delivery"],
   notes: "Deterministic local Telegram upstream shim for OpenClaw QA Lab channel assertions.",
   status: "ready",
 } as const satisfies ChannelDriverMetadata;
 
 export class TelegramLocalChannelDriver extends LocalChannelUpstream {
+  static readonly metadata = TELEGRAM_LOCAL_DRIVER_METADATA;
+
   constructor() {
     super(TELEGRAM_LOCAL_DRIVER_METADATA);
   }

--- a/src/channels/types.ts
+++ b/src/channels/types.ts
@@ -6,7 +6,7 @@ export type ChannelConversationKind = "dm" | "group";
 export type ChannelTranscriptKind = "action" | "connection" | "delivery" | "message";
 export type ChannelCapabilityStatus = "covered" | "planned" | "unsupported";
 
-export type LocalChannelDriverId = "telegram-local-v1";
+export type LocalChannelDriverId = "telegram";
 
 export type ChannelConversation = {
   id: string;
@@ -64,6 +64,7 @@ export type ChannelDriverMetadata = {
   channelLive: false;
   deterministic: true;
   driverId: LocalChannelDriverId;
+  driverVersion: number;
   eventKinds: readonly ChannelTranscriptKind[];
   notes: string;
   status: "ready";

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
+import { LOCAL_CHANNEL_DRIVER_METADATA } from "../channels/driver-registry.js";
 import { LOCAL_CHANNEL_DRIVER_MATRIX } from "../channels/matrix.js";
-import { TELEGRAM_LOCAL_DRIVER_METADATA } from "../channels/telegram.js";
 import { loadManifest } from "../config/load.js";
 import { createRegistry } from "../providers/registry.js";
 import { formatJson, formatRunResultText } from "../core/reporters.js";
@@ -59,7 +59,7 @@ export function createProgram(): Command {
     .action(() => {
       const options = program.opts() as GlobalOptions;
       const payload = {
-        drivers: [TELEGRAM_LOCAL_DRIVER_METADATA],
+        drivers: LOCAL_CHANNEL_DRIVER_METADATA,
         matrix: LOCAL_CHANNEL_DRIVER_MATRIX,
       };
       print(options.json ? formatJson(payload) : renderChannelMatrixText(payload));
@@ -241,6 +241,7 @@ function renderChannelMatrixText(payload: {
     channelLive: false;
     deterministic: true;
     driverId: string;
+    driverVersion: number;
     status: string;
   }>;
   matrix: ReadonlyArray<{
@@ -254,7 +255,7 @@ function renderChannelMatrixText(payload: {
   const lines = ["local channel drivers:"];
   for (const driver of payload.drivers) {
     lines.push(
-      `  ${driver.driverId} channel=${driver.channel} live=${String(driver.channelLive)} deterministic=${String(driver.deterministic)} status=${driver.status}`,
+      `  ${driver.driverId} channel=${driver.channel} version=${driver.driverVersion} live=${String(driver.channelLive)} deterministic=${String(driver.deterministic)} status=${driver.status}`,
     );
   }
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -147,8 +147,7 @@ const IMessageConfigSchema = z.object({
 });
 
 const ChannelConfigSchema = z.object({
-  botUserName: z.string().min(1).default("multipass_telegram_bot"),
-  driver: z.literal("telegram-local-v1").default("telegram-local-v1"),
+  botUserName: z.string().min(1).default("crabline_telegram_bot"),
   qaResponse: z
     .object({
       mode: z.enum(["ack", "echo", "none"]).default("none"),

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,11 @@ export {
   type LocalChannelDriverSmokeResult,
 } from "./local-channel-driver-api.js";
 export {
+  LOCAL_CHANNEL_DRIVER_METADATA,
   LOCAL_CHANNEL_DRIVER_MATRIX,
   TELEGRAM_LOCAL_DRIVER_ID,
   TELEGRAM_LOCAL_DRIVER_METADATA,
+  TELEGRAM_LOCAL_DRIVER_VERSION,
   TelegramLocalChannelDriver,
   type ChannelCapabilityMatrixRow,
   type ChannelDriverMetadata,

--- a/src/local-channel-driver-api.ts
+++ b/src/local-channel-driver-api.ts
@@ -4,11 +4,10 @@ import { LocalChannelProviderAdapter } from "./providers/builtin/channel.js";
 import { OPENCLAW_SUPPORT_CATALOG } from "./providers/catalog.js";
 import type { Registry } from "./providers/registry.js";
 import {
+  LOCAL_CHANNEL_DRIVER_METADATA,
   LOCAL_CHANNEL_DRIVER_MATRIX,
-  TELEGRAM_LOCAL_DRIVER_METADATA,
   type ChannelCapabilityMatrixRow,
   type ChannelDriverMetadata,
-  type LocalChannelDriverId,
 } from "./channels/index.js";
 
 export type LocalChannelDriverSmokeResult = {
@@ -19,21 +18,17 @@ export type LocalChannelDriverSmokeResult = {
 
 export function listLocalChannelDriverMatrix() {
   return {
-    drivers: [TELEGRAM_LOCAL_DRIVER_METADATA],
+    drivers: LOCAL_CHANNEL_DRIVER_METADATA,
     matrix: LOCAL_CHANNEL_DRIVER_MATRIX,
   };
 }
 
 export function findLocalChannelDriver(params: {
   channel: ProviderPlatform;
-  driverId?: LocalChannelDriverId;
 }): ChannelDriverMetadata | null {
   return (
-    listLocalChannelDriverMatrix().drivers.find(
-      (driver) =>
-        driver.channel === params.channel &&
-        (!params.driverId || driver.driverId === params.driverId),
-    ) ?? null
+    listLocalChannelDriverMatrix().drivers.find((driver) => driver.channel === params.channel) ??
+    null
   );
 }
 
@@ -55,7 +50,6 @@ function buildLocalChannelSmokeManifest(params: {
         adapter: "channel",
         platform: "telegram",
         channel: {
-          driver: params.driver.driverId,
           botUserName: "crabline_telegram_bot",
           qaResponse: {
             mode: "ack",
@@ -109,17 +103,14 @@ function createLocalChannelDriverRegistry(manifest: ManifestDefinition): Registr
 
 export async function runLocalChannelDriverSmoke(params: {
   channel: ProviderPlatform;
-  driverId?: LocalChannelDriverId;
   manifestPath?: string;
   userName?: string;
 }): Promise<LocalChannelDriverSmokeResult> {
   const driver = findLocalChannelDriver({
     channel: params.channel,
-    ...(params.driverId ? { driverId: params.driverId } : {}),
   });
   if (!driver) {
-    const suffix = params.driverId ? `/${params.driverId}` : "";
-    throw new Error(`local channel driver not found: ${params.channel}${suffix}`);
+    throw new Error(`local channel driver not found: ${params.channel}`);
   }
 
   const manifest = buildLocalChannelSmokeManifest({

--- a/src/providers/builtin/channel.ts
+++ b/src/providers/builtin/channel.ts
@@ -1,7 +1,11 @@
 import { extractNonce } from "../../core/nonces.js";
 import type { ProviderConfig } from "../../config/schema.js";
-import { TelegramLocalChannelDriver } from "../../channels/telegram.js";
-import type { ChannelTranscriptEntry } from "../../channels/types.js";
+import {
+  createLocalChannelDriver,
+  type LocalChannelDriver,
+} from "../../channels/driver-registry.js";
+import type { ChannelNativeAction, ChannelTranscriptEntry } from "../../channels/types.js";
+import { CrablineError } from "../../core/errors.js";
 import type {
   InboundEnvelope,
   NormalizedTarget,
@@ -20,17 +24,26 @@ function sleep(ms: number): Promise<void> {
 
 export class LocalChannelProviderAdapter implements ProviderAdapter {
   readonly id;
-  readonly platform = "telegram" as const;
+  readonly platform;
   readonly status = "ready" as const;
   readonly supports = ["probe", "send", "roundtrip", "agent"] as const;
 
   readonly #botUserName: string;
-  readonly #driver = new TelegramLocalChannelDriver();
+  readonly #driver: LocalChannelDriver;
   readonly #qaResponseMode: "ack" | "echo" | "none";
 
   constructor(id: string, config: ProviderConfig) {
     this.id = id;
-    this.#botUserName = config.channel?.botUserName ?? "multipass_telegram_bot";
+    this.platform = config.platform;
+    const driver = createLocalChannelDriver(config.platform);
+    if (!driver) {
+      throw new CrablineError(
+        `No local channel driver is available for platform "${config.platform}".`,
+        { kind: "config" },
+      );
+    }
+    this.#driver = driver;
+    this.#botUserName = config.channel?.botUserName ?? "crabline_telegram_bot";
     this.#qaResponseMode = config.channel?.qaResponse?.mode ?? "none";
   }
 
@@ -67,19 +80,23 @@ export class LocalChannelProviderAdapter implements ProviderAdapter {
       attachments: attachment ? [attachment] : [],
       conversation,
       kind: action ? "action" : "message",
-      raw: createTelegramRawInbound(target, context.text, action),
+      raw: createRawInbound(this.#driver, target, context.text, action),
       sentAt: new Date().toISOString(),
       text: context.text,
     });
 
     if (target.metadata.reconnect === "true") {
       this.#driver.ingestEvent({
-        actor: { id: "telegram-local-upstream", isBot: true, role: "system" },
+        actor: {
+          id: `${this.#driver.metadata.driverId}-local-upstream`,
+          isBot: true,
+          role: "system",
+        },
         conversation,
         kind: "connection",
         raw: { event: "reconnect", ok: true },
         sentAt: new Date().toISOString(),
-        text: "telegram reconnect",
+        text: `${this.#driver.metadata.channel} reconnect`,
       });
     }
 
@@ -154,11 +171,19 @@ export class LocalChannelProviderAdapter implements ProviderAdapter {
   }
 }
 
-function createTelegramRawInbound(
+function createRawInbound(
+  driver: LocalChannelDriver,
   target: NormalizedTarget,
   text: string,
-  action: ReturnType<TelegramLocalChannelDriver["createNativeAction"]>,
+  action: ChannelNativeAction | null,
 ): Record<string, unknown> {
+  if (driver.metadata.channel !== "telegram") {
+    return {
+      driverId: driver.metadata.driverId,
+      text,
+    };
+  }
+
   const chatType = target.metadata.chatType ?? "private";
   const raw: Record<string, unknown> = {
     chat: {

--- a/src/providers/catalog.ts
+++ b/src/providers/catalog.ts
@@ -66,7 +66,7 @@ export const OPENCLAW_SUPPORT_CATALOG = [
   createBridgeEntry("synologychat", "OpenClaw plugin channel via script bridge."),
   createBridgeEntry(
     "telegram",
-    "OpenClaw channel via script bridge; deterministic local driver available as telegram-local-v1.",
+    "OpenClaw channel via script bridge; deterministic local driver available via adapter=channel.",
   ),
   createBridgeEntry("tlon", "OpenClaw plugin channel via script bridge."),
   createBridgeEntry("twitch", "OpenClaw plugin channel via script bridge."),

--- a/test/channel-provider.test.ts
+++ b/test/channel-provider.test.ts
@@ -55,7 +55,6 @@ const manifest: ManifestDefinition = {
       capabilities: ["probe", "send", "roundtrip", "agent"],
       channel: {
         botUserName: "crabline_bot",
-        driver: "telegram-local-v1",
         qaResponse: { mode: "ack" },
       },
       env: [],
@@ -79,8 +78,8 @@ describe("local channel provider", () => {
     expect(result.ok).toBe(true);
     expect(result.diagnostics).toEqual(
       expect.arrayContaining([
-        expect.stringContaining("accepted message telegram-local-v1:event:1"),
-        expect.stringContaining("matched inbound telegram-local-v1:event:2"),
+        expect.stringContaining("accepted message telegram:event:1"),
+        expect.stringContaining("matched inbound telegram:event:2"),
       ]),
     );
   });
@@ -123,7 +122,7 @@ describe("local channel provider", () => {
     expect(inbound.action).toMatchObject({ id: "approve-1", payload: "approve:tool" });
     expect(inbound.attachments[0]).toMatchObject({ id: "file-123", kind: "image" });
     expect(inbound.channel).toBe("telegram");
-    expect(inbound.driverId).toBe("telegram-local-v1");
+    expect(inbound.driverId).toBe("telegram");
   });
 
   it("keeps local capability gaps visible for future channels", () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -72,10 +72,10 @@ describe("cli", () => {
     }
 
     const stdout = captured.stdout.join("");
-    expect(stdout).toContain("telegram-local-v1");
+    expect(stdout).toContain("telegram channel=telegram version=1");
     expect(stdout).toContain("telegram.dm.text");
     expect(JSON.parse(stdout.slice(stdout.indexOf("{")))).toMatchObject({
-      drivers: [expect.objectContaining({ driverId: "telegram-local-v1" })],
+      drivers: [expect.objectContaining({ driverId: "telegram", driverVersion: 1 })],
     });
   });
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -165,7 +165,7 @@ describe("manifest schema", () => {
     ).toThrow(/discord adapter must use platform=discord/u);
   });
 
-  it("parses the local Telegram channel driver config", () => {
+  it("parses the local Telegram channel config", () => {
     const manifest = ManifestSchema.parse({
       configVersion: 1,
       fixtures: [
@@ -187,7 +187,7 @@ describe("manifest schema", () => {
       },
     });
 
-    expect(manifest.providers["telegram-local"]?.channel?.driver).toBe("telegram-local-v1");
+    expect(manifest.providers["telegram-local"]?.platform).toBe("telegram");
     expect(manifest.providers["telegram-local"]?.channel?.qaResponse.mode).toBe("ack");
   });
 

--- a/test/local-channel-driver-api.test.ts
+++ b/test/local-channel-driver-api.test.ts
@@ -15,7 +15,8 @@ describe("local channel driver API", () => {
       channel: "telegram",
       channelLive: false,
       deterministic: true,
-      driverId: "telegram-local-v1",
+      driverId: "telegram",
+      driverVersion: 1,
       status: "ready",
     });
     expect(listLocalChannelDriverMatrix().matrix).toEqual(
@@ -23,7 +24,7 @@ describe("local channel driver API", () => {
         expect.objectContaining({
           capabilityId: "telegram.dm.text",
           channel: "telegram",
-          driverId: "telegram-local-v1",
+          driverId: "telegram",
           status: "covered",
         }),
       ]),
@@ -38,7 +39,8 @@ describe("local channel driver API", () => {
     ).resolves.toMatchObject({
       driver: {
         channel: "telegram",
-        driverId: "telegram-local-v1",
+        driverId: "telegram",
+        driverVersion: 1,
       },
       result: {
         fixtureId: "telegram-local-driver-smoke",

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -117,7 +117,6 @@ describe("registry", () => {
           capabilities: ["probe", "send", "roundtrip", "agent"],
           channel: {
             botUserName: "crabline_bot",
-            driver: "telegram-local-v1",
             qaResponse: { mode: "ack" },
           },
           env: [],


### PR DESCRIPTION
## Summary
- remove the user-facing channel.driver field and select the local channel driver from the provider platform
- rename the Telegram local driver id from telegram-local-v1 to telegram and add driverVersion metadata for in-code version tracking
- route channel matrix, CLI output, and smoke API through a local driver metadata registry

## Scope
This intentionally does not add WhatsApp local driver support. WhatsApp remains a planned local driver and script-bridge platform; the WhatsApp implementation will be a follow-up PR.

## Verification
- pnpm verify