### PR TITLE
Fix WhatsApp recorder inbound IDs

### DIFF
--- a/src/fake-servers/whatsapp-socket-factory.ts
+++ b/src/fake-servers/whatsapp-socket-factory.ts
@@ -73,6 +73,18 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
+function readRecordedInboundMessage(value: unknown): WhatsAppBaileysMessage | undefined {
+  if (!isRecord(value) || !isRecord(value.key) || !isRecord(value.message)) {
+    return undefined;
+  }
+  const id = readNonEmptyString(value.key.id);
+  const remoteJid = readNonEmptyString(value.key.remoteJid);
+  if (!id || !remoteJid || value.key.fromMe !== false) {
+    return undefined;
+  }
+  return value as WhatsAppBaileysMessage;
+}
+
 function getRecorderBridgeState(recorderPath: string): RecorderBridgeState {
   const globalState = globalThis as GlobalRecorderBridgeState;
   const states = globalState[RECORDER_BRIDGE_STATE_KEY] ?? new Map();
@@ -102,7 +114,14 @@ function createInboundMessageFromRecorderEvent(
   if (!isRecord(event) || event.type !== "admin" || typeof event.path !== "string") {
     return null;
   }
-  if (!event.path.endsWith("/crabline/whatsapp/inbound") || !isRecord(event.body)) {
+  if (!event.path.endsWith("/crabline/whatsapp/inbound")) {
+    return null;
+  }
+  const recordedMessage = readRecordedInboundMessage(event.message);
+  if (recordedMessage) {
+    return recordedMessage;
+  }
+  if (!isRecord(event.body)) {
     return null;
   }
 

--- a/src/fake-servers/whatsapp.ts
+++ b/src/fake-servers/whatsapp.ts
@@ -106,6 +106,15 @@ export type StartWhatsAppFakeServerParams = {
   selfJid?: string | undefined;
 };
 
+type WhatsAppAdminInboundResult = {
+  message?: WhatsAppBaileysMessage | undefined;
+  response: Response;
+};
+
+type WhatsAppRecorderEvent = FakeServerRequestEvent & {
+  message?: WhatsAppBaileysMessage | undefined;
+};
+
 function whatsappOk(value: Record<string, unknown> = {}): Response {
   return jsonResponse({ ok: true, ...value });
 }
@@ -476,21 +485,23 @@ async function handleSendMessage(params: {
 async function handleAdminInbound(params: {
   body: Record<string, unknown>;
   state: WhatsAppFakeServerState;
-}): Promise<Response> {
+}): Promise<WhatsAppAdminInboundResult> {
   const chatJid = requireWhatsAppJid(params.body.chatJid ?? params.body.chatId, "chatJid");
   if (chatJid instanceof Response) {
-    return chatJid;
+    return { response: chatJid };
   }
   const senderJid = requireWhatsAppJid(params.body.senderJid ?? params.body.from, "senderJid");
   if (senderJid instanceof Response) {
-    return senderJid;
+    return { response: senderJid };
   }
   const text = readTrimmedString(params.body.text);
   if (!text) {
-    return graphParameterError(
-      "(#100) Missing required parameter: text",
-      "An inbound WhatsApp fake event requires text.",
-    );
+    return {
+      response: graphParameterError(
+        "(#100) Missing required parameter: text",
+        "An inbound WhatsApp fake event requires text.",
+      ),
+    };
   }
   const message = createWhatsAppMessage({
     fromMe: false,
@@ -536,8 +547,7 @@ async function handleAdminInbound(params: {
     ],
     object: "whatsapp_business_account",
   };
-  params.state.baileysRegistry.emitInbound(params.state.apiRoot, message);
-  return whatsappOk({ message, webhook });
+  return { message, response: whatsappOk({ message, webhook }) };
 }
 
 async function handleRequest(params: { request: IncomingMessage; state: WhatsAppFakeServerState }) {
@@ -555,15 +565,23 @@ async function handleRequest(params: { request: IncomingMessage; state: WhatsApp
       return adminAuthError();
     }
     const body = await parseRequestBody(params.request);
-    await appendEvent(params.state, {
+    const result = await handleAdminInbound({ body, state: params.state });
+    const event: WhatsAppRecorderEvent = {
       at: new Date().toISOString(),
       body,
       method: params.request.method,
       path: url.pathname,
       query: queryRecord(url),
       type: "admin",
-    });
-    return await handleAdminInbound({ body, state: params.state });
+    };
+    if (result.message) {
+      event.message = result.message;
+    }
+    await appendEvent(params.state, event);
+    if (result.message) {
+      params.state.baileysRegistry.emitInbound(params.state.apiRoot, result.message);
+    }
+    return result.response;
   }
 
   const body =

--- a/test/whatsapp-fake-server.test.ts
+++ b/test/whatsapp-fake-server.test.ts
@@ -52,6 +52,23 @@ function restoreEnv(previous: Record<string, string | undefined>) {
   }
 }
 
+function readBaileysMessageId(message: unknown): string | undefined {
+  const key = isRecord(message) ? message.key : undefined;
+  const id = isRecord(key) ? key.id : undefined;
+  return typeof id === "string" ? id : undefined;
+}
+
+function readInboundResponseMessageId(payload: unknown): string | undefined {
+  return isRecord(payload) ? readBaileysMessageId(payload.message) : undefined;
+}
+
+function readUpsertMessageId(payload: unknown): string | undefined {
+  const firstMessage = isRecord(payload)
+    ? (payload.messages as Array<Record<string, unknown>> | undefined)?.[0]
+    : undefined;
+  return readBaileysMessageId(firstMessage);
+}
+
 afterEach(async () => {
   await Promise.all(servers.splice(0).map((server) => server.close()));
   await Promise.all(directories.splice(0).map(disposeTempDir));
@@ -252,6 +269,40 @@ describe("whatsapp fake provider server", () => {
     expect(recorder).toContain('"path":"/crabline/whatsapp/inbound"');
   });
 
+  it("does not emit admin inbound messages when recorder append fails", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const server = await startWhatsAppFakeServer({
+      adminToken: "fake-whatsapp-admin-token",
+      accessToken: "fake-whatsapp-token",
+      recorderPath: directory,
+    });
+    servers.push(server);
+    const inboundEvents: unknown[] = [];
+    const socket = server.createBaileysMockSocket();
+    socket.ev.on("messages.upsert", (payload) => {
+      inboundEvents.push(payload);
+    });
+
+    const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({
+        chatJid: "120363001234567890@g.us",
+        pushName: "Fake Sender",
+        senderJid: "15551234567@s.whatsapp.net",
+        text: "unrecordable inbound nonce",
+      }),
+      headers: {
+        "content-type": "application/json",
+        "x-crabline-admin-token": "fake-whatsapp-admin-token",
+      },
+      method: "POST",
+    });
+    expect(inbound.status).toBe(500);
+    await expect(inbound.json()).resolves.toMatchObject({ ok: false });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(inboundEvents).toEqual([]);
+  });
+
   it("exposes a Baileys-shaped mock socket over the fake provider server", async () => {
     const directory = await createTempDir();
     directories.push(directory);
@@ -360,6 +411,9 @@ describe("whatsapp fake provider server", () => {
         method: "POST",
       });
       expect(inbound.status).toBe(200);
+      const inboundBody: unknown = await inbound.json();
+      const inboundMessageId = readInboundResponseMessageId(inboundBody);
+      expect(inboundMessageId).toMatch(/^wamid\.FAKE/u);
       await waitForCondition(() => inboundEvents.length === 1, "WhatsApp recorder inbound event");
       expect(inboundEvents).toEqual([
         expect.objectContaining({
@@ -379,6 +433,7 @@ describe("whatsapp fake provider server", () => {
           type: "notify",
         }),
       ]);
+      expect(readUpsertMessageId(inboundEvents[0])).toBe(inboundMessageId);
 
       socket.end();
       expect(connectionUpdates).toContainEqual(
@@ -435,6 +490,9 @@ describe("whatsapp fake provider server", () => {
         method: "POST",
       });
       expect(inbound.status).toBe(200);
+      const inboundBody: unknown = await inbound.json();
+      const inboundMessageId = readInboundResponseMessageId(inboundBody);
+      expect(inboundMessageId).toMatch(/^wamid\.FAKE/u);
 
       await waitForCondition(
         () => firstInboundEvents.length === 1 && secondInboundEvents.length === 1,
@@ -458,6 +516,8 @@ describe("whatsapp fake provider server", () => {
       });
       expect(firstInboundEvents).toEqual([expectedPayload]);
       expect(secondInboundEvents).toEqual([expectedPayload]);
+      expect(readUpsertMessageId(firstInboundEvents[0])).toBe(inboundMessageId);
+      expect(readUpsertMessageId(secondInboundEvents[0])).toBe(inboundMessageId);
     } finally {
       firstSocket.end();
       secondSocket.end();


### PR DESCRIPTION
## Summary

- Fix ClawSweeper feedback from #20 by recording the canonical WhatsApp inbound Baileys message generated by the fake server.
- Make recorder-backed runtime sockets replay that recorded message so omitted `messageId` values stay identical across the admin HTTP response, in-process sockets, and recorder replay.
- Keep backward compatibility for older recorder lines by falling back to the existing body-derived replay path when no recorded message is present.
- Preserve recorder-before-delivery ordering so append failures do not emit in-process WhatsApp socket events.

## Validation

- `pnpm exec vitest run test/whatsapp-fake-server.test.ts`
- `pnpm verify`
- `pnpm build`