### PR TITLE
Add WhatsApp runtime socket factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,13 @@ The JSON manifest contains:
 - `adminToken`: send this as the `X-Crabline-Admin-Token` header when posting
   test user messages
 - `selfJid`: fake authenticated WhatsApp user JID
+- `env.CRABLINE_WHATSAPP_ACCESS_TOKEN`: access token for the runtime socket
+  factory
+- `env.CRABLINE_WHATSAPP_API_ROOT`: API root for the runtime socket factory
+- `env.CRABLINE_WHATSAPP_RECORDER_PATH`: recorder file followed by the runtime
+  socket factory for cross-process inbound delivery
+- `env.CRABLINE_WHATSAPP_SELF_JID`: fake authenticated WhatsApp user JID for
+  the runtime socket factory
 - `endpoints.adminInboundUrl`: authenticated POST endpoint for test user
   messages; subscribed Baileys mock sockets receive them as `messages.upsert`
 - `endpoints.messagesUrl`: fake text send endpoint used by the Baileys-shaped
@@ -196,19 +203,17 @@ The JSON manifest contains:
   `sendPresenceUpdate`
 - `recorderPath`: JSONL file of fake provider API/admin traffic
 
-The started WhatsApp fake server also exposes `createBaileysMockSocket()` so
-tests can exercise a Baileys-style WhatsApp `sendMessage()` /
-`sendPresenceUpdate()` surface while the fake server owns local provider
-simulation. The admin token is generated randomly unless `--admin-token <token>`
-is provided.
+Use the package subpath `@openclaw/crabline/whatsapp-socket-factory` when a
+runtime needs a Baileys-style module with `createWhatsAppSocket()`. The module
+reads the `CRABLINE_WHATSAPP_*` env vars emitted by the manifest, sends outbound
+traffic to the fake provider API, and follows the recorder for inbound
+`messages.upsert` events. The admin token is generated randomly unless
+`--admin-token <token>` is provided.
 
 OpenClaw bridge callers should post injected user messages with the
 `providerUrl`, `providerHeaders`, and `providerBody` returned by
-`createOpenClawCrablineInbound()`. For WhatsApp, inbound `messages.upsert`
-delivery is an in-process Baileys mock socket behavior: create the fake server
-and Baileys mock socket in the same Node process when testing listener-driven
-inbound delivery. If the socket is created outside the started server, pass the
-same `WhatsAppBaileysMockRegistry` to the server and socket helper.
+`createOpenClawCrablineInbound()`. For direct in-process tests, the started fake
+server also exposes `createBaileysMockSocket()`.
 
 ## Target IDs
 

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -149,25 +149,30 @@ Manifest fields:
 - `accessToken`: bearer token for fake provider requests
 - `adminToken`: value for the `X-Crabline-Admin-Token` header on admin ingress
 - `selfJid`: fake authenticated WhatsApp user JID
+- `env.CRABLINE_WHATSAPP_ACCESS_TOKEN`: access token for the runtime socket
+  factory
+- `env.CRABLINE_WHATSAPP_API_ROOT`: API root for the runtime socket factory
+- `env.CRABLINE_WHATSAPP_RECORDER_PATH`: recorder file followed by the runtime
+  socket factory for cross-process inbound delivery
+- `env.CRABLINE_WHATSAPP_SELF_JID`: fake authenticated WhatsApp user JID for
+  the runtime socket factory
 - `endpoints.adminInboundUrl`: authenticated admin ingress for test user
   messages; subscribed Baileys mock sockets receive them as `messages.upsert`
 - `endpoints.messagesUrl`: text send endpoint used by the Baileys-shaped mock
 - `endpoints.presenceUrl`: presence endpoint used by `sendPresenceUpdate`
 - `recorderPath`: JSONL provider traffic recorder
 
-Use the started server's `createBaileysMockSocket()` when a test needs a
-Baileys-style `sendMessage()` / `sendPresenceUpdate()` surface backed by the
-same fake provider server. The admin token is generated randomly unless
+Use the package subpath `@openclaw/crabline/whatsapp-socket-factory` when a
+runtime needs a Baileys-style module with `createWhatsAppSocket()`. The module
+reads the `CRABLINE_WHATSAPP_*` env vars emitted by the manifest, sends outbound
+traffic to the fake provider API, and follows the recorder for inbound
+`messages.upsert` events. The admin token is generated randomly unless
 `--admin-token <token>` is provided.
 
 OpenClaw bridge callers should post injected user messages with the
 `providerUrl`, `providerHeaders`, and `providerBody` returned by
-`createOpenClawCrablineInbound()`. For WhatsApp, inbound `messages.upsert`
-delivery is an in-process Baileys mock socket behavior: create the fake server
-and Baileys mock socket in the same Node process when testing listener-driven
-inbound delivery. If the socket is created outside the started server, pass the
-same `WhatsAppBaileysMockRegistry` to the server and socket helper.
-
+`createOpenClawCrablineInbound()`. For direct in-process tests, the started fake
+server also exposes `createBaileysMockSocket()`.
 The admin ingress accepts JSON like:
 
 ```json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/crabline",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Standalone CLI for deterministic messaging provider E2E tests",
   "homepage": "https://github.com/openclaw/crabline#readme",
   "bugs": {
@@ -27,6 +27,10 @@
     ".": {
       "types": "./dist/src/index.d.ts",
       "import": "./dist/src/index.js"
+    },
+    "./whatsapp-socket-factory": {
+      "types": "./dist/src/fake-servers/whatsapp-socket-factory.d.ts",
+      "import": "./dist/src/fake-servers/whatsapp-socket-factory.js"
     }
   },
   "scripts": {

--- a/src/fake-servers/whatsapp-socket-factory.ts
+++ b/src/fake-servers/whatsapp-socket-factory.ts
@@ -1,0 +1,252 @@
+import fs from "node:fs/promises";
+import {
+  createWhatsAppBaileysMockSocket,
+  type WhatsAppBaileysMessage,
+  type WhatsAppBaileysMockConfig,
+  type WhatsAppBaileysMockSocket,
+} from "./whatsapp.js";
+
+export const CRABLINE_WHATSAPP_ACCESS_TOKEN_ENV = "CRABLINE_WHATSAPP_ACCESS_TOKEN";
+export const CRABLINE_WHATSAPP_API_ROOT_ENV = "CRABLINE_WHATSAPP_API_ROOT";
+export const CRABLINE_WHATSAPP_RECORDER_PATH_ENV = "CRABLINE_WHATSAPP_RECORDER_PATH";
+export const CRABLINE_WHATSAPP_SELF_JID_ENV = "CRABLINE_WHATSAPP_SELF_JID";
+
+const DEFAULT_RECORDER_POLL_MS = 50;
+const RECORDER_BRIDGE_STATE_KEY = Symbol.for("crabline.whatsapp.baileysRecorderBridge");
+
+type RecorderBridgeState = {
+  cursor: number;
+  syncPromise: Promise<void> | null;
+};
+
+type RecorderBridgeStateMap = Map<string, RecorderBridgeState>;
+
+type GlobalRecorderBridgeState = typeof globalThis & {
+  [RECORDER_BRIDGE_STATE_KEY]?: RecorderBridgeStateMap;
+};
+
+export type WhatsAppBaileysRuntimeGroupMetadata = {
+  id: string;
+  participants: unknown[];
+  subject: string;
+};
+
+export type WhatsAppBaileysRuntimeMockSocket = WhatsAppBaileysMockSocket & {
+  end(error?: Error | undefined): void;
+  groupFetchAllParticipating(): Promise<Record<string, WhatsAppBaileysRuntimeGroupMetadata>>;
+  groupMetadata(jid: string): Promise<WhatsAppBaileysRuntimeGroupMetadata>;
+  readMessages(keys?: unknown[] | undefined): Promise<void>;
+};
+
+export type WhatsAppBaileysRuntimeMockConfig = WhatsAppBaileysMockConfig & {
+  emitConnectionOpen?: boolean | undefined;
+  recorderPath?: string | undefined;
+  recorderPollMs?: number | undefined;
+};
+
+export type WhatsAppSocketFactoryOptions = {
+  fetch?: typeof fetch | undefined;
+  selfJid?: string | undefined;
+};
+
+function readNonEmptyString(value: unknown): string | undefined {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  return trimmed || undefined;
+}
+
+function readRequiredEnv(env: NodeJS.ProcessEnv, key: string): string {
+  const value = readNonEmptyString(env[key]);
+  if (!value) {
+    throw new Error(`${key} is required to create a WhatsApp Baileys mock socket.`);
+  }
+  return value;
+}
+
+function readOptionalEnv(env: NodeJS.ProcessEnv, key: string): string | undefined {
+  return readNonEmptyString(env[key]);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function getRecorderBridgeState(recorderPath: string): RecorderBridgeState {
+  const globalState = globalThis as GlobalRecorderBridgeState;
+  const states = globalState[RECORDER_BRIDGE_STATE_KEY] ?? new Map();
+  globalState[RECORDER_BRIDGE_STATE_KEY] = states;
+  const state = states.get(recorderPath) ?? { cursor: 0, syncPromise: null };
+  states.set(recorderPath, state);
+  return state;
+}
+
+function parseRecorderLine(line: string): unknown {
+  try {
+    return JSON.parse(line);
+  } catch {
+    return null;
+  }
+}
+
+function createInboundMessageFromRecorderEvent(
+  event: unknown,
+  lineIndex: number,
+): WhatsAppBaileysMessage | null {
+  if (!isRecord(event) || event.type !== "admin" || typeof event.path !== "string") {
+    return null;
+  }
+  if (!event.path.endsWith("/crabline/whatsapp/inbound") || !isRecord(event.body)) {
+    return null;
+  }
+
+  const chatJid = readNonEmptyString(event.body.chatJid ?? event.body.chatId);
+  const senderJid = readNonEmptyString(event.body.senderJid ?? event.body.from);
+  const text = readNonEmptyString(event.body.text);
+  if (!chatJid || !senderJid || !text) {
+    return null;
+  }
+
+  const messageId =
+    readNonEmptyString(event.body.messageId) ??
+    `wamid.FAKEQA${String(lineIndex + 1).padStart(8, "0")}`;
+  return {
+    key: {
+      fromMe: false,
+      id: messageId,
+      ...(chatJid.endsWith("@g.us") ? { participant: senderJid } : {}),
+      remoteJid: chatJid,
+    },
+    message: {
+      conversation: text,
+    },
+    messageTimestamp: Math.floor(Date.now() / 1000),
+    pushName: readNonEmptyString(event.body.pushName) ?? "Test User",
+  };
+}
+
+async function readRecorderLines(recorderPath: string): Promise<string[]> {
+  const text = await fs.readFile(recorderPath, "utf8").catch((error: unknown) => {
+    if (isRecord(error) && error.code === "ENOENT") {
+      return "";
+    }
+    throw error;
+  });
+  return text.split(/\r?\n/u).filter((line) => line.trim().length > 0);
+}
+
+export function startWhatsAppBaileysRecorderBridge(params: {
+  recorderPath: string;
+  recorderPollMs?: number | undefined;
+  socket: WhatsAppBaileysMockSocket;
+}): () => void {
+  const state = getRecorderBridgeState(params.recorderPath);
+  const sync = async () => {
+    if (state.syncPromise) {
+      await state.syncPromise;
+      return;
+    }
+    state.syncPromise = (async () => {
+      const lines = await readRecorderLines(params.recorderPath);
+      if (lines.length < state.cursor) {
+        state.cursor = 0;
+      }
+      for (let lineIndex = state.cursor; lineIndex < lines.length; lineIndex += 1) {
+        const event = parseRecorderLine(lines[lineIndex] ?? "");
+        const message = createInboundMessageFromRecorderEvent(event, lineIndex);
+        if (message) {
+          params.socket.ev.emit("messages.upsert", { messages: [message], type: "notify" });
+        }
+      }
+      state.cursor = lines.length;
+    })();
+    try {
+      await state.syncPromise;
+    } finally {
+      state.syncPromise = null;
+    }
+  };
+
+  const interval = setInterval(() => {
+    void sync().catch(() => undefined);
+  }, params.recorderPollMs ?? DEFAULT_RECORDER_POLL_MS);
+  interval.unref?.();
+  void sync().catch(() => undefined);
+
+  return () => {
+    clearInterval(interval);
+  };
+}
+
+export function createWhatsAppBaileysRuntimeMockSocket(
+  config: WhatsAppBaileysRuntimeMockConfig,
+): WhatsAppBaileysRuntimeMockSocket {
+  const socket = createWhatsAppBaileysMockSocket(config);
+  const stopRecorderBridge = config.recorderPath
+    ? startWhatsAppBaileysRecorderBridge({
+        recorderPath: config.recorderPath,
+        recorderPollMs: config.recorderPollMs,
+        socket,
+      })
+    : () => {};
+  const openTimer =
+    config.emitConnectionOpen === false
+      ? null
+      : setTimeout(() => {
+          socket.ev.emit("connection.update", { connection: "open" });
+        }, 0);
+  openTimer?.unref?.();
+  let closed = false;
+
+  return {
+    ...socket,
+    end(error) {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      if (openTimer) {
+        clearTimeout(openTimer);
+      }
+      stopRecorderBridge();
+      socket.ev.emit("connection.update", {
+        connection: "close",
+        lastDisconnect: error ? { error } : undefined,
+      });
+    },
+    async groupFetchAllParticipating() {
+      return {};
+    },
+    async groupMetadata(jid) {
+      return {
+        id: jid,
+        participants: [],
+        subject: "Test Group",
+      };
+    },
+    async readMessages() {
+      return undefined;
+    },
+  };
+}
+
+export function createWhatsAppBaileysRuntimeMockSocketFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+  options: WhatsAppSocketFactoryOptions = {},
+): WhatsAppBaileysRuntimeMockSocket {
+  return createWhatsAppBaileysRuntimeMockSocket({
+    accessToken: readRequiredEnv(env, CRABLINE_WHATSAPP_ACCESS_TOKEN_ENV),
+    apiRoot: readRequiredEnv(env, CRABLINE_WHATSAPP_API_ROOT_ENV),
+    fetch: options.fetch,
+    recorderPath: readOptionalEnv(env, CRABLINE_WHATSAPP_RECORDER_PATH_ENV),
+    selfJid: readOptionalEnv(env, CRABLINE_WHATSAPP_SELF_JID_ENV) ?? options.selfJid,
+  });
+}
+
+export async function createWhatsAppSocket(
+  _printQr?: boolean,
+  _verbose?: boolean,
+  options: WhatsAppSocketFactoryOptions = {},
+): Promise<WhatsAppBaileysRuntimeMockSocket> {
+  return createWhatsAppBaileysRuntimeMockSocketFromEnv(process.env, options);
+}
+
+export default createWhatsAppSocket;

--- a/src/fake-servers/whatsapp-socket-factory.ts
+++ b/src/fake-servers/whatsapp-socket-factory.ts
@@ -1,4 +1,5 @@
-import fs from "node:fs/promises";
+import fs from "node:fs";
+import fsPromises from "node:fs/promises";
 import {
   createWhatsAppBaileysMockSocket,
   type WhatsAppBaileysMessage,
@@ -16,6 +17,8 @@ const RECORDER_BRIDGE_STATE_KEY = Symbol.for("crabline.whatsapp.baileysRecorderB
 
 type RecorderBridgeState = {
   cursor: number;
+  interval: ReturnType<typeof setInterval> | null;
+  sockets: Set<WhatsAppBaileysMockSocket>;
   syncPromise: Promise<void> | null;
 };
 
@@ -74,7 +77,12 @@ function getRecorderBridgeState(recorderPath: string): RecorderBridgeState {
   const globalState = globalThis as GlobalRecorderBridgeState;
   const states = globalState[RECORDER_BRIDGE_STATE_KEY] ?? new Map();
   globalState[RECORDER_BRIDGE_STATE_KEY] = states;
-  const state = states.get(recorderPath) ?? { cursor: 0, syncPromise: null };
+  const state = states.get(recorderPath) ?? {
+    cursor: readRecorderLineCountSync(recorderPath),
+    interval: null,
+    sockets: new Set<WhatsAppBaileysMockSocket>(),
+    syncPromise: null,
+  };
   states.set(recorderPath, state);
   return state;
 }
@@ -124,7 +132,7 @@ function createInboundMessageFromRecorderEvent(
 }
 
 async function readRecorderLines(recorderPath: string): Promise<string[]> {
-  const text = await fs.readFile(recorderPath, "utf8").catch((error: unknown) => {
+  const text = await fsPromises.readFile(recorderPath, "utf8").catch((error: unknown) => {
     if (isRecord(error) && error.code === "ENOENT") {
       return "";
     }
@@ -133,12 +141,27 @@ async function readRecorderLines(recorderPath: string): Promise<string[]> {
   return text.split(/\r?\n/u).filter((line) => line.trim().length > 0);
 }
 
+function readRecorderLineCountSync(recorderPath: string): number {
+  try {
+    return fs
+      .readFileSync(recorderPath, "utf8")
+      .split(/\r?\n/u)
+      .filter((line) => line.trim().length > 0).length;
+  } catch (error: unknown) {
+    if (isRecord(error) && error.code === "ENOENT") {
+      return 0;
+    }
+    throw error;
+  }
+}
+
 export function startWhatsAppBaileysRecorderBridge(params: {
   recorderPath: string;
   recorderPollMs?: number | undefined;
   socket: WhatsAppBaileysMockSocket;
 }): () => void {
   const state = getRecorderBridgeState(params.recorderPath);
+  state.sockets.add(params.socket);
   const sync = async () => {
     if (state.syncPromise) {
       await state.syncPromise;
@@ -153,7 +176,10 @@ export function startWhatsAppBaileysRecorderBridge(params: {
         const event = parseRecorderLine(lines[lineIndex] ?? "");
         const message = createInboundMessageFromRecorderEvent(event, lineIndex);
         if (message) {
-          params.socket.ev.emit("messages.upsert", { messages: [message], type: "notify" });
+          const payload = { messages: [message], type: "notify" };
+          for (const socket of state.sockets) {
+            socket.ev.emit("messages.upsert", payload);
+          }
         }
       }
       state.cursor = lines.length;
@@ -165,14 +191,20 @@ export function startWhatsAppBaileysRecorderBridge(params: {
     }
   };
 
-  const interval = setInterval(() => {
-    void sync().catch(() => undefined);
-  }, params.recorderPollMs ?? DEFAULT_RECORDER_POLL_MS);
-  interval.unref?.();
+  if (!state.interval) {
+    state.interval = setInterval(() => {
+      void sync().catch(() => undefined);
+    }, params.recorderPollMs ?? DEFAULT_RECORDER_POLL_MS);
+    state.interval.unref?.();
+  }
   void sync().catch(() => undefined);
 
   return () => {
-    clearInterval(interval);
+    state.sockets.delete(params.socket);
+    if (state.sockets.size === 0 && state.interval) {
+      clearInterval(state.interval);
+      state.interval = null;
+    }
   };
 }
 

--- a/src/fake-servers/whatsapp.ts
+++ b/src/fake-servers/whatsapp.ts
@@ -79,6 +79,7 @@ export type WhatsAppFakeServerManifest = {
     CRABLINE_WHATSAPP_ADMIN_TOKEN: string;
     CRABLINE_WHATSAPP_ACCESS_TOKEN: string;
     CRABLINE_WHATSAPP_API_ROOT: string;
+    CRABLINE_WHATSAPP_RECORDER_PATH: string;
     CRABLINE_WHATSAPP_SELF_JID: string;
   };
   provider: "whatsapp";
@@ -650,6 +651,7 @@ export async function startWhatsAppFakeServer(
         CRABLINE_WHATSAPP_ADMIN_TOKEN: state.adminToken,
         CRABLINE_WHATSAPP_ACCESS_TOKEN: state.accessToken,
         CRABLINE_WHATSAPP_API_ROOT: apiRoot,
+        CRABLINE_WHATSAPP_RECORDER_PATH: state.recorderPath,
         CRABLINE_WHATSAPP_SELF_JID: state.selfJid,
       },
       provider: "whatsapp",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,16 @@ export {
   WhatsAppBaileysMockRegistry,
 } from "./fake-servers/whatsapp.js";
 export {
+  CRABLINE_WHATSAPP_ACCESS_TOKEN_ENV,
+  CRABLINE_WHATSAPP_API_ROOT_ENV,
+  CRABLINE_WHATSAPP_RECORDER_PATH_ENV,
+  CRABLINE_WHATSAPP_SELF_JID_ENV,
+  createWhatsAppBaileysRuntimeMockSocket,
+  createWhatsAppBaileysRuntimeMockSocketFromEnv,
+  createWhatsAppSocket,
+  startWhatsAppBaileysRecorderBridge,
+} from "./fake-servers/whatsapp-socket-factory.js";
+export {
   CRABLINE_FAKE_PROVIDER_CHANNELS,
   isCrablineFakeProviderChannel,
   startCrablineFakeProviderServer,
@@ -83,6 +93,12 @@ export type {
   WhatsAppBaileysPresence,
   WhatsAppFakeServerManifest,
 } from "./fake-servers/whatsapp.js";
+export type {
+  WhatsAppBaileysRuntimeGroupMetadata,
+  WhatsAppBaileysRuntimeMockConfig,
+  WhatsAppBaileysRuntimeMockSocket,
+  WhatsAppSocketFactoryOptions,
+} from "./fake-servers/whatsapp-socket-factory.js";
 export type {
   CrablineFakeProviderChannel,
   CrablineFakeProviderManifest,

--- a/src/openclaw/bridges/whatsapp.ts
+++ b/src/openclaw/bridges/whatsapp.ts
@@ -38,6 +38,7 @@ export const WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
             CRABLINE_WHATSAPP_ADMIN_TOKEN: whatsapp.adminToken,
             CRABLINE_WHATSAPP_ACCESS_TOKEN: whatsapp.accessToken,
             CRABLINE_WHATSAPP_API_ROOT: whatsapp.endpoints.apiRoot,
+            CRABLINE_WHATSAPP_RECORDER_PATH: whatsapp.recorderPath,
             CRABLINE_WHATSAPP_SELF_JID: whatsapp.selfJid,
           }),
           createGatewayConfig: (openclawConfig = {}) => {

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -49,6 +49,7 @@ const whatsappManifest: CrablineFakeProviderManifest = {
     CRABLINE_WHATSAPP_ADMIN_TOKEN: "crabline-whatsapp-admin-token",
     CRABLINE_WHATSAPP_ACCESS_TOKEN: "crabline-whatsapp-access-token",
     CRABLINE_WHATSAPP_API_ROOT: "http://127.0.0.1:5678/crabline/whatsapp",
+    CRABLINE_WHATSAPP_RECORDER_PATH: "/tmp/crabline/whatsapp.jsonl",
     CRABLINE_WHATSAPP_SELF_JID: "15550000000@s.whatsapp.net",
   },
   provider: "whatsapp",
@@ -194,6 +195,7 @@ describe("OpenClaw fake provider bridge", () => {
       CRABLINE_WHATSAPP_ADMIN_TOKEN: "crabline-whatsapp-admin-token",
       CRABLINE_WHATSAPP_ACCESS_TOKEN: "crabline-whatsapp-access-token",
       CRABLINE_WHATSAPP_API_ROOT: "http://127.0.0.1:5678/crabline/whatsapp",
+      CRABLINE_WHATSAPP_RECORDER_PATH: "/tmp/crabline/whatsapp.jsonl",
       CRABLINE_WHATSAPP_SELF_JID: "15550000000@s.whatsapp.net",
     });
   });

--- a/test/whatsapp-fake-server.test.ts
+++ b/test/whatsapp-fake-server.test.ts
@@ -391,4 +391,77 @@ describe("whatsapp fake provider server", () => {
       restoreEnv(previousEnv);
     }
   });
+
+  it("fans out recorder inbound lines to runtime sockets sharing a recorder path", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const server = await startWhatsAppFakeServer({
+      accessToken: "fake-whatsapp-token",
+      adminToken: "fake-whatsapp-admin-token",
+      baileysRegistry: new WhatsAppBaileysMockRegistry(),
+      recorderPath: path.join(directory, "whatsapp.jsonl"),
+      selfJid: "15550000001@s.whatsapp.net",
+    });
+    servers.push(server);
+    const previousEnv = captureEnv();
+    process.env[CRABLINE_WHATSAPP_ACCESS_TOKEN_ENV] = server.manifest.accessToken;
+    process.env[CRABLINE_WHATSAPP_API_ROOT_ENV] = server.manifest.endpoints.apiRoot;
+    process.env[CRABLINE_WHATSAPP_RECORDER_PATH_ENV] = server.manifest.recorderPath;
+    process.env[CRABLINE_WHATSAPP_SELF_JID_ENV] = server.manifest.selfJid;
+
+    const firstSocket = await createWhatsAppSocket(false, false);
+    const secondSocket = await createWhatsAppSocket(false, false);
+    try {
+      const firstInboundEvents: unknown[] = [];
+      const secondInboundEvents: unknown[] = [];
+      firstSocket.ev.on("messages.upsert", (payload) => {
+        firstInboundEvents.push(payload);
+      });
+      secondSocket.ev.on("messages.upsert", (payload) => {
+        secondInboundEvents.push(payload);
+      });
+
+      const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({
+          chatJid: "120363001234567890@g.us",
+          pushName: "Fake Sender",
+          senderJid: "15551234567@s.whatsapp.net",
+          text: "fanout nonce",
+        }),
+        headers: {
+          "content-type": "application/json",
+          "x-crabline-admin-token": "fake-whatsapp-admin-token",
+        },
+        method: "POST",
+      });
+      expect(inbound.status).toBe(200);
+
+      await waitForCondition(
+        () => firstInboundEvents.length === 1 && secondInboundEvents.length === 1,
+        "WhatsApp recorder fan-out",
+      );
+      const expectedPayload = expect.objectContaining({
+        messages: [
+          expect.objectContaining({
+            key: expect.objectContaining({
+              fromMe: false,
+              participant: "15551234567@s.whatsapp.net",
+              remoteJid: "120363001234567890@g.us",
+            }),
+            message: {
+              conversation: "fanout nonce",
+            },
+            pushName: "Fake Sender",
+          }),
+        ],
+        type: "notify",
+      });
+      expect(firstInboundEvents).toEqual([expectedPayload]);
+      expect(secondInboundEvents).toEqual([expectedPayload]);
+    } finally {
+      firstSocket.end();
+      secondSocket.end();
+      restoreEnv(previousEnv);
+    }
+  });
 });

--- a/test/whatsapp-fake-server.test.ts
+++ b/test/whatsapp-fake-server.test.ts
@@ -1,11 +1,56 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { startWhatsAppFakeServer, type StartedWhatsAppFakeServer } from "../src/index.js";
+import {
+  CRABLINE_WHATSAPP_ACCESS_TOKEN_ENV,
+  CRABLINE_WHATSAPP_API_ROOT_ENV,
+  CRABLINE_WHATSAPP_RECORDER_PATH_ENV,
+  CRABLINE_WHATSAPP_SELF_JID_ENV,
+  createWhatsAppSocket,
+  startWhatsAppFakeServer,
+  WhatsAppBaileysMockRegistry,
+  type StartedWhatsAppFakeServer,
+} from "../src/index.js";
 import { createTempDir, disposeTempDir } from "./test-helpers.js";
 
 const servers: StartedWhatsAppFakeServer[] = [];
 const directories: string[] = [];
+const WHATSAPP_FACTORY_ENV_KEYS = [
+  CRABLINE_WHATSAPP_ACCESS_TOKEN_ENV,
+  CRABLINE_WHATSAPP_API_ROOT_ENV,
+  CRABLINE_WHATSAPP_RECORDER_PATH_ENV,
+  CRABLINE_WHATSAPP_SELF_JID_ENV,
+] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+async function waitForCondition(predicate: () => boolean, label: string): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`Timed out waiting for ${label}.`);
+}
+
+function captureEnv() {
+  return Object.fromEntries(WHATSAPP_FACTORY_ENV_KEYS.map((key) => [key, process.env[key]]));
+}
+
+function restoreEnv(previous: Record<string, string | undefined>) {
+  for (const key of WHATSAPP_FACTORY_ENV_KEYS) {
+    const value = previous[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
 
 afterEach(async () => {
   await Promise.all(servers.splice(0).map((server) => server.close()));
@@ -239,5 +284,111 @@ describe("whatsapp fake provider server", () => {
     const recorder = await fs.readFile(server.manifest.recorderPath, "utf8");
     expect(recorder).toContain('"path":"/crabline/whatsapp/messages"');
     expect(recorder).toContain('"path":"/crabline/whatsapp/presence"');
+  });
+
+  it("exposes an env-driven Baileys runtime socket factory backed by the recorder", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const server = await startWhatsAppFakeServer({
+      accessToken: "fake-whatsapp-token",
+      adminToken: "fake-whatsapp-admin-token",
+      baileysRegistry: new WhatsAppBaileysMockRegistry(),
+      recorderPath: path.join(directory, "whatsapp.jsonl"),
+      selfJid: "15550000001@s.whatsapp.net",
+    });
+    servers.push(server);
+    const previousEnv = captureEnv();
+    process.env[CRABLINE_WHATSAPP_ACCESS_TOKEN_ENV] = server.manifest.accessToken;
+    process.env[CRABLINE_WHATSAPP_API_ROOT_ENV] = server.manifest.endpoints.apiRoot;
+    process.env[CRABLINE_WHATSAPP_RECORDER_PATH_ENV] = server.manifest.recorderPath;
+    process.env[CRABLINE_WHATSAPP_SELF_JID_ENV] = server.manifest.selfJid;
+
+    const socket = await createWhatsAppSocket(false, false);
+    try {
+      const connectionUpdates: unknown[] = [];
+      const inboundEvents: unknown[] = [];
+      socket.ev.on("connection.update", (payload) => {
+        connectionUpdates.push(payload);
+      });
+      socket.ev.on("messages.upsert", (payload) => {
+        const firstMessage = isRecord(payload)
+          ? (payload.messages as Array<Record<string, unknown>> | undefined)?.[0]
+          : undefined;
+        const key = isRecord(firstMessage) ? firstMessage.key : undefined;
+        if (isRecord(key) && key.fromMe === false) {
+          inboundEvents.push(payload);
+        }
+      });
+
+      await waitForCondition(
+        () => connectionUpdates.some((update) => isRecord(update) && update.connection === "open"),
+        "WhatsApp runtime socket connection open",
+      );
+      const sentMessage = await socket.sendMessage("15551234567@s.whatsapp.net", {
+        text: "hello through env socket",
+      });
+      await socket.sendPresenceUpdate("composing", "15551234567@s.whatsapp.net");
+      await socket.readMessages([{ id: "wamid.READ", remoteJid: "15551234567@s.whatsapp.net" }]);
+
+      expect(sentMessage).toMatchObject({
+        key: {
+          fromMe: true,
+          remoteJid: "15551234567@s.whatsapp.net",
+        },
+        message: {
+          conversation: "hello through env socket",
+        },
+      });
+      await expect(socket.groupFetchAllParticipating()).resolves.toEqual({});
+      await expect(socket.groupMetadata("120363001234567890@g.us")).resolves.toEqual({
+        id: "120363001234567890@g.us",
+        participants: [],
+        subject: "Test Group",
+      });
+
+      const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({
+          chatJid: "120363001234567890@g.us",
+          pushName: "Fake Sender",
+          senderJid: "15551234567@s.whatsapp.net",
+          text: "user nonce from recorder",
+        }),
+        headers: {
+          "content-type": "application/json",
+          "x-crabline-admin-token": "fake-whatsapp-admin-token",
+        },
+        method: "POST",
+      });
+      expect(inbound.status).toBe(200);
+      await waitForCondition(() => inboundEvents.length === 1, "WhatsApp recorder inbound event");
+      expect(inboundEvents).toEqual([
+        expect.objectContaining({
+          messages: [
+            expect.objectContaining({
+              key: expect.objectContaining({
+                fromMe: false,
+                participant: "15551234567@s.whatsapp.net",
+                remoteJid: "120363001234567890@g.us",
+              }),
+              message: {
+                conversation: "user nonce from recorder",
+              },
+              pushName: "Fake Sender",
+            }),
+          ],
+          type: "notify",
+        }),
+      ]);
+
+      socket.end();
+      expect(connectionUpdates).toContainEqual(
+        expect.objectContaining({
+          connection: "close",
+        }),
+      );
+    } finally {
+      socket.end();
+      restoreEnv(previousEnv);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- add a package subpath that exports an env-driven Baileys-style WhatsApp socket factory
- include the WhatsApp recorder path in fake-provider manifest env so runtime sockets can receive inbound events across processes
- document the runtime factory contract and cover it with focused tests

## Validation
- pnpm lint
- pnpm test
- pnpm build