### PR TITLE
feat(openclaw): own QA channel driver helpers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,9 +8,18 @@ export {
 } from "./fake-servers/index.js";
 export {
   createOpenClawCrablineAgentDelivery,
+  createOpenClawCrablineChannelReportNotes,
   createOpenClawCrablineFakeProviderBinding,
   createOpenClawCrablineInbound,
   createOpenClawCrablineOutboundFromRecorderEvent,
+  OPENCLAW_CRABLINE_CHANNEL_CAPABILITY_MATRIX_PATH,
+  OPENCLAW_CRABLINE_CHANNEL_SMOKE_PATH,
+  OPENCLAW_CRABLINE_DEFAULT_CHANNEL,
+  OPENCLAW_CRABLINE_MANIFEST_PATH,
+  probeOpenClawCrablineFakeProvider,
+  resolveOpenClawCrablineChannel,
+  resolveOpenClawCrablineChannelDriverSelection,
+  runOpenClawCrablineChannelDriverSmoke,
   startOpenClawCrablineAdapter,
 } from "./openclaw.js";
 export {
@@ -60,6 +69,8 @@ export type {
 } from "./fake-servers/index.js";
 export type {
   OpenClawCrablineAgentDelivery,
+  OpenClawCrablineChannelDriverSelection,
+  OpenClawCrablineChannelDriverSmokeResult,
   OpenClawCrablineGatewayBinding,
   OpenClawCrablineInbound,
   OpenClawCrablineInboundInput,

--- a/src/openclaw.ts
+++ b/src/openclaw.ts
@@ -1,14 +1,36 @@
 import {
+  CRABLINE_FAKE_PROVIDER_CHANNELS,
+  isCrablineFakeProviderChannel,
   startCrablineFakeProviderServer,
   type CrablineFakeProviderChannel,
   type CrablineFakeProviderManifest,
   type StartedCrablineFakeProviderServer,
 } from "./fake-servers/index.js";
+import fs from "node:fs/promises";
+import path from "node:path";
 
 const TELEGRAM_ACCOUNT_ID = "default";
 const TELEGRAM_DIRECT_CHAT_ID = "100001";
 const TELEGRAM_GROUP_CHAT_ID = "-1001234567890";
 const TELEGRAM_DEFAULT_SENDER_ID = 100001;
+export const OPENCLAW_CRABLINE_CHANNEL_CAPABILITY_MATRIX_PATH =
+  "crabline-fake-provider-capabilities.json";
+export const OPENCLAW_CRABLINE_CHANNEL_SMOKE_PATH = "crabline-fake-provider-smoke.json";
+export const OPENCLAW_CRABLINE_MANIFEST_PATH = "crabline-fake-provider-server.json";
+export const OPENCLAW_CRABLINE_DEFAULT_CHANNEL = "telegram";
+
+export type OpenClawCrablineChannelDriverSelection = {
+  channel: CrablineFakeProviderChannel;
+  channelDriver: "crabline";
+  capabilityMatrixPath: typeof OPENCLAW_CRABLINE_CHANNEL_CAPABILITY_MATRIX_PATH;
+  smokeArtifactPath: typeof OPENCLAW_CRABLINE_CHANNEL_SMOKE_PATH;
+};
+
+export type OpenClawCrablineChannelDriverSmokeResult = {
+  capabilityReport: unknown;
+  manifestPath: string;
+  smoke: unknown;
+};
 
 export type OpenClawCrablineConversation = {
   id: string;
@@ -72,6 +94,7 @@ export type StartedOpenClawCrablineAdapter = OpenClawCrablineGatewayBinding & {
     targetByProviderTarget: ReadonlyMap<string, string>;
   }): OpenClawCrablineOutboundMessage | null;
   manifest: CrablineFakeProviderManifest;
+  probe(): Promise<unknown>;
 };
 
 type TelegramRecorderEvent = {
@@ -152,6 +175,42 @@ function requireTelegramManifest(manifest: CrablineFakeProviderManifest) {
     throw new Error(`Unsupported OpenClaw fake provider binding: ${String(manifest.provider)}`);
   }
   return manifest;
+}
+
+export function resolveOpenClawCrablineChannel(input?: string | null): CrablineFakeProviderChannel {
+  const channel = input?.trim().toLowerCase() || OPENCLAW_CRABLINE_DEFAULT_CHANNEL;
+  if (isCrablineFakeProviderChannel(channel)) {
+    return channel;
+  }
+  throw new Error(
+    `--channel must be one of ${CRABLINE_FAKE_PROVIDER_CHANNELS.join(", ")} for --channel-driver crabline, got "${input}".`,
+  );
+}
+
+export function resolveOpenClawCrablineChannelDriverSelection(params: {
+  channel?: string | null;
+}): OpenClawCrablineChannelDriverSelection {
+  return {
+    channel: resolveOpenClawCrablineChannel(params.channel),
+    channelDriver: "crabline",
+    capabilityMatrixPath: OPENCLAW_CRABLINE_CHANNEL_CAPABILITY_MATRIX_PATH,
+    smokeArtifactPath: OPENCLAW_CRABLINE_CHANNEL_SMOKE_PATH,
+  };
+}
+
+export async function probeOpenClawCrablineFakeProvider(
+  manifest: CrablineFakeProviderManifest,
+): Promise<unknown> {
+  if (manifest.provider !== "telegram") {
+    throw new Error(
+      `OpenClaw Crabline fake-provider smoke does not support ${String(manifest.provider)}.`,
+    );
+  }
+  const response = await fetch(`${manifest.endpoints.apiRoot}/bot${manifest.botToken}/getMe`);
+  if (!response.ok) {
+    throw new Error(`Crabline Telegram getMe probe failed with HTTP ${response.status}.`);
+  }
+  return await response.json();
 }
 
 export function createOpenClawCrablineFakeProviderBinding(
@@ -300,5 +359,66 @@ export async function startOpenClawCrablineAdapter(
         targetByProviderTarget,
       }),
     manifest: server.manifest,
+    probe: () => probeOpenClawCrablineFakeProvider(server.manifest),
   };
+}
+
+export async function runOpenClawCrablineChannelDriverSmoke(params: {
+  outputDir: string;
+  selection: OpenClawCrablineChannelDriverSelection;
+}): Promise<OpenClawCrablineChannelDriverSmokeResult> {
+  const manifestPath = path.join(params.outputDir, OPENCLAW_CRABLINE_MANIFEST_PATH);
+  const recorderPath = path.join(
+    params.outputDir,
+    "artifacts",
+    "crabline",
+    `${params.selection.channel}-fake-provider.jsonl`,
+  );
+  await fs.mkdir(path.dirname(recorderPath), { recursive: true });
+  const adapter = await startOpenClawCrablineAdapter({
+    channel: params.selection.channel,
+    openclawConfig: {},
+    recorderPath,
+  });
+  try {
+    await fs.writeFile(manifestPath, `${JSON.stringify(adapter.manifest, null, 2)}\n`, "utf8");
+    const probe = await adapter.probe();
+    return {
+      capabilityReport: {
+        result: {
+          driver: "crabline",
+          selectedChannel: params.selection.channel,
+          supportedChannels: [...CRABLINE_FAKE_PROVIDER_CHANNELS],
+        },
+      },
+      manifestPath: path.basename(manifestPath),
+      smoke: {
+        manifestPath: path.basename(manifestPath),
+        result: {
+          ok: true,
+          probe,
+          provider: adapter.manifest.provider,
+          endpoints: adapter.manifest.endpoints,
+          recorderPath: path.relative(params.outputDir, adapter.manifest.recorderPath),
+        },
+      },
+    };
+  } finally {
+    await adapter.close();
+  }
+}
+
+export function createOpenClawCrablineChannelReportNotes(
+  selection: OpenClawCrablineChannelDriverSelection | null | undefined,
+): string[] {
+  if (!selection) {
+    return [];
+  }
+
+  return [
+    `Channel driver: ${selection.channelDriver} fake provider for ${selection.channel}.`,
+    `Channel capability report: ${selection.capabilityMatrixPath}.`,
+    `Channel driver smoke: ${selection.smokeArtifactPath}.`,
+    "Crabline starts local provider-shaped servers; OpenClaw uses its normal channel adapter against those endpoints.",
+  ];
 }

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -1,9 +1,18 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   createOpenClawCrablineAgentDelivery,
+  createOpenClawCrablineChannelReportNotes,
   createOpenClawCrablineFakeProviderBinding,
   createOpenClawCrablineInbound,
   createOpenClawCrablineOutboundFromRecorderEvent,
+  OPENCLAW_CRABLINE_CHANNEL_CAPABILITY_MATRIX_PATH,
+  OPENCLAW_CRABLINE_CHANNEL_SMOKE_PATH,
+  OPENCLAW_CRABLINE_MANIFEST_PATH,
+  resolveOpenClawCrablineChannelDriverSelection,
+  runOpenClawCrablineChannelDriverSmoke,
   startOpenClawCrablineAdapter,
   type CrablineFakeProviderManifest,
 } from "../src/index.js";
@@ -24,6 +33,21 @@ const manifest: CrablineFakeProviderManifest = {
 };
 
 describe("OpenClaw fake provider bridge", () => {
+  it("resolves channel-driver metadata through Crabline", () => {
+    expect(resolveOpenClawCrablineChannelDriverSelection({})).toEqual({
+      capabilityMatrixPath: OPENCLAW_CRABLINE_CHANNEL_CAPABILITY_MATRIX_PATH,
+      channel: "telegram",
+      channelDriver: "crabline",
+      smokeArtifactPath: OPENCLAW_CRABLINE_CHANNEL_SMOKE_PATH,
+    });
+    expect(resolveOpenClawCrablineChannelDriverSelection({ channel: " TELEGRAM " })).toMatchObject({
+      channel: "telegram",
+    });
+    expect(() => resolveOpenClawCrablineChannelDriverSelection({ channel: "slack" })).toThrow(
+      '--channel must be one of telegram for --channel-driver crabline, got "slack"',
+    );
+  });
+
   it("maps a Telegram fake provider into OpenClaw channel config", () => {
     const binding = createOpenClawCrablineFakeProviderBinding(manifest);
 
@@ -129,5 +153,50 @@ describe("OpenClaw fake provider bridge", () => {
       text: "agent reply",
       to: "dm:alice",
     });
+  });
+
+  it("runs OpenClaw channel-driver smoke and writes fake-provider artifacts", async () => {
+    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-openclaw-smoke-"));
+    try {
+      const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
+      const result = await runOpenClawCrablineChannelDriverSmoke({
+        outputDir,
+        selection,
+      });
+
+      expect(result.capabilityReport).toMatchObject({
+        result: {
+          driver: "crabline",
+          selectedChannel: "telegram",
+          supportedChannels: ["telegram"],
+        },
+      });
+      expect(result.smoke).toMatchObject({
+        manifestPath: OPENCLAW_CRABLINE_MANIFEST_PATH,
+        result: {
+          ok: true,
+          provider: "telegram",
+          probe: {
+            ok: true,
+            result: {
+              is_bot: true,
+              username: "crabline_bot",
+            },
+          },
+        },
+      });
+      const writtenManifest = JSON.parse(
+        await fs.readFile(path.join(outputDir, OPENCLAW_CRABLINE_MANIFEST_PATH), "utf8"),
+      ) as { provider?: string };
+      expect(writtenManifest.provider).toBe("telegram");
+      expect(createOpenClawCrablineChannelReportNotes(selection)).toEqual([
+        "Channel driver: crabline fake provider for telegram.",
+        "Channel capability report: crabline-fake-provider-capabilities.json.",
+        "Channel driver smoke: crabline-fake-provider-smoke.json.",
+        "Crabline starts local provider-shaped servers; OpenClaw uses its normal channel adapter against those endpoints.",
+      ]);
+    } finally {
+      await fs.rm(outputDir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Adds Crabline-owned OpenClaw QA channel-driver helpers for channel selection, report notes, fake-provider probing, and smoke artifact generation.
- Adds `probe()` to the started OpenClaw Crabline adapter so OpenClaw does not need provider-specific probe utilities.
- Covers the OpenClaw-facing helper API in `test/openclaw.test.ts`.

## Why

OpenClaw QA Lab should only ask Crabline for the selected fake provider behavior. Channel support, default channel normalization, provider probing, and smoke artifact shape are Crabline semantics, so they should live in Crabline instead of being re-declared in OpenClaw.

## Validation

- `pnpm format:check`
- `pnpm typecheck`
- `pnpm exec vitest run test/openclaw.test.ts`
- `pnpm test` (passed on rerun; first run had a transient `test/run.e2e.test.ts` loopback roundtrip failure)
