### PR TITLE
Fix WhatsApp fake inbound delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,13 @@ a Baileys-style WhatsApp `sendMessage()` / `sendPresenceUpdate()` surface while
 the fake server owns local provider simulation. The admin token is generated
 randomly unless `--admin-token <token>` is provided.
 
+OpenClaw bridge callers should post injected user messages with the
+`providerUrl`, `providerHeaders`, and `providerBody` returned by
+`createOpenClawCrablineInbound()`. For WhatsApp, inbound `messages.upsert`
+delivery is an in-process Baileys mock socket behavior: create the fake server
+and `createWhatsAppBaileysMockSocket()` in the same Node process when testing
+listener-driven inbound delivery.
+
 ## Target IDs
 
 Built-in providers accept native channel identifiers. Crabline does not add

--- a/README.md
+++ b/README.md
@@ -172,17 +172,19 @@ The JSON manifest contains:
   `sendPresenceUpdate`
 - `recorderPath`: JSONL file of fake provider API/admin traffic
 
-Crabline also exports `createWhatsAppBaileysMockSocket()` so tests can exercise
-a Baileys-style WhatsApp `sendMessage()` / `sendPresenceUpdate()` surface while
-the fake server owns local provider simulation. The admin token is generated
-randomly unless `--admin-token <token>` is provided.
+The started WhatsApp fake server also exposes `createBaileysMockSocket()` so
+tests can exercise a Baileys-style WhatsApp `sendMessage()` /
+`sendPresenceUpdate()` surface while the fake server owns local provider
+simulation. The admin token is generated randomly unless `--admin-token <token>`
+is provided.
 
 OpenClaw bridge callers should post injected user messages with the
 `providerUrl`, `providerHeaders`, and `providerBody` returned by
 `createOpenClawCrablineInbound()`. For WhatsApp, inbound `messages.upsert`
 delivery is an in-process Baileys mock socket behavior: create the fake server
-and `createWhatsAppBaileysMockSocket()` in the same Node process when testing
-listener-driven inbound delivery.
+and Baileys mock socket in the same Node process when testing listener-driven
+inbound delivery. If the socket is created outside the started server, pass the
+same `WhatsAppBaileysMockRegistry` to the server and socket helper.
 
 ## Target IDs
 

--- a/README.md
+++ b/README.md
@@ -161,8 +161,11 @@ The JSON manifest contains:
 
 - `endpoints.apiRoot`: Crabline WhatsApp fake provider API root
 - `accessToken`: bearer token for fake provider requests
+- `adminToken`: send this as the `X-Crabline-Admin-Token` header when posting
+  test user messages
 - `selfJid`: fake authenticated WhatsApp user JID
-- `endpoints.adminInboundUrl`: POST endpoint for test user messages
+- `endpoints.adminInboundUrl`: authenticated POST endpoint for test user
+  messages; subscribed Baileys mock sockets receive them as `messages.upsert`
 - `endpoints.messagesUrl`: fake text send endpoint used by the Baileys-shaped
   mock
 - `endpoints.presenceUrl`: fake presence endpoint used by
@@ -171,7 +174,8 @@ The JSON manifest contains:
 
 Crabline also exports `createWhatsAppBaileysMockSocket()` so tests can exercise
 a Baileys-style WhatsApp `sendMessage()` / `sendPresenceUpdate()` surface while
-the fake server owns local provider simulation.
+the fake server owns local provider simulation. The admin token is generated
+randomly unless `--admin-token <token>` is provided.
 
 ## Target IDs
 

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -125,17 +125,18 @@ Manifest fields:
 - `endpoints.presenceUrl`: presence endpoint used by `sendPresenceUpdate`
 - `recorderPath`: JSONL provider traffic recorder
 
-Use `createWhatsAppBaileysMockSocket()` when a test needs a Baileys-style
-`sendMessage()` / `sendPresenceUpdate()` surface backed by the same fake
-provider server. The admin token is generated randomly unless
+Use the started server's `createBaileysMockSocket()` when a test needs a
+Baileys-style `sendMessage()` / `sendPresenceUpdate()` surface backed by the
+same fake provider server. The admin token is generated randomly unless
 `--admin-token <token>` is provided.
 
 OpenClaw bridge callers should post injected user messages with the
 `providerUrl`, `providerHeaders`, and `providerBody` returned by
 `createOpenClawCrablineInbound()`. For WhatsApp, inbound `messages.upsert`
 delivery is an in-process Baileys mock socket behavior: create the fake server
-and `createWhatsAppBaileysMockSocket()` in the same Node process when testing
-listener-driven inbound delivery.
+and Baileys mock socket in the same Node process when testing listener-driven
+inbound delivery. If the socket is created outside the started server, pass the
+same `WhatsAppBaileysMockRegistry` to the server and socket helper.
 
 The admin ingress accepts JSON like:
 

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -117,15 +117,18 @@ Manifest fields:
 
 - `endpoints.apiRoot`: Crabline WhatsApp fake provider API root
 - `accessToken`: bearer token for fake provider requests
+- `adminToken`: value for the `X-Crabline-Admin-Token` header on admin ingress
 - `selfJid`: fake authenticated WhatsApp user JID
-- `endpoints.adminInboundUrl`: admin ingress for test user messages
+- `endpoints.adminInboundUrl`: authenticated admin ingress for test user
+  messages; subscribed Baileys mock sockets receive them as `messages.upsert`
 - `endpoints.messagesUrl`: text send endpoint used by the Baileys-shaped mock
 - `endpoints.presenceUrl`: presence endpoint used by `sendPresenceUpdate`
 - `recorderPath`: JSONL provider traffic recorder
 
 Use `createWhatsAppBaileysMockSocket()` when a test needs a Baileys-style
 `sendMessage()` / `sendPresenceUpdate()` surface backed by the same fake
-provider server.
+provider server. The admin token is generated randomly unless
+`--admin-token <token>` is provided.
 
 The admin ingress accepts JSON like:
 

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -130,6 +130,13 @@ Use `createWhatsAppBaileysMockSocket()` when a test needs a Baileys-style
 provider server. The admin token is generated randomly unless
 `--admin-token <token>` is provided.
 
+OpenClaw bridge callers should post injected user messages with the
+`providerUrl`, `providerHeaders`, and `providerBody` returned by
+`createOpenClawCrablineInbound()`. For WhatsApp, inbound `messages.upsert`
+delivery is an in-process Baileys mock socket behavior: create the fake server
+and `createWhatsAppBaileysMockSocket()` in the same Node process when testing
+listener-driven inbound delivery.
+
 The admin ingress accepts JSON like:
 
 ```json

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -45,8 +45,6 @@ type ServeParamFactory = (
   commandOptions: ServeCommandOptions,
 ) => StartCrablineFakeProviderServerParams;
 
-type ServeTextRenderer = (manifest: CrablineFakeProviderManifest, lines: string[]) => void;
-
 const SERVE_PARAM_FACTORIES = {
   telegram: (shared, commandOptions) => ({
     ...shared,
@@ -63,25 +61,6 @@ const SERVE_PARAM_FACTORIES = {
     selfJid: commandOptions.selfJid,
   }),
 } satisfies Record<CrablineFakeProviderChannel, ServeParamFactory>;
-
-const SERVE_TEXT_RENDERERS = {
-  telegram: (manifest, lines) => {
-    const telegram = manifest as Extract<CrablineFakeProviderManifest, { provider: "telegram" }>;
-    lines.splice(2, 0, `  adminToken: ${telegram.adminToken}`, `  botToken: ${telegram.botToken}`);
-  },
-  whatsapp: (manifest, lines) => {
-    const whatsapp = manifest as Extract<CrablineFakeProviderManifest, { provider: "whatsapp" }>;
-    lines.splice(
-      2,
-      0,
-      `  adminToken: ${whatsapp.adminToken}`,
-      `  accessToken: ${whatsapp.accessToken}`,
-      `  messages: ${whatsapp.endpoints.messagesUrl}`,
-      `  presence: ${whatsapp.endpoints.presenceUrl}`,
-      `  selfJid: ${whatsapp.selfJid}`,
-    );
-  },
-} satisfies Record<CrablineFakeProviderChannel, ServeTextRenderer>;
 
 function print(value: string): void {
   process.stdout.write(`${value}\n`);
@@ -334,14 +313,30 @@ function renderServeText(manifest: CrablineFakeProviderManifest) {
     `  inbound: ${manifest.endpoints.adminInboundUrl}`,
     `  recorder: ${manifest.recorderPath}`,
   ];
-  const renderProviderFields = SERVE_TEXT_RENDERERS[manifest.provider];
-  if (!renderProviderFields) {
+  const providerFields = renderServeProviderFields(manifest);
+  if (!providerFields) {
     throw new CrablineError(`Unsupported fake provider server: ${String(manifest.provider)}`, {
       kind: "config",
     });
   }
-  renderProviderFields(manifest, lines);
+  lines.splice(2, 0, ...providerFields);
   return lines.join("\n");
+}
+
+function renderServeProviderFields(manifest: CrablineFakeProviderManifest): string[] | undefined {
+  if (manifest.provider === "telegram") {
+    return [`  adminToken: ${manifest.adminToken}`, `  botToken: ${manifest.botToken}`];
+  }
+  if (manifest.provider === "whatsapp") {
+    return [
+      `  adminToken: ${manifest.adminToken}`,
+      `  accessToken: ${manifest.accessToken}`,
+      `  messages: ${manifest.endpoints.messagesUrl}`,
+      `  presence: ${manifest.endpoints.presenceUrl}`,
+      `  selfJid: ${manifest.selfJid}`,
+    ];
+  }
+  return undefined;
 }
 
 function renderProvidersText(payload: {

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -9,7 +9,9 @@ import { CrablineError, ensureErrorMessage } from "../core/errors.js";
 import {
   isCrablineFakeProviderChannel,
   startCrablineFakeProviderServer,
+  type CrablineFakeProviderChannel,
   type CrablineFakeProviderManifest,
+  type StartCrablineFakeProviderServerParams,
 } from "../fake-servers/index.js";
 
 type GlobalOptions = {
@@ -18,6 +20,68 @@ type GlobalOptions = {
 };
 
 type SetExitCode = (code: number) => void;
+
+type ServeSharedOptions = {
+  host: string;
+  port: number;
+  recorderPath?: string | undefined;
+};
+
+type ServeCommandOptions = {
+  accessToken?: string | undefined;
+  adminToken?: string | undefined;
+  botToken?: string | undefined;
+  botUsername?: string | undefined;
+  host: string;
+  once?: boolean | undefined;
+  port: string;
+  readyFile?: string | undefined;
+  recorder?: string | undefined;
+  selfJid?: string | undefined;
+};
+
+type ServeParamFactory = (
+  shared: ServeSharedOptions,
+  commandOptions: ServeCommandOptions,
+) => StartCrablineFakeProviderServerParams;
+
+type ServeTextRenderer = (manifest: CrablineFakeProviderManifest, lines: string[]) => void;
+
+const SERVE_PARAM_FACTORIES = {
+  telegram: (shared, commandOptions) => ({
+    ...shared,
+    adminToken: commandOptions.adminToken,
+    botToken: commandOptions.botToken,
+    botUsername: commandOptions.botUsername,
+    channel: "telegram",
+  }),
+  whatsapp: (shared, commandOptions) => ({
+    ...shared,
+    accessToken: commandOptions.accessToken,
+    adminToken: commandOptions.adminToken,
+    channel: "whatsapp",
+    selfJid: commandOptions.selfJid,
+  }),
+} satisfies Record<CrablineFakeProviderChannel, ServeParamFactory>;
+
+const SERVE_TEXT_RENDERERS = {
+  telegram: (manifest, lines) => {
+    const telegram = manifest as Extract<CrablineFakeProviderManifest, { provider: "telegram" }>;
+    lines.splice(2, 0, `  adminToken: ${telegram.adminToken}`, `  botToken: ${telegram.botToken}`);
+  },
+  whatsapp: (manifest, lines) => {
+    const whatsapp = manifest as Extract<CrablineFakeProviderManifest, { provider: "whatsapp" }>;
+    lines.splice(
+      2,
+      0,
+      `  adminToken: ${whatsapp.adminToken}`,
+      `  accessToken: ${whatsapp.accessToken}`,
+      `  messages: ${whatsapp.endpoints.messagesUrl}`,
+      `  presence: ${whatsapp.endpoints.presenceUrl}`,
+      `  selfJid: ${whatsapp.selfJid}`,
+    );
+  },
+} satisfies Record<CrablineFakeProviderChannel, ServeTextRenderer>;
 
 function print(value: string): void {
   process.stdout.write(`${value}\n`);
@@ -195,7 +259,7 @@ export function createProgram(
     .option("--ready-file <path>", "Write the server runtime manifest to this path")
     .option("--self-jid <jid>", "Fake WhatsApp self JID")
     .option("--once", "Start, print the runtime manifest, and stop immediately", false)
-    .action(async (provider, commandOptions) => {
+    .action(async (provider, commandOptions: ServeCommandOptions) => {
       const options = program.opts() as GlobalOptions;
       if (!isCrablineFakeProviderChannel(provider)) {
         throw new CrablineError(`Unsupported fake provider server: ${provider}`, {
@@ -208,25 +272,22 @@ export function createProgram(
           kind: "config",
         });
       }
-      const server =
-        provider === "telegram"
-          ? await startCrablineFakeProviderServer({
-              adminToken: commandOptions.adminToken,
-              botToken: commandOptions.botToken,
-              botUsername: commandOptions.botUsername,
-              channel: "telegram",
-              host: commandOptions.host,
-              port,
-              recorderPath: commandOptions.recorder,
-            })
-          : await startCrablineFakeProviderServer({
-              accessToken: commandOptions.accessToken,
-              channel: "whatsapp",
-              host: commandOptions.host,
-              port,
-              recorderPath: commandOptions.recorder,
-              selfJid: commandOptions.selfJid,
-            });
+      const factory = SERVE_PARAM_FACTORIES[provider];
+      if (!factory) {
+        throw new CrablineError(`Unsupported fake provider server: ${provider}`, {
+          kind: "config",
+        });
+      }
+      const server = await startCrablineFakeProviderServer(
+        factory(
+          {
+            host: commandOptions.host,
+            port,
+            recorderPath: commandOptions.recorder,
+          },
+          commandOptions,
+        ),
+      );
       const payload = formatJson(server.manifest);
       if (commandOptions.readyFile) {
         await fs.mkdir(nodePath.dirname(commandOptions.readyFile), { recursive: true });
@@ -273,18 +334,13 @@ function renderServeText(manifest: CrablineFakeProviderManifest) {
     `  inbound: ${manifest.endpoints.adminInboundUrl}`,
     `  recorder: ${manifest.recorderPath}`,
   ];
-  if (manifest.provider === "telegram") {
-    lines.splice(2, 0, `  adminToken: ${manifest.adminToken}`, `  botToken: ${manifest.botToken}`);
-  } else {
-    lines.splice(
-      2,
-      0,
-      `  accessToken: ${manifest.accessToken}`,
-      `  messages: ${manifest.endpoints.messagesUrl}`,
-      `  presence: ${manifest.endpoints.presenceUrl}`,
-      `  selfJid: ${manifest.selfJid}`,
-    );
+  const renderProviderFields = SERVE_TEXT_RENDERERS[manifest.provider];
+  if (!renderProviderFields) {
+    throw new CrablineError(`Unsupported fake provider server: ${String(manifest.provider)}`, {
+      kind: "config",
+    });
   }
+  renderProviderFields(manifest, lines);
   return lines.join("\n");
 }
 

--- a/src/fake-servers/http.ts
+++ b/src/fake-servers/http.ts
@@ -1,4 +1,5 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { timingSafeEqual } from "node:crypto";
 import { CrablineError } from "../core/errors.js";
 
 export type FakeServerRequestEvent = {
@@ -9,6 +10,8 @@ export type FakeServerRequestEvent = {
   query: Record<string, string>;
   type: "admin" | "api";
 };
+
+export const ADMIN_TOKEN_HEADER = "x-crabline-admin-token";
 
 export function jsonResponse(value: unknown, status = 200): Response {
   return Response.json(value, { status });
@@ -129,4 +132,35 @@ export function readInteger(value: unknown): number | undefined {
     return undefined;
   }
   return Number(stringValue);
+}
+
+function readBearerToken(authorization: string | undefined): string | undefined {
+  if (!authorization) {
+    return undefined;
+  }
+  const trimmed = authorization.trimStart();
+  if (trimmed.slice(0, 7).toLowerCase() !== "bearer ") {
+    return undefined;
+  }
+  return trimmed.slice(7);
+}
+
+export function hasAdminToken(request: IncomingMessage, expectedToken: string): boolean {
+  const header = request.headers[ADMIN_TOKEN_HEADER];
+  const directToken = Array.isArray(header) ? header[0] : header;
+  const providedToken = directToken ?? readBearerToken(request.headers.authorization);
+  if (!providedToken) {
+    return false;
+  }
+
+  const provided = Buffer.from(providedToken);
+  const expected = Buffer.from(expectedToken);
+  return provided.length === expected.length && timingSafeEqual(provided, expected);
+}
+
+export function adminAuthError(): Response {
+  return new Response("unauthorized", {
+    headers: { "www-authenticate": "Bearer" },
+    status: 401,
+  });
 }

--- a/src/fake-servers/index.ts
+++ b/src/fake-servers/index.ts
@@ -10,6 +10,7 @@ import {
   type StartWhatsAppFakeServerParams,
   type WhatsAppFakeServerManifest,
 } from "./whatsapp.js";
+import { CrablineError } from "../core/errors.js";
 
 export const CRABLINE_FAKE_PROVIDER_CHANNELS = Object.freeze(["telegram", "whatsapp"] as const);
 
@@ -25,17 +26,41 @@ export type StartCrablineFakeProviderServerParams =
   | (StartTelegramFakeServerParams & { channel: "telegram" })
   | (StartWhatsAppFakeServerParams & { channel: "whatsapp" });
 
+type FakeProviderServerDefinition = {
+  start(params: StartCrablineFakeProviderServerParams): Promise<StartedCrablineFakeProviderServer>;
+};
+
+const FAKE_PROVIDER_SERVER_DEFINITIONS = {
+  telegram: {
+    start: async (params) =>
+      await startTelegramFakeServer(
+        params as StartTelegramFakeServerParams & {
+          channel: "telegram";
+        },
+      ),
+  },
+  whatsapp: {
+    start: async (params) =>
+      await startWhatsAppFakeServer(
+        params as StartWhatsAppFakeServerParams & {
+          channel: "whatsapp";
+        },
+      ),
+  },
+} satisfies Record<CrablineFakeProviderChannel, FakeProviderServerDefinition>;
+
 export function isCrablineFakeProviderChannel(value: string): value is CrablineFakeProviderChannel {
-  return CRABLINE_FAKE_PROVIDER_CHANNELS.includes(value as CrablineFakeProviderChannel);
+  return Object.hasOwn(FAKE_PROVIDER_SERVER_DEFINITIONS, value);
 }
 
 export async function startCrablineFakeProviderServer(
   params: StartCrablineFakeProviderServerParams,
 ): Promise<StartedCrablineFakeProviderServer> {
-  switch (params.channel) {
-    case "telegram":
-      return await startTelegramFakeServer(params);
-    case "whatsapp":
-      return await startWhatsAppFakeServer(params);
+  const definition = FAKE_PROVIDER_SERVER_DEFINITIONS[params.channel];
+  if (!definition) {
+    throw new CrablineError(`Unsupported fake provider server: ${String(params.channel)}`, {
+      kind: "config",
+    });
   }
+  return await definition.start(params);
 }

--- a/src/fake-servers/index.ts
+++ b/src/fake-servers/index.ts
@@ -26,41 +26,29 @@ export type StartCrablineFakeProviderServerParams =
   | (StartTelegramFakeServerParams & { channel: "telegram" })
   | (StartWhatsAppFakeServerParams & { channel: "whatsapp" });
 
-type FakeProviderServerDefinition = {
-  start(params: StartCrablineFakeProviderServerParams): Promise<StartedCrablineFakeProviderServer>;
-};
-
-const FAKE_PROVIDER_SERVER_DEFINITIONS = {
-  telegram: {
-    start: async (params) =>
-      await startTelegramFakeServer(
-        params as StartTelegramFakeServerParams & {
-          channel: "telegram";
-        },
-      ),
-  },
-  whatsapp: {
-    start: async (params) =>
-      await startWhatsAppFakeServer(
-        params as StartWhatsAppFakeServerParams & {
-          channel: "whatsapp";
-        },
-      ),
-  },
-} satisfies Record<CrablineFakeProviderChannel, FakeProviderServerDefinition>;
+const CRABLINE_FAKE_PROVIDER_CHANNEL_SET = new Set<string>(CRABLINE_FAKE_PROVIDER_CHANNELS);
 
 export function isCrablineFakeProviderChannel(value: string): value is CrablineFakeProviderChannel {
-  return Object.hasOwn(FAKE_PROVIDER_SERVER_DEFINITIONS, value);
+  return CRABLINE_FAKE_PROVIDER_CHANNEL_SET.has(value);
 }
 
+export function startCrablineFakeProviderServer(
+  params: StartTelegramFakeServerParams & { channel: "telegram" },
+): Promise<StartedTelegramFakeServer>;
+export function startCrablineFakeProviderServer(
+  params: StartWhatsAppFakeServerParams & { channel: "whatsapp" },
+): Promise<StartedWhatsAppFakeServer>;
+export function startCrablineFakeProviderServer(
+  params: StartCrablineFakeProviderServerParams,
+): Promise<StartedCrablineFakeProviderServer>;
 export async function startCrablineFakeProviderServer(
   params: StartCrablineFakeProviderServerParams,
 ): Promise<StartedCrablineFakeProviderServer> {
-  const definition = FAKE_PROVIDER_SERVER_DEFINITIONS[params.channel];
-  if (!definition) {
-    throw new CrablineError(`Unsupported fake provider server: ${String(params.channel)}`, {
-      kind: "config",
-    });
+  if (params.channel === "telegram") {
+    return await startTelegramFakeServer(params);
   }
-  return await definition.start(params);
+  if (params.channel === "whatsapp") {
+    return await startWhatsAppFakeServer(params);
+  }
+  throw new CrablineError("Unsupported fake provider server.", { kind: "config" });
 }

--- a/src/fake-servers/telegram.ts
+++ b/src/fake-servers/telegram.ts
@@ -1,8 +1,9 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
-import { randomBytes, timingSafeEqual } from "node:crypto";
+import { randomBytes } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { CrablineError } from "../core/errors.js";
+import { adminAuthError, hasAdminToken } from "./http.js";
 
 type TelegramFakeServerEvent = {
   at: string;
@@ -281,24 +282,6 @@ function queryRecord(url: URL): Record<string, string> {
   return Object.fromEntries(url.searchParams.entries());
 }
 
-function hasAdminToken(request: IncomingMessage, expectedToken: string): boolean {
-  const header = request.headers["x-crabline-admin-token"];
-  const directToken = Array.isArray(header) ? header[0] : header;
-  const authorization = request.headers.authorization;
-  const bearerToken =
-    typeof authorization === "string" && /^Bearer\s+/iu.test(authorization)
-      ? authorization.replace(/^Bearer\s+/iu, "")
-      : undefined;
-  const providedToken = directToken ?? bearerToken;
-  if (!providedToken) {
-    return false;
-  }
-
-  const provided = Buffer.from(providedToken);
-  const expected = Buffer.from(expectedToken);
-  return provided.length === expected.length && timingSafeEqual(provided, expected);
-}
-
 async function handleTelegramApi(params: {
   body: Record<string, unknown>;
   method: string;
@@ -358,10 +341,7 @@ async function handleRequest(params: { request: IncomingMessage; state: Telegram
       return new Response("not found", { status: 404 });
     }
     if (!hasAdminToken(params.request, params.state.adminToken)) {
-      return new Response("unauthorized", {
-        headers: { "www-authenticate": "Bearer" },
-        status: 401,
-      });
+      return adminAuthError();
     }
     const body = await parseRequestBody(params.request);
     const update = createInboundUpdate(params.state, body);

--- a/src/fake-servers/whatsapp.ts
+++ b/src/fake-servers/whatsapp.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage } from "node:http";
+import { randomBytes, timingSafeEqual } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import {
@@ -17,6 +18,8 @@ const WHATSAPP_LID_RE = /^\d{7,15}@lid$/iu;
 
 type WhatsAppFakeServerState = {
   accessToken: string;
+  adminToken: string;
+  apiRoot?: string | undefined;
   displayPhoneNumber: string;
   nextMessageId: number;
   phoneNumberId: string;
@@ -55,6 +58,7 @@ export type WhatsAppBaileysMockConfig = {
 
 export type WhatsAppFakeServerManifest = {
   accessToken: string;
+  adminToken: string;
   baseUrl: string;
   endpoints: {
     adminInboundUrl: string;
@@ -63,6 +67,7 @@ export type WhatsAppFakeServerManifest = {
     presenceUrl: string;
   };
   env: {
+    CRABLINE_WHATSAPP_ADMIN_TOKEN: string;
     CRABLINE_WHATSAPP_ACCESS_TOKEN: string;
     CRABLINE_WHATSAPP_API_ROOT: string;
     CRABLINE_WHATSAPP_SELF_JID: string;
@@ -80,6 +85,7 @@ export type StartedWhatsAppFakeServer = {
 
 export type StartWhatsAppFakeServerParams = {
   accessToken?: string | undefined;
+  adminToken?: string | undefined;
   host?: string | undefined;
   port?: number | undefined;
   recorderPath?: string | undefined;
@@ -163,6 +169,31 @@ function requireAuth(request: IncomingMessage, state: WhatsAppFakeServerState): 
   );
 }
 
+function hasAdminToken(request: IncomingMessage, expectedToken: string): boolean {
+  const header = request.headers["x-crabline-admin-token"];
+  const directToken = Array.isArray(header) ? header[0] : header;
+  const authorization = request.headers.authorization;
+  const bearerToken =
+    typeof authorization === "string" && authorization.slice(0, 7).toLowerCase() === "bearer "
+      ? authorization.slice(7)
+      : undefined;
+  const providedToken = directToken ?? bearerToken;
+  if (!providedToken) {
+    return false;
+  }
+
+  const provided = Buffer.from(providedToken);
+  const expected = Buffer.from(expectedToken);
+  return provided.length === expected.length && timingSafeEqual(provided, expected);
+}
+
+function adminAuthError(): Response {
+  return new Response("unauthorized", {
+    headers: { "www-authenticate": "Bearer" },
+    status: 401,
+  });
+}
+
 function nextMessageId(state: WhatsAppFakeServerState): string {
   return `wamid.FAKE${String(state.nextMessageId++).padStart(8, "0")}`;
 }
@@ -189,6 +220,10 @@ function trimLeadingSlashes(value: string): string {
 
 function joinUrl(root: string, pathPart: string): string {
   return `${trimTrailingSlashes(root)}/${trimLeadingSlashes(pathPart)}`;
+}
+
+function normalizeApiRoot(value: string): string {
+  return trimTrailingSlashes(value);
 }
 
 async function postJson(params: {
@@ -255,6 +290,7 @@ function readTextMessageBody(body: Record<string, unknown>): string | Response {
 function createWhatsAppMessage(params: {
   fromMe: boolean;
   id: string;
+  pushName?: string | undefined;
   remoteJid: string;
   senderJid?: string | undefined;
   text: string;
@@ -270,7 +306,7 @@ function createWhatsAppMessage(params: {
       conversation: params.text,
     },
     messageTimestamp: Math.floor(Date.now() / 1000),
-    pushName: params.fromMe ? "Test Bot" : "Test User",
+    pushName: params.pushName ?? (params.fromMe ? "Test Bot" : "Test User"),
   };
 }
 
@@ -329,12 +365,43 @@ function createEventBus(): WhatsAppBaileysMockSocket["ev"] {
   };
 }
 
+const baileysSocketBusesByApiRoot = new Map<string, Set<WhatsAppBaileysMockSocket["ev"]>>();
+
+function registerBaileysSocket(apiRoot: string, ev: WhatsAppBaileysMockSocket["ev"]): void {
+  const key = normalizeApiRoot(apiRoot);
+  const buses = baileysSocketBusesByApiRoot.get(key) ?? new Set<WhatsAppBaileysMockSocket["ev"]>();
+  buses.add(ev);
+  baileysSocketBusesByApiRoot.set(key, buses);
+}
+
+function clearBaileysSockets(apiRoot: string): void {
+  baileysSocketBusesByApiRoot.delete(normalizeApiRoot(apiRoot));
+}
+
+function emitInboundToBaileysSockets(params: {
+  apiRoot?: string | undefined;
+  message: WhatsAppBaileysMessage;
+}): void {
+  if (!params.apiRoot) {
+    return;
+  }
+  const buses = baileysSocketBusesByApiRoot.get(normalizeApiRoot(params.apiRoot));
+  if (!buses?.size) {
+    return;
+  }
+  const payload = { messages: [params.message], type: "notify" };
+  for (const ev of buses) {
+    ev.emit("messages.upsert", payload);
+  }
+}
+
 export function createWhatsAppBaileysMockSocket(
   config: WhatsAppBaileysMockConfig,
 ): WhatsAppBaileysMockSocket {
   const fetchImpl = config.fetch ?? fetch;
   const selfJid = config.selfJid ?? "15550000000@s.whatsapp.net";
   const ev = createEventBus();
+  registerBaileysSocket(config.apiRoot, ev);
   return {
     ev,
     async sendMessage(jid, content) {
@@ -431,6 +498,7 @@ async function handleAdminInbound(params: {
   const message = createWhatsAppMessage({
     fromMe: false,
     id: readTrimmedString(params.body.messageId) ?? nextMessageId(params.state),
+    pushName: readTrimmedString(params.body.pushName) ?? "Test User",
     remoteJid: chatJid,
     senderJid,
     text,
@@ -471,11 +539,39 @@ async function handleAdminInbound(params: {
     ],
     object: "whatsapp_business_account",
   };
+  emitInboundToBaileysSockets({
+    apiRoot: params.state.apiRoot,
+    message,
+  });
   return whatsappOk({ message, webhook });
 }
 
 async function handleRequest(params: { request: IncomingMessage; state: WhatsAppFakeServerState }) {
   const url = new URL(params.request.url ?? "/", "http://127.0.0.1");
+
+  if (url.pathname === "/crabline/whatsapp/health") {
+    return whatsappOk({ selfJid: params.state.selfJid });
+  }
+
+  if (url.pathname === "/crabline/whatsapp/inbound") {
+    if (params.request.method !== "POST") {
+      return new Response("not found", { status: 404 });
+    }
+    if (!hasAdminToken(params.request, params.state.adminToken)) {
+      return adminAuthError();
+    }
+    const body = await parseRequestBody(params.request);
+    await appendEvent(params.state, {
+      at: new Date().toISOString(),
+      body,
+      method: params.request.method,
+      path: url.pathname,
+      query: queryRecord(url),
+      type: "admin",
+    });
+    return await handleAdminInbound({ body, state: params.state });
+  }
+
   const body =
     params.request.method === "GET" ? queryRecord(url) : await parseRequestBody(params.request);
   await appendEvent(params.state, {
@@ -484,18 +580,9 @@ async function handleRequest(params: { request: IncomingMessage; state: WhatsApp
     method: params.request.method ?? "GET",
     path: url.pathname,
     query: queryRecord(url),
-    type: url.pathname.startsWith("/crabline/whatsapp/inbound") ? "admin" : "api",
+    type: "api",
   });
 
-  if (url.pathname === "/crabline/whatsapp/health") {
-    return whatsappOk({ selfJid: params.state.selfJid });
-  }
-  if (url.pathname === "/crabline/whatsapp/inbound") {
-    if (params.request.method !== "POST") {
-      return new Response("not found", { status: 404 });
-    }
-    return await handleAdminInbound({ body, state: params.state });
-  }
   if (!requireAuth(params.request, params.state)) {
     return graphAuthError();
   }
@@ -523,6 +610,7 @@ export async function startWhatsAppFakeServer(
 ): Promise<StartedWhatsAppFakeServer> {
   const state: WhatsAppFakeServerState = {
     accessToken: params.accessToken ?? "crabline-whatsapp-access-token",
+    adminToken: params.adminToken ?? randomBytes(24).toString("hex"),
     displayPhoneNumber: "15550000000",
     nextMessageId: 1,
     phoneNumberId: "TEST_PHONE_NUMBER_ID",
@@ -539,12 +627,15 @@ export async function startWhatsAppFakeServer(
   });
   const baseUrl = httpServer.baseUrl;
   const apiRoot = `${baseUrl}/crabline/whatsapp`;
+  state.apiRoot = apiRoot;
   return {
     async close() {
+      clearBaileysSockets(apiRoot);
       await httpServer.close();
     },
     manifest: {
       accessToken: state.accessToken,
+      adminToken: state.adminToken,
       baseUrl,
       endpoints: {
         adminInboundUrl: `${apiRoot}/inbound`,
@@ -553,6 +644,7 @@ export async function startWhatsAppFakeServer(
         presenceUrl: `${apiRoot}/presence`,
       },
       env: {
+        CRABLINE_WHATSAPP_ADMIN_TOKEN: state.adminToken,
         CRABLINE_WHATSAPP_ACCESS_TOKEN: state.accessToken,
         CRABLINE_WHATSAPP_API_ROOT: apiRoot,
         CRABLINE_WHATSAPP_SELF_JID: state.selfJid,

--- a/src/fake-servers/whatsapp.ts
+++ b/src/fake-servers/whatsapp.ts
@@ -1,8 +1,10 @@
 import type { IncomingMessage } from "node:http";
-import { randomBytes, timingSafeEqual } from "node:crypto";
+import { randomBytes } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import {
+  adminAuthError,
+  hasAdminToken,
   jsonResponse,
   parseRequestBody,
   queryRecord,
@@ -19,7 +21,8 @@ const WHATSAPP_LID_RE = /^\d{7,15}@lid$/iu;
 type WhatsAppFakeServerState = {
   accessToken: string;
   adminToken: string;
-  apiRoot?: string | undefined;
+  apiRoot: string;
+  baileysRegistry: WhatsAppBaileysMockRegistry;
   displayPhoneNumber: string;
   nextMessageId: number;
   phoneNumberId: string;
@@ -53,6 +56,12 @@ export type WhatsAppBaileysMockConfig = {
   accessToken: string;
   apiRoot: string;
   fetch?: typeof fetch | undefined;
+  registry?: WhatsAppBaileysMockRegistry | undefined;
+  selfJid?: string | undefined;
+};
+
+export type WhatsAppBaileysMockSocketOverrides = {
+  fetch?: typeof fetch | undefined;
   selfJid?: string | undefined;
 };
 
@@ -80,12 +89,16 @@ export type WhatsAppFakeServerManifest = {
 
 export type StartedWhatsAppFakeServer = {
   close(): Promise<void>;
+  createBaileysMockSocket(
+    config?: WhatsAppBaileysMockSocketOverrides | undefined,
+  ): WhatsAppBaileysMockSocket;
   manifest: WhatsAppFakeServerManifest;
 };
 
 export type StartWhatsAppFakeServerParams = {
   accessToken?: string | undefined;
   adminToken?: string | undefined;
+  baileysRegistry?: WhatsAppBaileysMockRegistry | undefined;
   host?: string | undefined;
   port?: number | undefined;
   recorderPath?: string | undefined;
@@ -167,31 +180,6 @@ function requireAuth(request: IncomingMessage, state: WhatsAppFakeServerState): 
   return (
     typeof authorization === "string" && authorization.trim() === `Bearer ${state.accessToken}`
   );
-}
-
-function hasAdminToken(request: IncomingMessage, expectedToken: string): boolean {
-  const header = request.headers["x-crabline-admin-token"];
-  const directToken = Array.isArray(header) ? header[0] : header;
-  const authorization = request.headers.authorization;
-  const bearerToken =
-    typeof authorization === "string" && authorization.slice(0, 7).toLowerCase() === "bearer "
-      ? authorization.slice(7)
-      : undefined;
-  const providedToken = directToken ?? bearerToken;
-  if (!providedToken) {
-    return false;
-  }
-
-  const provided = Buffer.from(providedToken);
-  const expected = Buffer.from(expectedToken);
-  return provided.length === expected.length && timingSafeEqual(provided, expected);
-}
-
-function adminAuthError(): Response {
-  return new Response("unauthorized", {
-    headers: { "www-authenticate": "Bearer" },
-    status: 401,
-  });
 }
 
 function nextMessageId(state: WhatsAppFakeServerState): string {
@@ -365,76 +353,84 @@ function createEventBus(): WhatsAppBaileysMockSocket["ev"] {
   };
 }
 
-const baileysSocketBusesByApiRoot = new Map<string, Set<WhatsAppBaileysMockSocket["ev"]>>();
+export class WhatsAppBaileysMockRegistry {
+  readonly #busesByApiRoot = new Map<string, Set<WhatsAppBaileysMockSocket["ev"]>>();
 
-function registerBaileysSocket(apiRoot: string, ev: WhatsAppBaileysMockSocket["ev"]): void {
-  const key = normalizeApiRoot(apiRoot);
-  const buses = baileysSocketBusesByApiRoot.get(key) ?? new Set<WhatsAppBaileysMockSocket["ev"]>();
-  buses.add(ev);
-  baileysSocketBusesByApiRoot.set(key, buses);
+  clear(apiRoot: string): void {
+    this.#busesByApiRoot.delete(normalizeApiRoot(apiRoot));
+  }
+
+  createSocket(config: Omit<WhatsAppBaileysMockConfig, "registry">): WhatsAppBaileysMockSocket {
+    const fetchImpl = config.fetch ?? fetch;
+    const selfJid = config.selfJid ?? "15550000000@s.whatsapp.net";
+    const ev = createEventBus();
+    this.register(config.apiRoot, ev);
+    return {
+      ev,
+      async sendMessage(jid, content) {
+        const text = readBaileysTextContent(content);
+        const body = await postJson({
+          accessToken: config.accessToken,
+          body: {
+            messaging_product: "whatsapp",
+            text: { body: text },
+            to: jid,
+            type: "text",
+          },
+          fetchImpl,
+          url: joinUrl(config.apiRoot, "messages"),
+        });
+        const message = readResponseMessage(body, jid);
+        ev.emit("messages.upsert", { messages: [message], type: "notify" });
+        return message;
+      },
+      async sendPresenceUpdate(presence, jid) {
+        await postJson({
+          accessToken: config.accessToken,
+          body: { ...(jid ? { jid } : {}), presence },
+          fetchImpl,
+          url: joinUrl(config.apiRoot, "presence"),
+        });
+        ev.emit("presence.update", { jid, presence });
+      },
+      user: {
+        id: selfJid,
+        name: "Test Bot",
+      },
+    };
+  }
+
+  emitInbound(apiRoot: string, message: WhatsAppBaileysMessage): void {
+    const buses = this.#busesByApiRoot.get(normalizeApiRoot(apiRoot));
+    if (!buses?.size) {
+      return;
+    }
+    const payload = { messages: [message], type: "notify" };
+    for (const ev of buses) {
+      ev.emit("messages.upsert", payload);
+    }
+  }
+
+  private register(apiRoot: string, ev: WhatsAppBaileysMockSocket["ev"]): void {
+    const key = normalizeApiRoot(apiRoot);
+    const buses = this.#busesByApiRoot.get(key) ?? new Set<WhatsAppBaileysMockSocket["ev"]>();
+    buses.add(ev);
+    this.#busesByApiRoot.set(key, buses);
+  }
 }
 
-function clearBaileysSockets(apiRoot: string): void {
-  baileysSocketBusesByApiRoot.delete(normalizeApiRoot(apiRoot));
-}
-
-function emitInboundToBaileysSockets(params: {
-  apiRoot?: string | undefined;
-  message: WhatsAppBaileysMessage;
-}): void {
-  if (!params.apiRoot) {
-    return;
-  }
-  const buses = baileysSocketBusesByApiRoot.get(normalizeApiRoot(params.apiRoot));
-  if (!buses?.size) {
-    return;
-  }
-  const payload = { messages: [params.message], type: "notify" };
-  for (const ev of buses) {
-    ev.emit("messages.upsert", payload);
-  }
-}
+export const DEFAULT_WHATSAPP_BAILEYS_MOCK_REGISTRY = new WhatsAppBaileysMockRegistry();
 
 export function createWhatsAppBaileysMockSocket(
   config: WhatsAppBaileysMockConfig,
 ): WhatsAppBaileysMockSocket {
-  const fetchImpl = config.fetch ?? fetch;
-  const selfJid = config.selfJid ?? "15550000000@s.whatsapp.net";
-  const ev = createEventBus();
-  registerBaileysSocket(config.apiRoot, ev);
-  return {
-    ev,
-    async sendMessage(jid, content) {
-      const text = readBaileysTextContent(content);
-      const body = await postJson({
-        accessToken: config.accessToken,
-        body: {
-          messaging_product: "whatsapp",
-          text: { body: text },
-          to: jid,
-          type: "text",
-        },
-        fetchImpl,
-        url: joinUrl(config.apiRoot, "messages"),
-      });
-      const message = readResponseMessage(body, jid);
-      ev.emit("messages.upsert", { messages: [message], type: "notify" });
-      return message;
-    },
-    async sendPresenceUpdate(presence, jid) {
-      await postJson({
-        accessToken: config.accessToken,
-        body: { ...(jid ? { jid } : {}), presence },
-        fetchImpl,
-        url: joinUrl(config.apiRoot, "presence"),
-      });
-      ev.emit("presence.update", { jid, presence });
-    },
-    user: {
-      id: selfJid,
-      name: "Test Bot",
-    },
-  };
+  const registry = config.registry ?? DEFAULT_WHATSAPP_BAILEYS_MOCK_REGISTRY;
+  return registry.createSocket({
+    accessToken: config.accessToken,
+    apiRoot: config.apiRoot,
+    fetch: config.fetch,
+    selfJid: config.selfJid,
+  });
 }
 
 async function handleSendMessage(params: {
@@ -539,10 +535,7 @@ async function handleAdminInbound(params: {
     ],
     object: "whatsapp_business_account",
   };
-  emitInboundToBaileysSockets({
-    apiRoot: params.state.apiRoot,
-    message,
-  });
+  params.state.baileysRegistry.emitInbound(params.state.apiRoot, message);
   return whatsappOk({ message, webhook });
 }
 
@@ -611,6 +604,8 @@ export async function startWhatsAppFakeServer(
   const state: WhatsAppFakeServerState = {
     accessToken: params.accessToken ?? "crabline-whatsapp-access-token",
     adminToken: params.adminToken ?? randomBytes(24).toString("hex"),
+    apiRoot: "",
+    baileysRegistry: params.baileysRegistry ?? DEFAULT_WHATSAPP_BAILEYS_MOCK_REGISTRY,
     displayPhoneNumber: "15550000000",
     nextMessageId: 1,
     phoneNumberId: "TEST_PHONE_NUMBER_ID",
@@ -630,8 +625,16 @@ export async function startWhatsAppFakeServer(
   state.apiRoot = apiRoot;
   return {
     async close() {
-      clearBaileysSockets(apiRoot);
+      state.baileysRegistry.clear(apiRoot);
       await httpServer.close();
+    },
+    createBaileysMockSocket(config = {}) {
+      return state.baileysRegistry.createSocket({
+        accessToken: state.accessToken,
+        apiRoot,
+        selfJid: state.selfJid,
+        ...config,
+      });
     },
     manifest: {
       accessToken: state.accessToken,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,9 @@ export { resolveWhatsAppAdapterConfig } from "./providers/builtin/whatsapp.js";
 export { startTelegramFakeServer } from "./fake-servers/telegram.js";
 export {
   createWhatsAppBaileysMockSocket,
+  DEFAULT_WHATSAPP_BAILEYS_MOCK_REGISTRY,
   startWhatsAppFakeServer,
+  WhatsAppBaileysMockRegistry,
 } from "./fake-servers/whatsapp.js";
 export {
   CRABLINE_FAKE_PROVIDER_CHANNELS,
@@ -70,6 +72,7 @@ export type {
   StartWhatsAppFakeServerParams,
   WhatsAppBaileysMessage,
   WhatsAppBaileysMockConfig,
+  WhatsAppBaileysMockSocketOverrides,
   WhatsAppBaileysMockSocket,
   WhatsAppBaileysPresence,
   WhatsAppFakeServerManifest,

--- a/src/openclaw.ts
+++ b/src/openclaw.ts
@@ -67,7 +67,9 @@ export type OpenClawCrablineInboundInput = {
 
 export type OpenClawCrablineInbound = {
   providerBody: Record<string, unknown>;
+  providerHeaders: Record<string, string>;
   providerTargetKey: string;
+  providerUrl: string;
   qaTarget: string;
   stateConversation: OpenClawCrablineConversation;
   threadId?: string | undefined;
@@ -194,6 +196,16 @@ function requireManifestProvider<TProvider extends CrablineFakeProviderManifest[
   return manifest as Extract<CrablineFakeProviderManifest, { provider: TProvider }>;
 }
 
+function createAdminInboundRequest(manifest: CrablineFakeProviderManifest) {
+  return {
+    providerHeaders: {
+      "content-type": "application/json",
+      "x-crabline-admin-token": manifest.adminToken,
+    },
+    providerUrl: manifest.endpoints.adminInboundUrl,
+  };
+}
+
 export function resolveOpenClawCrablineChannel(input?: string | null): CrablineFakeProviderChannel {
   const channel = input?.trim().toLowerCase() || OPENCLAW_CRABLINE_DEFAULT_CHANNEL;
   if (isCrablineFakeProviderChannel(channel)) {
@@ -308,11 +320,12 @@ const OPENCLAW_CRABLINE_PROVIDER_BRIDGES = {
       };
     },
     createInbound({ input, manifest }) {
-      requireManifestProvider(manifest, "telegram");
+      const telegram = requireManifestProvider(manifest, "telegram");
       const kind = input.conversation.kind === "direct" ? "direct" : "group";
       const chatId = normalizeTelegramChatId(kind, input.conversation.id);
       const threadId = readInteger(input.threadId);
       return {
+        ...createAdminInboundRequest(telegram),
         providerBody: {
           chatId,
           fromId: readInteger(input.senderId) ?? TELEGRAM_DEFAULT_SENDER_ID,
@@ -422,10 +435,11 @@ const OPENCLAW_CRABLINE_PROVIDER_BRIDGES = {
       };
     },
     createInbound({ input, manifest }) {
-      requireManifestProvider(manifest, "whatsapp");
+      const whatsapp = requireManifestProvider(manifest, "whatsapp");
       const chatJid = requireWhatsAppJid(input.conversation.id, "WhatsApp conversation");
       const senderJid = requireWhatsAppJid(input.senderId, "WhatsApp sender");
       return {
+        ...createAdminInboundRequest(whatsapp),
         providerBody: {
           chatJid,
           senderJid,

--- a/src/openclaw.ts
+++ b/src/openclaw.ts
@@ -215,32 +215,35 @@ export function resolveOpenClawCrablineChannelDriverSelection(params: {
   };
 }
 
-export async function probeOpenClawCrablineFakeProvider(
-  manifest: CrablineFakeProviderManifest,
-): Promise<unknown> {
-  switch (manifest.provider) {
-    case "telegram": {
-      const response = await fetch(`${manifest.endpoints.apiRoot}/bot${manifest.botToken}/getMe`);
+type OpenClawCrablineProviderBridge = {
+  createAgentDelivery(params: {
+    manifest: CrablineFakeProviderManifest;
+    parsed: ReturnType<typeof parseQaTarget>;
+  }): OpenClawCrablineAgentDelivery;
+  createBinding(manifest: CrablineFakeProviderManifest): OpenClawCrablineGatewayBinding;
+  createInbound(params: {
+    input: OpenClawCrablineInboundInput;
+    manifest: CrablineFakeProviderManifest;
+  }): OpenClawCrablineInbound;
+  createOutboundFromRecorderEvent(params: {
+    event: RecorderEvent;
+    manifest: CrablineFakeProviderManifest;
+    targetByProviderTarget: ReadonlyMap<string, string>;
+  }): OpenClawCrablineOutboundMessage | null;
+  probe(manifest: CrablineFakeProviderManifest): Promise<unknown>;
+};
+
+const OPENCLAW_CRABLINE_PROVIDER_BRIDGES = {
+  telegram: {
+    async probe(manifest) {
+      const telegram = requireManifestProvider(manifest, "telegram");
+      const response = await fetch(`${telegram.endpoints.apiRoot}/bot${telegram.botToken}/getMe`);
       if (!response.ok) {
         throw new Error(`Crabline Telegram getMe probe failed with HTTP ${response.status}.`);
       }
       return await response.json();
-    }
-    case "whatsapp": {
-      const response = await fetch(`${manifest.endpoints.apiRoot}/health`);
-      if (!response.ok) {
-        throw new Error(`Crabline WhatsApp health probe failed with HTTP ${response.status}.`);
-      }
-      return await response.json();
-    }
-  }
-}
-
-export function createOpenClawCrablineFakeProviderBinding(
-  manifest: CrablineFakeProviderManifest,
-): OpenClawCrablineGatewayBinding {
-  switch (manifest.provider) {
-    case "telegram": {
+    },
+    createBinding(manifest) {
       const telegram = requireManifestProvider(manifest, "telegram");
       return {
         accountId: DEFAULT_ACCOUNT_ID,
@@ -291,14 +294,88 @@ export function createOpenClawCrablineFakeProviderBinding(
         },
         requiredPluginIds: ["telegram"],
       };
-    }
-    case "whatsapp": {
+    },
+    createAgentDelivery({ manifest, parsed }) {
+      requireManifestProvider(manifest, "telegram");
+      const chatId = normalizeTelegramChatId(parsed.kind, parsed.id);
+      const threadId = readInteger(parsed.threadId);
+      const to = telegramTargetKey(chatId, threadId);
+      return {
+        channel: "telegram",
+        to,
+        replyChannel: "telegram",
+        replyTo: to,
+      };
+    },
+    createInbound({ input, manifest }) {
+      requireManifestProvider(manifest, "telegram");
+      const kind = input.conversation.kind === "direct" ? "direct" : "group";
+      const chatId = normalizeTelegramChatId(kind, input.conversation.id);
+      const threadId = readInteger(input.threadId);
+      return {
+        providerBody: {
+          chatId,
+          fromId: readInteger(input.senderId) ?? TELEGRAM_DEFAULT_SENDER_ID,
+          fromName: input.senderName ?? input.senderId,
+          ...(threadId !== undefined ? { messageThreadId: threadId } : {}),
+          text: input.text,
+        },
+        providerTargetKey: telegramTargetKey(chatId, threadId),
+        qaTarget: qaTargetForInbound(input),
+        stateConversation: {
+          id: chatId,
+          kind: kind === "group" ? "group" : "direct",
+        },
+        ...(threadId !== undefined ? { threadId: String(threadId) } : {}),
+      };
+    },
+    createOutboundFromRecorderEvent({ event, manifest, targetByProviderTarget }) {
+      requireManifestProvider(manifest, "telegram");
+      if (
+        event.type !== "api" ||
+        typeof event.path !== "string" ||
+        !event.path.endsWith("/sendMessage") ||
+        !event.body ||
+        typeof event.body !== "object"
+      ) {
+        return null;
+      }
+      const chatId = readString(event.body.chat_id);
+      const text =
+        typeof event.body.text === "string" && event.body.text.trim() ? event.body.text : undefined;
+      if (!chatId || !text) {
+        return null;
+      }
+      const threadId = readInteger(event.body.message_thread_id);
+      const providerTargetKey = telegramTargetKey(chatId, threadId);
+      return {
+        accountId: DEFAULT_ACCOUNT_ID,
+        senderId: "openclaw",
+        senderName: "OpenClaw QA",
+        text,
+        to:
+          targetByProviderTarget.get(providerTargetKey) ??
+          (threadId === undefined ? chatId : providerTargetKey),
+      };
+    },
+  },
+  whatsapp: {
+    async probe(manifest) {
+      const whatsapp = requireManifestProvider(manifest, "whatsapp");
+      const response = await fetch(`${whatsapp.endpoints.apiRoot}/health`);
+      if (!response.ok) {
+        throw new Error(`Crabline WhatsApp health probe failed with HTTP ${response.status}.`);
+      }
+      return await response.json();
+    },
+    createBinding(manifest) {
       const whatsapp = requireManifestProvider(manifest, "whatsapp");
       return {
         accountId: DEFAULT_ACCOUNT_ID,
         channel: "whatsapp",
         createChannelDriverSmokeEnv: (env) => ({
           ...env,
+          CRABLINE_WHATSAPP_ADMIN_TOKEN: whatsapp.adminToken,
           CRABLINE_WHATSAPP_ACCESS_TOKEN: whatsapp.accessToken,
           CRABLINE_WHATSAPP_API_ROOT: whatsapp.endpoints.apiRoot,
           CRABLINE_WHATSAPP_SELF_JID: whatsapp.selfJid,
@@ -333,30 +410,9 @@ export function createOpenClawCrablineFakeProviderBinding(
         },
         requiredPluginIds: ["whatsapp"],
       };
-    }
-  }
-}
-
-export function createOpenClawCrablineAgentDelivery(params: {
-  manifest: CrablineFakeProviderManifest;
-  target: string;
-}): OpenClawCrablineAgentDelivery {
-  const parsed = parseQaTarget(params.target);
-  switch (params.manifest.provider) {
-    case "telegram": {
-      requireManifestProvider(params.manifest, "telegram");
-      const chatId = normalizeTelegramChatId(parsed.kind, parsed.id);
-      const threadId = readInteger(parsed.threadId);
-      const to = telegramTargetKey(chatId, threadId);
-      return {
-        channel: "telegram",
-        to,
-        replyChannel: "telegram",
-        replyTo: to,
-      };
-    }
-    case "whatsapp": {
-      requireManifestProvider(params.manifest, "whatsapp");
+    },
+    createAgentDelivery({ manifest, parsed }) {
+      requireManifestProvider(manifest, "whatsapp");
       const to = requireWhatsAppJid(parsed.id, "WhatsApp target");
       return {
         channel: "whatsapp",
@@ -364,100 +420,35 @@ export function createOpenClawCrablineAgentDelivery(params: {
         replyChannel: "whatsapp",
         replyTo: to,
       };
-    }
-  }
-}
-
-export function createOpenClawCrablineInbound(params: {
-  input: OpenClawCrablineInboundInput;
-  manifest: CrablineFakeProviderManifest;
-}): OpenClawCrablineInbound {
-  switch (params.manifest.provider) {
-    case "telegram": {
-      requireManifestProvider(params.manifest, "telegram");
-      const kind = params.input.conversation.kind === "direct" ? "direct" : "group";
-      const chatId = normalizeTelegramChatId(kind, params.input.conversation.id);
-      const threadId = readInteger(params.input.threadId);
-      return {
-        providerBody: {
-          chatId,
-          fromId: readInteger(params.input.senderId) ?? TELEGRAM_DEFAULT_SENDER_ID,
-          fromName: params.input.senderName ?? params.input.senderId,
-          ...(threadId !== undefined ? { messageThreadId: threadId } : {}),
-          text: params.input.text,
-        },
-        providerTargetKey: telegramTargetKey(chatId, threadId),
-        qaTarget: qaTargetForInbound(params.input),
-        stateConversation: {
-          id: chatId,
-          kind: kind === "group" ? "group" : "direct",
-        },
-        ...(threadId !== undefined ? { threadId: String(threadId) } : {}),
-      };
-    }
-    case "whatsapp": {
-      requireManifestProvider(params.manifest, "whatsapp");
-      const chatJid = requireWhatsAppJid(params.input.conversation.id, "WhatsApp conversation");
-      const senderJid = requireWhatsAppJid(params.input.senderId, "WhatsApp sender");
+    },
+    createInbound({ input, manifest }) {
+      requireManifestProvider(manifest, "whatsapp");
+      const chatJid = requireWhatsAppJid(input.conversation.id, "WhatsApp conversation");
+      const senderJid = requireWhatsAppJid(input.senderId, "WhatsApp sender");
       return {
         providerBody: {
           chatJid,
           senderJid,
-          ...(params.input.senderName ? { pushName: params.input.senderName } : {}),
-          text: params.input.text,
+          ...(input.senderName ? { pushName: input.senderName } : {}),
+          text: input.text,
         },
         providerTargetKey: chatJid,
-        qaTarget: qaTargetForInbound(params.input),
+        qaTarget: qaTargetForInbound(input),
         stateConversation: {
           id: chatJid,
           kind: chatJid.endsWith("@g.us") ? "group" : "direct",
         },
       };
-    }
-  }
-}
-
-export function createOpenClawCrablineOutboundFromRecorderEvent(params: {
-  event: unknown;
-  manifest: CrablineFakeProviderManifest;
-  targetByProviderTarget: ReadonlyMap<string, string>;
-}): OpenClawCrablineOutboundMessage | null {
-  const event = params.event as RecorderEvent;
-  if (
-    event.type !== "api" ||
-    typeof event.path !== "string" ||
-    !event.body ||
-    typeof event.body !== "object"
-  ) {
-    return null;
-  }
-  switch (params.manifest.provider) {
-    case "telegram": {
-      requireManifestProvider(params.manifest, "telegram");
-      if (!event.path.endsWith("/sendMessage")) {
-        return null;
-      }
-      const chatId = readString(event.body.chat_id);
-      const text =
-        typeof event.body.text === "string" && event.body.text.trim() ? event.body.text : undefined;
-      if (!chatId || !text) {
-        return null;
-      }
-      const threadId = readInteger(event.body.message_thread_id);
-      const providerTargetKey = telegramTargetKey(chatId, threadId);
-      return {
-        accountId: DEFAULT_ACCOUNT_ID,
-        senderId: "openclaw",
-        senderName: "OpenClaw QA",
-        text,
-        to:
-          params.targetByProviderTarget.get(providerTargetKey) ??
-          (threadId === undefined ? chatId : providerTargetKey),
-      };
-    }
-    case "whatsapp": {
-      requireManifestProvider(params.manifest, "whatsapp");
-      if (!event.path.endsWith("/crabline/whatsapp/messages")) {
+    },
+    createOutboundFromRecorderEvent({ event, manifest, targetByProviderTarget }) {
+      requireManifestProvider(manifest, "whatsapp");
+      if (
+        event.type !== "api" ||
+        typeof event.path !== "string" ||
+        !event.path.endsWith("/crabline/whatsapp/messages") ||
+        !event.body ||
+        typeof event.body !== "object"
+      ) {
         return null;
       }
       const to = readString(event.body.to ?? event.body.jid);
@@ -474,10 +465,61 @@ export function createOpenClawCrablineOutboundFromRecorderEvent(params: {
         senderId: "openclaw",
         senderName: "OpenClaw QA",
         text,
-        to: params.targetByProviderTarget.get(to) ?? to,
+        to: targetByProviderTarget.get(to) ?? to,
       };
-    }
+    },
+  },
+} satisfies Record<CrablineFakeProviderChannel, OpenClawCrablineProviderBridge>;
+
+function getOpenClawCrablineProviderBridge(
+  manifest: CrablineFakeProviderManifest,
+): OpenClawCrablineProviderBridge {
+  const bridge = OPENCLAW_CRABLINE_PROVIDER_BRIDGES[manifest.provider];
+  if (!bridge) {
+    throw new Error(`Unsupported OpenClaw fake provider binding: ${String(manifest.provider)}`);
   }
+  return bridge;
+}
+
+export async function probeOpenClawCrablineFakeProvider(
+  manifest: CrablineFakeProviderManifest,
+): Promise<unknown> {
+  return await getOpenClawCrablineProviderBridge(manifest).probe(manifest);
+}
+
+export function createOpenClawCrablineFakeProviderBinding(
+  manifest: CrablineFakeProviderManifest,
+): OpenClawCrablineGatewayBinding {
+  return getOpenClawCrablineProviderBridge(manifest).createBinding(manifest);
+}
+
+export function createOpenClawCrablineAgentDelivery(params: {
+  manifest: CrablineFakeProviderManifest;
+  target: string;
+}): OpenClawCrablineAgentDelivery {
+  return getOpenClawCrablineProviderBridge(params.manifest).createAgentDelivery({
+    manifest: params.manifest,
+    parsed: parseQaTarget(params.target),
+  });
+}
+
+export function createOpenClawCrablineInbound(params: {
+  input: OpenClawCrablineInboundInput;
+  manifest: CrablineFakeProviderManifest;
+}): OpenClawCrablineInbound {
+  return getOpenClawCrablineProviderBridge(params.manifest).createInbound(params);
+}
+
+export function createOpenClawCrablineOutboundFromRecorderEvent(params: {
+  event: unknown;
+  manifest: CrablineFakeProviderManifest;
+  targetByProviderTarget: ReadonlyMap<string, string>;
+}): OpenClawCrablineOutboundMessage | null {
+  return getOpenClawCrablineProviderBridge(params.manifest).createOutboundFromRecorderEvent({
+    event: params.event as RecorderEvent,
+    manifest: params.manifest,
+    targetByProviderTarget: params.targetByProviderTarget,
+  });
 }
 
 export async function startOpenClawCrablineAdapter(

--- a/src/openclaw.ts
+++ b/src/openclaw.ts
@@ -6,204 +6,60 @@ import {
   type CrablineFakeProviderManifest,
   type StartedCrablineFakeProviderServer,
 } from "./fake-servers/index.js";
+import { TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE } from "./openclaw/bridges/telegram.js";
+import { WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE } from "./openclaw/bridges/whatsapp.js";
+import {
+  OPENCLAW_CRABLINE_CHANNEL_CAPABILITY_MATRIX_PATH,
+  OPENCLAW_CRABLINE_CHANNEL_SMOKE_PATH,
+  OPENCLAW_CRABLINE_DEFAULT_CHANNEL,
+  OPENCLAW_CRABLINE_MANIFEST_PATH,
+  parseQaTarget,
+  type OpenClawCrablineAgentDelivery,
+  type OpenClawCrablineChannelDriverSelection,
+  type OpenClawCrablineChannelDriverSmokeResult,
+  type OpenClawCrablineGatewayBinding,
+  type OpenClawCrablineInbound,
+  type OpenClawCrablineInboundInput,
+  type OpenClawCrablineOutboundMessage,
+  type OpenClawCrablineProviderBridge,
+  type StartedOpenClawCrablineAdapter,
+  type StartOpenClawCrablineAdapterParams,
+} from "./openclaw/shared.js";
 import fs from "node:fs/promises";
 import path from "node:path";
 
-const DEFAULT_ACCOUNT_ID = "default";
-const TELEGRAM_DIRECT_CHAT_ID = "100001";
-const TELEGRAM_GROUP_CHAT_ID = "-1001234567890";
-const TELEGRAM_DEFAULT_SENDER_ID = 100001;
-const WHATSAPP_JID_RE =
-  /^(?:\d{7,15}(?::\d+)?@s\.whatsapp\.net|\d{7,15}@c\.us|\d{5,}@g\.us|\d{7,15}@lid)$/iu;
-export const OPENCLAW_CRABLINE_CHANNEL_CAPABILITY_MATRIX_PATH =
-  "crabline-fake-provider-capabilities.json";
-export const OPENCLAW_CRABLINE_CHANNEL_SMOKE_PATH = "crabline-fake-provider-smoke.json";
-export const OPENCLAW_CRABLINE_MANIFEST_PATH = "crabline-fake-provider-server.json";
-export const OPENCLAW_CRABLINE_DEFAULT_CHANNEL = "telegram";
-
-export type OpenClawCrablineChannelDriverSelection = {
-  channel: CrablineFakeProviderChannel;
-  channelDriver: "crabline";
-  capabilityMatrixPath: typeof OPENCLAW_CRABLINE_CHANNEL_CAPABILITY_MATRIX_PATH;
-  smokeArtifactPath: typeof OPENCLAW_CRABLINE_CHANNEL_SMOKE_PATH;
+export {
+  OPENCLAW_CRABLINE_CHANNEL_CAPABILITY_MATRIX_PATH,
+  OPENCLAW_CRABLINE_CHANNEL_SMOKE_PATH,
+  OPENCLAW_CRABLINE_DEFAULT_CHANNEL,
+  OPENCLAW_CRABLINE_MANIFEST_PATH,
 };
+export type {
+  OpenClawCrablineAgentDelivery,
+  OpenClawCrablineChannelDriverSelection,
+  OpenClawCrablineChannelDriverSmokeResult,
+  OpenClawCrablineConversation,
+  OpenClawCrablineGatewayBinding,
+  OpenClawCrablineInbound,
+  OpenClawCrablineInboundInput,
+  OpenClawCrablineOutboundMessage,
+  StartedOpenClawCrablineAdapter,
+  StartOpenClawCrablineAdapterParams,
+} from "./openclaw/shared.js";
 
-export type OpenClawCrablineChannelDriverSmokeResult = {
-  capabilityReport: unknown;
-  manifestPath: string;
-  smoke: unknown;
-};
+const OPENCLAW_CRABLINE_PROVIDER_BRIDGES = {
+  telegram: TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE,
+  whatsapp: WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE,
+} satisfies Record<CrablineFakeProviderChannel, OpenClawCrablineProviderBridge>;
 
-export type OpenClawCrablineConversation = {
-  id: string;
-  kind: "direct" | "group";
-};
-
-export type OpenClawCrablineGatewayBinding = {
-  accountId: string;
-  channel: string;
-  createChannelDriverSmokeEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv;
-  createGatewayConfig(openclawConfig?: Record<string, unknown>): Record<string, unknown>;
-  requiredPluginIds: string[];
-};
-
-export type OpenClawCrablineAgentDelivery = {
-  channel: string;
-  replyChannel: string;
-  replyTo: string;
-  to: string;
-};
-
-export type OpenClawCrablineInboundInput = {
-  conversation: {
-    id: string;
-    kind: string;
-  };
-  senderId: string;
-  senderName?: string | undefined;
-  text: string;
-  threadId?: string | undefined;
-};
-
-export type OpenClawCrablineInbound = {
-  providerBody: Record<string, unknown>;
-  providerHeaders: Record<string, string>;
-  providerTargetKey: string;
-  providerUrl: string;
-  qaTarget: string;
-  stateConversation: OpenClawCrablineConversation;
-  threadId?: string | undefined;
-};
-
-export type OpenClawCrablineOutboundMessage = {
-  accountId: string;
-  senderId: string;
-  senderName: string;
-  text: string;
-  to: string;
-};
-
-export type StartOpenClawCrablineAdapterParams = {
-  channel: CrablineFakeProviderChannel;
-  openclawConfig?: Record<string, unknown> | undefined;
-  recorderPath?: string | undefined;
-};
-
-export type StartedOpenClawCrablineAdapter = OpenClawCrablineGatewayBinding & {
-  close(): Promise<void>;
-  createAgentDelivery(params: { target: string }): OpenClawCrablineAgentDelivery;
-  createInbound(params: { input: OpenClawCrablineInboundInput }): OpenClawCrablineInbound;
-  createOutboundFromRecorderEvent(params: {
-    event: unknown;
-    targetByProviderTarget: ReadonlyMap<string, string>;
-  }): OpenClawCrablineOutboundMessage | null;
-  manifest: CrablineFakeProviderManifest;
-  probe(): Promise<unknown>;
-};
-
-type RecorderEvent = {
-  body?: Record<string, unknown>;
-  path?: string;
-  type?: string;
-};
-
-function readString(value: unknown): string | undefined {
-  if (typeof value === "string" && value.trim()) {
-    return value.trim();
-  }
-  if (typeof value === "number" || typeof value === "bigint") {
-    return String(value);
-  }
-  return undefined;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function readInteger(value: unknown): number | undefined {
-  const stringValue = readString(value);
-  if (!stringValue || !/^-?\d+$/u.test(stringValue)) {
-    return undefined;
-  }
-  return Number(stringValue);
-}
-
-function parseQaTarget(target: string): {
-  kind: "direct" | "group";
-  id: string;
-  threadId?: string;
-} {
-  const trimmed = target.trim();
-  if (trimmed.startsWith("thread:")) {
-    const rest = trimmed.slice("thread:".length);
-    const slash = rest.indexOf("/");
-    if (slash > 0) {
-      return { kind: "group", id: rest.slice(0, slash), threadId: rest.slice(slash + 1) };
-    }
-  }
-  if (trimmed.startsWith("channel:")) {
-    return { kind: "group", id: trimmed.slice("channel:".length) };
-  }
-  if (trimmed.startsWith("group:")) {
-    return { kind: "group", id: trimmed.slice("group:".length) };
-  }
-  if (trimmed.startsWith("dm:")) {
-    return { kind: "direct", id: trimmed.slice("dm:".length) };
-  }
-  return { kind: "direct", id: trimmed };
-}
-
-function normalizeTelegramChatId(kind: "direct" | "group", id: string) {
-  return /^-?\d+$/u.test(id.trim())
-    ? id.trim()
-    : kind === "group"
-      ? TELEGRAM_GROUP_CHAT_ID
-      : TELEGRAM_DIRECT_CHAT_ID;
-}
-
-function telegramTargetKey(chatId: string, threadId?: number) {
-  return threadId === undefined ? chatId : `${chatId}:topic:${threadId}`;
-}
-
-function qaTargetForInbound(input: OpenClawCrablineInboundInput) {
-  const prefix =
-    input.conversation.kind === "direct"
-      ? "dm"
-      : input.conversation.kind === "channel"
-        ? "channel"
-        : "group";
-  return input.threadId
-    ? `thread:${input.conversation.id}/${input.threadId}`
-    : `${prefix}:${input.conversation.id}`;
-}
-
-function requireWhatsAppJid(value: string, label: string): string {
-  const trimmed = value.trim();
-  if (!WHATSAPP_JID_RE.test(trimmed)) {
-    throw new Error(`${label} must be a native WhatsApp JID.`);
-  }
-  return trimmed;
-}
-
-function requireManifestProvider<TProvider extends CrablineFakeProviderManifest["provider"]>(
+function getOpenClawCrablineProviderBridge(
   manifest: CrablineFakeProviderManifest,
-  provider: TProvider,
-): Extract<CrablineFakeProviderManifest, { provider: TProvider }> {
-  if (manifest.provider !== provider) {
+): OpenClawCrablineProviderBridge {
+  const bridge = OPENCLAW_CRABLINE_PROVIDER_BRIDGES[manifest.provider];
+  if (!bridge) {
     throw new Error(`Unsupported OpenClaw fake provider binding: ${String(manifest.provider)}`);
   }
-  return manifest as Extract<CrablineFakeProviderManifest, { provider: TProvider }>;
-}
-
-function createAdminInboundRequest(manifest: CrablineFakeProviderManifest) {
-  return {
-    providerHeaders: {
-      "content-type": "application/json",
-      "x-crabline-admin-token": manifest.adminToken,
-    },
-    providerUrl: manifest.endpoints.adminInboundUrl,
-  };
+  return bridge;
 }
 
 export function resolveOpenClawCrablineChannel(input?: string | null): CrablineFakeProviderChannel {
@@ -225,274 +81,6 @@ export function resolveOpenClawCrablineChannelDriverSelection(params: {
     capabilityMatrixPath: OPENCLAW_CRABLINE_CHANNEL_CAPABILITY_MATRIX_PATH,
     smokeArtifactPath: OPENCLAW_CRABLINE_CHANNEL_SMOKE_PATH,
   };
-}
-
-type OpenClawCrablineProviderBridge = {
-  createAgentDelivery(params: {
-    manifest: CrablineFakeProviderManifest;
-    parsed: ReturnType<typeof parseQaTarget>;
-  }): OpenClawCrablineAgentDelivery;
-  createBinding(manifest: CrablineFakeProviderManifest): OpenClawCrablineGatewayBinding;
-  createInbound(params: {
-    input: OpenClawCrablineInboundInput;
-    manifest: CrablineFakeProviderManifest;
-  }): OpenClawCrablineInbound;
-  createOutboundFromRecorderEvent(params: {
-    event: RecorderEvent;
-    manifest: CrablineFakeProviderManifest;
-    targetByProviderTarget: ReadonlyMap<string, string>;
-  }): OpenClawCrablineOutboundMessage | null;
-  probe(manifest: CrablineFakeProviderManifest): Promise<unknown>;
-};
-
-const OPENCLAW_CRABLINE_PROVIDER_BRIDGES = {
-  telegram: {
-    async probe(manifest) {
-      const telegram = requireManifestProvider(manifest, "telegram");
-      const response = await fetch(`${telegram.endpoints.apiRoot}/bot${telegram.botToken}/getMe`);
-      if (!response.ok) {
-        throw new Error(`Crabline Telegram getMe probe failed with HTTP ${response.status}.`);
-      }
-      return await response.json();
-    },
-    createBinding(manifest) {
-      const telegram = requireManifestProvider(manifest, "telegram");
-      return {
-        accountId: DEFAULT_ACCOUNT_ID,
-        channel: "telegram",
-        createChannelDriverSmokeEnv: (env) => ({
-          ...env,
-          TELEGRAM_BOT_TOKEN: telegram.botToken,
-        }),
-        createGatewayConfig: (openclawConfig = {}) => {
-          const channels = isRecord(openclawConfig.channels) ? openclawConfig.channels : {};
-          const telegramConfig = isRecord(channels.telegram) ? channels.telegram : {};
-          const groups = isRecord(telegramConfig.groups) ? telegramConfig.groups : {};
-          const defaultGroup = isRecord(groups["*"]) ? groups["*"] : {};
-          const messages = isRecord(openclawConfig.messages) ? openclawConfig.messages : {};
-          const groupChat = isRecord(messages.groupChat) ? messages.groupChat : {};
-
-          return {
-            ...openclawConfig,
-            channels: {
-              ...channels,
-              telegram: {
-                ...telegramConfig,
-                enabled: true,
-                botToken: telegram.botToken,
-                apiRoot: telegram.endpoints.apiRoot,
-                dmPolicy: "open",
-                groupPolicy: "open",
-                allowFrom: ["*"],
-                groupAllowFrom: ["*"],
-                groups: {
-                  ...groups,
-                  "*": {
-                    ...defaultGroup,
-                    requireMention: false,
-                  },
-                },
-              },
-            },
-            messages: {
-              ...messages,
-              groupChat: {
-                ...groupChat,
-                mentionPatterns: ["\\b@?openclaw\\b"],
-                visibleReplies: "automatic",
-              },
-            },
-          };
-        },
-        requiredPluginIds: ["telegram"],
-      };
-    },
-    createAgentDelivery({ manifest, parsed }) {
-      requireManifestProvider(manifest, "telegram");
-      const chatId = normalizeTelegramChatId(parsed.kind, parsed.id);
-      const threadId = readInteger(parsed.threadId);
-      const to = telegramTargetKey(chatId, threadId);
-      return {
-        channel: "telegram",
-        to,
-        replyChannel: "telegram",
-        replyTo: to,
-      };
-    },
-    createInbound({ input, manifest }) {
-      const telegram = requireManifestProvider(manifest, "telegram");
-      const kind = input.conversation.kind === "direct" ? "direct" : "group";
-      const chatId = normalizeTelegramChatId(kind, input.conversation.id);
-      const threadId = readInteger(input.threadId);
-      return {
-        ...createAdminInboundRequest(telegram),
-        providerBody: {
-          chatId,
-          fromId: readInteger(input.senderId) ?? TELEGRAM_DEFAULT_SENDER_ID,
-          fromName: input.senderName ?? input.senderId,
-          ...(threadId !== undefined ? { messageThreadId: threadId } : {}),
-          text: input.text,
-        },
-        providerTargetKey: telegramTargetKey(chatId, threadId),
-        qaTarget: qaTargetForInbound(input),
-        stateConversation: {
-          id: chatId,
-          kind: kind === "group" ? "group" : "direct",
-        },
-        ...(threadId !== undefined ? { threadId: String(threadId) } : {}),
-      };
-    },
-    createOutboundFromRecorderEvent({ event, manifest, targetByProviderTarget }) {
-      requireManifestProvider(manifest, "telegram");
-      if (
-        event.type !== "api" ||
-        typeof event.path !== "string" ||
-        !event.path.endsWith("/sendMessage") ||
-        !event.body ||
-        typeof event.body !== "object"
-      ) {
-        return null;
-      }
-      const chatId = readString(event.body.chat_id);
-      const text =
-        typeof event.body.text === "string" && event.body.text.trim() ? event.body.text : undefined;
-      if (!chatId || !text) {
-        return null;
-      }
-      const threadId = readInteger(event.body.message_thread_id);
-      const providerTargetKey = telegramTargetKey(chatId, threadId);
-      return {
-        accountId: DEFAULT_ACCOUNT_ID,
-        senderId: "openclaw",
-        senderName: "OpenClaw QA",
-        text,
-        to:
-          targetByProviderTarget.get(providerTargetKey) ??
-          (threadId === undefined ? chatId : providerTargetKey),
-      };
-    },
-  },
-  whatsapp: {
-    async probe(manifest) {
-      const whatsapp = requireManifestProvider(manifest, "whatsapp");
-      const response = await fetch(`${whatsapp.endpoints.apiRoot}/health`);
-      if (!response.ok) {
-        throw new Error(`Crabline WhatsApp health probe failed with HTTP ${response.status}.`);
-      }
-      return await response.json();
-    },
-    createBinding(manifest) {
-      const whatsapp = requireManifestProvider(manifest, "whatsapp");
-      return {
-        accountId: DEFAULT_ACCOUNT_ID,
-        channel: "whatsapp",
-        createChannelDriverSmokeEnv: (env) => ({
-          ...env,
-          CRABLINE_WHATSAPP_ADMIN_TOKEN: whatsapp.adminToken,
-          CRABLINE_WHATSAPP_ACCESS_TOKEN: whatsapp.accessToken,
-          CRABLINE_WHATSAPP_API_ROOT: whatsapp.endpoints.apiRoot,
-          CRABLINE_WHATSAPP_SELF_JID: whatsapp.selfJid,
-        }),
-        createGatewayConfig: (openclawConfig = {}) => {
-          const channels = isRecord(openclawConfig.channels) ? openclawConfig.channels : {};
-          const whatsappConfig = isRecord(channels.whatsapp) ? channels.whatsapp : {};
-          const groups = isRecord(whatsappConfig.groups) ? whatsappConfig.groups : {};
-          const defaultGroup = isRecord(groups["*"]) ? groups["*"] : {};
-
-          return {
-            ...openclawConfig,
-            channels: {
-              ...channels,
-              whatsapp: {
-                ...whatsappConfig,
-                enabled: true,
-                dmPolicy: "open",
-                groupPolicy: "open",
-                allowFrom: ["*"],
-                groupAllowFrom: ["*"],
-                groups: {
-                  ...groups,
-                  "*": {
-                    ...defaultGroup,
-                    requireMention: false,
-                  },
-                },
-              },
-            },
-          };
-        },
-        requiredPluginIds: ["whatsapp"],
-      };
-    },
-    createAgentDelivery({ manifest, parsed }) {
-      requireManifestProvider(manifest, "whatsapp");
-      const to = requireWhatsAppJid(parsed.id, "WhatsApp target");
-      return {
-        channel: "whatsapp",
-        to,
-        replyChannel: "whatsapp",
-        replyTo: to,
-      };
-    },
-    createInbound({ input, manifest }) {
-      const whatsapp = requireManifestProvider(manifest, "whatsapp");
-      const chatJid = requireWhatsAppJid(input.conversation.id, "WhatsApp conversation");
-      const senderJid = requireWhatsAppJid(input.senderId, "WhatsApp sender");
-      return {
-        ...createAdminInboundRequest(whatsapp),
-        providerBody: {
-          chatJid,
-          senderJid,
-          ...(input.senderName ? { pushName: input.senderName } : {}),
-          text: input.text,
-        },
-        providerTargetKey: chatJid,
-        qaTarget: qaTargetForInbound(input),
-        stateConversation: {
-          id: chatJid,
-          kind: chatJid.endsWith("@g.us") ? "group" : "direct",
-        },
-      };
-    },
-    createOutboundFromRecorderEvent({ event, manifest, targetByProviderTarget }) {
-      requireManifestProvider(manifest, "whatsapp");
-      if (
-        event.type !== "api" ||
-        typeof event.path !== "string" ||
-        !event.path.endsWith("/crabline/whatsapp/messages") ||
-        !event.body ||
-        typeof event.body !== "object"
-      ) {
-        return null;
-      }
-      const to = readString(event.body.to ?? event.body.jid);
-      const textPayload = event.body.text;
-      const text =
-        textPayload && typeof textPayload === "object"
-          ? readString((textPayload as Record<string, unknown>).body)
-          : readString(textPayload);
-      if (!to || !text) {
-        return null;
-      }
-      return {
-        accountId: DEFAULT_ACCOUNT_ID,
-        senderId: "openclaw",
-        senderName: "OpenClaw QA",
-        text,
-        to: targetByProviderTarget.get(to) ?? to,
-      };
-    },
-  },
-} satisfies Record<CrablineFakeProviderChannel, OpenClawCrablineProviderBridge>;
-
-function getOpenClawCrablineProviderBridge(
-  manifest: CrablineFakeProviderManifest,
-): OpenClawCrablineProviderBridge {
-  const bridge = OPENCLAW_CRABLINE_PROVIDER_BRIDGES[manifest.provider];
-  if (!bridge) {
-    throw new Error(`Unsupported OpenClaw fake provider binding: ${String(manifest.provider)}`);
-  }
-  return bridge;
 }
 
 export async function probeOpenClawCrablineFakeProvider(
@@ -529,11 +117,7 @@ export function createOpenClawCrablineOutboundFromRecorderEvent(params: {
   manifest: CrablineFakeProviderManifest;
   targetByProviderTarget: ReadonlyMap<string, string>;
 }): OpenClawCrablineOutboundMessage | null {
-  return getOpenClawCrablineProviderBridge(params.manifest).createOutboundFromRecorderEvent({
-    event: params.event as RecorderEvent,
-    manifest: params.manifest,
-    targetByProviderTarget: params.targetByProviderTarget,
-  });
+  return getOpenClawCrablineProviderBridge(params.manifest).createOutboundFromRecorderEvent(params);
 }
 
 export async function startOpenClawCrablineAdapter(

--- a/src/openclaw.ts
+++ b/src/openclaw.ts
@@ -21,7 +21,9 @@ import {
   type OpenClawCrablineInbound,
   type OpenClawCrablineInboundInput,
   type OpenClawCrablineOutboundMessage,
+  type OpenClawCrablineProviderAdapter,
   type OpenClawCrablineProviderBridge,
+  type OpenClawCrablineProviderBridgeRegistry,
   type StartedOpenClawCrablineAdapter,
   type StartOpenClawCrablineAdapterParams,
 } from "./openclaw/shared.js";
@@ -50,16 +52,22 @@ export type {
 const OPENCLAW_CRABLINE_PROVIDER_BRIDGES = {
   telegram: TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE,
   whatsapp: WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE,
-} satisfies Record<CrablineFakeProviderChannel, OpenClawCrablineProviderBridge>;
+} satisfies OpenClawCrablineProviderBridgeRegistry;
 
-function getOpenClawCrablineProviderBridge(
+const OPENCLAW_CRABLINE_PROVIDER_BRIDGE_LIST = Object.values(
+  OPENCLAW_CRABLINE_PROVIDER_BRIDGES,
+) as readonly OpenClawCrablineProviderBridge[];
+
+function createOpenClawCrablineProviderAdapter(
   manifest: CrablineFakeProviderManifest,
-): OpenClawCrablineProviderBridge {
-  const bridge = OPENCLAW_CRABLINE_PROVIDER_BRIDGES[manifest.provider];
-  if (!bridge) {
-    throw new Error(`Unsupported OpenClaw fake provider binding: ${String(manifest.provider)}`);
+): OpenClawCrablineProviderAdapter {
+  const bridge = OPENCLAW_CRABLINE_PROVIDER_BRIDGE_LIST.find(
+    (candidate) => candidate.provider === manifest.provider,
+  );
+  if (bridge) {
+    return bridge.createAdapterFromManifest(manifest);
   }
-  return bridge;
+  throw new Error("Unsupported OpenClaw fake provider binding.");
 }
 
 export function resolveOpenClawCrablineChannel(input?: string | null): CrablineFakeProviderChannel {
@@ -86,30 +94,29 @@ export function resolveOpenClawCrablineChannelDriverSelection(params: {
 export async function probeOpenClawCrablineFakeProvider(
   manifest: CrablineFakeProviderManifest,
 ): Promise<unknown> {
-  return await getOpenClawCrablineProviderBridge(manifest).probe(manifest);
+  return await createOpenClawCrablineProviderAdapter(manifest).probe();
 }
 
 export function createOpenClawCrablineFakeProviderBinding(
   manifest: CrablineFakeProviderManifest,
 ): OpenClawCrablineGatewayBinding {
-  return getOpenClawCrablineProviderBridge(manifest).createBinding(manifest);
+  return createOpenClawCrablineProviderAdapter(manifest).createBinding();
 }
 
 export function createOpenClawCrablineAgentDelivery(params: {
   manifest: CrablineFakeProviderManifest;
   target: string;
 }): OpenClawCrablineAgentDelivery {
-  return getOpenClawCrablineProviderBridge(params.manifest).createAgentDelivery({
-    manifest: params.manifest,
-    parsed: parseQaTarget(params.target),
-  });
+  return createOpenClawCrablineProviderAdapter(params.manifest).createAgentDelivery(
+    parseQaTarget(params.target),
+  );
 }
 
 export function createOpenClawCrablineInbound(params: {
   input: OpenClawCrablineInboundInput;
   manifest: CrablineFakeProviderManifest;
 }): OpenClawCrablineInbound {
-  return getOpenClawCrablineProviderBridge(params.manifest).createInbound(params);
+  return createOpenClawCrablineProviderAdapter(params.manifest).createInbound(params.input);
 }
 
 export function createOpenClawCrablineOutboundFromRecorderEvent(params: {
@@ -117,7 +124,10 @@ export function createOpenClawCrablineOutboundFromRecorderEvent(params: {
   manifest: CrablineFakeProviderManifest;
   targetByProviderTarget: ReadonlyMap<string, string>;
 }): OpenClawCrablineOutboundMessage | null {
-  return getOpenClawCrablineProviderBridge(params.manifest).createOutboundFromRecorderEvent(params);
+  return createOpenClawCrablineProviderAdapter(params.manifest).createOutboundFromRecorderEvent({
+    event: params.event,
+    targetByProviderTarget: params.targetByProviderTarget,
+  });
 }
 
 export async function startOpenClawCrablineAdapter(
@@ -127,30 +137,22 @@ export async function startOpenClawCrablineAdapter(
     channel: params.channel,
     recorderPath: params.recorderPath,
   });
-  const binding = createOpenClawCrablineFakeProviderBinding(server.manifest);
+  const providerAdapter = createOpenClawCrablineProviderAdapter(server.manifest);
+  const binding = providerAdapter.createBinding();
   return {
     ...binding,
     close: server.close,
     createGatewayConfig: (openclawConfig = params.openclawConfig ?? {}) =>
       binding.createGatewayConfig(openclawConfig),
-    createAgentDelivery: ({ target }) =>
-      createOpenClawCrablineAgentDelivery({
-        manifest: server.manifest,
-        target,
-      }),
-    createInbound: ({ input }) =>
-      createOpenClawCrablineInbound({
-        input,
-        manifest: server.manifest,
-      }),
+    createAgentDelivery: ({ target }) => providerAdapter.createAgentDelivery(parseQaTarget(target)),
+    createInbound: ({ input }) => providerAdapter.createInbound(input),
     createOutboundFromRecorderEvent: ({ event, targetByProviderTarget }) =>
-      createOpenClawCrablineOutboundFromRecorderEvent({
+      providerAdapter.createOutboundFromRecorderEvent({
         event,
-        manifest: server.manifest,
         targetByProviderTarget,
       }),
     manifest: server.manifest,
-    probe: () => probeOpenClawCrablineFakeProvider(server.manifest),
+    probe: () => providerAdapter.probe(),
   };
 }
 

--- a/src/openclaw/bridges/telegram.ts
+++ b/src/openclaw/bridges/telegram.ts
@@ -1,27 +1,16 @@
-import type { CrablineFakeProviderManifest } from "../../fake-servers/index.js";
-import type { TelegramFakeServerManifest } from "../../fake-servers/telegram.js";
 import {
   createAdminInboundRequest,
+  createOpenClawCrablineProviderBridge,
   DEFAULT_ACCOUNT_ID,
   isRecord,
   qaTargetForInbound,
   readInteger,
   readString,
-  type OpenClawCrablineProviderBridge,
 } from "../shared.js";
 
 const TELEGRAM_DIRECT_CHAT_ID = "100001";
 const TELEGRAM_GROUP_CHAT_ID = "-1001234567890";
 const TELEGRAM_DEFAULT_SENDER_ID = 100001;
-
-function requireTelegramManifest(
-  manifest: CrablineFakeProviderManifest,
-): TelegramFakeServerManifest {
-  if (manifest.provider !== "telegram") {
-    throw new Error(`Unsupported OpenClaw fake provider binding: ${String(manifest.provider)}`);
-  }
-  return manifest;
-}
 
 function normalizeTelegramChatId(kind: "direct" | "group", id: string) {
   return /^-?\d+$/u.test(id.trim())
@@ -35,126 +24,128 @@ function telegramTargetKey(chatId: string, threadId?: number) {
   return threadId === undefined ? chatId : `${chatId}:topic:${threadId}`;
 }
 
-export const TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE: OpenClawCrablineProviderBridge = {
-  async probe(manifest) {
-    const telegram = requireTelegramManifest(manifest);
-    const response = await fetch(`${telegram.endpoints.apiRoot}/bot${telegram.botToken}/getMe`);
-    if (!response.ok) {
-      throw new Error(`Crabline Telegram getMe probe failed with HTTP ${response.status}.`);
-    }
-    return await response.json();
-  },
-  createBinding(manifest) {
-    const telegram = requireTelegramManifest(manifest);
+export const TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablineProviderBridge({
+  provider: "telegram",
+  createAdapter(telegram) {
     return {
-      accountId: DEFAULT_ACCOUNT_ID,
-      channel: "telegram",
-      createChannelDriverSmokeEnv: (env) => ({
-        ...env,
-        TELEGRAM_BOT_TOKEN: telegram.botToken,
-      }),
-      createGatewayConfig: (openclawConfig = {}) => {
-        const channels = isRecord(openclawConfig.channels) ? openclawConfig.channels : {};
-        const telegramConfig = isRecord(channels.telegram) ? channels.telegram : {};
-        const groups = isRecord(telegramConfig.groups) ? telegramConfig.groups : {};
-        const defaultGroup = isRecord(groups["*"]) ? groups["*"] : {};
-        const messages = isRecord(openclawConfig.messages) ? openclawConfig.messages : {};
-        const groupChat = isRecord(messages.groupChat) ? messages.groupChat : {};
-
+      async probe() {
+        const response = await fetch(`${telegram.endpoints.apiRoot}/bot${telegram.botToken}/getMe`);
+        if (!response.ok) {
+          throw new Error(`Crabline Telegram getMe probe failed with HTTP ${response.status}.`);
+        }
+        return await response.json();
+      },
+      createBinding() {
         return {
-          ...openclawConfig,
-          channels: {
-            ...channels,
-            telegram: {
-              ...telegramConfig,
-              enabled: true,
-              botToken: telegram.botToken,
-              apiRoot: telegram.endpoints.apiRoot,
-              dmPolicy: "open",
-              groupPolicy: "open",
-              allowFrom: ["*"],
-              groupAllowFrom: ["*"],
-              groups: {
-                ...groups,
-                "*": {
-                  ...defaultGroup,
-                  requireMention: false,
+          accountId: DEFAULT_ACCOUNT_ID,
+          channel: "telegram",
+          createChannelDriverSmokeEnv: (env) => ({
+            ...env,
+            TELEGRAM_BOT_TOKEN: telegram.botToken,
+          }),
+          createGatewayConfig: (openclawConfig = {}) => {
+            const channels = isRecord(openclawConfig.channels) ? openclawConfig.channels : {};
+            const telegramConfig = isRecord(channels.telegram) ? channels.telegram : {};
+            const groups = isRecord(telegramConfig.groups) ? telegramConfig.groups : {};
+            const defaultGroup = isRecord(groups["*"]) ? groups["*"] : {};
+            const messages = isRecord(openclawConfig.messages) ? openclawConfig.messages : {};
+            const groupChat = isRecord(messages.groupChat) ? messages.groupChat : {};
+
+            return {
+              ...openclawConfig,
+              channels: {
+                ...channels,
+                telegram: {
+                  ...telegramConfig,
+                  enabled: true,
+                  botToken: telegram.botToken,
+                  apiRoot: telegram.endpoints.apiRoot,
+                  dmPolicy: "open",
+                  groupPolicy: "open",
+                  allowFrom: ["*"],
+                  groupAllowFrom: ["*"],
+                  groups: {
+                    ...groups,
+                    "*": {
+                      ...defaultGroup,
+                      requireMention: false,
+                    },
+                  },
                 },
               },
-            },
+              messages: {
+                ...messages,
+                groupChat: {
+                  ...groupChat,
+                  mentionPatterns: ["\\b@?openclaw\\b"],
+                  visibleReplies: "automatic",
+                },
+              },
+            };
           },
-          messages: {
-            ...messages,
-            groupChat: {
-              ...groupChat,
-              mentionPatterns: ["\\b@?openclaw\\b"],
-              visibleReplies: "automatic",
-            },
-          },
+          requiredPluginIds: ["telegram"],
         };
       },
-      requiredPluginIds: ["telegram"],
-    };
-  },
-  createAgentDelivery({ manifest, parsed }) {
-    requireTelegramManifest(manifest);
-    const chatId = normalizeTelegramChatId(parsed.kind, parsed.id);
-    const threadId = readInteger(parsed.threadId);
-    const to = telegramTargetKey(chatId, threadId);
-    return {
-      channel: "telegram",
-      to,
-      replyChannel: "telegram",
-      replyTo: to,
-    };
-  },
-  createInbound({ input, manifest }) {
-    const telegram = requireTelegramManifest(manifest);
-    const kind = input.conversation.kind === "direct" ? "direct" : "group";
-    const chatId = normalizeTelegramChatId(kind, input.conversation.id);
-    const threadId = readInteger(input.threadId);
-    return {
-      ...createAdminInboundRequest(telegram),
-      providerBody: {
-        chatId,
-        fromId: readInteger(input.senderId) ?? TELEGRAM_DEFAULT_SENDER_ID,
-        fromName: input.senderName ?? input.senderId,
-        ...(threadId !== undefined ? { messageThreadId: threadId } : {}),
-        text: input.text,
+      createAgentDelivery(parsed) {
+        const chatId = normalizeTelegramChatId(parsed.kind, parsed.id);
+        const threadId = readInteger(parsed.threadId);
+        const to = telegramTargetKey(chatId, threadId);
+        return {
+          channel: "telegram",
+          to,
+          replyChannel: "telegram",
+          replyTo: to,
+        };
       },
-      providerTargetKey: telegramTargetKey(chatId, threadId),
-      qaTarget: qaTargetForInbound(input),
-      stateConversation: {
-        id: chatId,
-        kind: kind === "group" ? "group" : "direct",
+      createInbound(input) {
+        const kind = input.conversation.kind === "direct" ? "direct" : "group";
+        const chatId = normalizeTelegramChatId(kind, input.conversation.id);
+        const threadId = readInteger(input.threadId);
+        return {
+          ...createAdminInboundRequest(telegram),
+          providerBody: {
+            chatId,
+            fromId: readInteger(input.senderId) ?? TELEGRAM_DEFAULT_SENDER_ID,
+            fromName: input.senderName ?? input.senderId,
+            ...(threadId !== undefined ? { messageThreadId: threadId } : {}),
+            text: input.text,
+          },
+          providerTargetKey: telegramTargetKey(chatId, threadId),
+          qaTarget: qaTargetForInbound(input),
+          stateConversation: {
+            id: chatId,
+            kind: kind === "group" ? "group" : "direct",
+          },
+          ...(threadId !== undefined ? { threadId: String(threadId) } : {}),
+        };
       },
-      ...(threadId !== undefined ? { threadId: String(threadId) } : {}),
+      createOutboundFromRecorderEvent({ event, targetByProviderTarget }) {
+        if (!isRecord(event) || event.type !== "api" || typeof event.path !== "string") {
+          return null;
+        }
+        if (!event.path.endsWith("/sendMessage") || !isRecord(event.body)) {
+          return null;
+        }
+        const chatId = readString(event.body.chat_id);
+        const text =
+          typeof event.body.text === "string" && event.body.text.trim()
+            ? event.body.text
+            : undefined;
+        if (!chatId || !text) {
+          return null;
+        }
+        const threadId = readInteger(event.body.message_thread_id);
+        const providerTargetKey = telegramTargetKey(chatId, threadId);
+        return {
+          accountId: DEFAULT_ACCOUNT_ID,
+          senderId: "openclaw",
+          senderName: "OpenClaw QA",
+          text,
+          to:
+            targetByProviderTarget.get(providerTargetKey) ??
+            (threadId === undefined ? chatId : providerTargetKey),
+        };
+      },
     };
   },
-  createOutboundFromRecorderEvent({ event, manifest, targetByProviderTarget }) {
-    requireTelegramManifest(manifest);
-    if (!isRecord(event) || event.type !== "api" || typeof event.path !== "string") {
-      return null;
-    }
-    if (!event.path.endsWith("/sendMessage") || !isRecord(event.body)) {
-      return null;
-    }
-    const chatId = readString(event.body.chat_id);
-    const text =
-      typeof event.body.text === "string" && event.body.text.trim() ? event.body.text : undefined;
-    if (!chatId || !text) {
-      return null;
-    }
-    const threadId = readInteger(event.body.message_thread_id);
-    const providerTargetKey = telegramTargetKey(chatId, threadId);
-    return {
-      accountId: DEFAULT_ACCOUNT_ID,
-      senderId: "openclaw",
-      senderName: "OpenClaw QA",
-      text,
-      to:
-        targetByProviderTarget.get(providerTargetKey) ??
-        (threadId === undefined ? chatId : providerTargetKey),
-    };
-  },
-};
+});

--- a/src/openclaw/bridges/telegram.ts
+++ b/src/openclaw/bridges/telegram.ts
@@ -1,0 +1,160 @@
+import type { CrablineFakeProviderManifest } from "../../fake-servers/index.js";
+import type { TelegramFakeServerManifest } from "../../fake-servers/telegram.js";
+import {
+  createAdminInboundRequest,
+  DEFAULT_ACCOUNT_ID,
+  isRecord,
+  qaTargetForInbound,
+  readInteger,
+  readString,
+  type OpenClawCrablineProviderBridge,
+} from "../shared.js";
+
+const TELEGRAM_DIRECT_CHAT_ID = "100001";
+const TELEGRAM_GROUP_CHAT_ID = "-1001234567890";
+const TELEGRAM_DEFAULT_SENDER_ID = 100001;
+
+function requireTelegramManifest(
+  manifest: CrablineFakeProviderManifest,
+): TelegramFakeServerManifest {
+  if (manifest.provider !== "telegram") {
+    throw new Error(`Unsupported OpenClaw fake provider binding: ${String(manifest.provider)}`);
+  }
+  return manifest;
+}
+
+function normalizeTelegramChatId(kind: "direct" | "group", id: string) {
+  return /^-?\d+$/u.test(id.trim())
+    ? id.trim()
+    : kind === "group"
+      ? TELEGRAM_GROUP_CHAT_ID
+      : TELEGRAM_DIRECT_CHAT_ID;
+}
+
+function telegramTargetKey(chatId: string, threadId?: number) {
+  return threadId === undefined ? chatId : `${chatId}:topic:${threadId}`;
+}
+
+export const TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE: OpenClawCrablineProviderBridge = {
+  async probe(manifest) {
+    const telegram = requireTelegramManifest(manifest);
+    const response = await fetch(`${telegram.endpoints.apiRoot}/bot${telegram.botToken}/getMe`);
+    if (!response.ok) {
+      throw new Error(`Crabline Telegram getMe probe failed with HTTP ${response.status}.`);
+    }
+    return await response.json();
+  },
+  createBinding(manifest) {
+    const telegram = requireTelegramManifest(manifest);
+    return {
+      accountId: DEFAULT_ACCOUNT_ID,
+      channel: "telegram",
+      createChannelDriverSmokeEnv: (env) => ({
+        ...env,
+        TELEGRAM_BOT_TOKEN: telegram.botToken,
+      }),
+      createGatewayConfig: (openclawConfig = {}) => {
+        const channels = isRecord(openclawConfig.channels) ? openclawConfig.channels : {};
+        const telegramConfig = isRecord(channels.telegram) ? channels.telegram : {};
+        const groups = isRecord(telegramConfig.groups) ? telegramConfig.groups : {};
+        const defaultGroup = isRecord(groups["*"]) ? groups["*"] : {};
+        const messages = isRecord(openclawConfig.messages) ? openclawConfig.messages : {};
+        const groupChat = isRecord(messages.groupChat) ? messages.groupChat : {};
+
+        return {
+          ...openclawConfig,
+          channels: {
+            ...channels,
+            telegram: {
+              ...telegramConfig,
+              enabled: true,
+              botToken: telegram.botToken,
+              apiRoot: telegram.endpoints.apiRoot,
+              dmPolicy: "open",
+              groupPolicy: "open",
+              allowFrom: ["*"],
+              groupAllowFrom: ["*"],
+              groups: {
+                ...groups,
+                "*": {
+                  ...defaultGroup,
+                  requireMention: false,
+                },
+              },
+            },
+          },
+          messages: {
+            ...messages,
+            groupChat: {
+              ...groupChat,
+              mentionPatterns: ["\\b@?openclaw\\b"],
+              visibleReplies: "automatic",
+            },
+          },
+        };
+      },
+      requiredPluginIds: ["telegram"],
+    };
+  },
+  createAgentDelivery({ manifest, parsed }) {
+    requireTelegramManifest(manifest);
+    const chatId = normalizeTelegramChatId(parsed.kind, parsed.id);
+    const threadId = readInteger(parsed.threadId);
+    const to = telegramTargetKey(chatId, threadId);
+    return {
+      channel: "telegram",
+      to,
+      replyChannel: "telegram",
+      replyTo: to,
+    };
+  },
+  createInbound({ input, manifest }) {
+    const telegram = requireTelegramManifest(manifest);
+    const kind = input.conversation.kind === "direct" ? "direct" : "group";
+    const chatId = normalizeTelegramChatId(kind, input.conversation.id);
+    const threadId = readInteger(input.threadId);
+    return {
+      ...createAdminInboundRequest(telegram),
+      providerBody: {
+        chatId,
+        fromId: readInteger(input.senderId) ?? TELEGRAM_DEFAULT_SENDER_ID,
+        fromName: input.senderName ?? input.senderId,
+        ...(threadId !== undefined ? { messageThreadId: threadId } : {}),
+        text: input.text,
+      },
+      providerTargetKey: telegramTargetKey(chatId, threadId),
+      qaTarget: qaTargetForInbound(input),
+      stateConversation: {
+        id: chatId,
+        kind: kind === "group" ? "group" : "direct",
+      },
+      ...(threadId !== undefined ? { threadId: String(threadId) } : {}),
+    };
+  },
+  createOutboundFromRecorderEvent({ event, manifest, targetByProviderTarget }) {
+    requireTelegramManifest(manifest);
+    if (!isRecord(event) || event.type !== "api" || typeof event.path !== "string") {
+      return null;
+    }
+    if (!event.path.endsWith("/sendMessage") || !isRecord(event.body)) {
+      return null;
+    }
+    const chatId = readString(event.body.chat_id);
+    const text =
+      typeof event.body.text === "string" && event.body.text.trim() ? event.body.text : undefined;
+    if (!chatId || !text) {
+      return null;
+    }
+    const threadId = readInteger(event.body.message_thread_id);
+    const providerTargetKey = telegramTargetKey(chatId, threadId);
+    return {
+      accountId: DEFAULT_ACCOUNT_ID,
+      senderId: "openclaw",
+      senderName: "OpenClaw QA",
+      text,
+      to:
+        targetByProviderTarget.get(providerTargetKey) ??
+        (threadId === undefined ? chatId : providerTargetKey),
+    };
+  },
+};

--- a/src/openclaw/bridges/whatsapp.ts
+++ b/src/openclaw/bridges/whatsapp.ts
@@ -1,25 +1,14 @@
-import type { CrablineFakeProviderManifest } from "../../fake-servers/index.js";
-import type { WhatsAppFakeServerManifest } from "../../fake-servers/whatsapp.js";
 import {
   createAdminInboundRequest,
+  createOpenClawCrablineProviderBridge,
   DEFAULT_ACCOUNT_ID,
   isRecord,
   qaTargetForInbound,
   readString,
-  type OpenClawCrablineProviderBridge,
 } from "../shared.js";
 
 const WHATSAPP_JID_RE =
   /^(?:\d{7,15}(?::\d+)?@s\.whatsapp\.net|\d{7,15}@c\.us|\d{5,}@g\.us|\d{7,15}@lid)$/iu;
-
-function requireWhatsAppManifest(
-  manifest: CrablineFakeProviderManifest,
-): WhatsAppFakeServerManifest {
-  if (manifest.provider !== "whatsapp") {
-    throw new Error(`Unsupported OpenClaw fake provider binding: ${String(manifest.provider)}`);
-  }
-  return manifest;
-}
 
 function requireWhatsAppJid(value: string, label: string): string {
   const trimmed = value.trim();
@@ -29,108 +18,108 @@ function requireWhatsAppJid(value: string, label: string): string {
   return trimmed;
 }
 
-export const WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE: OpenClawCrablineProviderBridge = {
-  async probe(manifest) {
-    const whatsapp = requireWhatsAppManifest(manifest);
-    const response = await fetch(`${whatsapp.endpoints.apiRoot}/health`);
-    if (!response.ok) {
-      throw new Error(`Crabline WhatsApp health probe failed with HTTP ${response.status}.`);
-    }
-    return await response.json();
-  },
-  createBinding(manifest) {
-    const whatsapp = requireWhatsAppManifest(manifest);
+export const WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablineProviderBridge({
+  provider: "whatsapp",
+  createAdapter(whatsapp) {
     return {
-      accountId: DEFAULT_ACCOUNT_ID,
-      channel: "whatsapp",
-      createChannelDriverSmokeEnv: (env) => ({
-        ...env,
-        CRABLINE_WHATSAPP_ADMIN_TOKEN: whatsapp.adminToken,
-        CRABLINE_WHATSAPP_ACCESS_TOKEN: whatsapp.accessToken,
-        CRABLINE_WHATSAPP_API_ROOT: whatsapp.endpoints.apiRoot,
-        CRABLINE_WHATSAPP_SELF_JID: whatsapp.selfJid,
-      }),
-      createGatewayConfig: (openclawConfig = {}) => {
-        const channels = isRecord(openclawConfig.channels) ? openclawConfig.channels : {};
-        const whatsappConfig = isRecord(channels.whatsapp) ? channels.whatsapp : {};
-        const groups = isRecord(whatsappConfig.groups) ? whatsappConfig.groups : {};
-        const defaultGroup = isRecord(groups["*"]) ? groups["*"] : {};
-
+      async probe() {
+        const response = await fetch(`${whatsapp.endpoints.apiRoot}/health`);
+        if (!response.ok) {
+          throw new Error(`Crabline WhatsApp health probe failed with HTTP ${response.status}.`);
+        }
+        return await response.json();
+      },
+      createBinding() {
         return {
-          ...openclawConfig,
-          channels: {
-            ...channels,
-            whatsapp: {
-              ...whatsappConfig,
-              enabled: true,
-              dmPolicy: "open",
-              groupPolicy: "open",
-              allowFrom: ["*"],
-              groupAllowFrom: ["*"],
-              groups: {
-                ...groups,
-                "*": {
-                  ...defaultGroup,
-                  requireMention: false,
+          accountId: DEFAULT_ACCOUNT_ID,
+          channel: "whatsapp",
+          createChannelDriverSmokeEnv: (env) => ({
+            ...env,
+            CRABLINE_WHATSAPP_ADMIN_TOKEN: whatsapp.adminToken,
+            CRABLINE_WHATSAPP_ACCESS_TOKEN: whatsapp.accessToken,
+            CRABLINE_WHATSAPP_API_ROOT: whatsapp.endpoints.apiRoot,
+            CRABLINE_WHATSAPP_SELF_JID: whatsapp.selfJid,
+          }),
+          createGatewayConfig: (openclawConfig = {}) => {
+            const channels = isRecord(openclawConfig.channels) ? openclawConfig.channels : {};
+            const whatsappConfig = isRecord(channels.whatsapp) ? channels.whatsapp : {};
+            const groups = isRecord(whatsappConfig.groups) ? whatsappConfig.groups : {};
+            const defaultGroup = isRecord(groups["*"]) ? groups["*"] : {};
+
+            return {
+              ...openclawConfig,
+              channels: {
+                ...channels,
+                whatsapp: {
+                  ...whatsappConfig,
+                  enabled: true,
+                  dmPolicy: "open",
+                  groupPolicy: "open",
+                  allowFrom: ["*"],
+                  groupAllowFrom: ["*"],
+                  groups: {
+                    ...groups,
+                    "*": {
+                      ...defaultGroup,
+                      requireMention: false,
+                    },
+                  },
                 },
               },
-            },
+            };
+          },
+          requiredPluginIds: ["whatsapp"],
+        };
+      },
+      createAgentDelivery(parsed) {
+        const to = requireWhatsAppJid(parsed.id, "WhatsApp target");
+        return {
+          channel: "whatsapp",
+          to,
+          replyChannel: "whatsapp",
+          replyTo: to,
+        };
+      },
+      createInbound(input) {
+        const chatJid = requireWhatsAppJid(input.conversation.id, "WhatsApp conversation");
+        const senderJid = requireWhatsAppJid(input.senderId, "WhatsApp sender");
+        return {
+          ...createAdminInboundRequest(whatsapp),
+          providerBody: {
+            chatJid,
+            senderJid,
+            ...(input.senderName ? { pushName: input.senderName } : {}),
+            text: input.text,
+          },
+          providerTargetKey: chatJid,
+          qaTarget: qaTargetForInbound(input),
+          stateConversation: {
+            id: chatJid,
+            kind: chatJid.endsWith("@g.us") ? "group" : "direct",
           },
         };
       },
-      requiredPluginIds: ["whatsapp"],
-    };
-  },
-  createAgentDelivery({ manifest, parsed }) {
-    requireWhatsAppManifest(manifest);
-    const to = requireWhatsAppJid(parsed.id, "WhatsApp target");
-    return {
-      channel: "whatsapp",
-      to,
-      replyChannel: "whatsapp",
-      replyTo: to,
-    };
-  },
-  createInbound({ input, manifest }) {
-    const whatsapp = requireWhatsAppManifest(manifest);
-    const chatJid = requireWhatsAppJid(input.conversation.id, "WhatsApp conversation");
-    const senderJid = requireWhatsAppJid(input.senderId, "WhatsApp sender");
-    return {
-      ...createAdminInboundRequest(whatsapp),
-      providerBody: {
-        chatJid,
-        senderJid,
-        ...(input.senderName ? { pushName: input.senderName } : {}),
-        text: input.text,
-      },
-      providerTargetKey: chatJid,
-      qaTarget: qaTargetForInbound(input),
-      stateConversation: {
-        id: chatJid,
-        kind: chatJid.endsWith("@g.us") ? "group" : "direct",
+      createOutboundFromRecorderEvent({ event, targetByProviderTarget }) {
+        if (!isRecord(event) || event.type !== "api" || typeof event.path !== "string") {
+          return null;
+        }
+        if (!event.path.endsWith("/crabline/whatsapp/messages") || !isRecord(event.body)) {
+          return null;
+        }
+        const to = readString(event.body.to ?? event.body.jid);
+        const textPayload = event.body.text;
+        const text = isRecord(textPayload) ? readString(textPayload.body) : readString(textPayload);
+        if (!to || !text) {
+          return null;
+        }
+        return {
+          accountId: DEFAULT_ACCOUNT_ID,
+          senderId: "openclaw",
+          senderName: "OpenClaw QA",
+          text,
+          to: targetByProviderTarget.get(to) ?? to,
+        };
       },
     };
   },
-  createOutboundFromRecorderEvent({ event, manifest, targetByProviderTarget }) {
-    requireWhatsAppManifest(manifest);
-    if (!isRecord(event) || event.type !== "api" || typeof event.path !== "string") {
-      return null;
-    }
-    if (!event.path.endsWith("/crabline/whatsapp/messages") || !isRecord(event.body)) {
-      return null;
-    }
-    const to = readString(event.body.to ?? event.body.jid);
-    const textPayload = event.body.text;
-    const text = isRecord(textPayload) ? readString(textPayload.body) : readString(textPayload);
-    if (!to || !text) {
-      return null;
-    }
-    return {
-      accountId: DEFAULT_ACCOUNT_ID,
-      senderId: "openclaw",
-      senderName: "OpenClaw QA",
-      text,
-      to: targetByProviderTarget.get(to) ?? to,
-    };
-  },
-};
+});

--- a/src/openclaw/bridges/whatsapp.ts
+++ b/src/openclaw/bridges/whatsapp.ts
@@ -1,0 +1,136 @@
+import type { CrablineFakeProviderManifest } from "../../fake-servers/index.js";
+import type { WhatsAppFakeServerManifest } from "../../fake-servers/whatsapp.js";
+import {
+  createAdminInboundRequest,
+  DEFAULT_ACCOUNT_ID,
+  isRecord,
+  qaTargetForInbound,
+  readString,
+  type OpenClawCrablineProviderBridge,
+} from "../shared.js";
+
+const WHATSAPP_JID_RE =
+  /^(?:\d{7,15}(?::\d+)?@s\.whatsapp\.net|\d{7,15}@c\.us|\d{5,}@g\.us|\d{7,15}@lid)$/iu;
+
+function requireWhatsAppManifest(
+  manifest: CrablineFakeProviderManifest,
+): WhatsAppFakeServerManifest {
+  if (manifest.provider !== "whatsapp") {
+    throw new Error(`Unsupported OpenClaw fake provider binding: ${String(manifest.provider)}`);
+  }
+  return manifest;
+}
+
+function requireWhatsAppJid(value: string, label: string): string {
+  const trimmed = value.trim();
+  if (!WHATSAPP_JID_RE.test(trimmed)) {
+    throw new Error(`${label} must be a native WhatsApp JID.`);
+  }
+  return trimmed;
+}
+
+export const WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE: OpenClawCrablineProviderBridge = {
+  async probe(manifest) {
+    const whatsapp = requireWhatsAppManifest(manifest);
+    const response = await fetch(`${whatsapp.endpoints.apiRoot}/health`);
+    if (!response.ok) {
+      throw new Error(`Crabline WhatsApp health probe failed with HTTP ${response.status}.`);
+    }
+    return await response.json();
+  },
+  createBinding(manifest) {
+    const whatsapp = requireWhatsAppManifest(manifest);
+    return {
+      accountId: DEFAULT_ACCOUNT_ID,
+      channel: "whatsapp",
+      createChannelDriverSmokeEnv: (env) => ({
+        ...env,
+        CRABLINE_WHATSAPP_ADMIN_TOKEN: whatsapp.adminToken,
+        CRABLINE_WHATSAPP_ACCESS_TOKEN: whatsapp.accessToken,
+        CRABLINE_WHATSAPP_API_ROOT: whatsapp.endpoints.apiRoot,
+        CRABLINE_WHATSAPP_SELF_JID: whatsapp.selfJid,
+      }),
+      createGatewayConfig: (openclawConfig = {}) => {
+        const channels = isRecord(openclawConfig.channels) ? openclawConfig.channels : {};
+        const whatsappConfig = isRecord(channels.whatsapp) ? channels.whatsapp : {};
+        const groups = isRecord(whatsappConfig.groups) ? whatsappConfig.groups : {};
+        const defaultGroup = isRecord(groups["*"]) ? groups["*"] : {};
+
+        return {
+          ...openclawConfig,
+          channels: {
+            ...channels,
+            whatsapp: {
+              ...whatsappConfig,
+              enabled: true,
+              dmPolicy: "open",
+              groupPolicy: "open",
+              allowFrom: ["*"],
+              groupAllowFrom: ["*"],
+              groups: {
+                ...groups,
+                "*": {
+                  ...defaultGroup,
+                  requireMention: false,
+                },
+              },
+            },
+          },
+        };
+      },
+      requiredPluginIds: ["whatsapp"],
+    };
+  },
+  createAgentDelivery({ manifest, parsed }) {
+    requireWhatsAppManifest(manifest);
+    const to = requireWhatsAppJid(parsed.id, "WhatsApp target");
+    return {
+      channel: "whatsapp",
+      to,
+      replyChannel: "whatsapp",
+      replyTo: to,
+    };
+  },
+  createInbound({ input, manifest }) {
+    const whatsapp = requireWhatsAppManifest(manifest);
+    const chatJid = requireWhatsAppJid(input.conversation.id, "WhatsApp conversation");
+    const senderJid = requireWhatsAppJid(input.senderId, "WhatsApp sender");
+    return {
+      ...createAdminInboundRequest(whatsapp),
+      providerBody: {
+        chatJid,
+        senderJid,
+        ...(input.senderName ? { pushName: input.senderName } : {}),
+        text: input.text,
+      },
+      providerTargetKey: chatJid,
+      qaTarget: qaTargetForInbound(input),
+      stateConversation: {
+        id: chatJid,
+        kind: chatJid.endsWith("@g.us") ? "group" : "direct",
+      },
+    };
+  },
+  createOutboundFromRecorderEvent({ event, manifest, targetByProviderTarget }) {
+    requireWhatsAppManifest(manifest);
+    if (!isRecord(event) || event.type !== "api" || typeof event.path !== "string") {
+      return null;
+    }
+    if (!event.path.endsWith("/crabline/whatsapp/messages") || !isRecord(event.body)) {
+      return null;
+    }
+    const to = readString(event.body.to ?? event.body.jid);
+    const textPayload = event.body.text;
+    const text = isRecord(textPayload) ? readString(textPayload.body) : readString(textPayload);
+    if (!to || !text) {
+      return null;
+    }
+    return {
+      accountId: DEFAULT_ACCOUNT_ID,
+      senderId: "openclaw",
+      senderName: "OpenClaw QA",
+      text,
+      to: targetByProviderTarget.get(to) ?? to,
+    };
+  },
+};

--- a/src/openclaw/shared.ts
+++ b/src/openclaw/shared.ts
@@ -1,0 +1,181 @@
+import { ADMIN_TOKEN_HEADER } from "../fake-servers/http.js";
+import type {
+  CrablineFakeProviderChannel,
+  CrablineFakeProviderManifest,
+} from "../fake-servers/index.js";
+
+export const DEFAULT_ACCOUNT_ID = "default";
+export const OPENCLAW_CRABLINE_CHANNEL_CAPABILITY_MATRIX_PATH =
+  "crabline-fake-provider-capabilities.json";
+export const OPENCLAW_CRABLINE_CHANNEL_SMOKE_PATH = "crabline-fake-provider-smoke.json";
+export const OPENCLAW_CRABLINE_MANIFEST_PATH = "crabline-fake-provider-server.json";
+export const OPENCLAW_CRABLINE_DEFAULT_CHANNEL = "telegram";
+
+export type OpenClawCrablineChannelDriverSelection = {
+  channel: CrablineFakeProviderChannel;
+  channelDriver: "crabline";
+  capabilityMatrixPath: typeof OPENCLAW_CRABLINE_CHANNEL_CAPABILITY_MATRIX_PATH;
+  smokeArtifactPath: typeof OPENCLAW_CRABLINE_CHANNEL_SMOKE_PATH;
+};
+
+export type OpenClawCrablineChannelDriverSmokeResult = {
+  capabilityReport: unknown;
+  manifestPath: string;
+  smoke: unknown;
+};
+
+export type OpenClawCrablineConversation = {
+  id: string;
+  kind: "direct" | "group";
+};
+
+export type OpenClawCrablineGatewayBinding = {
+  accountId: string;
+  channel: string;
+  createChannelDriverSmokeEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv;
+  createGatewayConfig(openclawConfig?: Record<string, unknown>): Record<string, unknown>;
+  requiredPluginIds: string[];
+};
+
+export type OpenClawCrablineAgentDelivery = {
+  channel: string;
+  replyChannel: string;
+  replyTo: string;
+  to: string;
+};
+
+export type OpenClawCrablineInboundInput = {
+  conversation: {
+    id: string;
+    kind: string;
+  };
+  senderId: string;
+  senderName?: string | undefined;
+  text: string;
+  threadId?: string | undefined;
+};
+
+export type OpenClawCrablineInbound = {
+  providerBody: Record<string, unknown>;
+  providerHeaders: Record<string, string>;
+  providerTargetKey: string;
+  providerUrl: string;
+  qaTarget: string;
+  stateConversation: OpenClawCrablineConversation;
+  threadId?: string | undefined;
+};
+
+export type OpenClawCrablineOutboundMessage = {
+  accountId: string;
+  senderId: string;
+  senderName: string;
+  text: string;
+  to: string;
+};
+
+export type StartOpenClawCrablineAdapterParams = {
+  channel: CrablineFakeProviderChannel;
+  openclawConfig?: Record<string, unknown> | undefined;
+  recorderPath?: string | undefined;
+};
+
+export type StartedOpenClawCrablineAdapter = OpenClawCrablineGatewayBinding & {
+  close(): Promise<void>;
+  createAgentDelivery(params: { target: string }): OpenClawCrablineAgentDelivery;
+  createInbound(params: { input: OpenClawCrablineInboundInput }): OpenClawCrablineInbound;
+  createOutboundFromRecorderEvent(params: {
+    event: unknown;
+    targetByProviderTarget: ReadonlyMap<string, string>;
+  }): OpenClawCrablineOutboundMessage | null;
+  manifest: CrablineFakeProviderManifest;
+  probe(): Promise<unknown>;
+};
+
+export type ParsedQaTarget = {
+  kind: "direct" | "group";
+  id: string;
+  threadId?: string;
+};
+
+export type OpenClawCrablineProviderBridge = {
+  createAgentDelivery(params: {
+    manifest: CrablineFakeProviderManifest;
+    parsed: ParsedQaTarget;
+  }): OpenClawCrablineAgentDelivery;
+  createBinding(manifest: CrablineFakeProviderManifest): OpenClawCrablineGatewayBinding;
+  createInbound(params: {
+    input: OpenClawCrablineInboundInput;
+    manifest: CrablineFakeProviderManifest;
+  }): OpenClawCrablineInbound;
+  createOutboundFromRecorderEvent(params: {
+    event: unknown;
+    manifest: CrablineFakeProviderManifest;
+    targetByProviderTarget: ReadonlyMap<string, string>;
+  }): OpenClawCrablineOutboundMessage | null;
+  probe(manifest: CrablineFakeProviderManifest): Promise<unknown>;
+};
+
+export function readString(value: unknown): string | undefined {
+  if (typeof value === "string" && value.trim()) {
+    return value.trim();
+  }
+  if (typeof value === "number" || typeof value === "bigint") {
+    return String(value);
+  }
+  return undefined;
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function readInteger(value: unknown): number | undefined {
+  const stringValue = readString(value);
+  if (!stringValue || !/^-?\d+$/u.test(stringValue)) {
+    return undefined;
+  }
+  return Number(stringValue);
+}
+
+export function parseQaTarget(target: string): ParsedQaTarget {
+  const trimmed = target.trim();
+  if (trimmed.startsWith("thread:")) {
+    const rest = trimmed.slice("thread:".length);
+    const slash = rest.indexOf("/");
+    if (slash > 0) {
+      return { kind: "group", id: rest.slice(0, slash), threadId: rest.slice(slash + 1) };
+    }
+  }
+  if (trimmed.startsWith("channel:")) {
+    return { kind: "group", id: trimmed.slice("channel:".length) };
+  }
+  if (trimmed.startsWith("group:")) {
+    return { kind: "group", id: trimmed.slice("group:".length) };
+  }
+  if (trimmed.startsWith("dm:")) {
+    return { kind: "direct", id: trimmed.slice("dm:".length) };
+  }
+  return { kind: "direct", id: trimmed };
+}
+
+export function qaTargetForInbound(input: OpenClawCrablineInboundInput) {
+  const prefix =
+    input.conversation.kind === "direct"
+      ? "dm"
+      : input.conversation.kind === "channel"
+        ? "channel"
+        : "group";
+  return input.threadId
+    ? `thread:${input.conversation.id}/${input.threadId}`
+    : `${prefix}:${input.conversation.id}`;
+}
+
+export function createAdminInboundRequest(manifest: CrablineFakeProviderManifest) {
+  return {
+    providerHeaders: {
+      "content-type": "application/json",
+      [ADMIN_TOKEN_HEADER]: manifest.adminToken,
+    },
+    providerUrl: manifest.endpoints.adminInboundUrl,
+  };
+}

--- a/src/openclaw/shared.ts
+++ b/src/openclaw/shared.ts
@@ -97,23 +97,56 @@ export type ParsedQaTarget = {
   threadId?: string;
 };
 
-export type OpenClawCrablineProviderBridge = {
-  createAgentDelivery(params: {
-    manifest: CrablineFakeProviderManifest;
-    parsed: ParsedQaTarget;
-  }): OpenClawCrablineAgentDelivery;
-  createBinding(manifest: CrablineFakeProviderManifest): OpenClawCrablineGatewayBinding;
-  createInbound(params: {
-    input: OpenClawCrablineInboundInput;
-    manifest: CrablineFakeProviderManifest;
-  }): OpenClawCrablineInbound;
+export type OpenClawCrablineProviderAdapter = {
+  createAgentDelivery(parsed: ParsedQaTarget): OpenClawCrablineAgentDelivery;
+  createBinding(): OpenClawCrablineGatewayBinding;
+  createInbound(input: OpenClawCrablineInboundInput): OpenClawCrablineInbound;
   createOutboundFromRecorderEvent(params: {
     event: unknown;
-    manifest: CrablineFakeProviderManifest;
     targetByProviderTarget: ReadonlyMap<string, string>;
   }): OpenClawCrablineOutboundMessage | null;
-  probe(manifest: CrablineFakeProviderManifest): Promise<unknown>;
+  probe(): Promise<unknown>;
 };
+
+export type OpenClawCrablineProviderBridge<
+  TManifest extends CrablineFakeProviderManifest = CrablineFakeProviderManifest,
+> = {
+  createAdapter(manifest: TManifest): OpenClawCrablineProviderAdapter;
+  createAdapterFromManifest(
+    manifest: CrablineFakeProviderManifest,
+  ): OpenClawCrablineProviderAdapter;
+  provider: TManifest["provider"];
+};
+
+export type OpenClawCrablineProviderBridgeRegistry = {
+  [Provider in CrablineFakeProviderManifest["provider"]]: OpenClawCrablineProviderBridge<
+    Extract<CrablineFakeProviderManifest, { provider: Provider }>
+  >;
+};
+
+export function createOpenClawCrablineProviderBridge<
+  TProvider extends CrablineFakeProviderManifest["provider"],
+>(params: {
+  createAdapter(
+    manifest: Extract<CrablineFakeProviderManifest, { provider: TProvider }>,
+  ): OpenClawCrablineProviderAdapter;
+  provider: TProvider;
+}): OpenClawCrablineProviderBridge<Extract<CrablineFakeProviderManifest, { provider: TProvider }>> {
+  type ProviderManifest = Extract<CrablineFakeProviderManifest, { provider: TProvider }>;
+  const bridge: OpenClawCrablineProviderBridge<ProviderManifest> = {
+    createAdapter: params.createAdapter,
+    createAdapterFromManifest(manifest) {
+      if (manifest.provider !== params.provider) {
+        throw new Error(
+          `Unsupported OpenClaw fake provider binding: expected ${params.provider}, got ${manifest.provider}.`,
+        );
+      }
+      return params.createAdapter(manifest as ProviderManifest);
+    },
+    provider: params.provider as ProviderManifest["provider"],
+  };
+  return bridge;
+}
 
 export function readString(value: unknown): string | undefined {
   if (typeof value === "string" && value.trim()) {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -238,6 +238,54 @@ describe("cli", () => {
     await expect(fs.readFile(readyFile, "utf8")).resolves.toContain('"provider": "telegram"');
   });
 
+  it("prints a fake WhatsApp server runtime manifest", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const readyFile = path.join(directory, ".crabline", "whatsapp-server.json");
+    const captured = captureWrites();
+
+    try {
+      expect(
+        await runCli([
+          "node",
+          "crabline",
+          "--json",
+          "serve",
+          "whatsapp",
+          "--once",
+          "--ready-file",
+          readyFile,
+          "--admin-token",
+          "test-whatsapp-admin-token",
+          "--access-token",
+          "test-whatsapp-access-token",
+          "--recorder",
+          path.join(directory, "whatsapp.jsonl"),
+        ]),
+      ).toBe(0);
+    } finally {
+      captured.restore();
+    }
+
+    const manifest = JSON.parse(captured.stdout.join("")) as {
+      accessToken?: string;
+      adminToken?: string;
+      endpoints?: { adminInboundUrl?: string; apiRoot?: string; messagesUrl?: string };
+      provider?: string;
+    };
+    expect(manifest.provider).toBe("whatsapp");
+    expect(manifest.accessToken).toBe("test-whatsapp-access-token");
+    expect(manifest.adminToken).toBe("test-whatsapp-admin-token");
+    expect(manifest.endpoints?.apiRoot).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/crabline\/whatsapp$/u);
+    expect(manifest.endpoints?.adminInboundUrl).toMatch(
+      /^http:\/\/127\.0\.0\.1:\d+\/crabline\/whatsapp\/inbound$/u,
+    );
+    expect(manifest.endpoints?.messagesUrl).toMatch(
+      /^http:\/\/127\.0\.0\.1:\d+\/crabline\/whatsapp\/messages$/u,
+    );
+    await expect(fs.readFile(readyFile, "utf8")).resolves.toContain('"provider": "whatsapp"');
+  });
+
   it("doctor accepts local mock slack without live env", async () => {
     const directory = await createTempDir();
     directories.push(directory);

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -8,6 +8,7 @@ import {
   createOpenClawCrablineFakeProviderBinding,
   createOpenClawCrablineInbound,
   createOpenClawCrablineOutboundFromRecorderEvent,
+  createWhatsAppBaileysMockSocket,
   OPENCLAW_CRABLINE_CHANNEL_CAPABILITY_MATRIX_PATH,
   OPENCLAW_CRABLINE_CHANNEL_SMOKE_PATH,
   OPENCLAW_CRABLINE_MANIFEST_PATH,
@@ -228,7 +229,12 @@ describe("OpenClaw fake provider bridge", () => {
         fromName: "Alice",
         text: "hello",
       },
+      providerHeaders: {
+        "content-type": "application/json",
+        "x-crabline-admin-token": "crabline-admin-token",
+      },
       providerTargetKey: "100001",
+      providerUrl: "http://127.0.0.1:1234/crabline/telegram/inbound",
       qaTarget: "dm:alice",
       stateConversation: {
         id: "100001",
@@ -287,7 +293,12 @@ describe("OpenClaw fake provider bridge", () => {
         pushName: "Alice",
         text: "hello",
       },
+      providerHeaders: {
+        "content-type": "application/json",
+        "x-crabline-admin-token": "crabline-whatsapp-admin-token",
+      },
       providerTargetKey: "120363001234567890@g.us",
+      providerUrl: "http://127.0.0.1:5678/crabline/whatsapp/inbound",
       qaTarget: "group:120363001234567890@g.us",
       stateConversation: {
         id: "120363001234567890@g.us",
@@ -315,6 +326,68 @@ describe("OpenClaw fake provider bridge", () => {
       text: "hello from openclaw",
       to: "dm:alice",
     });
+  });
+
+  it("posts WhatsApp OpenClaw inbound with admin headers into the Baileys listener path", async () => {
+    const adapter = await startOpenClawCrablineAdapter({ channel: "whatsapp" });
+    try {
+      if (adapter.manifest.provider !== "whatsapp") {
+        throw new Error("Expected WhatsApp fake provider manifest.");
+      }
+      const inboundEvents: unknown[] = [];
+      const socket = createWhatsAppBaileysMockSocket({
+        accessToken: adapter.manifest.accessToken,
+        apiRoot: adapter.manifest.endpoints.apiRoot,
+        selfJid: adapter.manifest.selfJid,
+      });
+      socket.ev.on("messages.upsert", (payload) => {
+        inboundEvents.push(payload);
+      });
+
+      const inbound = adapter.createInbound({
+        input: {
+          conversation: { id: "120363001234567890@g.us", kind: "group" },
+          senderId: "15551234567@s.whatsapp.net",
+          senderName: "Alice",
+          text: "hello from qa",
+        },
+      });
+
+      const rejected = await fetch(inbound.providerUrl, {
+        body: JSON.stringify(inbound.providerBody),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      expect(rejected.status).toBe(401);
+
+      const accepted = await fetch(inbound.providerUrl, {
+        body: JSON.stringify(inbound.providerBody),
+        headers: inbound.providerHeaders,
+        method: "POST",
+      });
+      expect(accepted.status).toBe(200);
+      await expect(accepted.json()).resolves.toMatchObject({ ok: true });
+      expect(inboundEvents).toEqual([
+        expect.objectContaining({
+          messages: [
+            expect.objectContaining({
+              key: expect.objectContaining({
+                fromMe: false,
+                participant: "15551234567@s.whatsapp.net",
+                remoteJid: "120363001234567890@g.us",
+              }),
+              message: {
+                conversation: "hello from qa",
+              },
+              pushName: "Alice",
+            }),
+          ],
+          type: "notify",
+        }),
+      ]);
+    } finally {
+      await adapter.close();
+    }
   });
 
   it("runs OpenClaw channel-driver smoke and writes fake-provider artifacts", async () => {

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -9,6 +9,7 @@ import {
   createOpenClawCrablineInbound,
   createOpenClawCrablineOutboundFromRecorderEvent,
   createWhatsAppBaileysMockSocket,
+  DEFAULT_WHATSAPP_BAILEYS_MOCK_REGISTRY,
   OPENCLAW_CRABLINE_CHANNEL_CAPABILITY_MATRIX_PATH,
   OPENCLAW_CRABLINE_CHANNEL_SMOKE_PATH,
   OPENCLAW_CRABLINE_MANIFEST_PATH,
@@ -338,6 +339,7 @@ describe("OpenClaw fake provider bridge", () => {
       const socket = createWhatsAppBaileysMockSocket({
         accessToken: adapter.manifest.accessToken,
         apiRoot: adapter.manifest.endpoints.apiRoot,
+        registry: DEFAULT_WHATSAPP_BAILEYS_MOCK_REGISTRY,
         selfJid: adapter.manifest.selfJid,
       });
       socket.ev.on("messages.upsert", (payload) => {

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -35,6 +35,7 @@ const manifest: CrablineFakeProviderManifest = {
 
 const whatsappManifest: CrablineFakeProviderManifest = {
   accessToken: "crabline-whatsapp-access-token",
+  adminToken: "crabline-whatsapp-admin-token",
   baseUrl: "http://127.0.0.1:5678",
   endpoints: {
     adminInboundUrl: "http://127.0.0.1:5678/crabline/whatsapp/inbound",
@@ -43,6 +44,7 @@ const whatsappManifest: CrablineFakeProviderManifest = {
     presenceUrl: "http://127.0.0.1:5678/crabline/whatsapp/presence",
   },
   env: {
+    CRABLINE_WHATSAPP_ADMIN_TOKEN: "crabline-whatsapp-admin-token",
     CRABLINE_WHATSAPP_ACCESS_TOKEN: "crabline-whatsapp-access-token",
     CRABLINE_WHATSAPP_API_ROOT: "http://127.0.0.1:5678/crabline/whatsapp",
     CRABLINE_WHATSAPP_SELF_JID: "15550000000@s.whatsapp.net",
@@ -164,6 +166,7 @@ describe("OpenClaw fake provider bridge", () => {
       },
     });
     expect(binding.createChannelDriverSmokeEnv({})).toMatchObject({
+      CRABLINE_WHATSAPP_ADMIN_TOKEN: "crabline-whatsapp-admin-token",
       CRABLINE_WHATSAPP_ACCESS_TOKEN: "crabline-whatsapp-access-token",
       CRABLINE_WHATSAPP_API_ROOT: "http://127.0.0.1:5678/crabline/whatsapp",
       CRABLINE_WHATSAPP_SELF_JID: "15550000000@s.whatsapp.net",

--- a/test/whatsapp-fake-server.test.ts
+++ b/test/whatsapp-fake-server.test.ts
@@ -1,11 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import {
-  createWhatsAppBaileysMockSocket,
-  startWhatsAppFakeServer,
-  type StartedWhatsAppFakeServer,
-} from "../src/index.js";
+import { startWhatsAppFakeServer, type StartedWhatsAppFakeServer } from "../src/index.js";
 import { createTempDir, disposeTempDir } from "./test-helpers.js";
 
 const servers: StartedWhatsAppFakeServer[] = [];
@@ -27,11 +23,7 @@ describe("whatsapp fake provider server", () => {
     });
     servers.push(server);
     const inboundEvents: unknown[] = [];
-    const socket = createWhatsAppBaileysMockSocket({
-      accessToken: server.manifest.accessToken,
-      apiRoot: server.manifest.endpoints.apiRoot,
-      selfJid: server.manifest.selfJid,
-    });
+    const socket = server.createBaileysMockSocket();
     socket.ev.on("messages.upsert", (payload) => {
       inboundEvents.push(payload);
     });
@@ -223,11 +215,7 @@ describe("whatsapp fake provider server", () => {
       recorderPath: path.join(directory, "whatsapp.jsonl"),
     });
     servers.push(server);
-    const socket = createWhatsAppBaileysMockSocket({
-      accessToken: server.manifest.accessToken,
-      apiRoot: server.manifest.endpoints.apiRoot,
-      selfJid: server.manifest.selfJid,
-    });
+    const socket = server.createBaileysMockSocket();
     const emitted: unknown[] = [];
     socket.ev.on("messages.upsert", (payload) => {
       emitted.push(payload);

--- a/test/whatsapp-fake-server.test.ts
+++ b/test/whatsapp-fake-server.test.ts
@@ -21,10 +21,20 @@ describe("whatsapp fake provider server", () => {
     const directory = await createTempDir();
     directories.push(directory);
     const server = await startWhatsAppFakeServer({
+      adminToken: "fake-whatsapp-admin-token",
       accessToken: "fake-whatsapp-token",
       recorderPath: path.join(directory, "whatsapp.jsonl"),
     });
     servers.push(server);
+    const inboundEvents: unknown[] = [];
+    const socket = createWhatsAppBaileysMockSocket({
+      accessToken: server.manifest.accessToken,
+      apiRoot: server.manifest.endpoints.apiRoot,
+      selfJid: server.manifest.selfJid,
+    });
+    socket.ev.on("messages.upsert", (payload) => {
+      inboundEvents.push(payload);
+    });
 
     const health = await fetch(`${server.manifest.endpoints.apiRoot}/health`);
     await expect(health.json()).resolves.toMatchObject({
@@ -120,13 +130,29 @@ describe("whatsapp fake provider server", () => {
       presence: "paused",
     });
 
-    const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+    const unauthenticatedInbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
       body: JSON.stringify({
         chatJid: "120363001234567890@g.us",
         senderJid: "15551234567@s.whatsapp.net",
-        text: "user nonce-1",
+        text: "forged user nonce",
       }),
       headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    expect(unauthenticatedInbound.status).toBe(401);
+    await expect(unauthenticatedInbound.text()).resolves.toBe("unauthorized");
+
+    const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({
+        chatJid: "120363001234567890@g.us",
+        pushName: "Fake Sender",
+        senderJid: "15551234567@s.whatsapp.net",
+        text: "user nonce-1",
+      }),
+      headers: {
+        "content-type": "application/json",
+        "x-crabline-admin-token": "fake-whatsapp-admin-token",
+      },
       method: "POST",
     });
     await expect(inbound.json()).resolves.toMatchObject({
@@ -139,6 +165,7 @@ describe("whatsapp fake provider server", () => {
         message: {
           conversation: "user nonce-1",
         },
+        pushName: "Fake Sender",
       },
       ok: true,
       webhook: {
@@ -165,6 +192,27 @@ describe("whatsapp fake provider server", () => {
         object: "whatsapp_business_account",
       },
     });
+    expect(inboundEvents).toEqual([
+      expect.objectContaining({
+        messages: [
+          expect.objectContaining({
+            key: expect.objectContaining({
+              fromMe: false,
+              participant: "15551234567@s.whatsapp.net",
+              remoteJid: "120363001234567890@g.us",
+            }),
+            message: {
+              conversation: "user nonce-1",
+            },
+            pushName: "Fake Sender",
+          }),
+        ],
+        type: "notify",
+      }),
+    ]);
+    const recorder = await fs.readFile(server.manifest.recorderPath, "utf8");
+    expect(recorder).not.toContain("forged user nonce");
+    expect(recorder).toContain('"path":"/crabline/whatsapp/inbound"');
   });
 
   it("exposes a Baileys-shaped mock socket over the fake provider server", async () => {


### PR DESCRIPTION
Follow-up to #18 addressing Clawsweeper feedback.

## Summary
- secure WhatsApp admin inbound with generated/admin-supplied token support and document the manifest/env contract
- route authenticated admin inbound into subscribed Baileys mock sockets as `messages.upsert`, preserving sender display name
- keep unauthenticated admin inbound out of the recorder and cover the rejection path
- replace brittle fake-provider ternary/switch dispatch with typed provider registries that explicitly error on unsupported channels

## Validation
- `pnpm verify`