### PR TITLE
Add built-in Teams and Google Chat providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ The current shape is:
 - built-in `loopback` provider for local development and contract tests
 - built-in `discord` provider
 - built-in `feishu` provider
+- built-in `googlechat` provider
 - built-in `mattermost` provider
+- built-in `msteams` provider
 - built-in `slack` provider
 - built-in `telegram` provider
 - built-in `whatsapp` provider
@@ -22,7 +24,7 @@ The current shape is:
 - `script` bridge for the remaining OpenClaw messaging channels
 - webhook-backed recorder mode for Slack `watch` / `webhook`
 - interactions-webhook + gateway-backed recorder mode for Discord
-- recorder-backed watch mode for Telegram, WhatsApp, Feishu, Mattermost, Zalo, Matrix, and iMessage
+- recorder-backed watch mode for Telegram, WhatsApp, Feishu, Google Chat, Mattermost, Microsoft Teams, Zalo, Matrix, and iMessage
 - nonce-based `send`, `roundtrip`, `agent`, `probe`, `run`, `watch`, `doctor`
 - text output by default, stable `--json` for automation
 - core provider model aligned with Vercel Chat SDK concepts
@@ -75,7 +77,7 @@ configVersion: 1
 userName: crabline
 providers:
   provider-id:
-    adapter: loopback | script | slack | discord | feishu | mattermost | telegram | whatsapp | zalo | matrix | imessage
+    adapter: loopback | script | slack | discord | feishu | googlechat | mattermost | msteams | telegram | whatsapp | zalo | matrix | imessage
     platform: required only when adapter is script
 fixtures:
   - id: string
@@ -109,10 +111,10 @@ For per-channel secrets, external setup, and smoke CI profile guidance, see
 
 ## Support Matrix
 
-- `ready`: `loopback`, built-in `slack`, built-in `discord`, built-in `feishu`, built-in `mattermost`, built-in `telegram`, built-in `whatsapp`, built-in `zalo`, adapter-backed `matrix`, adapter-backed `imessage`
-- `bridge`: `bluebubbles`, `googlechat`, `irc`, `line`, `msteams`, `nextcloudtalk`, `nostr`, `signal`, `synologychat`, `tlon`, `twitch`, `webchat`, `zalouser`
-- Plugin-backed in OpenClaw, available through the bridge: `line`, `msteams`, `nextcloudtalk`, `nostr`, `synologychat`, `tlon`, `twitch`, `zalouser`
-- Recommended bridge-only path today: `bluebubbles`, `googlechat`, `irc`, `signal`, `webchat`
+- `ready`: `loopback`, built-in `slack`, built-in `discord`, built-in `feishu`, built-in `googlechat`, built-in `mattermost`, built-in `msteams`, built-in `telegram`, built-in `whatsapp`, built-in `zalo`, adapter-backed `matrix`, adapter-backed `imessage`
+- `bridge`: `bluebubbles`, `irc`, `line`, `nextcloudtalk`, `nostr`, `signal`, `synologychat`, `tlon`, `twitch`, `webchat`, `zalouser`
+- Plugin-backed in OpenClaw, available through the bridge: `line`, `nextcloudtalk`, `nostr`, `synologychat`, `tlon`, `twitch`, `zalouser`
+- Recommended bridge-only path today: `bluebubbles`, `irc`, `signal`, `webchat`
 
 Telegram notes:
 
@@ -181,6 +183,27 @@ providers:
 
 Feishu uses the Chat SDK Lark adapter and WebSocket transport. Targets use `lark:{chatId}:{rootId}`. Raw `oc_*` chat ids are encoded automatically; raw `ou_*` user ids are treated as DM targets.
 
+Google Chat provider options:
+
+```yaml
+providers:
+  googlechat:
+    adapter: googlechat
+    env:
+      - GOOGLE_CHAT_CREDENTIALS
+    googlechat:
+      googleChatProjectNumber: "1234567890"
+      recorder:
+        path: ./.crabline/recorders/googlechat.jsonl
+      webhook:
+        host: 127.0.0.1
+        port: 8792
+        path: /googlechat/webhook
+        publicUrl: https://example.ngrok.app/googlechat/webhook # optional
+```
+
+Google Chat raw space targets use `spaces/...` and are encoded as `gchat:spaces/...`. Thread replies use `target.channelId` plus `target.threadId`, encoded as `gchat:{spaceName}:{base64urlThreadName}`.
+
 Mattermost provider options:
 
 ```yaml
@@ -201,6 +224,27 @@ providers:
 ```
 
 Mattermost raw channel ids are encoded as `mattermost:{base64urlChannelId}`. Thread replies use `target.channelId` plus `target.threadId`, encoded as `mattermost:{base64urlChannelId}:{base64urlRootPostId}`. User DMs can set `target.metadata.targetType: user`.
+
+Microsoft Teams provider options:
+
+```yaml
+providers:
+  msteams:
+    adapter: msteams
+    env:
+      - TEAMS_APP_ID
+      - TEAMS_APP_PASSWORD
+    msteams:
+      recorder:
+        path: ./.crabline/recorders/msteams.jsonl
+      webhook:
+        host: 127.0.0.1
+        port: 8791
+        path: /msteams/webhook
+        publicUrl: https://example.ngrok.app/msteams/webhook # optional
+```
+
+Microsoft Teams raw conversation targets require `target.metadata.serviceUrl` so Crabline can encode Chat SDK thread ids as `teams:{conversationId}:{serviceUrl}`. Encoded `teams:` ids are passed through.
 
 Zalo provider options:
 
@@ -393,6 +437,28 @@ MATTERMOST_BOT_TOKEN=... \
 pnpm dev watch mattermost-channel --config fixtures/examples/crabline.example.yaml
 ```
 
+Microsoft Teams:
+
+```bash
+TEAMS_APP_ID=... \
+TEAMS_APP_PASSWORD=... \
+pnpm dev probe msteams-channel --config fixtures/examples/crabline.example.yaml
+
+TEAMS_APP_ID=... \
+TEAMS_APP_PASSWORD=... \
+pnpm dev watch msteams-channel --config fixtures/examples/crabline.example.yaml
+```
+
+Google Chat:
+
+```bash
+GOOGLE_CHAT_CREDENTIALS='{"client_email":"...","private_key":"..."}' \
+pnpm dev probe googlechat-space --config fixtures/examples/crabline.example.yaml
+
+GOOGLE_CHAT_CREDENTIALS='{"client_email":"...","private_key":"..."}' \
+pnpm dev watch googlechat-space --config fixtures/examples/crabline.example.yaml
+```
+
 Zalo:
 
 ```bash
@@ -526,6 +592,6 @@ or:
 
 ## Current scope
 
-- Real built-in providers: `loopback`, built-in `slack`, built-in `discord`, built-in `feishu`, built-in `mattermost`, built-in `telegram`, built-in `whatsapp`, built-in `zalo`, adapter-backed `matrix`, adapter-backed `imessage`
+- Real built-in providers: `loopback`, built-in `slack`, built-in `discord`, built-in `feishu`, built-in `googlechat`, built-in `mattermost`, built-in `msteams`, built-in `telegram`, built-in `whatsapp`, built-in `zalo`, adapter-backed `matrix`, adapter-backed `imessage`
 - Real external bridge: `script` for the full OpenClaw channel matrix
 - Not implemented yet: richer recorder compaction/query tooling, live-model response generation

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -39,9 +39,9 @@ Recommended initial smoke order:
 1. `loopback`: no external dependencies.
 2. `telegram` with polling mode: easiest live messaging smoke because it does
    not require a public webhook URL.
-3. `slack`, `discord`, `matrix`, `imessage`, `feishu`, `mattermost`, or
-   `zalo`: depends on which shared test workspace/account OpenClaw already
-   maintains.
+3. `slack`, `discord`, `matrix`, `imessage`, `feishu`, `googlechat`,
+   `mattermost`, `msteams`, or `zalo`: depends on which shared test
+   workspace/account OpenClaw already maintains.
 4. `whatsapp`: needs a Meta app, a registered WhatsApp Business phone number,
    public webhook reachability, and a live recipient inside WhatsApp's messaging
    rules.
@@ -289,6 +289,120 @@ Target notes:
 - Raw targets are encoded as `whatsapp:{phoneNumberId}:{userWaId}`.
 - WhatsApp Cloud API does not provide normal message history, so smoke tests
   should rely on webhook delivery and the recorder.
+
+### Microsoft Teams
+
+Backed by `@chat-adapter/teams`.
+
+Required secrets:
+
+- `TEAMS_APP_ID`
+- `TEAMS_APP_PASSWORD`
+
+Alternative auth:
+
+- `TEAMS_FEDERATED_CLIENT_ID`
+- `TEAMS_FEDERATED_CLIENT_AUDIENCE`
+
+Optional env:
+
+- `TEAMS_APP_TENANT_ID`
+- `TEAMS_APP_TYPE`
+- `TEAMS_API_URL`
+- `TEAMS_BOT_USERNAME`
+
+External setup:
+
+1. Create or reuse a Microsoft Teams bot registration.
+2. Store the app id and app password, or configure workload identity federation.
+3. Configure the bot messaging endpoint to the public Crabline/OpenClaw URL
+   ending in `/msteams/webhook`.
+4. Install the bot into the dedicated smoke team/chat.
+5. Record the Teams conversation id and service URL for the smoke fixture, or
+   store the fully encoded `teams:` Chat SDK thread id.
+
+Provider:
+
+```yaml
+providers:
+  msteams:
+    adapter: msteams
+    env:
+      - TEAMS_APP_ID
+      - TEAMS_APP_PASSWORD
+    msteams:
+      webhook:
+        publicUrl: https://example.ngrok.app/msteams/webhook
+```
+
+Target notes:
+
+- Encoded `teams:` ids are accepted as `target.id`, `target.channelId`, or
+  `target.threadId`.
+- Raw Teams conversation ids require `target.metadata.serviceUrl`.
+- Thread replies use `target.threadId`; Crabline appends it to the raw
+  conversation id before encoding the SDK thread id.
+- User DMs use `target.id` as the Teams user id when no conversation id or
+  service URL is provided.
+
+### Google Chat
+
+Backed by `@chat-adapter/gchat`.
+
+Required auth config or env:
+
+- `googlechat.credentials` or `GOOGLE_CHAT_CREDENTIALS`
+- or `googlechat.useApplicationDefaultCredentials: true` /
+  `GOOGLE_CHAT_USE_ADC=true`
+
+Required webhook verification config:
+
+- `googlechat.googleChatProjectNumber`
+- or `googlechat.pubsubAudience`
+- or `googlechat.disableSignatureVerification: true` for local development
+
+Optional env:
+
+- `GOOGLE_CHAT_API_URL`
+- `GOOGLE_CHAT_BOT_USERNAME`
+- `GOOGLE_CHAT_ENDPOINT_URL`
+- `GOOGLE_CHAT_IMPERSONATE_USER`
+- `GOOGLE_CHAT_PROJECT_NUMBER`
+- `GOOGLE_CHAT_PUBSUB_AUDIENCE`
+- `GOOGLE_CHAT_PUBSUB_TOPIC`
+
+External setup:
+
+1. Create or reuse a Google Chat app in the smoke Google Cloud project.
+2. Enable the Google Chat API.
+3. Configure a service account credential or Application Default Credentials
+   for the smoke runner.
+4. Configure the HTTP endpoint to the public Crabline/OpenClaw URL ending in
+   `/googlechat/webhook`.
+5. Configure webhook verification through project-number JWT verification,
+   Pub/Sub audience verification, or local-only signature verification disable.
+6. Add the app to the dedicated smoke space and record its `spaces/...` id.
+
+Provider:
+
+```yaml
+providers:
+  googlechat:
+    adapter: googlechat
+    env:
+      - GOOGLE_CHAT_CREDENTIALS
+    googlechat:
+      googleChatProjectNumber: "1234567890"
+      webhook:
+        publicUrl: https://example.ngrok.app/googlechat/webhook
+```
+
+Target notes:
+
+- Raw space ids are accepted, for example `spaces/AAAA1234567`.
+- Encoded ids are also accepted, for example `gchat:spaces/AAAA1234567`.
+- Thread replies use `target.channelId` plus `target.threadId`; raw thread names
+  are base64url encoded into the Chat SDK thread id.
 
 ### Feishu
 
@@ -550,10 +664,10 @@ It must match an OpenClaw channel id. Bridge platform ids are
 `synologychat`, `telegram`, `tlon`, `twitch`, `webchat`, `whatsapp`, `zalo`,
 and `zalouser`.
 
-Telegram, WhatsApp, Feishu, Mattermost, and Zalo can also be exercised through
-script bridge profiles when the smoke goal is full OpenClaw channel routing
-rather than built-in adapter behavior. In that case, use the matching `platform`
-value with the shared OpenClaw bridge secrets above.
+Telegram, WhatsApp, Feishu, Mattermost, Microsoft Teams, Google Chat, and Zalo
+can also be exercised through script bridge profiles when the smoke goal is full
+OpenClaw channel routing rather than built-in adapter behavior. In that case,
+use the matching `platform` value with the shared OpenClaw bridge secrets above.
 
 ### OpenClaw E2E Smoke CI
 
@@ -803,6 +917,25 @@ WHATSAPP_ACCESS_TOKEN
 WHATSAPP_APP_SECRET
 WHATSAPP_PHONE_NUMBER_ID
 WHATSAPP_VERIFY_TOKEN
+```
+
+Microsoft Teams smoke adds:
+
+```text
+TEAMS_APP_ID
+TEAMS_APP_PASSWORD
+```
+
+Google Chat smoke adds one auth path:
+
+```text
+GOOGLE_CHAT_CREDENTIALS
+```
+
+or:
+
+```text
+GOOGLE_CHAT_USE_ADC
 ```
 
 Feishu smoke adds:

--- a/fixtures/examples/crabline.example.yaml
+++ b/fixtures/examples/crabline.example.yaml
@@ -37,6 +37,34 @@ providers:
         path: /whatsapp/webhook
         publicUrl: https://example.ngrok.app/whatsapp/webhook
 
+  msteams:
+    adapter: msteams
+    env:
+      - TEAMS_APP_ID
+      - TEAMS_APP_PASSWORD
+    msteams:
+      recorder:
+        path: ./.crabline/recorders/msteams.jsonl
+      webhook:
+        host: 127.0.0.1
+        port: 8791
+        path: /msteams/webhook
+        publicUrl: https://example.ngrok.app/msteams/webhook
+
+  googlechat:
+    adapter: googlechat
+    env:
+      - GOOGLE_CHAT_CREDENTIALS
+    googlechat:
+      googleChatProjectNumber: "1234567890"
+      recorder:
+        path: ./.crabline/recorders/googlechat.jsonl
+      webhook:
+        host: 127.0.0.1
+        port: 8792
+        path: /googlechat/webhook
+        publicUrl: https://example.ngrok.app/googlechat/webhook
+
   feishu:
     adapter: feishu
     env:
@@ -165,6 +193,28 @@ fixtures:
     mode: roundtrip
     target:
       id: "15551234567"
+    inboundMatch:
+      author: assistant
+      strategy: contains
+      nonce: contains
+
+  - id: msteams-channel
+    provider: msteams
+    mode: roundtrip
+    target:
+      id: "19:conversation@thread.v2"
+      metadata:
+        serviceUrl: https://smba.trafficmanager.net/amer/
+    inboundMatch:
+      author: assistant
+      strategy: contains
+      nonce: contains
+
+  - id: googlechat-space
+    provider: googlechat
+    mode: roundtrip
+    target:
+      id: spaces/AAAA1234567
     inboundMatch:
       author: assistant
       strategy: contains

--- a/package.json
+++ b/package.json
@@ -47,9 +47,11 @@
   "devDependencies": {
     "@beeper/chat-adapter-matrix": "^0.1.0",
     "@chat-adapter/discord": "^4.30.0",
+    "@chat-adapter/gchat": "^4.30.0",
     "@chat-adapter/shared": "^4.30.0",
     "@chat-adapter/slack": "^4.30.0",
     "@chat-adapter/state-memory": "^4.30.0",
+    "@chat-adapter/teams": "^4.30.0",
     "@chat-adapter/telegram": "^4.30.0",
     "@chat-adapter/whatsapp": "^4.30.0",
     "@larksuite/vercel-chat-adapter": "^0.1.2",
@@ -70,9 +72,11 @@
   "peerDependencies": {
     "@beeper/chat-adapter-matrix": "^0.1.0",
     "@chat-adapter/discord": "^4.30.0",
+    "@chat-adapter/gchat": "^4.30.0",
     "@chat-adapter/shared": "^4.30.0",
     "@chat-adapter/slack": "^4.30.0",
     "@chat-adapter/state-memory": "^4.30.0",
+    "@chat-adapter/teams": "^4.30.0",
     "@chat-adapter/telegram": "^4.30.0",
     "@chat-adapter/whatsapp": "^4.30.0",
     "@larksuite/vercel-chat-adapter": "^0.1.2",
@@ -88,6 +92,9 @@
     "@chat-adapter/discord": {
       "optional": true
     },
+    "@chat-adapter/gchat": {
+      "optional": true
+    },
     "@chat-adapter/shared": {
       "optional": true
     },
@@ -98,6 +105,9 @@
       "optional": true
     },
     "@chat-adapter/telegram": {
+      "optional": true
+    },
+    "@chat-adapter/teams": {
       "optional": true
     },
     "@chat-adapter/whatsapp": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@chat-adapter/discord':
         specifier: ^4.30.0
         version: 4.30.0(zod@4.4.3)
+      '@chat-adapter/gchat':
+        specifier: ^4.30.0
+        version: 4.30.0(zod@4.4.3)
       '@chat-adapter/shared':
         specifier: ^4.30.0
         version: 4.30.0(zod@4.4.3)
@@ -34,6 +37,9 @@ importers:
         specifier: ^4.30.0
         version: 4.30.0(zod@4.4.3)
       '@chat-adapter/state-memory':
+        specifier: ^4.30.0
+        version: 4.30.0(zod@4.4.3)
+      '@chat-adapter/teams':
         specifier: ^4.30.0
         version: 4.30.0(zod@4.4.3)
       '@chat-adapter/telegram':
@@ -87,6 +93,14 @@ importers:
 
 packages:
 
+  '@azure/msal-common@16.8.0':
+    resolution: {integrity: sha512-5S4RHOcInL2Nu2U217tDZbWGI6StMfcWCrA7TWvWdJmXQ+cYrrIqr84AsN62fGh2MDBysiBJPt6CfWceJfloEA==}
+    engines: {node: '>=0.8.0'}
+
+  '@azure/msal-node@5.2.4':
+    resolution: {integrity: sha512-rpBUg9dA8UpC2WiFt3KeDKVQmmmVrfxdRnW+F1ebgou/jX/0tAvYuonaq5RUo8OaqzOrj4x/HaI8DmY56RXZ2Q==}
+    engines: {node: '>=20'}
+
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
@@ -119,6 +133,10 @@ packages:
     resolution: {integrity: sha512-hWMwCwVgMeQWB5F2JL91GLTWcF8rlE4eewzXzfPSoAsM7Y71yBDCfQ9QfL5VODwPKtYnVPU5Go2pGsuauaZ/yw==}
     engines: {node: '>=20'}
 
+  '@chat-adapter/gchat@4.30.0':
+    resolution: {integrity: sha512-s3rqHJqW17RE1drBhS9H+YYDpiasfd4YBaXdLrNqao5AS5sNWR/ekWiDGPeF/zlzDkOUNdnyDq3NbA7/2HsHsQ==}
+    engines: {node: '>=20'}
+
   '@chat-adapter/shared@4.30.0':
     resolution: {integrity: sha512-IuYtbn/p1FBXvp7JYGEMLCt07GHOMlyjx7OlZXPJwLTravcyJuP7Q6N31r6c1yubMhM8PLb8eT8l/YnjwYjs9Q==}
     engines: {node: '>=20'}
@@ -133,6 +151,10 @@ packages:
 
   '@chat-adapter/state-redis@4.30.0':
     resolution: {integrity: sha512-Fj5g7UjIl8r0J4WUZnVgljije2yFd0/ZmOaIo5VXDs1TDz4X8I73xxYtLUmyHe5uNM2pGOu0DeYliy+mupaCGA==}
+    engines: {node: '>=20'}
+
+  '@chat-adapter/teams@4.30.0':
+    resolution: {integrity: sha512-5hm20xnePw8CeeGFAXIPI5D7gNL6TfwCE0sAhJIBwlH8H4SztxJWDvpp8AiHokYjck3ejtaHqXLiGrauUzAi0A==}
     engines: {node: '>=20'}
 
   '@chat-adapter/telegram@4.30.0':
@@ -492,6 +514,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@googleapis/chat@44.7.0':
+    resolution: {integrity: sha512-1TTvtQ/nRD4Yb5PcMWl1J6vN3QjOyDr3t9XtM1iRJlAO8wux5dOChJSOyAlm2IOcRrrqmL4d0DVUkgMqovHjNA==}
+    engines: {node: '>=12.0.0'}
+
+  '@googleapis/workspaceevents@9.2.0':
+    resolution: {integrity: sha512-9tU0h6O/Ao9k53TQSgLs6D/mN++wKTHPIpT8tbPaayhOL3e4OhtJ3t+OD42avMe2pBmFcdRUVOSpZvqytxvWEg==}
+    engines: {node: '>=12.0.0'}
+
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
@@ -645,6 +675,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
@@ -666,6 +700,30 @@ packages:
   '@matrix-org/matrix-sdk-crypto-wasm@18.3.1':
     resolution: {integrity: sha512-VRjWhE1UgHnPpJ3b9B5+8z71ZC/HICFngPPFIN6ktzmUBKI5RusPujzbAQUoB3CgZ0yU58L99AfSQS4YTztSWw==}
     engines: {node: '>= 18'}
+
+  '@microsoft/teams.api@2.0.13':
+    resolution: {integrity: sha512-PUbCxZhBLiRPchWeZNcgsXxBGY7lGJrLwqin9I+n+ND9iCwSTtDf9kzhvIWQSPXgxViK8znmKQshSguf1JRz3Q==}
+    engines: {node: '>=20'}
+
+  '@microsoft/teams.apps@2.0.13':
+    resolution: {integrity: sha512-md8DmJhu+TuMlNu5i9mU0yflZuXEvbyDkZq+DcYABM5xZcj0PTSAtTMcVqW+cdbBz/KYquix6YGWdcV9KOFl/g==}
+    engines: {node: '>=20'}
+
+  '@microsoft/teams.cards@2.0.13':
+    resolution: {integrity: sha512-eeXWvPTSQQZDeByVQOf9QTSfxnB0UvYBoAzgD2X+n+Q7nbsNBhId8nm0oipTF8E0uTp4i9iEb/5m9UkP/fmz6Q==}
+    engines: {node: '>=20'}
+
+  '@microsoft/teams.common@2.0.13':
+    resolution: {integrity: sha512-zDeKZBAsTCjvPCcAmMUpcttyAkQTSV78m3cG3hVYgHmkSupHd4z+pcCOHEw/Tto8gH346622KT7nj2Ar2cT2fg==}
+    engines: {node: '>=20'}
+
+  '@microsoft/teams.graph-endpoints@2.0.13':
+    resolution: {integrity: sha512-nhPk4BNQ3XbD+ntoGNKtXwhCoWHvmUVp5xuAXuxvv7doFTOJ7u1K/fWa7FLQaaAg/m/zOrEc20S5cJisunWp4A==}
+    engines: {node: '>=20'}
+
+  '@microsoft/teams.graph@2.0.13':
+    resolution: {integrity: sha512-df3lCP9UmU60hXOm9zMr/GTEzZZhovL2mj9uFizjCEP6u9pQsaTN+0ldHn44FOyHtn5M6x9fUlBxIOiu4VOg9Q==}
+    engines: {node: '>=20'}
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -964,6 +1022,10 @@ packages:
     resolution: {integrity: sha512-xteMkPqqWkPLv40M9gA1HJGS/fHXIWzzXNCwRfnC4+bj120KMXMacT9zOSoEcGk4MA0pGXcUMQPE16MdB+Bf/g==}
     engines: {node: '>=18.0.0'}
 
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
 
@@ -1181,6 +1243,9 @@ packages:
   '@types/events@3.0.3':
     resolution: {integrity: sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g==}
 
+  '@types/jsonwebtoken@9.0.10':
+    resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
+
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
@@ -1291,12 +1356,36 @@ packages:
   '@workflow/serde@4.1.0-beta.2':
     resolution: {integrity: sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   another-json@0.2.0:
     resolution: {integrity: sha512-/Ndrl68UQLhnCdsAzEXLMFuOR546o2qbYRqCglaNHbjXrwG1ayTcdwr3zkSGOGtGXDyR5X9nCFfnyG2AFJIsqg==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -1317,6 +1406,9 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   base-x@5.0.1:
     resolution: {integrity: sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==}
 
@@ -1331,21 +1423,38 @@ packages:
     resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
     engines: {node: '>=0.6'}
 
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   bplist-parser@0.3.2:
     resolution: {integrity: sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ==}
     engines: {node: '>= 5.10.0'}
 
+  brace-expansion@2.1.1:
+    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
+
   bs58@6.0.0:
     resolution: {integrity: sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==}
 
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -1401,6 +1510,13 @@ packages:
     resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
     engines: {node: '>=0.10.0'}
 
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
@@ -1413,12 +1529,40 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
 
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1443,6 +1587,10 @@ packages:
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -1472,6 +1620,25 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -1512,12 +1679,19 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
 
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
@@ -1537,6 +1711,10 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
@@ -1552,8 +1730,16 @@ packages:
       picomatch:
         optional: true
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
 
   follow-redirects@1.16.0:
     resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
@@ -1564,9 +1750,25 @@ packages:
       debug:
         optional: true
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -1579,6 +1781,14 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  gaxios@7.1.3:
+    resolution: {integrity: sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.3:
+    resolution: {integrity: sha512-ziTrzUhhpL9Zk5k0HHzgP/KIpWDJT0VMBC/ynt/QIBvTW+UUcSivQRl6VlwTf/EilDxtSWklHoRsKy1c4k+59w==}
+    engines: {node: '>=18'}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -1590,9 +1800,30 @@ packages:
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
+  google-auth-library@10.5.0:
+    resolution: {integrity: sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
+
+  googleapis-common@8.0.2:
+    resolution: {integrity: sha512-5MXeQzIZaqCH7B+HJWqhQm946VARpZep6acbWSr/fcgF2cQANq7allgX+i/G0EqF0WyUxB277gtWMzRYHMl9tg==}
+    engines: {node: '>=18.0.0'}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
+
+  gtoken@8.0.0:
+    resolution: {integrity: sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==}
+    engines: {node: '>=18'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -1613,9 +1844,21 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -1626,8 +1869,16 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
   is-electron@2.2.2:
     resolution: {integrity: sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
 
   is-network-error@1.3.2:
     resolution: {integrity: sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==}
@@ -1637,9 +1888,15 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -1653,8 +1910,31 @@ packages:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
 
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  jose@4.15.9:
+    resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
+
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
+  jsonwebtoken@9.0.3:
+    resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
+    engines: {node: '>=12', npm: '>=6'}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jwks-rsa@3.2.2:
+    resolution: {integrity: sha512-BqTyEDV+lS8F2trk3A+qJnxV5Q9EqKCBJOPti3W97r7qTympCZjb7h2X6f2kc+0K3rsSTY1/6YG2eaXKoj497w==}
+    engines: {node: '>=14'}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   jwt-decode@4.0.0:
     resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
@@ -1734,11 +2014,38 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  limiter@1.1.5:
+    resolution: {integrity: sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==}
+
+  lodash.clonedeep@4.5.0:
+    resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
+
   lodash.identity@3.0.0:
     resolution: {integrity: sha512-AupTIzdLQxJS5wIYUQlgGyk2XRTfGXA+MCghDHqZk0pzUNYvd3EESS6dkChNauNYVIutcb0dfHw1ri9Q1yPV8Q==}
 
+  lodash.includes@4.3.0:
+    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+
+  lodash.isboolean@3.0.3:
+    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
+  lodash.isinteger@4.0.4:
+    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
+
+  lodash.isnumber@3.0.3:
+    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
+  lodash.isstring@4.0.1:
+    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash.once@4.1.1:
+    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
   lodash.pickby@4.6.0:
     resolution: {integrity: sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q==}
@@ -1758,6 +2065,16 @@ packages:
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
+
+  lru-memoizer@2.3.0:
+    resolution: {integrity: sha512-GXn7gyHAMhO13WSKrIiNfztwxodVsP8IoZ3XfrJV4yH2x0/OeTO/FIaAHTY5YekdGgW94njfuKmyyt1E0mR6Ug==}
 
   magic-bytes.js@1.13.0:
     resolution: {integrity: sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==}
@@ -1821,6 +2138,14 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -1910,16 +2235,32 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
@@ -1935,12 +2276,29 @@ packages:
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   node-abi@3.92.0:
     resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
     engines: {node: '>=10'}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   node-typedstream@1.4.1:
     resolution: {integrity: sha512-W9zcPlI3RRPOmwaDjwRyr7aYLoJFbvLIIHluFM3I+KZjAlbyhG4L3jSTEJlQmDqrMRQlFVTmivgJWgFlvWXx2Q==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -1953,6 +2311,10 @@ packages:
   oidc-client-ts@3.5.0:
     resolution: {integrity: sha512-l2q8l9CTCTOlbX+AnK4p3M+4CEpKpyQhle6blQkdFhm0IsBqsxm15bYaSa11G7pWdsYr6epdsRZxJpCyCRbT8A==}
     engines: {node: '>=18'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -1999,6 +2361,24 @@ packages:
     resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
     engines: {node: '>=8'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -2023,6 +2403,10 @@ packages:
     resolution: {integrity: sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==}
     engines: {node: '>=12.0.0'}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
@@ -2036,6 +2420,14 @@ packages:
   qs@6.15.2:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -2068,13 +2460,24 @@ packages:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
 
+  rimraf@5.0.10:
+    resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
+    hasBin: true
+
   rolldown@1.0.0-rc.9:
     resolution: {integrity: sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   sdp-transform@3.0.0:
     resolution: {integrity: sha512-gfYVRGxjHkGF2NPeUWHw5u6T/KGFtS5/drPms73gaSuMaVHKCY3lpLnGDfswVQO0kddeePoti09AwhYP4zA8dQ==}
@@ -2085,9 +2488,28 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
 
   side-channel-list@1.0.1:
     resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
@@ -2107,6 +2529,10 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
 
   simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
@@ -2129,11 +2555,31 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
@@ -2169,6 +2615,10 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
@@ -2185,6 +2635,10 @@ packages:
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
 
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
@@ -2216,8 +2670,19 @@ packages:
   unist-util-visit@5.1.0:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
+  url-template@2.0.8:
+    resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -2309,10 +2774,27 @@ packages:
       jsdom:
         optional: true
 
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -2345,6 +2827,9 @@ packages:
     resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
     engines: {node: '>=0.4.0'}
 
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
@@ -2357,6 +2842,13 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@azure/msal-common@16.8.0': {}
+
+  '@azure/msal-node@5.2.4':
+    dependencies:
+      '@azure/msal-common': 16.8.0
+      jsonwebtoken: 9.0.3
 
   '@babel/helper-string-parser@7.29.7': {}
 
@@ -2402,6 +2894,17 @@ snapshots:
       - utf-8-validate
       - zod
 
+  '@chat-adapter/gchat@4.30.0(zod@4.4.3)':
+    dependencies:
+      '@chat-adapter/shared': 4.30.0(zod@4.4.3)
+      '@googleapis/chat': 44.7.0
+      '@googleapis/workspaceevents': 9.2.0
+      chat: 4.30.0(zod@4.4.3)
+    transitivePeerDependencies:
+      - ai
+      - supports-color
+      - zod
+
   '@chat-adapter/shared@4.30.0(zod@4.4.3)':
     dependencies:
       chat: 4.30.0(zod@4.4.3)
@@ -2440,6 +2943,20 @@ snapshots:
       - '@node-rs/xxhash'
       - '@opentelemetry/api'
       - ai
+      - supports-color
+      - zod
+
+  '@chat-adapter/teams@4.30.0(zod@4.4.3)':
+    dependencies:
+      '@chat-adapter/shared': 4.30.0(zod@4.4.3)
+      '@microsoft/teams.api': 2.0.13
+      '@microsoft/teams.apps': 2.0.13
+      '@microsoft/teams.cards': 2.0.13
+      '@microsoft/teams.graph-endpoints': 2.0.13
+      chat: 4.30.0(zod@4.4.3)
+    transitivePeerDependencies:
+      - ai
+      - debug
       - supports-color
       - zod
 
@@ -2682,6 +3199,18 @@ snapshots:
   '@esbuild/win32-x64@0.28.0':
     optional: true
 
+  '@googleapis/chat@44.7.0':
+    dependencies:
+      googleapis-common: 8.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@googleapis/workspaceevents@9.2.0':
+    dependencies:
+      googleapis-common: 8.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
@@ -2778,6 +3307,15 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
@@ -2815,6 +3353,51 @@ snapshots:
       - utf-8-validate
 
   '@matrix-org/matrix-sdk-crypto-wasm@18.3.1': {}
+
+  '@microsoft/teams.api@2.0.13':
+    dependencies:
+      '@microsoft/teams.cards': 2.0.13
+      '@microsoft/teams.common': 2.0.13
+      jwt-decode: 4.0.0
+      qs: 6.15.2
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@microsoft/teams.apps@2.0.13':
+    dependencies:
+      '@azure/msal-node': 5.2.4
+      '@microsoft/teams.api': 2.0.13
+      '@microsoft/teams.common': 2.0.13
+      '@microsoft/teams.graph': 2.0.13
+      axios: 1.17.0
+      cors: 2.8.6
+      express: 5.2.1
+      jsonwebtoken: 9.0.3
+      jwks-rsa: 3.2.2
+      reflect-metadata: 0.2.2
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@microsoft/teams.cards@2.0.13': {}
+
+  '@microsoft/teams.common@2.0.13':
+    dependencies:
+      axios: 1.17.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@microsoft/teams.graph-endpoints@2.0.13': {}
+
+  '@microsoft/teams.graph@2.0.13':
+    dependencies:
+      '@microsoft/teams.common': 2.0.13
+      qs: 6.15.2
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.0)(@emnapi/runtime@1.11.0)':
     dependencies:
@@ -2981,6 +3564,9 @@ snapshots:
     optionalDependencies:
       better-sqlite3: 12.10.0
 
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
+
   '@protobufjs/aspromise@1.1.2': {}
 
   '@protobufjs/base64@1.1.2': {}
@@ -3146,6 +3732,11 @@ snapshots:
 
   '@types/events@3.0.3': {}
 
+  '@types/jsonwebtoken@9.0.10':
+    dependencies:
+      '@types/ms': 2.1.0
+      '@types/node': 25.9.2
+
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -3254,13 +3845,30 @@ snapshots:
 
   '@workflow/serde@4.1.0-beta.2': {}
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   agent-base@6.0.2:
     dependencies:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
+  agent-base@7.1.4: {}
+
   another-json@0.2.0: {}
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
 
   assertion-error@2.0.1: {}
 
@@ -3292,10 +3900,11 @@ snapshots:
 
   bail@2.0.2: {}
 
+  balanced-match@1.0.2: {}
+
   base-x@5.0.1: {}
 
-  base64-js@1.5.1:
-    optional: true
+  base64-js@1.5.1: {}
 
   better-sqlite3@12.10.0:
     dependencies:
@@ -3304,6 +3913,8 @@ snapshots:
     optional: true
 
   big-integer@1.6.52: {}
+
+  bignumber.js@9.3.1: {}
 
   bindings@1.5.0:
     dependencies:
@@ -3317,19 +3928,41 @@ snapshots:
       readable-stream: 3.6.2
     optional: true
 
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.2
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   bplist-parser@0.3.2:
     dependencies:
       big-integer: 1.6.52
 
+  brace-expansion@2.1.1:
+    dependencies:
+      balanced-match: 1.0.2
+
   bs58@6.0.0:
     dependencies:
       base-x: 5.0.1
+
+  buffer-equal-constant-time@1.0.1: {}
 
   buffer@5.7.1:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
     optional: true
+
+  bytes@3.1.2: {}
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -3395,6 +4028,12 @@ snapshots:
 
   cluster-key-slot@1.1.2: {}
 
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
@@ -3403,9 +4042,30 @@ snapshots:
 
   consola@3.4.2: {}
 
+  content-disposition@1.1.0: {}
+
   content-type@1.0.5: {}
 
+  content-type@2.0.0: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  data-uri-to-buffer@4.0.1: {}
 
   debug@4.4.3:
     dependencies:
@@ -3424,6 +4084,8 @@ snapshots:
     optional: true
 
   delayed-stream@1.0.0: {}
+
+  depd@2.0.0: {}
 
   dequal@2.0.3: {}
 
@@ -3463,6 +4125,20 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  ee-first@1.1.1: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
+
+  encodeurl@2.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -3559,11 +4235,15 @@ snapshots:
       '@esbuild/win32-ia32': 0.28.0
       '@esbuild/win32-x64': 0.28.0
 
+  escape-html@1.0.3: {}
+
   escape-string-regexp@5.0.0: {}
 
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
+
+  etag@1.8.1: {}
 
   eventemitter3@4.0.7: {}
 
@@ -3576,6 +4256,39 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.2
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   extend@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
@@ -3584,10 +4297,31 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
   file-uri-to-path@1.0.0:
     optional: true
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   follow-redirects@1.16.0: {}
+
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
 
   form-data@4.0.5:
     dependencies:
@@ -3597,6 +4331,14 @@ snapshots:
       hasown: 2.0.4
       mime-types: 2.1.35
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
   fs-constants@1.0.0:
     optional: true
 
@@ -3604,6 +4346,23 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  gaxios@7.1.3:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+      rimraf: 5.0.10
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.3:
+    dependencies:
+      gaxios: 7.1.3
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -3626,7 +4385,48 @@ snapshots:
   github-from-package@0.0.0:
     optional: true
 
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
+  google-auth-library@10.5.0:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.3
+      gcp-metadata: 8.1.3
+      google-logging-utils: 1.1.3
+      gtoken: 8.0.0
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
+
+  googleapis-common@8.0.2:
+    dependencies:
+      extend: 3.0.2
+      gaxios: 7.1.3
+      google-auth-library: 10.5.0
+      google-logging-utils: 1.1.3
+      qs: 6.15.2
+      url-template: 2.0.8
+    transitivePeerDependencies:
+      - supports-color
+
   gopd@1.2.0: {}
+
+  gtoken@8.0.0:
+    dependencies:
+      gaxios: 7.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   has-flag@4.0.0: {}
 
@@ -3642,6 +4442,14 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
@@ -3649,22 +4457,40 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ieee754@1.2.1:
     optional: true
 
-  inherits@2.0.4:
-    optional: true
+  inherits@2.0.4: {}
 
   ini@1.3.8:
     optional: true
 
+  ipaddr.js@1.9.1: {}
+
   is-electron@2.2.2: {}
+
+  is-fullwidth-code-point@3.0.0: {}
 
   is-network-error@1.3.2: {}
 
   is-plain-obj@4.1.0: {}
 
+  is-promise@4.0.0: {}
+
   is-stream@2.0.1: {}
+
+  isexe@2.0.0: {}
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -3679,7 +4505,53 @@ snapshots:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
 
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
+  jose@4.15.9: {}
+
   js-tokens@10.0.0: {}
+
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
+  jsonwebtoken@9.0.3:
+    dependencies:
+      jws: 4.0.1
+      lodash.includes: 4.3.0
+      lodash.isboolean: 3.0.3
+      lodash.isinteger: 4.0.4
+      lodash.isnumber: 3.0.3
+      lodash.isplainobject: 4.0.6
+      lodash.isstring: 4.0.1
+      lodash.once: 4.1.1
+      ms: 2.1.3
+      semver: 7.8.3
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jwks-rsa@3.2.2:
+    dependencies:
+      '@types/jsonwebtoken': 9.0.10
+      debug: 4.4.3
+      jose: 4.15.9
+      limiter: 1.1.5
+      lru-memoizer: 2.3.0
+    transitivePeerDependencies:
+      - supports-color
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   jwt-decode@4.0.0: {}
 
@@ -3732,9 +4604,27 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  limiter@1.1.5: {}
+
+  lodash.clonedeep@4.5.0: {}
+
   lodash.identity@3.0.0: {}
 
+  lodash.includes@4.3.0: {}
+
+  lodash.isboolean@3.0.3: {}
+
+  lodash.isinteger@4.0.4: {}
+
+  lodash.isnumber@3.0.3: {}
+
+  lodash.isplainobject@4.0.6: {}
+
+  lodash.isstring@4.0.1: {}
+
   lodash.merge@4.6.2: {}
+
+  lodash.once@4.1.1: {}
 
   lodash.pickby@4.6.0: {}
 
@@ -3747,6 +4637,17 @@ snapshots:
   long@5.3.2: {}
 
   longest-streak@3.1.0: {}
+
+  lru-cache@10.4.3: {}
+
+  lru-cache@6.0.0:
+    dependencies:
+      yallist: 4.0.0
+
+  lru-memoizer@2.3.0:
+    dependencies:
+      lodash.clonedeep: 4.5.0
+      lru-cache: 6.0.0
 
   magic-bytes.js@1.13.0: {}
 
@@ -3892,6 +4793,10 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -4086,15 +4991,27 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
 
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
   mimic-response@3.1.0:
     optional: true
 
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.1
+
   minimist@1.2.8:
     optional: true
+
+  minipass@7.1.3: {}
 
   mkdirp-classic@0.5.3:
     optional: true
@@ -4106,14 +5023,26 @@ snapshots:
   napi-build-utils@2.0.0:
     optional: true
 
+  negotiator@1.0.0: {}
+
   node-abi@3.92.0:
     dependencies:
       semver: 7.8.3
     optional: true
 
+  node-domexception@1.0.0: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
+
   node-typedstream@1.4.1:
     dependencies:
       bplist-parser: 0.3.2
+
+  object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
 
@@ -4123,10 +5052,13 @@ snapshots:
     dependencies:
       jwt-decode: 4.0.0
 
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
-    optional: true
 
   oxfmt@0.47.0:
     dependencies:
@@ -4204,6 +5136,19 @@ snapshots:
     dependencies:
       p-finally: 1.0.0
 
+  package-json-from-dist@1.0.1: {}
+
+  parseurl@1.3.3: {}
+
+  path-key@3.1.1: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
+
+  path-to-regexp@8.4.2: {}
+
   pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
@@ -4246,6 +5191,11 @@ snapshots:
       '@types/node': 25.9.2
       long: 5.3.2
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   proxy-from-env@1.1.0: {}
 
   proxy-from-env@2.1.0: {}
@@ -4259,6 +5209,15 @@ snapshots:
   qs@6.15.2:
     dependencies:
       side-channel: 1.1.1
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   rc@1.2.8:
     dependencies:
@@ -4318,6 +5277,10 @@ snapshots:
 
   retry@0.13.1: {}
 
+  rimraf@5.0.10:
+    dependencies:
+      glob: 10.5.0
+
   rolldown@1.0.0-rc.9(@emnapi/core@1.9.0)(@emnapi/runtime@1.11.0):
     dependencies:
       '@oxc-project/types': 0.115.0
@@ -4342,12 +5305,50 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  safe-buffer@5.2.1:
-    optional: true
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
+  safe-buffer@5.2.1: {}
+
+  safer-buffer@2.1.2: {}
 
   sdp-transform@3.0.0: {}
 
   semver@7.8.3: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
 
   sharp@0.34.5:
     dependencies:
@@ -4380,6 +5381,12 @@ snapshots:
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
 
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
   side-channel-list@1.0.1:
     dependencies:
       es-errors: 1.3.0
@@ -4409,6 +5416,8 @@ snapshots:
       side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
+
+  signal-exit@4.1.0: {}
 
   simple-concat@1.0.1:
     optional: true
@@ -4442,12 +5451,34 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  statuses@2.0.2: {}
+
   std-env@4.1.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
 
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
     optional: true
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-json-comments@2.0.1:
     optional: true
@@ -4486,6 +5517,8 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  toidentifier@1.0.1: {}
+
   trough@2.2.0: {}
 
   ts-mixer@6.0.4: {}
@@ -4502,6 +5535,12 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
     optional: true
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
 
   typescript@6.0.3: {}
 
@@ -4540,8 +5579,14 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
+  unpipe@1.0.0: {}
+
+  url-template@2.0.8: {}
+
   util-deprecate@1.0.2:
     optional: true
+
+  vary@1.1.2: {}
 
   vfile-message@4.0.3:
     dependencies:
@@ -4599,19 +5644,38 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
+  web-streams-polyfill@3.3.3: {}
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  wrappy@1.0.2:
-    optional: true
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
+
+  wrappy@1.0.2: {}
 
   ws@8.20.1: {}
 
   ws@8.21.0: {}
 
   xmlhttprequest-ssl@2.1.2: {}
+
+  yallist@4.0.0: {}
 
   yaml@2.9.0: {}
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -7,10 +7,12 @@ export const INBOUND_NONCE_MODES = ["contains", "exact", "ignore"] as const;
 export const BUILTIN_ADAPTERS = [
   "discord",
   "feishu",
+  "googlechat",
   "imessage",
   "loopback",
   "matrix",
   "mattermost",
+  "msteams",
   "script",
   "slack",
   "telegram",
@@ -158,6 +160,77 @@ const WhatsAppConfigSchema = z.object({
   }),
 });
 
+const MsTeamsFederatedSchema = z.object({
+  clientAudience: z.string().min(1).optional(),
+  clientId: z.string().min(1),
+});
+
+const MsTeamsRecorderSchema = z.object({
+  path: z.string().min(1).optional(),
+});
+
+const MsTeamsWebhookSchema = z.object({
+  host: z.string().min(1).default("127.0.0.1"),
+  path: z.string().min(1).default("/msteams/webhook"),
+  port: z.number().int().min(0).max(65_535).default(8791),
+  publicUrl: z.string().url().optional(),
+});
+
+const MsTeamsConfigSchema = z.object({
+  apiUrl: z.string().url().optional(),
+  appId: z.string().min(1).optional(),
+  appPassword: z.string().min(1).optional(),
+  appTenantId: z.string().min(1).optional(),
+  appType: z.enum(["MultiTenant", "SingleTenant"]).optional(),
+  dialogOpenTimeoutMs: z.number().int().min(0).optional(),
+  federated: MsTeamsFederatedSchema.optional(),
+  recorder: MsTeamsRecorderSchema.default({}),
+  userName: z.string().min(1).optional(),
+  webhook: MsTeamsWebhookSchema.default({
+    host: "127.0.0.1",
+    path: "/msteams/webhook",
+    port: 8791,
+  }),
+});
+
+const GoogleChatCredentialsSchema = z
+  .object({
+    client_email: z.string().min(1),
+    private_key: z.string().min(1),
+    project_id: z.string().min(1).optional(),
+  })
+  .passthrough();
+
+const GoogleChatRecorderSchema = z.object({
+  path: z.string().min(1).optional(),
+});
+
+const GoogleChatWebhookSchema = z.object({
+  host: z.string().min(1).default("127.0.0.1"),
+  path: z.string().min(1).default("/googlechat/webhook"),
+  port: z.number().int().min(0).max(65_535).default(8792),
+  publicUrl: z.string().url().optional(),
+});
+
+const GoogleChatConfigSchema = z.object({
+  apiUrl: z.string().url().optional(),
+  credentials: GoogleChatCredentialsSchema.optional(),
+  disableSignatureVerification: z.boolean().optional(),
+  endpointUrl: z.string().url().optional(),
+  googleChatProjectNumber: z.string().min(1).optional(),
+  impersonateUser: z.string().min(1).optional(),
+  pubsubAudience: z.string().min(1).optional(),
+  pubsubTopic: z.string().min(1).optional(),
+  recorder: GoogleChatRecorderSchema.default({}),
+  useApplicationDefaultCredentials: z.boolean().optional(),
+  userName: z.string().min(1).optional(),
+  webhook: GoogleChatWebhookSchema.default({
+    host: "127.0.0.1",
+    path: "/googlechat/webhook",
+    port: 8792,
+  }),
+});
+
 const TelegramLongPollingSchema = z.object({
   allowedUpdates: z.array(z.string().min(1)).optional(),
   deleteWebhook: z.boolean().optional(),
@@ -291,10 +364,12 @@ export const ProviderConfigSchema = z
     discord: DiscordConfigSchema.optional(),
     env: z.array(z.string().min(1)).default([]),
     feishu: FeishuConfigSchema.optional(),
+    googlechat: GoogleChatConfigSchema.optional(),
     imessage: IMessageConfigSchema.optional(),
     loopback: LoopbackConfigSchema.optional(),
     matrix: MatrixConfigSchema.optional(),
     mattermost: MattermostConfigSchema.optional(),
+    msteams: MsTeamsConfigSchema.optional(),
     notes: z.string().optional(),
     platform: z.enum(PROVIDER_PLATFORMS).optional(),
     slack: SlackConfigSchema.optional(),
@@ -355,10 +430,26 @@ export const ProviderConfigSchema = z
       });
     }
 
+    if (value.adapter === "googlechat" && platform !== "googlechat") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "googlechat adapter must use platform=googlechat",
+        path: ["platform"],
+      });
+    }
+
     if (value.adapter === "mattermost" && platform !== "mattermost") {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: "mattermost adapter must use platform=mattermost",
+        path: ["platform"],
+      });
+    }
+
+    if (value.adapter === "msteams" && platform !== "msteams") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "msteams adapter must use platform=msteams",
         path: ["platform"],
       });
     }

--- a/src/providers/builtin/googlechat.ts
+++ b/src/providers/builtin/googlechat.ts
@@ -1,0 +1,518 @@
+import path from "node:path";
+import {
+  createGoogleChatAdapter,
+  type GoogleChatAdapterBaseConfig,
+  type GoogleChatAdapterConfig,
+  type ServiceAccountCredentials,
+} from "@chat-adapter/gchat";
+import { createMemoryState } from "@chat-adapter/state-memory";
+import { Chat, type Adapter } from "chat";
+import { CrablineError, ensureErrorMessage } from "../../core/errors.js";
+import type { ProviderConfig } from "../../config/schema.js";
+import {
+  appendRecordedInbound,
+  waitForRecordedInbound,
+  watchRecordedInbound,
+} from "../recorder.js";
+import type {
+  InboundEnvelope,
+  NormalizedTarget,
+  ProbeResult,
+  ProviderAdapter,
+  ProviderContext,
+  SendContext,
+  SendResult,
+  WaitContext,
+  WatchContext,
+} from "../types.js";
+import { startWebhookServer, type StartedWebhookServer } from "../webhook-server.js";
+
+type GoogleChatThread = {
+  id: string;
+};
+
+type GoogleChatMessage = {
+  author: {
+    isBot: boolean;
+  };
+  id: string;
+  metadata: {
+    dateSent: Date;
+  };
+  raw?: unknown;
+  text: string;
+  threadId: string;
+};
+
+type GoogleChatState = {
+  subscribe(threadId: string): Promise<void>;
+};
+
+type GoogleChatAdapterApi = {
+  fetchChannelInfo(channelId: string): Promise<unknown>;
+  handleWebhook(request: Request): Promise<Response>;
+  openDM(userId: string): Promise<string>;
+  postMessage(
+    threadId: string,
+    message: string,
+  ): Promise<{
+    id: string;
+    threadId: string;
+  }>;
+};
+
+type GoogleChatChat = {
+  getState(): GoogleChatState;
+  initialize(): Promise<void>;
+  onDirectMessage(
+    handler: (thread: GoogleChatThread, message: GoogleChatMessage) => void | Promise<void>,
+  ): void;
+  onNewMention(
+    handler: (thread: GoogleChatThread, message: GoogleChatMessage) => void | Promise<void>,
+  ): void;
+  onNewMessage(
+    pattern: RegExp,
+    handler: (thread: GoogleChatThread, message: GoogleChatMessage) => void | Promise<void>,
+  ): void;
+  onSubscribedMessage(
+    handler: (thread: GoogleChatThread, message: GoogleChatMessage) => void | Promise<void>,
+  ): void;
+};
+
+type GoogleChatRuntime = {
+  createAdapter(config: ProviderConfig): GoogleChatAdapterApi;
+  createChat(adapter: GoogleChatAdapterApi, userName: string): GoogleChatChat;
+};
+
+type GoogleChatEnvironment = Partial<
+  Pick<
+    NodeJS.ProcessEnv,
+    | "GOOGLE_CHAT_API_URL"
+    | "GOOGLE_CHAT_BOT_USERNAME"
+    | "GOOGLE_CHAT_CREDENTIALS"
+    | "GOOGLE_CHAT_DISABLE_SIGNATURE_VERIFICATION"
+    | "GOOGLE_CHAT_ENDPOINT_URL"
+    | "GOOGLE_CHAT_IMPERSONATE_USER"
+    | "GOOGLE_CHAT_PROJECT_NUMBER"
+    | "GOOGLE_CHAT_PUBSUB_AUDIENCE"
+    | "GOOGLE_CHAT_PUBSUB_TOPIC"
+    | "GOOGLE_CHAT_USE_ADC"
+  >
+>;
+
+function parseBooleanEnv(value: string | undefined): boolean | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  return /^(1|true|yes)$/iu.test(value);
+}
+
+function parseCredentials(value: string | undefined): ServiceAccountCredentials | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch (error) {
+    throw new CrablineError("GOOGLE_CHAT_CREDENTIALS must be valid JSON.", {
+      cause: error,
+      kind: "config",
+    });
+  }
+
+  if (
+    !parsed ||
+    typeof parsed !== "object" ||
+    typeof (parsed as { client_email?: unknown }).client_email !== "string" ||
+    typeof (parsed as { private_key?: unknown }).private_key !== "string"
+  ) {
+    throw new CrablineError("GOOGLE_CHAT_CREDENTIALS must include client_email and private_key.", {
+      kind: "config",
+    });
+  }
+
+  return parsed as ServiceAccountCredentials;
+}
+
+export function resolveGoogleChatAdapterConfig(
+  config: ProviderConfig,
+  env: GoogleChatEnvironment = process.env,
+) {
+  const googleChatConfig = config.googlechat;
+  const credentials = (googleChatConfig?.credentials ??
+    parseCredentials(env.GOOGLE_CHAT_CREDENTIALS)) as ServiceAccountCredentials | undefined;
+  const useApplicationDefaultCredentials =
+    googleChatConfig?.useApplicationDefaultCredentials ?? parseBooleanEnv(env.GOOGLE_CHAT_USE_ADC);
+  const disableSignatureVerification =
+    googleChatConfig?.disableSignatureVerification ??
+    parseBooleanEnv(env.GOOGLE_CHAT_DISABLE_SIGNATURE_VERIFICATION);
+  const googleChatProjectNumber =
+    googleChatConfig?.googleChatProjectNumber ?? env.GOOGLE_CHAT_PROJECT_NUMBER;
+  const pubsubAudience = googleChatConfig?.pubsubAudience ?? env.GOOGLE_CHAT_PUBSUB_AUDIENCE;
+
+  if (!credentials && !useApplicationDefaultCredentials) {
+    throw new CrablineError(
+      "Google Chat credentials are required. Set googlechat.credentials, GOOGLE_CHAT_CREDENTIALS, googlechat.useApplicationDefaultCredentials, or GOOGLE_CHAT_USE_ADC.",
+      { kind: "config" },
+    );
+  }
+
+  if (!googleChatProjectNumber && !pubsubAudience && !disableSignatureVerification) {
+    throw new CrablineError(
+      "Google Chat webhook verification is required. Set googlechat.googleChatProjectNumber, googlechat.pubsubAudience, or googlechat.disableSignatureVerification.",
+      { kind: "config" },
+    );
+  }
+
+  const baseConfig: GoogleChatAdapterBaseConfig = {
+    ...(disableSignatureVerification !== undefined ? { disableSignatureVerification } : {}),
+    ...(googleChatProjectNumber ? { googleChatProjectNumber } : {}),
+    ...(pubsubAudience ? { pubsubAudience } : {}),
+    ...((googleChatConfig?.apiUrl ?? env.GOOGLE_CHAT_API_URL)
+      ? { apiUrl: googleChatConfig?.apiUrl ?? env.GOOGLE_CHAT_API_URL! }
+      : {}),
+    ...((googleChatConfig?.endpointUrl ??
+    googleChatConfig?.webhook.publicUrl ??
+    env.GOOGLE_CHAT_ENDPOINT_URL)
+      ? {
+          endpointUrl:
+            googleChatConfig?.endpointUrl ??
+            googleChatConfig?.webhook.publicUrl ??
+            env.GOOGLE_CHAT_ENDPOINT_URL!,
+        }
+      : {}),
+    ...((googleChatConfig?.impersonateUser ?? env.GOOGLE_CHAT_IMPERSONATE_USER)
+      ? {
+          impersonateUser: googleChatConfig?.impersonateUser ?? env.GOOGLE_CHAT_IMPERSONATE_USER!,
+        }
+      : {}),
+    ...((googleChatConfig?.pubsubTopic ?? env.GOOGLE_CHAT_PUBSUB_TOPIC)
+      ? { pubsubTopic: googleChatConfig?.pubsubTopic ?? env.GOOGLE_CHAT_PUBSUB_TOPIC! }
+      : {}),
+    ...((googleChatConfig?.userName ?? env.GOOGLE_CHAT_BOT_USERNAME)
+      ? { userName: googleChatConfig?.userName ?? env.GOOGLE_CHAT_BOT_USERNAME! }
+      : {}),
+  };
+
+  const adapterConfig: GoogleChatAdapterConfig = credentials
+    ? {
+        ...baseConfig,
+        credentials,
+      }
+    : {
+        ...baseConfig,
+        useApplicationDefaultCredentials: true,
+      };
+
+  return adapterConfig;
+}
+
+const DEFAULT_RUNTIME: GoogleChatRuntime = {
+  createAdapter(config) {
+    return createGoogleChatAdapter(
+      resolveGoogleChatAdapterConfig(config),
+    ) as unknown as GoogleChatAdapterApi;
+  },
+  createChat(adapter, userName) {
+    return new Chat<{ gchat: Adapter }>({
+      adapters: { gchat: adapter as unknown as Adapter },
+      state: createMemoryState(),
+      userName,
+    }) as unknown as GoogleChatChat;
+  },
+};
+
+function base64Url(value: string): string {
+  return Buffer.from(value, "utf8").toString("base64url");
+}
+
+function isAddressInChannel(threadId: string, channelId?: string): boolean {
+  if (!channelId) {
+    return true;
+  }
+
+  return threadId === channelId || threadId.startsWith(`${channelId}:`);
+}
+
+function isGoogleChatEncodedId(value: string): boolean {
+  return value.startsWith("gchat:");
+}
+
+function normalizeGoogleChatChannelId(value: string): string {
+  return isGoogleChatEncodedId(value) ? value : `gchat:${value}`;
+}
+
+function normalizeGoogleChatThreadId(channelId: string, threadId: string): string {
+  if (isGoogleChatEncodedId(threadId)) {
+    return threadId;
+  }
+
+  const spaceName = channelId.replace(/^gchat:/u, "");
+  return `gchat:${spaceName}:${base64Url(threadId)}`;
+}
+
+function isGoogleChatSpaceId(value: string): boolean {
+  return value.startsWith("spaces/") || value.startsWith("gchat:spaces/");
+}
+
+function toWebhookPath(config: ProviderConfig): string {
+  return config.googlechat?.webhook.path ?? "/googlechat/webhook";
+}
+
+function toRecorderPath(providerId: string, config: ProviderConfig): string {
+  const configuredPath = config.googlechat?.recorder.path;
+  if (configuredPath) {
+    return path.resolve(configuredPath);
+  }
+
+  return path.resolve(".crabline", "recorders", `${providerId}.jsonl`);
+}
+
+function classifyGoogleChatFailure(error: unknown): CrablineError {
+  if (error instanceof CrablineError) {
+    return error;
+  }
+
+  const message = ensureErrorMessage(error);
+  if (/401|403|credentials|private_key|signature|unauthorized|forbidden|token/i.test(message)) {
+    return new CrablineError(message, { cause: error, kind: "auth" });
+  }
+
+  return new CrablineError(message, { cause: error, kind: "connectivity" });
+}
+
+export class GoogleChatProviderAdapter implements ProviderAdapter {
+  readonly id;
+  readonly platform = "googlechat" as const;
+  readonly status = "ready" as const;
+  readonly supports = ["probe", "send", "roundtrip", "agent"] as const;
+
+  readonly #config: ProviderConfig;
+  readonly #recorderPath: string;
+  readonly #runtime: GoogleChatRuntime;
+  readonly #seenMessages = new Set<string>();
+  readonly #userName: string;
+  #adapter: GoogleChatAdapterApi | null = null;
+  #chat: GoogleChatChat | null = null;
+  #server: StartedWebhookServer | null = null;
+
+  constructor(
+    id: string,
+    config: ProviderConfig,
+    userName: string,
+    runtime: GoogleChatRuntime = DEFAULT_RUNTIME,
+  ) {
+    this.id = id;
+    this.#config = config;
+    this.#recorderPath = toRecorderPath(id, config);
+    this.#runtime = runtime;
+    this.#userName = userName;
+  }
+
+  normalizeTarget(target: ProviderContext["fixture"]["target"]): NormalizedTarget {
+    const normalized: NormalizedTarget = {
+      id: target.id,
+      metadata: target.metadata,
+    };
+
+    if (target.channelId) {
+      normalized.channelId = normalizeGoogleChatChannelId(target.channelId);
+    } else if (!target.threadId && isGoogleChatSpaceId(target.id)) {
+      normalized.channelId = normalizeGoogleChatChannelId(target.id);
+    }
+
+    if (target.threadId) {
+      if (!normalized.channelId) {
+        normalized.channelId = normalizeGoogleChatChannelId(target.id);
+      }
+
+      normalized.threadId = normalizeGoogleChatThreadId(normalized.channelId, target.threadId);
+    }
+
+    return normalized;
+  }
+
+  async probe(context: ProviderContext): Promise<ProbeResult> {
+    try {
+      await this.#getChat().initialize();
+      const server = await this.#ensureWebhookServer(true);
+      const target = this.normalizeTarget(context.fixture.target);
+      const details = [
+        `recorder path ${this.#recorderPath}`,
+        `webhook endpoint ${server.endpointUrl}`,
+      ];
+
+      if (this.#config.googlechat?.webhook.publicUrl) {
+        details.push(`public webhook ${this.#config.googlechat.webhook.publicUrl}`);
+      }
+
+      if (target.channelId) {
+        await this.#getAdapter().fetchChannelInfo(target.channelId);
+        details.push(`space reachable ${target.channelId}`);
+      } else {
+        const threadId = await this.#getAdapter().openDM(target.id);
+        details.push(`dm reachable ${threadId}`);
+      }
+
+      return {
+        details,
+        healthy: true,
+      };
+    } catch (error) {
+      throw classifyGoogleChatFailure(error);
+    }
+  }
+
+  async send(context: SendContext): Promise<SendResult> {
+    try {
+      const chat = this.#getChat();
+      await chat.initialize();
+      const threadId = await this.#resolveThreadId(context.fixture.target);
+      await chat.getState().subscribe(threadId);
+      const sent = await this.#getAdapter().postMessage(threadId, context.text);
+      return {
+        accepted: true,
+        messageId: sent.id,
+        threadId: sent.threadId,
+      };
+    } catch (error) {
+      const kind = error instanceof CrablineError ? error.kind : "outbound";
+      throw new CrablineError(ensureErrorMessage(error), {
+        cause: error,
+        ...(kind ? { kind } : {}),
+      });
+    }
+  }
+
+  async waitForInbound(context: WaitContext): Promise<InboundEnvelope | null> {
+    try {
+      await this.#ensureWebhookServer(true);
+      const target = this.normalizeTarget(context.fixture.target);
+      const inbound = await waitForRecordedInbound({
+        filePath: this.#recorderPath,
+        matches: (event) =>
+          event.provider === this.id &&
+          isAddressInChannel(event.threadId, context.threadId ?? target.channelId),
+        since: context.since,
+        timeoutMs: context.timeoutMs,
+      });
+      return inbound ?? null;
+    } catch (error) {
+      throw classifyGoogleChatFailure(error);
+    }
+  }
+
+  async *watch(context: WatchContext): AsyncIterable<InboundEnvelope> {
+    const target = this.normalizeTarget(context.fixture.target);
+    await this.#ensureWebhookServer(false);
+
+    for await (const event of watchRecordedInbound({
+      filePath: this.#recorderPath,
+      matches: (entry) =>
+        entry.provider === this.id && isAddressInChannel(entry.threadId, target.channelId),
+      since: context.since,
+    })) {
+      yield event;
+    }
+  }
+
+  async cleanup(): Promise<void> {
+    if (!this.#server) {
+      return;
+    }
+
+    await this.#server.close();
+    this.#server = null;
+  }
+
+  #registerInboundHandlers(): void {
+    const chat = this.#chat;
+    if (!chat) {
+      return;
+    }
+    const record = async (thread: GoogleChatThread, message: GoogleChatMessage) => {
+      const key = `${thread.id}:${message.id}`;
+      if (this.#seenMessages.has(key)) {
+        return;
+      }
+      this.#seenMessages.add(key);
+
+      await appendRecordedInbound(this.#recorderPath, {
+        author: message.author.isBot ? "assistant" : "user",
+        id: message.id,
+        provider: this.id,
+        raw: message.raw,
+        sentAt: message.metadata.dateSent.toISOString(),
+        text: message.text,
+        threadId: thread.id,
+      });
+    };
+
+    chat.onDirectMessage(record);
+    chat.onNewMention(record);
+    chat.onNewMessage(/[\s\S]+/u, record);
+    chat.onSubscribedMessage(record);
+  }
+
+  async #ensureWebhookServer(allowExisting: boolean): Promise<StartedWebhookServer> {
+    if (this.#server) {
+      return this.#server;
+    }
+
+    try {
+      this.#server = await startWebhookServer({
+        handle: (request) => this.#getAdapter().handleWebhook(request),
+        host: this.#config.googlechat?.webhook.host ?? "127.0.0.1",
+        path: toWebhookPath(this.#config),
+        port: this.#config.googlechat?.webhook.port ?? 8792,
+      });
+      return this.#server;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (allowExisting && code === "EADDRINUSE") {
+        return {
+          async close() {},
+          endpointUrl: `http://${this.#config.googlechat?.webhook.host ?? "127.0.0.1"}:${this.#config.googlechat?.webhook.port ?? 8792}${toWebhookPath(this.#config)}`,
+        };
+      }
+
+      throw new CrablineError(`Google Chat webhook server failed: ${ensureErrorMessage(error)}`, {
+        cause: error,
+        kind: "connectivity",
+      });
+    }
+  }
+
+  async #resolveThreadId(target: ProviderContext["fixture"]["target"]): Promise<string> {
+    const normalized = this.normalizeTarget(target);
+    if (normalized.threadId) {
+      return normalized.threadId;
+    }
+
+    if (normalized.channelId) {
+      return normalized.channelId;
+    }
+
+    return this.#getAdapter().openDM(normalized.id);
+  }
+
+  #getAdapter(): GoogleChatAdapterApi {
+    if (!this.#adapter) {
+      this.#adapter = this.#runtime.createAdapter(this.#config);
+    }
+
+    return this.#adapter;
+  }
+
+  #getChat(): GoogleChatChat {
+    if (!this.#chat) {
+      this.#chat = this.#runtime.createChat(this.#getAdapter(), this.#userName);
+      this.#registerInboundHandlers();
+    }
+
+    return this.#chat;
+  }
+}

--- a/src/providers/builtin/msteams.ts
+++ b/src/providers/builtin/msteams.ts
@@ -1,0 +1,493 @@
+import path from "node:path";
+import { createTeamsAdapter, type TeamsAdapterConfig } from "@chat-adapter/teams";
+import { createMemoryState } from "@chat-adapter/state-memory";
+import { Chat, type Adapter } from "chat";
+import { CrablineError, ensureErrorMessage } from "../../core/errors.js";
+import type { ProviderConfig } from "../../config/schema.js";
+import {
+  appendRecordedInbound,
+  waitForRecordedInbound,
+  watchRecordedInbound,
+} from "../recorder.js";
+import type {
+  InboundEnvelope,
+  NormalizedTarget,
+  ProbeResult,
+  ProviderAdapter,
+  ProviderContext,
+  SendContext,
+  SendResult,
+  WaitContext,
+  WatchContext,
+} from "../types.js";
+import { startWebhookServer, type StartedWebhookServer } from "../webhook-server.js";
+
+type MsTeamsThread = {
+  id: string;
+};
+
+type MsTeamsMessage = {
+  author: {
+    isBot: boolean;
+  };
+  id: string;
+  metadata: {
+    dateSent: Date;
+  };
+  raw?: unknown;
+  text: string;
+  threadId: string;
+};
+
+type MsTeamsState = {
+  subscribe(threadId: string): Promise<void>;
+};
+
+type MsTeamsAdapterApi = {
+  fetchChannelInfo(channelId: string): Promise<unknown>;
+  handleWebhook(request: Request): Promise<Response>;
+  openDM(userId: string): Promise<string>;
+  postMessage(
+    threadId: string,
+    message: string,
+  ): Promise<{
+    id: string;
+    threadId: string;
+  }>;
+};
+
+type MsTeamsChat = {
+  getState(): MsTeamsState;
+  initialize(): Promise<void>;
+  onDirectMessage(
+    handler: (thread: MsTeamsThread, message: MsTeamsMessage) => void | Promise<void>,
+  ): void;
+  onNewMention(
+    handler: (thread: MsTeamsThread, message: MsTeamsMessage) => void | Promise<void>,
+  ): void;
+  onNewMessage(
+    pattern: RegExp,
+    handler: (thread: MsTeamsThread, message: MsTeamsMessage) => void | Promise<void>,
+  ): void;
+  onSubscribedMessage(
+    handler: (thread: MsTeamsThread, message: MsTeamsMessage) => void | Promise<void>,
+  ): void;
+};
+
+type MsTeamsRuntime = {
+  createAdapter(config: ProviderConfig): MsTeamsAdapterApi;
+  createChat(adapter: MsTeamsAdapterApi, userName: string): MsTeamsChat;
+};
+
+type MsTeamsEnvironment = Partial<
+  Pick<
+    NodeJS.ProcessEnv,
+    | "TEAMS_API_URL"
+    | "TEAMS_APP_ID"
+    | "TEAMS_APP_PASSWORD"
+    | "TEAMS_APP_TENANT_ID"
+    | "TEAMS_APP_TYPE"
+    | "TEAMS_BOT_USERNAME"
+    | "TEAMS_FEDERATED_CLIENT_AUDIENCE"
+    | "TEAMS_FEDERATED_CLIENT_ID"
+  >
+>;
+
+export function resolveMsTeamsAdapterConfig(
+  config: ProviderConfig,
+  env: MsTeamsEnvironment = process.env,
+) {
+  const teamsConfig = config.msteams;
+  const appId = teamsConfig?.appId ?? env.TEAMS_APP_ID;
+  const appPassword = teamsConfig?.appPassword ?? env.TEAMS_APP_PASSWORD;
+  const appTenantId = teamsConfig?.appTenantId ?? env.TEAMS_APP_TENANT_ID;
+  const appType = teamsConfig?.appType ?? env.TEAMS_APP_TYPE;
+  const resolvedAppType =
+    appType === "MultiTenant" || appType === "SingleTenant" ? appType : undefined;
+  const federatedClientId = teamsConfig?.federated?.clientId ?? env.TEAMS_FEDERATED_CLIENT_ID;
+  const federatedClientAudience =
+    teamsConfig?.federated?.clientAudience ?? env.TEAMS_FEDERATED_CLIENT_AUDIENCE;
+
+  if (!appId) {
+    throw new CrablineError(
+      "Microsoft Teams app id is required. Set msteams.appId or TEAMS_APP_ID.",
+      {
+        kind: "config",
+      },
+    );
+  }
+
+  if (!appPassword && !federatedClientId) {
+    throw new CrablineError(
+      "Microsoft Teams app password or federated client id is required. Set msteams.appPassword, TEAMS_APP_PASSWORD, msteams.federated.clientId, or TEAMS_FEDERATED_CLIENT_ID.",
+      { kind: "config" },
+    );
+  }
+
+  if (resolvedAppType === "SingleTenant" && !appTenantId) {
+    throw new CrablineError(
+      "Microsoft Teams single-tenant apps require msteams.appTenantId or TEAMS_APP_TENANT_ID.",
+      { kind: "config" },
+    );
+  }
+
+  const adapterConfig: TeamsAdapterConfig = {
+    appId,
+    ...(appPassword ? { appPassword } : {}),
+    ...(appTenantId ? { appTenantId } : {}),
+    ...(resolvedAppType ? { appType: resolvedAppType } : {}),
+    ...((teamsConfig?.apiUrl ?? env.TEAMS_API_URL)
+      ? { apiUrl: teamsConfig?.apiUrl ?? env.TEAMS_API_URL! }
+      : {}),
+    ...(teamsConfig?.dialogOpenTimeoutMs !== undefined
+      ? { dialogOpenTimeoutMs: teamsConfig.dialogOpenTimeoutMs }
+      : {}),
+    ...(federatedClientId
+      ? {
+          federated: {
+            clientId: federatedClientId,
+            ...(federatedClientAudience ? { clientAudience: federatedClientAudience } : {}),
+          },
+        }
+      : {}),
+    ...((teamsConfig?.userName ?? env.TEAMS_BOT_USERNAME)
+      ? { userName: teamsConfig?.userName ?? env.TEAMS_BOT_USERNAME! }
+      : {}),
+  };
+
+  return adapterConfig;
+}
+
+const DEFAULT_RUNTIME: MsTeamsRuntime = {
+  createAdapter(config) {
+    return createTeamsAdapter(resolveMsTeamsAdapterConfig(config)) as unknown as MsTeamsAdapterApi;
+  },
+  createChat(adapter, userName) {
+    return new Chat<{ teams: Adapter }>({
+      adapters: { teams: adapter as unknown as Adapter },
+      state: createMemoryState(),
+      userName,
+    }) as unknown as MsTeamsChat;
+  },
+};
+
+function base64Url(value: string): string {
+  return Buffer.from(value, "utf8").toString("base64url");
+}
+
+function isAddressInChannel(threadId: string, channelId?: string): boolean {
+  if (!channelId) {
+    return true;
+  }
+
+  return threadId === channelId || threadId.startsWith(`${channelId}:`);
+}
+
+function isMsTeamsEncodedId(value: string): boolean {
+  return value.startsWith("teams:");
+}
+
+function encodeMsTeamsThreadId(conversationId: string, serviceUrl: string): string {
+  return `teams:${base64Url(conversationId)}:${base64Url(serviceUrl)}`;
+}
+
+function normalizeMsTeamsChannelId(
+  target: ProviderContext["fixture"]["target"],
+  value: string,
+): string {
+  if (isMsTeamsEncodedId(value)) {
+    return value;
+  }
+
+  const serviceUrl = target.metadata.serviceUrl;
+  if (!serviceUrl) {
+    throw new CrablineError(
+      "Microsoft Teams raw channel targets require target.metadata.serviceUrl or an encoded teams: thread id.",
+      { kind: "config" },
+    );
+  }
+
+  return encodeMsTeamsThreadId(value, serviceUrl);
+}
+
+function normalizeMsTeamsThreadId(
+  target: ProviderContext["fixture"]["target"],
+  threadId: string,
+): string {
+  if (isMsTeamsEncodedId(threadId)) {
+    return threadId;
+  }
+
+  const serviceUrl = target.metadata.serviceUrl;
+  if (!serviceUrl) {
+    throw new CrablineError(
+      "Microsoft Teams raw thread targets require target.metadata.serviceUrl or an encoded teams: thread id.",
+      { kind: "config" },
+    );
+  }
+
+  const conversationId = target.channelId ?? target.id;
+  const replyConversationId = `${conversationId};messageid=${threadId}`;
+  return encodeMsTeamsThreadId(replyConversationId, serviceUrl);
+}
+
+function toWebhookPath(config: ProviderConfig): string {
+  return config.msteams?.webhook.path ?? "/msteams/webhook";
+}
+
+function toRecorderPath(providerId: string, config: ProviderConfig): string {
+  const configuredPath = config.msteams?.recorder.path;
+  if (configuredPath) {
+    return path.resolve(configuredPath);
+  }
+
+  return path.resolve(".crabline", "recorders", `${providerId}.jsonl`);
+}
+
+function classifyMsTeamsFailure(error: unknown): CrablineError {
+  if (error instanceof CrablineError) {
+    return error;
+  }
+
+  const message = ensureErrorMessage(error);
+  if (/401|403|app id|app password|tenant|unauthorized|forbidden|token/i.test(message)) {
+    return new CrablineError(message, { cause: error, kind: "auth" });
+  }
+
+  return new CrablineError(message, { cause: error, kind: "connectivity" });
+}
+
+export class MsTeamsProviderAdapter implements ProviderAdapter {
+  readonly id;
+  readonly platform = "msteams" as const;
+  readonly status = "ready" as const;
+  readonly supports = ["probe", "send", "roundtrip", "agent"] as const;
+
+  readonly #config: ProviderConfig;
+  readonly #recorderPath: string;
+  readonly #runtime: MsTeamsRuntime;
+  readonly #seenMessages = new Set<string>();
+  readonly #userName: string;
+  #adapter: MsTeamsAdapterApi | null = null;
+  #chat: MsTeamsChat | null = null;
+  #server: StartedWebhookServer | null = null;
+
+  constructor(
+    id: string,
+    config: ProviderConfig,
+    userName: string,
+    runtime: MsTeamsRuntime = DEFAULT_RUNTIME,
+  ) {
+    this.id = id;
+    this.#config = config;
+    this.#recorderPath = toRecorderPath(id, config);
+    this.#runtime = runtime;
+    this.#userName = userName;
+  }
+
+  normalizeTarget(target: ProviderContext["fixture"]["target"]): NormalizedTarget {
+    const normalized: NormalizedTarget = {
+      id: target.id,
+      metadata: target.metadata,
+    };
+
+    if (target.channelId) {
+      normalized.channelId = normalizeMsTeamsChannelId(target, target.channelId);
+    } else if (isMsTeamsEncodedId(target.id)) {
+      normalized.channelId = target.id;
+    } else if (!target.threadId && target.metadata.serviceUrl) {
+      normalized.channelId = normalizeMsTeamsChannelId(target, target.id);
+    }
+
+    if (target.threadId) {
+      normalized.threadId = normalizeMsTeamsThreadId(target, target.threadId);
+      normalized.channelId ??= normalized.threadId;
+    }
+
+    return normalized;
+  }
+
+  async probe(context: ProviderContext): Promise<ProbeResult> {
+    try {
+      await this.#getChat().initialize();
+      const server = await this.#ensureWebhookServer(true);
+      const target = this.normalizeTarget(context.fixture.target);
+      const details = [
+        `recorder path ${this.#recorderPath}`,
+        `webhook endpoint ${server.endpointUrl}`,
+      ];
+
+      if (this.#config.msteams?.webhook.publicUrl) {
+        details.push(`public webhook ${this.#config.msteams.webhook.publicUrl}`);
+      }
+
+      if (target.channelId) {
+        await this.#getAdapter().fetchChannelInfo(target.channelId);
+        details.push(`conversation reachable ${target.channelId}`);
+      } else {
+        const threadId = await this.#getAdapter().openDM(target.id);
+        details.push(`dm reachable ${threadId}`);
+      }
+
+      return {
+        details,
+        healthy: true,
+      };
+    } catch (error) {
+      throw classifyMsTeamsFailure(error);
+    }
+  }
+
+  async send(context: SendContext): Promise<SendResult> {
+    try {
+      const chat = this.#getChat();
+      await chat.initialize();
+      const threadId = await this.#resolveThreadId(context.fixture.target);
+      await chat.getState().subscribe(threadId);
+      const sent = await this.#getAdapter().postMessage(threadId, context.text);
+      return {
+        accepted: true,
+        messageId: sent.id,
+        threadId: sent.threadId,
+      };
+    } catch (error) {
+      const kind = error instanceof CrablineError ? error.kind : "outbound";
+      throw new CrablineError(ensureErrorMessage(error), {
+        cause: error,
+        ...(kind ? { kind } : {}),
+      });
+    }
+  }
+
+  async waitForInbound(context: WaitContext): Promise<InboundEnvelope | null> {
+    try {
+      await this.#ensureWebhookServer(true);
+      const target = this.normalizeTarget(context.fixture.target);
+      const inbound = await waitForRecordedInbound({
+        filePath: this.#recorderPath,
+        matches: (event) =>
+          event.provider === this.id &&
+          isAddressInChannel(event.threadId, context.threadId ?? target.channelId),
+        since: context.since,
+        timeoutMs: context.timeoutMs,
+      });
+      return inbound ?? null;
+    } catch (error) {
+      throw classifyMsTeamsFailure(error);
+    }
+  }
+
+  async *watch(context: WatchContext): AsyncIterable<InboundEnvelope> {
+    const target = this.normalizeTarget(context.fixture.target);
+    await this.#ensureWebhookServer(false);
+
+    for await (const event of watchRecordedInbound({
+      filePath: this.#recorderPath,
+      matches: (entry) =>
+        entry.provider === this.id && isAddressInChannel(entry.threadId, target.channelId),
+      since: context.since,
+    })) {
+      yield event;
+    }
+  }
+
+  async cleanup(): Promise<void> {
+    if (!this.#server) {
+      return;
+    }
+
+    await this.#server.close();
+    this.#server = null;
+  }
+
+  #registerInboundHandlers(): void {
+    const chat = this.#chat;
+    if (!chat) {
+      return;
+    }
+    const record = async (thread: MsTeamsThread, message: MsTeamsMessage) => {
+      const key = `${thread.id}:${message.id}`;
+      if (this.#seenMessages.has(key)) {
+        return;
+      }
+      this.#seenMessages.add(key);
+
+      await appendRecordedInbound(this.#recorderPath, {
+        author: message.author.isBot ? "assistant" : "user",
+        id: message.id,
+        provider: this.id,
+        raw: message.raw,
+        sentAt: message.metadata.dateSent.toISOString(),
+        text: message.text,
+        threadId: thread.id,
+      });
+    };
+
+    chat.onDirectMessage(record);
+    chat.onNewMention(record);
+    chat.onNewMessage(/[\s\S]+/u, record);
+    chat.onSubscribedMessage(record);
+  }
+
+  async #ensureWebhookServer(allowExisting: boolean): Promise<StartedWebhookServer> {
+    if (this.#server) {
+      return this.#server;
+    }
+
+    try {
+      this.#server = await startWebhookServer({
+        handle: (request) => this.#getAdapter().handleWebhook(request),
+        host: this.#config.msteams?.webhook.host ?? "127.0.0.1",
+        path: toWebhookPath(this.#config),
+        port: this.#config.msteams?.webhook.port ?? 8791,
+      });
+      return this.#server;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (allowExisting && code === "EADDRINUSE") {
+        return {
+          async close() {},
+          endpointUrl: `http://${this.#config.msteams?.webhook.host ?? "127.0.0.1"}:${this.#config.msteams?.webhook.port ?? 8791}${toWebhookPath(this.#config)}`,
+        };
+      }
+
+      throw new CrablineError(
+        `Microsoft Teams webhook server failed: ${ensureErrorMessage(error)}`,
+        {
+          cause: error,
+          kind: "connectivity",
+        },
+      );
+    }
+  }
+
+  async #resolveThreadId(target: ProviderContext["fixture"]["target"]): Promise<string> {
+    const normalized = this.normalizeTarget(target);
+    if (normalized.threadId) {
+      return normalized.threadId;
+    }
+
+    if (normalized.channelId) {
+      return normalized.channelId;
+    }
+
+    return this.#getAdapter().openDM(normalized.id);
+  }
+
+  #getAdapter(): MsTeamsAdapterApi {
+    if (!this.#adapter) {
+      this.#adapter = this.#runtime.createAdapter(this.#config);
+    }
+
+    return this.#adapter;
+  }
+
+  #getChat(): MsTeamsChat {
+    if (!this.#chat) {
+      this.#chat = this.#runtime.createChat(this.#getAdapter(), this.#userName);
+      this.#registerInboundHandlers();
+    }
+
+    return this.#chat;
+  }
+}

--- a/src/providers/catalog.ts
+++ b/src/providers/catalog.ts
@@ -42,7 +42,12 @@ export const OPENCLAW_SUPPORT_CATALOG = [
     status: "ready",
     supports: COMMON_BRIDGE_SUPPORT,
   },
-  createBridgeEntry("googlechat", "OpenClaw channel via script bridge."),
+  {
+    notes: "Built-in provider for Google Chat.",
+    platform: "googlechat",
+    status: "ready",
+    supports: COMMON_BRIDGE_SUPPORT,
+  },
   {
     notes: "Adapter-backed provider for iMessage.",
     platform: "imessage",
@@ -63,7 +68,12 @@ export const OPENCLAW_SUPPORT_CATALOG = [
     status: "ready",
     supports: COMMON_BRIDGE_SUPPORT,
   },
-  createBridgeEntry("msteams", "OpenClaw plugin channel via script bridge."),
+  {
+    notes: "Built-in provider for Microsoft Teams.",
+    platform: "msteams",
+    status: "ready",
+    supports: COMMON_BRIDGE_SUPPORT,
+  },
   createBridgeEntry("nextcloudtalk", "OpenClaw plugin channel via script bridge."),
   createBridgeEntry("nostr", "OpenClaw plugin channel via script bridge."),
   createBridgeEntry("signal", "OpenClaw channel via script bridge."),

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -49,6 +49,10 @@ const LAZY_PROVIDER_FACTORIES = {
     const { FeishuProviderAdapter } = await import("./builtin/feishu.js");
     return new FeishuProviderAdapter(providerId, config, userName);
   },
+  async googlechat({ config, providerId, userName }) {
+    const { GoogleChatProviderAdapter } = await import("./builtin/googlechat.js");
+    return new GoogleChatProviderAdapter(providerId, config, userName);
+  },
   async imessage({ config, providerId, userName }) {
     const { IMessageProviderAdapter } = await import("./builtin/imessage.js");
     return new IMessageProviderAdapter(providerId, config, userName);
@@ -64,6 +68,10 @@ const LAZY_PROVIDER_FACTORIES = {
   async mattermost({ config, providerId, userName }) {
     const { MattermostProviderAdapter } = await import("./builtin/mattermost.js");
     return new MattermostProviderAdapter(providerId, config, userName);
+  },
+  async msteams({ config, providerId, userName }) {
+    const { MsTeamsProviderAdapter } = await import("./builtin/msteams.js");
+    return new MsTeamsProviderAdapter(providerId, config, userName);
   },
   async slack({ config, providerId, userName }) {
     const { SlackProviderAdapter } = await import("./builtin/slack.js");

--- a/test/catalog.test.ts
+++ b/test/catalog.test.ts
@@ -57,12 +57,32 @@ describe("support catalog", () => {
           ];
         }
 
+        if (entry.platform === "googlechat") {
+          return [
+            entry.platform,
+            {
+              adapter: "googlechat",
+              googlechat: {},
+            },
+          ];
+        }
+
         if (entry.platform === "mattermost") {
           return [
             entry.platform,
             {
               adapter: "mattermost",
               mattermost: {},
+            },
+          ];
+        }
+
+        if (entry.platform === "msteams") {
+          return [
+            entry.platform,
+            {
+              adapter: "msteams",
+              msteams: {},
             },
           ];
         }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -165,7 +165,7 @@ describe("manifest schema", () => {
     ).toThrow(/discord adapter must use platform=discord/u);
   });
 
-  it("parses built-in telegram, whatsapp, feishu, mattermost, and zalo provider config", () => {
+  it("parses built-in telegram, whatsapp, feishu, googlechat, mattermost, msteams, and zalo provider config", () => {
     const manifest = ManifestSchema.parse({
       configVersion: 1,
       fixtures: [
@@ -188,10 +188,25 @@ describe("manifest schema", () => {
           target: { id: "oc_123" },
         },
         {
+          id: "googlechat-space",
+          mode: "roundtrip",
+          provider: "googlechat",
+          target: { id: "spaces/AAAA1234567" },
+        },
+        {
           id: "mattermost-channel",
           mode: "roundtrip",
           provider: "mattermost",
           target: { id: "channel-id" },
+        },
+        {
+          id: "msteams-channel",
+          mode: "roundtrip",
+          provider: "msteams",
+          target: {
+            id: "19:conversation@thread.v2",
+            metadata: { serviceUrl: "https://smba.trafficmanager.net/amer/" },
+          },
         },
         {
           id: "zalo-chat",
@@ -207,10 +222,22 @@ describe("manifest schema", () => {
             appId: "feishu-app",
           },
         },
+        googlechat: {
+          adapter: "googlechat",
+          googlechat: {
+            disableSignatureVerification: true,
+          },
+        },
         mattermost: {
           adapter: "mattermost",
           mattermost: {
             baseUrl: "https://mattermost.example.com",
+          },
+        },
+        msteams: {
+          adapter: "msteams",
+          msteams: {
+            appId: "teams-app",
           },
         },
         telegram: {
@@ -236,8 +263,12 @@ describe("manifest schema", () => {
 
     expect(manifest.providers["feishu"]?.feishu?.recorder).toEqual({});
     expect(manifest.providers["feishu"]?.platform).toBe("feishu");
+    expect(manifest.providers["googlechat"]?.googlechat?.webhook.port).toBe(8792);
+    expect(manifest.providers["googlechat"]?.platform).toBe("googlechat");
     expect(manifest.providers["mattermost"]?.mattermost?.webhook.path).toBe("/mattermost/webhook");
     expect(manifest.providers["mattermost"]?.platform).toBe("mattermost");
+    expect(manifest.providers["msteams"]?.msteams?.webhook.path).toBe("/msteams/webhook");
+    expect(manifest.providers["msteams"]?.platform).toBe("msteams");
     expect(manifest.providers["telegram"]?.telegram?.webhook.port).toBe(8790);
     expect(manifest.providers["telegram"]?.telegram?.mode).toBe("polling");
     expect(manifest.providers["telegram"]?.platform).toBe("telegram");
@@ -247,7 +278,7 @@ describe("manifest schema", () => {
     expect(manifest.providers["zalo"]?.platform).toBe("zalo");
   });
 
-  it("rejects built-in telegram, whatsapp, feishu, mattermost, and zalo adapters on the wrong platform", () => {
+  it("rejects built-in telegram, whatsapp, feishu, googlechat, mattermost, msteams, and zalo adapters on the wrong platform", () => {
     expect(() =>
       ManifestSchema.parse({
         configVersion: 1,
@@ -266,6 +297,19 @@ describe("manifest schema", () => {
         configVersion: 1,
         fixtures: [],
         providers: {
+          googlechat: {
+            adapter: "googlechat",
+            platform: "msteams",
+          },
+        },
+      }),
+    ).toThrow(/googlechat adapter must use platform=googlechat/u);
+
+    expect(() =>
+      ManifestSchema.parse({
+        configVersion: 1,
+        fixtures: [],
+        providers: {
           mattermost: {
             adapter: "mattermost",
             platform: "feishu",
@@ -273,6 +317,19 @@ describe("manifest schema", () => {
         },
       }),
     ).toThrow(/mattermost adapter must use platform=mattermost/u);
+
+    expect(() =>
+      ManifestSchema.parse({
+        configVersion: 1,
+        fixtures: [],
+        providers: {
+          msteams: {
+            adapter: "msteams",
+            platform: "googlechat",
+          },
+        },
+      }),
+    ).toThrow(/msteams adapter must use platform=msteams/u);
 
     expect(() =>
       ManifestSchema.parse({

--- a/test/googlechat-provider.test.ts
+++ b/test/googlechat-provider.test.ts
@@ -1,0 +1,508 @@
+import path from "node:path";
+import { createServer } from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  GoogleChatProviderAdapter,
+  resolveGoogleChatAdapterConfig,
+} from "../src/providers/builtin/googlechat.js";
+import type { ProviderConfig } from "../src/config/schema.js";
+import type { ProviderContext } from "../src/providers/types.js";
+import { createTempDir, disposeTempDir } from "./test-helpers.js";
+
+type FakeInboundPayload = {
+  authorIsBot?: boolean;
+  id: string;
+  text: string;
+  threadId: string;
+};
+
+type FakeMessage = {
+  author: { isBot: boolean };
+  id: string;
+  metadata: { dateSent: Date };
+  raw: Record<string, never>;
+  text: string;
+  threadId: string;
+};
+
+const directories: string[] = [];
+const providers: GoogleChatProviderAdapter[] = [];
+
+afterEach(async () => {
+  await Promise.all(providers.splice(0).map((provider) => provider.cleanup()));
+  await Promise.all(directories.splice(0).map(disposeTempDir));
+});
+
+function base64Url(value: string): string {
+  return Buffer.from(value, "utf8").toString("base64url");
+}
+
+async function occupyPort(): Promise<{ close: () => Promise<void>; port: number }> {
+  const server = createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("expected TCP server address");
+  }
+
+  return {
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      }),
+    port: address.port,
+  };
+}
+
+async function createGoogleChatConfig(port: number): Promise<ProviderConfig> {
+  const directory = await createTempDir();
+  directories.push(directory);
+
+  return {
+    adapter: "googlechat",
+    capabilities: ["probe", "send", "roundtrip", "agent"],
+    env: [],
+    googlechat: {
+      credentials: {
+        client_email: "bot@example.iam.gserviceaccount.com",
+        private_key: "private-key",
+      },
+      disableSignatureVerification: true,
+      recorder: { path: path.join(directory, "googlechat.jsonl") },
+      webhook: {
+        host: "127.0.0.1",
+        path: "/googlechat/webhook",
+        port,
+      },
+    },
+    platform: "googlechat",
+    status: "active",
+  };
+}
+
+function createFakeGoogleChatRuntime() {
+  const directHandlers: Array<
+    (thread: { id: string }, message: FakeMessage) => Promise<void> | void
+  > = [];
+  const mentionHandlers: typeof directHandlers = [];
+  const messageHandlers: typeof directHandlers = [];
+  const subscribedHandlers: typeof directHandlers = [];
+  const subscriptions = new Set<string>();
+
+  const adapter = {
+    fetchChannelInfo: vi.fn(async (channelId: string) => ({ id: channelId })),
+    handleWebhook: vi.fn(async (request: Request) => {
+      const payload = (await request.json()) as {
+        kind?: "direct" | "mention" | "message" | "subscribed";
+        message: FakeInboundPayload;
+      };
+      const handlersByKind = {
+        direct: directHandlers,
+        mention: mentionHandlers,
+        message: messageHandlers,
+        subscribed: subscribedHandlers,
+      } as const;
+
+      const kind = payload.kind ?? "subscribed";
+      const message = createFakeMessage(payload.message);
+      const thread = { id: message.threadId };
+      for (const handler of handlersByKind[kind]) {
+        await handler(thread, message);
+      }
+
+      return new Response("ok");
+    }),
+    openDM: vi.fn(async (userId: string) => `gchat:${userId}:dm`),
+    postMessage: vi.fn(async (threadId: string, _text: string) => ({
+      id: "googlechat-sent",
+      threadId,
+    })),
+  };
+
+  const chat = {
+    getState() {
+      return {
+        subscribe: vi.fn(async (threadId: string) => {
+          subscriptions.add(threadId);
+        }),
+      };
+    },
+    initialize: vi.fn(async () => {}),
+    onDirectMessage(
+      handler: (thread: { id: string }, message: FakeMessage) => Promise<void> | void,
+    ) {
+      directHandlers.push(handler);
+    },
+    onNewMention(handler: (thread: { id: string }, message: FakeMessage) => Promise<void> | void) {
+      mentionHandlers.push(handler);
+    },
+    onNewMessage(
+      _pattern: RegExp,
+      handler: (thread: { id: string }, message: FakeMessage) => Promise<void> | void,
+    ) {
+      messageHandlers.push(handler);
+    },
+    onSubscribedMessage(
+      handler: (thread: { id: string }, message: FakeMessage) => Promise<void> | void,
+    ) {
+      subscribedHandlers.push(handler);
+    },
+  };
+
+  return {
+    adapter,
+    chat,
+    runtime: {
+      createAdapter: () => adapter,
+      createChat: () => chat,
+    },
+    subscriptions,
+  };
+}
+
+function createFakeMessage(payload: FakeInboundPayload): FakeMessage {
+  return {
+    author: { isBot: payload.authorIsBot ?? true },
+    id: payload.id,
+    metadata: { dateSent: new Date() },
+    raw: {},
+    text: payload.text,
+    threadId: payload.threadId,
+  };
+}
+
+function createContext(config: ProviderConfig): ProviderContext {
+  return {
+    config,
+    fixture: {
+      env: [],
+      id: "googlechat-agent",
+      inboundMatch: { author: "assistant", nonce: "contains", strategy: "contains" },
+      mode: "agent",
+      provider: "googlechat",
+      retries: 0,
+      tags: [],
+      target: {
+        id: "spaces/AAAA1234567",
+        metadata: {},
+      },
+      timeoutMs: 500,
+    },
+    manifestPath: "/tmp/crabline.yaml",
+    providerId: "googlechat",
+    userName: "crabline",
+  };
+}
+
+describe("googlechat provider", () => {
+  it("resolves adapter config from provider settings and env", () => {
+    expect(
+      resolveGoogleChatAdapterConfig(
+        {
+          adapter: "googlechat",
+          capabilities: ["probe", "send", "roundtrip", "agent"],
+          env: [],
+          googlechat: {
+            credentials: {
+              client_email: "config@example.iam.gserviceaccount.com",
+              private_key: "private-key",
+            },
+            disableSignatureVerification: true,
+            recorder: {},
+            webhook: {
+              host: "127.0.0.1",
+              path: "/googlechat/webhook",
+              port: 8792,
+              publicUrl: "https://example.com/googlechat/webhook",
+            },
+          },
+          platform: "googlechat",
+          status: "active",
+        },
+        {
+          GOOGLE_CHAT_BOT_USERNAME: "crabline_gchat",
+          GOOGLE_CHAT_PUBSUB_TOPIC: "projects/test/topics/chat",
+        },
+      ),
+    ).toMatchObject({
+      credentials: {
+        client_email: "config@example.iam.gserviceaccount.com",
+      },
+      disableSignatureVerification: true,
+      endpointUrl: "https://example.com/googlechat/webhook",
+      pubsubTopic: "projects/test/topics/chat",
+      userName: "crabline_gchat",
+    });
+  });
+
+  it("parses credentials JSON from env", () => {
+    expect(
+      resolveGoogleChatAdapterConfig(
+        {
+          adapter: "googlechat",
+          capabilities: ["probe", "send", "roundtrip", "agent"],
+          env: [],
+          googlechat: {
+            googleChatProjectNumber: "1234567890",
+            recorder: {},
+            webhook: { host: "127.0.0.1", path: "/googlechat/webhook", port: 8792 },
+          },
+          platform: "googlechat",
+          status: "active",
+        },
+        {
+          GOOGLE_CHAT_CREDENTIALS: JSON.stringify({
+            client_email: "env@example.iam.gserviceaccount.com",
+            private_key: "private-key",
+          }),
+        },
+      ),
+    ).toMatchObject({
+      credentials: {
+        client_email: "env@example.iam.gserviceaccount.com",
+      },
+      googleChatProjectNumber: "1234567890",
+    });
+  });
+
+  it("validates adapter auth and webhook verification config", () => {
+    const baseConfig: ProviderConfig = {
+      adapter: "googlechat",
+      capabilities: ["probe", "send", "roundtrip", "agent"],
+      env: [],
+      googlechat: {
+        recorder: {},
+        webhook: { host: "127.0.0.1", path: "/googlechat/webhook", port: 8792 },
+      },
+      platform: "googlechat",
+      status: "active",
+    };
+
+    expect(() => resolveGoogleChatAdapterConfig(baseConfig, {})).toThrow(
+      /credentials are required/u,
+    );
+    expect(() =>
+      resolveGoogleChatAdapterConfig(
+        {
+          ...baseConfig,
+          googlechat: {
+            ...baseConfig.googlechat!,
+            credentials: {
+              client_email: "config@example.iam.gserviceaccount.com",
+              private_key: "private-key",
+            },
+          },
+        },
+        {},
+      ),
+    ).toThrow(/webhook verification is required/u);
+    expect(() =>
+      resolveGoogleChatAdapterConfig(baseConfig, {
+        GOOGLE_CHAT_CREDENTIALS: "{bad-json",
+      }),
+    ).toThrow(/valid JSON/u);
+    expect(() =>
+      resolveGoogleChatAdapterConfig(baseConfig, {
+        GOOGLE_CHAT_CREDENTIALS: JSON.stringify({ client_email: "missing-private-key" }),
+      }),
+    ).toThrow(/client_email and private_key/u);
+  });
+
+  it("supports Application Default Credentials from env", () => {
+    expect(
+      resolveGoogleChatAdapterConfig(
+        {
+          adapter: "googlechat",
+          capabilities: ["probe", "send", "roundtrip", "agent"],
+          env: [],
+          googlechat: {
+            recorder: {},
+            webhook: { host: "127.0.0.1", path: "/googlechat/webhook", port: 8792 },
+          },
+          platform: "googlechat",
+          status: "active",
+        },
+        {
+          GOOGLE_CHAT_DISABLE_SIGNATURE_VERIFICATION: "true",
+          GOOGLE_CHAT_USE_ADC: "true",
+        },
+      ),
+    ).toMatchObject({
+      disableSignatureVerification: true,
+      useApplicationDefaultCredentials: true,
+    });
+  });
+
+  it("normalizes raw Google Chat IDs into Chat SDK thread IDs", async () => {
+    const runtime = createFakeGoogleChatRuntime();
+    const config = await createGoogleChatConfig(0);
+    const provider = new GoogleChatProviderAdapter(
+      "googlechat",
+      config,
+      "crabline",
+      runtime.runtime,
+    );
+    providers.push(provider);
+
+    expect(provider.normalizeTarget({ id: "spaces/AAAA1234567", metadata: {} })).toMatchObject({
+      channelId: "gchat:spaces/AAAA1234567",
+    });
+    expect(
+      provider.normalizeTarget({
+        id: "spaces/AAAA1234567",
+        metadata: {},
+        threadId: "spaces/AAAA1234567/threads/thread-1",
+      }),
+    ).toMatchObject({
+      threadId: `gchat:spaces/AAAA1234567:${base64Url("spaces/AAAA1234567/threads/thread-1")}`,
+    });
+
+    const sendResult = await provider.send({
+      ...createContext(config),
+      fixture: {
+        ...createContext(config).fixture,
+        target: {
+          id: "spaces/AAAA1234567",
+          metadata: {},
+          threadId: "spaces/AAAA1234567/threads/thread-1",
+        },
+      },
+      mode: "roundtrip",
+      nonce: "nonce-thread",
+      text: "hello thread",
+    });
+    expect(sendResult.threadId).toBe(
+      `gchat:spaces/AAAA1234567:${base64Url("spaces/AAAA1234567/threads/thread-1")}`,
+    );
+  });
+
+  it("probes and sends through the provider adapter", async () => {
+    const runtime = createFakeGoogleChatRuntime();
+    const config = await createGoogleChatConfig(0);
+    const provider = new GoogleChatProviderAdapter(
+      "googlechat",
+      config,
+      "crabline",
+      runtime.runtime,
+    );
+    providers.push(provider);
+
+    const probe = await provider.probe(createContext(config));
+    expect(probe.healthy).toBe(true);
+    expect(probe.details.join("\n")).toContain("webhook endpoint http://127.0.0.1:");
+
+    const result = await provider.send({
+      ...createContext(config),
+      mode: "roundtrip",
+      nonce: "nonce-1",
+      text: "hello",
+    });
+
+    expect(result.threadId).toBe("gchat:spaces/AAAA1234567");
+    expect(runtime.adapter.postMessage).toHaveBeenCalledWith("gchat:spaces/AAAA1234567", "hello");
+    expect(runtime.subscriptions.has("gchat:spaces/AAAA1234567")).toBe(true);
+  });
+
+  it("opens DMs when the target is not a space id", async () => {
+    const runtime = createFakeGoogleChatRuntime();
+    const config = await createGoogleChatConfig(0);
+    const provider = new GoogleChatProviderAdapter(
+      "googlechat",
+      config,
+      "crabline",
+      runtime.runtime,
+    );
+    providers.push(provider);
+
+    const result = await provider.send({
+      ...createContext(config),
+      fixture: {
+        ...createContext(config).fixture,
+        target: { id: "users/1234567890", metadata: {} },
+      },
+      mode: "roundtrip",
+      nonce: "nonce-dm",
+      text: "hello dm",
+    });
+
+    expect(result.threadId).toBe("gchat:users/1234567890:dm");
+    expect(runtime.adapter.openDM).toHaveBeenCalledWith("users/1234567890");
+  });
+
+  it("reports the configured webhook endpoint when its port is already in use", async () => {
+    const occupied = await occupyPort();
+    try {
+      const runtime = createFakeGoogleChatRuntime();
+      const config = await createGoogleChatConfig(occupied.port);
+      config.googlechat!.webhook.publicUrl = "https://example.com/googlechat/webhook";
+      const provider = new GoogleChatProviderAdapter(
+        "googlechat",
+        config,
+        "crabline",
+        runtime.runtime,
+      );
+      providers.push(provider);
+
+      const probe = await provider.probe(createContext(config));
+
+      expect(probe).toMatchObject({ healthy: true });
+      expect(probe.details).toContain(
+        `webhook endpoint http://127.0.0.1:${occupied.port}/googlechat/webhook`,
+      );
+      expect(probe.details).toContain("public webhook https://example.com/googlechat/webhook");
+    } finally {
+      await occupied.close();
+    }
+  });
+
+  it("records webhook inbound events", async () => {
+    const runtime = createFakeGoogleChatRuntime();
+    const config = await createGoogleChatConfig(0);
+    const provider = new GoogleChatProviderAdapter(
+      "googlechat",
+      config,
+      "crabline",
+      runtime.runtime,
+    );
+    providers.push(provider);
+
+    const probe = await provider.probe(createContext(config));
+    const endpoint = probe.details.find((detail) => detail.startsWith("webhook endpoint "));
+    expect(endpoint).toBeDefined();
+
+    const waitPromise = provider.waitForInbound({
+      ...createContext(config),
+      nonce: "nonce-2",
+      since: new Date(Date.now() - 1000).toISOString(),
+      threadId: "gchat:spaces/AAAA1234567",
+      timeoutMs: 500,
+    });
+
+    await fetch(endpoint!.replace("webhook endpoint ", ""), {
+      body: JSON.stringify({
+        message: {
+          id: "evt-1",
+          text: "ACK nonce-2",
+          threadId: "gchat:spaces/AAAA1234567",
+        },
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+
+    await expect(waitPromise).resolves.toMatchObject({
+      id: "evt-1",
+      text: "ACK nonce-2",
+    });
+  });
+});

--- a/test/msteams-provider.test.ts
+++ b/test/msteams-provider.test.ts
@@ -1,0 +1,457 @@
+import path from "node:path";
+import { createServer } from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  MsTeamsProviderAdapter,
+  resolveMsTeamsAdapterConfig,
+} from "../src/providers/builtin/msteams.js";
+import type { ProviderConfig } from "../src/config/schema.js";
+import type { ProviderContext } from "../src/providers/types.js";
+import { createTempDir, disposeTempDir } from "./test-helpers.js";
+
+type FakeInboundPayload = {
+  authorIsBot?: boolean;
+  id: string;
+  text: string;
+  threadId: string;
+};
+
+type FakeMessage = {
+  author: { isBot: boolean };
+  id: string;
+  metadata: { dateSent: Date };
+  raw: Record<string, never>;
+  text: string;
+  threadId: string;
+};
+
+const directories: string[] = [];
+const providers: MsTeamsProviderAdapter[] = [];
+
+afterEach(async () => {
+  await Promise.all(providers.splice(0).map((provider) => provider.cleanup()));
+  await Promise.all(directories.splice(0).map(disposeTempDir));
+});
+
+function base64Url(value: string): string {
+  return Buffer.from(value, "utf8").toString("base64url");
+}
+
+function encodeTeamsThreadId(conversationId: string, serviceUrl: string): string {
+  return `teams:${base64Url(conversationId)}:${base64Url(serviceUrl)}`;
+}
+
+async function occupyPort(): Promise<{ close: () => Promise<void>; port: number }> {
+  const server = createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("expected TCP server address");
+  }
+
+  return {
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      }),
+    port: address.port,
+  };
+}
+
+async function createMsTeamsConfig(port: number): Promise<ProviderConfig> {
+  const directory = await createTempDir();
+  directories.push(directory);
+
+  return {
+    adapter: "msteams",
+    capabilities: ["probe", "send", "roundtrip", "agent"],
+    env: [],
+    msteams: {
+      appId: "teams-app",
+      appPassword: "teams-secret",
+      recorder: { path: path.join(directory, "msteams.jsonl") },
+      webhook: {
+        host: "127.0.0.1",
+        path: "/msteams/webhook",
+        port,
+      },
+    },
+    platform: "msteams",
+    status: "active",
+  };
+}
+
+function createFakeMsTeamsRuntime() {
+  const directHandlers: Array<
+    (thread: { id: string }, message: FakeMessage) => Promise<void> | void
+  > = [];
+  const mentionHandlers: typeof directHandlers = [];
+  const messageHandlers: typeof directHandlers = [];
+  const subscribedHandlers: typeof directHandlers = [];
+  const subscriptions = new Set<string>();
+
+  const adapter = {
+    fetchChannelInfo: vi.fn(async (channelId: string) => ({ id: channelId })),
+    handleWebhook: vi.fn(async (request: Request) => {
+      const payload = (await request.json()) as {
+        kind?: "direct" | "mention" | "message" | "subscribed";
+        message: FakeInboundPayload;
+      };
+      const handlersByKind = {
+        direct: directHandlers,
+        mention: mentionHandlers,
+        message: messageHandlers,
+        subscribed: subscribedHandlers,
+      } as const;
+
+      const kind = payload.kind ?? "subscribed";
+      const message = createFakeMessage(payload.message);
+      const thread = { id: message.threadId };
+      for (const handler of handlersByKind[kind]) {
+        await handler(thread, message);
+      }
+
+      return new Response("ok");
+    }),
+    openDM: vi.fn(async (userId: string) => `teams:dm:${userId}`),
+    postMessage: vi.fn(async (threadId: string, _text: string) => ({
+      id: "teams-sent",
+      threadId,
+    })),
+  };
+
+  const chat = {
+    getState() {
+      return {
+        subscribe: vi.fn(async (threadId: string) => {
+          subscriptions.add(threadId);
+        }),
+      };
+    },
+    initialize: vi.fn(async () => {}),
+    onDirectMessage(
+      handler: (thread: { id: string }, message: FakeMessage) => Promise<void> | void,
+    ) {
+      directHandlers.push(handler);
+    },
+    onNewMention(handler: (thread: { id: string }, message: FakeMessage) => Promise<void> | void) {
+      mentionHandlers.push(handler);
+    },
+    onNewMessage(
+      _pattern: RegExp,
+      handler: (thread: { id: string }, message: FakeMessage) => Promise<void> | void,
+    ) {
+      messageHandlers.push(handler);
+    },
+    onSubscribedMessage(
+      handler: (thread: { id: string }, message: FakeMessage) => Promise<void> | void,
+    ) {
+      subscribedHandlers.push(handler);
+    },
+  };
+
+  return {
+    adapter,
+    chat,
+    runtime: {
+      createAdapter: () => adapter,
+      createChat: () => chat,
+    },
+    subscriptions,
+  };
+}
+
+function createFakeMessage(payload: FakeInboundPayload): FakeMessage {
+  return {
+    author: { isBot: payload.authorIsBot ?? true },
+    id: payload.id,
+    metadata: { dateSent: new Date() },
+    raw: {},
+    text: payload.text,
+    threadId: payload.threadId,
+  };
+}
+
+function createContext(config: ProviderConfig): ProviderContext {
+  return {
+    config,
+    fixture: {
+      env: [],
+      id: "msteams-agent",
+      inboundMatch: { author: "assistant", nonce: "contains", strategy: "contains" },
+      mode: "agent",
+      provider: "msteams",
+      retries: 0,
+      tags: [],
+      target: {
+        id: "19:conversation@thread.v2",
+        metadata: { serviceUrl: "https://smba.trafficmanager.net/amer/" },
+      },
+      timeoutMs: 500,
+    },
+    manifestPath: "/tmp/crabline.yaml",
+    providerId: "msteams",
+    userName: "crabline",
+  };
+}
+
+describe("msteams provider", () => {
+  it("resolves adapter config from provider settings and env", () => {
+    expect(
+      resolveMsTeamsAdapterConfig(
+        {
+          adapter: "msteams",
+          capabilities: ["probe", "send", "roundtrip", "agent"],
+          env: [],
+          msteams: {
+            appId: "config-app",
+            appPassword: "config-secret",
+            recorder: {},
+            webhook: { host: "127.0.0.1", path: "/msteams/webhook", port: 8791 },
+          },
+          platform: "msteams",
+          status: "active",
+        },
+        {
+          TEAMS_API_URL: "https://teams.example.com",
+          TEAMS_APP_TYPE: "MultiTenant",
+          TEAMS_BOT_USERNAME: "crabline_teams",
+        },
+      ),
+    ).toMatchObject({
+      apiUrl: "https://teams.example.com",
+      appId: "config-app",
+      appPassword: "config-secret",
+      appType: "MultiTenant",
+      userName: "crabline_teams",
+    });
+  });
+
+  it("validates required adapter auth config", () => {
+    const baseConfig: ProviderConfig = {
+      adapter: "msteams",
+      capabilities: ["probe", "send", "roundtrip", "agent"],
+      env: [],
+      msteams: {
+        recorder: {},
+        webhook: { host: "127.0.0.1", path: "/msteams/webhook", port: 8791 },
+      },
+      platform: "msteams",
+      status: "active",
+    };
+
+    expect(() => resolveMsTeamsAdapterConfig(baseConfig, {})).toThrow(/app id is required/u);
+    expect(() =>
+      resolveMsTeamsAdapterConfig(
+        {
+          ...baseConfig,
+          msteams: {
+            ...baseConfig.msteams!,
+            appId: "teams-app",
+            appPassword: "teams-secret",
+            appType: "SingleTenant",
+          },
+        },
+        {},
+      ),
+    ).toThrow(/single-tenant apps require/u);
+  });
+
+  it("supports federated adapter auth config", () => {
+    expect(
+      resolveMsTeamsAdapterConfig(
+        {
+          adapter: "msteams",
+          capabilities: ["probe", "send", "roundtrip", "agent"],
+          env: [],
+          msteams: {
+            appId: "teams-app",
+            recorder: {},
+            webhook: { host: "127.0.0.1", path: "/msteams/webhook", port: 8791 },
+          },
+          platform: "msteams",
+          status: "active",
+        },
+        {
+          TEAMS_FEDERATED_CLIENT_AUDIENCE: "api://AzureADTokenExchange",
+          TEAMS_FEDERATED_CLIENT_ID: "client-id",
+        },
+      ),
+    ).toMatchObject({
+      federated: {
+        clientAudience: "api://AzureADTokenExchange",
+        clientId: "client-id",
+      },
+    });
+  });
+
+  it("normalizes raw Teams conversation IDs into Chat SDK thread IDs", async () => {
+    const runtime = createFakeMsTeamsRuntime();
+    const config = await createMsTeamsConfig(0);
+    const provider = new MsTeamsProviderAdapter("msteams", config, "crabline", runtime.runtime);
+    providers.push(provider);
+
+    expect(
+      provider.normalizeTarget({
+        id: "19:conversation@thread.v2",
+        metadata: { serviceUrl: "https://smba.trafficmanager.net/amer/" },
+      }),
+    ).toMatchObject({
+      channelId: encodeTeamsThreadId(
+        "19:conversation@thread.v2",
+        "https://smba.trafficmanager.net/amer/",
+      ),
+    });
+    expect(
+      provider.normalizeTarget({
+        id: "19:conversation@thread.v2",
+        metadata: { serviceUrl: "https://smba.trafficmanager.net/amer/" },
+        threadId: "1710000000000",
+      }),
+    ).toMatchObject({
+      threadId: encodeTeamsThreadId(
+        "19:conversation@thread.v2;messageid=1710000000000",
+        "https://smba.trafficmanager.net/amer/",
+      ),
+    });
+
+    const sendResult = await provider.send({
+      ...createContext(config),
+      fixture: {
+        ...createContext(config).fixture,
+        target: {
+          id: "19:conversation@thread.v2",
+          metadata: { serviceUrl: "https://smba.trafficmanager.net/amer/" },
+          threadId: "1710000000000",
+        },
+      },
+      mode: "roundtrip",
+      nonce: "nonce-thread",
+      text: "hello thread",
+    });
+    expect(sendResult.threadId).toBe(
+      encodeTeamsThreadId(
+        "19:conversation@thread.v2;messageid=1710000000000",
+        "https://smba.trafficmanager.net/amer/",
+      ),
+    );
+  });
+
+  it("probes and sends through the provider adapter", async () => {
+    const runtime = createFakeMsTeamsRuntime();
+    const config = await createMsTeamsConfig(0);
+    const provider = new MsTeamsProviderAdapter("msteams", config, "crabline", runtime.runtime);
+    providers.push(provider);
+
+    const probe = await provider.probe(createContext(config));
+    expect(probe.healthy).toBe(true);
+    expect(probe.details.join("\n")).toContain("webhook endpoint http://127.0.0.1:");
+
+    const result = await provider.send({
+      ...createContext(config),
+      mode: "roundtrip",
+      nonce: "nonce-1",
+      text: "hello",
+    });
+
+    const threadId = encodeTeamsThreadId(
+      "19:conversation@thread.v2",
+      "https://smba.trafficmanager.net/amer/",
+    );
+    expect(result.threadId).toBe(threadId);
+    expect(runtime.adapter.postMessage).toHaveBeenCalledWith(threadId, "hello");
+    expect(runtime.subscriptions.has(threadId)).toBe(true);
+  });
+
+  it("opens DMs when the target is not a conversation id", async () => {
+    const runtime = createFakeMsTeamsRuntime();
+    const config = await createMsTeamsConfig(0);
+    const provider = new MsTeamsProviderAdapter("msteams", config, "crabline", runtime.runtime);
+    providers.push(provider);
+
+    const result = await provider.send({
+      ...createContext(config),
+      fixture: {
+        ...createContext(config).fixture,
+        target: { id: "user-123", metadata: {} },
+      },
+      mode: "roundtrip",
+      nonce: "nonce-dm",
+      text: "hello dm",
+    });
+
+    expect(result.threadId).toBe("teams:dm:user-123");
+    expect(runtime.adapter.openDM).toHaveBeenCalledWith("user-123");
+  });
+
+  it("reports the configured webhook endpoint when its port is already in use", async () => {
+    const occupied = await occupyPort();
+    try {
+      const runtime = createFakeMsTeamsRuntime();
+      const config = await createMsTeamsConfig(occupied.port);
+      config.msteams!.webhook.publicUrl = "https://example.com/msteams/webhook";
+      const provider = new MsTeamsProviderAdapter("msteams", config, "crabline", runtime.runtime);
+      providers.push(provider);
+
+      const probe = await provider.probe(createContext(config));
+
+      expect(probe).toMatchObject({ healthy: true });
+      expect(probe.details).toContain(
+        `webhook endpoint http://127.0.0.1:${occupied.port}/msteams/webhook`,
+      );
+      expect(probe.details).toContain("public webhook https://example.com/msteams/webhook");
+    } finally {
+      await occupied.close();
+    }
+  });
+
+  it("records webhook inbound events", async () => {
+    const runtime = createFakeMsTeamsRuntime();
+    const config = await createMsTeamsConfig(0);
+    const provider = new MsTeamsProviderAdapter("msteams", config, "crabline", runtime.runtime);
+    providers.push(provider);
+
+    const probe = await provider.probe(createContext(config));
+    const endpoint = probe.details.find((detail) => detail.startsWith("webhook endpoint "));
+    expect(endpoint).toBeDefined();
+
+    const threadId = encodeTeamsThreadId(
+      "19:conversation@thread.v2",
+      "https://smba.trafficmanager.net/amer/",
+    );
+    const waitPromise = provider.waitForInbound({
+      ...createContext(config),
+      nonce: "nonce-2",
+      since: new Date(Date.now() - 1000).toISOString(),
+      threadId,
+      timeoutMs: 500,
+    });
+
+    await fetch(endpoint!.replace("webhook endpoint ", ""), {
+      body: JSON.stringify({
+        message: {
+          id: "evt-1",
+          text: "ACK nonce-2",
+          threadId,
+        },
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+
+    await expect(waitPromise).resolves.toMatchObject({
+      id: "evt-1",
+      text: "ACK nonce-2",
+    });
+  });
+});

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -100,7 +100,7 @@ describe("registry", () => {
     expect(provider.status).toBe("ready");
   });
 
-  it("resolves built-in discord, matrix, imessage, feishu, mattermost, telegram, whatsapp, and zalo providers", () => {
+  it("resolves built-in discord, matrix, imessage, feishu, googlechat, mattermost, msteams, telegram, whatsapp, and zalo providers", () => {
     const nativeManifest: ManifestDefinition = {
       ...manifest,
       providers: {
@@ -133,6 +133,26 @@ describe("registry", () => {
             recorder: { path: "/tmp/crabline-feishu-test.jsonl" },
           },
           platform: "feishu",
+          status: "active",
+        },
+        googlechat: {
+          adapter: "googlechat",
+          capabilities: ["probe", "send", "roundtrip", "agent"],
+          env: [],
+          googlechat: {
+            credentials: {
+              client_email: "bot@example.iam.gserviceaccount.com",
+              private_key: "private-key",
+            },
+            disableSignatureVerification: true,
+            recorder: { path: "/tmp/crabline-googlechat-test.jsonl" },
+            webhook: {
+              host: "127.0.0.1",
+              path: "/googlechat/webhook",
+              port: 8792,
+            },
+          },
+          platform: "googlechat",
           status: "active",
         },
         imessage: {
@@ -174,6 +194,23 @@ describe("registry", () => {
             },
           },
           platform: "mattermost",
+          status: "active",
+        },
+        msteams: {
+          adapter: "msteams",
+          capabilities: ["probe", "send", "roundtrip", "agent"],
+          env: [],
+          msteams: {
+            appId: "teams-app",
+            appPassword: "teams-secret",
+            recorder: { path: "/tmp/crabline-msteams-test.jsonl" },
+            webhook: {
+              host: "127.0.0.1",
+              path: "/msteams/webhook",
+              port: 8791,
+            },
+          },
+          platform: "msteams",
           status: "active",
         },
         telegram: {
@@ -248,6 +285,12 @@ describe("registry", () => {
         },
         {
           ...manifest.fixtures[0]!,
+          id: "googlechat-fixture",
+          provider: "googlechat",
+          target: { id: "spaces/AAAA1234567", metadata: {} },
+        },
+        {
+          ...manifest.fixtures[0]!,
           id: "imessage-fixture",
           provider: "imessage",
           target: { id: "chat-guid", metadata: {} },
@@ -263,6 +306,15 @@ describe("registry", () => {
           id: "mattermost-fixture",
           provider: "mattermost",
           target: { id: "channel-id", metadata: {} },
+        },
+        {
+          ...manifest.fixtures[0]!,
+          id: "msteams-fixture",
+          provider: "msteams",
+          target: {
+            id: "19:conversation@thread.v2",
+            metadata: { serviceUrl: "https://smba.trafficmanager.net/amer/" },
+          },
         },
         {
           ...manifest.fixtures[0]!,
@@ -288,9 +340,11 @@ describe("registry", () => {
     const registry = createRegistry(nativeManifest, "/tmp/crabline.yaml");
     expect(registry.resolve("discord", "discord-fixture").platform).toBe("discord");
     expect(registry.resolve("feishu", "feishu-fixture").platform).toBe("feishu");
+    expect(registry.resolve("googlechat", "googlechat-fixture").platform).toBe("googlechat");
     expect(registry.resolve("imessage", "imessage-fixture").platform).toBe("imessage");
     expect(registry.resolve("matrix", "matrix-fixture").platform).toBe("matrix");
     expect(registry.resolve("mattermost", "mattermost-fixture").platform).toBe("mattermost");
+    expect(registry.resolve("msteams", "msteams-fixture").platform).toBe("msteams");
     expect(registry.resolve("telegram", "telegram-fixture").platform).toBe("telegram");
     expect(registry.resolve("whatsapp", "whatsapp-fixture").platform).toBe("whatsapp");
     expect(registry.resolve("zalo", "zalo-fixture").platform).toBe("zalo");


### PR DESCRIPTION
## Summary
- add built-in Microsoft Teams and Google Chat provider adapters backed by Chat SDK packages
- add config schemas, lazy registry factories, catalog readiness, docs, and example fixtures
- add fake-runtime provider tests for config resolution, target normalization, sends, and inbound recorder paths

## Tests
- pnpm verify