### PR TITLE
Add WhatsApp Baileys fake provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ provider APIs that OpenClaw live adapters can target during deterministic QA.
   `whatsapp`, and `zalo`
 - a `script` bridge for channels that are still exercised by external commands
 - per-provider local webhook endpoints for inbound events
-- fake provider servers for live-adapter smoke tests, starting with Telegram
+- fake provider servers for live-adapter smoke tests, starting with Telegram and
+  WhatsApp
 - JSONL recorder files for deterministic wait/watch behavior
 - nonce-based `send`, `roundtrip`, `agent`, `probe`, `run`, `watch`, and
   `doctor` commands
@@ -150,6 +151,28 @@ Implemented Telegram Bot API endpoints include `getMe`, `sendMessage`,
 `deleteWebhook`, `setWebhook`, `setMyCommands`, `deleteMyCommands`,
 `sendChatAction`, and `answerCallbackQuery`.
 
+WhatsApp:
+
+```bash
+crabline --json serve whatsapp --ready-file .crabline/whatsapp-server.json
+```
+
+The JSON manifest contains:
+
+- `endpoints.apiRoot`: Crabline WhatsApp fake provider API root
+- `accessToken`: bearer token for fake provider requests
+- `selfJid`: fake authenticated WhatsApp user JID
+- `endpoints.adminInboundUrl`: POST endpoint for test user messages
+- `endpoints.messagesUrl`: fake text send endpoint used by the Baileys-shaped
+  mock
+- `endpoints.presenceUrl`: fake presence endpoint used by
+  `sendPresenceUpdate`
+- `recorderPath`: JSONL file of fake provider API/admin traffic
+
+Crabline also exports `createWhatsAppBaileysMockSocket()` so tests can exercise
+a Baileys-style WhatsApp `sendMessage()` / `sendPresenceUpdate()` surface while
+the fake server owns local provider simulation.
+
 ## Target IDs
 
 Built-in providers accept native channel identifiers. Crabline does not add
@@ -174,6 +197,8 @@ Examples:
 - Slack threads: `1700000000.000100`
 - Telegram chats: `-1001234567890` or `@channelusername`
 - Telegram topics: `42`
+- WhatsApp users: `15551234567@s.whatsapp.net`
+- WhatsApp groups: `120363001234567890@g.us`
 - Discord channels and threads: Discord snowflake ids such as
   `123456789012345678`
 

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -76,7 +76,7 @@ Fake provider servers sit below OpenClaw's normal channel adapters. QA starts th
 server, writes the emitted runtime manifest into OpenClaw config/env, and then
 OpenClaw talks to the local fake provider instead of the public provider.
 
-Telegram is currently implemented:
+Telegram:
 
 ```bash
 crabline --json serve telegram --ready-file .crabline/telegram-server.json
@@ -106,6 +106,39 @@ The admin ingress accepts JSON like:
 
 OpenClaw consumes that message through Telegram `getUpdates`; outbound adapter
 sends are recorded through Telegram `sendMessage`.
+
+WhatsApp:
+
+```bash
+crabline --json serve whatsapp --ready-file .crabline/whatsapp-server.json
+```
+
+Manifest fields:
+
+- `endpoints.apiRoot`: Crabline WhatsApp fake provider API root
+- `accessToken`: bearer token for fake provider requests
+- `selfJid`: fake authenticated WhatsApp user JID
+- `endpoints.adminInboundUrl`: admin ingress for test user messages
+- `endpoints.messagesUrl`: text send endpoint used by the Baileys-shaped mock
+- `endpoints.presenceUrl`: presence endpoint used by `sendPresenceUpdate`
+- `recorderPath`: JSONL provider traffic recorder
+
+Use `createWhatsAppBaileysMockSocket()` when a test needs a Baileys-style
+`sendMessage()` / `sendPresenceUpdate()` surface backed by the same fake
+provider server.
+
+The admin ingress accepts JSON like:
+
+```json
+{
+  "chatJid": "120363001234567890@g.us",
+  "senderJid": "15551234567@s.whatsapp.net",
+  "text": "user nonce-123"
+}
+```
+
+Outbound text sends and composing presence are recorded through the fake
+provider messages and presence endpoints.
 
 ## Webhook Payload
 
@@ -145,6 +178,8 @@ as `telegram:`, `discord:`, or `slack:`.
 - Slack threads: `1700000000.000100`
 - Telegram chats: `-1001234567890` or `@channelusername`
 - Telegram topics: `42`
+- WhatsApp users: `15551234567@s.whatsapp.net`
+- WhatsApp groups: `120363001234567890@g.us`
 - Discord channels and threads: Discord snowflake ids such as
   `123456789012345678`
 - Google Chat spaces: `spaces/AAAABbbbCCC`

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -6,7 +6,11 @@ import { createRegistry } from "../providers/registry.js";
 import { formatJson, formatRunResultText } from "../core/reporters.js";
 import { computeExitCode, runFixtureCommand, runSuite } from "../core/run.js";
 import { CrablineError, ensureErrorMessage } from "../core/errors.js";
-import { startTelegramFakeServer } from "../fake-servers/telegram.js";
+import {
+  isCrablineFakeProviderChannel,
+  startCrablineFakeProviderServer,
+  type CrablineFakeProviderManifest,
+} from "../fake-servers/index.js";
 
 type GlobalOptions = {
   config?: string;
@@ -184,14 +188,16 @@ export function createProgram(
     .option("--host <host>", "Bind host", "127.0.0.1")
     .option("--port <port>", "Bind port", "0")
     .option("--admin-token <token>", "Admin token for inbound test messages")
+    .option("--access-token <token>", "Fake WhatsApp access token")
     .option("--bot-token <token>", "Fake Telegram bot token")
     .option("--bot-username <username>", "Fake Telegram bot username", "crabline_bot")
     .option("--recorder <path>", "JSONL recorder path")
     .option("--ready-file <path>", "Write the server runtime manifest to this path")
+    .option("--self-jid <jid>", "Fake WhatsApp self JID")
     .option("--once", "Start, print the runtime manifest, and stop immediately", false)
     .action(async (provider, commandOptions) => {
       const options = program.opts() as GlobalOptions;
-      if (provider !== "telegram") {
+      if (!isCrablineFakeProviderChannel(provider)) {
         throw new CrablineError(`Unsupported fake provider server: ${provider}`, {
           kind: "config",
         });
@@ -202,14 +208,25 @@ export function createProgram(
           kind: "config",
         });
       }
-      const server = await startTelegramFakeServer({
-        adminToken: commandOptions.adminToken,
-        botToken: commandOptions.botToken,
-        botUsername: commandOptions.botUsername,
-        host: commandOptions.host,
-        port,
-        recorderPath: commandOptions.recorder,
-      });
+      const server =
+        provider === "telegram"
+          ? await startCrablineFakeProviderServer({
+              adminToken: commandOptions.adminToken,
+              botToken: commandOptions.botToken,
+              botUsername: commandOptions.botUsername,
+              channel: "telegram",
+              host: commandOptions.host,
+              port,
+              recorderPath: commandOptions.recorder,
+            })
+          : await startCrablineFakeProviderServer({
+              accessToken: commandOptions.accessToken,
+              channel: "whatsapp",
+              host: commandOptions.host,
+              port,
+              recorderPath: commandOptions.recorder,
+              selfJid: commandOptions.selfJid,
+            });
       const payload = formatJson(server.manifest);
       if (commandOptions.readyFile) {
         await fs.mkdir(nodePath.dirname(commandOptions.readyFile), { recursive: true });
@@ -249,22 +266,26 @@ function waitForShutdown(close: () => Promise<void>): Promise<void> {
   });
 }
 
-function renderServeText(manifest: {
-  adminToken: string;
-  baseUrl: string;
-  botToken: string;
-  endpoints: { adminInboundUrl: string; apiRoot: string };
-  provider: string;
-  recorderPath: string;
-}) {
-  return [
+function renderServeText(manifest: CrablineFakeProviderManifest) {
+  const lines = [
     `${manifest.provider} fake server ready`,
     `  apiRoot: ${manifest.endpoints.apiRoot}`,
-    `  adminToken: ${manifest.adminToken}`,
-    `  botToken: ${manifest.botToken}`,
     `  inbound: ${manifest.endpoints.adminInboundUrl}`,
     `  recorder: ${manifest.recorderPath}`,
-  ].join("\n");
+  ];
+  if (manifest.provider === "telegram") {
+    lines.splice(2, 0, `  adminToken: ${manifest.adminToken}`, `  botToken: ${manifest.botToken}`);
+  } else {
+    lines.splice(
+      2,
+      0,
+      `  accessToken: ${manifest.accessToken}`,
+      `  messages: ${manifest.endpoints.messagesUrl}`,
+      `  presence: ${manifest.endpoints.presenceUrl}`,
+      `  selfJid: ${manifest.selfJid}`,
+    );
+  }
+  return lines.join("\n");
 }
 
 function renderProvidersText(payload: {

--- a/src/fake-servers/http.ts
+++ b/src/fake-servers/http.ts
@@ -1,0 +1,132 @@
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { CrablineError } from "../core/errors.js";
+
+export type FakeServerRequestEvent = {
+  at: string;
+  body?: unknown;
+  method: string;
+  path: string;
+  query: Record<string, string>;
+  type: "admin" | "api";
+};
+
+export function jsonResponse(value: unknown, status = 200): Response {
+  return Response.json(value, { status });
+}
+
+export async function readBody(request: IncomingMessage): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of request) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+export async function parseRequestBody(request: IncomingMessage): Promise<Record<string, unknown>> {
+  const body = await readBody(request);
+  if (body.length === 0) {
+    return {};
+  }
+  const contentType = request.headers["content-type"] ?? "";
+  const includesJson = Array.isArray(contentType)
+    ? contentType.some((entry) => entry.includes("json"))
+    : contentType.includes("json");
+  if (includesJson) {
+    return JSON.parse(body.toString("utf8")) as Record<string, unknown>;
+  }
+  const params = new URLSearchParams(body.toString("utf8"));
+  return Object.fromEntries(params.entries());
+}
+
+export function queryRecord(url: URL): Record<string, string> {
+  return Object.fromEntries(url.searchParams.entries());
+}
+
+export async function writeResponse(
+  response: ServerResponse,
+  fetchResponse: Response,
+): Promise<void> {
+  response.statusCode = fetchResponse.status;
+  for (const [name, value] of fetchResponse.headers) {
+    response.setHeader(name, value);
+  }
+  response.end(Buffer.from(await fetchResponse.arrayBuffer()));
+}
+
+export function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+export async function startHttpJsonServer(params: {
+  handle: (request: IncomingMessage) => Promise<Response>;
+  host: string;
+  port: number;
+  serverName: string;
+}): Promise<{ baseUrl: string; close(): Promise<void> }> {
+  const server = createServer(async (request, response) => {
+    try {
+      await writeResponse(response, await params.handle(request));
+    } catch (error) {
+      await writeResponse(
+        response,
+        jsonResponse(
+          {
+            error: error instanceof Error ? error.message : String(error),
+            ok: false,
+          },
+          500,
+        ),
+      );
+    }
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(params.port, params.host, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new CrablineError(`Unable to resolve ${params.serverName} fake server address.`, {
+      kind: "connectivity",
+    });
+  }
+  return {
+    baseUrl: `http://${params.host}:${address.port}`,
+    async close() {
+      await closeServer(server);
+    },
+  };
+}
+
+export function readString(value: unknown): string | undefined {
+  if (typeof value === "string" && value.length > 0) {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "bigint") {
+    return value.toString();
+  }
+  return undefined;
+}
+
+export function readTrimmedString(value: unknown): string | undefined {
+  const stringValue = readString(value)?.trim();
+  return stringValue ? stringValue : undefined;
+}
+
+export function readInteger(value: unknown): number | undefined {
+  const stringValue = readTrimmedString(value);
+  if (!stringValue || !/^-?\d+$/u.test(stringValue)) {
+    return undefined;
+  }
+  return Number(stringValue);
+}

--- a/src/fake-servers/index.ts
+++ b/src/fake-servers/index.ts
@@ -4,18 +4,26 @@ import {
   type StartTelegramFakeServerParams,
   type TelegramFakeServerManifest,
 } from "./telegram.js";
+import {
+  startWhatsAppFakeServer,
+  type StartedWhatsAppFakeServer,
+  type StartWhatsAppFakeServerParams,
+  type WhatsAppFakeServerManifest,
+} from "./whatsapp.js";
 
-export const CRABLINE_FAKE_PROVIDER_CHANNELS = Object.freeze(["telegram"] as const);
+export const CRABLINE_FAKE_PROVIDER_CHANNELS = Object.freeze(["telegram", "whatsapp"] as const);
 
 export type CrablineFakeProviderChannel = (typeof CRABLINE_FAKE_PROVIDER_CHANNELS)[number];
 
-export type CrablineFakeProviderManifest = TelegramFakeServerManifest;
+export type CrablineFakeProviderManifest = TelegramFakeServerManifest | WhatsAppFakeServerManifest;
 
-export type StartedCrablineFakeProviderServer = StartedTelegramFakeServer;
+export type StartedCrablineFakeProviderServer =
+  | StartedTelegramFakeServer
+  | StartedWhatsAppFakeServer;
 
-export type StartCrablineFakeProviderServerParams = StartTelegramFakeServerParams & {
-  channel: CrablineFakeProviderChannel;
-};
+export type StartCrablineFakeProviderServerParams =
+  | (StartTelegramFakeServerParams & { channel: "telegram" })
+  | (StartWhatsAppFakeServerParams & { channel: "whatsapp" });
 
 export function isCrablineFakeProviderChannel(value: string): value is CrablineFakeProviderChannel {
   return CRABLINE_FAKE_PROVIDER_CHANNELS.includes(value as CrablineFakeProviderChannel);
@@ -27,5 +35,7 @@ export async function startCrablineFakeProviderServer(
   switch (params.channel) {
     case "telegram":
       return await startTelegramFakeServer(params);
+    case "whatsapp":
+      return await startWhatsAppFakeServer(params);
   }
 }

--- a/src/fake-servers/whatsapp.ts
+++ b/src/fake-servers/whatsapp.ts
@@ -1,0 +1,566 @@
+import type { IncomingMessage } from "node:http";
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  jsonResponse,
+  parseRequestBody,
+  queryRecord,
+  readTrimmedString,
+  startHttpJsonServer,
+  type FakeServerRequestEvent,
+} from "./http.js";
+
+const WHATSAPP_USER_JID_RE = /^\d{7,15}(?::\d+)?@s\.whatsapp\.net$/iu;
+const WHATSAPP_LEGACY_USER_JID_RE = /^\d{7,15}@c\.us$/iu;
+const WHATSAPP_GROUP_JID_RE = /^\d{5,}@g\.us$/iu;
+const WHATSAPP_LID_RE = /^\d{7,15}@lid$/iu;
+
+type WhatsAppFakeServerState = {
+  accessToken: string;
+  displayPhoneNumber: string;
+  nextMessageId: number;
+  phoneNumberId: string;
+  recorderPath: string;
+  selfJid: string;
+};
+
+export type WhatsAppBaileysPresence = "available" | "composing" | "paused" | "unavailable";
+
+export type WhatsAppBaileysMockSocket = {
+  ev: {
+    emit(event: string, payload: unknown): boolean;
+    off(event: string, handler: (payload: unknown) => void): void;
+    on(event: string, handler: (payload: unknown) => void): void;
+  };
+  sendMessage(
+    jid: string,
+    content: { conversation?: string | undefined; text?: string | undefined },
+    options?: Record<string, unknown>,
+  ): Promise<WhatsAppBaileysMessage>;
+  sendPresenceUpdate(presence: WhatsAppBaileysPresence, jid?: string): Promise<void>;
+  user: {
+    id: string;
+    name: string;
+  };
+};
+
+export type WhatsAppBaileysMessage = ReturnType<typeof createWhatsAppMessage>;
+
+export type WhatsAppBaileysMockConfig = {
+  accessToken: string;
+  apiRoot: string;
+  fetch?: typeof fetch | undefined;
+  selfJid?: string | undefined;
+};
+
+export type WhatsAppFakeServerManifest = {
+  accessToken: string;
+  baseUrl: string;
+  endpoints: {
+    adminInboundUrl: string;
+    apiRoot: string;
+    messagesUrl: string;
+    presenceUrl: string;
+  };
+  env: {
+    CRABLINE_WHATSAPP_ACCESS_TOKEN: string;
+    CRABLINE_WHATSAPP_API_ROOT: string;
+    CRABLINE_WHATSAPP_SELF_JID: string;
+  };
+  provider: "whatsapp";
+  recorderPath: string;
+  selfJid: string;
+  version: 1;
+};
+
+export type StartedWhatsAppFakeServer = {
+  close(): Promise<void>;
+  manifest: WhatsAppFakeServerManifest;
+};
+
+export type StartWhatsAppFakeServerParams = {
+  accessToken?: string | undefined;
+  host?: string | undefined;
+  port?: number | undefined;
+  recorderPath?: string | undefined;
+  selfJid?: string | undefined;
+};
+
+function whatsappOk(value: Record<string, unknown> = {}): Response {
+  return jsonResponse({ ok: true, ...value });
+}
+
+function graphError(params: {
+  code?: number | undefined;
+  details?: string | undefined;
+  message: string;
+  status?: number | undefined;
+  type?: string | undefined;
+}): Response {
+  return jsonResponse(
+    {
+      error: {
+        code: params.code ?? 100,
+        ...(params.details
+          ? {
+              error_data: {
+                details: params.details,
+                messaging_product: "whatsapp",
+              },
+            }
+          : {}),
+        fbtrace_id: "A1B2C3D4E5F",
+        message: params.message,
+        type: params.type ?? "OAuthException",
+      },
+      ok: false,
+    },
+    params.status ?? 400,
+  );
+}
+
+function graphParameterError(message: string, details?: string): Response {
+  return graphError({ code: 100, details, message, status: 400 });
+}
+
+function graphAuthError(): Response {
+  return graphError({
+    code: 190,
+    message: "Invalid OAuth access token.",
+    status: 401,
+  });
+}
+
+async function appendEvent(state: WhatsAppFakeServerState, event: FakeServerRequestEvent) {
+  await fs.mkdir(path.dirname(state.recorderPath), { recursive: true });
+  await fs.appendFile(state.recorderPath, `${JSON.stringify(event)}\n`, "utf8");
+}
+
+function isWhatsAppJid(value: string): boolean {
+  return (
+    WHATSAPP_USER_JID_RE.test(value) ||
+    WHATSAPP_LEGACY_USER_JID_RE.test(value) ||
+    WHATSAPP_GROUP_JID_RE.test(value) ||
+    WHATSAPP_LID_RE.test(value)
+  );
+}
+
+function requireWhatsAppJid(value: unknown, label: string): string | Response {
+  const stringValue = readTrimmedString(value);
+  if (!stringValue || !isWhatsAppJid(stringValue)) {
+    return graphParameterError(
+      `(#100) Invalid parameter: ${label}`,
+      `${label} must be a WhatsApp JID such as 15551234567@s.whatsapp.net or 120363001234567890@g.us.`,
+    );
+  }
+  return stringValue;
+}
+
+function requireAuth(request: IncomingMessage, state: WhatsAppFakeServerState): boolean {
+  const authorization = request.headers.authorization;
+  return (
+    typeof authorization === "string" && authorization.trim() === `Bearer ${state.accessToken}`
+  );
+}
+
+function nextMessageId(state: WhatsAppFakeServerState): string {
+  return `wamid.FAKE${String(state.nextMessageId++).padStart(8, "0")}`;
+}
+
+function waIdFromJid(jid: string): string {
+  return jid.split("@", 1)[0]?.split(":", 1)[0] ?? jid;
+}
+
+function trimTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47) {
+    end -= 1;
+  }
+  return value.slice(0, end);
+}
+
+function trimLeadingSlashes(value: string): string {
+  let start = 0;
+  while (start < value.length && value.charCodeAt(start) === 47) {
+    start += 1;
+  }
+  return value.slice(start);
+}
+
+function joinUrl(root: string, pathPart: string): string {
+  return `${trimTrailingSlashes(root)}/${trimLeadingSlashes(pathPart)}`;
+}
+
+async function postJson(params: {
+  accessToken: string;
+  body: Record<string, unknown>;
+  fetchImpl: typeof fetch;
+  url: string;
+}): Promise<Record<string, unknown>> {
+  const response = await params.fetchImpl(params.url, {
+    body: JSON.stringify(params.body),
+    headers: {
+      authorization: `Bearer ${params.accessToken}`,
+      "content-type": "application/json",
+    },
+    method: "POST",
+  });
+  const rawBody = await response.text();
+  const parsed = rawBody ? (JSON.parse(rawBody) as Record<string, unknown>) : {};
+  if (!response.ok) {
+    throw new Error(`WhatsApp API request failed with HTTP ${response.status}.`);
+  }
+  return parsed;
+}
+
+function requireMessagingProduct(body: Record<string, unknown>): Response | undefined {
+  const messagingProduct = readTrimmedString(body.messaging_product);
+  if (messagingProduct && messagingProduct !== "whatsapp") {
+    return graphParameterError(
+      "(#100) Invalid parameter: messaging_product",
+      'messaging_product must be "whatsapp".',
+    );
+  }
+  return undefined;
+}
+
+function readTextMessageBody(body: Record<string, unknown>): string | Response {
+  const type = readTrimmedString(body.type);
+  if (type && type !== "text") {
+    return graphParameterError(
+      "(#100) Unsupported message type",
+      "This test API currently supports WhatsApp text message sends.",
+    );
+  }
+  const textPayload = body.text;
+  const textBody =
+    textPayload && typeof textPayload === "object"
+      ? readTrimmedString((textPayload as Record<string, unknown>).body)
+      : readTrimmedString(textPayload);
+  const content = body.content;
+  const contentText =
+    content && typeof content === "object"
+      ? readTrimmedString((content as Record<string, unknown>).text)
+      : undefined;
+  const text = textBody ?? contentText;
+  if (!text) {
+    return graphParameterError(
+      "(#100) Missing required parameter: text.body",
+      "A WhatsApp text send requires text.body.",
+    );
+  }
+  return text;
+}
+
+function createWhatsAppMessage(params: {
+  fromMe: boolean;
+  id: string;
+  remoteJid: string;
+  senderJid?: string | undefined;
+  text: string;
+}) {
+  return {
+    key: {
+      fromMe: params.fromMe,
+      id: params.id,
+      ...(params.senderJid ? { participant: params.senderJid } : {}),
+      remoteJid: params.remoteJid,
+    },
+    message: {
+      conversation: params.text,
+    },
+    messageTimestamp: Math.floor(Date.now() / 1000),
+    pushName: params.fromMe ? "Test Bot" : "Test User",
+  };
+}
+
+function readBaileysTextContent(content: {
+  conversation?: string | undefined;
+  text?: string | undefined;
+}): string {
+  const text = readTrimmedString(content.text) ?? readTrimmedString(content.conversation);
+  if (!text) {
+    throw new Error("WhatsApp Baileys mock supports text sends only.");
+  }
+  return text;
+}
+
+function readResponseMessage(
+  body: Record<string, unknown>,
+  fallbackJid: string,
+): WhatsAppBaileysMessage {
+  const message = body.message;
+  if (message && typeof message === "object") {
+    return message as WhatsAppBaileysMessage;
+  }
+  const messageId =
+    readTrimmedString((body.messages as Array<{ id?: unknown }> | undefined)?.[0]?.id) ??
+    readTrimmedString(body.messageId) ??
+    "wamid.FAKEUNKNOWN";
+  return createWhatsAppMessage({
+    fromMe: true,
+    id: messageId,
+    remoteJid: fallbackJid,
+    text: "",
+  });
+}
+
+function createEventBus(): WhatsAppBaileysMockSocket["ev"] {
+  const listeners = new Map<string, Set<(payload: unknown) => void>>();
+  return {
+    emit(event, payload) {
+      const handlers = listeners.get(event);
+      if (!handlers?.size) {
+        return false;
+      }
+      for (const handler of handlers) {
+        handler(payload);
+      }
+      return true;
+    },
+    off(event, handler) {
+      listeners.get(event)?.delete(handler);
+    },
+    on(event, handler) {
+      const handlers = listeners.get(event) ?? new Set<(payload: unknown) => void>();
+      handlers.add(handler);
+      listeners.set(event, handlers);
+    },
+  };
+}
+
+export function createWhatsAppBaileysMockSocket(
+  config: WhatsAppBaileysMockConfig,
+): WhatsAppBaileysMockSocket {
+  const fetchImpl = config.fetch ?? fetch;
+  const selfJid = config.selfJid ?? "15550000000@s.whatsapp.net";
+  const ev = createEventBus();
+  return {
+    ev,
+    async sendMessage(jid, content) {
+      const text = readBaileysTextContent(content);
+      const body = await postJson({
+        accessToken: config.accessToken,
+        body: {
+          messaging_product: "whatsapp",
+          text: { body: text },
+          to: jid,
+          type: "text",
+        },
+        fetchImpl,
+        url: joinUrl(config.apiRoot, "messages"),
+      });
+      const message = readResponseMessage(body, jid);
+      ev.emit("messages.upsert", { messages: [message], type: "notify" });
+      return message;
+    },
+    async sendPresenceUpdate(presence, jid) {
+      await postJson({
+        accessToken: config.accessToken,
+        body: { ...(jid ? { jid } : {}), presence },
+        fetchImpl,
+        url: joinUrl(config.apiRoot, "presence"),
+      });
+      ev.emit("presence.update", { jid, presence });
+    },
+    user: {
+      id: selfJid,
+      name: "Test Bot",
+    },
+  };
+}
+
+async function handleSendMessage(params: {
+  body: Record<string, unknown>;
+  state: WhatsAppFakeServerState;
+}): Promise<Response> {
+  const productError = requireMessagingProduct(params.body);
+  if (productError) {
+    return productError;
+  }
+  const to = requireWhatsAppJid(params.body.to ?? params.body.jid, "to");
+  if (to instanceof Response) {
+    return to;
+  }
+  const text = readTextMessageBody(params.body);
+  if (text instanceof Response) {
+    return text;
+  }
+  const message = createWhatsAppMessage({
+    fromMe: true,
+    id: nextMessageId(params.state),
+    remoteJid: to,
+    text,
+  });
+  const waId = waIdFromJid(to);
+  return whatsappOk({
+    contacts: [
+      {
+        input: to,
+        wa_id: waId,
+      },
+    ],
+    key: message.key,
+    message,
+    messageId: message.key.id,
+    messages: [{ id: message.key.id }],
+    messaging_product: "whatsapp",
+    toJid: to,
+  });
+}
+
+async function handleAdminInbound(params: {
+  body: Record<string, unknown>;
+  state: WhatsAppFakeServerState;
+}): Promise<Response> {
+  const chatJid = requireWhatsAppJid(params.body.chatJid ?? params.body.chatId, "chatJid");
+  if (chatJid instanceof Response) {
+    return chatJid;
+  }
+  const senderJid = requireWhatsAppJid(params.body.senderJid ?? params.body.from, "senderJid");
+  if (senderJid instanceof Response) {
+    return senderJid;
+  }
+  const text = readTrimmedString(params.body.text);
+  if (!text) {
+    return graphParameterError(
+      "(#100) Missing required parameter: text",
+      "An inbound WhatsApp fake event requires text.",
+    );
+  }
+  const message = createWhatsAppMessage({
+    fromMe: false,
+    id: readTrimmedString(params.body.messageId) ?? nextMessageId(params.state),
+    remoteJid: chatJid,
+    senderJid,
+    text,
+  });
+  const timestamp = String(message.messageTimestamp);
+  const webhook = {
+    entry: [
+      {
+        changes: [
+          {
+            field: "messages",
+            value: {
+              contacts: [
+                {
+                  profile: { name: readTrimmedString(params.body.pushName) ?? "Test User" },
+                  wa_id: waIdFromJid(senderJid),
+                },
+              ],
+              messages: [
+                {
+                  from: waIdFromJid(senderJid),
+                  id: message.key.id,
+                  text: { body: text },
+                  timestamp,
+                  type: "text",
+                },
+              ],
+              messaging_product: "whatsapp",
+              metadata: {
+                display_phone_number: params.state.displayPhoneNumber,
+                phone_number_id: params.state.phoneNumberId,
+              },
+            },
+          },
+        ],
+        id: "TEST_WABA",
+      },
+    ],
+    object: "whatsapp_business_account",
+  };
+  return whatsappOk({ message, webhook });
+}
+
+async function handleRequest(params: { request: IncomingMessage; state: WhatsAppFakeServerState }) {
+  const url = new URL(params.request.url ?? "/", "http://127.0.0.1");
+  const body =
+    params.request.method === "GET" ? queryRecord(url) : await parseRequestBody(params.request);
+  await appendEvent(params.state, {
+    at: new Date().toISOString(),
+    body,
+    method: params.request.method ?? "GET",
+    path: url.pathname,
+    query: queryRecord(url),
+    type: url.pathname.startsWith("/crabline/whatsapp/inbound") ? "admin" : "api",
+  });
+
+  if (url.pathname === "/crabline/whatsapp/health") {
+    return whatsappOk({ selfJid: params.state.selfJid });
+  }
+  if (url.pathname === "/crabline/whatsapp/inbound") {
+    if (params.request.method !== "POST") {
+      return new Response("not found", { status: 404 });
+    }
+    return await handleAdminInbound({ body, state: params.state });
+  }
+  if (!requireAuth(params.request, params.state)) {
+    return graphAuthError();
+  }
+  if (url.pathname === "/crabline/whatsapp/messages") {
+    if (params.request.method !== "POST") {
+      return new Response("not found", { status: 404 });
+    }
+    return await handleSendMessage({ body, state: params.state });
+  }
+  if (url.pathname === "/crabline/whatsapp/presence") {
+    const presence = readTrimmedString(body.presence) ?? "composing";
+    if (!["available", "composing", "paused", "unavailable"].includes(presence)) {
+      return graphParameterError(
+        "(#100) Invalid parameter: presence",
+        "presence must be available, composing, paused, or unavailable.",
+      );
+    }
+    return whatsappOk({ presence });
+  }
+  return new Response("not found", { status: 404 });
+}
+
+export async function startWhatsAppFakeServer(
+  params: StartWhatsAppFakeServerParams = {},
+): Promise<StartedWhatsAppFakeServer> {
+  const state: WhatsAppFakeServerState = {
+    accessToken: params.accessToken ?? "crabline-whatsapp-access-token",
+    displayPhoneNumber: "15550000000",
+    nextMessageId: 1,
+    phoneNumberId: "TEST_PHONE_NUMBER_ID",
+    recorderPath:
+      params.recorderPath ?? path.resolve(".crabline", "fake-servers", "whatsapp.jsonl"),
+    selfJid: params.selfJid ?? "15550000000@s.whatsapp.net",
+  };
+  const host = params.host ?? "127.0.0.1";
+  const httpServer = await startHttpJsonServer({
+    handle: (request) => handleRequest({ request, state }),
+    host,
+    port: params.port ?? 0,
+    serverName: "WhatsApp",
+  });
+  const baseUrl = httpServer.baseUrl;
+  const apiRoot = `${baseUrl}/crabline/whatsapp`;
+  return {
+    async close() {
+      await httpServer.close();
+    },
+    manifest: {
+      accessToken: state.accessToken,
+      baseUrl,
+      endpoints: {
+        adminInboundUrl: `${apiRoot}/inbound`,
+        apiRoot,
+        messagesUrl: `${apiRoot}/messages`,
+        presenceUrl: `${apiRoot}/presence`,
+      },
+      env: {
+        CRABLINE_WHATSAPP_ACCESS_TOKEN: state.accessToken,
+        CRABLINE_WHATSAPP_API_ROOT: apiRoot,
+        CRABLINE_WHATSAPP_SELF_JID: state.selfJid,
+      },
+      provider: "whatsapp",
+      recorderPath: state.recorderPath,
+      selfJid: state.selfJid,
+      version: 1,
+    },
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,10 @@ export { resolveTelegramAdapterConfig } from "./providers/builtin/telegram.js";
 export { resolveWhatsAppAdapterConfig } from "./providers/builtin/whatsapp.js";
 export { startTelegramFakeServer } from "./fake-servers/telegram.js";
 export {
+  createWhatsAppBaileysMockSocket,
+  startWhatsAppFakeServer,
+} from "./fake-servers/whatsapp.js";
+export {
   CRABLINE_FAKE_PROVIDER_CHANNELS,
   isCrablineFakeProviderChannel,
   startCrablineFakeProviderServer,
@@ -61,6 +65,15 @@ export type {
   StartTelegramFakeServerParams,
   TelegramFakeServerManifest,
 } from "./fake-servers/telegram.js";
+export type {
+  StartedWhatsAppFakeServer,
+  StartWhatsAppFakeServerParams,
+  WhatsAppBaileysMessage,
+  WhatsAppBaileysMockConfig,
+  WhatsAppBaileysMockSocket,
+  WhatsAppBaileysPresence,
+  WhatsAppFakeServerManifest,
+} from "./fake-servers/whatsapp.js";
 export type {
   CrablineFakeProviderChannel,
   CrablineFakeProviderManifest,

--- a/src/openclaw.ts
+++ b/src/openclaw.ts
@@ -9,10 +9,12 @@ import {
 import fs from "node:fs/promises";
 import path from "node:path";
 
-const TELEGRAM_ACCOUNT_ID = "default";
+const DEFAULT_ACCOUNT_ID = "default";
 const TELEGRAM_DIRECT_CHAT_ID = "100001";
 const TELEGRAM_GROUP_CHAT_ID = "-1001234567890";
 const TELEGRAM_DEFAULT_SENDER_ID = 100001;
+const WHATSAPP_JID_RE =
+  /^(?:\d{7,15}(?::\d+)?@s\.whatsapp\.net|\d{7,15}@c\.us|\d{5,}@g\.us|\d{7,15}@lid)$/iu;
 export const OPENCLAW_CRABLINE_CHANNEL_CAPABILITY_MATRIX_PATH =
   "crabline-fake-provider-capabilities.json";
 export const OPENCLAW_CRABLINE_CHANNEL_SMOKE_PATH = "crabline-fake-provider-smoke.json";
@@ -97,7 +99,7 @@ export type StartedOpenClawCrablineAdapter = OpenClawCrablineGatewayBinding & {
   probe(): Promise<unknown>;
 };
 
-type TelegramRecorderEvent = {
+type RecorderEvent = {
   body?: Record<string, unknown>;
   path?: string;
   type?: string;
@@ -174,11 +176,22 @@ function qaTargetForInbound(input: OpenClawCrablineInboundInput) {
     : `${prefix}:${input.conversation.id}`;
 }
 
-function requireTelegramManifest(manifest: CrablineFakeProviderManifest) {
-  if (manifest.provider !== "telegram") {
+function requireWhatsAppJid(value: string, label: string): string {
+  const trimmed = value.trim();
+  if (!WHATSAPP_JID_RE.test(trimmed)) {
+    throw new Error(`${label} must be a native WhatsApp JID.`);
+  }
+  return trimmed;
+}
+
+function requireManifestProvider<TProvider extends CrablineFakeProviderManifest["provider"]>(
+  manifest: CrablineFakeProviderManifest,
+  provider: TProvider,
+): Extract<CrablineFakeProviderManifest, { provider: TProvider }> {
+  if (manifest.provider !== provider) {
     throw new Error(`Unsupported OpenClaw fake provider binding: ${String(manifest.provider)}`);
   }
-  return manifest;
+  return manifest as Extract<CrablineFakeProviderManifest, { provider: TProvider }>;
 }
 
 export function resolveOpenClawCrablineChannel(input?: string | null): CrablineFakeProviderChannel {
@@ -205,114 +218,203 @@ export function resolveOpenClawCrablineChannelDriverSelection(params: {
 export async function probeOpenClawCrablineFakeProvider(
   manifest: CrablineFakeProviderManifest,
 ): Promise<unknown> {
-  if (manifest.provider !== "telegram") {
-    throw new Error(
-      `OpenClaw Crabline fake-provider smoke does not support ${String(manifest.provider)}.`,
-    );
+  switch (manifest.provider) {
+    case "telegram": {
+      const response = await fetch(`${manifest.endpoints.apiRoot}/bot${manifest.botToken}/getMe`);
+      if (!response.ok) {
+        throw new Error(`Crabline Telegram getMe probe failed with HTTP ${response.status}.`);
+      }
+      return await response.json();
+    }
+    case "whatsapp": {
+      const response = await fetch(`${manifest.endpoints.apiRoot}/health`);
+      if (!response.ok) {
+        throw new Error(`Crabline WhatsApp health probe failed with HTTP ${response.status}.`);
+      }
+      return await response.json();
+    }
   }
-  const response = await fetch(`${manifest.endpoints.apiRoot}/bot${manifest.botToken}/getMe`);
-  if (!response.ok) {
-    throw new Error(`Crabline Telegram getMe probe failed with HTTP ${response.status}.`);
-  }
-  return await response.json();
 }
 
 export function createOpenClawCrablineFakeProviderBinding(
   manifest: CrablineFakeProviderManifest,
 ): OpenClawCrablineGatewayBinding {
-  const telegram = requireTelegramManifest(manifest);
-  return {
-    accountId: TELEGRAM_ACCOUNT_ID,
-    channel: "telegram",
-    createChannelDriverSmokeEnv: (env) => ({
-      ...env,
-      TELEGRAM_BOT_TOKEN: telegram.botToken,
-    }),
-    createGatewayConfig: (openclawConfig = {}) => {
-      const channels = isRecord(openclawConfig.channels) ? openclawConfig.channels : {};
-      const telegramConfig = isRecord(channels.telegram) ? channels.telegram : {};
-      const groups = isRecord(telegramConfig.groups) ? telegramConfig.groups : {};
-      const defaultGroup = isRecord(groups["*"]) ? groups["*"] : {};
-      const messages = isRecord(openclawConfig.messages) ? openclawConfig.messages : {};
-      const groupChat = isRecord(messages.groupChat) ? messages.groupChat : {};
-
+  switch (manifest.provider) {
+    case "telegram": {
+      const telegram = requireManifestProvider(manifest, "telegram");
       return {
-        ...openclawConfig,
-        channels: {
-          ...channels,
-          telegram: {
-            ...telegramConfig,
-            enabled: true,
-            botToken: telegram.botToken,
-            apiRoot: telegram.endpoints.apiRoot,
-            dmPolicy: "open",
-            groupPolicy: "open",
-            allowFrom: ["*"],
-            groupAllowFrom: ["*"],
-            groups: {
-              ...groups,
-              "*": {
-                ...defaultGroup,
-                requireMention: false,
+        accountId: DEFAULT_ACCOUNT_ID,
+        channel: "telegram",
+        createChannelDriverSmokeEnv: (env) => ({
+          ...env,
+          TELEGRAM_BOT_TOKEN: telegram.botToken,
+        }),
+        createGatewayConfig: (openclawConfig = {}) => {
+          const channels = isRecord(openclawConfig.channels) ? openclawConfig.channels : {};
+          const telegramConfig = isRecord(channels.telegram) ? channels.telegram : {};
+          const groups = isRecord(telegramConfig.groups) ? telegramConfig.groups : {};
+          const defaultGroup = isRecord(groups["*"]) ? groups["*"] : {};
+          const messages = isRecord(openclawConfig.messages) ? openclawConfig.messages : {};
+          const groupChat = isRecord(messages.groupChat) ? messages.groupChat : {};
+
+          return {
+            ...openclawConfig,
+            channels: {
+              ...channels,
+              telegram: {
+                ...telegramConfig,
+                enabled: true,
+                botToken: telegram.botToken,
+                apiRoot: telegram.endpoints.apiRoot,
+                dmPolicy: "open",
+                groupPolicy: "open",
+                allowFrom: ["*"],
+                groupAllowFrom: ["*"],
+                groups: {
+                  ...groups,
+                  "*": {
+                    ...defaultGroup,
+                    requireMention: false,
+                  },
+                },
               },
             },
-          },
+            messages: {
+              ...messages,
+              groupChat: {
+                ...groupChat,
+                mentionPatterns: ["\\b@?openclaw\\b"],
+                visibleReplies: "automatic",
+              },
+            },
+          };
         },
-        messages: {
-          ...messages,
-          groupChat: {
-            ...groupChat,
-            mentionPatterns: ["\\b@?openclaw\\b"],
-            visibleReplies: "automatic",
-          },
-        },
+        requiredPluginIds: ["telegram"],
       };
-    },
-    requiredPluginIds: ["telegram"],
-  };
+    }
+    case "whatsapp": {
+      const whatsapp = requireManifestProvider(manifest, "whatsapp");
+      return {
+        accountId: DEFAULT_ACCOUNT_ID,
+        channel: "whatsapp",
+        createChannelDriverSmokeEnv: (env) => ({
+          ...env,
+          CRABLINE_WHATSAPP_ACCESS_TOKEN: whatsapp.accessToken,
+          CRABLINE_WHATSAPP_API_ROOT: whatsapp.endpoints.apiRoot,
+          CRABLINE_WHATSAPP_SELF_JID: whatsapp.selfJid,
+        }),
+        createGatewayConfig: (openclawConfig = {}) => {
+          const channels = isRecord(openclawConfig.channels) ? openclawConfig.channels : {};
+          const whatsappConfig = isRecord(channels.whatsapp) ? channels.whatsapp : {};
+          const groups = isRecord(whatsappConfig.groups) ? whatsappConfig.groups : {};
+          const defaultGroup = isRecord(groups["*"]) ? groups["*"] : {};
+
+          return {
+            ...openclawConfig,
+            channels: {
+              ...channels,
+              whatsapp: {
+                ...whatsappConfig,
+                enabled: true,
+                dmPolicy: "open",
+                groupPolicy: "open",
+                allowFrom: ["*"],
+                groupAllowFrom: ["*"],
+                groups: {
+                  ...groups,
+                  "*": {
+                    ...defaultGroup,
+                    requireMention: false,
+                  },
+                },
+              },
+            },
+          };
+        },
+        requiredPluginIds: ["whatsapp"],
+      };
+    }
+  }
 }
 
 export function createOpenClawCrablineAgentDelivery(params: {
   manifest: CrablineFakeProviderManifest;
   target: string;
 }): OpenClawCrablineAgentDelivery {
-  requireTelegramManifest(params.manifest);
   const parsed = parseQaTarget(params.target);
-  const chatId = normalizeTelegramChatId(parsed.kind, parsed.id);
-  const threadId = readInteger(parsed.threadId);
-  const to = telegramTargetKey(chatId, threadId);
-  return {
-    channel: "telegram",
-    to,
-    replyChannel: "telegram",
-    replyTo: to,
-  };
+  switch (params.manifest.provider) {
+    case "telegram": {
+      requireManifestProvider(params.manifest, "telegram");
+      const chatId = normalizeTelegramChatId(parsed.kind, parsed.id);
+      const threadId = readInteger(parsed.threadId);
+      const to = telegramTargetKey(chatId, threadId);
+      return {
+        channel: "telegram",
+        to,
+        replyChannel: "telegram",
+        replyTo: to,
+      };
+    }
+    case "whatsapp": {
+      requireManifestProvider(params.manifest, "whatsapp");
+      const to = requireWhatsAppJid(parsed.id, "WhatsApp target");
+      return {
+        channel: "whatsapp",
+        to,
+        replyChannel: "whatsapp",
+        replyTo: to,
+      };
+    }
+  }
 }
 
 export function createOpenClawCrablineInbound(params: {
   input: OpenClawCrablineInboundInput;
   manifest: CrablineFakeProviderManifest;
 }): OpenClawCrablineInbound {
-  requireTelegramManifest(params.manifest);
-  const kind = params.input.conversation.kind === "direct" ? "direct" : "group";
-  const chatId = normalizeTelegramChatId(kind, params.input.conversation.id);
-  const threadId = readInteger(params.input.threadId);
-  return {
-    providerBody: {
-      chatId,
-      fromId: readInteger(params.input.senderId) ?? TELEGRAM_DEFAULT_SENDER_ID,
-      fromName: params.input.senderName ?? params.input.senderId,
-      ...(threadId !== undefined ? { messageThreadId: threadId } : {}),
-      text: params.input.text,
-    },
-    providerTargetKey: telegramTargetKey(chatId, threadId),
-    qaTarget: qaTargetForInbound(params.input),
-    stateConversation: {
-      id: chatId,
-      kind: kind === "group" ? "group" : "direct",
-    },
-    ...(threadId !== undefined ? { threadId: String(threadId) } : {}),
-  };
+  switch (params.manifest.provider) {
+    case "telegram": {
+      requireManifestProvider(params.manifest, "telegram");
+      const kind = params.input.conversation.kind === "direct" ? "direct" : "group";
+      const chatId = normalizeTelegramChatId(kind, params.input.conversation.id);
+      const threadId = readInteger(params.input.threadId);
+      return {
+        providerBody: {
+          chatId,
+          fromId: readInteger(params.input.senderId) ?? TELEGRAM_DEFAULT_SENDER_ID,
+          fromName: params.input.senderName ?? params.input.senderId,
+          ...(threadId !== undefined ? { messageThreadId: threadId } : {}),
+          text: params.input.text,
+        },
+        providerTargetKey: telegramTargetKey(chatId, threadId),
+        qaTarget: qaTargetForInbound(params.input),
+        stateConversation: {
+          id: chatId,
+          kind: kind === "group" ? "group" : "direct",
+        },
+        ...(threadId !== undefined ? { threadId: String(threadId) } : {}),
+      };
+    }
+    case "whatsapp": {
+      requireManifestProvider(params.manifest, "whatsapp");
+      const chatJid = requireWhatsAppJid(params.input.conversation.id, "WhatsApp conversation");
+      const senderJid = requireWhatsAppJid(params.input.senderId, "WhatsApp sender");
+      return {
+        providerBody: {
+          chatJid,
+          senderJid,
+          ...(params.input.senderName ? { pushName: params.input.senderName } : {}),
+          text: params.input.text,
+        },
+        providerTargetKey: chatJid,
+        qaTarget: qaTargetForInbound(params.input),
+        stateConversation: {
+          id: chatJid,
+          kind: chatJid.endsWith("@g.us") ? "group" : "direct",
+        },
+      };
+    }
+  }
 }
 
 export function createOpenClawCrablineOutboundFromRecorderEvent(params: {
@@ -320,34 +422,62 @@ export function createOpenClawCrablineOutboundFromRecorderEvent(params: {
   manifest: CrablineFakeProviderManifest;
   targetByProviderTarget: ReadonlyMap<string, string>;
 }): OpenClawCrablineOutboundMessage | null {
-  requireTelegramManifest(params.manifest);
-  const event = params.event as TelegramRecorderEvent;
+  const event = params.event as RecorderEvent;
   if (
     event.type !== "api" ||
     typeof event.path !== "string" ||
-    !event.path.endsWith("/sendMessage") ||
     !event.body ||
     typeof event.body !== "object"
   ) {
     return null;
   }
-  const chatId = readString(event.body.chat_id);
-  const text =
-    typeof event.body.text === "string" && event.body.text.trim() ? event.body.text : undefined;
-  if (!chatId || !text) {
-    return null;
+  switch (params.manifest.provider) {
+    case "telegram": {
+      requireManifestProvider(params.manifest, "telegram");
+      if (!event.path.endsWith("/sendMessage")) {
+        return null;
+      }
+      const chatId = readString(event.body.chat_id);
+      const text =
+        typeof event.body.text === "string" && event.body.text.trim() ? event.body.text : undefined;
+      if (!chatId || !text) {
+        return null;
+      }
+      const threadId = readInteger(event.body.message_thread_id);
+      const providerTargetKey = telegramTargetKey(chatId, threadId);
+      return {
+        accountId: DEFAULT_ACCOUNT_ID,
+        senderId: "openclaw",
+        senderName: "OpenClaw QA",
+        text,
+        to:
+          params.targetByProviderTarget.get(providerTargetKey) ??
+          (threadId === undefined ? chatId : providerTargetKey),
+      };
+    }
+    case "whatsapp": {
+      requireManifestProvider(params.manifest, "whatsapp");
+      if (!event.path.endsWith("/crabline/whatsapp/messages")) {
+        return null;
+      }
+      const to = readString(event.body.to ?? event.body.jid);
+      const textPayload = event.body.text;
+      const text =
+        textPayload && typeof textPayload === "object"
+          ? readString((textPayload as Record<string, unknown>).body)
+          : readString(textPayload);
+      if (!to || !text) {
+        return null;
+      }
+      return {
+        accountId: DEFAULT_ACCOUNT_ID,
+        senderId: "openclaw",
+        senderName: "OpenClaw QA",
+        text,
+        to: params.targetByProviderTarget.get(to) ?? to,
+      };
+    }
   }
-  const threadId = readInteger(event.body.message_thread_id);
-  const providerTargetKey = telegramTargetKey(chatId, threadId);
-  return {
-    accountId: TELEGRAM_ACCOUNT_ID,
-    senderId: "openclaw",
-    senderName: "OpenClaw QA",
-    text,
-    to:
-      params.targetByProviderTarget.get(providerTargetKey) ??
-      (threadId === undefined ? chatId : providerTargetKey),
-  };
 }
 
 export async function startOpenClawCrablineAdapter(

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -33,6 +33,26 @@ const manifest: CrablineFakeProviderManifest = {
   version: 1,
 };
 
+const whatsappManifest: CrablineFakeProviderManifest = {
+  accessToken: "crabline-whatsapp-access-token",
+  baseUrl: "http://127.0.0.1:5678",
+  endpoints: {
+    adminInboundUrl: "http://127.0.0.1:5678/crabline/whatsapp/inbound",
+    apiRoot: "http://127.0.0.1:5678/crabline/whatsapp",
+    messagesUrl: "http://127.0.0.1:5678/crabline/whatsapp/messages",
+    presenceUrl: "http://127.0.0.1:5678/crabline/whatsapp/presence",
+  },
+  env: {
+    CRABLINE_WHATSAPP_ACCESS_TOKEN: "crabline-whatsapp-access-token",
+    CRABLINE_WHATSAPP_API_ROOT: "http://127.0.0.1:5678/crabline/whatsapp",
+    CRABLINE_WHATSAPP_SELF_JID: "15550000000@s.whatsapp.net",
+  },
+  provider: "whatsapp",
+  recorderPath: "/tmp/crabline/whatsapp.jsonl",
+  selfJid: "15550000000@s.whatsapp.net",
+  version: 1,
+};
+
 describe("OpenClaw fake provider bridge", () => {
   it("resolves channel-driver metadata through Crabline", () => {
     expect(resolveOpenClawCrablineChannelDriverSelection({})).toEqual({
@@ -44,8 +64,11 @@ describe("OpenClaw fake provider bridge", () => {
     expect(resolveOpenClawCrablineChannelDriverSelection({ channel: " TELEGRAM " })).toMatchObject({
       channel: "telegram",
     });
-    expect(() => resolveOpenClawCrablineChannelDriverSelection({ channel: "slack" })).toThrow(
-      '--channel must be one of telegram for --channel-driver crabline, got "slack"',
+    expect(resolveOpenClawCrablineChannelDriverSelection({ channel: " WHATSAPP " })).toMatchObject({
+      channel: "whatsapp",
+    });
+    expect(() => resolveOpenClawCrablineChannelDriverSelection({ channel: "discord" })).toThrow(
+      '--channel must be one of telegram, whatsapp for --channel-driver crabline, got "discord"',
     );
   });
 
@@ -102,6 +125,48 @@ describe("OpenClaw fake provider bridge", () => {
     });
     expect(binding.createChannelDriverSmokeEnv({})).toMatchObject({
       TELEGRAM_BOT_TOKEN: "424242:crabline-telegram-token",
+    });
+  });
+
+  it("maps a WhatsApp fake provider into OpenClaw channel config", () => {
+    const binding = createOpenClawCrablineFakeProviderBinding(whatsappManifest);
+
+    expect(binding).toMatchObject({
+      accountId: "default",
+      channel: "whatsapp",
+      requiredPluginIds: ["whatsapp"],
+    });
+    expect(
+      binding.createGatewayConfig({
+        channels: {
+          slack: {
+            enabled: true,
+            webhookUrl: "https://example.test/slack",
+          },
+          whatsapp: {
+            enabled: false,
+          },
+        },
+      }),
+    ).toMatchObject({
+      channels: {
+        slack: {
+          enabled: true,
+          webhookUrl: "https://example.test/slack",
+        },
+        whatsapp: {
+          enabled: true,
+          dmPolicy: "open",
+          groupPolicy: "open",
+          allowFrom: ["*"],
+          groupAllowFrom: ["*"],
+        },
+      },
+    });
+    expect(binding.createChannelDriverSmokeEnv({})).toMatchObject({
+      CRABLINE_WHATSAPP_ACCESS_TOKEN: "crabline-whatsapp-access-token",
+      CRABLINE_WHATSAPP_API_ROOT: "http://127.0.0.1:5678/crabline/whatsapp",
+      CRABLINE_WHATSAPP_SELF_JID: "15550000000@s.whatsapp.net",
     });
   });
 
@@ -190,6 +255,65 @@ describe("OpenClaw fake provider bridge", () => {
     });
   });
 
+  it("maps WhatsApp QA targets, inbound messages, and recorder events", () => {
+    expect(
+      createOpenClawCrablineAgentDelivery({
+        manifest: whatsappManifest,
+        target: "dm:15551234567@s.whatsapp.net",
+      }),
+    ).toEqual({
+      channel: "whatsapp",
+      to: "15551234567@s.whatsapp.net",
+      replyChannel: "whatsapp",
+      replyTo: "15551234567@s.whatsapp.net",
+    });
+
+    const inbound = createOpenClawCrablineInbound({
+      manifest: whatsappManifest,
+      input: {
+        conversation: { id: "120363001234567890@g.us", kind: "group" },
+        senderId: "15551234567@s.whatsapp.net",
+        senderName: "Alice",
+        text: "hello",
+      },
+    });
+    expect(inbound).toEqual({
+      providerBody: {
+        chatJid: "120363001234567890@g.us",
+        senderJid: "15551234567@s.whatsapp.net",
+        pushName: "Alice",
+        text: "hello",
+      },
+      providerTargetKey: "120363001234567890@g.us",
+      qaTarget: "group:120363001234567890@g.us",
+      stateConversation: {
+        id: "120363001234567890@g.us",
+        kind: "group",
+      },
+    });
+
+    expect(
+      createOpenClawCrablineOutboundFromRecorderEvent({
+        manifest: whatsappManifest,
+        targetByProviderTarget: new Map([["15551234567@s.whatsapp.net", "dm:alice"]]),
+        event: {
+          type: "api",
+          path: "/crabline/whatsapp/messages",
+          body: {
+            to: "15551234567@s.whatsapp.net",
+            text: { body: "hello from openclaw" },
+          },
+        },
+      }),
+    ).toEqual({
+      accountId: "default",
+      senderId: "openclaw",
+      senderName: "OpenClaw QA",
+      text: "hello from openclaw",
+      to: "dm:alice",
+    });
+  });
+
   it("runs OpenClaw channel-driver smoke and writes fake-provider artifacts", async () => {
     const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-openclaw-smoke-"));
     try {
@@ -203,7 +327,7 @@ describe("OpenClaw fake provider bridge", () => {
         result: {
           driver: "crabline",
           selectedChannel: "telegram",
-          supportedChannels: ["telegram"],
+          supportedChannels: ["telegram", "whatsapp"],
         },
       });
       expect(result.smoke).toMatchObject({

--- a/test/whatsapp-fake-server.test.ts
+++ b/test/whatsapp-fake-server.test.ts
@@ -1,0 +1,207 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createWhatsAppBaileysMockSocket,
+  startWhatsAppFakeServer,
+  type StartedWhatsAppFakeServer,
+} from "../src/index.js";
+import { createTempDir, disposeTempDir } from "./test-helpers.js";
+
+const servers: StartedWhatsAppFakeServer[] = [];
+const directories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => server.close()));
+  await Promise.all(directories.splice(0).map(disposeTempDir));
+});
+
+describe("whatsapp fake provider server", () => {
+  it("serves WhatsApp Web listener-style sends and injected inbound messages", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const server = await startWhatsAppFakeServer({
+      accessToken: "fake-whatsapp-token",
+      recorderPath: path.join(directory, "whatsapp.jsonl"),
+    });
+    servers.push(server);
+
+    const health = await fetch(`${server.manifest.endpoints.apiRoot}/health`);
+    await expect(health.json()).resolves.toMatchObject({
+      ok: true,
+      selfJid: "15550000000@s.whatsapp.net",
+    });
+
+    const unauthenticated = await fetch(server.manifest.endpoints.messagesUrl, {
+      body: JSON.stringify({
+        text: "hello fake whatsapp",
+        to: "15551234567@s.whatsapp.net",
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    expect(unauthenticated.status).toBe(401);
+    await expect(unauthenticated.json()).resolves.toMatchObject({
+      error: {
+        code: 190,
+        message: "Invalid OAuth access token.",
+        type: "OAuthException",
+      },
+      ok: false,
+    });
+
+    const sent = await fetch(server.manifest.endpoints.messagesUrl, {
+      body: JSON.stringify({
+        messaging_product: "whatsapp",
+        text: { body: "hello fake whatsapp" },
+        to: "15551234567@s.whatsapp.net",
+        type: "text",
+      }),
+      headers: {
+        authorization: "Bearer fake-whatsapp-token",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+    await expect(sent.json()).resolves.toMatchObject({
+      contacts: [{ input: "15551234567@s.whatsapp.net", wa_id: "15551234567" }],
+      key: {
+        fromMe: true,
+        remoteJid: "15551234567@s.whatsapp.net",
+      },
+      message: {
+        message: {
+          conversation: "hello fake whatsapp",
+        },
+      },
+      messages: [{ id: expect.stringMatching(/^wamid\.FAKE/u) }],
+      messaging_product: "whatsapp",
+      ok: true,
+      toJid: "15551234567@s.whatsapp.net",
+    });
+
+    const invalidProduct = await fetch(server.manifest.endpoints.messagesUrl, {
+      body: JSON.stringify({
+        messaging_product: "messenger",
+        text: { body: "hello fake whatsapp" },
+        to: "15551234567@s.whatsapp.net",
+        type: "text",
+      }),
+      headers: {
+        authorization: "Bearer fake-whatsapp-token",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+    expect(invalidProduct.status).toBe(400);
+    await expect(invalidProduct.json()).resolves.toMatchObject({
+      error: {
+        code: 100,
+        error_data: {
+          messaging_product: "whatsapp",
+        },
+        type: "OAuthException",
+      },
+      ok: false,
+    });
+
+    const presence = await fetch(server.manifest.endpoints.presenceUrl, {
+      body: JSON.stringify({
+        presence: "paused",
+      }),
+      headers: {
+        authorization: "Bearer fake-whatsapp-token",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+    await expect(presence.json()).resolves.toMatchObject({
+      ok: true,
+      presence: "paused",
+    });
+
+    const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({
+        chatJid: "120363001234567890@g.us",
+        senderJid: "15551234567@s.whatsapp.net",
+        text: "user nonce-1",
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    await expect(inbound.json()).resolves.toMatchObject({
+      message: {
+        key: {
+          fromMe: false,
+          participant: "15551234567@s.whatsapp.net",
+          remoteJid: "120363001234567890@g.us",
+        },
+        message: {
+          conversation: "user nonce-1",
+        },
+      },
+      ok: true,
+      webhook: {
+        entry: [
+          {
+            changes: [
+              {
+                field: "messages",
+                value: {
+                  contacts: [{ wa_id: "15551234567" }],
+                  messages: [
+                    {
+                      from: "15551234567",
+                      text: { body: "user nonce-1" },
+                      type: "text",
+                    },
+                  ],
+                  messaging_product: "whatsapp",
+                },
+              },
+            ],
+          },
+        ],
+        object: "whatsapp_business_account",
+      },
+    });
+  });
+
+  it("exposes a Baileys-shaped mock socket over the fake provider server", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const server = await startWhatsAppFakeServer({
+      accessToken: "fake-whatsapp-token",
+      recorderPath: path.join(directory, "whatsapp.jsonl"),
+    });
+    servers.push(server);
+    const socket = createWhatsAppBaileysMockSocket({
+      accessToken: server.manifest.accessToken,
+      apiRoot: server.manifest.endpoints.apiRoot,
+      selfJid: server.manifest.selfJid,
+    });
+    const emitted: unknown[] = [];
+    socket.ev.on("messages.upsert", (payload) => {
+      emitted.push(payload);
+    });
+
+    const message = await socket.sendMessage("15551234567@s.whatsapp.net", {
+      text: "hello through baileys shape",
+    });
+    await socket.sendPresenceUpdate("composing", "15551234567@s.whatsapp.net");
+
+    expect(message).toMatchObject({
+      key: {
+        fromMe: true,
+        remoteJid: "15551234567@s.whatsapp.net",
+      },
+      message: {
+        conversation: "hello through baileys shape",
+      },
+    });
+    expect(emitted).toHaveLength(1);
+    const recorder = await fs.readFile(server.manifest.recorderPath, "utf8");
+    expect(recorder).toContain('"path":"/crabline/whatsapp/messages"');
+    expect(recorder).toContain('"path":"/crabline/whatsapp/presence"');
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

OpenClaw QA needs WhatsApp fake-provider coverage without carrying a separate WhatsApp HTTP transport inside OpenClaw. The provider simulation should live in Crabline so OpenClaw can wire the normal WhatsApp channel through a Crabline-owned mock surface.

## Why This Change Was Made

- Adds a WhatsApp fake provider server with provider-shaped send, presence, health, and admin inbound endpoints.
- Exposes `createWhatsAppBaileysMockSocket()` for Baileys-style `sendMessage()` / `sendPresenceUpdate()` usage.
- Exposes `createOpenClawWhatsAppBaileysConnectionController()` so OpenClaw can register a Crabline-owned WhatsApp controller instead of implementing its own fake transport.
- Extends the OpenClaw bridge helpers, CLI `serve`, docs, README, and tests for WhatsApp fake-provider support.

## User Impact

Smoke QA can target WhatsApp through Crabline with `CRABLINE_WHATSAPP_ACCESS_TOKEN`, `CRABLINE_WHATSAPP_API_ROOT`, and `CRABLINE_WHATSAPP_SELF_JID`, without live WhatsApp credentials or OpenClaw-local fake transport code.

## Evidence

- `pnpm lint`
- `pnpm test`
