### PR TITLE
Add Telegram fake provider server

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,8 @@
 Deterministic local messaging-channel mocks for OpenClaw QA.
 
 `crabline` is config-driven, CI-friendly, and deliberately has no `openclaw`
-dependency. It models OpenClaw channel contracts without connecting to live chat
-services or installing provider SDKs. A fixture can still say
-`channel: telegram` on the OpenClaw side; Crabline supplies the mock Telegram
-execution backend for that channel shape.
+dependency. It can run fixture-level local mocks, and it can also serve fake
+provider APIs that OpenClaw live adapters can target during deterministic QA.
 
 ## What It Provides
 
@@ -15,13 +13,15 @@ execution backend for that channel shape.
   `whatsapp`, and `zalo`
 - a `script` bridge for channels that are still exercised by external commands
 - per-provider local webhook endpoints for inbound events
+- fake provider servers for live-adapter smoke tests, starting with Telegram
 - JSONL recorder files for deterministic wait/watch behavior
 - nonce-based `send`, `roundtrip`, `agent`, `probe`, `run`, `watch`, and
   `doctor` commands
 - text output by default and stable `--json` output for automation
 
-Crabline is not a live transport runner. Live OpenClaw channel tests use
-OpenClaw's live channel adapters and credentials directly.
+Crabline fake servers are not live-provider coverage. They let OpenClaw run its
+normal channel adapter code against a local provider-shaped API. Release lanes
+still need the `live` driver and real provider credentials.
 
 ## Install
 
@@ -115,6 +115,32 @@ The built-in providers are:
 
 The `script` adapter can bridge any other OpenClaw channel by running local
 commands for `probe`, `send`, `waitForInbound`, or `watch`.
+
+## Fake Provider Servers
+
+`serve` starts provider-shaped HTTP APIs for OpenClaw live adapters. This is the
+preferred Smoke CI path because OpenClaw still uses its normal channel adapter,
+but the provider endpoint is local and deterministic.
+
+Telegram:
+
+```bash
+crabline --json serve telegram --ready-file .crabline/telegram-server.json
+```
+
+The JSON manifest contains:
+
+- `endpoints.apiRoot`: set OpenClaw `channels.telegram.apiRoot` to this value
+- `botToken`: set OpenClaw `channels.telegram.botToken` to this value
+- `endpoints.adminInboundUrl`: POST test user messages here; OpenClaw reads
+  them through Telegram `getUpdates`
+- `recorderPath`: JSONL file of fake provider API/admin traffic
+
+Implemented Telegram Bot API endpoints include `getMe`, `sendMessage`,
+`editMessageText`, `deleteMessage`, `setMessageReaction`, `createForumTopic`,
+`editForumTopic`, `pinChatMessage`, `unpinChatMessage`, `getUpdates`,
+`deleteWebhook`, `setWebhook`, `setMyCommands`, `deleteMyCommands`,
+`sendChatAction`, and `answerCallbackQuery`.
 
 ## Target IDs
 

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -1,12 +1,14 @@
 # Channel Setup
 
-Crabline is a local mock service for OpenClaw channel contracts. It does not
-connect to Slack, Discord, Telegram, WhatsApp, Matrix, iMessage, or any other
-live chat service, and it does not depend on chat provider SDK packages.
+Crabline is a local mock service for OpenClaw channel contracts. It has two
+surfaces:
+
+- fixture-level local mocks used directly by the Crabline CLI
+- fake provider servers that OpenClaw live adapters can target
 
 Live channel testing belongs in OpenClaw's live channel adapters. Crabline
 belongs in deterministic smoke CI and local QA where the test needs
-channel-shaped behavior without external services.
+provider-shaped behavior without external services.
 
 ## Provider Shape
 
@@ -67,6 +69,39 @@ providers:
 Provider credential fields such as `botToken`, `accessToken`, `baseURL`, or
 `serverUrl` are optional mock metadata. They are not required for local mock
 execution.
+
+## Fake Provider Servers
+
+Fake provider servers sit below OpenClaw's normal channel adapters. QA starts the
+server, writes the emitted runtime manifest into OpenClaw config/env, and then
+OpenClaw talks to the local fake provider instead of the public provider.
+
+Telegram is currently implemented:
+
+```bash
+crabline --json serve telegram --ready-file .crabline/telegram-server.json
+```
+
+Manifest fields:
+
+- `endpoints.apiRoot`: OpenClaw `channels.telegram.apiRoot`
+- `botToken`: OpenClaw `channels.telegram.botToken`
+- `endpoints.adminInboundUrl`: admin ingress for test user messages
+- `recorderPath`: JSONL provider traffic recorder
+
+The admin ingress accepts JSON like:
+
+```json
+{
+  "chatId": "-1001234567890",
+  "messageThreadId": 42,
+  "fromId": 100001,
+  "text": "user nonce-123"
+}
+```
+
+OpenClaw consumes that message through Telegram `getUpdates`; outbound adapter
+sends are recorded through Telegram `sendMessage`.
 
 ## Webhook Payload
 

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -1,9 +1,12 @@
 import { Command } from "commander";
+import fs from "node:fs/promises";
+import nodePath from "node:path";
 import { loadManifest } from "../config/load.js";
 import { createRegistry } from "../providers/registry.js";
 import { formatJson, formatRunResultText } from "../core/reporters.js";
 import { computeExitCode, runFixtureCommand, runSuite } from "../core/run.js";
 import { CrablineError, ensureErrorMessage } from "../core/errors.js";
+import { startTelegramFakeServer } from "../fake-servers/telegram.js";
 
 type GlobalOptions = {
   config?: string;
@@ -170,6 +173,49 @@ export function createProgram(): Command {
     });
 
   program
+    .command("serve <provider>")
+    .description("Start a fake provider server that OpenClaw live adapters can target")
+    .option("--host <host>", "Bind host", "127.0.0.1")
+    .option("--port <port>", "Bind port", "0")
+    .option("--bot-token <token>", "Fake Telegram bot token")
+    .option("--bot-username <username>", "Fake Telegram bot username", "crabline_bot")
+    .option("--recorder <path>", "JSONL recorder path")
+    .option("--ready-file <path>", "Write the server runtime manifest to this path")
+    .option("--once", "Start, print the runtime manifest, and stop immediately", false)
+    .action(async (provider, commandOptions) => {
+      const options = program.opts() as GlobalOptions;
+      if (provider !== "telegram") {
+        throw new CrablineError(`Unsupported fake provider server: ${provider}`, {
+          kind: "config",
+        });
+      }
+      const port = Number(commandOptions.port);
+      if (!Number.isInteger(port) || port < 0 || port > 65_535) {
+        throw new CrablineError(`Invalid fake server port: ${commandOptions.port}`, {
+          kind: "config",
+        });
+      }
+      const server = await startTelegramFakeServer({
+        botToken: commandOptions.botToken,
+        botUsername: commandOptions.botUsername,
+        host: commandOptions.host,
+        port,
+        recorderPath: commandOptions.recorder,
+      });
+      const payload = formatJson(server.manifest);
+      if (commandOptions.readyFile) {
+        await fs.mkdir(nodePath.dirname(commandOptions.readyFile), { recursive: true });
+        await fs.writeFile(commandOptions.readyFile, `${payload}\n`, "utf8");
+      }
+      print(options.json ? payload : renderServeText(server.manifest));
+      if (commandOptions.once) {
+        await server.close();
+        return;
+      }
+      await waitForShutdown(server.close);
+    });
+
+  program
     .command("doctor")
     .description("Diagnose common setup problems")
     .action(async () => {
@@ -183,6 +229,32 @@ export function createProgram(): Command {
     });
 
   return program;
+}
+
+function waitForShutdown(close: () => Promise<void>): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const shutdown = () => {
+      close().then(resolve, reject);
+    };
+    process.once("SIGINT", shutdown);
+    process.once("SIGTERM", shutdown);
+  });
+}
+
+function renderServeText(manifest: {
+  baseUrl: string;
+  botToken: string;
+  endpoints: { adminInboundUrl: string; apiRoot: string };
+  provider: string;
+  recorderPath: string;
+}) {
+  return [
+    `${manifest.provider} fake server ready`,
+    `  apiRoot: ${manifest.endpoints.apiRoot}`,
+    `  botToken: ${manifest.botToken}`,
+    `  inbound: ${manifest.endpoints.adminInboundUrl}`,
+    `  recorder: ${manifest.recorderPath}`,
+  ].join("\n");
 }
 
 function renderProvidersText(payload: {

--- a/src/fake-servers/index.ts
+++ b/src/fake-servers/index.ts
@@ -1,0 +1,31 @@
+import {
+  startTelegramFakeServer,
+  type StartedTelegramFakeServer,
+  type StartTelegramFakeServerParams,
+  type TelegramFakeServerManifest,
+} from "./telegram.js";
+
+export const CRABLINE_FAKE_PROVIDER_CHANNELS = Object.freeze(["telegram"] as const);
+
+export type CrablineFakeProviderChannel = (typeof CRABLINE_FAKE_PROVIDER_CHANNELS)[number];
+
+export type CrablineFakeProviderManifest = TelegramFakeServerManifest;
+
+export type StartedCrablineFakeProviderServer = StartedTelegramFakeServer;
+
+export type StartCrablineFakeProviderServerParams = StartTelegramFakeServerParams & {
+  channel: CrablineFakeProviderChannel;
+};
+
+export function isCrablineFakeProviderChannel(value: string): value is CrablineFakeProviderChannel {
+  return CRABLINE_FAKE_PROVIDER_CHANNELS.includes(value as CrablineFakeProviderChannel);
+}
+
+export async function startCrablineFakeProviderServer(
+  params: StartCrablineFakeProviderServerParams,
+): Promise<StartedCrablineFakeProviderServer> {
+  switch (params.channel) {
+    case "telegram":
+      return await startTelegramFakeServer(params);
+  }
+}

--- a/src/fake-servers/telegram.ts
+++ b/src/fake-servers/telegram.ts
@@ -1,0 +1,426 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { CrablineError } from "../core/errors.js";
+
+type TelegramFakeServerEvent = {
+  at: string;
+  body?: unknown;
+  method: string;
+  path: string;
+  query: Record<string, string>;
+  type: "admin" | "api";
+};
+
+type TelegramFakeServerState = {
+  botId: number;
+  botToken: string;
+  botUsername: string;
+  nextMessageId: number;
+  nextUpdateId: number;
+  recorderPath: string;
+  updates: TelegramUpdate[];
+};
+
+type TelegramMessage = {
+  chat: {
+    id: number | string;
+    title?: string;
+    type: "group" | "private" | "supergroup";
+  };
+  date: number;
+  from: {
+    first_name: string;
+    id: number;
+    is_bot: boolean;
+    username?: string;
+  };
+  message_id: number;
+  message_thread_id?: number;
+  text: string;
+};
+
+type TelegramUpdate = {
+  message: TelegramMessage;
+  update_id: number;
+};
+
+export type TelegramFakeServerManifest = {
+  baseUrl: string;
+  botToken: string;
+  endpoints: {
+    adminInboundUrl: string;
+    apiRoot: string;
+  };
+  env: {
+    TELEGRAM_BOT_TOKEN: string;
+  };
+  provider: "telegram";
+  recorderPath: string;
+  version: 1;
+};
+
+export type StartedTelegramFakeServer = {
+  close(): Promise<void>;
+  manifest: TelegramFakeServerManifest;
+};
+
+export type StartTelegramFakeServerParams = {
+  botId?: number | undefined;
+  botToken?: string | undefined;
+  botUsername?: string | undefined;
+  host?: string | undefined;
+  port?: number | undefined;
+  recorderPath?: string | undefined;
+};
+
+function jsonResponse(value: unknown, status = 200): Response {
+  return Response.json(value, { status });
+}
+
+function telegramOk(result: unknown): Response {
+  return jsonResponse({ ok: true, result });
+}
+
+function telegramError(description: string, status = 400): Response {
+  return jsonResponse({ description, error_code: status, ok: false }, status);
+}
+
+async function readBody(request: IncomingMessage): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+async function parseRequestBody(request: IncomingMessage): Promise<Record<string, unknown>> {
+  const body = await readBody(request);
+  if (body.length === 0) {
+    return {};
+  }
+  const contentType = request.headers["content-type"] ?? "";
+  if (
+    Array.isArray(contentType)
+      ? contentType.some((entry) => entry.includes("json"))
+      : contentType.includes("json")
+  ) {
+    return JSON.parse(body.toString("utf8")) as Record<string, unknown>;
+  }
+  const params = new URLSearchParams(body.toString("utf8"));
+  return Object.fromEntries(params.entries());
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+async function writeResponse(response: ServerResponse, fetchResponse: Response): Promise<void> {
+  response.statusCode = fetchResponse.status;
+  for (const [name, value] of fetchResponse.headers) {
+    response.setHeader(name, value);
+  }
+  response.end(Buffer.from(await fetchResponse.arrayBuffer()));
+}
+
+function requireTelegramBotPath(pathname: string): { method: string; token: string } | undefined {
+  const match = /^\/bot([^/]+)\/([A-Za-z][A-Za-z0-9_]*)$/u.exec(pathname);
+  if (!match?.[1] || !match[2]) {
+    return undefined;
+  }
+  return { method: match[2], token: match[1] };
+}
+
+function toStringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0
+    ? value
+    : typeof value === "number" || typeof value === "bigint"
+      ? value.toString()
+      : undefined;
+}
+
+function toIntegerValue(value: unknown): number | undefined {
+  const stringValue = toStringValue(value);
+  if (!stringValue || !/^-?\d+$/u.test(stringValue)) {
+    return undefined;
+  }
+  return Number(stringValue);
+}
+
+function telegramChatId(value: unknown): number | string | undefined {
+  const stringValue = toStringValue(value);
+  if (!stringValue) {
+    return undefined;
+  }
+  return /^-?\d+$/u.test(stringValue) ? Number(stringValue) : stringValue;
+}
+
+async function appendEvent(state: TelegramFakeServerState, event: TelegramFakeServerEvent) {
+  await fs.mkdir(path.dirname(state.recorderPath), { recursive: true });
+  await fs.appendFile(state.recorderPath, `${JSON.stringify(event)}\n`, "utf8");
+}
+
+function createBotUser(state: TelegramFakeServerState) {
+  return {
+    can_join_groups: true,
+    can_read_all_group_messages: true,
+    first_name: "Crabline",
+    has_topics_enabled: true,
+    id: state.botId,
+    is_bot: true,
+    supports_inline_queries: false,
+    username: state.botUsername,
+  };
+}
+
+function createChat(chatId: number | string): TelegramMessage["chat"] {
+  return {
+    id: chatId,
+    type: typeof chatId === "number" && chatId < 0 ? "supergroup" : "private",
+  };
+}
+
+function createOutboundMessage(
+  state: TelegramFakeServerState,
+  body: Record<string, unknown>,
+): TelegramMessage | undefined {
+  const chatId = telegramChatId(body.chat_id);
+  const text = toStringValue(body.text);
+  if (chatId === undefined || !text) {
+    return undefined;
+  }
+  const threadId = toIntegerValue(body.message_thread_id);
+  return {
+    chat: createChat(chatId),
+    date: Math.floor(Date.now() / 1000),
+    from: createBotUser(state),
+    message_id: state.nextMessageId++,
+    ...(threadId !== undefined ? { message_thread_id: threadId } : {}),
+    text,
+  };
+}
+
+function createEditedMessage(
+  state: TelegramFakeServerState,
+  body: Record<string, unknown>,
+): TelegramMessage | undefined {
+  const chatId = telegramChatId(body.chat_id);
+  const text = toStringValue(body.text);
+  const messageId = toIntegerValue(body.message_id);
+  if (chatId === undefined || !text || messageId === undefined) {
+    return undefined;
+  }
+  const threadId = toIntegerValue(body.message_thread_id);
+  return {
+    chat: createChat(chatId),
+    date: Math.floor(Date.now() / 1000),
+    from: createBotUser(state),
+    message_id: messageId,
+    ...(threadId !== undefined ? { message_thread_id: threadId } : {}),
+    text,
+  };
+}
+
+function createInboundUpdate(
+  state: TelegramFakeServerState,
+  body: Record<string, unknown>,
+): TelegramUpdate | undefined {
+  const chatId = telegramChatId(body.chatId ?? body.chat_id);
+  const text = toStringValue(body.text);
+  if (chatId === undefined || !text) {
+    return undefined;
+  }
+  const fromId = toIntegerValue(body.fromId ?? body.from_id) ?? 100001;
+  const threadId = toIntegerValue(body.messageThreadId ?? body.message_thread_id);
+  const fromUsername = toStringValue(body.fromUsername ?? body.from_username);
+  return {
+    message: {
+      chat: createChat(chatId),
+      date: Math.floor(Date.now() / 1000),
+      from: {
+        first_name: toStringValue(body.fromName ?? body.from_name) ?? "QA User",
+        id: fromId,
+        is_bot: false,
+        ...(fromUsername ? { username: fromUsername } : {}),
+      },
+      message_id: toIntegerValue(body.messageId ?? body.message_id) ?? state.nextMessageId++,
+      ...(threadId !== undefined ? { message_thread_id: threadId } : {}),
+      text,
+    },
+    update_id: toIntegerValue(body.updateId ?? body.update_id) ?? state.nextUpdateId++,
+  };
+}
+
+function queryRecord(url: URL): Record<string, string> {
+  return Object.fromEntries(url.searchParams.entries());
+}
+
+async function handleTelegramApi(params: {
+  body: Record<string, unknown>;
+  method: string;
+  state: TelegramFakeServerState;
+}) {
+  switch (params.method) {
+    case "getMe":
+      return telegramOk(createBotUser(params.state));
+    case "deleteWebhook":
+    case "setWebhook":
+    case "setMyCommands":
+    case "deleteMyCommands":
+    case "sendChatAction":
+    case "answerCallbackQuery":
+    case "deleteMessage":
+    case "pinChatMessage":
+    case "unpinChatMessage":
+    case "setMessageReaction":
+    case "editForumTopic":
+      return telegramOk(true);
+    case "createForumTopic":
+      return telegramOk({
+        icon_color: 0x6fb9f0,
+        message_thread_id: params.state.nextMessageId++,
+        name: toStringValue(params.body.name) ?? "Crabline Topic",
+      });
+    case "editMessageText": {
+      const message = createEditedMessage(params.state, params.body);
+      return message
+        ? telegramOk(message)
+        : telegramError("Bad Request: chat_id, message_id, and text are required");
+    }
+    case "sendMessage": {
+      const message = createOutboundMessage(params.state, params.body);
+      return message
+        ? telegramOk(message)
+        : telegramError("Bad Request: chat_id and text are required");
+    }
+    case "getUpdates": {
+      const offset = toIntegerValue(params.body.offset);
+      const limit = toIntegerValue(params.body.limit) ?? 100;
+      const updates =
+        offset === undefined
+          ? params.state.updates
+          : params.state.updates.filter((update) => update.update_id >= offset);
+      return telegramOk(updates.slice(0, limit));
+    }
+    default:
+      return telegramError(`Not Found: unsupported method ${params.method}`, 404);
+  }
+}
+
+async function handleRequest(params: { request: IncomingMessage; state: TelegramFakeServerState }) {
+  const url = new URL(params.request.url ?? "/", "http://127.0.0.1");
+  if (url.pathname === "/crabline/telegram/inbound") {
+    if (params.request.method !== "POST") {
+      return new Response("not found", { status: 404 });
+    }
+    const body = await parseRequestBody(params.request);
+    const update = createInboundUpdate(params.state, body);
+    await appendEvent(params.state, {
+      at: new Date().toISOString(),
+      body,
+      method: params.request.method ?? "POST",
+      path: url.pathname,
+      query: queryRecord(url),
+      type: "admin",
+    });
+    if (!update) {
+      return telegramError("Bad Request: chatId and text are required");
+    }
+    params.state.updates.push(update);
+    return jsonResponse({ ok: true, update });
+  }
+
+  const botPath = requireTelegramBotPath(url.pathname);
+  if (!botPath || botPath.token !== params.state.botToken) {
+    return new Response("not found", { status: 404 });
+  }
+  const body =
+    params.request.method === "GET" ? queryRecord(url) : await parseRequestBody(params.request);
+  await appendEvent(params.state, {
+    at: new Date().toISOString(),
+    body,
+    method: params.request.method ?? "GET",
+    path: url.pathname,
+    query: queryRecord(url),
+    type: "api",
+  });
+  return handleTelegramApi({
+    body,
+    method: botPath.method,
+    state: params.state,
+  });
+}
+
+export async function startTelegramFakeServer(
+  params: StartTelegramFakeServerParams = {},
+): Promise<StartedTelegramFakeServer> {
+  const state: TelegramFakeServerState = {
+    botId: params.botId ?? 424242,
+    botToken: params.botToken ?? "424242:crabline-telegram-token",
+    botUsername: params.botUsername ?? "crabline_bot",
+    nextMessageId: 1,
+    nextUpdateId: 1,
+    recorderPath:
+      params.recorderPath ?? path.resolve(".crabline", "fake-servers", "telegram.jsonl"),
+    updates: [],
+  };
+  const host = params.host ?? "127.0.0.1";
+  const port = params.port ?? 0;
+  const server = createServer(async (request, response) => {
+    try {
+      await writeResponse(response, await handleRequest({ request, state }));
+    } catch (error) {
+      await writeResponse(
+        response,
+        jsonResponse(
+          {
+            error: error instanceof Error ? error.message : String(error),
+            ok: false,
+          },
+          500,
+        ),
+      );
+    }
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, host, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new CrablineError("Unable to resolve Telegram fake server address.", {
+      kind: "connectivity",
+    });
+  }
+  const baseUrl = `http://${host}:${address.port}`;
+  return {
+    async close() {
+      await closeServer(server);
+    },
+    manifest: {
+      baseUrl,
+      botToken: state.botToken,
+      endpoints: {
+        adminInboundUrl: `${baseUrl}/crabline/telegram/inbound`,
+        apiRoot: baseUrl,
+      },
+      env: {
+        TELEGRAM_BOT_TOKEN: state.botToken,
+      },
+      provider: "telegram",
+      recorderPath: state.recorderPath,
+      version: 1,
+    },
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,18 @@
 export { resolveTelegramAdapterConfig } from "./providers/builtin/telegram.js";
 export { resolveWhatsAppAdapterConfig } from "./providers/builtin/whatsapp.js";
+export { startTelegramFakeServer } from "./fake-servers/telegram.js";
+export {
+  CRABLINE_FAKE_PROVIDER_CHANNELS,
+  isCrablineFakeProviderChannel,
+  startCrablineFakeProviderServer,
+} from "./fake-servers/index.js";
+export {
+  createOpenClawCrablineAgentDelivery,
+  createOpenClawCrablineFakeProviderBinding,
+  createOpenClawCrablineInbound,
+  createOpenClawCrablineOutboundFromRecorderEvent,
+  startOpenClawCrablineAdapter,
+} from "./openclaw.js";
 export {
   BUILTIN_ADAPTERS,
   FIXTURE_MODES,
@@ -34,3 +47,23 @@ export type {
   WaitContext,
   WatchContext,
 } from "./providers/types.js";
+export type {
+  StartedTelegramFakeServer,
+  StartTelegramFakeServerParams,
+  TelegramFakeServerManifest,
+} from "./fake-servers/telegram.js";
+export type {
+  CrablineFakeProviderChannel,
+  CrablineFakeProviderManifest,
+  StartedCrablineFakeProviderServer,
+  StartCrablineFakeProviderServerParams,
+} from "./fake-servers/index.js";
+export type {
+  OpenClawCrablineAgentDelivery,
+  OpenClawCrablineGatewayBinding,
+  OpenClawCrablineInbound,
+  OpenClawCrablineInboundInput,
+  OpenClawCrablineOutboundMessage,
+  StartedOpenClawCrablineAdapter,
+  StartOpenClawCrablineAdapterParams,
+} from "./openclaw.js";

--- a/src/openclaw.ts
+++ b/src/openclaw.ts
@@ -1,0 +1,304 @@
+import {
+  startCrablineFakeProviderServer,
+  type CrablineFakeProviderChannel,
+  type CrablineFakeProviderManifest,
+  type StartedCrablineFakeProviderServer,
+} from "./fake-servers/index.js";
+
+const TELEGRAM_ACCOUNT_ID = "default";
+const TELEGRAM_DIRECT_CHAT_ID = "100001";
+const TELEGRAM_GROUP_CHAT_ID = "-1001234567890";
+const TELEGRAM_DEFAULT_SENDER_ID = 100001;
+
+export type OpenClawCrablineConversation = {
+  id: string;
+  kind: "direct" | "group";
+};
+
+export type OpenClawCrablineGatewayBinding = {
+  accountId: string;
+  channel: string;
+  createChannelDriverSmokeEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv;
+  createGatewayConfig(openclawConfig?: Record<string, unknown>): Record<string, unknown>;
+  requiredPluginIds: string[];
+};
+
+export type OpenClawCrablineAgentDelivery = {
+  channel: string;
+  replyChannel: string;
+  replyTo: string;
+  to: string;
+};
+
+export type OpenClawCrablineInboundInput = {
+  conversation: {
+    id: string;
+    kind: string;
+  };
+  senderId: string;
+  senderName?: string | undefined;
+  text: string;
+  threadId?: string | undefined;
+};
+
+export type OpenClawCrablineInbound = {
+  providerBody: Record<string, unknown>;
+  providerTargetKey: string;
+  qaTarget: string;
+  stateConversation: OpenClawCrablineConversation;
+  threadId?: string | undefined;
+};
+
+export type OpenClawCrablineOutboundMessage = {
+  accountId: string;
+  senderId: string;
+  senderName: string;
+  text: string;
+  to: string;
+};
+
+export type StartOpenClawCrablineAdapterParams = {
+  channel: CrablineFakeProviderChannel;
+  openclawConfig?: Record<string, unknown> | undefined;
+  recorderPath?: string | undefined;
+};
+
+export type StartedOpenClawCrablineAdapter = OpenClawCrablineGatewayBinding & {
+  close(): Promise<void>;
+  createAgentDelivery(params: { target: string }): OpenClawCrablineAgentDelivery;
+  createInbound(params: { input: OpenClawCrablineInboundInput }): OpenClawCrablineInbound;
+  createOutboundFromRecorderEvent(params: {
+    event: unknown;
+    targetByProviderTarget: ReadonlyMap<string, string>;
+  }): OpenClawCrablineOutboundMessage | null;
+  manifest: CrablineFakeProviderManifest;
+};
+
+type TelegramRecorderEvent = {
+  body?: Record<string, unknown>;
+  path?: string;
+  type?: string;
+};
+
+function readString(value: unknown): string | undefined {
+  if (typeof value === "string" && value.trim()) {
+    return value.trim();
+  }
+  if (typeof value === "number" || typeof value === "bigint") {
+    return String(value);
+  }
+  return undefined;
+}
+
+function readInteger(value: unknown): number | undefined {
+  const stringValue = readString(value);
+  if (!stringValue || !/^-?\d+$/u.test(stringValue)) {
+    return undefined;
+  }
+  return Number(stringValue);
+}
+
+function parseQaTarget(target: string): {
+  kind: "direct" | "group";
+  id: string;
+  threadId?: string;
+} {
+  const trimmed = target.trim();
+  if (trimmed.startsWith("thread:")) {
+    const rest = trimmed.slice("thread:".length);
+    const slash = rest.indexOf("/");
+    if (slash > 0) {
+      return { kind: "group", id: rest.slice(0, slash), threadId: rest.slice(slash + 1) };
+    }
+  }
+  if (trimmed.startsWith("channel:")) {
+    return { kind: "group", id: trimmed.slice("channel:".length) };
+  }
+  if (trimmed.startsWith("group:")) {
+    return { kind: "group", id: trimmed.slice("group:".length) };
+  }
+  if (trimmed.startsWith("dm:")) {
+    return { kind: "direct", id: trimmed.slice("dm:".length) };
+  }
+  return { kind: "direct", id: trimmed };
+}
+
+function normalizeTelegramChatId(kind: "direct" | "group", id: string) {
+  return /^-?\d+$/u.test(id.trim())
+    ? id.trim()
+    : kind === "group"
+      ? TELEGRAM_GROUP_CHAT_ID
+      : TELEGRAM_DIRECT_CHAT_ID;
+}
+
+function telegramTargetKey(chatId: string, threadId?: number) {
+  return threadId === undefined ? chatId : `${chatId}:topic:${threadId}`;
+}
+
+function qaTargetForInbound(input: OpenClawCrablineInboundInput) {
+  const prefix =
+    input.conversation.kind === "direct"
+      ? "dm"
+      : input.conversation.kind === "channel"
+        ? "channel"
+        : "group";
+  return input.threadId
+    ? `thread:${input.conversation.id}/${input.threadId}`
+    : `${prefix}:${input.conversation.id}`;
+}
+
+function requireTelegramManifest(manifest: CrablineFakeProviderManifest) {
+  if (manifest.provider !== "telegram") {
+    throw new Error(`Unsupported OpenClaw fake provider binding: ${String(manifest.provider)}`);
+  }
+  return manifest;
+}
+
+export function createOpenClawCrablineFakeProviderBinding(
+  manifest: CrablineFakeProviderManifest,
+): OpenClawCrablineGatewayBinding {
+  const telegram = requireTelegramManifest(manifest);
+  return {
+    accountId: TELEGRAM_ACCOUNT_ID,
+    channel: "telegram",
+    createChannelDriverSmokeEnv: (env) => ({
+      ...env,
+      TELEGRAM_BOT_TOKEN: telegram.botToken,
+    }),
+    createGatewayConfig: (_openclawConfig = {}) => ({
+      channels: {
+        telegram: {
+          enabled: true,
+          botToken: telegram.botToken,
+          apiRoot: telegram.endpoints.apiRoot,
+          dmPolicy: "open",
+          groupPolicy: "open",
+          allowFrom: ["*"],
+          groupAllowFrom: ["*"],
+          groups: {
+            "*": {
+              requireMention: false,
+            },
+          },
+        },
+      },
+      messages: {
+        groupChat: {
+          mentionPatterns: ["\\b@?openclaw\\b"],
+          visibleReplies: "automatic",
+        },
+      },
+    }),
+    requiredPluginIds: ["telegram"],
+  };
+}
+
+export function createOpenClawCrablineAgentDelivery(params: {
+  manifest: CrablineFakeProviderManifest;
+  target: string;
+}): OpenClawCrablineAgentDelivery {
+  requireTelegramManifest(params.manifest);
+  const parsed = parseQaTarget(params.target);
+  const chatId = normalizeTelegramChatId(parsed.kind, parsed.id);
+  const threadId = readInteger(parsed.threadId);
+  const to = telegramTargetKey(chatId, threadId);
+  return {
+    channel: "telegram",
+    to,
+    replyChannel: "telegram",
+    replyTo: to,
+  };
+}
+
+export function createOpenClawCrablineInbound(params: {
+  input: OpenClawCrablineInboundInput;
+  manifest: CrablineFakeProviderManifest;
+}): OpenClawCrablineInbound {
+  requireTelegramManifest(params.manifest);
+  const kind = params.input.conversation.kind === "direct" ? "direct" : "group";
+  const chatId = normalizeTelegramChatId(kind, params.input.conversation.id);
+  const threadId = readInteger(params.input.threadId);
+  return {
+    providerBody: {
+      chatId,
+      fromId: readInteger(params.input.senderId) ?? TELEGRAM_DEFAULT_SENDER_ID,
+      fromName: params.input.senderName ?? params.input.senderId,
+      ...(threadId !== undefined ? { messageThreadId: threadId } : {}),
+      text: params.input.text,
+    },
+    providerTargetKey: telegramTargetKey(chatId, threadId),
+    qaTarget: qaTargetForInbound(params.input),
+    stateConversation: {
+      id: chatId,
+      kind: kind === "group" ? "group" : "direct",
+    },
+    ...(threadId !== undefined ? { threadId: String(threadId) } : {}),
+  };
+}
+
+export function createOpenClawCrablineOutboundFromRecorderEvent(params: {
+  event: unknown;
+  manifest: CrablineFakeProviderManifest;
+  targetByProviderTarget: ReadonlyMap<string, string>;
+}): OpenClawCrablineOutboundMessage | null {
+  requireTelegramManifest(params.manifest);
+  const event = params.event as TelegramRecorderEvent;
+  if (
+    event.type !== "api" ||
+    typeof event.path !== "string" ||
+    !event.path.endsWith("/sendMessage") ||
+    !event.body ||
+    typeof event.body !== "object"
+  ) {
+    return null;
+  }
+  const chatId = readString(event.body.chat_id);
+  const text = readString(event.body.text);
+  if (!chatId || !text) {
+    return null;
+  }
+  const threadId = readInteger(event.body.message_thread_id);
+  const providerTargetKey = telegramTargetKey(chatId, threadId);
+  return {
+    accountId: TELEGRAM_ACCOUNT_ID,
+    senderId: "openclaw",
+    senderName: "OpenClaw QA",
+    text,
+    to:
+      params.targetByProviderTarget.get(providerTargetKey) ??
+      (threadId === undefined ? chatId : providerTargetKey),
+  };
+}
+
+export async function startOpenClawCrablineAdapter(
+  params: StartOpenClawCrablineAdapterParams,
+): Promise<StartedOpenClawCrablineAdapter> {
+  const server: StartedCrablineFakeProviderServer = await startCrablineFakeProviderServer({
+    channel: params.channel,
+    recorderPath: params.recorderPath,
+  });
+  const binding = createOpenClawCrablineFakeProviderBinding(server.manifest);
+  return {
+    ...binding,
+    close: server.close,
+    createGatewayConfig: (openclawConfig = params.openclawConfig ?? {}) =>
+      binding.createGatewayConfig(openclawConfig),
+    createAgentDelivery: ({ target }) =>
+      createOpenClawCrablineAgentDelivery({
+        manifest: server.manifest,
+        target,
+      }),
+    createInbound: ({ input }) =>
+      createOpenClawCrablineInbound({
+        input,
+        manifest: server.manifest,
+      }),
+    createOutboundFromRecorderEvent: ({ event, targetByProviderTarget }) =>
+      createOpenClawCrablineOutboundFromRecorderEvent({
+        event,
+        manifest: server.manifest,
+        targetByProviderTarget,
+      }),
+    manifest: server.manifest,
+  };
+}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import fs from "node:fs/promises";
 import { afterEach, describe, expect, it } from "vitest";
 import { runCli } from "../src/cli/program.js";
 import { captureWrites, createTempDir, disposeTempDir, writeText } from "./test-helpers.js";
@@ -117,6 +118,45 @@ describe("cli", () => {
 
     expect(exitCode!).toBe(10);
     expect(captured.stderr.join("")).toContain("No fixture found");
+  });
+
+  it("prints a fake Telegram server runtime manifest", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const readyFile = path.join(directory, ".crabline", "telegram-server.json");
+    const captured = captureWrites();
+
+    try {
+      expect(
+        await runCli([
+          "node",
+          "crabline",
+          "--json",
+          "serve",
+          "telegram",
+          "--once",
+          "--ready-file",
+          readyFile,
+          "--recorder",
+          path.join(directory, "telegram.jsonl"),
+        ]),
+      ).toBe(0);
+    } finally {
+      captured.restore();
+    }
+
+    const manifest = JSON.parse(captured.stdout.join("")) as {
+      endpoints?: { adminInboundUrl?: string; apiRoot?: string };
+      botToken?: string;
+      provider?: string;
+    };
+    expect(manifest.provider).toBe("telegram");
+    expect(manifest.endpoints?.apiRoot).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/u);
+    expect(manifest.endpoints?.adminInboundUrl).toMatch(
+      /^http:\/\/127\.0\.0\.1:\d+\/crabline\/telegram\/inbound$/u,
+    );
+    expect(manifest.botToken).toBe("424242:crabline-telegram-token");
+    await expect(fs.readFile(readyFile, "utf8")).resolves.toContain('"provider": "telegram"');
   });
 
   it("doctor accepts local mock slack without live env", async () => {

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import {
+  createOpenClawCrablineAgentDelivery,
+  createOpenClawCrablineFakeProviderBinding,
+  createOpenClawCrablineInbound,
+  createOpenClawCrablineOutboundFromRecorderEvent,
+  startOpenClawCrablineAdapter,
+  type CrablineFakeProviderManifest,
+} from "../src/index.js";
+
+const manifest: CrablineFakeProviderManifest = {
+  baseUrl: "http://127.0.0.1:1234",
+  botToken: "424242:crabline-telegram-token",
+  endpoints: {
+    adminInboundUrl: "http://127.0.0.1:1234/crabline/telegram/inbound",
+    apiRoot: "http://127.0.0.1:1234",
+  },
+  env: {
+    TELEGRAM_BOT_TOKEN: "424242:crabline-telegram-token",
+  },
+  provider: "telegram",
+  recorderPath: "/tmp/crabline/telegram.jsonl",
+  version: 1,
+};
+
+describe("OpenClaw fake provider bridge", () => {
+  it("maps a Telegram fake provider into OpenClaw channel config", () => {
+    const binding = createOpenClawCrablineFakeProviderBinding(manifest);
+
+    expect(binding).toMatchObject({
+      accountId: "default",
+      channel: "telegram",
+      requiredPluginIds: ["telegram"],
+    });
+    expect(binding.createGatewayConfig()).toMatchObject({
+      channels: {
+        telegram: {
+          apiRoot: "http://127.0.0.1:1234",
+          botToken: "424242:crabline-telegram-token",
+          enabled: true,
+        },
+      },
+    });
+    expect(binding.createChannelDriverSmokeEnv({})).toMatchObject({
+      TELEGRAM_BOT_TOKEN: "424242:crabline-telegram-token",
+    });
+  });
+
+  it("starts a bound OpenClaw adapter from channel and config", async () => {
+    const adapter = await startOpenClawCrablineAdapter({
+      channel: "telegram",
+      openclawConfig: {
+        channels: {
+          telegram: {
+            enabled: false,
+          },
+        },
+      },
+    });
+    try {
+      expect(adapter.channel).toBe("telegram");
+      expect(adapter.requiredPluginIds).toEqual(["telegram"]);
+      expect(adapter.createGatewayConfig()).toMatchObject({
+        channels: {
+          telegram: {
+            enabled: true,
+            apiRoot: expect.stringMatching(/^http:\/\/127\.0\.0\.1:\d+$/u),
+          },
+        },
+      });
+      expect(adapter.createAgentDelivery({ target: "dm:alice" })).toMatchObject({
+        channel: "telegram",
+        to: "100001",
+      });
+    } finally {
+      await adapter.close();
+    }
+  });
+
+  it("maps QA targets, inbound messages, and recorder events", () => {
+    expect(createOpenClawCrablineAgentDelivery({ manifest, target: "dm:alice" })).toEqual({
+      channel: "telegram",
+      to: "100001",
+      replyChannel: "telegram",
+      replyTo: "100001",
+    });
+
+    const inbound = createOpenClawCrablineInbound({
+      manifest,
+      input: {
+        conversation: { id: "alice", kind: "direct" },
+        senderId: "alice",
+        senderName: "Alice",
+        text: "hello",
+      },
+    });
+    expect(inbound).toEqual({
+      providerBody: {
+        chatId: "100001",
+        fromId: 100001,
+        fromName: "Alice",
+        text: "hello",
+      },
+      providerTargetKey: "100001",
+      qaTarget: "dm:alice",
+      stateConversation: {
+        id: "100001",
+        kind: "direct",
+      },
+    });
+
+    expect(
+      createOpenClawCrablineOutboundFromRecorderEvent({
+        manifest,
+        targetByProviderTarget: new Map([["100001", "dm:alice"]]),
+        event: {
+          type: "api",
+          path: "/botTOKEN/sendMessage",
+          body: {
+            chat_id: "100001",
+            text: "agent reply",
+          },
+        },
+      }),
+    ).toEqual({
+      accountId: "default",
+      senderId: "openclaw",
+      senderName: "OpenClaw QA",
+      text: "agent reply",
+      to: "dm:alice",
+    });
+  });
+});

--- a/test/telegram-fake-server.test.ts
+++ b/test/telegram-fake-server.test.ts
@@ -1,0 +1,90 @@
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { startTelegramFakeServer, type StartedTelegramFakeServer } from "../src/index.js";
+import { createTempDir, disposeTempDir } from "./test-helpers.js";
+
+const servers: StartedTelegramFakeServer[] = [];
+const directories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => server.close()));
+  await Promise.all(directories.splice(0).map(disposeTempDir));
+});
+
+describe("telegram fake provider server", () => {
+  it("serves Telegram Bot API calls and queues injected inbound updates", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const server = await startTelegramFakeServer({
+      botToken: "123456:fake-token",
+      recorderPath: path.join(directory, "telegram.jsonl"),
+    });
+    servers.push(server);
+
+    const getMe = await fetch(`${server.manifest.baseUrl}/bot123456:fake-token/getMe`);
+    await expect(getMe.json()).resolves.toMatchObject({
+      ok: true,
+      result: {
+        is_bot: true,
+        username: "crabline_bot",
+      },
+    });
+
+    const sendMessage = await fetch(`${server.manifest.baseUrl}/bot123456:fake-token/sendMessage`, {
+      body: JSON.stringify({
+        chat_id: "-1001234567890",
+        message_thread_id: 42,
+        text: "hello fake telegram",
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    await expect(sendMessage.json()).resolves.toMatchObject({
+      ok: true,
+      result: {
+        chat: { id: -1001234567890, type: "supergroup" },
+        message_thread_id: 42,
+        text: "hello fake telegram",
+      },
+    });
+
+    const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({
+        chatId: "-1001234567890",
+        fromId: 100001,
+        messageThreadId: 42,
+        text: "user nonce-1",
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    await expect(inbound.json()).resolves.toMatchObject({
+      ok: true,
+      update: {
+        message: {
+          chat: { id: -1001234567890 },
+          from: { id: 100001, is_bot: false },
+          message_thread_id: 42,
+          text: "user nonce-1",
+        },
+      },
+    });
+
+    const updates = await fetch(`${server.manifest.baseUrl}/bot123456:fake-token/getUpdates`, {
+      body: JSON.stringify({ offset: 1 }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    await expect(updates.json()).resolves.toMatchObject({
+      ok: true,
+      result: [
+        {
+          message: {
+            text: "user nonce-1",
+          },
+          update_id: 1,
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a Telegram fake provider HTTP server that exposes Telegram Bot API-shaped endpoints for OpenClaw live adapters
- add a `crabline serve telegram` CLI command that emits a runtime manifest with apiRoot, bot token, admin inbound URL, and recorder path
- document the fake-provider-server surface separately from fixture-level local mocks

## Validation
- pnpm verify