### PR TITLE
Export runtime catalog API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,18 @@
 export { resolveTelegramAdapterConfig } from "./providers/builtin/telegram.js";
 export { resolveWhatsAppAdapterConfig } from "./providers/builtin/whatsapp.js";
+export {
+  BUILTIN_ADAPTERS,
+  FIXTURE_MODES,
+  INBOUND_AUTHORS,
+  INBOUND_NONCE_MODES,
+  INBOUND_STRATEGIES,
+  ManifestSchema,
+  PROVIDER_PLATFORMS,
+  ProviderConfigSchema,
+} from "./config/schema.js";
+export { OPENCLAW_SUPPORT_CATALOG } from "./providers/catalog.js";
 export { createRegistry } from "./providers/registry.js";
+export type { CatalogEntry } from "./providers/catalog.js";
 export type { Registry } from "./providers/registry.js";
 export type {
   BuiltinAdapterId,
@@ -16,6 +28,7 @@ export type {
   ProbeResult,
   ProviderAdapter,
   ProviderContext,
+  ProviderSupportStatus,
   SendContext,
   SendResult,
   WaitContext,


### PR DESCRIPTION
## Summary
- export Crabline manifest schema and provider config schema from the package entry point
- export the support catalog and catalog/support-status types for OpenClaw QA Lab integrations

## Tests
- pnpm typecheck
- pnpm build