### PR TITLE
Add built-in Feishu Mattermost and Zalo providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,17 @@ The current shape is:
 
 - built-in `loopback` provider for local development and contract tests
 - built-in `discord` provider
+- built-in `feishu` provider
+- built-in `mattermost` provider
 - built-in `slack` provider
 - built-in `telegram` provider
 - built-in `whatsapp` provider
+- built-in `zalo` provider
 - adapter-backed providers for `matrix` and `imessage`
 - `script` bridge for the remaining OpenClaw messaging channels
 - webhook-backed recorder mode for Slack `watch` / `webhook`
 - interactions-webhook + gateway-backed recorder mode for Discord
-- recorder-backed watch mode for Telegram, WhatsApp, Matrix, and iMessage
+- recorder-backed watch mode for Telegram, WhatsApp, Feishu, Mattermost, Zalo, Matrix, and iMessage
 - nonce-based `send`, `roundtrip`, `agent`, `probe`, `run`, `watch`, `doctor`
 - text output by default, stable `--json` for automation
 - core provider model aligned with Vercel Chat SDK concepts
@@ -72,7 +75,7 @@ configVersion: 1
 userName: crabline
 providers:
   provider-id:
-    adapter: loopback | script | slack | discord | telegram | whatsapp | matrix | imessage
+    adapter: loopback | script | slack | discord | feishu | mattermost | telegram | whatsapp | zalo | matrix | imessage
     platform: required only when adapter is script
 fixtures:
   - id: string
@@ -106,9 +109,9 @@ For per-channel secrets, external setup, and smoke CI profile guidance, see
 
 ## Support Matrix
 
-- `ready`: `loopback`, built-in `slack`, built-in `discord`, built-in `telegram`, built-in `whatsapp`, adapter-backed `matrix`, adapter-backed `imessage`
-- `bridge`: `bluebubbles`, `feishu`, `googlechat`, `irc`, `line`, `mattermost`, `msteams`, `nextcloudtalk`, `nostr`, `signal`, `synologychat`, `tlon`, `twitch`, `webchat`, `zalo`, `zalouser`
-- Plugin-backed in OpenClaw, available through the bridge: `feishu`, `line`, `mattermost`, `msteams`, `nextcloudtalk`, `nostr`, `synologychat`, `tlon`, `twitch`, `zalo`, `zalouser`
+- `ready`: `loopback`, built-in `slack`, built-in `discord`, built-in `feishu`, built-in `mattermost`, built-in `telegram`, built-in `whatsapp`, built-in `zalo`, adapter-backed `matrix`, adapter-backed `imessage`
+- `bridge`: `bluebubbles`, `googlechat`, `irc`, `line`, `msteams`, `nextcloudtalk`, `nostr`, `signal`, `synologychat`, `tlon`, `twitch`, `webchat`, `zalouser`
+- Plugin-backed in OpenClaw, available through the bridge: `line`, `msteams`, `nextcloudtalk`, `nostr`, `synologychat`, `tlon`, `twitch`, `zalouser`
 - Recommended bridge-only path today: `bluebubbles`, `googlechat`, `irc`, `signal`, `webchat`
 
 Telegram notes:
@@ -161,6 +164,64 @@ providers:
 ```
 
 WhatsApp targets use Chat SDK thread ids: `whatsapp:{phoneNumberId}:{userWaId}`. Raw `target.id` values are encoded from `WHATSAPP_PHONE_NUMBER_ID` or `whatsapp.phoneNumberId`.
+
+Feishu provider options:
+
+```yaml
+providers:
+  feishu:
+    adapter: feishu
+    env:
+      - FEISHU_APP_ID
+      - FEISHU_APP_SECRET
+    feishu:
+      recorder:
+        path: ./.crabline/recorders/feishu.jsonl
+```
+
+Feishu uses the Chat SDK Lark adapter and WebSocket transport. Targets use `lark:{chatId}:{rootId}`. Raw `oc_*` chat ids are encoded automatically; raw `ou_*` user ids are treated as DM targets.
+
+Mattermost provider options:
+
+```yaml
+providers:
+  mattermost:
+    adapter: mattermost
+    env:
+      - MATTERMOST_BASE_URL
+      - MATTERMOST_BOT_TOKEN
+    mattermost:
+      recorder:
+        path: ./.crabline/recorders/mattermost.jsonl
+      webhook:
+        host: 127.0.0.1
+        port: 8793
+        path: /mattermost/webhook
+        publicUrl: https://example.ngrok.app/mattermost/webhook # optional
+```
+
+Mattermost raw channel ids are encoded as `mattermost:{base64urlChannelId}`. Thread replies use `target.channelId` plus `target.threadId`, encoded as `mattermost:{base64urlChannelId}:{base64urlRootPostId}`. User DMs can set `target.metadata.targetType: user`.
+
+Zalo provider options:
+
+```yaml
+providers:
+  zalo:
+    adapter: zalo
+    env:
+      - ZALO_BOT_TOKEN
+      - ZALO_WEBHOOK_SECRET
+    zalo:
+      recorder:
+        path: ./.crabline/recorders/zalo.jsonl
+      webhook:
+        host: 127.0.0.1
+        port: 8794
+        path: /zalo/webhook
+        publicUrl: https://example.ngrok.app/zalo/webhook # optional
+```
+
+Zalo targets use Chat SDK thread ids: `zalo:{chatId}`. Raw `target.id` values are encoded automatically.
 
 Discord provider options:
 
@@ -308,6 +369,42 @@ WHATSAPP_VERIFY_TOKEN=... \
 pnpm dev watch whatsapp-dm --config fixtures/examples/crabline.example.yaml
 ```
 
+Feishu:
+
+```bash
+FEISHU_APP_ID=... \
+FEISHU_APP_SECRET=... \
+pnpm dev probe feishu-chat --config fixtures/examples/crabline.example.yaml
+
+FEISHU_APP_ID=... \
+FEISHU_APP_SECRET=... \
+pnpm dev watch feishu-chat --config fixtures/examples/crabline.example.yaml
+```
+
+Mattermost:
+
+```bash
+MATTERMOST_BASE_URL=https://mattermost.example.com \
+MATTERMOST_BOT_TOKEN=... \
+pnpm dev probe mattermost-channel --config fixtures/examples/crabline.example.yaml
+
+MATTERMOST_BASE_URL=https://mattermost.example.com \
+MATTERMOST_BOT_TOKEN=... \
+pnpm dev watch mattermost-channel --config fixtures/examples/crabline.example.yaml
+```
+
+Zalo:
+
+```bash
+ZALO_BOT_TOKEN=... \
+ZALO_WEBHOOK_SECRET=... \
+pnpm dev probe zalo-chat --config fixtures/examples/crabline.example.yaml
+
+ZALO_BOT_TOKEN=... \
+ZALO_WEBHOOK_SECRET=... \
+pnpm dev watch zalo-chat --config fixtures/examples/crabline.example.yaml
+```
+
 Matrix:
 
 ```bash
@@ -429,6 +526,6 @@ or:
 
 ## Current scope
 
-- Real built-in providers: `loopback`, built-in `slack`, built-in `discord`, built-in `telegram`, built-in `whatsapp`, adapter-backed `matrix`, adapter-backed `imessage`
+- Real built-in providers: `loopback`, built-in `slack`, built-in `discord`, built-in `feishu`, built-in `mattermost`, built-in `telegram`, built-in `whatsapp`, built-in `zalo`, adapter-backed `matrix`, adapter-backed `imessage`
 - Real external bridge: `script` for the full OpenClaw channel matrix
 - Not implemented yet: richer recorder compaction/query tooling, live-model response generation

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -39,8 +39,9 @@ Recommended initial smoke order:
 1. `loopback`: no external dependencies.
 2. `telegram` with polling mode: easiest live messaging smoke because it does
    not require a public webhook URL.
-3. `slack`, `discord`, `matrix`, or `imessage`: depends on which shared test
-   workspace/account OpenClaw already maintains.
+3. `slack`, `discord`, `matrix`, `imessage`, `feishu`, `mattermost`, or
+   `zalo`: depends on which shared test workspace/account OpenClaw already
+   maintains.
 4. `whatsapp`: needs a Meta app, a registered WhatsApp Business phone number,
    public webhook reachability, and a live recipient inside WhatsApp's messaging
    rules.
@@ -289,6 +290,137 @@ Target notes:
 - WhatsApp Cloud API does not provide normal message history, so smoke tests
   should rely on webhook delivery and the recorder.
 
+### Feishu
+
+Backed by `@larksuite/vercel-chat-adapter`.
+
+Required secrets:
+
+- `FEISHU_APP_ID`
+- `FEISHU_APP_SECRET`
+
+Lark env aliases are also accepted:
+
+- `LARK_APP_ID`
+- `LARK_APP_SECRET`
+
+Optional env:
+
+- `FEISHU_BOT_USERNAME`
+- `LARK_BOT_USERNAME`
+
+External setup:
+
+1. Create or reuse a Feishu/Lark app with bot permissions.
+2. Store the app id and app secret in CI secrets.
+3. Enable the app's WebSocket event delivery for the bot.
+4. Add the bot to the dedicated smoke chat.
+5. Record the `oc_*` chat id, or the `ou_*` user open id for DM smoke.
+
+Provider:
+
+```yaml
+providers:
+  feishu:
+    adapter: feishu
+    env:
+      - FEISHU_APP_ID
+      - FEISHU_APP_SECRET
+```
+
+Target notes:
+
+- Encoded `lark:{chatId}:{rootId}` ids are accepted.
+- Raw `oc_*` chat ids are encoded as `lark:{chatId}:`.
+- Raw `ou_*` user ids are treated as DM targets.
+- Thread replies use `target.channelId` plus `target.threadId`.
+
+### Mattermost
+
+Backed by `chat-adapter-mattermost`.
+
+Required config or env:
+
+- `mattermost.baseUrl` or `MATTERMOST_BASE_URL`
+- `mattermost.botToken` or `MATTERMOST_BOT_TOKEN`
+
+Optional env:
+
+- `MATTERMOST_BOT_USERNAME`
+- `MATTERMOST_CALLBACK_URL`
+
+External setup:
+
+1. Create or reuse a Mattermost bot account and personal access token.
+2. Invite the bot to the dedicated smoke channel.
+3. Store the Mattermost base URL and bot token in CI secrets.
+4. For interactive action callbacks, configure a public callback URL ending in
+   `/mattermost/webhook`.
+5. Record a stable channel id or user id for the smoke fixture.
+
+Provider:
+
+```yaml
+providers:
+  mattermost:
+    adapter: mattermost
+    env:
+      - MATTERMOST_BASE_URL
+      - MATTERMOST_BOT_TOKEN
+    mattermost:
+      webhook:
+        publicUrl: https://example.ngrok.app/mattermost/webhook
+```
+
+Target notes:
+
+- Raw channel ids are encoded as `mattermost:{base64urlChannelId}`.
+- Thread replies use `target.channelId` plus `target.threadId`, encoded as
+  `mattermost:{base64urlChannelId}:{base64urlRootPostId}`.
+- User DMs use `target.metadata.targetType: user`.
+- Mattermost inbound message smoke uses the adapter WebSocket and local recorder;
+  the webhook endpoint is for interactive callbacks.
+
+### Zalo
+
+Backed by `chat-adapter-zalo` for the Zalo Bot Platform.
+
+Required secrets:
+
+- `ZALO_BOT_TOKEN`
+- `ZALO_WEBHOOK_SECRET`
+
+Optional env:
+
+- `ZALO_BOT_USERNAME`
+
+External setup:
+
+1. Create or reuse a Zalo bot.
+2. Store the bot token and webhook secret in CI secrets.
+3. Configure the Zalo webhook callback URL to the public Crabline/OpenClaw URL
+   ending in `/zalo/webhook`.
+4. Keep a dedicated private or group chat id for smoke fixtures.
+
+Provider:
+
+```yaml
+providers:
+  zalo:
+    adapter: zalo
+    env:
+      - ZALO_BOT_TOKEN
+      - ZALO_WEBHOOK_SECRET
+    zalo:
+      webhook:
+        publicUrl: https://example.ngrok.app/zalo/webhook
+```
+
+Target notes:
+
+- Raw `target.id` is encoded as `zalo:{chatId}`.
+- Zalo has no native thread concept, so channel and thread ids are the same.
+
 ### Matrix
 
 Backed by `@beeper/chat-adapter-matrix`.
@@ -418,10 +550,10 @@ It must match an OpenClaw channel id. Bridge platform ids are
 `synologychat`, `telegram`, `tlon`, `twitch`, `webchat`, `whatsapp`, `zalo`,
 and `zalouser`.
 
-Telegram and WhatsApp can also be exercised through script bridge profiles when
-the smoke goal is full OpenClaw channel routing rather than built-in
-adapter behavior. In that case, use `platform: telegram` or `platform: whatsapp`
-with the shared OpenClaw bridge secrets above.
+Telegram, WhatsApp, Feishu, Mattermost, and Zalo can also be exercised through
+script bridge profiles when the smoke goal is full OpenClaw channel routing
+rather than built-in adapter behavior. In that case, use the matching `platform`
+value with the shared OpenClaw bridge secrets above.
 
 ### OpenClaw E2E Smoke CI
 
@@ -671,6 +803,27 @@ WHATSAPP_ACCESS_TOKEN
 WHATSAPP_APP_SECRET
 WHATSAPP_PHONE_NUMBER_ID
 WHATSAPP_VERIFY_TOKEN
+```
+
+Feishu smoke adds:
+
+```text
+FEISHU_APP_ID
+FEISHU_APP_SECRET
+```
+
+Mattermost smoke adds:
+
+```text
+MATTERMOST_BASE_URL
+MATTERMOST_BOT_TOKEN
+```
+
+Zalo smoke adds:
+
+```text
+ZALO_BOT_TOKEN
+ZALO_WEBHOOK_SECRET
 ```
 
 OpenClaw bridge smoke adds:

--- a/fixtures/examples/crabline.example.yaml
+++ b/fixtures/examples/crabline.example.yaml
@@ -37,6 +37,44 @@ providers:
         path: /whatsapp/webhook
         publicUrl: https://example.ngrok.app/whatsapp/webhook
 
+  feishu:
+    adapter: feishu
+    env:
+      - FEISHU_APP_ID
+      - FEISHU_APP_SECRET
+    feishu:
+      recorder:
+        path: ./.crabline/recorders/feishu.jsonl
+
+  mattermost:
+    adapter: mattermost
+    env:
+      - MATTERMOST_BASE_URL
+      - MATTERMOST_BOT_TOKEN
+    mattermost:
+      baseUrl: https://mattermost.example.com
+      recorder:
+        path: ./.crabline/recorders/mattermost.jsonl
+      webhook:
+        host: 127.0.0.1
+        port: 8793
+        path: /mattermost/webhook
+        publicUrl: https://example.ngrok.app/mattermost/webhook
+
+  zalo:
+    adapter: zalo
+    env:
+      - ZALO_BOT_TOKEN
+      - ZALO_WEBHOOK_SECRET
+    zalo:
+      recorder:
+        path: ./.crabline/recorders/zalo.jsonl
+      webhook:
+        host: 127.0.0.1
+        port: 8794
+        path: /zalo/webhook
+        publicUrl: https://example.ngrok.app/zalo/webhook
+
   slack:
     adapter: slack
     env:
@@ -127,6 +165,36 @@ fixtures:
     mode: roundtrip
     target:
       id: "15551234567"
+    inboundMatch:
+      author: assistant
+      strategy: contains
+      nonce: contains
+
+  - id: feishu-chat
+    provider: feishu
+    mode: roundtrip
+    target:
+      id: oc_123
+    inboundMatch:
+      author: assistant
+      strategy: contains
+      nonce: contains
+
+  - id: mattermost-channel
+    provider: mattermost
+    mode: roundtrip
+    target:
+      id: channel-id
+    inboundMatch:
+      author: assistant
+      strategy: contains
+      nonce: contains
+
+  - id: zalo-chat
+    provider: zalo
+    mode: roundtrip
+    target:
+      id: chat-123
     inboundMatch:
       author: assistant
       strategy: contains

--- a/package.json
+++ b/package.json
@@ -47,15 +47,19 @@
   "devDependencies": {
     "@beeper/chat-adapter-matrix": "^0.1.0",
     "@chat-adapter/discord": "^4.30.0",
+    "@chat-adapter/shared": "^4.30.0",
     "@chat-adapter/slack": "^4.30.0",
     "@chat-adapter/state-memory": "^4.30.0",
     "@chat-adapter/telegram": "^4.30.0",
     "@chat-adapter/whatsapp": "^4.30.0",
+    "@larksuite/vercel-chat-adapter": "^0.1.2",
     "@types/node": "^25.9.2",
     "@typescript/native-preview": "7.0.0-dev.20260503.1",
     "@vitest/coverage-v8": "^4.1.8",
     "chat": "^4.30.0",
     "chat-adapter-imessage": "^0.1.1",
+    "chat-adapter-mattermost": "^1.1.3",
+    "chat-adapter-zalo": "^0.1.0",
     "oxfmt": "^0.47.0",
     "oxlint": "^1.69.0",
     "oxlint-tsgolint": "^0.22.1",
@@ -66,18 +70,25 @@
   "peerDependencies": {
     "@beeper/chat-adapter-matrix": "^0.1.0",
     "@chat-adapter/discord": "^4.30.0",
+    "@chat-adapter/shared": "^4.30.0",
     "@chat-adapter/slack": "^4.30.0",
     "@chat-adapter/state-memory": "^4.30.0",
     "@chat-adapter/telegram": "^4.30.0",
     "@chat-adapter/whatsapp": "^4.30.0",
+    "@larksuite/vercel-chat-adapter": "^0.1.2",
     "chat": "^4.30.0",
-    "chat-adapter-imessage": "^0.1.1"
+    "chat-adapter-imessage": "^0.1.1",
+    "chat-adapter-mattermost": "^1.1.3",
+    "chat-adapter-zalo": "^0.1.0"
   },
   "peerDependenciesMeta": {
     "@beeper/chat-adapter-matrix": {
       "optional": true
     },
     "@chat-adapter/discord": {
+      "optional": true
+    },
+    "@chat-adapter/shared": {
       "optional": true
     },
     "@chat-adapter/slack": {
@@ -92,7 +103,16 @@
     "@chat-adapter/whatsapp": {
       "optional": true
     },
+    "@larksuite/vercel-chat-adapter": {
+      "optional": true
+    },
     "chat": {
+      "optional": true
+    },
+    "chat-adapter-mattermost": {
+      "optional": true
+    },
+    "chat-adapter-zalo": {
       "optional": true
     },
     "chat-adapter-imessage": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@chat-adapter/discord':
         specifier: ^4.30.0
         version: 4.30.0(zod@4.4.3)
+      '@chat-adapter/shared':
+        specifier: ^4.30.0
+        version: 4.30.0(zod@4.4.3)
       '@chat-adapter/slack':
         specifier: ^4.30.0
         version: 4.30.0(zod@4.4.3)
@@ -39,6 +42,9 @@ importers:
       '@chat-adapter/whatsapp':
         specifier: ^4.30.0
         version: 4.30.0(zod@4.4.3)
+      '@larksuite/vercel-chat-adapter':
+        specifier: ^0.1.2
+        version: 0.1.2(chat@4.30.0(zod@4.4.3))(zod@4.4.3)
       '@types/node':
         specifier: ^25.9.2
         version: 25.9.2
@@ -54,6 +60,12 @@ importers:
       chat-adapter-imessage:
         specifier: ^0.1.1
         version: 0.1.1(chat@4.30.0(zod@4.4.3))(typescript@6.0.3)(zod@4.4.3)
+      chat-adapter-mattermost:
+        specifier: ^1.1.3
+        version: 1.1.3(chat@4.30.0(zod@4.4.3))(zod@4.4.3)
+      chat-adapter-zalo:
+        specifier: ^0.1.0
+        version: 0.1.0(@chat-adapter/shared@4.30.0(zod@4.4.3))(chat@4.30.0(zod@4.4.3))
       oxfmt:
         specifier: ^0.47.0
         version: 0.47.0
@@ -643,6 +655,14 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@larksuite/vercel-chat-adapter@0.1.2':
+    resolution: {integrity: sha512-SRanjyZKuzMP71+NP+c72NR97FiNCHYzOwsCYTao0Lc+oZCQ5WZy47ZPdgKnY2R89FJbIODC92RZr06EkKWngw==}
+    peerDependencies:
+      chat: ^4.26.0
+
+  '@larksuiteoapi/node-sdk@1.63.1':
+    resolution: {integrity: sha512-bVC2QVkITZ1i6kLP7hI7DXtp61ic9shP/F+bp/2qZ0ISSvrcHp2euu1xt6C29jPJVNieRgvdsBPuapOlybviVw==}
+
   '@matrix-org/matrix-sdk-crypto-wasm@18.3.1':
     resolution: {integrity: sha512-VRjWhE1UgHnPpJ3b9B5+8z71ZC/HICFngPPFIN6ktzmUBKI5RusPujzbAQUoB3CgZ0yU58L99AfSQS4YTztSWw==}
     engines: {node: '>= 18'}
@@ -943,6 +963,33 @@ packages:
   '@photon-ai/imessage-kit@2.1.2':
     resolution: {integrity: sha512-xteMkPqqWkPLv40M9gA1HJGS/fHXIWzzXNCwRfnC4+bj120KMXMacT9zOSoEcGk4MA0pGXcUMQPE16MdB+Bf/g==}
     engines: {node: '>=18.0.0'}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
   '@redis/bloom@5.12.1':
     resolution: {integrity: sha512-PUUfv+ms7jgPSBVoo/DN4AkPHj4D5TZSd6SbJX7egzBplkYUcKmHRE8RKia7UtZ8bSQbLguLvxVO+asKtQfZWA==}
@@ -1261,6 +1308,9 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  axios@1.13.6:
+    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
+
   axios@1.17.0:
     resolution: {integrity: sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==}
 
@@ -1301,6 +1351,10 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
@@ -1315,6 +1369,18 @@ packages:
     resolution: {integrity: sha512-Lq4FZqvV8QnwtD3CVUPF56L6J4aIEaOY08+uuSWBsxKKtTBH/rbJltJiiz2QRGvvWRyuBsjJ0RzXn4kiDG0LaQ==}
     peerDependencies:
       chat: ^4.14.0
+
+  chat-adapter-mattermost@1.1.3:
+    resolution: {integrity: sha512-IQk6RGb5JAdyOxR7djSSVhZoYnfY/BdpzG48Gslnna8sprbp1kpCfYWy3z1Gh9jxjwTm9Wpcj9UkajzcVQ+fhg==}
+    engines: {node: '>=20', pnpm: '>=10'}
+    peerDependencies:
+      chat: ^4.29.0
+
+  chat-adapter-zalo@0.1.0:
+    resolution: {integrity: sha512-dHjLch8L32mwIfVvcaH4qzUpiJgeWr+w3qWG2JhtC7PugDlJjM7ZrGcmvW+v9jB8vD8uW/1PqB2ealAI5I0B4w==}
+    peerDependencies:
+      '@chat-adapter/shared': '>=4.0.0'
+      chat: '>=4.0.0'
 
   chat@4.30.0:
     resolution: {integrity: sha512-8LXrauKckMmR83FcYC/R8nNEda5VJDDdIhZwUUu+hzaSbk4lqsro0IWm7rB1GGYXONRrUOG2XJlkNr4C15vgMA==}
@@ -1668,6 +1734,15 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  lodash.identity@3.0.0:
+    resolution: {integrity: sha512-AupTIzdLQxJS5wIYUQlgGyk2XRTfGXA+MCghDHqZk0pzUNYvd3EESS6dkChNauNYVIutcb0dfHw1ri9Q1yPV8Q==}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash.pickby@4.6.0:
+    resolution: {integrity: sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q==}
+
   lodash.snakecase@4.1.1:
     resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}
 
@@ -1677,6 +1752,9 @@ packages:
   loglevel@1.9.2:
     resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
     engines: {node: '>= 0.6.0'}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -1864,6 +1942,10 @@ packages:
   node-typedstream@1.4.1:
     resolution: {integrity: sha512-W9zcPlI3RRPOmwaDjwRyr7aYLoJFbvLIIHluFM3I+KZjAlbyhG4L3jSTEJlQmDqrMRQlFVTmivgJWgFlvWXx2Q==}
 
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   obug@2.1.2:
     resolution: {integrity: sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==}
     engines: {node: '>=12.20.0'}
@@ -1937,12 +2019,23 @@ packages:
     deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
+  protobufjs@7.6.4:
+    resolution: {integrity: sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==}
+    engines: {node: '>=12.0.0'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
     engines: {node: '>=10'}
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+    engines: {node: '>=0.6'}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -1995,6 +2088,22 @@ packages:
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -2678,6 +2787,33 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@larksuite/vercel-chat-adapter@0.1.2(chat@4.30.0(zod@4.4.3))(zod@4.4.3)':
+    dependencies:
+      '@chat-adapter/shared': 4.30.0(zod@4.4.3)
+      '@larksuiteoapi/node-sdk': 1.63.1
+      chat: 4.30.0(zod@4.4.3)
+    transitivePeerDependencies:
+      - ai
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+      - zod
+
+  '@larksuiteoapi/node-sdk@1.63.1':
+    dependencies:
+      axios: 1.13.6
+      lodash.identity: 3.0.0
+      lodash.merge: 4.6.2
+      lodash.pickby: 4.6.0
+      protobufjs: 7.6.4
+      qs: 6.15.2
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+
   '@matrix-org/matrix-sdk-crypto-wasm@18.3.1': {}
 
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.0)(@emnapi/runtime@1.11.0)':
@@ -2844,6 +2980,26 @@ snapshots:
       node-typedstream: 1.4.1
     optionalDependencies:
       better-sqlite3: 12.10.0
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
 
   '@redis/bloom@5.12.1(@redis/client@5.12.1)':
     dependencies:
@@ -3116,6 +3272,14 @@ snapshots:
 
   asynckit@0.4.0: {}
 
+  axios@1.13.6:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.5
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
   axios@1.17.0:
     dependencies:
       follow-redirects: 1.16.0
@@ -3172,6 +3336,11 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
   ccount@2.0.1: {}
 
   chai@6.2.2: {}
@@ -3192,6 +3361,20 @@ snapshots:
       - typescript
       - utf-8-validate
       - zod
+
+  chat-adapter-mattermost@1.1.3(chat@4.30.0(zod@4.4.3))(zod@4.4.3):
+    dependencies:
+      '@chat-adapter/shared': 4.30.0(zod@4.4.3)
+      chat: 4.30.0(zod@4.4.3)
+    transitivePeerDependencies:
+      - ai
+      - supports-color
+      - zod
+
+  chat-adapter-zalo@0.1.0(@chat-adapter/shared@4.30.0(zod@4.4.3))(chat@4.30.0(zod@4.4.3)):
+    dependencies:
+      '@chat-adapter/shared': 4.30.0(zod@4.4.3)
+      chat: 4.30.0(zod@4.4.3)
 
   chat@4.30.0(zod@4.4.3):
     dependencies:
@@ -3549,11 +3732,19 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  lodash.identity@3.0.0: {}
+
+  lodash.merge@4.6.2: {}
+
+  lodash.pickby@4.6.0: {}
+
   lodash.snakecase@4.1.1: {}
 
   lodash@4.18.1: {}
 
   loglevel@1.9.2: {}
+
+  long@5.3.2: {}
 
   longest-streak@3.1.0: {}
 
@@ -3924,6 +4115,8 @@ snapshots:
     dependencies:
       bplist-parser: 0.3.2
 
+  object-inspect@1.13.4: {}
+
   obug@2.1.2: {}
 
   oidc-client-ts@3.5.0:
@@ -4039,6 +4232,22 @@ snapshots:
       tunnel-agent: 0.6.0
     optional: true
 
+  protobufjs@7.6.4:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 25.9.2
+      long: 5.3.2
+
+  proxy-from-env@1.1.0: {}
+
   proxy-from-env@2.1.0: {}
 
   pump@3.0.4:
@@ -4046,6 +4255,10 @@ snapshots:
       end-of-stream: 1.4.5
       once: 1.4.0
     optional: true
+
+  qs@6.15.2:
+    dependencies:
+      side-channel: 1.1.1
 
   rc@1.2.8:
     dependencies:
@@ -4166,6 +4379,34 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -6,13 +6,16 @@ export const INBOUND_STRATEGIES = ["contains", "exact", "regex"] as const;
 export const INBOUND_NONCE_MODES = ["contains", "exact", "ignore"] as const;
 export const BUILTIN_ADAPTERS = [
   "discord",
+  "feishu",
   "imessage",
   "loopback",
   "matrix",
+  "mattermost",
   "script",
   "slack",
   "telegram",
   "whatsapp",
+  "zalo",
 ] as const;
 export const PROVIDER_PLATFORMS = [
   "bluebubbles",
@@ -190,6 +193,67 @@ const TelegramConfigSchema = z.object({
   }),
 });
 
+const FeishuConfigSchema = z.object({
+  appId: z.string().min(1).optional(),
+  appSecret: z.string().min(1).optional(),
+  recorder: z.object({ path: z.string().min(1).optional() }).default({}),
+  userName: z.string().min(1).optional(),
+});
+
+const MattermostRecorderSchema = z.object({
+  path: z.string().min(1).optional(),
+});
+
+const MattermostWebhookSchema = z.object({
+  host: z.string().min(1).default("127.0.0.1"),
+  path: z.string().min(1).default("/mattermost/webhook"),
+  port: z.number().int().min(0).max(65_535).default(8793),
+  publicUrl: z.string().url().optional(),
+});
+
+const MattermostWebsocketSchema = z.object({
+  enabled: z.boolean().optional(),
+  maxReconnectDelayMs: z.number().int().min(0).optional(),
+  reconnectDelayMs: z.number().int().min(0).optional(),
+});
+
+const MattermostConfigSchema = z.object({
+  baseUrl: z.string().url().optional(),
+  botToken: z.string().min(1).optional(),
+  callbackUrl: z.string().url().optional(),
+  recorder: MattermostRecorderSchema.default({}),
+  userName: z.string().min(1).optional(),
+  webhook: MattermostWebhookSchema.default({
+    host: "127.0.0.1",
+    path: "/mattermost/webhook",
+    port: 8793,
+  }),
+  websocket: MattermostWebsocketSchema.optional(),
+});
+
+const ZaloRecorderSchema = z.object({
+  path: z.string().min(1).optional(),
+});
+
+const ZaloWebhookSchema = z.object({
+  host: z.string().min(1).default("127.0.0.1"),
+  path: z.string().min(1).default("/zalo/webhook"),
+  port: z.number().int().min(0).max(65_535).default(8794),
+  publicUrl: z.string().url().optional(),
+});
+
+const ZaloConfigSchema = z.object({
+  botToken: z.string().min(1).optional(),
+  recorder: ZaloRecorderSchema.default({}),
+  userName: z.string().min(1).optional(),
+  webhook: ZaloWebhookSchema.default({
+    host: "127.0.0.1",
+    path: "/zalo/webhook",
+    port: 8794,
+  }),
+  webhookSecret: z.string().min(1).optional(),
+});
+
 const MatrixAccessTokenAuthSchema = z.object({
   accessToken: z.string().min(1),
   type: z.literal("accessToken"),
@@ -226,9 +290,11 @@ export const ProviderConfigSchema = z
     capabilities: z.array(z.enum(FIXTURE_MODES)).default(["probe", "send", "roundtrip", "agent"]),
     discord: DiscordConfigSchema.optional(),
     env: z.array(z.string().min(1)).default([]),
+    feishu: FeishuConfigSchema.optional(),
     imessage: IMessageConfigSchema.optional(),
     loopback: LoopbackConfigSchema.optional(),
     matrix: MatrixConfigSchema.optional(),
+    mattermost: MattermostConfigSchema.optional(),
     notes: z.string().optional(),
     platform: z.enum(PROVIDER_PLATFORMS).optional(),
     slack: SlackConfigSchema.optional(),
@@ -236,6 +302,7 @@ export const ProviderConfigSchema = z
     status: z.enum(["active", "disabled", "planned"]).default("active"),
     telegram: TelegramConfigSchema.optional(),
     whatsapp: WhatsAppConfigSchema.optional(),
+    zalo: ZaloConfigSchema.optional(),
   })
   .superRefine((value, ctx) => {
     const platform = value.platform ?? inferProviderPlatform(value.adapter);
@@ -280,6 +347,22 @@ export const ProviderConfigSchema = z
       });
     }
 
+    if (value.adapter === "feishu" && platform !== "feishu") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "feishu adapter must use platform=feishu",
+        path: ["platform"],
+      });
+    }
+
+    if (value.adapter === "mattermost" && platform !== "mattermost") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "mattermost adapter must use platform=mattermost",
+        path: ["platform"],
+      });
+    }
+
     if (value.adapter === "whatsapp" && platform !== "whatsapp") {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
@@ -308,6 +391,14 @@ export const ProviderConfigSchema = z
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: "imessage adapter must use platform=imessage",
+        path: ["platform"],
+      });
+    }
+
+    if (value.adapter === "zalo" && platform !== "zalo") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "zalo adapter must use platform=zalo",
         path: ["platform"],
       });
     }

--- a/src/providers/builtin/feishu.ts
+++ b/src/providers/builtin/feishu.ts
@@ -1,0 +1,372 @@
+import path from "node:path";
+import { createLarkAdapter, type LarkAdapterConfig } from "@larksuite/vercel-chat-adapter";
+import { createMemoryState } from "@chat-adapter/state-memory";
+import { Chat, type Adapter } from "chat";
+import { CrablineError, ensureErrorMessage } from "../../core/errors.js";
+import type { ProviderConfig } from "../../config/schema.js";
+import {
+  appendRecordedInbound,
+  waitForRecordedInbound,
+  watchRecordedInbound,
+} from "../recorder.js";
+import type {
+  InboundEnvelope,
+  NormalizedTarget,
+  ProbeResult,
+  ProviderAdapter,
+  ProviderContext,
+  SendContext,
+  SendResult,
+  WaitContext,
+  WatchContext,
+} from "../types.js";
+
+type FeishuThread = {
+  id: string;
+};
+
+type FeishuMessage = {
+  author: {
+    isBot: boolean;
+  };
+  id: string;
+  metadata: {
+    dateSent: Date;
+  };
+  raw?: unknown;
+  text: string;
+  threadId: string;
+};
+
+type FeishuState = {
+  subscribe(threadId: string): Promise<void>;
+};
+
+type FeishuAdapterApi = {
+  disconnect?(): Promise<void>;
+  fetchChannelInfo(channelId: string): Promise<unknown>;
+  openDM(userId: string): Promise<string>;
+  postMessage(
+    threadId: string,
+    message: string,
+  ): Promise<{
+    id: string;
+    threadId: string;
+  }>;
+};
+
+type FeishuChat = {
+  getState(): FeishuState;
+  initialize(): Promise<void>;
+  onDirectMessage(
+    handler: (thread: FeishuThread, message: FeishuMessage) => void | Promise<void>,
+  ): void;
+  onNewMention(
+    handler: (thread: FeishuThread, message: FeishuMessage) => void | Promise<void>,
+  ): void;
+  onNewMessage(
+    pattern: RegExp,
+    handler: (thread: FeishuThread, message: FeishuMessage) => void | Promise<void>,
+  ): void;
+  onSubscribedMessage(
+    handler: (thread: FeishuThread, message: FeishuMessage) => void | Promise<void>,
+  ): void;
+};
+
+type FeishuRuntime = {
+  createAdapter(config: ProviderConfig): FeishuAdapterApi;
+  createChat(adapter: FeishuAdapterApi, userName: string): FeishuChat;
+};
+
+type FeishuEnvironment = Partial<
+  Pick<
+    NodeJS.ProcessEnv,
+    | "FEISHU_APP_ID"
+    | "FEISHU_APP_SECRET"
+    | "FEISHU_BOT_USERNAME"
+    | "LARK_APP_ID"
+    | "LARK_APP_SECRET"
+    | "LARK_BOT_USERNAME"
+  >
+>;
+
+export function resolveFeishuAdapterConfig(
+  config: ProviderConfig,
+  env: FeishuEnvironment = process.env,
+): LarkAdapterConfig {
+  const feishuConfig = config.feishu;
+  const appId = feishuConfig?.appId ?? env.FEISHU_APP_ID ?? env.LARK_APP_ID;
+  const appSecret = feishuConfig?.appSecret ?? env.FEISHU_APP_SECRET ?? env.LARK_APP_SECRET;
+
+  if (!appId) {
+    throw new CrablineError("Feishu app id is required. Set feishu.appId or FEISHU_APP_ID.", {
+      kind: "config",
+    });
+  }
+
+  if (!appSecret) {
+    throw new CrablineError(
+      "Feishu app secret is required. Set feishu.appSecret or FEISHU_APP_SECRET.",
+      { kind: "config" },
+    );
+  }
+
+  return {
+    appId,
+    appSecret,
+    ...((feishuConfig?.userName ?? env.FEISHU_BOT_USERNAME ?? env.LARK_BOT_USERNAME)
+      ? { userName: feishuConfig?.userName ?? env.FEISHU_BOT_USERNAME ?? env.LARK_BOT_USERNAME! }
+      : {}),
+  };
+}
+
+const DEFAULT_RUNTIME: FeishuRuntime = {
+  createAdapter(config) {
+    return createLarkAdapter(resolveFeishuAdapterConfig(config)) as unknown as FeishuAdapterApi;
+  },
+  createChat(adapter, userName) {
+    return new Chat<{ lark: Adapter }>({
+      adapters: { lark: adapter as unknown as Adapter },
+      state: createMemoryState(),
+      userName,
+    }) as unknown as FeishuChat;
+  },
+};
+
+function isAddressInChannel(threadId: string, channelId?: string): boolean {
+  if (!channelId) {
+    return true;
+  }
+
+  return threadId === channelId || threadId.startsWith(`${channelId}:`);
+}
+
+function isFeishuEncodedId(value: string): boolean {
+  return value.startsWith("lark:");
+}
+
+function isFeishuChatId(value: string): boolean {
+  return value.startsWith("oc_");
+}
+
+function normalizeFeishuChannelId(value: string): string {
+  return isFeishuEncodedId(value) ? value : `lark:${value}:`;
+}
+
+function normalizeFeishuThreadId(channelId: string, threadId: string): string {
+  if (isFeishuEncodedId(threadId)) {
+    return threadId;
+  }
+
+  const chatId = channelId.replace(/^lark:/u, "").replace(/:$/u, "");
+  return `lark:${chatId}:${threadId}`;
+}
+
+function toRecorderPath(providerId: string, config: ProviderConfig): string {
+  const configuredPath = config.feishu?.recorder.path;
+  if (configuredPath) {
+    return path.resolve(configuredPath);
+  }
+
+  return path.resolve(".crabline", "recorders", `${providerId}.jsonl`);
+}
+
+function classifyFeishuFailure(error: unknown): CrablineError {
+  if (error instanceof CrablineError) {
+    return error;
+  }
+
+  const message = ensureErrorMessage(error);
+  if (/401|403|app id|app secret|unauthorized|forbidden|token/i.test(message)) {
+    return new CrablineError(message, { cause: error, kind: "auth" });
+  }
+
+  return new CrablineError(message, { cause: error, kind: "connectivity" });
+}
+
+export class FeishuProviderAdapter implements ProviderAdapter {
+  readonly id;
+  readonly platform = "feishu" as const;
+  readonly status = "ready" as const;
+  readonly supports = ["probe", "send", "roundtrip", "agent"] as const;
+
+  readonly #config: ProviderConfig;
+  readonly #recorderPath: string;
+  readonly #runtime: FeishuRuntime;
+  readonly #seenMessages = new Set<string>();
+  readonly #userName: string;
+  #adapter: FeishuAdapterApi | null = null;
+  #chat: FeishuChat | null = null;
+
+  constructor(
+    id: string,
+    config: ProviderConfig,
+    userName: string,
+    runtime: FeishuRuntime = DEFAULT_RUNTIME,
+  ) {
+    this.id = id;
+    this.#config = config;
+    this.#recorderPath = toRecorderPath(id, config);
+    this.#runtime = runtime;
+    this.#userName = userName;
+  }
+
+  normalizeTarget(target: ProviderContext["fixture"]["target"]): NormalizedTarget {
+    const normalized: NormalizedTarget = {
+      id: target.id,
+      metadata: target.metadata,
+    };
+
+    if (target.channelId) {
+      normalized.channelId = normalizeFeishuChannelId(target.channelId);
+    } else if (!target.threadId && (isFeishuEncodedId(target.id) || isFeishuChatId(target.id))) {
+      normalized.channelId = normalizeFeishuChannelId(target.id);
+    }
+
+    if (target.threadId) {
+      normalized.channelId ??= normalizeFeishuChannelId(target.channelId ?? target.id);
+      normalized.threadId = normalizeFeishuThreadId(normalized.channelId, target.threadId);
+    }
+
+    return normalized;
+  }
+
+  async probe(context: ProviderContext): Promise<ProbeResult> {
+    try {
+      await this.#getChat().initialize();
+      const target = this.normalizeTarget(context.fixture.target);
+      const details = [`recorder path ${this.#recorderPath}`, "websocket transport enabled"];
+
+      if (target.channelId) {
+        await this.#getAdapter().fetchChannelInfo(target.channelId);
+        details.push(`chat reachable ${target.channelId}`);
+      } else {
+        const threadId = await this.#getAdapter().openDM(target.id);
+        details.push(`dm reachable ${threadId}`);
+      }
+
+      return {
+        details,
+        healthy: true,
+      };
+    } catch (error) {
+      throw classifyFeishuFailure(error);
+    }
+  }
+
+  async send(context: SendContext): Promise<SendResult> {
+    try {
+      const chat = this.#getChat();
+      await chat.initialize();
+      const threadId = await this.#resolveThreadId(context.fixture.target);
+      await chat.getState().subscribe(threadId);
+      const sent = await this.#getAdapter().postMessage(threadId, context.text);
+      return {
+        accepted: true,
+        messageId: sent.id,
+        threadId: sent.threadId,
+      };
+    } catch (error) {
+      const kind = error instanceof CrablineError ? error.kind : "outbound";
+      throw new CrablineError(ensureErrorMessage(error), {
+        cause: error,
+        ...(kind ? { kind } : {}),
+      });
+    }
+  }
+
+  async waitForInbound(context: WaitContext): Promise<InboundEnvelope | null> {
+    try {
+      await this.#getChat().initialize();
+      const target = this.normalizeTarget(context.fixture.target);
+      const inbound = await waitForRecordedInbound({
+        filePath: this.#recorderPath,
+        matches: (event) =>
+          event.provider === this.id &&
+          isAddressInChannel(event.threadId, context.threadId ?? target.channelId),
+        since: context.since,
+        timeoutMs: context.timeoutMs,
+      });
+      return inbound ?? null;
+    } catch (error) {
+      throw classifyFeishuFailure(error);
+    }
+  }
+
+  async *watch(context: WatchContext): AsyncIterable<InboundEnvelope> {
+    const target = this.normalizeTarget(context.fixture.target);
+    await this.#getChat().initialize();
+
+    for await (const event of watchRecordedInbound({
+      filePath: this.#recorderPath,
+      matches: (entry) =>
+        entry.provider === this.id && isAddressInChannel(entry.threadId, target.channelId),
+      since: context.since,
+    })) {
+      yield event;
+    }
+  }
+
+  async cleanup(): Promise<void> {
+    await this.#adapter?.disconnect?.();
+  }
+
+  #registerInboundHandlers(): void {
+    const chat = this.#chat;
+    if (!chat) {
+      return;
+    }
+    const record = async (thread: FeishuThread, message: FeishuMessage) => {
+      const key = `${thread.id}:${message.id}`;
+      if (this.#seenMessages.has(key)) {
+        return;
+      }
+      this.#seenMessages.add(key);
+
+      await appendRecordedInbound(this.#recorderPath, {
+        author: message.author.isBot ? "assistant" : "user",
+        id: message.id,
+        provider: this.id,
+        raw: message.raw,
+        sentAt: message.metadata.dateSent.toISOString(),
+        text: message.text,
+        threadId: thread.id,
+      });
+    };
+
+    chat.onDirectMessage(record);
+    chat.onNewMention(record);
+    chat.onNewMessage(/[\s\S]+/u, record);
+    chat.onSubscribedMessage(record);
+  }
+
+  async #resolveThreadId(target: ProviderContext["fixture"]["target"]): Promise<string> {
+    const normalized = this.normalizeTarget(target);
+    if (normalized.threadId) {
+      return normalized.threadId;
+    }
+
+    if (normalized.channelId) {
+      return normalized.channelId;
+    }
+
+    return this.#getAdapter().openDM(normalized.id);
+  }
+
+  #getAdapter(): FeishuAdapterApi {
+    if (!this.#adapter) {
+      this.#adapter = this.#runtime.createAdapter(this.#config);
+    }
+
+    return this.#adapter;
+  }
+
+  #getChat(): FeishuChat {
+    if (!this.#chat) {
+      this.#chat = this.#runtime.createChat(this.#getAdapter(), this.#userName);
+      this.#registerInboundHandlers();
+    }
+
+    return this.#chat;
+  }
+}

--- a/src/providers/builtin/mattermost.ts
+++ b/src/providers/builtin/mattermost.ts
@@ -1,0 +1,455 @@
+import path from "node:path";
+import { createMattermostAdapter, type MattermostAdapterConfig } from "chat-adapter-mattermost";
+import { createMemoryState } from "@chat-adapter/state-memory";
+import { Chat, type Adapter } from "chat";
+import { CrablineError, ensureErrorMessage } from "../../core/errors.js";
+import type { ProviderConfig } from "../../config/schema.js";
+import {
+  appendRecordedInbound,
+  waitForRecordedInbound,
+  watchRecordedInbound,
+} from "../recorder.js";
+import type {
+  InboundEnvelope,
+  NormalizedTarget,
+  ProbeResult,
+  ProviderAdapter,
+  ProviderContext,
+  SendContext,
+  SendResult,
+  WaitContext,
+  WatchContext,
+} from "../types.js";
+import { startWebhookServer, type StartedWebhookServer } from "../webhook-server.js";
+
+type MattermostThread = {
+  id: string;
+};
+
+type MattermostMessage = {
+  author: {
+    isBot: boolean;
+  };
+  id: string;
+  metadata: {
+    dateSent: Date;
+  };
+  raw?: unknown;
+  text: string;
+  threadId: string;
+};
+
+type MattermostState = {
+  subscribe(threadId: string): Promise<void>;
+};
+
+type MattermostAdapterApi = {
+  disconnect?(): Promise<void>;
+  fetchChannelInfo(channelId: string): Promise<unknown>;
+  handleWebhook(request: Request): Promise<Response>;
+  openDM(userId: string): Promise<string>;
+  postMessage(
+    threadId: string,
+    message: string,
+  ): Promise<{
+    id: string;
+    threadId: string;
+  }>;
+};
+
+type MattermostChat = {
+  getState(): MattermostState;
+  initialize(): Promise<void>;
+  onDirectMessage(
+    handler: (thread: MattermostThread, message: MattermostMessage) => void | Promise<void>,
+  ): void;
+  onNewMention(
+    handler: (thread: MattermostThread, message: MattermostMessage) => void | Promise<void>,
+  ): void;
+  onNewMessage(
+    pattern: RegExp,
+    handler: (thread: MattermostThread, message: MattermostMessage) => void | Promise<void>,
+  ): void;
+  onSubscribedMessage(
+    handler: (thread: MattermostThread, message: MattermostMessage) => void | Promise<void>,
+  ): void;
+};
+
+type MattermostRuntime = {
+  createAdapter(config: ProviderConfig): MattermostAdapterApi;
+  createChat(adapter: MattermostAdapterApi, userName: string): MattermostChat;
+};
+
+type MattermostEnvironment = Partial<
+  Pick<
+    NodeJS.ProcessEnv,
+    | "MATTERMOST_BASE_URL"
+    | "MATTERMOST_BOT_TOKEN"
+    | "MATTERMOST_BOT_USERNAME"
+    | "MATTERMOST_CALLBACK_URL"
+  >
+>;
+
+export function resolveMattermostAdapterConfig(
+  config: ProviderConfig,
+  env: MattermostEnvironment = process.env,
+): MattermostAdapterConfig {
+  const mattermostConfig = config.mattermost;
+  const baseUrl = mattermostConfig?.baseUrl ?? env.MATTERMOST_BASE_URL;
+  const botToken = mattermostConfig?.botToken ?? env.MATTERMOST_BOT_TOKEN;
+
+  if (!baseUrl) {
+    throw new CrablineError(
+      "Mattermost base URL is required. Set mattermost.baseUrl or MATTERMOST_BASE_URL.",
+      { kind: "config" },
+    );
+  }
+
+  if (!botToken) {
+    throw new CrablineError(
+      "Mattermost bot token is required. Set mattermost.botToken or MATTERMOST_BOT_TOKEN.",
+      { kind: "config" },
+    );
+  }
+
+  return {
+    baseUrl,
+    botToken,
+    ...((mattermostConfig?.callbackUrl ??
+    mattermostConfig?.webhook.publicUrl ??
+    env.MATTERMOST_CALLBACK_URL)
+      ? {
+          callbackUrl:
+            mattermostConfig?.callbackUrl ??
+            mattermostConfig?.webhook.publicUrl ??
+            env.MATTERMOST_CALLBACK_URL!,
+        }
+      : {}),
+    ...((mattermostConfig?.userName ?? env.MATTERMOST_BOT_USERNAME)
+      ? { userName: mattermostConfig?.userName ?? env.MATTERMOST_BOT_USERNAME! }
+      : {}),
+    ...(mattermostConfig?.websocket
+      ? {
+          websocket: {
+            ...(mattermostConfig.websocket.enabled !== undefined
+              ? { enabled: mattermostConfig.websocket.enabled }
+              : {}),
+            ...(mattermostConfig.websocket.maxReconnectDelayMs !== undefined
+              ? { maxReconnectDelayMs: mattermostConfig.websocket.maxReconnectDelayMs }
+              : {}),
+            ...(mattermostConfig.websocket.reconnectDelayMs !== undefined
+              ? { reconnectDelayMs: mattermostConfig.websocket.reconnectDelayMs }
+              : {}),
+          },
+        }
+      : {}),
+  };
+}
+
+const DEFAULT_RUNTIME: MattermostRuntime = {
+  createAdapter(config) {
+    return createMattermostAdapter(
+      resolveMattermostAdapterConfig(config),
+    ) as unknown as MattermostAdapterApi;
+  },
+  createChat(adapter, userName) {
+    return new Chat<{ mattermost: Adapter }>({
+      adapters: { mattermost: adapter as unknown as Adapter },
+      state: createMemoryState(),
+      userName,
+    }) as unknown as MattermostChat;
+  },
+};
+
+function base64Url(value: string): string {
+  return Buffer.from(value, "utf8").toString("base64url");
+}
+
+function isAddressInChannel(threadId: string, channelId?: string): boolean {
+  if (!channelId) {
+    return true;
+  }
+
+  return threadId === channelId || threadId.startsWith(`${channelId}:`);
+}
+
+function isMattermostEncodedId(value: string): boolean {
+  return value.startsWith("mattermost:");
+}
+
+function isMattermostUserTarget(target: ProviderContext["fixture"]["target"]): boolean {
+  return target.metadata.type === "dm" || target.metadata.targetType === "user";
+}
+
+function normalizeMattermostChannelId(value: string): string {
+  return isMattermostEncodedId(value) ? value : `mattermost:${base64Url(value)}`;
+}
+
+function normalizeMattermostThreadId(channelId: string, threadId: string): string {
+  if (isMattermostEncodedId(threadId)) {
+    return threadId;
+  }
+
+  return `${channelId}:${base64Url(threadId)}`;
+}
+
+function toWebhookPath(config: ProviderConfig): string {
+  return config.mattermost?.webhook.path ?? "/mattermost/webhook";
+}
+
+function toRecorderPath(providerId: string, config: ProviderConfig): string {
+  const configuredPath = config.mattermost?.recorder.path;
+  if (configuredPath) {
+    return path.resolve(configuredPath);
+  }
+
+  return path.resolve(".crabline", "recorders", `${providerId}.jsonl`);
+}
+
+function classifyMattermostFailure(error: unknown): CrablineError {
+  if (error instanceof CrablineError) {
+    return error;
+  }
+
+  const message = ensureErrorMessage(error);
+  if (/401|403|bot token|unauthorized|forbidden|token/i.test(message)) {
+    return new CrablineError(message, { cause: error, kind: "auth" });
+  }
+
+  return new CrablineError(message, { cause: error, kind: "connectivity" });
+}
+
+export class MattermostProviderAdapter implements ProviderAdapter {
+  readonly id;
+  readonly platform = "mattermost" as const;
+  readonly status = "ready" as const;
+  readonly supports = ["probe", "send", "roundtrip", "agent"] as const;
+
+  readonly #config: ProviderConfig;
+  readonly #recorderPath: string;
+  readonly #runtime: MattermostRuntime;
+  readonly #seenMessages = new Set<string>();
+  readonly #userName: string;
+  #adapter: MattermostAdapterApi | null = null;
+  #chat: MattermostChat | null = null;
+  #server: StartedWebhookServer | null = null;
+
+  constructor(
+    id: string,
+    config: ProviderConfig,
+    userName: string,
+    runtime: MattermostRuntime = DEFAULT_RUNTIME,
+  ) {
+    this.id = id;
+    this.#config = config;
+    this.#recorderPath = toRecorderPath(id, config);
+    this.#runtime = runtime;
+    this.#userName = userName;
+  }
+
+  normalizeTarget(target: ProviderContext["fixture"]["target"]): NormalizedTarget {
+    const normalized: NormalizedTarget = {
+      id: target.id,
+      metadata: target.metadata,
+    };
+
+    if (target.channelId) {
+      normalized.channelId = normalizeMattermostChannelId(target.channelId);
+    } else if (!target.threadId && !isMattermostUserTarget(target)) {
+      normalized.channelId = normalizeMattermostChannelId(target.id);
+    }
+
+    if (target.threadId) {
+      normalized.channelId ??= normalizeMattermostChannelId(target.channelId ?? target.id);
+      normalized.threadId = normalizeMattermostThreadId(normalized.channelId, target.threadId);
+    }
+
+    return normalized;
+  }
+
+  async probe(context: ProviderContext): Promise<ProbeResult> {
+    try {
+      await this.#getChat().initialize();
+      const server = await this.#ensureWebhookServer(true);
+      const target = this.normalizeTarget(context.fixture.target);
+      const details = [
+        `recorder path ${this.#recorderPath}`,
+        "websocket transport enabled",
+        `webhook endpoint ${server.endpointUrl}`,
+      ];
+
+      if (this.#config.mattermost?.webhook.publicUrl) {
+        details.push(`public webhook ${this.#config.mattermost.webhook.publicUrl}`);
+      }
+
+      if (target.channelId) {
+        await this.#getAdapter().fetchChannelInfo(target.channelId);
+        details.push(`channel reachable ${target.channelId}`);
+      } else {
+        const threadId = await this.#getAdapter().openDM(target.id);
+        details.push(`dm reachable ${threadId}`);
+      }
+
+      return {
+        details,
+        healthy: true,
+      };
+    } catch (error) {
+      throw classifyMattermostFailure(error);
+    }
+  }
+
+  async send(context: SendContext): Promise<SendResult> {
+    try {
+      const chat = this.#getChat();
+      await chat.initialize();
+      const threadId = await this.#resolveThreadId(context.fixture.target);
+      await chat.getState().subscribe(threadId);
+      const sent = await this.#getAdapter().postMessage(threadId, context.text);
+      return {
+        accepted: true,
+        messageId: sent.id,
+        threadId: sent.threadId,
+      };
+    } catch (error) {
+      const kind = error instanceof CrablineError ? error.kind : "outbound";
+      throw new CrablineError(ensureErrorMessage(error), {
+        cause: error,
+        ...(kind ? { kind } : {}),
+      });
+    }
+  }
+
+  async waitForInbound(context: WaitContext): Promise<InboundEnvelope | null> {
+    try {
+      await this.#getChat().initialize();
+      await this.#ensureWebhookServer(true);
+      const target = this.normalizeTarget(context.fixture.target);
+      const inbound = await waitForRecordedInbound({
+        filePath: this.#recorderPath,
+        matches: (event) =>
+          event.provider === this.id &&
+          isAddressInChannel(event.threadId, context.threadId ?? target.channelId),
+        since: context.since,
+        timeoutMs: context.timeoutMs,
+      });
+      return inbound ?? null;
+    } catch (error) {
+      throw classifyMattermostFailure(error);
+    }
+  }
+
+  async *watch(context: WatchContext): AsyncIterable<InboundEnvelope> {
+    const target = this.normalizeTarget(context.fixture.target);
+    await this.#getChat().initialize();
+    await this.#ensureWebhookServer(false);
+
+    for await (const event of watchRecordedInbound({
+      filePath: this.#recorderPath,
+      matches: (entry) =>
+        entry.provider === this.id && isAddressInChannel(entry.threadId, target.channelId),
+      since: context.since,
+    })) {
+      yield event;
+    }
+  }
+
+  async cleanup(): Promise<void> {
+    await this.#adapter?.disconnect?.();
+
+    if (!this.#server) {
+      return;
+    }
+
+    await this.#server.close();
+    this.#server = null;
+  }
+
+  #registerInboundHandlers(): void {
+    const chat = this.#chat;
+    if (!chat) {
+      return;
+    }
+    const record = async (thread: MattermostThread, message: MattermostMessage) => {
+      const key = `${thread.id}:${message.id}`;
+      if (this.#seenMessages.has(key)) {
+        return;
+      }
+      this.#seenMessages.add(key);
+
+      await appendRecordedInbound(this.#recorderPath, {
+        author: message.author.isBot ? "assistant" : "user",
+        id: message.id,
+        provider: this.id,
+        raw: message.raw,
+        sentAt: message.metadata.dateSent.toISOString(),
+        text: message.text,
+        threadId: thread.id,
+      });
+    };
+
+    chat.onDirectMessage(record);
+    chat.onNewMention(record);
+    chat.onNewMessage(/[\s\S]+/u, record);
+    chat.onSubscribedMessage(record);
+  }
+
+  async #ensureWebhookServer(allowExisting: boolean): Promise<StartedWebhookServer> {
+    if (this.#server) {
+      return this.#server;
+    }
+
+    try {
+      this.#server = await startWebhookServer({
+        handle: (request) => this.#getAdapter().handleWebhook(request),
+        host: this.#config.mattermost?.webhook.host ?? "127.0.0.1",
+        path: toWebhookPath(this.#config),
+        port: this.#config.mattermost?.webhook.port ?? 8793,
+      });
+      return this.#server;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (allowExisting && code === "EADDRINUSE") {
+        return {
+          async close() {},
+          endpointUrl: `http://${this.#config.mattermost?.webhook.host ?? "127.0.0.1"}:${this.#config.mattermost?.webhook.port ?? 8793}${toWebhookPath(this.#config)}`,
+        };
+      }
+
+      throw new CrablineError(`Mattermost webhook server failed: ${ensureErrorMessage(error)}`, {
+        cause: error,
+        kind: "connectivity",
+      });
+    }
+  }
+
+  async #resolveThreadId(target: ProviderContext["fixture"]["target"]): Promise<string> {
+    const normalized = this.normalizeTarget(target);
+    if (normalized.threadId) {
+      return normalized.threadId;
+    }
+
+    if (normalized.channelId) {
+      return normalized.channelId;
+    }
+
+    return this.#getAdapter().openDM(normalized.id);
+  }
+
+  #getAdapter(): MattermostAdapterApi {
+    if (!this.#adapter) {
+      this.#adapter = this.#runtime.createAdapter(this.#config);
+    }
+
+    return this.#adapter;
+  }
+
+  #getChat(): MattermostChat {
+    if (!this.#chat) {
+      this.#chat = this.#runtime.createChat(this.#getAdapter(), this.#userName);
+      this.#registerInboundHandlers();
+    }
+
+    return this.#chat;
+  }
+}

--- a/src/providers/builtin/zalo.ts
+++ b/src/providers/builtin/zalo.ts
@@ -1,0 +1,378 @@
+import path from "node:path";
+import { createZaloAdapter } from "chat-adapter-zalo";
+import { createMemoryState } from "@chat-adapter/state-memory";
+import { Chat, type Adapter } from "chat";
+import { CrablineError, ensureErrorMessage } from "../../core/errors.js";
+import type { ProviderConfig } from "../../config/schema.js";
+import {
+  appendRecordedInbound,
+  waitForRecordedInbound,
+  watchRecordedInbound,
+} from "../recorder.js";
+import type {
+  InboundEnvelope,
+  NormalizedTarget,
+  ProbeResult,
+  ProviderAdapter,
+  ProviderContext,
+  SendContext,
+  SendResult,
+  WaitContext,
+  WatchContext,
+} from "../types.js";
+import { startWebhookServer, type StartedWebhookServer } from "../webhook-server.js";
+
+type ZaloThread = {
+  id: string;
+};
+
+type ZaloMessage = {
+  author: {
+    isBot: boolean;
+  };
+  id: string;
+  metadata: {
+    dateSent: Date;
+  };
+  raw?: unknown;
+  text: string;
+  threadId: string;
+};
+
+type ZaloState = {
+  subscribe(threadId: string): Promise<void>;
+};
+
+type ZaloAdapterApi = {
+  fetchThread(threadId: string): Promise<unknown>;
+  handleWebhook(request: Request): Promise<Response>;
+  openDM(userId: string): Promise<string>;
+  postMessage(
+    threadId: string,
+    message: string,
+  ): Promise<{
+    id: string;
+    threadId: string;
+  }>;
+};
+
+type ZaloChat = {
+  getState(): ZaloState;
+  initialize(): Promise<void>;
+  onDirectMessage(
+    handler: (thread: ZaloThread, message: ZaloMessage) => void | Promise<void>,
+  ): void;
+  onNewMention(handler: (thread: ZaloThread, message: ZaloMessage) => void | Promise<void>): void;
+  onNewMessage(
+    pattern: RegExp,
+    handler: (thread: ZaloThread, message: ZaloMessage) => void | Promise<void>,
+  ): void;
+  onSubscribedMessage(
+    handler: (thread: ZaloThread, message: ZaloMessage) => void | Promise<void>,
+  ): void;
+};
+
+type ZaloRuntime = {
+  createAdapter(config: ProviderConfig): ZaloAdapterApi;
+  createChat(adapter: ZaloAdapterApi, userName: string): ZaloChat;
+};
+
+type ZaloEnvironment = Partial<
+  Pick<NodeJS.ProcessEnv, "ZALO_BOT_TOKEN" | "ZALO_BOT_USERNAME" | "ZALO_WEBHOOK_SECRET">
+>;
+
+export function resolveZaloAdapterConfig(
+  config: ProviderConfig,
+  env: ZaloEnvironment = process.env,
+) {
+  const zaloConfig = config.zalo;
+  const botToken = zaloConfig?.botToken ?? env.ZALO_BOT_TOKEN;
+  const webhookSecret = zaloConfig?.webhookSecret ?? env.ZALO_WEBHOOK_SECRET;
+
+  if (!botToken) {
+    throw new CrablineError("Zalo bot token is required. Set zalo.botToken or ZALO_BOT_TOKEN.", {
+      kind: "config",
+    });
+  }
+
+  if (!webhookSecret) {
+    throw new CrablineError(
+      "Zalo webhook secret is required. Set zalo.webhookSecret or ZALO_WEBHOOK_SECRET.",
+      { kind: "config" },
+    );
+  }
+
+  return {
+    botToken,
+    webhookSecret,
+    ...((zaloConfig?.userName ?? env.ZALO_BOT_USERNAME)
+      ? { userName: zaloConfig?.userName ?? env.ZALO_BOT_USERNAME! }
+      : {}),
+  };
+}
+
+const DEFAULT_RUNTIME: ZaloRuntime = {
+  createAdapter(config) {
+    return createZaloAdapter(resolveZaloAdapterConfig(config)) as unknown as ZaloAdapterApi;
+  },
+  createChat(adapter, userName) {
+    return new Chat<{ zalo: Adapter }>({
+      adapters: { zalo: adapter as unknown as Adapter },
+      state: createMemoryState(),
+      userName,
+    }) as unknown as ZaloChat;
+  },
+};
+
+function isAddressInChannel(threadId: string, channelId?: string): boolean {
+  if (!channelId) {
+    return true;
+  }
+
+  return threadId === channelId || threadId.startsWith(`${channelId}:`);
+}
+
+function isZaloEncodedId(value: string): boolean {
+  return value.startsWith("zalo:");
+}
+
+function normalizeZaloThreadId(value: string): string {
+  return isZaloEncodedId(value) ? value : `zalo:${value}`;
+}
+
+function toWebhookPath(config: ProviderConfig): string {
+  return config.zalo?.webhook.path ?? "/zalo/webhook";
+}
+
+function toRecorderPath(providerId: string, config: ProviderConfig): string {
+  const configuredPath = config.zalo?.recorder.path;
+  if (configuredPath) {
+    return path.resolve(configuredPath);
+  }
+
+  return path.resolve(".crabline", "recorders", `${providerId}.jsonl`);
+}
+
+function classifyZaloFailure(error: unknown): CrablineError {
+  if (error instanceof CrablineError) {
+    return error;
+  }
+
+  const message = ensureErrorMessage(error);
+  if (/401|403|bot token|webhook secret|secret token|unauthorized|forbidden/i.test(message)) {
+    return new CrablineError(message, { cause: error, kind: "auth" });
+  }
+
+  return new CrablineError(message, { cause: error, kind: "connectivity" });
+}
+
+export class ZaloProviderAdapter implements ProviderAdapter {
+  readonly id;
+  readonly platform = "zalo" as const;
+  readonly status = "ready" as const;
+  readonly supports = ["probe", "send", "roundtrip", "agent"] as const;
+
+  readonly #config: ProviderConfig;
+  readonly #recorderPath: string;
+  readonly #runtime: ZaloRuntime;
+  readonly #seenMessages = new Set<string>();
+  readonly #userName: string;
+  #adapter: ZaloAdapterApi | null = null;
+  #chat: ZaloChat | null = null;
+  #server: StartedWebhookServer | null = null;
+
+  constructor(
+    id: string,
+    config: ProviderConfig,
+    userName: string,
+    runtime: ZaloRuntime = DEFAULT_RUNTIME,
+  ) {
+    this.id = id;
+    this.#config = config;
+    this.#recorderPath = toRecorderPath(id, config);
+    this.#runtime = runtime;
+    this.#userName = userName;
+  }
+
+  normalizeTarget(target: ProviderContext["fixture"]["target"]): NormalizedTarget {
+    const normalizedThreadId = normalizeZaloThreadId(
+      target.threadId ?? target.channelId ?? target.id,
+    );
+    return {
+      channelId: normalizedThreadId,
+      id: target.id,
+      metadata: target.metadata,
+      ...(target.threadId ? { threadId: normalizedThreadId } : {}),
+    };
+  }
+
+  async probe(context: ProviderContext): Promise<ProbeResult> {
+    try {
+      await this.#getChat().initialize();
+      const server = await this.#ensureWebhookServer(true);
+      const target = this.normalizeTarget(context.fixture.target);
+      const details = [
+        `recorder path ${this.#recorderPath}`,
+        `webhook endpoint ${server.endpointUrl}`,
+      ];
+
+      if (this.#config.zalo?.webhook.publicUrl) {
+        details.push(`public webhook ${this.#config.zalo.webhook.publicUrl}`);
+      }
+
+      await this.#getAdapter().fetchThread(target.threadId ?? target.channelId ?? target.id);
+      details.push(`chat reachable ${target.threadId ?? target.channelId ?? target.id}`);
+
+      return {
+        details,
+        healthy: true,
+      };
+    } catch (error) {
+      throw classifyZaloFailure(error);
+    }
+  }
+
+  async send(context: SendContext): Promise<SendResult> {
+    try {
+      const chat = this.#getChat();
+      await chat.initialize();
+      const threadId = this.#resolveThreadId(context.fixture.target);
+      await chat.getState().subscribe(threadId);
+      const sent = await this.#getAdapter().postMessage(threadId, context.text);
+      return {
+        accepted: true,
+        messageId: sent.id,
+        threadId: sent.threadId,
+      };
+    } catch (error) {
+      const kind = error instanceof CrablineError ? error.kind : "outbound";
+      throw new CrablineError(ensureErrorMessage(error), {
+        cause: error,
+        ...(kind ? { kind } : {}),
+      });
+    }
+  }
+
+  async waitForInbound(context: WaitContext): Promise<InboundEnvelope | null> {
+    try {
+      await this.#ensureWebhookServer(true);
+      const target = this.normalizeTarget(context.fixture.target);
+      const inbound = await waitForRecordedInbound({
+        filePath: this.#recorderPath,
+        matches: (event) =>
+          event.provider === this.id &&
+          isAddressInChannel(event.threadId, context.threadId ?? target.channelId),
+        since: context.since,
+        timeoutMs: context.timeoutMs,
+      });
+      return inbound ?? null;
+    } catch (error) {
+      throw classifyZaloFailure(error);
+    }
+  }
+
+  async *watch(context: WatchContext): AsyncIterable<InboundEnvelope> {
+    const target = this.normalizeTarget(context.fixture.target);
+    await this.#ensureWebhookServer(false);
+
+    for await (const event of watchRecordedInbound({
+      filePath: this.#recorderPath,
+      matches: (entry) =>
+        entry.provider === this.id && isAddressInChannel(entry.threadId, target.channelId),
+      since: context.since,
+    })) {
+      yield event;
+    }
+  }
+
+  async cleanup(): Promise<void> {
+    if (!this.#server) {
+      return;
+    }
+
+    await this.#server.close();
+    this.#server = null;
+  }
+
+  #registerInboundHandlers(): void {
+    const chat = this.#chat;
+    if (!chat) {
+      return;
+    }
+    const record = async (thread: ZaloThread, message: ZaloMessage) => {
+      const key = `${thread.id}:${message.id}`;
+      if (this.#seenMessages.has(key)) {
+        return;
+      }
+      this.#seenMessages.add(key);
+
+      await appendRecordedInbound(this.#recorderPath, {
+        author: message.author.isBot ? "assistant" : "user",
+        id: message.id,
+        provider: this.id,
+        raw: message.raw,
+        sentAt: message.metadata.dateSent.toISOString(),
+        text: message.text,
+        threadId: thread.id,
+      });
+    };
+
+    chat.onDirectMessage(record);
+    chat.onNewMention(record);
+    chat.onNewMessage(/[\s\S]+/u, record);
+    chat.onSubscribedMessage(record);
+  }
+
+  async #ensureWebhookServer(allowExisting: boolean): Promise<StartedWebhookServer> {
+    if (this.#server) {
+      return this.#server;
+    }
+
+    try {
+      const chat = this.#getChat();
+      await chat.initialize();
+      this.#server = await startWebhookServer({
+        handle: (request) => this.#getAdapter().handleWebhook(request),
+        host: this.#config.zalo?.webhook.host ?? "127.0.0.1",
+        path: toWebhookPath(this.#config),
+        port: this.#config.zalo?.webhook.port ?? 8794,
+      });
+      return this.#server;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (allowExisting && code === "EADDRINUSE") {
+        return {
+          async close() {},
+          endpointUrl: `http://${this.#config.zalo?.webhook.host ?? "127.0.0.1"}:${this.#config.zalo?.webhook.port ?? 8794}${toWebhookPath(this.#config)}`,
+        };
+      }
+
+      throw new CrablineError(`Zalo webhook server failed: ${ensureErrorMessage(error)}`, {
+        cause: error,
+        kind: "connectivity",
+      });
+    }
+  }
+
+  #resolveThreadId(target: ProviderContext["fixture"]["target"]): string {
+    const normalized = this.normalizeTarget(target);
+    return normalized.threadId ?? normalized.channelId ?? normalizeZaloThreadId(normalized.id);
+  }
+
+  #getAdapter(): ZaloAdapterApi {
+    if (!this.#adapter) {
+      this.#adapter = this.#runtime.createAdapter(this.#config);
+    }
+
+    return this.#adapter;
+  }
+
+  #getChat(): ZaloChat {
+    if (!this.#chat) {
+      this.#chat = this.#runtime.createChat(this.#getAdapter(), this.#userName);
+      this.#registerInboundHandlers();
+    }
+
+    return this.#chat;
+  }
+}

--- a/src/providers/catalog.ts
+++ b/src/providers/catalog.ts
@@ -36,7 +36,12 @@ export const OPENCLAW_SUPPORT_CATALOG = [
     status: "ready",
     supports: COMMON_BRIDGE_SUPPORT,
   },
-  createBridgeEntry("feishu", "OpenClaw plugin channel via script bridge."),
+  {
+    notes: "Built-in provider for Feishu/Lark.",
+    platform: "feishu",
+    status: "ready",
+    supports: COMMON_BRIDGE_SUPPORT,
+  },
   createBridgeEntry("googlechat", "OpenClaw channel via script bridge."),
   {
     notes: "Adapter-backed provider for iMessage.",
@@ -52,7 +57,12 @@ export const OPENCLAW_SUPPORT_CATALOG = [
     status: "ready",
     supports: COMMON_BRIDGE_SUPPORT,
   },
-  createBridgeEntry("mattermost", "OpenClaw plugin channel via script bridge."),
+  {
+    notes: "Built-in provider for Mattermost.",
+    platform: "mattermost",
+    status: "ready",
+    supports: COMMON_BRIDGE_SUPPORT,
+  },
   createBridgeEntry("msteams", "OpenClaw plugin channel via script bridge."),
   createBridgeEntry("nextcloudtalk", "OpenClaw plugin channel via script bridge."),
   createBridgeEntry("nostr", "OpenClaw plugin channel via script bridge."),
@@ -79,6 +89,11 @@ export const OPENCLAW_SUPPORT_CATALOG = [
     status: "ready",
     supports: COMMON_BRIDGE_SUPPORT,
   },
-  createBridgeEntry("zalo", "OpenClaw plugin channel via script bridge."),
+  {
+    notes: "Built-in provider for Zalo Bot Platform.",
+    platform: "zalo",
+    status: "ready",
+    supports: COMMON_BRIDGE_SUPPORT,
+  },
   createBridgeEntry("zalouser", "OpenClaw plugin personal-account channel via script bridge."),
 ] as const satisfies readonly CatalogEntry[];

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -45,6 +45,10 @@ const LAZY_PROVIDER_FACTORIES = {
     const { DiscordProviderAdapter } = await import("./builtin/discord.js");
     return new DiscordProviderAdapter(providerId, config, userName);
   },
+  async feishu({ config, providerId, userName }) {
+    const { FeishuProviderAdapter } = await import("./builtin/feishu.js");
+    return new FeishuProviderAdapter(providerId, config, userName);
+  },
   async imessage({ config, providerId, userName }) {
     const { IMessageProviderAdapter } = await import("./builtin/imessage.js");
     return new IMessageProviderAdapter(providerId, config, userName);
@@ -57,6 +61,10 @@ const LAZY_PROVIDER_FACTORIES = {
     const { MatrixProviderAdapter } = await import("./builtin/matrix.js");
     return new MatrixProviderAdapter(providerId, config, userName);
   },
+  async mattermost({ config, providerId, userName }) {
+    const { MattermostProviderAdapter } = await import("./builtin/mattermost.js");
+    return new MattermostProviderAdapter(providerId, config, userName);
+  },
   async slack({ config, providerId, userName }) {
     const { SlackProviderAdapter } = await import("./builtin/slack.js");
     return new SlackProviderAdapter(providerId, config, userName);
@@ -68,6 +76,10 @@ const LAZY_PROVIDER_FACTORIES = {
   async whatsapp({ config, providerId, userName }) {
     const { WhatsAppProviderAdapter } = await import("./builtin/whatsapp.js");
     return new WhatsAppProviderAdapter(providerId, config, userName);
+  },
+  async zalo({ config, providerId, userName }) {
+    const { ZaloProviderAdapter } = await import("./builtin/zalo.js");
+    return new ZaloProviderAdapter(providerId, config, userName);
   },
 } satisfies Record<LazyAdapterId, LazyProviderFactory>;
 

--- a/test/catalog.test.ts
+++ b/test/catalog.test.ts
@@ -47,12 +47,42 @@ describe("support catalog", () => {
           ];
         }
 
+        if (entry.platform === "feishu") {
+          return [
+            entry.platform,
+            {
+              adapter: "feishu",
+              feishu: {},
+            },
+          ];
+        }
+
+        if (entry.platform === "mattermost") {
+          return [
+            entry.platform,
+            {
+              adapter: "mattermost",
+              mattermost: {},
+            },
+          ];
+        }
+
         if (entry.platform === "whatsapp") {
           return [
             entry.platform,
             {
               adapter: "whatsapp",
               whatsapp: {},
+            },
+          ];
+        }
+
+        if (entry.platform === "zalo") {
+          return [
+            entry.platform,
+            {
+              adapter: "zalo",
+              zalo: {},
             },
           ];
         }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -165,7 +165,7 @@ describe("manifest schema", () => {
     ).toThrow(/discord adapter must use platform=discord/u);
   });
 
-  it("parses built-in telegram and whatsapp provider config", () => {
+  it("parses built-in telegram, whatsapp, feishu, mattermost, and zalo provider config", () => {
     const manifest = ManifestSchema.parse({
       configVersion: 1,
       fixtures: [
@@ -181,8 +181,38 @@ describe("manifest schema", () => {
           provider: "whatsapp",
           target: { id: "15551234567" },
         },
+        {
+          id: "feishu-chat",
+          mode: "roundtrip",
+          provider: "feishu",
+          target: { id: "oc_123" },
+        },
+        {
+          id: "mattermost-channel",
+          mode: "roundtrip",
+          provider: "mattermost",
+          target: { id: "channel-id" },
+        },
+        {
+          id: "zalo-chat",
+          mode: "roundtrip",
+          provider: "zalo",
+          target: { id: "chat-123" },
+        },
       ],
       providers: {
+        feishu: {
+          adapter: "feishu",
+          feishu: {
+            appId: "feishu-app",
+          },
+        },
+        mattermost: {
+          adapter: "mattermost",
+          mattermost: {
+            baseUrl: "https://mattermost.example.com",
+          },
+        },
         telegram: {
           adapter: "telegram",
           telegram: {
@@ -195,17 +225,55 @@ describe("manifest schema", () => {
             phoneNumberId: "1234567890",
           },
         },
+        zalo: {
+          adapter: "zalo",
+          zalo: {
+            botToken: "zalo-token",
+          },
+        },
       },
     });
 
+    expect(manifest.providers["feishu"]?.feishu?.recorder).toEqual({});
+    expect(manifest.providers["feishu"]?.platform).toBe("feishu");
+    expect(manifest.providers["mattermost"]?.mattermost?.webhook.path).toBe("/mattermost/webhook");
+    expect(manifest.providers["mattermost"]?.platform).toBe("mattermost");
     expect(manifest.providers["telegram"]?.telegram?.webhook.port).toBe(8790);
     expect(manifest.providers["telegram"]?.telegram?.mode).toBe("polling");
     expect(manifest.providers["telegram"]?.platform).toBe("telegram");
     expect(manifest.providers["whatsapp"]?.whatsapp?.webhook.path).toBe("/whatsapp/webhook");
     expect(manifest.providers["whatsapp"]?.platform).toBe("whatsapp");
+    expect(manifest.providers["zalo"]?.zalo?.webhook.port).toBe(8794);
+    expect(manifest.providers["zalo"]?.platform).toBe("zalo");
   });
 
-  it("rejects built-in telegram and whatsapp adapters on the wrong platform", () => {
+  it("rejects built-in telegram, whatsapp, feishu, mattermost, and zalo adapters on the wrong platform", () => {
+    expect(() =>
+      ManifestSchema.parse({
+        configVersion: 1,
+        fixtures: [],
+        providers: {
+          feishu: {
+            adapter: "feishu",
+            platform: "zalo",
+          },
+        },
+      }),
+    ).toThrow(/feishu adapter must use platform=feishu/u);
+
+    expect(() =>
+      ManifestSchema.parse({
+        configVersion: 1,
+        fixtures: [],
+        providers: {
+          mattermost: {
+            adapter: "mattermost",
+            platform: "feishu",
+          },
+        },
+      }),
+    ).toThrow(/mattermost adapter must use platform=mattermost/u);
+
     expect(() =>
       ManifestSchema.parse({
         configVersion: 1,
@@ -231,6 +299,19 @@ describe("manifest schema", () => {
         },
       }),
     ).toThrow(/whatsapp adapter must use platform=whatsapp/u);
+
+    expect(() =>
+      ManifestSchema.parse({
+        configVersion: 1,
+        fixtures: [],
+        providers: {
+          zalo: {
+            adapter: "zalo",
+            platform: "zalouser",
+          },
+        },
+      }),
+    ).toThrow(/zalo adapter must use platform=zalo/u);
   });
 
   it("requires platform only for script providers", () => {

--- a/test/feishu-provider.test.ts
+++ b/test/feishu-provider.test.ts
@@ -1,0 +1,279 @@
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  FeishuProviderAdapter,
+  resolveFeishuAdapterConfig,
+} from "../src/providers/builtin/feishu.js";
+import type { ProviderConfig } from "../src/config/schema.js";
+import type { ProviderContext } from "../src/providers/types.js";
+import { createTempDir, disposeTempDir } from "./test-helpers.js";
+
+type FakeInboundPayload = {
+  authorIsBot?: boolean;
+  id: string;
+  text: string;
+  threadId: string;
+};
+
+type FakeMessage = {
+  author: { isBot: boolean };
+  id: string;
+  metadata: { dateSent: Date };
+  raw: Record<string, never>;
+  text: string;
+  threadId: string;
+};
+
+const directories: string[] = [];
+const providers: FeishuProviderAdapter[] = [];
+
+afterEach(async () => {
+  await Promise.all(providers.splice(0).map((provider) => provider.cleanup()));
+  await Promise.all(directories.splice(0).map(disposeTempDir));
+});
+
+async function createFeishuConfig(): Promise<ProviderConfig> {
+  const directory = await createTempDir();
+  directories.push(directory);
+
+  return {
+    adapter: "feishu",
+    capabilities: ["probe", "send", "roundtrip", "agent"],
+    env: [],
+    feishu: {
+      appId: "feishu-app",
+      appSecret: "feishu-secret",
+      recorder: { path: path.join(directory, "feishu.jsonl") },
+    },
+    platform: "feishu",
+    status: "active",
+  };
+}
+
+function createFakeFeishuRuntime() {
+  const directHandlers: Array<
+    (thread: { id: string }, message: FakeMessage) => Promise<void> | void
+  > = [];
+  const mentionHandlers: typeof directHandlers = [];
+  const messageHandlers: typeof directHandlers = [];
+  const subscribedHandlers: typeof directHandlers = [];
+  const subscriptions = new Set<string>();
+
+  const adapter = {
+    disconnect: vi.fn(async () => {}),
+    fetchChannelInfo: vi.fn(async (channelId: string) => ({ id: channelId })),
+    openDM: vi.fn(async (userId: string) => `lark:${userId}:`),
+    postMessage: vi.fn(async (threadId: string, _text: string) => ({
+      id: "feishu-sent",
+      threadId,
+    })),
+  };
+
+  const chat = {
+    getState() {
+      return {
+        subscribe: vi.fn(async (threadId: string) => {
+          subscriptions.add(threadId);
+        }),
+      };
+    },
+    initialize: vi.fn(async () => {}),
+    onDirectMessage(
+      handler: (thread: { id: string }, message: FakeMessage) => Promise<void> | void,
+    ) {
+      directHandlers.push(handler);
+    },
+    onNewMention(handler: (thread: { id: string }, message: FakeMessage) => Promise<void> | void) {
+      mentionHandlers.push(handler);
+    },
+    onNewMessage(
+      _pattern: RegExp,
+      handler: (thread: { id: string }, message: FakeMessage) => Promise<void> | void,
+    ) {
+      messageHandlers.push(handler);
+    },
+    onSubscribedMessage(
+      handler: (thread: { id: string }, message: FakeMessage) => Promise<void> | void,
+    ) {
+      subscribedHandlers.push(handler);
+    },
+  };
+
+  async function emitInbound(payload: FakeInboundPayload, kind = "subscribed") {
+    const handlersByKind = {
+      direct: directHandlers,
+      mention: mentionHandlers,
+      message: messageHandlers,
+      subscribed: subscribedHandlers,
+    } as const;
+    const message = createFakeMessage(payload);
+    const thread = { id: message.threadId };
+    for (const handler of handlersByKind[kind as keyof typeof handlersByKind]) {
+      await handler(thread, message);
+    }
+  }
+
+  return {
+    adapter,
+    chat,
+    emitInbound,
+    runtime: {
+      createAdapter: () => adapter,
+      createChat: () => chat,
+    },
+    subscriptions,
+  };
+}
+
+function createFakeMessage(payload: FakeInboundPayload): FakeMessage {
+  return {
+    author: { isBot: payload.authorIsBot ?? true },
+    id: payload.id,
+    metadata: { dateSent: new Date() },
+    raw: {},
+    text: payload.text,
+    threadId: payload.threadId,
+  };
+}
+
+function createContext(config: ProviderConfig): ProviderContext {
+  return {
+    config,
+    fixture: {
+      env: [],
+      id: "feishu-agent",
+      inboundMatch: { author: "assistant", nonce: "contains", strategy: "contains" },
+      mode: "agent",
+      provider: "feishu",
+      retries: 0,
+      tags: [],
+      target: {
+        id: "oc_123",
+        metadata: {},
+      },
+      timeoutMs: 500,
+    },
+    manifestPath: "/tmp/crabline.yaml",
+    providerId: "feishu",
+    userName: "crabline",
+  };
+}
+
+describe("feishu provider", () => {
+  it("resolves adapter config from provider settings and env", () => {
+    expect(
+      resolveFeishuAdapterConfig(
+        {
+          adapter: "feishu",
+          capabilities: ["probe", "send", "roundtrip", "agent"],
+          env: [],
+          feishu: {
+            appId: "config-app",
+            appSecret: "config-secret",
+            recorder: {},
+          },
+          platform: "feishu",
+          status: "active",
+        },
+        { FEISHU_BOT_USERNAME: "crabline_feishu" },
+      ),
+    ).toMatchObject({
+      appId: "config-app",
+      appSecret: "config-secret",
+      userName: "crabline_feishu",
+    });
+  });
+
+  it("validates required adapter config", () => {
+    const config: ProviderConfig = {
+      adapter: "feishu",
+      capabilities: ["probe", "send", "roundtrip", "agent"],
+      env: [],
+      feishu: { recorder: {} },
+      platform: "feishu",
+      status: "active",
+    };
+
+    expect(() => resolveFeishuAdapterConfig(config, {})).toThrow(/app id is required/u);
+    expect(() =>
+      resolveFeishuAdapterConfig({ ...config, feishu: { appId: "app", recorder: {} } }, {}),
+    ).toThrow(/app secret is required/u);
+  });
+
+  it("normalizes Feishu chat and thread IDs", async () => {
+    const runtime = createFakeFeishuRuntime();
+    const config = await createFeishuConfig();
+    const provider = new FeishuProviderAdapter("feishu", config, "crabline", runtime.runtime);
+    providers.push(provider);
+
+    expect(provider.normalizeTarget({ id: "oc_123", metadata: {} })).toMatchObject({
+      channelId: "lark:oc_123:",
+    });
+    expect(
+      provider.normalizeTarget({ id: "oc_123", metadata: {}, threadId: "om_root" }),
+    ).toMatchObject({
+      threadId: "lark:oc_123:om_root",
+    });
+  });
+
+  it("probes, sends, and records inbound events", async () => {
+    const runtime = createFakeFeishuRuntime();
+    const config = await createFeishuConfig();
+    const provider = new FeishuProviderAdapter("feishu", config, "crabline", runtime.runtime);
+    providers.push(provider);
+
+    const probe = await provider.probe(createContext(config));
+    expect(probe.healthy).toBe(true);
+    expect(probe.details.join("\n")).toContain("websocket transport enabled");
+
+    const result = await provider.send({
+      ...createContext(config),
+      mode: "roundtrip",
+      nonce: "nonce-1",
+      text: "hello",
+    });
+    expect(result.threadId).toBe("lark:oc_123:");
+    expect(runtime.adapter.postMessage).toHaveBeenCalledWith("lark:oc_123:", "hello");
+    expect(runtime.subscriptions.has("lark:oc_123:")).toBe(true);
+
+    const waitPromise = provider.waitForInbound({
+      ...createContext(config),
+      nonce: "nonce-2",
+      since: new Date(Date.now() - 1000).toISOString(),
+      threadId: "lark:oc_123:",
+      timeoutMs: 500,
+    });
+
+    await runtime.emitInbound({
+      id: "evt-1",
+      text: "ACK nonce-2",
+      threadId: "lark:oc_123:",
+    });
+
+    await expect(waitPromise).resolves.toMatchObject({
+      id: "evt-1",
+      text: "ACK nonce-2",
+    });
+  });
+
+  it("opens DMs when the target is a user id", async () => {
+    const runtime = createFakeFeishuRuntime();
+    const config = await createFeishuConfig();
+    const provider = new FeishuProviderAdapter("feishu", config, "crabline", runtime.runtime);
+    providers.push(provider);
+
+    const result = await provider.send({
+      ...createContext(config),
+      fixture: {
+        ...createContext(config).fixture,
+        target: { id: "ou_123", metadata: {} },
+      },
+      mode: "roundtrip",
+      nonce: "nonce-dm",
+      text: "hello dm",
+    });
+
+    expect(result.threadId).toBe("lark:ou_123:");
+    expect(runtime.adapter.openDM).toHaveBeenCalledWith("ou_123");
+  });
+});

--- a/test/mattermost-provider.test.ts
+++ b/test/mattermost-provider.test.ts
@@ -1,0 +1,333 @@
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  MattermostProviderAdapter,
+  resolveMattermostAdapterConfig,
+} from "../src/providers/builtin/mattermost.js";
+import type { ProviderConfig } from "../src/config/schema.js";
+import type { ProviderContext } from "../src/providers/types.js";
+import { createTempDir, disposeTempDir } from "./test-helpers.js";
+
+type FakeInboundPayload = {
+  authorIsBot?: boolean;
+  id: string;
+  text: string;
+  threadId: string;
+};
+
+type FakeMessage = {
+  author: { isBot: boolean };
+  id: string;
+  metadata: { dateSent: Date };
+  raw: Record<string, never>;
+  text: string;
+  threadId: string;
+};
+
+const directories: string[] = [];
+const providers: MattermostProviderAdapter[] = [];
+
+afterEach(async () => {
+  await Promise.all(providers.splice(0).map((provider) => provider.cleanup()));
+  await Promise.all(directories.splice(0).map(disposeTempDir));
+});
+
+function base64Url(value: string): string {
+  return Buffer.from(value, "utf8").toString("base64url");
+}
+
+async function createMattermostConfig(port: number): Promise<ProviderConfig> {
+  const directory = await createTempDir();
+  directories.push(directory);
+
+  return {
+    adapter: "mattermost",
+    capabilities: ["probe", "send", "roundtrip", "agent"],
+    env: [],
+    mattermost: {
+      baseUrl: "https://mattermost.example.com",
+      botToken: "mattermost-token",
+      recorder: { path: path.join(directory, "mattermost.jsonl") },
+      webhook: {
+        host: "127.0.0.1",
+        path: "/mattermost/webhook",
+        port,
+      },
+    },
+    platform: "mattermost",
+    status: "active",
+  };
+}
+
+function createFakeMattermostRuntime() {
+  const directHandlers: Array<
+    (thread: { id: string }, message: FakeMessage) => Promise<void> | void
+  > = [];
+  const mentionHandlers: typeof directHandlers = [];
+  const messageHandlers: typeof directHandlers = [];
+  const subscribedHandlers: typeof directHandlers = [];
+  const subscriptions = new Set<string>();
+
+  const adapter = {
+    disconnect: vi.fn(async () => {}),
+    fetchChannelInfo: vi.fn(async (channelId: string) => ({ id: channelId })),
+    handleWebhook: vi.fn(async (request: Request) => {
+      const payload = (await request.json()) as {
+        kind?: "direct" | "mention" | "message" | "subscribed";
+        message: FakeInboundPayload;
+      };
+      const handlersByKind = {
+        direct: directHandlers,
+        mention: mentionHandlers,
+        message: messageHandlers,
+        subscribed: subscribedHandlers,
+      } as const;
+
+      const kind = payload.kind ?? "subscribed";
+      const message = createFakeMessage(payload.message);
+      const thread = { id: message.threadId };
+      for (const handler of handlersByKind[kind]) {
+        await handler(thread, message);
+      }
+
+      return new Response("ok");
+    }),
+    openDM: vi.fn(async (userId: string) => `mattermost:dm:${userId}`),
+    postMessage: vi.fn(async (threadId: string, _text: string) => ({
+      id: "mattermost-sent",
+      threadId,
+    })),
+  };
+
+  const chat = {
+    getState() {
+      return {
+        subscribe: vi.fn(async (threadId: string) => {
+          subscriptions.add(threadId);
+        }),
+      };
+    },
+    initialize: vi.fn(async () => {}),
+    onDirectMessage(
+      handler: (thread: { id: string }, message: FakeMessage) => Promise<void> | void,
+    ) {
+      directHandlers.push(handler);
+    },
+    onNewMention(handler: (thread: { id: string }, message: FakeMessage) => Promise<void> | void) {
+      mentionHandlers.push(handler);
+    },
+    onNewMessage(
+      _pattern: RegExp,
+      handler: (thread: { id: string }, message: FakeMessage) => Promise<void> | void,
+    ) {
+      messageHandlers.push(handler);
+    },
+    onSubscribedMessage(
+      handler: (thread: { id: string }, message: FakeMessage) => Promise<void> | void,
+    ) {
+      subscribedHandlers.push(handler);
+    },
+  };
+
+  return {
+    adapter,
+    chat,
+    runtime: {
+      createAdapter: () => adapter,
+      createChat: () => chat,
+    },
+    subscriptions,
+  };
+}
+
+function createFakeMessage(payload: FakeInboundPayload): FakeMessage {
+  return {
+    author: { isBot: payload.authorIsBot ?? true },
+    id: payload.id,
+    metadata: { dateSent: new Date() },
+    raw: {},
+    text: payload.text,
+    threadId: payload.threadId,
+  };
+}
+
+function createContext(config: ProviderConfig): ProviderContext {
+  return {
+    config,
+    fixture: {
+      env: [],
+      id: "mattermost-agent",
+      inboundMatch: { author: "assistant", nonce: "contains", strategy: "contains" },
+      mode: "agent",
+      provider: "mattermost",
+      retries: 0,
+      tags: [],
+      target: {
+        id: "channel-id",
+        metadata: {},
+      },
+      timeoutMs: 500,
+    },
+    manifestPath: "/tmp/crabline.yaml",
+    providerId: "mattermost",
+    userName: "crabline",
+  };
+}
+
+describe("mattermost provider", () => {
+  it("resolves adapter config from provider settings and webhook public URL", () => {
+    expect(
+      resolveMattermostAdapterConfig(
+        {
+          adapter: "mattermost",
+          capabilities: ["probe", "send", "roundtrip", "agent"],
+          env: [],
+          mattermost: {
+            baseUrl: "https://mattermost.example.com",
+            botToken: "config-token",
+            recorder: {},
+            userName: "crabline_mm",
+            webhook: {
+              host: "127.0.0.1",
+              path: "/mattermost/webhook",
+              port: 8793,
+              publicUrl: "https://example.com/mattermost/webhook",
+            },
+            websocket: { enabled: false },
+          },
+          platform: "mattermost",
+          status: "active",
+        },
+        {},
+      ),
+    ).toMatchObject({
+      baseUrl: "https://mattermost.example.com",
+      botToken: "config-token",
+      callbackUrl: "https://example.com/mattermost/webhook",
+      userName: "crabline_mm",
+      websocket: { enabled: false },
+    });
+  });
+
+  it("validates required adapter config", () => {
+    const config: ProviderConfig = {
+      adapter: "mattermost",
+      capabilities: ["probe", "send", "roundtrip", "agent"],
+      env: [],
+      mattermost: {
+        recorder: {},
+        webhook: { host: "127.0.0.1", path: "/mattermost/webhook", port: 8793 },
+      },
+      platform: "mattermost",
+      status: "active",
+    };
+
+    expect(() => resolveMattermostAdapterConfig(config, {})).toThrow(/base URL is required/u);
+    expect(() =>
+      resolveMattermostAdapterConfig(
+        { ...config, mattermost: { ...config.mattermost!, baseUrl: "https://example.com" } },
+        {},
+      ),
+    ).toThrow(/bot token is required/u);
+  });
+
+  it("normalizes raw Mattermost IDs into Chat SDK thread IDs", async () => {
+    const runtime = createFakeMattermostRuntime();
+    const config = await createMattermostConfig(0);
+    const provider = new MattermostProviderAdapter(
+      "mattermost",
+      config,
+      "crabline",
+      runtime.runtime,
+    );
+    providers.push(provider);
+
+    expect(provider.normalizeTarget({ id: "channel-id", metadata: {} })).toMatchObject({
+      channelId: `mattermost:${base64Url("channel-id")}`,
+    });
+    expect(
+      provider.normalizeTarget({ id: "channel-id", metadata: {}, threadId: "root-post" }),
+    ).toMatchObject({
+      threadId: `mattermost:${base64Url("channel-id")}:${base64Url("root-post")}`,
+    });
+  });
+
+  it("probes, sends, and records webhook inbound events", async () => {
+    const runtime = createFakeMattermostRuntime();
+    const config = await createMattermostConfig(0);
+    const provider = new MattermostProviderAdapter(
+      "mattermost",
+      config,
+      "crabline",
+      runtime.runtime,
+    );
+    providers.push(provider);
+
+    const probe = await provider.probe(createContext(config));
+    expect(probe.healthy).toBe(true);
+    expect(probe.details.join("\n")).toContain("webhook endpoint http://127.0.0.1:");
+
+    const threadId = `mattermost:${base64Url("channel-id")}`;
+    const result = await provider.send({
+      ...createContext(config),
+      mode: "roundtrip",
+      nonce: "nonce-1",
+      text: "hello",
+    });
+    expect(result.threadId).toBe(threadId);
+    expect(runtime.adapter.postMessage).toHaveBeenCalledWith(threadId, "hello");
+    expect(runtime.subscriptions.has(threadId)).toBe(true);
+
+    const endpoint = probe.details.find((detail) => detail.startsWith("webhook endpoint "));
+    const waitPromise = provider.waitForInbound({
+      ...createContext(config),
+      nonce: "nonce-2",
+      since: new Date(Date.now() - 1000).toISOString(),
+      threadId,
+      timeoutMs: 500,
+    });
+
+    await fetch(endpoint!.replace("webhook endpoint ", ""), {
+      body: JSON.stringify({
+        message: {
+          id: "evt-1",
+          text: "ACK nonce-2",
+          threadId,
+        },
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+
+    await expect(waitPromise).resolves.toMatchObject({
+      id: "evt-1",
+      text: "ACK nonce-2",
+    });
+  });
+
+  it("opens DMs when the target is marked as a user", async () => {
+    const runtime = createFakeMattermostRuntime();
+    const config = await createMattermostConfig(0);
+    const provider = new MattermostProviderAdapter(
+      "mattermost",
+      config,
+      "crabline",
+      runtime.runtime,
+    );
+    providers.push(provider);
+
+    const result = await provider.send({
+      ...createContext(config),
+      fixture: {
+        ...createContext(config).fixture,
+        target: { id: "user-id", metadata: { targetType: "user" } },
+      },
+      mode: "roundtrip",
+      nonce: "nonce-dm",
+      text: "hello dm",
+    });
+
+    expect(result.threadId).toBe("mattermost:dm:user-id");
+    expect(runtime.adapter.openDM).toHaveBeenCalledWith("user-id");
+  });
+});

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -100,7 +100,7 @@ describe("registry", () => {
     expect(provider.status).toBe("ready");
   });
 
-  it("resolves built-in discord, matrix, imessage, telegram, and whatsapp providers", () => {
+  it("resolves built-in discord, matrix, imessage, feishu, mattermost, telegram, whatsapp, and zalo providers", () => {
     const nativeManifest: ManifestDefinition = {
       ...manifest,
       providers: {
@@ -121,6 +121,18 @@ describe("registry", () => {
           },
           env: [],
           platform: "discord",
+          status: "active",
+        },
+        feishu: {
+          adapter: "feishu",
+          capabilities: ["probe", "send", "roundtrip", "agent"],
+          env: [],
+          feishu: {
+            appId: "feishu-app",
+            appSecret: "feishu-secret",
+            recorder: { path: "/tmp/crabline-feishu-test.jsonl" },
+          },
+          platform: "feishu",
           status: "active",
         },
         imessage: {
@@ -145,6 +157,23 @@ describe("registry", () => {
             recorder: { path: "/tmp/crabline-matrix-test.jsonl" },
           },
           platform: "matrix",
+          status: "active",
+        },
+        mattermost: {
+          adapter: "mattermost",
+          capabilities: ["probe", "send", "roundtrip", "agent"],
+          env: [],
+          mattermost: {
+            baseUrl: "https://mattermost.example.com",
+            botToken: "mattermost-token",
+            recorder: { path: "/tmp/crabline-mattermost-test.jsonl" },
+            webhook: {
+              host: "127.0.0.1",
+              path: "/mattermost/webhook",
+              port: 8793,
+            },
+          },
+          platform: "mattermost",
           status: "active",
         },
         telegram: {
@@ -183,6 +212,23 @@ describe("registry", () => {
             },
           },
         },
+        zalo: {
+          adapter: "zalo",
+          capabilities: ["probe", "send", "roundtrip", "agent"],
+          env: [],
+          platform: "zalo",
+          status: "active",
+          zalo: {
+            botToken: "zalo-token",
+            recorder: { path: "/tmp/crabline-zalo-test.jsonl" },
+            webhook: {
+              host: "127.0.0.1",
+              path: "/zalo/webhook",
+              port: 8794,
+            },
+            webhookSecret: "zalo-secret",
+          },
+        },
       },
       fixtures: [
         {
@@ -193,6 +239,12 @@ describe("registry", () => {
             id: "123456789012345678",
             metadata: { guildId: "987654321098765432" },
           },
+        },
+        {
+          ...manifest.fixtures[0]!,
+          id: "feishu-fixture",
+          provider: "feishu",
+          target: { id: "oc_123", metadata: {} },
         },
         {
           ...manifest.fixtures[0]!,
@@ -208,6 +260,12 @@ describe("registry", () => {
         },
         {
           ...manifest.fixtures[0]!,
+          id: "mattermost-fixture",
+          provider: "mattermost",
+          target: { id: "channel-id", metadata: {} },
+        },
+        {
+          ...manifest.fixtures[0]!,
           id: "telegram-fixture",
           provider: "telegram",
           target: { id: "123456789", metadata: {} },
@@ -218,14 +276,23 @@ describe("registry", () => {
           provider: "whatsapp",
           target: { id: "15551234567", metadata: {} },
         },
+        {
+          ...manifest.fixtures[0]!,
+          id: "zalo-fixture",
+          provider: "zalo",
+          target: { id: "chat-123", metadata: {} },
+        },
       ],
     };
 
     const registry = createRegistry(nativeManifest, "/tmp/crabline.yaml");
     expect(registry.resolve("discord", "discord-fixture").platform).toBe("discord");
+    expect(registry.resolve("feishu", "feishu-fixture").platform).toBe("feishu");
     expect(registry.resolve("imessage", "imessage-fixture").platform).toBe("imessage");
     expect(registry.resolve("matrix", "matrix-fixture").platform).toBe("matrix");
+    expect(registry.resolve("mattermost", "mattermost-fixture").platform).toBe("mattermost");
     expect(registry.resolve("telegram", "telegram-fixture").platform).toBe("telegram");
     expect(registry.resolve("whatsapp", "whatsapp-fixture").platform).toBe("whatsapp");
+    expect(registry.resolve("zalo", "zalo-fixture").platform).toBe("zalo");
   });
 });

--- a/test/zalo-provider.test.ts
+++ b/test/zalo-provider.test.ts
@@ -1,0 +1,277 @@
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveZaloAdapterConfig, ZaloProviderAdapter } from "../src/providers/builtin/zalo.js";
+import type { ProviderConfig } from "../src/config/schema.js";
+import type { ProviderContext } from "../src/providers/types.js";
+import { createTempDir, disposeTempDir } from "./test-helpers.js";
+
+type FakeInboundPayload = {
+  authorIsBot?: boolean;
+  id: string;
+  text: string;
+  threadId: string;
+};
+
+type FakeMessage = {
+  author: { isBot: boolean };
+  id: string;
+  metadata: { dateSent: Date };
+  raw: Record<string, never>;
+  text: string;
+  threadId: string;
+};
+
+const directories: string[] = [];
+const providers: ZaloProviderAdapter[] = [];
+
+afterEach(async () => {
+  await Promise.all(providers.splice(0).map((provider) => provider.cleanup()));
+  await Promise.all(directories.splice(0).map(disposeTempDir));
+});
+
+async function createZaloConfig(port: number): Promise<ProviderConfig> {
+  const directory = await createTempDir();
+  directories.push(directory);
+
+  return {
+    adapter: "zalo",
+    capabilities: ["probe", "send", "roundtrip", "agent"],
+    env: [],
+    platform: "zalo",
+    status: "active",
+    zalo: {
+      botToken: "zalo-token",
+      recorder: { path: path.join(directory, "zalo.jsonl") },
+      webhook: {
+        host: "127.0.0.1",
+        path: "/zalo/webhook",
+        port,
+      },
+      webhookSecret: "zalo-secret",
+    },
+  };
+}
+
+function createFakeZaloRuntime() {
+  const directHandlers: Array<
+    (thread: { id: string }, message: FakeMessage) => Promise<void> | void
+  > = [];
+  const mentionHandlers: typeof directHandlers = [];
+  const messageHandlers: typeof directHandlers = [];
+  const subscribedHandlers: typeof directHandlers = [];
+  const subscriptions = new Set<string>();
+
+  const adapter = {
+    fetchThread: vi.fn(async (threadId: string) => ({ id: threadId })),
+    handleWebhook: vi.fn(async (request: Request) => {
+      const payload = (await request.json()) as {
+        kind?: "direct" | "mention" | "message" | "subscribed";
+        message: FakeInboundPayload;
+      };
+      const handlersByKind = {
+        direct: directHandlers,
+        mention: mentionHandlers,
+        message: messageHandlers,
+        subscribed: subscribedHandlers,
+      } as const;
+
+      const kind = payload.kind ?? "subscribed";
+      const message = createFakeMessage(payload.message);
+      const thread = { id: message.threadId };
+      for (const handler of handlersByKind[kind]) {
+        await handler(thread, message);
+      }
+
+      return new Response("ok");
+    }),
+    openDM: vi.fn(async (userId: string) => `zalo:${userId}`),
+    postMessage: vi.fn(async (threadId: string, _text: string) => ({
+      id: "zalo-sent",
+      threadId,
+    })),
+  };
+
+  const chat = {
+    getState() {
+      return {
+        subscribe: vi.fn(async (threadId: string) => {
+          subscriptions.add(threadId);
+        }),
+      };
+    },
+    initialize: vi.fn(async () => {}),
+    onDirectMessage(
+      handler: (thread: { id: string }, message: FakeMessage) => Promise<void> | void,
+    ) {
+      directHandlers.push(handler);
+    },
+    onNewMention(handler: (thread: { id: string }, message: FakeMessage) => Promise<void> | void) {
+      mentionHandlers.push(handler);
+    },
+    onNewMessage(
+      _pattern: RegExp,
+      handler: (thread: { id: string }, message: FakeMessage) => Promise<void> | void,
+    ) {
+      messageHandlers.push(handler);
+    },
+    onSubscribedMessage(
+      handler: (thread: { id: string }, message: FakeMessage) => Promise<void> | void,
+    ) {
+      subscribedHandlers.push(handler);
+    },
+  };
+
+  return {
+    adapter,
+    chat,
+    runtime: {
+      createAdapter: () => adapter,
+      createChat: () => chat,
+    },
+    subscriptions,
+  };
+}
+
+function createFakeMessage(payload: FakeInboundPayload): FakeMessage {
+  return {
+    author: { isBot: payload.authorIsBot ?? true },
+    id: payload.id,
+    metadata: { dateSent: new Date() },
+    raw: {},
+    text: payload.text,
+    threadId: payload.threadId,
+  };
+}
+
+function createContext(config: ProviderConfig): ProviderContext {
+  return {
+    config,
+    fixture: {
+      env: [],
+      id: "zalo-agent",
+      inboundMatch: { author: "assistant", nonce: "contains", strategy: "contains" },
+      mode: "agent",
+      provider: "zalo",
+      retries: 0,
+      tags: [],
+      target: {
+        id: "chat-123",
+        metadata: {},
+      },
+      timeoutMs: 500,
+    },
+    manifestPath: "/tmp/crabline.yaml",
+    providerId: "zalo",
+    userName: "crabline",
+  };
+}
+
+describe("zalo provider", () => {
+  it("resolves adapter config from provider settings and env", () => {
+    expect(
+      resolveZaloAdapterConfig(
+        {
+          adapter: "zalo",
+          capabilities: ["probe", "send", "roundtrip", "agent"],
+          env: [],
+          platform: "zalo",
+          status: "active",
+          zalo: {
+            botToken: "config-token",
+            recorder: {},
+            userName: "crabline_zalo",
+            webhook: { host: "127.0.0.1", path: "/zalo/webhook", port: 8794 },
+            webhookSecret: "config-secret",
+          },
+        },
+        {},
+      ),
+    ).toMatchObject({
+      botToken: "config-token",
+      userName: "crabline_zalo",
+      webhookSecret: "config-secret",
+    });
+  });
+
+  it("validates required adapter config", () => {
+    const config: ProviderConfig = {
+      adapter: "zalo",
+      capabilities: ["probe", "send", "roundtrip", "agent"],
+      env: [],
+      platform: "zalo",
+      status: "active",
+      zalo: {
+        recorder: {},
+        webhook: { host: "127.0.0.1", path: "/zalo/webhook", port: 8794 },
+      },
+    };
+
+    expect(() => resolveZaloAdapterConfig(config, {})).toThrow(/bot token is required/u);
+    expect(() =>
+      resolveZaloAdapterConfig({ ...config, zalo: { ...config.zalo!, botToken: "token" } }, {}),
+    ).toThrow(/webhook secret is required/u);
+  });
+
+  it("normalizes raw Zalo IDs into Chat SDK thread IDs", async () => {
+    const runtime = createFakeZaloRuntime();
+    const config = await createZaloConfig(0);
+    const provider = new ZaloProviderAdapter("zalo", config, "crabline", runtime.runtime);
+    providers.push(provider);
+
+    expect(provider.normalizeTarget({ id: "chat-123", metadata: {} })).toMatchObject({
+      channelId: "zalo:chat-123",
+    });
+    expect(
+      provider.normalizeTarget({ id: "ignored", metadata: {}, threadId: "zalo:chat-456" }),
+    ).toMatchObject({
+      threadId: "zalo:chat-456",
+    });
+  });
+
+  it("probes, sends, and records webhook inbound events", async () => {
+    const runtime = createFakeZaloRuntime();
+    const config = await createZaloConfig(0);
+    const provider = new ZaloProviderAdapter("zalo", config, "crabline", runtime.runtime);
+    providers.push(provider);
+
+    const probe = await provider.probe(createContext(config));
+    expect(probe.healthy).toBe(true);
+    expect(probe.details.join("\n")).toContain("webhook endpoint http://127.0.0.1:");
+
+    const result = await provider.send({
+      ...createContext(config),
+      mode: "roundtrip",
+      nonce: "nonce-1",
+      text: "hello",
+    });
+    expect(result.threadId).toBe("zalo:chat-123");
+    expect(runtime.adapter.postMessage).toHaveBeenCalledWith("zalo:chat-123", "hello");
+    expect(runtime.subscriptions.has("zalo:chat-123")).toBe(true);
+
+    const endpoint = probe.details.find((detail) => detail.startsWith("webhook endpoint "));
+    const waitPromise = provider.waitForInbound({
+      ...createContext(config),
+      nonce: "nonce-2",
+      since: new Date(Date.now() - 1000).toISOString(),
+      threadId: "zalo:chat-123",
+      timeoutMs: 500,
+    });
+
+    await fetch(endpoint!.replace("webhook endpoint ", ""), {
+      body: JSON.stringify({
+        message: {
+          id: "evt-1",
+          text: "ACK nonce-2",
+          threadId: "zalo:chat-123",
+        },
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+
+    await expect(waitPromise).resolves.toMatchObject({
+      id: "evt-1",
+      text: "ACK nonce-2",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add built-in Feishu/Lark, Mattermost, and Zalo provider adapters backed by Chat SDK packages
- add config schemas, lazy registry factories, catalog readiness, docs, and example fixtures
- add fake-runtime provider tests for config resolution, target normalization, sends, and inbound recorder paths

## Tests
- pnpm verify