### PR TITLE
Add Slack fake provider server

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ provider APIs that OpenClaw live adapters can target during deterministic QA.
   `whatsapp`, and `zalo`
 - a `script` bridge for channels that are still exercised by external commands
 - per-provider local webhook endpoints for inbound events
-- fake provider servers for live-adapter smoke tests, starting with Telegram and
-  WhatsApp
+- fake provider servers for live-adapter smoke tests, starting with Slack,
+  Telegram, and WhatsApp
 - JSONL recorder files for deterministic wait/watch behavior
 - nonce-based `send`, `roundtrip`, `agent`, `probe`, `run`, `watch`, and
   `doctor` commands
@@ -124,6 +124,30 @@ commands for `probe`, `send`, `waitForInbound`, or `watch`.
 `serve` starts provider-shaped HTTP APIs for OpenClaw live adapters. This is the
 preferred Smoke CI path because OpenClaw still uses its normal channel adapter,
 but the provider endpoint is local and deterministic.
+
+Slack:
+
+```bash
+crabline --json serve slack --ready-file .crabline/slack-server.json
+```
+
+The JSON manifest contains:
+
+- `endpoints.apiRoot`: set OpenClaw's Slack API override / `SLACK_API_URL` to
+  this value
+- `botToken`: set OpenClaw `channels.slack.botToken` to this value
+- `signingSecret`: set OpenClaw `channels.slack.signingSecret` to this value
+- `adminToken`: send this as the `X-Crabline-Admin-Token` header when posting
+  test user messages
+- `endpoints.adminInboundUrl`: authenticated POST endpoint for Events API-shaped
+  test user messages
+- `endpoints.eventsUrl`: local Slack Events API endpoint
+- `recorderPath`: JSONL file of fake provider API/admin traffic
+
+The admin token is generated randomly unless `--admin-token <token>` is
+provided. Implemented Slack Web API endpoints include `auth.test`,
+`chat.postMessage`, `conversations.open`, `conversations.info`,
+`conversations.history`, and `conversations.replies`.
 
 Telegram:
 

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -76,6 +76,36 @@ Fake provider servers sit below OpenClaw's normal channel adapters. QA starts th
 server, writes the emitted runtime manifest into OpenClaw config/env, and then
 OpenClaw talks to the local fake provider instead of the public provider.
 
+Slack:
+
+```bash
+crabline --json serve slack --ready-file .crabline/slack-server.json
+```
+
+Manifest fields:
+
+- `endpoints.apiRoot`: OpenClaw Slack Web API root / `SLACK_API_URL`
+- `botToken`: OpenClaw `channels.slack.botToken`
+- `signingSecret`: OpenClaw `channels.slack.signingSecret`
+- `adminToken`: value for the `X-Crabline-Admin-Token` header on admin ingress
+- `endpoints.adminInboundUrl`: authenticated admin ingress for test user messages
+- `endpoints.eventsUrl`: local Slack Events API endpoint
+- `recorderPath`: JSONL provider traffic recorder
+
+The admin ingress accepts JSON like:
+
+```json
+{
+  "channel": "C1234567890",
+  "threadTs": "1700000000.000100",
+  "user": "U1234567890",
+  "text": "user nonce-123"
+}
+```
+
+OpenClaw consumes that message through Slack Events API shape; outbound adapter
+sends are recorded through Slack `chat.postMessage`.
+
 Telegram:
 
 ```bash

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -38,6 +38,7 @@ type ServeCommandOptions = {
   readyFile?: string | undefined;
   recorder?: string | undefined;
   selfJid?: string | undefined;
+  signingSecret?: string | undefined;
 };
 
 type ServeParamFactory = (
@@ -46,6 +47,13 @@ type ServeParamFactory = (
 ) => StartCrablineFakeProviderServerParams;
 
 const SERVE_PARAM_FACTORIES = {
+  slack: (shared, commandOptions) => ({
+    ...shared,
+    adminToken: commandOptions.adminToken,
+    botToken: commandOptions.botToken,
+    channel: "slack",
+    signingSecret: commandOptions.signingSecret,
+  }),
   telegram: (shared, commandOptions) => ({
     ...shared,
     adminToken: commandOptions.adminToken,
@@ -232,11 +240,12 @@ export function createProgram(
     .option("--port <port>", "Bind port", "0")
     .option("--admin-token <token>", "Admin token for inbound test messages")
     .option("--access-token <token>", "Fake WhatsApp access token")
-    .option("--bot-token <token>", "Fake Telegram bot token")
+    .option("--bot-token <token>", "Fake Telegram or Slack bot token")
     .option("--bot-username <username>", "Fake Telegram bot username", "crabline_bot")
     .option("--recorder <path>", "JSONL recorder path")
     .option("--ready-file <path>", "Write the server runtime manifest to this path")
     .option("--self-jid <jid>", "Fake WhatsApp self JID")
+    .option("--signing-secret <secret>", "Fake Slack signing secret")
     .option("--once", "Start, print the runtime manifest, and stop immediately", false)
     .action(async (provider, commandOptions: ServeCommandOptions) => {
       const options = program.opts() as GlobalOptions;

--- a/src/fake-servers/index.ts
+++ b/src/fake-servers/index.ts
@@ -1,4 +1,10 @@
 import {
+  startSlackFakeServer,
+  type SlackFakeServerManifest,
+  type StartedSlackFakeServer,
+  type StartSlackFakeServerParams,
+} from "./slack.js";
+import {
   startTelegramFakeServer,
   type StartedTelegramFakeServer,
   type StartTelegramFakeServerParams,
@@ -12,17 +18,26 @@ import {
 } from "./whatsapp.js";
 import { CrablineError } from "../core/errors.js";
 
-export const CRABLINE_FAKE_PROVIDER_CHANNELS = Object.freeze(["telegram", "whatsapp"] as const);
+export const CRABLINE_FAKE_PROVIDER_CHANNELS = Object.freeze([
+  "slack",
+  "telegram",
+  "whatsapp",
+] as const);
 
 export type CrablineFakeProviderChannel = (typeof CRABLINE_FAKE_PROVIDER_CHANNELS)[number];
 
-export type CrablineFakeProviderManifest = TelegramFakeServerManifest | WhatsAppFakeServerManifest;
+export type CrablineFakeProviderManifest =
+  | SlackFakeServerManifest
+  | TelegramFakeServerManifest
+  | WhatsAppFakeServerManifest;
 
 export type StartedCrablineFakeProviderServer =
+  | StartedSlackFakeServer
   | StartedTelegramFakeServer
   | StartedWhatsAppFakeServer;
 
 export type StartCrablineFakeProviderServerParams =
+  | (StartSlackFakeServerParams & { channel: "slack" })
   | (StartTelegramFakeServerParams & { channel: "telegram" })
   | (StartWhatsAppFakeServerParams & { channel: "whatsapp" });
 
@@ -32,6 +47,9 @@ export function isCrablineFakeProviderChannel(value: string): value is CrablineF
   return CRABLINE_FAKE_PROVIDER_CHANNEL_SET.has(value);
 }
 
+export function startCrablineFakeProviderServer(
+  params: StartSlackFakeServerParams & { channel: "slack" },
+): Promise<StartedSlackFakeServer>;
 export function startCrablineFakeProviderServer(
   params: StartTelegramFakeServerParams & { channel: "telegram" },
 ): Promise<StartedTelegramFakeServer>;
@@ -44,6 +62,9 @@ export function startCrablineFakeProviderServer(
 export async function startCrablineFakeProviderServer(
   params: StartCrablineFakeProviderServerParams,
 ): Promise<StartedCrablineFakeProviderServer> {
+  if (params.channel === "slack") {
+    return await startSlackFakeServer(params);
+  }
   if (params.channel === "telegram") {
     return await startTelegramFakeServer(params);
   }

--- a/src/fake-servers/slack.ts
+++ b/src/fake-servers/slack.ts
@@ -1,0 +1,607 @@
+import type { IncomingMessage } from "node:http";
+import { randomBytes } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  adminAuthError,
+  hasAdminToken,
+  jsonResponse,
+  parseRequestBody,
+  queryRecord,
+  readInteger,
+  readTrimmedString,
+  startHttpJsonServer,
+  type FakeServerRequestEvent,
+} from "./http.js";
+import {
+  SLACK_CHANNEL_ID_RULE,
+  SLACK_SEND_TARGET_ID_RULE,
+  SLACK_TS_RULE,
+  SLACK_USER_ID_RULE,
+} from "../providers/slack-ids.js";
+
+type SlackMessage = {
+  attachments?: unknown;
+  blocks?: unknown;
+  bot_id?: string;
+  channel: string;
+  metadata?: unknown;
+  reply_broadcast?: boolean;
+  text: string;
+  thread_ts?: string;
+  ts: string;
+  type: "message";
+  unfurl_links?: boolean;
+  unfurl_media?: boolean;
+  user: string;
+};
+
+type SlackFakeServerState = {
+  adminToken: string;
+  botId: string;
+  botToken: string;
+  botUserId: string;
+  nextDmIndex: number;
+  nextTsIndex: number;
+  recorderPath: string;
+  signingSecret: string;
+  userDmChannels: Map<string, string>;
+  messagesByChannel: Map<string, SlackMessage[]>;
+};
+
+export type SlackFakeServerManifest = {
+  adminToken: string;
+  baseUrl: string;
+  botToken: string;
+  endpoints: {
+    adminInboundUrl: string;
+    apiRoot: string;
+    eventsUrl: string;
+  };
+  env: {
+    SLACK_API_URL: string;
+    SLACK_BOT_TOKEN: string;
+    SLACK_SIGNING_SECRET: string;
+  };
+  provider: "slack";
+  recorderPath: string;
+  signingSecret: string;
+  version: 1;
+};
+
+export type StartedSlackFakeServer = {
+  close(): Promise<void>;
+  manifest: SlackFakeServerManifest;
+};
+
+export type StartSlackFakeServerParams = {
+  adminToken?: string | undefined;
+  botId?: string | undefined;
+  botToken?: string | undefined;
+  botUserId?: string | undefined;
+  host?: string | undefined;
+  port?: number | undefined;
+  recorderPath?: string | undefined;
+  signingSecret?: string | undefined;
+};
+
+function slackOk(result: Record<string, unknown> = {}): Response {
+  return jsonResponse({ ok: true, ...result });
+}
+
+function slackError(error: string, status = 200): Response {
+  return jsonResponse({ error, ok: false }, status);
+}
+
+function slackRateLimited(retryAfterSeconds = 1): Response {
+  return new Response(JSON.stringify({ error: "ratelimited", ok: false }), {
+    headers: {
+      "content-type": "application/json",
+      "retry-after": String(retryAfterSeconds),
+    },
+    status: 429,
+  });
+}
+
+function requireSlackToken(
+  request: IncomingMessage,
+  body: Record<string, unknown>,
+  state: SlackFakeServerState,
+): Response | undefined {
+  const authorization = request.headers.authorization;
+  const tokenFromHeader =
+    typeof authorization === "string" && authorization.startsWith("Bearer ")
+      ? authorization.slice("Bearer ".length).trim()
+      : undefined;
+  const token = tokenFromHeader ?? readTrimmedString(body.token);
+  if (!token) {
+    return slackError("not_authed");
+  }
+  if (token !== state.botToken) {
+    return slackError("invalid_auth");
+  }
+  return undefined;
+}
+
+function requireSlackChannelId(value: unknown): string | Response {
+  const stringValue = readTrimmedString(value);
+  if (!stringValue || !SLACK_CHANNEL_ID_RULE.pattern.test(stringValue)) {
+    return slackError("channel_not_found");
+  }
+  return stringValue;
+}
+
+function requireSlackSendTargetId(value: unknown): string | Response {
+  const stringValue = readTrimmedString(value);
+  if (!stringValue || !SLACK_SEND_TARGET_ID_RULE.pattern.test(stringValue)) {
+    return slackError("channel_not_found");
+  }
+  return stringValue;
+}
+
+function requireSlackUserId(value: unknown): string | Response {
+  const stringValue = readTrimmedString(value);
+  if (!stringValue || !SLACK_USER_ID_RULE.pattern.test(stringValue)) {
+    return slackError("invalid_users");
+  }
+  return stringValue;
+}
+
+function requireSlackThreadTs(value: unknown): string | Response | undefined {
+  const stringValue = readTrimmedString(value);
+  if (!stringValue) {
+    return undefined;
+  }
+  if (!SLACK_TS_RULE.pattern.test(stringValue)) {
+    return slackError("invalid_ts");
+  }
+  return stringValue;
+}
+
+function readBoolean(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") {
+    return value;
+  }
+  const stringValue = readTrimmedString(value)?.toLowerCase();
+  if (stringValue === "true" || stringValue === "1") {
+    return true;
+  }
+  if (stringValue === "false" || stringValue === "0") {
+    return false;
+  }
+  return undefined;
+}
+
+function readStructuredValue(value: unknown): unknown {
+  if (typeof value !== "string") {
+    return value;
+  }
+  const stringValue = value.trim();
+  if (!stringValue) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(stringValue) as unknown;
+  } catch {
+    return value;
+  }
+}
+
+function hasStructuredMessageContent(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+  return Boolean(value && typeof value === "object");
+}
+
+function messagesForChannel(state: SlackFakeServerState, channel: string): SlackMessage[] {
+  return state.messagesByChannel.get(channel) ?? [];
+}
+
+function hasThreadParent(
+  state: SlackFakeServerState,
+  params: {
+    channel: string;
+    threadTs: string;
+  },
+): boolean {
+  return messagesForChannel(state, params.channel).some(
+    (message) => message.ts === params.threadTs || message.thread_ts === params.threadTs,
+  );
+}
+
+function nextSlackTs(state: SlackFakeServerState): string {
+  const index = state.nextTsIndex++;
+  return `${1_700_000_000 + Math.floor(index / 1_000_000)}.${String(index % 1_000_000).padStart(6, "0")}`;
+}
+
+function nextDmChannelId(state: SlackFakeServerState): string {
+  const index = state.nextDmIndex++;
+  return `D${String(index).padStart(9, "0")}`;
+}
+
+function dmChannelForUser(state: SlackFakeServerState, userId: string): string {
+  const existing = state.userDmChannels.get(userId);
+  if (existing) {
+    return existing;
+  }
+  const channelId = nextDmChannelId(state);
+  state.userDmChannels.set(userId, channelId);
+  return channelId;
+}
+
+function appendMessage(state: SlackFakeServerState, message: SlackMessage): SlackMessage {
+  const messages = state.messagesByChannel.get(message.channel) ?? [];
+  messages.push(message);
+  state.messagesByChannel.set(message.channel, messages);
+  return message;
+}
+
+async function appendEvent(state: SlackFakeServerState, event: FakeServerRequestEvent) {
+  await fs.mkdir(path.dirname(state.recorderPath), { recursive: true });
+  await fs.appendFile(state.recorderPath, `${JSON.stringify(event)}\n`, "utf8");
+}
+
+function redactSlackAuthFields(value: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [
+      key,
+      key.toLowerCase() === "token" ? "[redacted]" : entry,
+    ]),
+  );
+}
+
+function redactSlackAuthQuery(value: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [
+      key,
+      key.toLowerCase() === "token" ? "[redacted]" : entry,
+    ]),
+  );
+}
+
+function createSlackMessage(
+  state: SlackFakeServerState,
+  params: {
+    channel: string;
+    text: string;
+    threadTs?: string | undefined;
+    user?: string | undefined;
+    bot?: boolean | undefined;
+    ts?: string | undefined;
+    attachments?: unknown;
+    blocks?: unknown;
+    metadata?: unknown;
+    replyBroadcast?: boolean | undefined;
+    unfurlLinks?: boolean | undefined;
+    unfurlMedia?: boolean | undefined;
+  },
+): SlackMessage {
+  const ts = params.ts ?? nextSlackTs(state);
+  return {
+    ...(params.attachments ? { attachments: params.attachments } : {}),
+    ...(params.blocks ? { blocks: params.blocks } : {}),
+    ...(params.bot ? { bot_id: state.botId } : {}),
+    channel: params.channel,
+    ...(params.metadata ? { metadata: params.metadata } : {}),
+    ...(params.replyBroadcast === undefined ? {} : { reply_broadcast: params.replyBroadcast }),
+    text: params.text,
+    ...(params.threadTs ? { thread_ts: params.threadTs } : {}),
+    ts,
+    type: "message",
+    ...(params.unfurlLinks === undefined ? {} : { unfurl_links: params.unfurlLinks }),
+    ...(params.unfurlMedia === undefined ? {} : { unfurl_media: params.unfurlMedia }),
+    user: params.user ?? (params.bot ? state.botUserId : "UCRABUSER"),
+  };
+}
+
+function asSlackEventCallback(message: SlackMessage) {
+  return {
+    api_app_id: "ACRABLINE",
+    authorizations: [],
+    event: message,
+    event_id: `Ev${message.ts.replace(".", "")}`,
+    event_time: Number(message.ts.slice(0, 10)),
+    team_id: "TCRABLINE",
+    token: "crabline-event-token",
+    type: "event_callback",
+  };
+}
+
+async function handleSlackApi(params: {
+  body: Record<string, unknown>;
+  method: string;
+  request: IncomingMessage;
+  state: SlackFakeServerState;
+}): Promise<Response> {
+  const authError = requireSlackToken(params.request, params.body, params.state);
+  if (authError) {
+    return authError;
+  }
+
+  switch (params.method) {
+    case "auth.test":
+      return slackOk({
+        bot_id: params.state.botId,
+        response_metadata: {
+          scopes: [
+            "chat:write",
+            "channels:history",
+            "groups:history",
+            "im:history",
+            "mpim:history",
+          ],
+        },
+        team: "Crabline",
+        team_id: "TCRABLINE",
+        url: "https://crabline.slack.test/",
+        user: "crabline",
+        user_id: params.state.botUserId,
+      });
+    case "chat.postMessage": {
+      if (readBoolean(params.body.simulate_rate_limit) === true) {
+        return slackRateLimited(readInteger(params.body.retry_after) ?? 1);
+      }
+      const channel = requireSlackSendTargetId(params.body.channel);
+      if (channel instanceof Response) {
+        return channel;
+      }
+      const text = readTrimmedString(params.body.text) ?? "";
+      const attachments = readStructuredValue(params.body.attachments);
+      const blocks = readStructuredValue(params.body.blocks);
+      const metadata = readStructuredValue(params.body.metadata);
+      if (
+        !text &&
+        !hasStructuredMessageContent(blocks) &&
+        !hasStructuredMessageContent(attachments)
+      ) {
+        return slackError("no_text");
+      }
+      if (text.length > 40_000) {
+        return slackError("msg_too_long");
+      }
+      const threadTs = requireSlackThreadTs(params.body.thread_ts);
+      if (threadTs instanceof Response) {
+        return threadTs;
+      }
+      if (threadTs && !hasThreadParent(params.state, { channel, threadTs })) {
+        return slackError("thread_not_found");
+      }
+      const message = appendMessage(
+        params.state,
+        createSlackMessage(params.state, {
+          attachments,
+          blocks,
+          bot: true,
+          channel,
+          metadata,
+          replyBroadcast: readBoolean(params.body.reply_broadcast),
+          text,
+          threadTs,
+          unfurlLinks: readBoolean(params.body.unfurl_links),
+          unfurlMedia: readBoolean(params.body.unfurl_media),
+        }),
+      );
+      return slackOk({ channel, message, ts: message.ts });
+    }
+    case "conversations.open": {
+      const users = readTrimmedString(params.body.users);
+      const firstUser = users?.split(",")[0]?.trim();
+      const user = requireSlackUserId(firstUser);
+      if (user instanceof Response) {
+        return user;
+      }
+      return slackOk({
+        channel: {
+          id: dmChannelForUser(params.state, user),
+          is_im: true,
+          user,
+        },
+      });
+    }
+    case "conversations.info": {
+      const channel = requireSlackChannelId(params.body.channel);
+      if (channel instanceof Response) {
+        return channel;
+      }
+      return slackOk({
+        channel: {
+          id: channel,
+          is_channel: channel.startsWith("C"),
+          is_group: channel.startsWith("G"),
+          is_im: channel.startsWith("D"),
+          name: "crabline",
+        },
+      });
+    }
+    case "conversations.history": {
+      const channel = requireSlackChannelId(params.body.channel);
+      if (channel instanceof Response) {
+        return channel;
+      }
+      const oldest = requireSlackThreadTs(params.body.oldest);
+      if (oldest instanceof Response) {
+        return oldest;
+      }
+      const latest = requireSlackThreadTs(params.body.latest);
+      if (latest instanceof Response) {
+        return latest;
+      }
+      const limit = readInteger(params.body.limit) ?? 100;
+      const messages = messagesForChannel(params.state, channel).filter((message) => {
+        if (oldest && message.ts <= oldest) {
+          return false;
+        }
+        if (latest && message.ts >= latest) {
+          return false;
+        }
+        return true;
+      });
+      return slackOk({
+        has_more: messages.length > limit,
+        messages: [...messages].reverse().slice(0, limit),
+      });
+    }
+    case "conversations.replies": {
+      const channel = requireSlackChannelId(params.body.channel);
+      if (channel instanceof Response) {
+        return channel;
+      }
+      const ts = requireSlackThreadTs(params.body.ts);
+      if (ts instanceof Response) {
+        return ts;
+      }
+      if (!ts) {
+        return slackError("message_not_found");
+      }
+      const limit = readInteger(params.body.limit) ?? 100;
+      const messages = messagesForChannel(params.state, channel).filter(
+        (message) => message.ts === ts || message.thread_ts === ts,
+      );
+      if (messages.length === 0) {
+        return slackError("thread_not_found");
+      }
+      return slackOk({ has_more: messages.length > limit, messages: messages.slice(0, limit) });
+    }
+    default:
+      return slackError("unknown_method", 404);
+  }
+}
+
+async function handleAdminInbound(params: {
+  body: Record<string, unknown>;
+  state: SlackFakeServerState;
+}): Promise<Response> {
+  const channel = requireSlackChannelId(params.body.channel);
+  if (channel instanceof Response) {
+    return channel;
+  }
+  const text = readTrimmedString(params.body.text);
+  if (!text) {
+    return slackError("text is required", 400);
+  }
+  const user = requireSlackUserId(params.body.user ?? "UCRABUSER");
+  if (user instanceof Response) {
+    return user;
+  }
+  const threadTs = requireSlackThreadTs(params.body.threadTs ?? params.body.thread_ts);
+  if (threadTs instanceof Response) {
+    return threadTs;
+  }
+  const ts = requireSlackThreadTs(params.body.ts);
+  if (ts instanceof Response) {
+    return ts;
+  }
+  const message = appendMessage(
+    params.state,
+    createSlackMessage(params.state, {
+      channel,
+      text,
+      threadTs,
+      ts,
+      user,
+    }),
+  );
+  return slackOk({ event: asSlackEventCallback(message), message });
+}
+
+async function handleRequest(params: { request: IncomingMessage; state: SlackFakeServerState }) {
+  const url = new URL(params.request.url ?? "/", "http://127.0.0.1");
+  if (url.pathname === "/crabline/slack/inbound") {
+    if (params.request.method !== "POST") {
+      return new Response("not found", { status: 404 });
+    }
+    if (!hasAdminToken(params.request, params.state.adminToken)) {
+      return adminAuthError();
+    }
+    const body = await parseRequestBody(params.request);
+    await appendEvent(params.state, {
+      at: new Date().toISOString(),
+      body,
+      method: params.request.method,
+      path: url.pathname,
+      query: queryRecord(url),
+      type: "admin",
+    });
+    return await handleAdminInbound({ body, state: params.state });
+  }
+
+  const query = queryRecord(url);
+  const body = params.request.method === "GET" ? query : await parseRequestBody(params.request);
+  await appendEvent(params.state, {
+    at: new Date().toISOString(),
+    body: redactSlackAuthFields(body),
+    method: params.request.method ?? "GET",
+    path: url.pathname,
+    query: redactSlackAuthQuery(query),
+    type: "api",
+  });
+
+  if (url.pathname === "/slack/events") {
+    if (body.type === "url_verification") {
+      return jsonResponse({ challenge: readTrimmedString(body.challenge) ?? "" });
+    }
+    return slackOk();
+  }
+
+  const methodMatch = /^\/api\/([a-z]+(?:\.[a-zA-Z]+)*)$/u.exec(url.pathname);
+  if (!methodMatch?.[1]) {
+    return new Response("not found", { status: 404 });
+  }
+  return await handleSlackApi({
+    body,
+    method: methodMatch[1],
+    request: params.request,
+    state: params.state,
+  });
+}
+
+export async function startSlackFakeServer(
+  params: StartSlackFakeServerParams = {},
+): Promise<StartedSlackFakeServer> {
+  const state: SlackFakeServerState = {
+    adminToken: params.adminToken ?? randomBytes(24).toString("base64url"),
+    botId: params.botId ?? "BCRABLINE",
+    botToken: params.botToken ?? "xoxb-crabline-slack-token",
+    botUserId: params.botUserId ?? "UCRABBOT",
+    nextDmIndex: 1,
+    nextTsIndex: 100,
+    recorderPath: params.recorderPath ?? path.resolve(".crabline", "fake-servers", "slack.jsonl"),
+    signingSecret: params.signingSecret ?? "crabline-slack-signing-secret",
+    userDmChannels: new Map(),
+    messagesByChannel: new Map(),
+  };
+  const host = params.host ?? "127.0.0.1";
+  const httpServer = await startHttpJsonServer({
+    handle: (request) => handleRequest({ request, state }),
+    host,
+    port: params.port ?? 0,
+    serverName: "Slack",
+  });
+  const baseUrl = httpServer.baseUrl;
+  const apiRoot = `${baseUrl}/api/`;
+  return {
+    async close() {
+      await httpServer.close();
+    },
+    manifest: {
+      adminToken: state.adminToken,
+      baseUrl,
+      botToken: state.botToken,
+      endpoints: {
+        adminInboundUrl: `${baseUrl}/crabline/slack/inbound`,
+        apiRoot,
+        eventsUrl: `${baseUrl}/slack/events`,
+      },
+      env: {
+        SLACK_API_URL: apiRoot,
+        SLACK_BOT_TOKEN: state.botToken,
+        SLACK_SIGNING_SECRET: state.signingSecret,
+      },
+      provider: "slack",
+      recorderPath: state.recorderPath,
+      signingSecret: state.signingSecret,
+      version: 1,
+    },
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { resolveTelegramAdapterConfig } from "./providers/builtin/telegram.js";
 export { resolveWhatsAppAdapterConfig } from "./providers/builtin/whatsapp.js";
+export { startSlackFakeServer } from "./fake-servers/slack.js";
 export { startTelegramFakeServer } from "./fake-servers/telegram.js";
 export {
   createWhatsAppBaileysMockSocket,
@@ -62,6 +63,11 @@ export type {
   WaitContext,
   WatchContext,
 } from "./providers/types.js";
+export type {
+  SlackFakeServerManifest,
+  StartedSlackFakeServer,
+  StartSlackFakeServerParams,
+} from "./fake-servers/slack.js";
 export type {
   StartedTelegramFakeServer,
   StartTelegramFakeServerParams,

--- a/src/openclaw.ts
+++ b/src/openclaw.ts
@@ -6,6 +6,7 @@ import {
   type CrablineFakeProviderManifest,
   type StartedCrablineFakeProviderServer,
 } from "./fake-servers/index.js";
+import { SLACK_OPENCLAW_CRABLINE_PROVIDER_BRIDGE } from "./openclaw/bridges/slack.js";
 import { TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE } from "./openclaw/bridges/telegram.js";
 import { WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE } from "./openclaw/bridges/whatsapp.js";
 import {
@@ -50,6 +51,7 @@ export type {
 } from "./openclaw/shared.js";
 
 const OPENCLAW_CRABLINE_PROVIDER_BRIDGES = {
+  slack: SLACK_OPENCLAW_CRABLINE_PROVIDER_BRIDGE,
   telegram: TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE,
   whatsapp: WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE,
 } satisfies OpenClawCrablineProviderBridgeRegistry;

--- a/src/openclaw/bridges/slack.ts
+++ b/src/openclaw/bridges/slack.ts
@@ -1,0 +1,169 @@
+import {
+  createAdminInboundRequest,
+  createOpenClawCrablineProviderBridge,
+  DEFAULT_ACCOUNT_ID,
+  isRecord,
+  qaTargetForInbound,
+  readString,
+} from "../shared.js";
+import {
+  slackTargetKey,
+  SLACK_CHANNEL_ID_RULE,
+  SLACK_SEND_TARGET_ID_RULE,
+  SLACK_TS_RULE,
+  SLACK_USER_ID_RULE,
+} from "../../providers/slack-ids.js";
+
+function requireSlackSendTargetId(value: string, label: string): string {
+  const trimmed = value.trim();
+  if (!SLACK_SEND_TARGET_ID_RULE.pattern.test(trimmed)) {
+    throw new Error(`${label} must be a native Slack conversation or user id.`);
+  }
+  return trimmed;
+}
+
+function requireSlackChannelId(value: string, label: string): string {
+  const trimmed = value.trim();
+  if (!SLACK_CHANNEL_ID_RULE.pattern.test(trimmed)) {
+    throw new Error(`${label} must be a native Slack conversation id.`);
+  }
+  return trimmed;
+}
+
+function requireSlackUserId(value: string, label: string): string {
+  const trimmed = value.trim();
+  if (!SLACK_USER_ID_RULE.pattern.test(trimmed)) {
+    throw new Error(`${label} must be a native Slack user id.`);
+  }
+  return trimmed;
+}
+
+function requireSlackThreadTs(value: string | undefined, label: string): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (!SLACK_TS_RULE.pattern.test(trimmed)) {
+    throw new Error(`${label} must be a native Slack timestamp.`);
+  }
+  return trimmed;
+}
+
+export const SLACK_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablineProviderBridge({
+  provider: "slack",
+  createAdapter(slack) {
+    return {
+      async probe() {
+        const response = await fetch(`${slack.endpoints.apiRoot}auth.test`, {
+          headers: { authorization: `Bearer ${slack.botToken}` },
+          method: "POST",
+        });
+        if (!response.ok) {
+          throw new Error(`Crabline Slack auth.test probe failed with HTTP ${response.status}.`);
+        }
+        return await response.json();
+      },
+      createBinding() {
+        return {
+          accountId: DEFAULT_ACCOUNT_ID,
+          channel: "slack",
+          createChannelDriverSmokeEnv: (env) => ({
+            ...env,
+            SLACK_API_URL: slack.endpoints.apiRoot,
+            SLACK_BOT_TOKEN: slack.botToken,
+            SLACK_SIGNING_SECRET: slack.signingSecret,
+          }),
+          createGatewayConfig: (openclawConfig = {}) => {
+            const channels = isRecord(openclawConfig.channels) ? openclawConfig.channels : {};
+            const slackConfig = isRecord(channels.slack) ? channels.slack : {};
+            const slackChannels = isRecord(slackConfig.channels) ? slackConfig.channels : {};
+            const defaultSlackChannel = isRecord(slackChannels["*"]) ? slackChannels["*"] : {};
+
+            return {
+              ...openclawConfig,
+              channels: {
+                ...channels,
+                slack: {
+                  ...slackConfig,
+                  enabled: true,
+                  mode: "http",
+                  botToken: slack.botToken,
+                  signingSecret: slack.signingSecret,
+                  webhookPath: "/slack/events",
+                  dmPolicy: "open",
+                  allowFrom: ["*"],
+                  groupPolicy: "open",
+                  channels: {
+                    ...slackChannels,
+                    "*": {
+                      ...defaultSlackChannel,
+                      requireMention: false,
+                    },
+                  },
+                },
+              },
+            };
+          },
+          requiredPluginIds: ["slack"],
+        };
+      },
+      createAgentDelivery(parsed) {
+        const to = requireSlackSendTargetId(parsed.id, "Slack target");
+        const threadTs = requireSlackThreadTs(parsed.threadId, "Slack target thread");
+        return {
+          channel: "slack",
+          to,
+          replyChannel: "slack",
+          replyTo: slackTargetKey(to, threadTs),
+        };
+      },
+      createInbound(input) {
+        const channel = requireSlackChannelId(input.conversation.id, "Slack conversation");
+        const user = requireSlackUserId(input.senderId, "Slack sender");
+        const threadTs = requireSlackThreadTs(input.threadId, "Slack thread");
+        return {
+          ...createAdminInboundRequest(slack),
+          providerBody: {
+            channel,
+            user,
+            ...(input.senderName ? { username: input.senderName } : {}),
+            ...(threadTs ? { threadTs } : {}),
+            text: input.text,
+          },
+          providerTargetKey: slackTargetKey(channel, threadTs),
+          qaTarget: qaTargetForInbound(input),
+          stateConversation: {
+            id: channel,
+            kind: channel.startsWith("D") ? "direct" : "group",
+          },
+          ...(threadTs ? { threadId: threadTs } : {}),
+        };
+      },
+      createOutboundFromRecorderEvent({ event, targetByProviderTarget }) {
+        if (!isRecord(event) || event.type !== "api" || typeof event.path !== "string") {
+          return null;
+        }
+        if (!event.path.endsWith("/api/chat.postMessage") || !isRecord(event.body)) {
+          return null;
+        }
+        const channel = readString(event.body.channel);
+        const text =
+          typeof event.body.text === "string" && event.body.text.trim()
+            ? event.body.text
+            : undefined;
+        if (!channel || !text) {
+          return null;
+        }
+        const threadTs = readString(event.body.thread_ts);
+        const providerTargetKey = slackTargetKey(channel, threadTs);
+        return {
+          accountId: DEFAULT_ACCOUNT_ID,
+          senderId: "openclaw",
+          senderName: "OpenClaw QA",
+          text,
+          to: targetByProviderTarget.get(providerTargetKey) ?? providerTargetKey,
+        };
+      },
+    };
+  },
+});

--- a/src/providers/builtin/native-local-mock.ts
+++ b/src/providers/builtin/native-local-mock.ts
@@ -1,12 +1,9 @@
 import { CrablineError } from "../../core/errors.js";
 import type { LocalMockTargetCodec } from "../local-mock.js";
+import type { NativeIdRule } from "../native-ids.js";
 import type { InboundEnvelope, NormalizedTarget, ProviderContext } from "../types.js";
 
-export type NativeIdRule = {
-  example: string;
-  name: string;
-  pattern: RegExp;
-};
+export type { NativeIdRule } from "../native-ids.js";
 
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);

--- a/src/providers/builtin/slack.ts
+++ b/src/providers/builtin/slack.ts
@@ -12,20 +12,8 @@ import {
   genericMockPayloadWithNativeThread,
   isRecord,
   requireNativeInboundId,
-  type NativeIdRule,
 } from "./native-local-mock.js";
-
-const SLACK_CHANNEL_ID_RULE: NativeIdRule = {
-  example: "C1234567890",
-  name: "Slack conversation id",
-  pattern: /^[CDG][A-Z0-9]{2,}$/u,
-};
-
-const SLACK_TS_RULE: NativeIdRule = {
-  example: "1700000000.000100",
-  name: "Slack timestamp",
-  pattern: /^\d{10}\.\d{6}$/u,
-};
+import { SLACK_CHANNEL_ID_RULE, SLACK_TS_RULE } from "../slack-ids.js";
 
 function requireSlackChannelId(value: string, label: string): string {
   if (!SLACK_CHANNEL_ID_RULE.pattern.test(value)) {

--- a/src/providers/native-ids.ts
+++ b/src/providers/native-ids.ts
@@ -1,0 +1,5 @@
+export type NativeIdRule = {
+  example: string;
+  name: string;
+  pattern: RegExp;
+};

--- a/src/providers/slack-ids.ts
+++ b/src/providers/slack-ids.ts
@@ -1,0 +1,29 @@
+import type { NativeIdRule } from "./native-ids.js";
+
+export const SLACK_CHANNEL_ID_RULE: NativeIdRule = {
+  example: "C1234567890",
+  name: "Slack conversation id",
+  pattern: /^[CDG][A-Z0-9]{2,}$/u,
+};
+
+export const SLACK_SEND_TARGET_ID_RULE: NativeIdRule = {
+  example: "C1234567890",
+  name: "Slack conversation or user id",
+  pattern: /^[CDGUW][A-Z0-9]{2,}$/u,
+};
+
+export const SLACK_USER_ID_RULE: NativeIdRule = {
+  example: "U1234567890",
+  name: "Slack user id",
+  pattern: /^[UW][A-Z0-9]{2,}$/u,
+};
+
+export const SLACK_TS_RULE: NativeIdRule = {
+  example: "1700000000.000100",
+  name: "Slack timestamp",
+  pattern: /^\d{10}\.\d{6}$/u,
+};
+
+export function slackTargetKey(channel: string, threadTs?: string) {
+  return threadTs ? `${channel}:thread:${threadTs}` : channel;
+}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -238,6 +238,56 @@ describe("cli", () => {
     await expect(fs.readFile(readyFile, "utf8")).resolves.toContain('"provider": "telegram"');
   });
 
+  it("prints a fake Slack server runtime manifest", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const readyFile = path.join(directory, ".crabline", "slack-server.json");
+    const captured = captureWrites();
+
+    try {
+      expect(
+        await runCli([
+          "node",
+          "crabline",
+          "--json",
+          "serve",
+          "slack",
+          "--once",
+          "--ready-file",
+          readyFile,
+          "--admin-token",
+          "test-admin-token",
+          "--bot-token",
+          "xoxb-test",
+          "--signing-secret",
+          "test-signing-secret",
+          "--recorder",
+          path.join(directory, "slack.jsonl"),
+        ]),
+      ).toBe(0);
+    } finally {
+      captured.restore();
+    }
+
+    const manifest = JSON.parse(captured.stdout.join("")) as {
+      adminToken?: string;
+      botToken?: string;
+      endpoints?: { adminInboundUrl?: string; apiRoot?: string; eventsUrl?: string };
+      provider?: string;
+      signingSecret?: string;
+    };
+    expect(manifest.provider).toBe("slack");
+    expect(manifest.adminToken).toBe("test-admin-token");
+    expect(manifest.botToken).toBe("xoxb-test");
+    expect(manifest.signingSecret).toBe("test-signing-secret");
+    expect(manifest.endpoints?.apiRoot).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/api\/$/u);
+    expect(manifest.endpoints?.adminInboundUrl).toMatch(
+      /^http:\/\/127\.0\.0\.1:\d+\/crabline\/slack\/inbound$/u,
+    );
+    expect(manifest.endpoints?.eventsUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/slack\/events$/u);
+    await expect(fs.readFile(readyFile, "utf8")).resolves.toContain('"provider": "slack"');
+  });
+
   it("prints a fake WhatsApp server runtime manifest", async () => {
     const directory = await createTempDir();
     directories.push(directory);

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -57,6 +57,26 @@ const whatsappManifest: CrablineFakeProviderManifest = {
   version: 1,
 };
 
+const slackManifest: CrablineFakeProviderManifest = {
+  adminToken: "crabline-slack-admin-token",
+  baseUrl: "http://127.0.0.1:2468",
+  botToken: "xoxb-crabline-slack-token",
+  endpoints: {
+    adminInboundUrl: "http://127.0.0.1:2468/crabline/slack/inbound",
+    apiRoot: "http://127.0.0.1:2468/api/",
+    eventsUrl: "http://127.0.0.1:2468/slack/events",
+  },
+  env: {
+    SLACK_API_URL: "http://127.0.0.1:2468/api/",
+    SLACK_BOT_TOKEN: "xoxb-crabline-slack-token",
+    SLACK_SIGNING_SECRET: "crabline-slack-signing-secret",
+  },
+  provider: "slack",
+  recorderPath: "/tmp/crabline/slack.jsonl",
+  signingSecret: "crabline-slack-signing-secret",
+  version: 1,
+};
+
 describe("OpenClaw fake provider bridge", () => {
   it("resolves channel-driver metadata through Crabline", () => {
     expect(resolveOpenClawCrablineChannelDriverSelection({})).toEqual({
@@ -71,8 +91,11 @@ describe("OpenClaw fake provider bridge", () => {
     expect(resolveOpenClawCrablineChannelDriverSelection({ channel: " WHATSAPP " })).toMatchObject({
       channel: "whatsapp",
     });
+    expect(resolveOpenClawCrablineChannelDriverSelection({ channel: " SLACK " })).toMatchObject({
+      channel: "slack",
+    });
     expect(() => resolveOpenClawCrablineChannelDriverSelection({ channel: "discord" })).toThrow(
-      '--channel must be one of telegram, whatsapp for --channel-driver crabline, got "discord"',
+      '--channel must be one of slack, telegram, whatsapp for --channel-driver crabline, got "discord"',
     );
   });
 
@@ -172,6 +195,46 @@ describe("OpenClaw fake provider bridge", () => {
       CRABLINE_WHATSAPP_ACCESS_TOKEN: "crabline-whatsapp-access-token",
       CRABLINE_WHATSAPP_API_ROOT: "http://127.0.0.1:5678/crabline/whatsapp",
       CRABLINE_WHATSAPP_SELF_JID: "15550000000@s.whatsapp.net",
+    });
+  });
+
+  it("maps a Slack fake provider into OpenClaw channel config", () => {
+    const binding = createOpenClawCrablineFakeProviderBinding(slackManifest);
+
+    expect(binding).toMatchObject({
+      accountId: "default",
+      channel: "slack",
+      requiredPluginIds: ["slack"],
+    });
+    expect(
+      binding.createGatewayConfig({
+        channels: {
+          slack: {
+            enabled: false,
+          },
+          telegram: {
+            enabled: true,
+          },
+        },
+      }),
+    ).toMatchObject({
+      channels: {
+        slack: {
+          botToken: "xoxb-crabline-slack-token",
+          enabled: true,
+          mode: "http",
+          signingSecret: "crabline-slack-signing-secret",
+          webhookPath: "/slack/events",
+        },
+        telegram: {
+          enabled: true,
+        },
+      },
+    });
+    expect(binding.createChannelDriverSmokeEnv({})).toMatchObject({
+      SLACK_API_URL: "http://127.0.0.1:2468/api/",
+      SLACK_BOT_TOKEN: "xoxb-crabline-slack-token",
+      SLACK_SIGNING_SECRET: "crabline-slack-signing-secret",
     });
   });
 
@@ -329,6 +392,76 @@ describe("OpenClaw fake provider bridge", () => {
     });
   });
 
+  it("maps Slack QA targets, inbound messages, and recorder events", () => {
+    expect(
+      createOpenClawCrablineAgentDelivery({
+        manifest: slackManifest,
+        target: "thread:C1234567890/1700000000.000100",
+      }),
+    ).toEqual({
+      channel: "slack",
+      to: "C1234567890",
+      replyChannel: "slack",
+      replyTo: "C1234567890:thread:1700000000.000100",
+    });
+
+    const inbound = createOpenClawCrablineInbound({
+      manifest: slackManifest,
+      input: {
+        conversation: { id: "C1234567890", kind: "group" },
+        senderId: "U1234567890",
+        senderName: "Alice",
+        text: "hello",
+        threadId: "1700000000.000100",
+      },
+    });
+    expect(inbound).toEqual({
+      providerBody: {
+        channel: "C1234567890",
+        user: "U1234567890",
+        username: "Alice",
+        threadTs: "1700000000.000100",
+        text: "hello",
+      },
+      providerHeaders: {
+        "content-type": "application/json",
+        "x-crabline-admin-token": "crabline-slack-admin-token",
+      },
+      providerTargetKey: "C1234567890:thread:1700000000.000100",
+      providerUrl: "http://127.0.0.1:2468/crabline/slack/inbound",
+      qaTarget: "thread:C1234567890/1700000000.000100",
+      stateConversation: {
+        id: "C1234567890",
+        kind: "group",
+      },
+      threadId: "1700000000.000100",
+    });
+
+    expect(
+      createOpenClawCrablineOutboundFromRecorderEvent({
+        manifest: slackManifest,
+        targetByProviderTarget: new Map([
+          ["C1234567890:thread:1700000000.000100", "thread:qa/parent"],
+        ]),
+        event: {
+          type: "api",
+          path: "/api/chat.postMessage",
+          body: {
+            channel: "C1234567890",
+            text: "hello from openclaw",
+            thread_ts: "1700000000.000100",
+          },
+        },
+      }),
+    ).toEqual({
+      accountId: "default",
+      senderId: "openclaw",
+      senderName: "OpenClaw QA",
+      text: "hello from openclaw",
+      to: "thread:qa/parent",
+    });
+  });
+
   it("posts WhatsApp OpenClaw inbound with admin headers into the Baileys listener path", async () => {
     const adapter = await startOpenClawCrablineAdapter({ channel: "whatsapp" });
     try {
@@ -405,7 +538,7 @@ describe("OpenClaw fake provider bridge", () => {
         result: {
           driver: "crabline",
           selectedChannel: "telegram",
-          supportedChannels: ["telegram", "whatsapp"],
+          supportedChannels: ["slack", "telegram", "whatsapp"],
         },
       });
       expect(result.smoke).toMatchObject({

--- a/test/slack-fake-server.test.ts
+++ b/test/slack-fake-server.test.ts
@@ -1,0 +1,305 @@
+import path from "node:path";
+import fs from "node:fs/promises";
+import { afterEach, describe, expect, it } from "vitest";
+import { startSlackFakeServer, type StartedSlackFakeServer } from "../src/index.js";
+import { createTempDir, disposeTempDir } from "./test-helpers.js";
+
+const servers: StartedSlackFakeServer[] = [];
+const directories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => server.close()));
+  await Promise.all(directories.splice(0).map(disposeTempDir));
+});
+
+async function startTestSlackServer(): Promise<StartedSlackFakeServer> {
+  const directory = await createTempDir();
+  directories.push(directory);
+  const server = await startSlackFakeServer({
+    adminToken: "admin-token",
+    botToken: "xoxb-fake",
+    recorderPath: path.join(directory, "slack.jsonl"),
+  });
+  servers.push(server);
+  return server;
+}
+
+async function slackApi(
+  server: StartedSlackFakeServer,
+  method: string,
+  body: Record<string, unknown> = {},
+): Promise<Response> {
+  return await fetch(`${server.manifest.endpoints.apiRoot}${method}`, {
+    body: JSON.stringify(body),
+    headers: {
+      authorization: "Bearer xoxb-fake",
+      "content-type": "application/json",
+    },
+    method: "POST",
+  });
+}
+
+async function postMessage(
+  server: StartedSlackFakeServer,
+  body: Record<string, unknown>,
+): Promise<{ ts: string }> {
+  const response = await slackApi(server, "chat.postMessage", body);
+  const payload = (await response.json()) as { ts: string };
+  expect(payload).toMatchObject({ ok: true });
+  return payload;
+}
+
+describe("slack fake provider server", () => {
+  it("serves Slack auth and conversation APIs", async () => {
+    const server = await startTestSlackServer();
+
+    await expect((await slackApi(server, "auth.test")).json()).resolves.toMatchObject({
+      ok: true,
+      team_id: "TCRABLINE",
+      user_id: "UCRABBOT",
+    });
+
+    const unauthenticated = await fetch(`${server.manifest.endpoints.apiRoot}auth.test`, {
+      method: "POST",
+    });
+    await expect(unauthenticated.json()).resolves.toMatchObject({
+      error: "not_authed",
+      ok: false,
+    });
+
+    await expect(
+      (
+        await slackApi(server, "conversations.open", {
+          users: "U1234567890",
+        })
+      ).json(),
+    ).resolves.toMatchObject({
+      channel: {
+        id: "D000000001",
+        is_im: true,
+        user: "U1234567890",
+      },
+      ok: true,
+    });
+
+    await expect(
+      (
+        await slackApi(server, "conversations.info", {
+          channel: "C1234567890",
+        })
+      ).json(),
+    ).resolves.toMatchObject({
+      channel: {
+        id: "C1234567890",
+        is_channel: true,
+      },
+      ok: true,
+    });
+  });
+
+  it("posts messages and serves thread/history reads", async () => {
+    const server = await startTestSlackServer();
+
+    const parent = await postMessage(server, {
+      attachments: [{ fallback: "fallback text", text: "attachment text" }],
+      blocks: [{ text: { text: "block text", type: "mrkdwn" }, type: "section" }],
+      channel: "C1234567890",
+      text: "hello fake slack",
+      unfurl_links: false,
+    });
+
+    await expect(
+      (
+        await slackApi(server, "chat.postMessage", {
+          channel: "C1234567890",
+          text: "thread reply",
+          thread_ts: parent.ts,
+        })
+      ).json(),
+    ).resolves.toMatchObject({
+      channel: "C1234567890",
+      message: {
+        text: "thread reply",
+        thread_ts: parent.ts,
+      },
+      ok: true,
+    });
+
+    await expect(
+      (
+        await slackApi(server, "conversations.replies", {
+          channel: "C1234567890",
+          ts: parent.ts,
+        })
+      ).json(),
+    ).resolves.toMatchObject({
+      messages: [{ text: "hello fake slack" }, { text: "thread reply" }],
+      ok: true,
+    });
+
+    await expect(
+      (
+        await slackApi(server, "conversations.history", {
+          channel: "C1234567890",
+          limit: 1,
+          oldest: parent.ts,
+        })
+      ).json(),
+    ).resolves.toMatchObject({
+      has_more: false,
+      messages: [{ text: "thread reply" }],
+      ok: true,
+    });
+  });
+
+  it("accepts authenticated admin inbound messages", async () => {
+    const server = await startTestSlackServer();
+    const parent = await postMessage(server, {
+      channel: "C1234567890",
+      text: "hello fake slack",
+    });
+
+    const rejected = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({
+        channel: "C1234567890",
+        text: "user nonce-1",
+        threadTs: parent.ts,
+        user: "U1234567890",
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    expect(rejected.status).toBe(401);
+
+    const accepted = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({
+        channel: "C1234567890",
+        text: "user nonce-1",
+        threadTs: parent.ts,
+        user: "U1234567890",
+      }),
+      headers: {
+        "content-type": "application/json",
+        "x-crabline-admin-token": "admin-token",
+      },
+      method: "POST",
+    });
+    await expect(accepted.json()).resolves.toMatchObject({
+      event: {
+        event: {
+          channel: "C1234567890",
+          text: "user nonce-1",
+          thread_ts: parent.ts,
+          user: "U1234567890",
+        },
+        type: "event_callback",
+      },
+      ok: true,
+    });
+
+    await expect(
+      (
+        await slackApi(server, "conversations.replies", {
+          channel: "C1234567890",
+          ts: parent.ts,
+        })
+      ).json(),
+    ).resolves.toMatchObject({
+      messages: [{ text: "hello fake slack" }, { text: "user nonce-1" }],
+      ok: true,
+    });
+  });
+
+  it("redacts body/query tokens and skips rejected admin inbound recording", async () => {
+    const server = await startTestSlackServer();
+
+    await expect(
+      (
+        await fetch(`${server.manifest.endpoints.apiRoot}auth.test?token=xoxb-fake`, {
+          method: "GET",
+        })
+      ).json(),
+    ).resolves.toMatchObject({ ok: true });
+    await expect(
+      (
+        await fetch(`${server.manifest.endpoints.apiRoot}auth.test`, {
+          body: JSON.stringify({ token: "xoxb-fake" }),
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        })
+      ).json(),
+    ).resolves.toMatchObject({ ok: true });
+
+    const rejected = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({
+        channel: "C1234567890",
+        text: "secret rejected inbound",
+        user: "U1234567890",
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    expect(rejected.status).toBe(401);
+
+    const recorder = await fs.readFile(server.manifest.recorderPath, "utf8");
+    expect(recorder).not.toContain("xoxb-fake");
+    expect(recorder).not.toContain("secret rejected inbound");
+    const events = recorder
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { body: { token?: string }; query: { token?: string } });
+    expect(events).toEqual([
+      expect.objectContaining({
+        body: expect.objectContaining({ token: "[redacted]" }),
+        query: expect.objectContaining({ token: "[redacted]" }),
+      }),
+      expect.objectContaining({
+        body: expect.objectContaining({ token: "[redacted]" }),
+      }),
+    ]);
+  });
+
+  it("returns Slack-shaped posting errors", async () => {
+    const server = await startTestSlackServer();
+
+    await expect(
+      (
+        await slackApi(server, "chat.postMessage", {
+          channel: "C1234567890",
+          text: "reply without parent",
+          thread_ts: "1700000000.999999",
+        })
+      ).json(),
+    ).resolves.toMatchObject({
+      error: "thread_not_found",
+      ok: false,
+    });
+
+    const rateLimited = await slackApi(server, "chat.postMessage", {
+      channel: "C1234567890",
+      retry_after: 2,
+      simulate_rate_limit: true,
+      text: "slow down",
+    });
+    expect(rateLimited.status).toBe(429);
+    expect(rateLimited.headers.get("retry-after")).toBe("2");
+    await expect(rateLimited.json()).resolves.toMatchObject({
+      error: "ratelimited",
+      ok: false,
+    });
+  });
+
+  it("handles Slack Events API URL verification", async () => {
+    const server = await startTestSlackServer();
+
+    const response = await fetch(server.manifest.endpoints.eventsUrl, {
+      body: JSON.stringify({
+        challenge: "challenge-token",
+        type: "url_verification",
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    await expect(response.json()).resolves.toEqual({ challenge: "challenge-token" });
+  });
+});


### PR DESCRIPTION
## Summary
- add a provider-shaped fake server for Slack alongside the existing Telegram and WhatsApp fake-provider support
- wire Slack through the fake-provider registry, CLI serve command, public exports, and OpenClaw adapter helpers
- document the supported Slack fake server and native Slack target identifiers

## Related context
- WhatsApp fake-provider support already landed in #18 and #19; this PR intentionally no longer carries WhatsApp changes.

## Details
- Slack fake server implements auth.test, chat.postMessage, conversations.open, conversations.info, conversations.history, conversations.replies, plus authenticated admin inbound event injection.
- Slack recorder output redacts token fields and does not record rejected admin inbound payloads.
- The OpenClaw adapter keeps Telegram/WhatsApp compatibility and adds native-ID-only Slack mappings.

## Verification
- pnpm verify