### PR TITLE
Add signal-cli HTTP daemon mock

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,19 +157,19 @@ crabline --json serve signal --ready-file .crabline/signal-server.json
 
 The JSON manifest contains:
 
-- `endpoints.apiRoot`: set OpenClaw `channels.signal.httpUrl` to this value
-- `account`: set OpenClaw `channels.signal.account` to this value
+- `endpoints.apiRoot`: `signal-cli daemon --http`-compatible API root
+- `account`: mock Signal account served by the daemon
 - `adminToken`: send this as the `X-Crabline-Admin-Token` header when posting
   test user messages
 - `endpoints.adminInboundUrl`: authenticated POST endpoint for inbound messages
-- `endpoints.eventsUrl`: native Signal SSE receive endpoint
-- `endpoints.rpcUrl`: native Signal JSON-RPC endpoint
+- `endpoints.eventsUrl`: `signal-cli` SSE receive endpoint
+- `endpoints.rpcUrl`: `signal-cli` JSON-RPC endpoint
 - `recorderPath`: JSONL file of local provider API/admin traffic
 
-The server implements OpenClaw's native Signal `check`, `events`, and JSON-RPC
-surfaces. It supports text sends, typing, receipts, reactions, and text-only
-inbound messages; it does not emulate `signal-cli`, registration, linking, or
-Signal cryptography.
+The server implements the HTTP surface exposed by `signal-cli daemon --http`:
+`check`, `events`, and the JSON-RPC methods needed for text sends, typing,
+receipts, and reactions. Admin ingress injects text-only receive events. It does
+not replace the `signal-cli` client or pretend to be Signal's public service.
 
 Telegram:
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ provider APIs that OpenClaw live adapters can target during deterministic QA.
   `whatsapp`, and `zalo`
 - a `script` bridge for channels that are still exercised by external commands
 - per-provider local webhook endpoints for inbound events
-- local provider servers for live-adapter smoke tests, starting with Slack,
+- local provider servers for live-adapter smoke tests for Signal, Slack,
   Telegram, and WhatsApp
 - JSONL recorder files for deterministic wait/watch behavior
 - nonce-based `send`, `roundtrip`, `agent`, `probe`, `run`, `watch`, and
@@ -148,6 +148,28 @@ The admin token is generated randomly unless `--admin-token <token>` is
 provided. Implemented Slack Web API endpoints include `auth.test`,
 `chat.postMessage`, `conversations.open`, `conversations.info`,
 `conversations.history`, and `conversations.replies`.
+
+Signal:
+
+```bash
+crabline --json serve signal --ready-file .crabline/signal-server.json
+```
+
+The JSON manifest contains:
+
+- `endpoints.apiRoot`: set OpenClaw `channels.signal.httpUrl` to this value
+- `account`: set OpenClaw `channels.signal.account` to this value
+- `adminToken`: send this as the `X-Crabline-Admin-Token` header when posting
+  test user messages
+- `endpoints.adminInboundUrl`: authenticated POST endpoint for inbound messages
+- `endpoints.eventsUrl`: native Signal SSE receive endpoint
+- `endpoints.rpcUrl`: native Signal JSON-RPC endpoint
+- `recorderPath`: JSONL file of local provider API/admin traffic
+
+The server implements OpenClaw's native Signal `check`, `events`, and JSON-RPC
+surfaces. It supports text sends, typing, receipts, reactions, and text-only
+inbound messages; it does not emulate `signal-cli`, registration, linking, or
+Signal cryptography.
 
 Telegram:
 

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -106,6 +106,38 @@ The admin ingress accepts JSON like:
 OpenClaw consumes that message through Slack Events API shape; outbound adapter
 sends are recorded through Slack `chat.postMessage`.
 
+Signal:
+
+```bash
+crabline --json serve signal --ready-file .crabline/signal-server.json
+```
+
+Manifest fields:
+
+- `endpoints.apiRoot`: OpenClaw `channels.signal.httpUrl`
+- `account`: OpenClaw `channels.signal.account`
+- `adminToken`: value for the `X-Crabline-Admin-Token` header on admin ingress
+- `endpoints.adminInboundUrl`: authenticated admin ingress for test user messages
+- `endpoints.eventsUrl`: native Signal SSE receive endpoint
+- `endpoints.rpcUrl`: native Signal JSON-RPC endpoint
+- `recorderPath`: JSONL provider traffic recorder
+
+The admin ingress accepts JSON like:
+
+```json
+{
+  "groupId": "signal-group-1",
+  "sourceName": "Alice",
+  "sourceNumber": "+15551234567",
+  "text": "user nonce-123"
+}
+```
+
+OpenClaw consumes that message through the native Signal SSE surface; outbound
+text sends are recorded through the native `send` JSON-RPC method. The local
+server also accepts typing, receipt, and reaction RPCs. It does not emulate
+`signal-cli`, registration, linking, or Signal cryptography.
+
 Telegram:
 
 ```bash

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -114,12 +114,12 @@ crabline --json serve signal --ready-file .crabline/signal-server.json
 
 Manifest fields:
 
-- `endpoints.apiRoot`: OpenClaw `channels.signal.httpUrl`
-- `account`: OpenClaw `channels.signal.account`
+- `endpoints.apiRoot`: `signal-cli daemon --http`-compatible API root
+- `account`: mock Signal account served by the daemon
 - `adminToken`: value for the `X-Crabline-Admin-Token` header on admin ingress
 - `endpoints.adminInboundUrl`: authenticated admin ingress for test user messages
-- `endpoints.eventsUrl`: native Signal SSE receive endpoint
-- `endpoints.rpcUrl`: native Signal JSON-RPC endpoint
+- `endpoints.eventsUrl`: `signal-cli` SSE receive endpoint
+- `endpoints.rpcUrl`: `signal-cli` JSON-RPC endpoint
 - `recorderPath`: JSONL provider traffic recorder
 
 The admin ingress accepts JSON like:
@@ -133,10 +133,10 @@ The admin ingress accepts JSON like:
 }
 ```
 
-OpenClaw consumes that message through the native Signal SSE surface; outbound
-text sends are recorded through the native `send` JSON-RPC method. The local
-server also accepts typing, receipt, and reaction RPCs. It does not emulate
-`signal-cli`, registration, linking, or Signal cryptography.
+Clients consume that message through the `signal-cli` SSE surface; outbound text
+sends are recorded through its `send` JSON-RPC method. The local server also
+accepts typing, receipt, and reaction RPCs. OpenClaw-specific config and target
+mapping live in Crabline's OpenClaw bridge, outside the provider server.
 
 Telegram:
 

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -28,6 +28,7 @@ type ServeSharedOptions = {
 };
 
 type ServeCommandOptions = {
+  account?: string | undefined;
   accessToken?: string | undefined;
   adminToken?: string | undefined;
   botToken?: string | undefined;
@@ -47,6 +48,12 @@ type ServeParamFactory = (
 ) => StartCrablineServerParams;
 
 const SERVE_PARAM_FACTORIES = {
+  signal: (shared, commandOptions) => ({
+    ...shared,
+    account: commandOptions.account,
+    adminToken: commandOptions.adminToken,
+    channel: "signal",
+  }),
   slack: (shared, commandOptions) => ({
     ...shared,
     adminToken: commandOptions.adminToken,
@@ -239,6 +246,7 @@ export function createProgram(
     .option("--host <host>", "Bind host", "127.0.0.1")
     .option("--port <port>", "Bind port", "0")
     .option("--admin-token <token>", "Admin token for inbound test messages")
+    .option("--account <number>", "Signal account number")
     .option("--access-token <token>", "WhatsApp access token")
     .option("--bot-token <token>", "Telegram or Slack bot token")
     .option("--bot-username <username>", "Telegram bot username", "crabline_bot")
@@ -333,6 +341,16 @@ function renderServeText(manifest: CrablineServerManifest) {
 }
 
 function renderServeProviderFields(manifest: CrablineServerManifest): string[] | undefined {
+  if (manifest.provider === "signal") {
+    return [`  adminToken: ${manifest.adminToken}`, `  account: ${manifest.account}`];
+  }
+  if (manifest.provider === "slack") {
+    return [
+      `  adminToken: ${manifest.adminToken}`,
+      `  botToken: ${manifest.botToken}`,
+      `  signingSecret: ${manifest.signingSecret}`,
+    ];
+  }
   if (manifest.provider === "telegram") {
     return [`  adminToken: ${manifest.adminToken}`, `  botToken: ${manifest.botToken}`];
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { resolveTelegramAdapterConfig } from "./providers/builtin/telegram.js";
 export { resolveWhatsAppAdapterConfig } from "./providers/builtin/whatsapp.js";
+export { startSignalServer } from "./servers/signal.js";
 export { startSlackServer, startSlackServer as startSlackFakeServer } from "./servers/slack.js";
 export {
   startTelegramServer,
@@ -69,6 +70,11 @@ export type {
   WaitContext,
   WatchContext,
 } from "./providers/types.js";
+export type {
+  SignalServerManifest,
+  StartedSignalServer,
+  StartSignalServerParams,
+} from "./servers/signal.js";
 export type {
   SlackServerManifest as SlackFakeServerManifest,
   SlackServerManifest,

--- a/src/openclaw.ts
+++ b/src/openclaw.ts
@@ -7,6 +7,7 @@ import {
   type StartedCrablineServer,
 } from "./servers/index.js";
 import { SLACK_OPENCLAW_CRABLINE_PROVIDER_BRIDGE } from "./openclaw/bridges/slack.js";
+import { SIGNAL_OPENCLAW_CRABLINE_PROVIDER_BRIDGE } from "./openclaw/bridges/signal.js";
 import { TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE } from "./openclaw/bridges/telegram.js";
 import { WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE } from "./openclaw/bridges/whatsapp.js";
 import {
@@ -51,6 +52,7 @@ export type {
 } from "./openclaw/shared.js";
 
 const OPENCLAW_CRABLINE_PROVIDER_BRIDGES = {
+  signal: SIGNAL_OPENCLAW_CRABLINE_PROVIDER_BRIDGE,
   slack: SLACK_OPENCLAW_CRABLINE_PROVIDER_BRIDGE,
   telegram: TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE,
   whatsapp: WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE,

--- a/src/openclaw/bridges/signal.ts
+++ b/src/openclaw/bridges/signal.ts
@@ -24,7 +24,7 @@ export const SIGNAL_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablinePr
         if (!response.ok) {
           throw new Error(`Crabline Signal check probe failed with HTTP ${response.status}.`);
         }
-        return await response.json();
+        return { ok: true, status: response.status };
       },
       createBinding() {
         return {

--- a/src/openclaw/bridges/signal.ts
+++ b/src/openclaw/bridges/signal.ts
@@ -1,0 +1,112 @@
+import {
+  createAdminInboundRequest,
+  createOpenClawCrablineProviderBridge,
+  DEFAULT_ACCOUNT_ID,
+  isRecord,
+  qaTargetForInbound,
+  readString,
+} from "../shared.js";
+
+function signalTarget(kind: "direct" | "group", id: string): string {
+  const value = id.trim();
+  if (!value) {
+    throw new Error("Signal target is required.");
+  }
+  return kind === "group" ? `group:${value}` : value;
+}
+
+export const SIGNAL_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablineProviderBridge({
+  provider: "signal",
+  createAdapter(signal) {
+    return {
+      async probe() {
+        const response = await fetch(`${signal.baseUrl}/api/v1/check`);
+        if (!response.ok) {
+          throw new Error(`Crabline Signal check probe failed with HTTP ${response.status}.`);
+        }
+        return await response.json();
+      },
+      createBinding() {
+        return {
+          accountId: DEFAULT_ACCOUNT_ID,
+          channel: "signal",
+          createChannelDriverSmokeEnv: (env) => env,
+          createGatewayConfig: (openclawConfig = {}) => {
+            const channels = isRecord(openclawConfig.channels) ? openclawConfig.channels : {};
+            const signalConfig = isRecord(channels.signal) ? channels.signal : {};
+            return {
+              ...openclawConfig,
+              channels: {
+                ...channels,
+                signal: {
+                  ...signalConfig,
+                  account: signal.account,
+                  allowFrom: ["*"],
+                  apiMode: "native",
+                  autoStart: false,
+                  dmPolicy: "open",
+                  enabled: true,
+                  groupAllowFrom: ["*"],
+                  groupPolicy: "open",
+                  httpUrl: signal.baseUrl,
+                },
+              },
+            };
+          },
+          requiredPluginIds: ["signal"],
+        };
+      },
+      createAgentDelivery(parsed) {
+        const to = signalTarget(parsed.kind, parsed.id);
+        return { channel: "signal", replyChannel: "signal", replyTo: to, to };
+      },
+      createInbound(input) {
+        const kind = input.conversation.kind === "direct" ? "direct" : "group";
+        const conversationId = input.conversation.id.trim();
+        const senderId = input.senderId.trim();
+        if (!conversationId || !senderId) {
+          throw new Error("Signal conversation and sender are required.");
+        }
+        return {
+          ...createAdminInboundRequest(signal),
+          providerBody: {
+            ...(kind === "group" ? { groupId: conversationId } : {}),
+            ...(input.senderName ? { sourceName: input.senderName } : {}),
+            sourceNumber: senderId,
+            text: input.text,
+          },
+          providerTargetKey: kind === "group" ? `group:${conversationId}` : senderId,
+          qaTarget: qaTargetForInbound(input),
+          stateConversation: { id: conversationId, kind },
+        };
+      },
+      createOutboundFromRecorderEvent({ event, targetByProviderTarget }) {
+        if (
+          !isRecord(event) ||
+          event.type !== "api" ||
+          event.path !== "/api/v1/rpc" ||
+          !isRecord(event.body) ||
+          event.body.method !== "send" ||
+          !isRecord(event.body.params)
+        ) {
+          return null;
+        }
+        const text = readString(event.body.params.message);
+        const groupId = readString(event.body.params.groupId);
+        const recipients = event.body.params.recipient;
+        const recipient = Array.isArray(recipients) ? readString(recipients[0]) : undefined;
+        const target = groupId ? `group:${groupId}` : recipient;
+        if (!text || !target) {
+          return null;
+        }
+        return {
+          accountId: DEFAULT_ACCOUNT_ID,
+          senderId: "openclaw",
+          senderName: "OpenClaw QA",
+          text,
+          to: targetByProviderTarget.get(target) ?? target,
+        };
+      },
+    };
+  },
+});

--- a/src/openclaw/bridges/signal.ts
+++ b/src/openclaw/bridges/signal.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import {
   createAdminInboundRequest,
   createOpenClawCrablineProviderBridge,
@@ -7,12 +8,21 @@ import {
   readString,
 } from "../shared.js";
 
+function signalDirectId(id: string): string {
+  const value = id.trim();
+  if (/^\+?\d{3,}$/u.test(value)) {
+    return value.startsWith("+") ? value : `+${value}`;
+  }
+  const suffix = createHash("sha256").update(value).digest().readUInt32BE() % 10_000_000;
+  return `+1555${String(suffix).padStart(7, "0")}`;
+}
+
 function signalTarget(kind: "direct" | "group", id: string): string {
   const value = id.trim();
   if (!value) {
     throw new Error("Signal target is required.");
   }
-  return kind === "group" ? `group:${value}` : value;
+  return kind === "group" ? `group:${value}` : signalDirectId(value);
 }
 
 export const SIGNAL_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablineProviderBridge({
@@ -67,15 +77,16 @@ export const SIGNAL_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablinePr
         if (!conversationId || !senderId) {
           throw new Error("Signal conversation and sender are required.");
         }
+        const sourceNumber = signalDirectId(senderId);
         return {
           ...createAdminInboundRequest(signal),
           providerBody: {
             ...(kind === "group" ? { groupId: conversationId } : {}),
             ...(input.senderName ? { sourceName: input.senderName } : {}),
-            sourceNumber: senderId,
+            sourceNumber,
             text: input.text,
           },
-          providerTargetKey: kind === "group" ? `group:${conversationId}` : senderId,
+          providerTargetKey: kind === "group" ? `group:${conversationId}` : sourceNumber,
           qaTarget: qaTargetForInbound(input),
           stateConversation: { id: conversationId, kind },
         };

--- a/src/providers/catalog.ts
+++ b/src/providers/catalog.ts
@@ -76,7 +76,10 @@ export const OPENCLAW_SUPPORT_CATALOG = [
   },
   createBridgeEntry("nextcloudtalk", "OpenClaw plugin channel via script bridge."),
   createBridgeEntry("nostr", "OpenClaw plugin channel via script bridge."),
-  createBridgeEntry("signal", "OpenClaw channel via script bridge."),
+  createBridgeEntry(
+    "signal",
+    "OpenClaw channel via script bridge; native local provider server available.",
+  ),
   {
     notes: "Built-in local Slack mock with events webhook shape.",
     platform: "slack",

--- a/src/providers/catalog.ts
+++ b/src/providers/catalog.ts
@@ -78,7 +78,7 @@ export const OPENCLAW_SUPPORT_CATALOG = [
   createBridgeEntry("nostr", "OpenClaw plugin channel via script bridge."),
   createBridgeEntry(
     "signal",
-    "OpenClaw channel via script bridge; native local provider server available.",
+    "OpenClaw channel via script bridge; signal-cli HTTP-compatible local server available.",
   ),
   {
     notes: "Built-in local Slack mock with events webhook shape.",

--- a/src/servers/index.ts
+++ b/src/servers/index.ts
@@ -1,4 +1,10 @@
 import {
+  startSignalServer,
+  type SignalServerManifest,
+  type StartedSignalServer,
+  type StartSignalServerParams,
+} from "./signal.js";
+import {
   startSlackServer,
   type SlackServerManifest,
   type StartedSlackServer,
@@ -18,21 +24,29 @@ import {
 } from "./whatsapp.js";
 import { CrablineError } from "../core/errors.js";
 
-export const CRABLINE_SERVER_CHANNELS = Object.freeze(["slack", "telegram", "whatsapp"] as const);
+export const CRABLINE_SERVER_CHANNELS = Object.freeze([
+  "signal",
+  "slack",
+  "telegram",
+  "whatsapp",
+] as const);
 
 export type CrablineServerChannel = (typeof CRABLINE_SERVER_CHANNELS)[number];
 
 export type CrablineServerManifest =
+  | SignalServerManifest
   | SlackServerManifest
   | TelegramServerManifest
   | WhatsAppServerManifest;
 
 export type StartedCrablineServer =
+  | StartedSignalServer
   | StartedSlackServer
   | StartedTelegramServer
   | StartedWhatsAppServer;
 
 export type StartCrablineServerParams =
+  | (StartSignalServerParams & { channel: "signal" })
   | (StartSlackServerParams & { channel: "slack" })
   | (StartTelegramServerParams & { channel: "telegram" })
   | (StartWhatsAppServerParams & { channel: "whatsapp" });
@@ -43,6 +57,9 @@ export function isCrablineServerChannel(value: string): value is CrablineServerC
   return CRABLINE_SERVER_CHANNEL_SET.has(value);
 }
 
+export function startCrablineServer(
+  params: StartSignalServerParams & { channel: "signal" },
+): Promise<StartedSignalServer>;
 export function startCrablineServer(
   params: StartSlackServerParams & { channel: "slack" },
 ): Promise<StartedSlackServer>;
@@ -58,6 +75,9 @@ export function startCrablineServer(
 export async function startCrablineServer(
   params: StartCrablineServerParams,
 ): Promise<StartedCrablineServer> {
+  if (params.channel === "signal") {
+    return await startSignalServer(params);
+  }
   if (params.channel === "slack") {
     return await startSlackServer(params);
   }

--- a/src/servers/signal.ts
+++ b/src/servers/signal.ts
@@ -24,6 +24,8 @@ type SignalServerState = {
   recorderPath: string;
 };
 
+const SIGNAL_CLI_SSE_KEEPALIVE_MS = 15_000;
+
 export type SignalServerManifest = {
   account: string;
   adminToken: string;
@@ -63,7 +65,7 @@ function rpcResponse(id: unknown, result: unknown): Response {
 }
 
 function emitSignalEvent(state: SignalServerState, payload: unknown): void {
-  const event = `event: receive\ndata: ${JSON.stringify(payload)}\n\n`;
+  const event = `event:receive\ndata:${JSON.stringify(payload)}\n\n`;
   if (state.clients.size === 0) {
     state.pendingEvents.push(event);
     return;
@@ -181,7 +183,7 @@ async function handleRequest(params: {
       query: queryRecord(url),
       type: "api",
     });
-    fetchResponse = jsonResponse({ ok: true });
+    fetchResponse = new Response(null, { status: 200 });
   } else if (url.pathname === "/api/v1/rpc" && params.request.method === "POST") {
     const body = await parseRequestBody(params.request);
     await appendEvent(params.state, {
@@ -226,6 +228,12 @@ export async function startSignalServer(
       }
     });
   });
+  const keepalive = setInterval(() => {
+    for (const client of state.clients) {
+      client.write(":\n");
+    }
+  }, SIGNAL_CLI_SSE_KEEPALIVE_MS);
+  keepalive.unref();
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject);
     server.listen(params.port ?? 0, host, () => {
@@ -241,6 +249,7 @@ export async function startSignalServer(
   const baseUrl = `http://${host}:${address.port}`;
   return {
     async close() {
+      clearInterval(keepalive);
       for (const client of state.clients) {
         client.end();
       }

--- a/src/servers/signal.ts
+++ b/src/servers/signal.ts
@@ -246,7 +246,7 @@ export async function startSignalServer(
     await closeServer(server);
     throw new Error("Unable to resolve Signal local server address.");
   }
-  const baseUrl = `http://${host}:${address.port}`;
+  const baseUrl = `http://${host.includes(":") ? `[${host}]` : host}:${address.port}`;
   return {
     async close() {
       clearInterval(keepalive);

--- a/src/servers/signal.ts
+++ b/src/servers/signal.ts
@@ -1,0 +1,265 @@
+import { randomBytes } from "node:crypto";
+import fs from "node:fs/promises";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import path from "node:path";
+import {
+  adminAuthError,
+  closeServer,
+  hasAdminToken,
+  jsonResponse,
+  parseRequestBody,
+  queryRecord,
+  readInteger,
+  readTrimmedString,
+  type ServerRequestEvent,
+  writeResponse,
+} from "./http.js";
+
+type SignalServerState = {
+  account: string;
+  adminToken: string;
+  clients: Set<ServerResponse>;
+  nextTimestamp: number;
+  pendingEvents: string[];
+  recorderPath: string;
+};
+
+export type SignalServerManifest = {
+  account: string;
+  adminToken: string;
+  baseUrl: string;
+  endpoints: {
+    adminInboundUrl: string;
+    apiRoot: string;
+    eventsUrl: string;
+    rpcUrl: string;
+  };
+  env: Record<string, never>;
+  provider: "signal";
+  recorderPath: string;
+  version: 1;
+};
+
+export type StartedSignalServer = {
+  close(): Promise<void>;
+  manifest: SignalServerManifest;
+};
+
+export type StartSignalServerParams = {
+  account?: string | undefined;
+  adminToken?: string | undefined;
+  host?: string | undefined;
+  port?: number | undefined;
+  recorderPath?: string | undefined;
+};
+
+async function appendEvent(state: SignalServerState, event: ServerRequestEvent): Promise<void> {
+  await fs.mkdir(path.dirname(state.recorderPath), { recursive: true });
+  await fs.appendFile(state.recorderPath, `${JSON.stringify(event)}\n`, "utf8");
+}
+
+function rpcResponse(id: unknown, result: unknown): Response {
+  return jsonResponse({ id: id ?? null, jsonrpc: "2.0", result });
+}
+
+function emitSignalEvent(state: SignalServerState, payload: unknown): void {
+  const event = `event: receive\ndata: ${JSON.stringify(payload)}\n\n`;
+  if (state.clients.size === 0) {
+    state.pendingEvents.push(event);
+    return;
+  }
+  for (const client of state.clients) {
+    client.write(event);
+  }
+}
+
+async function handleAdminInbound(params: {
+  body: Record<string, unknown>;
+  state: SignalServerState;
+}): Promise<Response> {
+  const text = readTrimmedString(params.body.text);
+  const sourceNumber = readTrimmedString(params.body.sourceNumber ?? params.body.senderId);
+  if (!text || !sourceNumber) {
+    return jsonResponse({ error: "sourceNumber and text are required", ok: false }, 400);
+  }
+  const timestamp = readInteger(params.body.timestamp) ?? params.state.nextTimestamp++;
+  const groupId = readTrimmedString(params.body.groupId);
+  const payload = {
+    envelope: {
+      sourceName: readTrimmedString(params.body.sourceName ?? params.body.senderName),
+      sourceNumber,
+      timestamp,
+      dataMessage: {
+        message: text,
+        timestamp,
+        ...(groupId ? { groupInfo: { groupId } } : {}),
+      },
+    },
+  };
+  emitSignalEvent(params.state, payload);
+  return jsonResponse({ event: payload, ok: true });
+}
+
+async function handleRpc(params: {
+  body: Record<string, unknown>;
+  state: SignalServerState;
+}): Promise<Response> {
+  const method = readTrimmedString(params.body.method);
+  if (!method) {
+    return jsonResponse(
+      {
+        error: { code: -32600, message: "Invalid Request" },
+        id: params.body.id ?? null,
+        jsonrpc: "2.0",
+      },
+      400,
+    );
+  }
+  if (method === "version") {
+    return rpcResponse(params.body.id, { version: "crabline-signal-1" });
+  }
+  if (["send", "sendReaction", "sendReceipt", "sendTyping"].includes(method)) {
+    const timestamp = params.state.nextTimestamp++;
+    return rpcResponse(params.body.id, method === "sendTyping" ? {} : { timestamp });
+  }
+  return jsonResponse({
+    error: { code: -32601, message: `Method not found: ${method}` },
+    id: params.body.id ?? null,
+    jsonrpc: "2.0",
+  });
+}
+
+async function handleRequest(params: {
+  request: IncomingMessage;
+  response: ServerResponse;
+  state: SignalServerState;
+}): Promise<void> {
+  const url = new URL(params.request.url ?? "/", "http://localhost");
+  if (url.pathname === "/api/v1/events" && params.request.method === "GET") {
+    await appendEvent(params.state, {
+      at: new Date().toISOString(),
+      method: "GET",
+      path: url.pathname,
+      query: queryRecord(url),
+      type: "api",
+    });
+    params.response.writeHead(200, {
+      "cache-control": "no-cache",
+      connection: "keep-alive",
+      "content-type": "text/event-stream",
+    });
+    params.response.flushHeaders();
+    params.state.clients.add(params.response);
+    for (const event of params.state.pendingEvents.splice(0)) {
+      params.response.write(event);
+    }
+    params.response.once("close", () => params.state.clients.delete(params.response));
+    return;
+  }
+
+  let fetchResponse: Response;
+  if (url.pathname === "/crabline/signal/inbound" && params.request.method === "POST") {
+    if (!hasAdminToken(params.request, params.state.adminToken)) {
+      fetchResponse = adminAuthError();
+    } else {
+      const body = await parseRequestBody(params.request);
+      await appendEvent(params.state, {
+        at: new Date().toISOString(),
+        body,
+        method: "POST",
+        path: url.pathname,
+        query: queryRecord(url),
+        type: "admin",
+      });
+      fetchResponse = await handleAdminInbound({ body, state: params.state });
+    }
+  } else if (url.pathname === "/api/v1/check" && params.request.method === "GET") {
+    await appendEvent(params.state, {
+      at: new Date().toISOString(),
+      method: "GET",
+      path: url.pathname,
+      query: queryRecord(url),
+      type: "api",
+    });
+    fetchResponse = jsonResponse({ ok: true });
+  } else if (url.pathname === "/api/v1/rpc" && params.request.method === "POST") {
+    const body = await parseRequestBody(params.request);
+    await appendEvent(params.state, {
+      at: new Date().toISOString(),
+      body,
+      method: "POST",
+      path: url.pathname,
+      query: queryRecord(url),
+      type: "api",
+    });
+    fetchResponse = await handleRpc({ body, state: params.state });
+  } else {
+    fetchResponse = new Response("not found", { status: 404 });
+  }
+  await writeResponse(params.response, fetchResponse);
+}
+
+export async function startSignalServer(
+  params: StartSignalServerParams = {},
+): Promise<StartedSignalServer> {
+  const state: SignalServerState = {
+    account: params.account ?? "+15550000000",
+    adminToken: params.adminToken ?? randomBytes(24).toString("base64url"),
+    clients: new Set(),
+    nextTimestamp: Date.now(),
+    pendingEvents: [],
+    recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "signal.jsonl"),
+  };
+  const host = params.host ?? "127.0.0.1";
+  const server = createServer((request, response) => {
+    void handleRequest({ request, response, state }).catch(async (error) => {
+      if (!response.headersSent) {
+        await writeResponse(
+          response,
+          jsonResponse(
+            { error: error instanceof Error ? error.message : String(error), ok: false },
+            500,
+          ),
+        );
+      } else {
+        response.destroy(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(params.port ?? 0, host, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    await closeServer(server);
+    throw new Error("Unable to resolve Signal local server address.");
+  }
+  const baseUrl = `http://${host}:${address.port}`;
+  return {
+    async close() {
+      for (const client of state.clients) {
+        client.end();
+      }
+      await closeServer(server);
+    },
+    manifest: {
+      account: state.account,
+      adminToken: state.adminToken,
+      baseUrl,
+      endpoints: {
+        adminInboundUrl: `${baseUrl}/crabline/signal/inbound`,
+        apiRoot: baseUrl,
+        eventsUrl: `${baseUrl}/api/v1/events`,
+        rpcUrl: `${baseUrl}/api/v1/rpc`,
+      },
+      env: {},
+      provider: "signal",
+      recorderPath: state.recorderPath,
+      version: 1,
+    },
+  };
+}

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -43,6 +43,22 @@ const manifest: CrablineServerManifest = {
   version: 1,
 };
 
+const signalManifest: CrablineServerManifest = {
+  account: "+15550000000",
+  adminToken: "crabline-signal-admin-token",
+  baseUrl: "http://127.0.0.1:1357",
+  endpoints: {
+    adminInboundUrl: "http://127.0.0.1:1357/crabline/signal/inbound",
+    apiRoot: "http://127.0.0.1:1357",
+    eventsUrl: "http://127.0.0.1:1357/api/v1/events",
+    rpcUrl: "http://127.0.0.1:1357/api/v1/rpc",
+  },
+  env: {},
+  provider: "signal",
+  recorderPath: "/tmp/crabline/signal.jsonl",
+  version: 1,
+};
+
 const whatsappManifest: CrablineServerManifest = {
   accessToken: "crabline-whatsapp-access-token",
   adminToken: "crabline-whatsapp-admin-token",
@@ -118,9 +134,37 @@ describe("OpenClaw local provider bridge", () => {
     expect(resolveOpenClawCrablineChannelDriverSelection({ channel: " SLACK " })).toMatchObject({
       channel: "slack",
     });
+    expect(resolveOpenClawCrablineChannelDriverSelection({ channel: " SIGNAL " })).toMatchObject({
+      channel: "signal",
+    });
     expect(() => resolveOpenClawCrablineChannelDriverSelection({ channel: "discord" })).toThrow(
-      '--channel must be one of slack, telegram, whatsapp for --channel-driver crabline, got "discord"',
+      '--channel must be one of signal, slack, telegram, whatsapp for --channel-driver crabline, got "discord"',
     );
+  });
+
+  it("maps a Signal local provider into OpenClaw channel config", () => {
+    const binding = createOpenClawCrablineProviderBinding(signalManifest);
+
+    expect(binding).toMatchObject({
+      accountId: "default",
+      channel: "signal",
+      requiredPluginIds: ["signal"],
+    });
+    expect(binding.createGatewayConfig()).toMatchObject({
+      channels: {
+        signal: {
+          account: "+15550000000",
+          allowFrom: ["*"],
+          apiMode: "native",
+          autoStart: false,
+          dmPolicy: "open",
+          enabled: true,
+          groupAllowFrom: ["*"],
+          groupPolicy: "open",
+          httpUrl: "http://127.0.0.1:1357",
+        },
+      },
+    });
   });
 
   it("maps a Telegram local provider into OpenClaw channel config", () => {
@@ -487,6 +531,60 @@ describe("OpenClaw local provider bridge", () => {
     });
   });
 
+  it("maps Signal QA targets, inbound messages, and recorder events", () => {
+    expect(
+      createOpenClawCrablineAgentDelivery({ manifest: signalManifest, target: "group:group-1" }),
+    ).toEqual({
+      channel: "signal",
+      replyChannel: "signal",
+      replyTo: "group:group-1",
+      to: "group:group-1",
+    });
+
+    expect(
+      createOpenClawCrablineInbound({
+        manifest: signalManifest,
+        input: {
+          conversation: { id: "group-1", kind: "group" },
+          senderId: "+15551234567",
+          senderName: "Alice",
+          text: "hello",
+        },
+      }),
+    ).toMatchObject({
+      providerBody: {
+        groupId: "group-1",
+        sourceName: "Alice",
+        sourceNumber: "+15551234567",
+        text: "hello",
+      },
+      providerTargetKey: "group:group-1",
+      providerUrl: "http://127.0.0.1:1357/crabline/signal/inbound",
+      qaTarget: "group:group-1",
+    });
+
+    expect(
+      createOpenClawCrablineOutboundFromRecorderEvent({
+        manifest: signalManifest,
+        targetByProviderTarget: new Map([["group:group-1", "group:qa"]]),
+        event: {
+          body: {
+            method: "send",
+            params: { groupId: "group-1", message: "hello from openclaw" },
+          },
+          path: "/api/v1/rpc",
+          type: "api",
+        },
+      }),
+    ).toEqual({
+      accountId: "default",
+      senderId: "openclaw",
+      senderName: "OpenClaw QA",
+      text: "hello from openclaw",
+      to: "group:qa",
+    });
+  });
+
   it("posts WhatsApp OpenClaw inbound with admin headers into the local provider", async () => {
     const adapter = await startOpenClawCrablineAdapter({ channel: "whatsapp" });
     try {
@@ -535,7 +633,7 @@ describe("OpenClaw local provider bridge", () => {
         result: {
           driver: "crabline",
           selectedChannel: "telegram",
-          supportedChannels: ["slack", "telegram", "whatsapp"],
+          supportedChannels: ["signal", "slack", "telegram", "whatsapp"],
         },
       });
       expect(result.smoke).toMatchObject({

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -541,6 +541,38 @@ describe("OpenClaw local provider bridge", () => {
       to: "group:group-1",
     });
 
+    const directDelivery = createOpenClawCrablineAgentDelivery({
+      manifest: signalManifest,
+      target: "dm:qa-operator",
+    });
+    expect(directDelivery.to).toMatch(/^\+1555\d{7}$/u);
+
+    const directInbound = createOpenClawCrablineInbound({
+      manifest: signalManifest,
+      input: {
+        conversation: { id: "qa-operator", kind: "direct" },
+        senderId: "qa-operator",
+        text: "hello",
+      },
+    });
+    expect(directInbound.providerBody).toMatchObject({ sourceNumber: directDelivery.to });
+    expect(directInbound.providerTargetKey).toBe(directDelivery.to);
+
+    expect(
+      createOpenClawCrablineOutboundFromRecorderEvent({
+        manifest: signalManifest,
+        targetByProviderTarget: new Map([[directInbound.providerTargetKey, "dm:qa-operator"]]),
+        event: {
+          body: {
+            method: "send",
+            params: { message: "direct reply", recipient: [directDelivery.to] },
+          },
+          path: "/api/v1/rpc",
+          type: "api",
+        },
+      }),
+    ).toMatchObject({ text: "direct reply", to: "dm:qa-operator" });
+
     expect(
       createOpenClawCrablineInbound({
         manifest: signalManifest,

--- a/test/signal-server.test.ts
+++ b/test/signal-server.test.ts
@@ -22,6 +22,7 @@ describe("signal local provider server", () => {
 
     const check = await fetch(`${server.manifest.baseUrl}/api/v1/check`);
     expect(check.status).toBe(200);
+    await expect(check.text()).resolves.toBe("");
 
     const send = await fetch(server.manifest.endpoints.rpcUrl, {
       body: JSON.stringify({
@@ -68,7 +69,7 @@ describe("signal local provider server", () => {
     const chunk = await reader?.read();
     controller.abort();
     expect(new TextDecoder().decode(chunk?.value)).toContain(
-      'event: receive\ndata: {"envelope":{"sourceName":"Alice","sourceNumber":"+15557654321","timestamp":1700000000000,"dataMessage":{"message":"user nonce-1","timestamp":1700000000000,"groupInfo":{"groupId":"signal-group-1"}}}}',
+      'event:receive\ndata:{"envelope":{"sourceName":"Alice","sourceNumber":"+15557654321","timestamp":1700000000000,"dataMessage":{"message":"user nonce-1","timestamp":1700000000000,"groupInfo":{"groupId":"signal-group-1"}}}}',
     );
 
     const recorded = await fs.readFile(recorderPath, "utf8");

--- a/test/signal-server.test.ts
+++ b/test/signal-server.test.ts
@@ -1,0 +1,78 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { startSignalServer, type StartedSignalServer } from "../src/index.js";
+import { createTempDir, disposeTempDir } from "./test-helpers.js";
+
+const servers: StartedSignalServer[] = [];
+const directories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => server.close()));
+  await Promise.all(directories.splice(0).map(disposeTempDir));
+});
+
+describe("signal local provider server", () => {
+  it("serves native RPC and delivers authenticated inbound messages over SSE", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const recorderPath = path.join(directory, "signal.jsonl");
+    const server = await startSignalServer({ adminToken: "admin-secret", recorderPath });
+    servers.push(server);
+
+    const check = await fetch(`${server.manifest.baseUrl}/api/v1/check`);
+    expect(check.status).toBe(200);
+
+    const send = await fetch(server.manifest.endpoints.rpcUrl, {
+      body: JSON.stringify({
+        id: "rpc-1",
+        jsonrpc: "2.0",
+        method: "send",
+        params: { message: "hello", recipient: ["+15551234567"] },
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    await expect(send.json()).resolves.toMatchObject({
+      id: "rpc-1",
+      jsonrpc: "2.0",
+      result: { timestamp: expect.any(Number) },
+    });
+
+    const rejected = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({ sourceNumber: "+15557654321", text: "nope" }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    expect(rejected.status).toBe(401);
+
+    const accepted = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({
+        groupId: "signal-group-1",
+        sourceName: "Alice",
+        sourceNumber: "+15557654321",
+        text: "user nonce-1",
+        timestamp: 1_700_000_000_000,
+      }),
+      headers: {
+        "content-type": "application/json",
+        "x-crabline-admin-token": "admin-secret",
+      },
+      method: "POST",
+    });
+    expect(accepted.status).toBe(200);
+
+    const controller = new AbortController();
+    const events = await fetch(server.manifest.endpoints.eventsUrl, { signal: controller.signal });
+    const reader = events.body?.getReader();
+    const chunk = await reader?.read();
+    controller.abort();
+    expect(new TextDecoder().decode(chunk?.value)).toContain(
+      'event: receive\ndata: {"envelope":{"sourceName":"Alice","sourceNumber":"+15557654321","timestamp":1700000000000,"dataMessage":{"message":"user nonce-1","timestamp":1700000000000,"groupInfo":{"groupId":"signal-group-1"}}}}',
+    );
+
+    const recorded = await fs.readFile(recorderPath, "utf8");
+    expect(recorded).toContain('"method":"send"');
+    expect(recorded).toContain('"path":"/crabline/signal/inbound"');
+  });
+});

--- a/test/signal-server.test.ts
+++ b/test/signal-server.test.ts
@@ -13,6 +13,20 @@ afterEach(async () => {
 });
 
 describe("signal local provider server", () => {
+  it("advertises valid URLs when bound to IPv6", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const server = await startSignalServer({
+      host: "::1",
+      recorderPath: path.join(directory, "signal-ipv6.jsonl"),
+    });
+    servers.push(server);
+
+    expect(new URL(server.manifest.baseUrl).hostname).toBe("[::1]");
+    const check = await fetch(`${server.manifest.baseUrl}/api/v1/check`);
+    expect(check.status).toBe(200);
+  });
+
   it("serves native RPC and delivers authenticated inbound messages over SSE", async () => {
     const directory = await createTempDir();
     directories.push(directory);


### PR DESCRIPTION
## Summary

- add a provider-neutral mock of the HTTP API exposed by `signal-cli daemon --http`
- support health checks, receive events over SSE, and the JSON-RPC methods needed for sends, typing, receipts, and reactions
- keep OpenClaw config, target, and recorder mapping isolated in the OpenClaw bridge
- register the server in the CLI and document its provider contract

This does not fake Signal's upstream network service or replace the `signal-cli` client. Applications that normally talk to a `signal-cli` HTTP daemon can point at Crabline.

## Validation

- `pnpm verify`
- integration check using OpenClaw `signalCheck`, `signalRpcRequest`, and `streamSignalEvents` against the Crabline server
- compared endpoint status/body and SSE framing against current `signal-cli` source and manual