### PR TITLE
Make local channel mocks use native ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,71 +118,41 @@ commands for `probe`, `send`, `waitForInbound`, or `watch`.
 
 ## Target IDs
 
-Generic mock providers encode raw target ids with the platform prefix:
+Built-in providers accept native channel identifiers. Crabline does not add
+`telegram:`, `discord:`, `slack:`, or other local prefixes.
 
 ```yaml
 target:
-  id: "123"
+  id: "C1234567890"
 ```
 
-becomes:
-
-```text
-telegram:123
-```
-
-Thread targets use `target.channelId` plus `target.threadId`:
+Thread targets use the platform's native thread identifier:
 
 ```yaml
 target:
-  channelId: "room-1"
-  threadId: "thread-1"
+  channelId: "C1234567890"
+  threadId: "1700000000.000100"
 ```
 
-becomes:
+Examples:
 
-```text
-telegram:room-1:thread-1
-```
-
-Discord keeps a Discord-shaped guild/channel/thread encoding:
-
-```yaml
-target:
-  id: "123456789012345678"
-  metadata:
-    guildId: "987654321098765432"
-```
-
-becomes:
-
-```text
-discord:987654321098765432:123456789012345678
-```
-
-Telegram keeps topic-style thread IDs:
-
-```yaml
-target:
-  channelId: "-100123"
-  threadId: "42"
-```
-
-becomes:
-
-```text
-telegram:-100123:42
-```
+- Slack conversations: `C1234567890`, `G1234567890`, or `D1234567890`
+- Slack threads: `1700000000.000100`
+- Telegram chats: `-1001234567890` or `@channelusername`
+- Telegram topics: `42`
+- Discord channels and threads: Discord snowflake ids such as
+  `123456789012345678`
 
 ## Webhooks
 
 Each built-in provider starts a local webhook during `probe`, `waitForInbound`,
-or `watch`. Webhook requests must be JSON:
+or `watch`. Webhook requests can use the provider's native event shape, or this
+simple JSON shape with native thread ids:
 
 ```json
 {
-  "id": "telegram-inbound-1",
-  "threadId": "telegram:100000001",
+  "id": "slack-inbound-1",
+  "threadId": "C1234567890",
   "text": "reply nonce-123",
   "author": "assistant"
 }
@@ -193,8 +163,8 @@ Nested message payloads are also accepted:
 ```json
 {
   "message": {
-    "id": "telegram-inbound-1",
-    "threadId": "telegram:100000001",
+    "id": "slack-inbound-1",
+    "threadId": "C1234567890",
     "text": "reply nonce-123"
   }
 }

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -70,12 +70,14 @@ execution.
 
 ## Webhook Payload
 
-All mock webhooks accept the same simple JSON shape:
+Mock webhooks accept provider-native event payloads where Crabline has a built-in
+adapter for the channel. They also accept this simple JSON shape with native
+thread ids:
 
 ```json
 {
   "id": "inbound-1",
-  "threadId": "slack:C1234567890",
+  "threadId": "C1234567890",
   "text": "reply nonce-123",
   "author": "assistant"
 }
@@ -87,7 +89,7 @@ The nested form is also accepted:
 {
   "message": {
     "id": "inbound-1",
-    "threadId": "slack:C1234567890",
+    "threadId": "C1234567890",
     "text": "reply nonce-123"
   }
 }
@@ -95,27 +97,19 @@ The nested form is also accepted:
 
 Missing `threadId` or `text` returns `400`. Non-JSON requests return `415`.
 
-## Target Encoding
+## Target IDs
 
-Most local mocks encode raw targets as:
+Targets use native channel identifiers. Crabline does not add local prefixes such
+as `telegram:`, `discord:`, or `slack:`.
 
-```text
-{platform}:{target.id}
-```
-
-Thread fixtures encode as:
-
-```text
-{platform}:{channelId}:{threadId}
-```
-
-Telegram and Discord keep channel-specific target conventions for the cases QA
-already models:
-
-- Telegram topics: `telegram:{chatId}:{messageThreadId}`
-- Discord guild channels: `discord:{guildId}:{channelId}`
-- Discord threads: `discord:{guildId}:{channelId}:{threadId}`
-- Discord DMs: `discord:@me:dm-{target.id}`
+- Slack conversations: `C1234567890`, `G1234567890`, or `D1234567890`
+- Slack threads: `1700000000.000100`
+- Telegram chats: `-1001234567890` or `@channelusername`
+- Telegram topics: `42`
+- Discord channels and threads: Discord snowflake ids such as
+  `123456789012345678`
+- Google Chat spaces: `spaces/AAAABbbbCCC`
+- Google Chat threads: `spaces/AAAABbbbCCC/threads/BBBBccccDDD`
 
 ## Smoke CI Guidance
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,18 @@
 export { resolveTelegramAdapterConfig } from "./providers/builtin/telegram.js";
 export { resolveWhatsAppAdapterConfig } from "./providers/builtin/whatsapp.js";
+export {
+  BUILTIN_ADAPTERS,
+  FIXTURE_MODES,
+  INBOUND_AUTHORS,
+  INBOUND_NONCE_MODES,
+  INBOUND_STRATEGIES,
+  ManifestSchema,
+  PROVIDER_PLATFORMS,
+  ProviderConfigSchema,
+} from "./config/schema.js";
+export { OPENCLAW_SUPPORT_CATALOG } from "./providers/catalog.js";
 export { createRegistry } from "./providers/registry.js";
+export type { CatalogEntry } from "./providers/catalog.js";
 export type { Registry } from "./providers/registry.js";
 export type {
   BuiltinAdapterId,
@@ -16,6 +28,7 @@ export type {
   ProbeResult,
   ProviderAdapter,
   ProviderContext,
+  ProviderSupportStatus,
   SendContext,
   SendResult,
   WaitContext,

--- a/src/providers/builtin/discord.ts
+++ b/src/providers/builtin/discord.ts
@@ -1,8 +1,18 @@
 import path from "node:path";
 import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
-import { LocalMockProviderAdapter, type LocalMockTargetCodec } from "../local-mock.js";
-import type { NormalizedTarget, ProviderAdapter, ProviderContext } from "../types.js";
+import { LocalMockProviderAdapter } from "../local-mock.js";
+import type { ProviderAdapter } from "../types.js";
+import {
+  authorFromBotFlag,
+  createNativeTargetCodec,
+  genericMockPayloadWithNativeThread,
+  isRecord,
+  optionalRecord,
+  optionalString,
+  requireNativeInboundId,
+  type NativeIdRule,
+} from "./native-local-mock.js";
 
 type DiscordEnvironment = Partial<
   Pick<NodeJS.ProcessEnv, "DISCORD_APPLICATION_ID" | "DISCORD_BOT_TOKEN" | "DISCORD_PUBLIC_KEY">
@@ -30,30 +40,6 @@ export async function resolveDiscordAdapterConfig(
   };
 }
 
-function isDiscordEncodedId(value: string): boolean {
-  return value.startsWith("discord:");
-}
-
-function normalizeDiscordChannelId(channelId: string, guildId?: string): string {
-  if (isDiscordEncodedId(channelId)) {
-    return channelId.split(":").slice(0, 3).join(":");
-  }
-  if (!guildId) {
-    throw new CrablineError(
-      "Discord guild channels require target.metadata.guildId unless target id is already encoded as discord:guild:channel.",
-      { kind: "config" },
-    );
-  }
-  return `discord:${guildId}:${channelId}`;
-}
-
-function normalizeDiscordThreadId(channelId: string, threadId: string): string {
-  if (isDiscordEncodedId(threadId)) {
-    return threadId;
-  }
-  return `${channelId}:${threadId}`;
-}
-
 function toRecorderPath(providerId: string, config: ProviderConfig): string {
   const configuredPath = config.discord?.recorder.path;
   return configuredPath
@@ -61,51 +47,54 @@ function toRecorderPath(providerId: string, config: ProviderConfig): string {
     : path.resolve(".crabline", "recorders", `${providerId}.jsonl`);
 }
 
-const DISCORD_CODEC: LocalMockTargetCodec = {
-  normalize(target: ProviderContext["fixture"]["target"]): NormalizedTarget {
-    const normalized: NormalizedTarget = {
-      id: target.id,
-      metadata: target.metadata,
-    };
-
-    if (isDiscordEncodedId(target.id)) {
-      const parts = target.id.split(":");
-      if (parts.length >= 3) {
-        normalized.channelId = parts.slice(0, 3).join(":");
-      }
-      if (parts.length >= 4) {
-        normalized.threadId = target.id;
-      }
-    }
-
-    if (target.channelId) {
-      normalized.channelId = normalizeDiscordChannelId(target.channelId, target.metadata.guildId);
-    } else if (!target.threadId && target.metadata.guildId && !normalized.channelId) {
-      normalized.channelId = normalizeDiscordChannelId(target.id, target.metadata.guildId);
-    }
-
-    if (target.threadId) {
-      if (!normalized.channelId) {
-        normalized.channelId = target.metadata.guildId
-          ? normalizeDiscordChannelId(target.id, target.metadata.guildId)
-          : undefined;
-      }
-      if (!normalized.channelId) {
-        throw new CrablineError(
-          `Discord target "${target.id}" requires target.metadata.guildId or an encoded target.channelId for thread send.`,
-          { kind: "config" },
-        );
-      }
-      normalized.threadId = normalizeDiscordThreadId(normalized.channelId, target.threadId);
-    }
-
-    return normalized;
-  },
-  resolveThreadId(target) {
-    const normalized = this.normalize(target);
-    return normalized.threadId ?? normalized.channelId ?? `discord:@me:dm-${normalized.id}`;
-  },
+const DISCORD_SNOWFLAKE_RULE: NativeIdRule = {
+  example: "123456789012345678",
+  name: "Discord snowflake id",
+  pattern: /^\d{17,20}$/u,
 };
+
+const DISCORD_CODEC = createNativeTargetCodec({
+  channel: DISCORD_SNOWFLAKE_RULE,
+  channelLabel: "Discord channel_id",
+  thread: DISCORD_SNOWFLAKE_RULE,
+  threadLabel: "Discord thread id",
+});
+
+function normalizeDiscordWebhookPayload(payload: unknown) {
+  if (!isRecord(payload)) {
+    throw new CrablineError("Discord webhook payload must be an object", { kind: "inbound" });
+  }
+
+  if (optionalRecord(payload, "message")) {
+    return genericMockPayloadWithNativeThread({
+      channelRule: DISCORD_SNOWFLAKE_RULE,
+      payload,
+      threadRule: DISCORD_SNOWFLAKE_RULE,
+    });
+  }
+
+  const data = optionalRecord(payload, "data");
+  const author = optionalRecord(payload, "author") ?? optionalRecord(payload, "member")?.user;
+  const channelId = optionalString(payload, "channel_id");
+  const text =
+    optionalString(payload, "content") ??
+    (data ? (optionalString(data, "content") ?? optionalString(data, "name")) : undefined);
+  if (!channelId || !text) {
+    throw new CrablineError("Discord event payload requires channel_id and content", {
+      kind: "inbound",
+    });
+  }
+
+  const authorRecord = isRecord(author) ? author : undefined;
+  const threadId = optionalString(payload, "thread_id") ?? channelId;
+  return {
+    author: authorFromBotFlag(authorRecord?.bot === true),
+    ...(optionalString(payload, "id") ? { id: optionalString(payload, "id") } : {}),
+    raw: payload,
+    text,
+    threadId: requireNativeInboundId(threadId, DISCORD_SNOWFLAKE_RULE, "Discord thread_id"),
+  };
+}
 
 export class DiscordProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string) {
@@ -120,6 +109,7 @@ export class DiscordProviderAdapter extends LocalMockProviderAdapter implements 
           port: 8788,
         },
         endpointLabel: "interactions endpoint",
+        normalizeWebhookPayload: normalizeDiscordWebhookPayload,
         platform: "discord",
         publicUrl: config.discord?.webhook.publicUrl,
         recorderPath: toRecorderPath(id, config),

--- a/src/providers/builtin/feishu.ts
+++ b/src/providers/builtin/feishu.ts
@@ -1,7 +1,30 @@
 import path from "node:path";
+import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
-import { createGenericLocalMockTargetCodec, LocalMockProviderAdapter } from "../local-mock.js";
+import { LocalMockProviderAdapter } from "../local-mock.js";
 import type { ProviderAdapter } from "../types.js";
+import {
+  authorFromBotFlag,
+  createNativeTargetCodec,
+  genericMockPayloadWithNativeThread,
+  isRecord,
+  optionalRecord,
+  optionalString,
+  requireNativeInboundId,
+  type NativeIdRule,
+} from "./native-local-mock.js";
+
+const FEISHU_CHAT_ID_RULE: NativeIdRule = {
+  example: "oc_abc123",
+  name: "Feishu chat_id",
+  pattern: /^oc_[A-Za-z0-9_-]+$/u,
+};
+
+const FEISHU_MESSAGE_ID_RULE: NativeIdRule = {
+  example: "om_abc123",
+  name: "Feishu message_id",
+  pattern: /^om_[A-Za-z0-9_-]+$/u,
+};
 
 export function resolveFeishuAdapterConfig(
   config: ProviderConfig,
@@ -16,12 +39,18 @@ export function resolveFeishuAdapterConfig(
 export class FeishuProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
     super({
-      codec: createGenericLocalMockTargetCodec("feishu"),
+      codec: createNativeTargetCodec({
+        channel: FEISHU_CHAT_ID_RULE,
+        channelLabel: "Feishu chat_id",
+        thread: FEISHU_MESSAGE_ID_RULE,
+        threadLabel: "Feishu message_id",
+      }),
       config,
       id,
       options: {
         defaultWebhook: { host: "127.0.0.1", path: "/feishu/webhook", port: 8795 },
         endpointLabel: "webhook endpoint",
+        normalizeWebhookPayload: normalizeFeishuWebhookPayload,
         platform: "feishu",
         publicUrl: config.feishu?.webhook.publicUrl,
         recorderPath: config.feishu?.recorder.path
@@ -31,4 +60,57 @@ export class FeishuProviderAdapter extends LocalMockProviderAdapter implements P
       },
     });
   }
+}
+
+function normalizeFeishuWebhookPayload(payload: unknown) {
+  if (!isRecord(payload)) {
+    throw new CrablineError("Feishu webhook payload must be an object", { kind: "inbound" });
+  }
+
+  const event = optionalRecord(payload, "event");
+  const message = event ? optionalRecord(event, "message") : undefined;
+  if (!message) {
+    return genericMockPayloadWithNativeThread({
+      channelRule: FEISHU_CHAT_ID_RULE,
+      payload,
+      threadRule: FEISHU_MESSAGE_ID_RULE,
+    });
+  }
+
+  const chatId = optionalString(message, "chat_id");
+  const messageId = optionalString(message, "message_id");
+  const rawContent = optionalString(message, "content");
+  const text = parseFeishuText(rawContent);
+  if (!chatId || !text) {
+    throw new CrablineError("Feishu event payload requires message.chat_id and message.content", {
+      kind: "inbound",
+    });
+  }
+
+  return {
+    author: authorFromBotFlag(false),
+    ...(messageId
+      ? { id: requireNativeInboundId(messageId, FEISHU_MESSAGE_ID_RULE, "Feishu message_id") }
+      : {}),
+    raw: payload,
+    text,
+    threadId: messageId
+      ? requireNativeInboundId(messageId, FEISHU_MESSAGE_ID_RULE, "Feishu message_id")
+      : requireNativeInboundId(chatId, FEISHU_CHAT_ID_RULE, "Feishu chat_id"),
+  };
+}
+
+function parseFeishuText(content: string | undefined): string | undefined {
+  if (!content) {
+    return undefined;
+  }
+  try {
+    const parsed: unknown = JSON.parse(content);
+    if (isRecord(parsed) && typeof parsed.text === "string") {
+      return parsed.text;
+    }
+  } catch {
+    return content;
+  }
+  return content;
 }

--- a/src/providers/builtin/googlechat.ts
+++ b/src/providers/builtin/googlechat.ts
@@ -1,7 +1,30 @@
 import path from "node:path";
+import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
-import { createGenericLocalMockTargetCodec, LocalMockProviderAdapter } from "../local-mock.js";
+import { LocalMockProviderAdapter } from "../local-mock.js";
 import type { ProviderAdapter } from "../types.js";
+import {
+  authorFromBotFlag,
+  createNativeTargetCodec,
+  genericMockPayloadWithNativeThread,
+  isRecord,
+  optionalRecord,
+  optionalString,
+  requireNativeInboundId,
+  type NativeIdRule,
+} from "./native-local-mock.js";
+
+const GOOGLE_CHAT_SPACE_RULE: NativeIdRule = {
+  example: "spaces/AAAABbbbCCC",
+  name: "Google Chat space name",
+  pattern: /^spaces\/[A-Za-z0-9_-]+$/u,
+};
+
+const GOOGLE_CHAT_THREAD_RULE: NativeIdRule = {
+  example: "spaces/AAAABbbbCCC/threads/BBBBccccDDD",
+  name: "Google Chat thread name",
+  pattern: /^spaces\/[A-Za-z0-9_-]+\/threads\/[A-Za-z0-9_-]+$/u,
+};
 
 export function resolveGoogleChatAdapterConfig(
   config: ProviderConfig,
@@ -17,12 +40,18 @@ export function resolveGoogleChatAdapterConfig(
 export class GoogleChatProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
     super({
-      codec: createGenericLocalMockTargetCodec("googlechat"),
+      codec: createNativeTargetCodec({
+        channel: GOOGLE_CHAT_SPACE_RULE,
+        channelLabel: "Google Chat space.name",
+        thread: GOOGLE_CHAT_THREAD_RULE,
+        threadLabel: "Google Chat thread.name",
+      }),
       config,
       id,
       options: {
         defaultWebhook: { host: "127.0.0.1", path: "/googlechat/webhook", port: 8792 },
         endpointLabel: "webhook endpoint",
+        normalizeWebhookPayload: normalizeGoogleChatWebhookPayload,
         platform: "googlechat",
         publicUrl: config.googlechat?.webhook.publicUrl,
         recorderPath: config.googlechat?.recorder.path
@@ -32,4 +61,44 @@ export class GoogleChatProviderAdapter extends LocalMockProviderAdapter implemen
       },
     });
   }
+}
+
+function normalizeGoogleChatWebhookPayload(payload: unknown) {
+  if (!isRecord(payload)) {
+    throw new CrablineError("Google Chat webhook payload must be an object", {
+      kind: "inbound",
+    });
+  }
+
+  const payloadMessage = optionalRecord(payload, "message");
+  const message = payloadMessage ?? payload;
+  if (payloadMessage && optionalString(payloadMessage, "threadId")) {
+    return genericMockPayloadWithNativeThread({
+      channelRule: GOOGLE_CHAT_SPACE_RULE,
+      payload,
+      threadRule: GOOGLE_CHAT_THREAD_RULE,
+    });
+  }
+
+  const space = optionalRecord(message, "space");
+  const thread = optionalRecord(message, "thread");
+  const sender = optionalRecord(message, "sender");
+  const spaceName = space ? optionalString(space, "name") : undefined;
+  const threadName = thread ? optionalString(thread, "name") : undefined;
+  const text = optionalString(message, "text") ?? optionalString(message, "argumentText");
+  if (!spaceName || !text) {
+    throw new CrablineError("Google Chat message payload requires space.name and text", {
+      kind: "inbound",
+    });
+  }
+
+  return {
+    author: authorFromBotFlag(optionalString(sender ?? {}, "type") === "BOT"),
+    ...(optionalString(message, "name") ? { id: optionalString(message, "name") } : {}),
+    raw: payload,
+    text,
+    threadId: threadName
+      ? requireNativeInboundId(threadName, GOOGLE_CHAT_THREAD_RULE, "Google Chat thread.name")
+      : requireNativeInboundId(spaceName, GOOGLE_CHAT_SPACE_RULE, "Google Chat space.name"),
+  };
 }

--- a/src/providers/builtin/imessage.ts
+++ b/src/providers/builtin/imessage.ts
@@ -1,7 +1,25 @@
 import path from "node:path";
+import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
-import { createGenericLocalMockTargetCodec, LocalMockProviderAdapter } from "../local-mock.js";
+import { LocalMockProviderAdapter } from "../local-mock.js";
 import type { ProviderAdapter } from "../types.js";
+import {
+  authorFromBotFlag,
+  createNativeTargetCodec,
+  genericMockPayloadWithNativeThread,
+  isRecord,
+  optionalRecord,
+  optionalString,
+  requireNativeInboundId,
+  type NativeIdRule,
+} from "./native-local-mock.js";
+
+const IMESSAGE_THREAD_RULE: NativeIdRule = {
+  example: "+15551234567, user@example.com, or iMessage;-;chat-guid",
+  name: "iMessage recipient or chat GUID",
+  pattern:
+    /^(?:\+[1-9]\d{6,14}|[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}|(?:iMessage|SMS);[+-];.+)$/u,
+};
 
 export function resolveIMessageAdapterConfig(
   config: ProviderConfig,
@@ -17,12 +35,16 @@ export function resolveIMessageAdapterConfig(
 export class IMessageProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
     super({
-      codec: createGenericLocalMockTargetCodec("imessage"),
+      codec: createNativeTargetCodec({
+        channel: IMESSAGE_THREAD_RULE,
+        channelLabel: "iMessage recipient or chat GUID",
+      }),
       config,
       id,
       options: {
         defaultWebhook: { host: "127.0.0.1", path: "/imessage/webhook", port: 8796 },
         endpointLabel: "webhook endpoint",
+        normalizeWebhookPayload: normalizeIMessageWebhookPayload,
         platform: "imessage",
         publicUrl: config.imessage?.webhook.publicUrl,
         recorderPath: config.imessage?.recorder.path
@@ -32,4 +54,35 @@ export class IMessageProviderAdapter extends LocalMockProviderAdapter implements
       },
     });
   }
+}
+
+function normalizeIMessageWebhookPayload(payload: unknown) {
+  if (!isRecord(payload)) {
+    throw new CrablineError("iMessage webhook payload must be an object", { kind: "inbound" });
+  }
+
+  if (optionalRecord(payload, "message")) {
+    return genericMockPayloadWithNativeThread({
+      channelRule: IMESSAGE_THREAD_RULE,
+      payload,
+      threadRule: IMESSAGE_THREAD_RULE,
+    });
+  }
+
+  const data = optionalRecord(payload, "data") ?? payload;
+  const threadId = optionalString(data, "chatGuid") ?? optionalString(data, "chatIdentifier");
+  const text = optionalString(data, "text") ?? optionalString(data, "message");
+  if (!threadId || !text) {
+    throw new CrablineError("iMessage webhook payload requires chatGuid and text", {
+      kind: "inbound",
+    });
+  }
+
+  return {
+    author: authorFromBotFlag(data.isFromMe === true),
+    ...(optionalString(data, "guid") ? { id: optionalString(data, "guid") } : {}),
+    raw: payload,
+    text,
+    threadId: requireNativeInboundId(threadId, IMESSAGE_THREAD_RULE, "iMessage chatGuid"),
+  };
 }

--- a/src/providers/builtin/matrix.ts
+++ b/src/providers/builtin/matrix.ts
@@ -1,7 +1,30 @@
 import path from "node:path";
+import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
-import { createGenericLocalMockTargetCodec, LocalMockProviderAdapter } from "../local-mock.js";
+import { LocalMockProviderAdapter } from "../local-mock.js";
 import type { ProviderAdapter } from "../types.js";
+import {
+  authorFromBotFlag,
+  createNativeTargetCodec,
+  genericMockPayloadWithNativeThread,
+  isRecord,
+  optionalRecord,
+  optionalString,
+  requireNativeInboundId,
+  type NativeIdRule,
+} from "./native-local-mock.js";
+
+const MATRIX_ROOM_ID_RULE: NativeIdRule = {
+  example: "!abcdef:matrix.org",
+  name: "Matrix room id",
+  pattern: /^![^:\s]+:[^\s]+$/u,
+};
+
+const MATRIX_EVENT_ID_RULE: NativeIdRule = {
+  example: "$eventid:matrix.org",
+  name: "Matrix event id",
+  pattern: /^\$[^\s]+(?::[^\s]+)?$/u,
+};
 
 export function resolveMatrixAdapterConfig(
   config: ProviderConfig,
@@ -23,12 +46,18 @@ export function resolveMatrixAdapterConfig(
 export class MatrixProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
     super({
-      codec: createGenericLocalMockTargetCodec("matrix"),
+      codec: createNativeTargetCodec({
+        channel: MATRIX_ROOM_ID_RULE,
+        channelLabel: "Matrix room_id",
+        thread: MATRIX_EVENT_ID_RULE,
+        threadLabel: "Matrix event_id",
+      }),
       config,
       id,
       options: {
         defaultWebhook: { host: "127.0.0.1", path: "/matrix/webhook", port: 8797 },
         endpointLabel: "webhook endpoint",
+        normalizeWebhookPayload: normalizeMatrixWebhookPayload,
         platform: "matrix",
         publicUrl: config.matrix?.webhook.publicUrl,
         recorderPath: config.matrix?.recorder.path
@@ -38,4 +67,40 @@ export class MatrixProviderAdapter extends LocalMockProviderAdapter implements P
       },
     });
   }
+}
+
+function normalizeMatrixWebhookPayload(payload: unknown) {
+  if (!isRecord(payload)) {
+    throw new CrablineError("Matrix webhook payload must be an object", { kind: "inbound" });
+  }
+
+  if (optionalRecord(payload, "message")) {
+    return genericMockPayloadWithNativeThread({
+      channelRule: MATRIX_ROOM_ID_RULE,
+      payload,
+      threadRule: MATRIX_EVENT_ID_RULE,
+    });
+  }
+
+  const content = optionalRecord(payload, "content");
+  const roomId = optionalString(payload, "room_id");
+  const eventId = optionalString(payload, "event_id");
+  const text = content ? optionalString(content, "body") : undefined;
+  if (!roomId || !text) {
+    throw new CrablineError("Matrix event payload requires room_id and content.body", {
+      kind: "inbound",
+    });
+  }
+
+  return {
+    author: authorFromBotFlag(false),
+    ...(eventId
+      ? { id: requireNativeInboundId(eventId, MATRIX_EVENT_ID_RULE, "Matrix event_id") }
+      : {}),
+    raw: payload,
+    text,
+    threadId: eventId
+      ? requireNativeInboundId(eventId, MATRIX_EVENT_ID_RULE, "Matrix event_id")
+      : requireNativeInboundId(roomId, MATRIX_ROOM_ID_RULE, "Matrix room_id"),
+  };
 }

--- a/src/providers/builtin/mattermost.ts
+++ b/src/providers/builtin/mattermost.ts
@@ -1,7 +1,24 @@
 import path from "node:path";
+import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
-import { createGenericLocalMockTargetCodec, LocalMockProviderAdapter } from "../local-mock.js";
+import { LocalMockProviderAdapter } from "../local-mock.js";
 import type { ProviderAdapter } from "../types.js";
+import {
+  authorFromBotFlag,
+  createNativeTargetCodec,
+  genericMockPayloadWithNativeThread,
+  isRecord,
+  optionalRecord,
+  optionalString,
+  requireNativeInboundId,
+  type NativeIdRule,
+} from "./native-local-mock.js";
+
+const MATTERMOST_ID_RULE: NativeIdRule = {
+  example: "abcdefghijklmnopqrstuvwx12",
+  name: "Mattermost id",
+  pattern: /^[a-z0-9]{26}$/u,
+};
 
 export function resolveMattermostAdapterConfig(
   config: ProviderConfig,
@@ -17,12 +34,16 @@ export function resolveMattermostAdapterConfig(
 export class MattermostProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
     super({
-      codec: createGenericLocalMockTargetCodec("mattermost"),
+      codec: createNativeTargetCodec({
+        channel: MATTERMOST_ID_RULE,
+        channelLabel: "Mattermost channel_id",
+      }),
       config,
       id,
       options: {
         defaultWebhook: { host: "127.0.0.1", path: "/mattermost/webhook", port: 8793 },
         endpointLabel: "webhook endpoint",
+        normalizeWebhookPayload: normalizeMattermostWebhookPayload,
         platform: "mattermost",
         publicUrl: config.mattermost?.webhook.publicUrl,
         recorderPath: config.mattermost?.recorder.path
@@ -32,4 +53,35 @@ export class MattermostProviderAdapter extends LocalMockProviderAdapter implemen
       },
     });
   }
+}
+
+function normalizeMattermostWebhookPayload(payload: unknown) {
+  if (!isRecord(payload)) {
+    throw new CrablineError("Mattermost webhook payload must be an object", { kind: "inbound" });
+  }
+
+  if (optionalRecord(payload, "message")) {
+    return genericMockPayloadWithNativeThread({
+      channelRule: MATTERMOST_ID_RULE,
+      payload,
+      threadRule: MATTERMOST_ID_RULE,
+    });
+  }
+
+  const channelId = optionalString(payload, "channel_id");
+  const threadId = optionalString(payload, "root_id") ?? channelId;
+  const text = optionalString(payload, "text");
+  if (!channelId || !threadId || !text) {
+    throw new CrablineError("Mattermost webhook payload requires channel_id and text", {
+      kind: "inbound",
+    });
+  }
+
+  return {
+    author: authorFromBotFlag(false),
+    ...(optionalString(payload, "post_id") ? { id: optionalString(payload, "post_id") } : {}),
+    raw: payload,
+    text,
+    threadId: requireNativeInboundId(threadId, MATTERMOST_ID_RULE, "Mattermost root_id"),
+  };
 }

--- a/src/providers/builtin/msteams.ts
+++ b/src/providers/builtin/msteams.ts
@@ -1,7 +1,24 @@
 import path from "node:path";
+import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
-import { createGenericLocalMockTargetCodec, LocalMockProviderAdapter } from "../local-mock.js";
+import { LocalMockProviderAdapter } from "../local-mock.js";
 import type { ProviderAdapter } from "../types.js";
+import {
+  authorFromBotFlag,
+  createNativeTargetCodec,
+  genericMockPayloadWithNativeThread,
+  isRecord,
+  optionalRecord,
+  optionalString,
+  requireNativeInboundId,
+  type NativeIdRule,
+} from "./native-local-mock.js";
+
+const MSTEAMS_CONVERSATION_ID_RULE: NativeIdRule = {
+  example: "19:meeting_abc@thread.v2",
+  name: "Microsoft Teams conversation id",
+  pattern: /^19:[^@]+@thread\.[A-Za-z0-9.]+$/u,
+};
 
 export function resolveMsTeamsAdapterConfig(
   config: ProviderConfig,
@@ -19,12 +36,16 @@ export function resolveMsTeamsAdapterConfig(
 export class MsTeamsProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
     super({
-      codec: createGenericLocalMockTargetCodec("msteams"),
+      codec: createNativeTargetCodec({
+        channel: MSTEAMS_CONVERSATION_ID_RULE,
+        channelLabel: "Microsoft Teams conversation.id",
+      }),
       config,
       id,
       options: {
         defaultWebhook: { host: "127.0.0.1", path: "/msteams/webhook", port: 8791 },
         endpointLabel: "webhook endpoint",
+        normalizeWebhookPayload: normalizeMsTeamsWebhookPayload,
         platform: "msteams",
         publicUrl: config.msteams?.webhook.publicUrl,
         recorderPath: config.msteams?.recorder.path
@@ -34,4 +55,42 @@ export class MsTeamsProviderAdapter extends LocalMockProviderAdapter implements 
       },
     });
   }
+}
+
+function normalizeMsTeamsWebhookPayload(payload: unknown) {
+  if (!isRecord(payload)) {
+    throw new CrablineError("Microsoft Teams webhook payload must be an object", {
+      kind: "inbound",
+    });
+  }
+
+  if (optionalRecord(payload, "message")) {
+    return genericMockPayloadWithNativeThread({
+      channelRule: MSTEAMS_CONVERSATION_ID_RULE,
+      payload,
+      threadRule: MSTEAMS_CONVERSATION_ID_RULE,
+    });
+  }
+
+  const conversation = optionalRecord(payload, "conversation");
+  const from = optionalRecord(payload, "from");
+  const conversationId = conversation ? optionalString(conversation, "id") : undefined;
+  const text = optionalString(payload, "text");
+  if (!conversationId || !text) {
+    throw new CrablineError("Microsoft Teams activity payload requires conversation.id and text", {
+      kind: "inbound",
+    });
+  }
+
+  return {
+    author: authorFromBotFlag(optionalString(from ?? {}, "role") === "bot"),
+    ...(optionalString(payload, "id") ? { id: optionalString(payload, "id") } : {}),
+    raw: payload,
+    text,
+    threadId: requireNativeInboundId(
+      conversationId,
+      MSTEAMS_CONVERSATION_ID_RULE,
+      "Microsoft Teams conversation.id",
+    ),
+  };
 }

--- a/src/providers/builtin/native-local-mock.ts
+++ b/src/providers/builtin/native-local-mock.ts
@@ -1,0 +1,164 @@
+import { CrablineError } from "../../core/errors.js";
+import type { LocalMockTargetCodec } from "../local-mock.js";
+import type { InboundEnvelope, NormalizedTarget, ProviderContext } from "../types.js";
+
+export type NativeIdRule = {
+  example: string;
+  name: string;
+  pattern: RegExp;
+};
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+export function optionalRecord(
+  value: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> | undefined {
+  const child = value[key];
+  return isRecord(child) ? child : undefined;
+}
+
+export function optionalString(value: Record<string, unknown>, key: string): string | undefined {
+  const child = value[key];
+  return typeof child === "string" && child.length > 0 ? child : undefined;
+}
+
+export function optionalNumberString(
+  value: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const child = value[key];
+  return typeof child === "number" || typeof child === "bigint" ? child.toString() : undefined;
+}
+
+export function optionalStringish(value: Record<string, unknown>, key: string): string | undefined {
+  return optionalString(value, key) ?? optionalNumberString(value, key);
+}
+
+export function normalizeAuthor(value: unknown): "assistant" | "system" | "user" | undefined {
+  return value === "assistant" || value === "system" || value === "user" ? value : undefined;
+}
+
+export function requireNativeId(value: string, rule: NativeIdRule, label: string): string {
+  if (!rule.pattern.test(value)) {
+    throw new CrablineError(`${label} must be a native ${rule.name} such as ${rule.example}.`, {
+      kind: "config",
+    });
+  }
+  return value;
+}
+
+export function requireNativeInboundId(value: string, rule: NativeIdRule, label: string): string {
+  if (!rule.pattern.test(value)) {
+    throw new CrablineError(`${label} must be a native ${rule.name} such as ${rule.example}.`, {
+      kind: "inbound",
+    });
+  }
+  return value;
+}
+
+export function createNativeTargetCodec(options: {
+  channel: NativeIdRule;
+  channelLabel?: string | undefined;
+  thread?: NativeIdRule | undefined;
+  threadLabel?: string | undefined;
+}): LocalMockTargetCodec {
+  const channelLabel = options.channelLabel ?? "channelId";
+  const threadLabel = options.threadLabel ?? "threadId";
+  const threadRule = options.thread ?? options.channel;
+
+  return {
+    normalize(target: ProviderContext["fixture"]["target"]): NormalizedTarget {
+      const channelId = requireNativeId(
+        target.channelId ?? target.id,
+        options.channel,
+        channelLabel,
+      );
+      const normalized: NormalizedTarget = {
+        channelId,
+        id: target.id,
+        metadata: target.metadata,
+      };
+      if (target.threadId) {
+        normalized.threadId = requireNativeId(target.threadId, threadRule, threadLabel);
+      }
+      return normalized;
+    },
+    resolveThreadId(target) {
+      const normalized = this.normalize(target);
+      return normalized.threadId ?? normalized.channelId ?? normalized.id;
+    },
+  };
+}
+
+export function genericMockPayloadWithNativeThread(params: {
+  channelRule?: NativeIdRule | undefined;
+  payload: Record<string, unknown>;
+  threadRule: NativeIdRule;
+}) {
+  const message = optionalRecord(params.payload, "message");
+  const threadId = message
+    ? optionalString(message, "threadId")
+    : optionalString(params.payload, "threadId");
+  if (!threadId) {
+    return {
+      ...(normalizeAuthor(params.payload.author)
+        ? { author: normalizeAuthor(params.payload.author) }
+        : {}),
+      ...(typeof params.payload.authorIsBot === "boolean"
+        ? { authorIsBot: params.payload.authorIsBot }
+        : {}),
+      ...(optionalString(params.payload, "id") ? { id: optionalString(params.payload, "id") } : {}),
+      raw: params.payload.raw ?? params.payload,
+      ...(optionalString(params.payload, "text")
+        ? { text: optionalString(params.payload, "text") }
+        : {}),
+    };
+  }
+
+  const isValidThread = params.threadRule.pattern.test(threadId);
+  const isValidChannel = params.channelRule?.pattern.test(threadId) ?? false;
+  if (!isValidThread && !isValidChannel) {
+    throw new CrablineError(
+      `mock webhook threadId must be a native ${params.threadRule.name}${
+        params.channelRule ? ` or ${params.channelRule.name}` : ""
+      }.`,
+      { kind: "inbound" },
+    );
+  }
+
+  return {
+    ...(normalizeAuthor(params.payload.author)
+      ? { author: normalizeAuthor(params.payload.author) }
+      : {}),
+    ...(typeof params.payload.authorIsBot === "boolean"
+      ? { authorIsBot: params.payload.authorIsBot }
+      : {}),
+    ...(optionalString(params.payload, "id") ? { id: optionalString(params.payload, "id") } : {}),
+    ...(message
+      ? {
+          message: {
+            ...(normalizeAuthor(message.author) ? { author: normalizeAuthor(message.author) } : {}),
+            ...(typeof message.authorIsBot === "boolean"
+              ? { authorIsBot: message.authorIsBot }
+              : {}),
+            ...(optionalString(message, "id") ? { id: optionalString(message, "id") } : {}),
+            ...(message.raw !== undefined ? { raw: message.raw } : {}),
+            ...(optionalString(message, "text") ? { text: optionalString(message, "text") } : {}),
+            threadId,
+          },
+        }
+      : {}),
+    raw: params.payload.raw ?? params.payload,
+    ...(optionalString(params.payload, "text")
+      ? { text: optionalString(params.payload, "text") }
+      : {}),
+    threadId,
+  };
+}
+
+export function authorFromBotFlag(isBot: boolean | undefined): InboundEnvelope["author"] {
+  return isBot ? "assistant" : "user";
+}

--- a/src/providers/builtin/slack.ts
+++ b/src/providers/builtin/slack.ts
@@ -1,17 +1,124 @@
 import path from "node:path";
+import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
-import { createGenericLocalMockTargetCodec, LocalMockProviderAdapter } from "../local-mock.js";
-import type { ProviderAdapter } from "../types.js";
+import { LocalMockProviderAdapter, type LocalMockTargetCodec } from "../local-mock.js";
+import type {
+  InboundEnvelope,
+  NormalizedTarget,
+  ProviderAdapter,
+  ProviderContext,
+} from "../types.js";
+import {
+  genericMockPayloadWithNativeThread,
+  isRecord,
+  requireNativeInboundId,
+  type NativeIdRule,
+} from "./native-local-mock.js";
+
+const SLACK_CHANNEL_ID_RULE: NativeIdRule = {
+  example: "C1234567890",
+  name: "Slack conversation id",
+  pattern: /^[CDG][A-Z0-9]{2,}$/u,
+};
+
+const SLACK_TS_RULE: NativeIdRule = {
+  example: "1700000000.000100",
+  name: "Slack timestamp",
+  pattern: /^\d{10}\.\d{6}$/u,
+};
+
+function requireSlackChannelId(value: string, label: string): string {
+  if (!SLACK_CHANNEL_ID_RULE.pattern.test(value)) {
+    throw new CrablineError(
+      `Slack ${label} must be a native Slack conversation id such as C1234567890, G1234567890, or D1234567890.`,
+      { kind: "config" },
+    );
+  }
+  return value;
+}
+
+function requireSlackThreadTs(value: string, label: string): string {
+  if (!SLACK_TS_RULE.pattern.test(value)) {
+    throw new CrablineError(`Slack ${label} must be a Slack timestamp such as 1700000000.000100.`, {
+      kind: "config",
+    });
+  }
+  return value;
+}
+
+function slackAuthorFromEvent(event: Record<string, unknown>): InboundEnvelope["author"] {
+  if (typeof event.bot_id === "string" || event.subtype === "bot_message") {
+    return "assistant";
+  }
+  return "user";
+}
+
+function normalizeSlackEventsPayload(payload: unknown) {
+  if (!isRecord(payload)) {
+    throw new CrablineError("Slack webhook payload must be an object", { kind: "inbound" });
+  }
+
+  if (isRecord(payload.event)) {
+    const event = payload.event;
+    const channel = event.channel;
+    const text = event.text;
+    if (typeof channel !== "string" || typeof text !== "string") {
+      throw new CrablineError("Slack event payload requires event.channel and event.text", {
+        kind: "inbound",
+      });
+    }
+    const threadTs = event.thread_ts;
+    const ts = event.ts;
+    return {
+      author: slackAuthorFromEvent(event),
+      ...(typeof ts === "string"
+        ? { id: requireNativeInboundId(ts, SLACK_TS_RULE, "Slack event.ts") }
+        : {}),
+      raw: payload,
+      text,
+      threadId:
+        typeof threadTs === "string"
+          ? requireNativeInboundId(threadTs, SLACK_TS_RULE, "Slack event.thread_ts")
+          : requireNativeInboundId(channel, SLACK_CHANNEL_ID_RULE, "Slack event.channel"),
+    };
+  }
+
+  return genericMockPayloadWithNativeThread({
+    channelRule: SLACK_CHANNEL_ID_RULE,
+    payload,
+    threadRule: SLACK_TS_RULE,
+  });
+}
+
+const SLACK_CODEC: LocalMockTargetCodec = {
+  normalize(target: ProviderContext["fixture"]["target"]): NormalizedTarget {
+    const channelId = requireSlackChannelId(target.channelId ?? target.id, "channelId");
+    const normalized: NormalizedTarget = {
+      channelId,
+      id: target.id,
+      metadata: target.metadata,
+    };
+    if (target.threadId) {
+      normalized.threadId = requireSlackThreadTs(target.threadId, "threadId");
+    }
+    return normalized;
+  },
+  resolveThreadId(target) {
+    const normalized = this.normalize(target);
+    return normalized.threadId ?? normalized.channelId ?? normalized.id;
+  },
+};
 
 export class SlackProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
     super({
-      codec: createGenericLocalMockTargetCodec("slack"),
+      codec: SLACK_CODEC,
       config,
       id,
       options: {
         defaultWebhook: { host: "127.0.0.1", path: "/slack/events", port: 8787 },
         endpointLabel: "events endpoint",
+        normalizeWebhookPayload: normalizeSlackEventsPayload,
         platform: "slack",
         publicUrl: config.slack?.webhook.publicUrl,
         recorderPath: config.slack?.recorder.path

--- a/src/providers/builtin/telegram.ts
+++ b/src/providers/builtin/telegram.ts
@@ -1,7 +1,19 @@
 import path from "node:path";
+import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
-import { LocalMockProviderAdapter, type LocalMockTargetCodec } from "../local-mock.js";
-import type { NormalizedTarget, ProviderAdapter, ProviderContext } from "../types.js";
+import { LocalMockProviderAdapter } from "../local-mock.js";
+import type { ProviderAdapter } from "../types.js";
+import {
+  authorFromBotFlag,
+  createNativeTargetCodec,
+  genericMockPayloadWithNativeThread,
+  isRecord,
+  optionalRecord,
+  optionalString,
+  optionalStringish,
+  requireNativeInboundId,
+  type NativeIdRule,
+} from "./native-local-mock.js";
 
 type TelegramEnvironment = Partial<
   Pick<
@@ -29,22 +41,6 @@ export function resolveTelegramAdapterConfig(
   };
 }
 
-function isTelegramEncodedId(value: string): boolean {
-  return value.startsWith("telegram:");
-}
-
-function normalizeTelegramChannelId(value: string): string {
-  return isTelegramEncodedId(value) ? value : `telegram:${value}`;
-}
-
-function normalizeTelegramThreadId(channelId: string, threadId: string): string {
-  if (isTelegramEncodedId(threadId)) {
-    return threadId;
-  }
-  const chatId = channelId.replace(/^telegram:/u, "");
-  return `telegram:${chatId}:${threadId}`;
-}
-
 function toRecorderPath(providerId: string, config: ProviderConfig): string {
   const configuredPath = config.telegram?.recorder.path;
   return configuredPath
@@ -52,33 +48,71 @@ function toRecorderPath(providerId: string, config: ProviderConfig): string {
     : path.resolve(".crabline", "recorders", `${providerId}.jsonl`);
 }
 
-const TELEGRAM_CODEC: LocalMockTargetCodec = {
-  normalize(target: ProviderContext["fixture"]["target"]): NormalizedTarget {
-    const normalized: NormalizedTarget = {
-      id: target.id,
-      metadata: target.metadata,
-    };
-
-    if (target.channelId) {
-      normalized.channelId = normalizeTelegramChannelId(target.channelId);
-    } else if (!target.threadId) {
-      normalized.channelId = normalizeTelegramChannelId(target.id);
-    }
-
-    if (target.threadId) {
-      if (!normalized.channelId) {
-        normalized.channelId = normalizeTelegramChannelId(target.id);
-      }
-      normalized.threadId = normalizeTelegramThreadId(normalized.channelId, target.threadId);
-    }
-
-    return normalized;
-  },
-  resolveThreadId(target) {
-    const normalized = this.normalize(target);
-    return normalized.threadId ?? normalized.channelId ?? normalizeTelegramChannelId(normalized.id);
-  },
+const TELEGRAM_CHAT_ID_RULE: NativeIdRule = {
+  example: "-1001234567890 or @channelusername",
+  name: "Telegram chat id",
+  pattern: /^(?:-?\d+|@[A-Za-z][A-Za-z0-9_]{4,31})$/u,
 };
+
+const TELEGRAM_MESSAGE_THREAD_ID_RULE: NativeIdRule = {
+  example: "42",
+  name: "Telegram message_thread_id",
+  pattern: /^\d+$/u,
+};
+
+const TELEGRAM_CODEC = createNativeTargetCodec({
+  channel: TELEGRAM_CHAT_ID_RULE,
+  channelLabel: "Telegram chat_id",
+  thread: TELEGRAM_MESSAGE_THREAD_ID_RULE,
+  threadLabel: "Telegram message_thread_id",
+});
+
+function normalizeTelegramWebhookPayload(payload: unknown) {
+  if (!isRecord(payload)) {
+    throw new CrablineError("Telegram webhook payload must be an object", { kind: "inbound" });
+  }
+
+  const message =
+    optionalRecord(payload, "message") ??
+    optionalRecord(payload, "edited_message") ??
+    optionalRecord(payload, "channel_post");
+  if (!message) {
+    return genericMockPayloadWithNativeThread({
+      channelRule: TELEGRAM_CHAT_ID_RULE,
+      payload,
+      threadRule: TELEGRAM_MESSAGE_THREAD_ID_RULE,
+    });
+  }
+
+  const chat = optionalRecord(message, "chat");
+  const chatId = chat ? optionalStringish(chat, "id") : undefined;
+  const text = optionalString(message, "text") ?? optionalString(message, "caption");
+  if (!chatId || !text) {
+    throw new CrablineError("Telegram update requires message.chat.id and message.text", {
+      kind: "inbound",
+    });
+  }
+
+  const topicId = optionalStringish(message, "message_thread_id");
+  const from = optionalRecord(message, "from");
+  return {
+    author: authorFromBotFlag(from?.is_bot === true),
+    ...(optionalStringish(message, "message_id")
+      ? { id: optionalStringish(message, "message_id") }
+      : optionalStringish(payload, "update_id")
+        ? { id: optionalStringish(payload, "update_id") }
+        : {}),
+    raw: payload,
+    text,
+    threadId: topicId
+      ? requireNativeInboundId(
+          topicId,
+          TELEGRAM_MESSAGE_THREAD_ID_RULE,
+          "Telegram message.message_thread_id",
+        )
+      : requireNativeInboundId(chatId, TELEGRAM_CHAT_ID_RULE, "Telegram message.chat.id"),
+  };
+}
 
 export class TelegramProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string) {
@@ -93,6 +127,7 @@ export class TelegramProviderAdapter extends LocalMockProviderAdapter implements
           port: 8790,
         },
         endpointLabel: "webhook endpoint",
+        normalizeWebhookPayload: normalizeTelegramWebhookPayload,
         platform: "telegram",
         publicUrl: config.telegram?.webhook.publicUrl,
         recorderPath: toRecorderPath(id, config),

--- a/src/providers/builtin/whatsapp.ts
+++ b/src/providers/builtin/whatsapp.ts
@@ -1,7 +1,24 @@
 import path from "node:path";
+import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
-import { createGenericLocalMockTargetCodec, LocalMockProviderAdapter } from "../local-mock.js";
+import { LocalMockProviderAdapter } from "../local-mock.js";
 import type { ProviderAdapter } from "../types.js";
+import {
+  authorFromBotFlag,
+  createNativeTargetCodec,
+  genericMockPayloadWithNativeThread,
+  isRecord,
+  optionalRecord,
+  optionalString,
+  requireNativeInboundId,
+  type NativeIdRule,
+} from "./native-local-mock.js";
+
+const WHATSAPP_WA_ID_RULE: NativeIdRule = {
+  example: "15551234567",
+  name: "WhatsApp wa_id",
+  pattern: /^\d{7,15}$/u,
+};
 
 export function resolveWhatsAppAdapterConfig(
   config: ProviderConfig,
@@ -19,12 +36,16 @@ export function resolveWhatsAppAdapterConfig(
 export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
     super({
-      codec: createGenericLocalMockTargetCodec("whatsapp"),
+      codec: createNativeTargetCodec({
+        channel: WHATSAPP_WA_ID_RULE,
+        channelLabel: "WhatsApp wa_id",
+      }),
       config,
       id,
       options: {
         defaultWebhook: { host: "127.0.0.1", path: "/whatsapp/webhook", port: 8789 },
         endpointLabel: "webhook endpoint",
+        normalizeWebhookPayload: normalizeWhatsAppWebhookPayload,
         platform: "whatsapp",
         publicUrl: config.whatsapp?.webhook.publicUrl,
         recorderPath: config.whatsapp?.recorder.path
@@ -34,4 +55,40 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
       },
     });
   }
+}
+
+function normalizeWhatsAppWebhookPayload(payload: unknown) {
+  if (!isRecord(payload)) {
+    throw new CrablineError("WhatsApp webhook payload must be an object", { kind: "inbound" });
+  }
+
+  const entry = Array.isArray(payload.entry) ? payload.entry.find(isRecord) : undefined;
+  const change = entry && Array.isArray(entry.changes) ? entry.changes.find(isRecord) : undefined;
+  const value = change ? optionalRecord(change, "value") : undefined;
+  const message =
+    value && Array.isArray(value.messages) ? value.messages.find(isRecord) : undefined;
+  if (!message) {
+    return genericMockPayloadWithNativeThread({
+      channelRule: WHATSAPP_WA_ID_RULE,
+      payload,
+      threadRule: WHATSAPP_WA_ID_RULE,
+    });
+  }
+
+  const text = optionalRecord(message, "text");
+  const from = optionalString(message, "from");
+  const body = text ? optionalString(text, "body") : undefined;
+  if (!from || !body) {
+    throw new CrablineError("WhatsApp webhook payload requires messages[].from and text.body", {
+      kind: "inbound",
+    });
+  }
+
+  return {
+    author: authorFromBotFlag(false),
+    ...(optionalString(message, "id") ? { id: optionalString(message, "id") } : {}),
+    raw: payload,
+    text: body,
+    threadId: requireNativeInboundId(from, WHATSAPP_WA_ID_RULE, "WhatsApp messages[].from"),
+  };
 }

--- a/src/providers/builtin/zalo.ts
+++ b/src/providers/builtin/zalo.ts
@@ -1,7 +1,24 @@
 import path from "node:path";
+import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
-import { createGenericLocalMockTargetCodec, LocalMockProviderAdapter } from "../local-mock.js";
+import { LocalMockProviderAdapter } from "../local-mock.js";
 import type { ProviderAdapter } from "../types.js";
+import {
+  authorFromBotFlag,
+  createNativeTargetCodec,
+  genericMockPayloadWithNativeThread,
+  isRecord,
+  optionalRecord,
+  optionalString,
+  requireNativeInboundId,
+  type NativeIdRule,
+} from "./native-local-mock.js";
+
+const ZALO_ID_RULE: NativeIdRule = {
+  example: "123456789012345678",
+  name: "Zalo user or OA id",
+  pattern: /^\d{6,20}$/u,
+};
 
 export function resolveZaloAdapterConfig(
   config: ProviderConfig,
@@ -16,12 +33,16 @@ export function resolveZaloAdapterConfig(
 export class ZaloProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
     super({
-      codec: createGenericLocalMockTargetCodec("zalo"),
+      codec: createNativeTargetCodec({
+        channel: ZALO_ID_RULE,
+        channelLabel: "Zalo user_id or oa_id",
+      }),
       config,
       id,
       options: {
         defaultWebhook: { host: "127.0.0.1", path: "/zalo/webhook", port: 8794 },
         endpointLabel: "webhook endpoint",
+        normalizeWebhookPayload: normalizeZaloWebhookPayload,
         platform: "zalo",
         publicUrl: config.zalo?.webhook.publicUrl,
         recorderPath: config.zalo?.recorder.path
@@ -31,4 +52,41 @@ export class ZaloProviderAdapter extends LocalMockProviderAdapter implements Pro
       },
     });
   }
+}
+
+function normalizeZaloWebhookPayload(payload: unknown) {
+  if (!isRecord(payload)) {
+    throw new CrablineError("Zalo webhook payload must be an object", { kind: "inbound" });
+  }
+
+  if (
+    optionalRecord(payload, "message") &&
+    optionalString(optionalRecord(payload, "message")!, "threadId")
+  ) {
+    return genericMockPayloadWithNativeThread({
+      channelRule: ZALO_ID_RULE,
+      payload,
+      threadRule: ZALO_ID_RULE,
+    });
+  }
+
+  const sender = optionalRecord(payload, "sender");
+  const message = optionalRecord(payload, "message");
+  const senderId = sender ? optionalString(sender, "id") : undefined;
+  const text = message ? optionalString(message, "text") : undefined;
+  if (!senderId || !text) {
+    throw new CrablineError("Zalo webhook payload requires sender.id and message.text", {
+      kind: "inbound",
+    });
+  }
+
+  return {
+    author: authorFromBotFlag(false),
+    ...(message && optionalString(message, "msg_id")
+      ? { id: optionalString(message, "msg_id") }
+      : {}),
+    raw: payload,
+    text,
+    threadId: requireNativeInboundId(senderId, ZALO_ID_RULE, "Zalo sender.id"),
+  };
 }

--- a/src/providers/local-mock.ts
+++ b/src/providers/local-mock.ts
@@ -25,6 +25,7 @@ export type LocalMockWebhookConfig = {
 export type LocalMockAdapterOptions = {
   defaultWebhook: Required<Pick<LocalMockWebhookConfig, "host" | "path" | "port">>;
   endpointLabel: string;
+  normalizeWebhookPayload?: (payload: unknown) => unknown;
   platform: ProviderPlatform;
   publicUrl?: string | undefined;
   recorderPath?: string | undefined;
@@ -259,7 +260,12 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
     }
     let payload: MockWebhookPayload;
     try {
-      payload = normalizeWebhookPayload(await request.json());
+      const rawPayload = await request.json();
+      payload = normalizeWebhookPayload(
+        this.#options.normalizeWebhookPayload
+          ? this.#options.normalizeWebhookPayload(rawPayload)
+          : rawPayload,
+      );
     } catch (error) {
       return new Response(ensureErrorMessage(error), { status: 400 });
     }

--- a/test/discord-provider.test.ts
+++ b/test/discord-provider.test.ts
@@ -82,7 +82,7 @@ function createContext(config: ProviderConfig): ProviderContext {
 }
 
 describe("discord provider", () => {
-  it("normalizes channel, thread, encoded, and DM targets", async () => {
+  it("normalizes native channel and thread targets", async () => {
     const config = await createDiscordConfig(0);
     const provider = new DiscordProviderAdapter("discord", config, "crabline");
     providers.push(provider);
@@ -93,45 +93,35 @@ describe("discord provider", () => {
         metadata: { guildId: "987654321098765432" },
       }),
     ).toMatchObject({
-      channelId: "discord:987654321098765432:123456789012345678",
+      channelId: "123456789012345678",
     });
     expect(
       provider.normalizeTarget({
         channelId: "123456789012345678",
-        id: "reply-target",
+        id: "123456789012345678",
         metadata: { guildId: "987654321098765432" },
         threadId: "223456789012345678",
       }),
     ).toMatchObject({
-      channelId: "discord:987654321098765432:123456789012345678",
-      threadId: "discord:987654321098765432:123456789012345678:223456789012345678",
-    });
-    expect(
-      provider.normalizeTarget({
-        id: "discord:987654321098765432:123456789012345678:223456789012345678",
-        metadata: {},
-      }),
-    ).toMatchObject({
-      channelId: "discord:987654321098765432:123456789012345678",
-      threadId: "discord:987654321098765432:123456789012345678:223456789012345678",
-    });
-    expect(provider.normalizeTarget({ id: "555555555555555555", metadata: {} })).toMatchObject({
-      id: "555555555555555555",
+      channelId: "123456789012345678",
+      threadId: "223456789012345678",
     });
   });
 
-  it("rejects thread targets without guild metadata", async () => {
+  it("rejects encoded or non-snowflake targets", async () => {
     const config = await createDiscordConfig(0);
     const provider = new DiscordProviderAdapter("discord", config, "crabline");
     providers.push(provider);
 
     expect(() =>
       provider.normalizeTarget({
-        id: "123456789012345678",
+        id: "discord:987654321098765432:123456789012345678",
         metadata: {},
-        threadId: "223456789012345678",
       }),
-    ).toThrow(/requires target.metadata.guildId/u);
+    ).toThrow(/Discord channel_id/u);
+    expect(() => provider.normalizeTarget({ id: "target-1", metadata: {} })).toThrow(
+      /Discord channel_id/u,
+    );
   });
 
   it("probes built-in discord configuration and DM targets", async () => {
@@ -147,9 +137,7 @@ describe("discord provider", () => {
     expect(result.details.join("\n")).toContain(
       "public webhook https://example.ngrok.app/discord/interactions",
     );
-    expect(result.details.join("\n")).toContain(
-      "channel reachable discord:987654321098765432:123456789012345678",
-    );
+    expect(result.details.join("\n")).toContain("channel reachable 123456789012345678");
 
     const dmResult = await provider.probe({
       ...createContext(config),
@@ -161,7 +149,7 @@ describe("discord provider", () => {
         },
       },
     });
-    expect(dmResult.details.join("\n")).toContain("dm reachable discord:@me:dm-555555555555555555");
+    expect(dmResult.details.join("\n")).toContain("channel reachable 555555555555555555");
   });
 
   it("sends to a discord channel and records a local mock reply", async () => {
@@ -177,7 +165,7 @@ describe("discord provider", () => {
     });
 
     expect(result.accepted).toBe(true);
-    expect(result.threadId).toBe("discord:987654321098765432:123456789012345678");
+    expect(result.threadId).toBe("123456789012345678");
     await expect(
       provider.waitForInbound({
         ...createContext(config),
@@ -206,18 +194,16 @@ describe("discord provider", () => {
       ...createContext(config),
       nonce: "nonce-2",
       since: new Date(Date.now() - 1000).toISOString(),
-      threadId: "discord:987654321098765432:123456789012345678",
+      threadId: "123456789012345678",
       timeoutMs: 500,
     });
 
     const response = await fetch(endpoint!.replace("interactions endpoint ", ""), {
       body: JSON.stringify({
-        kind: "subscribed",
-        message: {
-          id: "evt-1",
-          text: "ACK nonce-2",
-          threadId: "discord:987654321098765432:123456789012345678",
-        },
+        author: { bot: true },
+        channel_id: "123456789012345678",
+        content: "ACK nonce-2",
+        id: "333456789012345678",
       }),
       headers: { "content-type": "application/json" },
       method: "POST",
@@ -225,7 +211,7 @@ describe("discord provider", () => {
 
     expect(response.status).toBe(200);
     await expect(waitPromise).resolves.toMatchObject({
-      id: "evt-1",
+      id: "333456789012345678",
       text: "ACK nonce-2",
     });
   });
@@ -251,7 +237,7 @@ describe("discord provider", () => {
           author: "user",
           id: "evt-2",
           text: "user message",
-          threadId: "discord:987654321098765432:123456789012345678",
+          threadId: "123456789012345678",
         },
       }),
       headers: { "content-type": "application/json" },

--- a/test/feishu-provider.test.ts
+++ b/test/feishu-provider.test.ts
@@ -4,5 +4,25 @@ import { runLocalMockProviderContract } from "./local-mock-provider-helpers.js";
 runLocalMockProviderContract({
   Adapter: FeishuProviderAdapter,
   endpointPath: "/feishu/webhook",
+  expectedChannelId: "oc_abc123",
+  expectedThreadId: "om_abc123",
   platform: "feishu",
+  target: { id: "oc_abc123", metadata: {} },
+  threadTarget: {
+    channelId: "oc_abc123",
+    id: "oc_abc123",
+    metadata: {},
+    threadId: "om_abc123",
+  },
+  webhookExpected: { author: "user", id: "om_abc123", text: "reply nonce-2" },
+  webhookPayload: {
+    event: {
+      message: {
+        chat_id: "oc_abc123",
+        content: JSON.stringify({ text: "reply nonce-2" }),
+        message_id: "om_abc123",
+      },
+    },
+  },
+  webhookThreadId: "om_abc123",
 });

--- a/test/googlechat-provider.test.ts
+++ b/test/googlechat-provider.test.ts
@@ -4,5 +4,29 @@ import { runLocalMockProviderContract } from "./local-mock-provider-helpers.js";
 runLocalMockProviderContract({
   Adapter: GoogleChatProviderAdapter,
   endpointPath: "/googlechat/webhook",
+  expectedChannelId: "spaces/AAAABbbbCCC",
+  expectedThreadId: "spaces/AAAABbbbCCC/threads/BBBBccccDDD",
   platform: "googlechat",
+  target: { id: "spaces/AAAABbbbCCC", metadata: {} },
+  threadTarget: {
+    channelId: "spaces/AAAABbbbCCC",
+    id: "spaces/AAAABbbbCCC",
+    metadata: {},
+    threadId: "spaces/AAAABbbbCCC/threads/BBBBccccDDD",
+  },
+  webhookExpected: {
+    author: "user",
+    id: "spaces/AAAABbbbCCC/messages/msg-1",
+    text: "reply nonce-2",
+  },
+  webhookPayload: {
+    message: {
+      name: "spaces/AAAABbbbCCC/messages/msg-1",
+      sender: { type: "HUMAN" },
+      space: { name: "spaces/AAAABbbbCCC" },
+      text: "reply nonce-2",
+      thread: { name: "spaces/AAAABbbbCCC/threads/BBBBccccDDD" },
+    },
+  },
+  webhookThreadId: "spaces/AAAABbbbCCC/threads/BBBBccccDDD",
 });

--- a/test/imessage-provider.test.ts
+++ b/test/imessage-provider.test.ts
@@ -4,5 +4,22 @@ import { runLocalMockProviderContract } from "./local-mock-provider-helpers.js";
 runLocalMockProviderContract({
   Adapter: IMessageProviderAdapter,
   endpointPath: "/imessage/webhook",
+  expectedChannelId: "+15551234567",
+  expectedThreadId: "iMessage;-;chat-guid-1",
   platform: "imessage",
+  target: { id: "+15551234567", metadata: {} },
+  threadTarget: {
+    channelId: "+15551234567",
+    id: "+15551234567",
+    metadata: {},
+    threadId: "iMessage;-;chat-guid-1",
+  },
+  webhookExpected: { author: "user", id: "imsg-guid-1", text: "reply nonce-2" },
+  webhookPayload: {
+    chatGuid: "iMessage;-;chat-guid-1",
+    guid: "imsg-guid-1",
+    isFromMe: false,
+    text: "reply nonce-2",
+  },
+  webhookThreadId: "iMessage;-;chat-guid-1",
 });

--- a/test/local-mock-provider-helpers.ts
+++ b/test/local-mock-provider-helpers.ts
@@ -16,6 +16,18 @@ type ContractOptions = {
   adapter?: BuiltinAdapterId;
   endpointPath: string;
   endpointText?: string;
+  expectedChannelId: string;
+  expectedThreadId?: string | undefined;
+  invalidTargets?: ProviderContext["fixture"]["target"][] | undefined;
+  target: ProviderContext["fixture"]["target"];
+  threadTarget?: ProviderContext["fixture"]["target"] | undefined;
+  webhookExpected: {
+    author?: "assistant" | "system" | "user" | undefined;
+    id?: string | undefined;
+    text: string;
+  };
+  webhookPayload: unknown;
+  webhookThreadId: string;
   platform: ProviderPlatform;
 };
 
@@ -86,7 +98,7 @@ function endpointFromDetails(details: string[]): string {
 
 export function runLocalMockProviderContract(options: ContractOptions): void {
   describe(`${options.platform} local mock provider`, () => {
-    it("normalizes targets with the platform channel prefix", async () => {
+    it("normalizes native channel targets and rejects synthetic local ids", async () => {
       const config = await createLocalMockConfig(
         options.platform,
         options.endpointPath,
@@ -95,20 +107,19 @@ export function runLocalMockProviderContract(options: ContractOptions): void {
       const provider = new options.Adapter(options.platform, config, "crabline");
       providers.push(provider);
 
-      expect(provider.normalizeTarget({ id: "target-1", metadata: {} })).toMatchObject({
-        channelId: `${options.platform}:target-1`,
+      expect(provider.normalizeTarget(options.target)).toMatchObject({
+        channelId: options.expectedChannelId,
       });
-      expect(
-        provider.normalizeTarget({
-          channelId: `${options.platform}:room-1`,
-          id: "target-1",
-          metadata: {},
-          threadId: "thread-1",
-        }),
-      ).toMatchObject({
-        channelId: `${options.platform}:room-1`,
-        threadId: `${options.platform}:room-1:thread-1`,
+      expect(provider.normalizeTarget(options.threadTarget ?? options.target)).toMatchObject({
+        channelId: options.expectedChannelId,
+        ...(options.expectedThreadId ? { threadId: options.expectedThreadId } : {}),
       });
+      for (const target of options.invalidTargets ?? [
+        { id: `target-1`, metadata: {} },
+        { id: `${options.platform}:${options.expectedChannelId}`, metadata: {} },
+      ]) {
+        expect(() => provider.normalizeTarget(target)).toThrow(/must be|requires|native/u);
+      }
     });
 
     it("probes, sends, and waits for a deterministic mock reply", async () => {
@@ -119,7 +130,7 @@ export function runLocalMockProviderContract(options: ContractOptions): void {
       );
       const provider = new options.Adapter(options.platform, config, "crabline");
       providers.push(provider);
-      const context = createProviderContext(options.platform, config);
+      const context = createProviderContext(options.platform, config, options.target);
 
       const probe = await provider.probe(context);
       expect(probe.healthy).toBe(true);
@@ -134,7 +145,7 @@ export function runLocalMockProviderContract(options: ContractOptions): void {
         text: "hello nonce-1",
       });
       expect(result.accepted).toBe(true);
-      expect(result.threadId).toBe(`${options.platform}:target-1`);
+      expect(result.threadId).toBe(options.expectedChannelId);
 
       await expect(
         provider.waitForInbound({
@@ -159,7 +170,12 @@ export function runLocalMockProviderContract(options: ContractOptions): void {
       );
       const provider = new options.Adapter(options.platform, config, "crabline");
       providers.push(provider);
-      const context = createProviderContext(options.platform, config);
+      const context = createProviderContext(options.platform, config, options.target);
+      context.fixture.inboundMatch = {
+        author: options.webhookExpected.author ?? "any",
+        nonce: "contains",
+        strategy: "contains",
+      };
       const endpoint = endpointFromDetails((await provider.probe(context)).details);
 
       const since = new Date(Date.now() - 1000).toISOString();
@@ -171,11 +187,7 @@ export function runLocalMockProviderContract(options: ContractOptions): void {
       expect(malformed.status).toBe(400);
 
       const response = await fetch(endpoint, {
-        body: JSON.stringify({
-          id: `${options.platform}-inbound`,
-          text: "reply nonce-2",
-          threadId: `${options.platform}:target-1`,
-        }),
+        body: JSON.stringify(options.webhookPayload),
         headers: { "content-type": "application/json" },
         method: "POST",
       });
@@ -186,12 +198,11 @@ export function runLocalMockProviderContract(options: ContractOptions): void {
           ...context,
           nonce: "nonce-2",
           since,
-          threadId: `${options.platform}:target-1`,
+          threadId: options.webhookThreadId,
           timeoutMs: 500,
         }),
       ).resolves.toMatchObject({
-        id: `${options.platform}-inbound`,
-        text: "reply nonce-2",
+        ...options.webhookExpected,
       });
     });
 
@@ -203,7 +214,7 @@ export function runLocalMockProviderContract(options: ContractOptions): void {
       );
       const provider = new options.Adapter(options.platform, config, "crabline");
       providers.push(provider);
-      const context = createProviderContext(options.platform, config);
+      const context = createProviderContext(options.platform, config, options.target);
       context.fixture.inboundMatch = {
         author: "user",
         nonce: "contains",
@@ -214,10 +225,12 @@ export function runLocalMockProviderContract(options: ContractOptions): void {
 
       const response = await fetch(endpoint, {
         body: JSON.stringify({
-          author: "user",
-          id: `${options.platform}-user-inbound`,
-          text: "user nonce-3",
-          threadId: `${options.platform}:target-1`,
+          message: {
+            author: "user",
+            id: `${options.platform}-user-inbound`,
+            text: "user nonce-3",
+            threadId: options.expectedChannelId,
+          },
         }),
         headers: { "content-type": "application/json" },
         method: "POST",
@@ -229,7 +242,7 @@ export function runLocalMockProviderContract(options: ContractOptions): void {
           ...context,
           nonce: "nonce-3",
           since,
-          threadId: `${options.platform}:target-1`,
+          threadId: options.expectedChannelId,
           timeoutMs: 500,
         }),
       ).resolves.toMatchObject({

--- a/test/matrix-provider.test.ts
+++ b/test/matrix-provider.test.ts
@@ -4,5 +4,23 @@ import { runLocalMockProviderContract } from "./local-mock-provider-helpers.js";
 runLocalMockProviderContract({
   Adapter: MatrixProviderAdapter,
   endpointPath: "/matrix/webhook",
+  expectedChannelId: "!abc123:matrix.org",
+  expectedThreadId: "$event123:matrix.org",
   platform: "matrix",
+  target: { id: "!abc123:matrix.org", metadata: {} },
+  threadTarget: {
+    channelId: "!abc123:matrix.org",
+    id: "!abc123:matrix.org",
+    metadata: {},
+    threadId: "$event123:matrix.org",
+  },
+  webhookExpected: { author: "user", id: "$event123:matrix.org", text: "reply nonce-2" },
+  webhookPayload: {
+    content: { body: "reply nonce-2", msgtype: "m.text" },
+    event_id: "$event123:matrix.org",
+    room_id: "!abc123:matrix.org",
+    sender: "@user:matrix.org",
+    type: "m.room.message",
+  },
+  webhookThreadId: "$event123:matrix.org",
 });

--- a/test/mattermost-provider.test.ts
+++ b/test/mattermost-provider.test.ts
@@ -4,5 +4,22 @@ import { runLocalMockProviderContract } from "./local-mock-provider-helpers.js";
 runLocalMockProviderContract({
   Adapter: MattermostProviderAdapter,
   endpointPath: "/mattermost/webhook",
+  expectedChannelId: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+  expectedThreadId: "bbbbbbbbbbbbbbbbbbbbbbbbbb",
   platform: "mattermost",
+  target: { id: "aaaaaaaaaaaaaaaaaaaaaaaaaa", metadata: {} },
+  threadTarget: {
+    channelId: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+    id: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+    metadata: {},
+    threadId: "bbbbbbbbbbbbbbbbbbbbbbbbbb",
+  },
+  webhookExpected: { author: "user", id: "cccccccccccccccccccccccccc", text: "reply nonce-2" },
+  webhookPayload: {
+    channel_id: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+    post_id: "cccccccccccccccccccccccccc",
+    root_id: "bbbbbbbbbbbbbbbbbbbbbbbbbb",
+    text: "reply nonce-2",
+  },
+  webhookThreadId: "bbbbbbbbbbbbbbbbbbbbbbbbbb",
 });

--- a/test/msteams-provider.test.ts
+++ b/test/msteams-provider.test.ts
@@ -4,5 +4,15 @@ import { runLocalMockProviderContract } from "./local-mock-provider-helpers.js";
 runLocalMockProviderContract({
   Adapter: MsTeamsProviderAdapter,
   endpointPath: "/msteams/webhook",
+  expectedChannelId: "19:meeting_abc123@thread.v2",
   platform: "msteams",
+  target: { id: "19:meeting_abc123@thread.v2", metadata: {} },
+  webhookExpected: { author: "user", id: "teams-activity-1", text: "reply nonce-2" },
+  webhookPayload: {
+    conversation: { id: "19:meeting_abc123@thread.v2" },
+    from: { role: "user" },
+    id: "teams-activity-1",
+    text: "reply nonce-2",
+  },
+  webhookThreadId: "19:meeting_abc123@thread.v2",
 });

--- a/test/slack-provider.test.ts
+++ b/test/slack-provider.test.ts
@@ -1,9 +1,217 @@
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ProviderConfig } from "../src/config/schema.js";
 import { SlackProviderAdapter } from "../src/providers/builtin/slack.js";
-import { runLocalMockProviderContract } from "./local-mock-provider-helpers.js";
+import type { ProviderContext } from "../src/providers/types.js";
+import { createTempDir, disposeTempDir } from "./test-helpers.js";
 
-runLocalMockProviderContract({
-  Adapter: SlackProviderAdapter,
-  endpointPath: "/slack/events",
-  endpointText: "events endpoint",
-  platform: "slack",
+const directories: string[] = [];
+const providers: SlackProviderAdapter[] = [];
+
+afterEach(async () => {
+  await Promise.all(providers.splice(0).map((provider) => provider.cleanup()));
+  await Promise.all(directories.splice(0).map(disposeTempDir));
+});
+
+async function createSlackConfig(port: number): Promise<ProviderConfig> {
+  const directory = await createTempDir();
+  directories.push(directory);
+
+  return {
+    adapter: "slack",
+    capabilities: ["probe", "send", "roundtrip", "agent"],
+    env: [],
+    platform: "slack",
+    slack: {
+      recorder: { path: path.join(directory, "slack.jsonl") },
+      webhook: {
+        host: "127.0.0.1",
+        path: "/slack/events",
+        port,
+      },
+    },
+    status: "active",
+  };
+}
+
+function createContext(
+  config: ProviderConfig,
+  target: ProviderContext["fixture"]["target"] = {
+    id: "C1234567890",
+    metadata: {},
+  },
+): ProviderContext {
+  return {
+    config,
+    fixture: {
+      env: [],
+      id: "slack-agent",
+      inboundMatch: { author: "assistant", nonce: "contains", strategy: "contains" },
+      mode: "agent",
+      provider: "slack",
+      retries: 0,
+      tags: [],
+      target,
+      timeoutMs: 500,
+    },
+    manifestPath: "/tmp/crabline.yaml",
+    providerId: "slack",
+    userName: "crabline",
+  };
+}
+
+function endpointFromDetails(details: string[]): string {
+  const detail = details.find((entry) => entry.startsWith("events endpoint "));
+  if (!detail) {
+    throw new Error(`No Slack events endpoint detail found in ${details.join("\n")}`);
+  }
+  return detail.replace("events endpoint ", "");
+}
+
+describe("slack provider", () => {
+  it("keeps native Slack conversation and thread timestamp ids", async () => {
+    const config = await createSlackConfig(0);
+    const provider = new SlackProviderAdapter("slack", config, "crabline");
+    providers.push(provider);
+
+    expect(provider.normalizeTarget({ id: "C1234567890", metadata: {} })).toMatchObject({
+      channelId: "C1234567890",
+    });
+    expect(
+      provider.normalizeTarget({
+        channelId: "C1234567890",
+        id: "reply-target",
+        metadata: {},
+        threadId: "1700000000.000100",
+      }),
+    ).toMatchObject({
+      channelId: "C1234567890",
+      threadId: "1700000000.000100",
+    });
+  });
+
+  it("rejects generic and Crabline-prefixed Slack ids", async () => {
+    const config = await createSlackConfig(0);
+    const provider = new SlackProviderAdapter("slack", config, "crabline");
+    providers.push(provider);
+
+    expect(() => provider.normalizeTarget({ id: "target-1", metadata: {} })).toThrow(
+      /native Slack conversation id/u,
+    );
+    expect(() => provider.normalizeTarget({ id: "slack:C1234567890", metadata: {} })).toThrow(
+      /native Slack conversation id/u,
+    );
+    expect(() =>
+      provider.normalizeTarget({
+        channelId: "C1234567890",
+        id: "reply-target",
+        metadata: {},
+        threadId: "thread-1",
+      }),
+    ).toThrow(/Slack timestamp/u);
+  });
+
+  it("probes and sends with Slack-shaped ids", async () => {
+    const config = await createSlackConfig(0);
+    const provider = new SlackProviderAdapter("slack", config, "crabline");
+    providers.push(provider);
+
+    const context = createContext(config);
+    const probe = await provider.probe(context);
+    expect(probe.healthy).toBe(true);
+    expect(probe.details.join("\n")).toContain("slack local mock ready");
+    expect(probe.details.join("\n")).toContain("events endpoint http://127.0.0.1:");
+    expect(probe.details.join("\n")).toContain("channel reachable C1234567890");
+
+    const result = await provider.send({
+      ...context,
+      mode: "roundtrip",
+      nonce: "nonce-1",
+      text: "hello nonce-1",
+    });
+    expect(result.accepted).toBe(true);
+    expect(result.threadId).toBe("C1234567890");
+
+    await expect(
+      provider.waitForInbound({
+        ...context,
+        nonce: "nonce-1",
+        since: new Date(Date.now() - 1000).toISOString(),
+        threadId: result.threadId,
+        timeoutMs: 500,
+      }),
+    ).resolves.toMatchObject({
+      author: "assistant",
+      text: "[slack mock] hello nonce-1",
+      threadId: "C1234567890",
+    });
+  });
+
+  it("accepts Slack Events API-style inbound messages", async () => {
+    const config = await createSlackConfig(0);
+    const provider = new SlackProviderAdapter("slack", config, "crabline");
+    providers.push(provider);
+
+    const context = createContext(config, {
+      channelId: "C1234567890",
+      id: "reply-target",
+      metadata: {},
+      threadId: "1700000000.000100",
+    });
+    context.fixture.inboundMatch = { author: "user", nonce: "contains", strategy: "contains" };
+    const endpoint = endpointFromDetails((await provider.probe(context)).details);
+    const waitPromise = provider.waitForInbound({
+      ...context,
+      nonce: "nonce-2",
+      since: new Date(Date.now() - 1000).toISOString(),
+      threadId: "1700000000.000100",
+      timeoutMs: 500,
+    });
+
+    const response = await fetch(endpoint, {
+      body: JSON.stringify({
+        event: {
+          channel: "C1234567890",
+          text: "ACK nonce-2",
+          thread_ts: "1700000000.000100",
+          ts: "1700000001.000200",
+          type: "message",
+          user: "U1234567890",
+        },
+        team_id: "T1234567890",
+        type: "event_callback",
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    expect(response.status).toBe(200);
+
+    await expect(waitPromise).resolves.toMatchObject({
+      author: "user",
+      id: "1700000001.000200",
+      text: "ACK nonce-2",
+      threadId: "1700000000.000100",
+    });
+  });
+
+  it("rejects mock webhook thread ids that are not Slack-shaped", async () => {
+    const config = await createSlackConfig(0);
+    const provider = new SlackProviderAdapter("slack", config, "crabline");
+    providers.push(provider);
+
+    const endpoint = endpointFromDetails((await provider.probe(createContext(config))).details);
+    const response = await fetch(endpoint, {
+      body: JSON.stringify({
+        id: "bad-slack-inbound",
+        text: "bad nonce",
+        threadId: "slack:C1234567890",
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    expect(response.status).toBe(400);
+    await expect(response.text()).resolves.toContain(
+      "native Slack timestamp or Slack conversation id",
+    );
+  });
 });

--- a/test/telegram-provider.test.ts
+++ b/test/telegram-provider.test.ts
@@ -97,19 +97,22 @@ describe("telegram provider", () => {
     providers.push(provider);
 
     expect(provider.normalizeTarget({ id: "-100123", metadata: {} })).toMatchObject({
-      channelId: "telegram:-100123",
+      channelId: "-100123",
     });
     expect(
       provider.normalizeTarget({
-        channelId: "telegram:-100123",
+        channelId: "-100123",
         id: "topic",
         metadata: {},
         threadId: "42",
       }),
     ).toMatchObject({
-      channelId: "telegram:-100123",
-      threadId: "telegram:-100123:42",
+      channelId: "-100123",
+      threadId: "42",
     });
+    expect(() => provider.normalizeTarget({ id: "telegram:-100123", metadata: {} })).toThrow(
+      /Telegram chat_id/u,
+    );
   });
 
   it("probes and sends through the local mock service", async () => {
@@ -121,7 +124,7 @@ describe("telegram provider", () => {
     expect(probe.healthy).toBe(true);
     expect(probe.details.join("\n")).toContain("telegram local mock ready");
     expect(probe.details.join("\n")).toContain("webhook endpoint http://127.0.0.1:");
-    expect(probe.details.join("\n")).toContain("channel reachable telegram:123456789");
+    expect(probe.details.join("\n")).toContain("channel reachable 123456789");
 
     const result = await provider.send({
       ...createContext(config),
@@ -131,7 +134,7 @@ describe("telegram provider", () => {
     });
 
     expect(result.accepted).toBe(true);
-    expect(result.threadId).toBe("telegram:123456789");
+    expect(result.threadId).toBe("123456789");
 
     await expect(
       provider.waitForInbound({
@@ -160,17 +163,19 @@ describe("telegram provider", () => {
       ...createContext(config),
       nonce: "nonce-2",
       since: new Date(Date.now() - 1000).toISOString(),
-      threadId: "telegram:123456789",
+      threadId: "123456789",
       timeoutMs: 500,
     });
 
     const response = await fetch(endpoint!.replace("webhook endpoint ", ""), {
       body: JSON.stringify({
         message: {
-          id: "evt-1",
+          chat: { id: 123456789 },
+          from: { is_bot: true },
+          message_id: 1,
           text: "ACK nonce-2",
-          threadId: "telegram:123456789",
         },
+        update_id: 2,
       }),
       headers: { "content-type": "application/json" },
       method: "POST",
@@ -178,7 +183,7 @@ describe("telegram provider", () => {
 
     expect(response.status).toBe(200);
     await expect(waitPromise).resolves.toMatchObject({
-      id: "evt-1",
+      id: "1",
       text: "ACK nonce-2",
     });
   });
@@ -193,12 +198,12 @@ describe("telegram provider", () => {
     expect(endpoint).toBeDefined();
 
     const response = await fetch(endpoint!.replace("webhook endpoint ", ""), {
-      body: JSON.stringify({ message: { id: "evt-bad", text: "missing thread" } }),
+      body: JSON.stringify({ message: { message_id: 1, text: "missing thread" } }),
       headers: { "content-type": "application/json" },
       method: "POST",
     });
 
     expect(response.status).toBe(400);
-    await expect(response.text()).resolves.toContain("threadId");
+    await expect(response.text()).resolves.toContain("message.chat.id");
   });
 });

--- a/test/whatsapp-provider.test.ts
+++ b/test/whatsapp-provider.test.ts
@@ -4,5 +4,28 @@ import { runLocalMockProviderContract } from "./local-mock-provider-helpers.js";
 runLocalMockProviderContract({
   Adapter: WhatsAppProviderAdapter,
   endpointPath: "/whatsapp/webhook",
+  expectedChannelId: "15551234567",
   platform: "whatsapp",
+  target: { id: "15551234567", metadata: {} },
+  webhookExpected: { author: "user", id: "wamid.abc123", text: "reply nonce-2" },
+  webhookPayload: {
+    entry: [
+      {
+        changes: [
+          {
+            value: {
+              messages: [
+                {
+                  from: "15551234567",
+                  id: "wamid.abc123",
+                  text: { body: "reply nonce-2" },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  },
+  webhookThreadId: "15551234567",
 });

--- a/test/zalo-provider.test.ts
+++ b/test/zalo-provider.test.ts
@@ -4,5 +4,13 @@ import { runLocalMockProviderContract } from "./local-mock-provider-helpers.js";
 runLocalMockProviderContract({
   Adapter: ZaloProviderAdapter,
   endpointPath: "/zalo/webhook",
+  expectedChannelId: "123456789012",
   platform: "zalo",
+  target: { id: "123456789012", metadata: {} },
+  webhookExpected: { author: "user", id: "zalo-msg-1", text: "reply nonce-2" },
+  webhookPayload: {
+    message: { msg_id: "zalo-msg-1", text: "reply nonce-2" },
+    sender: { id: "123456789012" },
+  },
+  webhookThreadId: "123456789012",
 });


### PR DESCRIPTION
## Summary
- replace generic platform-prefixed target encoding with native channel/thread validation for built-in mocks
- add provider-native webhook normalization for Slack, Telegram, Discord, WhatsApp, Teams, Google Chat, Feishu, Mattermost, Matrix, iMessage, and Zalo
- update docs and provider tests to use native IDs and reject synthetic Crabline prefixes

## Verification
- pnpm verify
