### PR TITLE
Add Mattermost provider server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,27 +1,5 @@
 # AGENTS.md
 
-## Provider Server Fidelity
-
-- Provider servers under `src/servers/` must emulate the real provider's public
-  protocol as faithfully as practical for the supported subset. Implement
-  provider-native routes, authentication, status codes, errors, payloads,
-  event ordering, connection behavior, and state transitions. Do not implement
-  an OpenClaw-shaped shortcut merely because it satisfies one current caller.
-- A provider server must remain independently usable by any compatible client.
-  Its production code must not import OpenClaw code or contain OpenClaw-specific
-  configuration, target syntax, QA assumptions, or conditional behavior.
-- OpenClaw integration may live in this repository only under OpenClaw-specific
-  bridge code such as `src/openclaw/bridges/`. Gateway configuration, QA target
-  translation, recorder normalization, and OpenClaw capability limitations
-  belong there or in the OpenClaw repository, never in the provider server.
-- Admin ingress is Crabline's out-of-band test control plane. It must translate
-  injected state into the provider's normal inbound transport and observable
-  behavior rather than exposing a QA-only path to provider clients.
-- Verify new provider behavior against authoritative provider documentation or
-  source and, when practical, an actual client implementation. Tests that only
-  prove OpenClaw accepts the mock are not sufficient evidence of protocol
-  fidelity.
-
 ## Documentation
 
 - Keep `docs/channel-setup.md` current whenever provider/channel support,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,27 @@
 # AGENTS.md
 
+## Provider Server Fidelity
+
+- Provider servers under `src/servers/` must emulate the real provider's public
+  protocol as faithfully as practical for the supported subset. Implement
+  provider-native routes, authentication, status codes, errors, payloads,
+  event ordering, connection behavior, and state transitions. Do not implement
+  an OpenClaw-shaped shortcut merely because it satisfies one current caller.
+- A provider server must remain independently usable by any compatible client.
+  Its production code must not import OpenClaw code or contain OpenClaw-specific
+  configuration, target syntax, QA assumptions, or conditional behavior.
+- OpenClaw integration may live in this repository only under OpenClaw-specific
+  bridge code such as `src/openclaw/bridges/`. Gateway configuration, QA target
+  translation, recorder normalization, and OpenClaw capability limitations
+  belong there or in the OpenClaw repository, never in the provider server.
+- Admin ingress is Crabline's out-of-band test control plane. It must translate
+  injected state into the provider's normal inbound transport and observable
+  behavior rather than exposing a QA-only path to provider clients.
+- Verify new provider behavior against authoritative provider documentation or
+  source and, when practical, an actual client implementation. Tests that only
+  prove OpenClaw accepts the mock are not sufficient evidence of protocol
+  fidelity.
+
 ## Documentation
 
 - Keep `docs/channel-setup.md` current whenever provider/channel support,

--- a/README.md
+++ b/README.md
@@ -125,6 +125,26 @@ commands for `probe`, `send`, `waitForInbound`, or `watch`.
 preferred Smoke CI path because OpenClaw still uses its normal channel adapter,
 but the provider endpoint is local and deterministic.
 
+Mattermost:
+
+```bash
+crabline --json serve mattermost --ready-file .crabline/mattermost-server.json
+```
+
+The JSON manifest contains:
+
+- `baseUrl`: OpenClaw `channels.mattermost.baseUrl` / `MATTERMOST_URL`
+- `botToken`: OpenClaw `channels.mattermost.botToken` / `MATTERMOST_BOT_TOKEN`
+- `endpoints.websocketUrl`: native Mattermost WebSocket endpoint
+- `adminToken`: send this as the `X-Crabline-Admin-Token` header when posting
+  test user messages
+- `endpoints.adminInboundUrl`: authenticated POST endpoint for inbound messages
+- `recorderPath`: JSONL file of local provider API/admin traffic
+
+The server implements the Mattermost REST and WebSocket paths used for text DM
+and channel roundtrips. Admin-injected messages are delivered as native
+`posted` events; outbound sends are recorded through `POST /api/v4/posts`.
+
 Slack:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -141,9 +141,11 @@ The JSON manifest contains:
 - `endpoints.adminInboundUrl`: authenticated POST endpoint for inbound messages
 - `recorderPath`: JSONL file of local provider API/admin traffic
 
-The server implements the Mattermost REST and WebSocket paths used for text DM
-and channel roundtrips. Admin-injected messages are delivered as native
-`posted` events; outbound sends are recorded through `POST /api/v4/posts`.
+The server implements a Mattermost API subset for text DM and channel
+roundtrips, including REST authentication/status codes, WebSocket
+authentication and `hello`, sequenced events, typing, and post
+create/edit/delete events. Admin ingress is only the test control plane;
+injected messages are delivered to clients as native `posted` events.
 
 Slack:
 

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -94,6 +94,12 @@ Admin inbound accepts `channelId`, `senderId`, `text`, optional `senderName`,
 written to the manifest's recorder. QA agent delivery currently supports DM and
 channel targets; thread targets require the later OpenClaw QA wiring step.
 
+The server itself is provider-shaped and has no OpenClaw runtime dependency. It
+implements Mattermost REST error/status behavior plus WebSocket authentication,
+`hello`, event sequencing, typing, and post mutation events for the supported
+subset. OpenClaw configuration and QA target mapping remain in the separate
+OpenClaw bridge.
+
 Local provider servers sit below OpenClaw's normal channel adapters. QA starts the
 server, writes the emitted runtime manifest into OpenClaw config/env, and then
 OpenClaw talks to the local provider instead of the public provider.

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -72,6 +72,28 @@ execution.
 
 ## Local Provider Servers
 
+Server-backed channels currently include Mattermost, Signal, Slack, Telegram,
+and WhatsApp.
+
+### Mattermost
+
+Start the server:
+
+```bash
+crabline --json serve mattermost --ready-file .crabline/mattermost-server.json
+```
+
+Use the manifest's `baseUrl` and `botToken` as OpenClaw's Mattermost endpoint
+and credential. Because the server is loopback HTTP, trusted QA configuration
+must also set `channels.mattermost.network.dangerouslyAllowPrivateNetwork` to
+`true`. The OpenClaw bridge does this automatically.
+
+Admin inbound accepts `channelId`, `senderId`, `text`, optional `senderName`,
+`channelType`, and `rootId`. It emits the message through Mattermost's native
+`/api/v4/websocket` `posted` event. Text sends through `POST /api/v4/posts` are
+written to the manifest's recorder. QA agent delivery currently supports DM and
+channel targets; thread targets require the later OpenClaw QA wiring step.
+
 Local provider servers sit below OpenClaw's normal channel adapters. QA starts the
 server, writes the emitted runtime manifest into OpenClaw config/env, and then
 OpenClaw talks to the local provider instead of the public provider.

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -48,6 +48,13 @@ type ServeParamFactory = (
 ) => StartCrablineServerParams;
 
 const SERVE_PARAM_FACTORIES = {
+  mattermost: (shared, commandOptions) => ({
+    ...shared,
+    adminToken: commandOptions.adminToken,
+    botToken: commandOptions.botToken,
+    botUsername: commandOptions.botUsername,
+    channel: "mattermost",
+  }),
   signal: (shared, commandOptions) => ({
     ...shared,
     account: commandOptions.account,
@@ -248,8 +255,8 @@ export function createProgram(
     .option("--admin-token <token>", "Admin token for inbound test messages")
     .option("--account <number>", "Signal account number")
     .option("--access-token <token>", "WhatsApp access token")
-    .option("--bot-token <token>", "Telegram or Slack bot token")
-    .option("--bot-username <username>", "Telegram bot username", "crabline_bot")
+    .option("--bot-token <token>", "Mattermost, Telegram, or Slack bot token")
+    .option("--bot-username <username>", "Mattermost or Telegram bot username", "crabline_bot")
     .option("--recorder <path>", "JSONL recorder path")
     .option("--ready-file <path>", "Write the server runtime manifest to this path")
     .option("--self-jid <jid>", "WhatsApp self JID")
@@ -341,6 +348,13 @@ function renderServeText(manifest: CrablineServerManifest) {
 }
 
 function renderServeProviderFields(manifest: CrablineServerManifest): string[] | undefined {
+  if (manifest.provider === "mattermost") {
+    return [
+      `  adminToken: ${manifest.adminToken}`,
+      `  botToken: ${manifest.botToken}`,
+      `  websocket: ${manifest.endpoints.websocketUrl}`,
+    ];
+  }
   if (manifest.provider === "signal") {
     return [`  adminToken: ${manifest.adminToken}`, `  account: ${manifest.account}`];
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { resolveTelegramAdapterConfig } from "./providers/builtin/telegram.js";
 export { resolveWhatsAppAdapterConfig } from "./providers/builtin/whatsapp.js";
+export { startMattermostServer } from "./servers/mattermost.js";
 export { startSignalServer } from "./servers/signal.js";
 export { startSlackServer, startSlackServer as startSlackFakeServer } from "./servers/slack.js";
 export {
@@ -70,6 +71,11 @@ export type {
   WaitContext,
   WatchContext,
 } from "./providers/types.js";
+export type {
+  MattermostServerManifest,
+  StartedMattermostServer,
+  StartMattermostServerParams,
+} from "./servers/mattermost.js";
 export type {
   SignalServerManifest,
   StartedSignalServer,

--- a/src/openclaw.ts
+++ b/src/openclaw.ts
@@ -7,6 +7,7 @@ import {
   type StartedCrablineServer,
 } from "./servers/index.js";
 import { SLACK_OPENCLAW_CRABLINE_PROVIDER_BRIDGE } from "./openclaw/bridges/slack.js";
+import { MATTERMOST_OPENCLAW_CRABLINE_PROVIDER_BRIDGE } from "./openclaw/bridges/mattermost.js";
 import { SIGNAL_OPENCLAW_CRABLINE_PROVIDER_BRIDGE } from "./openclaw/bridges/signal.js";
 import { TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE } from "./openclaw/bridges/telegram.js";
 import { WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE } from "./openclaw/bridges/whatsapp.js";
@@ -52,6 +53,7 @@ export type {
 } from "./openclaw/shared.js";
 
 const OPENCLAW_CRABLINE_PROVIDER_BRIDGES = {
+  mattermost: MATTERMOST_OPENCLAW_CRABLINE_PROVIDER_BRIDGE,
   signal: SIGNAL_OPENCLAW_CRABLINE_PROVIDER_BRIDGE,
   slack: SLACK_OPENCLAW_CRABLINE_PROVIDER_BRIDGE,
   telegram: TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE,

--- a/src/openclaw/bridges/mattermost.ts
+++ b/src/openclaw/bridges/mattermost.ts
@@ -1,0 +1,129 @@
+import {
+  createAdminInboundRequest,
+  createOpenClawCrablineProviderBridge,
+  DEFAULT_ACCOUNT_ID,
+  isRecord,
+  qaTargetForInbound,
+  readString,
+} from "../shared.js";
+import { mattermostId } from "../../servers/mattermost.js";
+
+function nativeId(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error("Mattermost target is required.");
+  }
+  return /^[a-z0-9]{26}$/u.test(trimmed) ? trimmed : mattermostId(trimmed);
+}
+
+function directChannelId(botUserId: string, userId: string): string {
+  return mattermostId(`dm:${[botUserId, userId].sort().join(":")}`);
+}
+
+function targetKey(channelId: string, rootId?: string): string {
+  return rootId ? `${channelId}:thread:${rootId}` : channelId;
+}
+
+export const MATTERMOST_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablineProviderBridge({
+  provider: "mattermost",
+  createAdapter(mattermost) {
+    return {
+      async probe() {
+        const response = await fetch(`${mattermost.endpoints.apiRoot}/users/me`, {
+          headers: { authorization: `Bearer ${mattermost.botToken}` },
+        });
+        if (!response.ok) {
+          throw new Error(`Crabline Mattermost probe failed with HTTP ${response.status}.`);
+        }
+        return await response.json();
+      },
+      createBinding() {
+        return {
+          accountId: DEFAULT_ACCOUNT_ID,
+          channel: "mattermost",
+          createChannelDriverSmokeEnv: (env) => ({ ...env, ...mattermost.env }),
+          createGatewayConfig: (openclawConfig = {}) => {
+            const channels = isRecord(openclawConfig.channels) ? openclawConfig.channels : {};
+            const mattermostConfig = isRecord(channels.mattermost) ? channels.mattermost : {};
+            return {
+              ...openclawConfig,
+              channels: {
+                ...channels,
+                mattermost: {
+                  ...mattermostConfig,
+                  allowFrom: ["*"],
+                  baseUrl: mattermost.baseUrl,
+                  botToken: mattermost.botToken,
+                  chatmode: "onmessage",
+                  dmPolicy: "open",
+                  enabled: true,
+                  groupAllowFrom: ["*"],
+                  groupPolicy: "open",
+                  network: { dangerouslyAllowPrivateNetwork: true },
+                  streaming: "off",
+                },
+              },
+            };
+          },
+          requiredPluginIds: ["mattermost"],
+        };
+      },
+      createAgentDelivery(parsed) {
+        if (parsed.threadId) {
+          throw new Error("Mattermost thread targets require OpenClaw QA thread forwarding.");
+        }
+        const id = nativeId(parsed.id);
+        const to = parsed.kind === "direct" ? `user:${id}` : `channel:${id}`;
+        return { channel: "mattermost", replyChannel: "mattermost", replyTo: to, to };
+      },
+      createInbound(input) {
+        const kind = input.conversation.kind === "direct" ? "direct" : "group";
+        const senderId = nativeId(input.senderId);
+        const channelId =
+          kind === "direct"
+            ? directChannelId(mattermost.botUserId, senderId)
+            : nativeId(input.conversation.id);
+        const rootId = input.threadId ? nativeId(input.threadId) : undefined;
+        return {
+          ...createAdminInboundRequest(mattermost),
+          providerBody: {
+            channelId,
+            channelType: kind === "direct" ? "D" : "O",
+            ...(rootId ? { rootId } : {}),
+            senderId,
+            ...(input.senderName ? { senderName: input.senderName } : {}),
+            text: input.text,
+          },
+          providerTargetKey: targetKey(channelId, rootId),
+          qaTarget: qaTargetForInbound(input),
+          stateConversation: { id: input.conversation.id, kind },
+          ...(input.threadId ? { threadId: input.threadId } : {}),
+        };
+      },
+      createOutboundFromRecorderEvent({ event, targetByProviderTarget }) {
+        if (
+          !isRecord(event) ||
+          event.type !== "api" ||
+          event.method !== "POST" ||
+          event.path !== "/api/v4/posts" ||
+          !isRecord(event.body)
+        ) {
+          return null;
+        }
+        const channelId = readString(event.body.channel_id);
+        const rootId = readString(event.body.root_id);
+        const text = readString(event.body.message);
+        if (!channelId || !text) {
+          return null;
+        }
+        return {
+          accountId: DEFAULT_ACCOUNT_ID,
+          senderId: mattermost.botUserId,
+          senderName: "OpenClaw QA",
+          text,
+          to: targetByProviderTarget.get(targetKey(channelId, rootId)) ?? channelId,
+        };
+      },
+    };
+  },
+});

--- a/src/servers/http.ts
+++ b/src/servers/http.ts
@@ -104,7 +104,7 @@ export async function startHttpJsonServer(params: {
     });
   }
   return {
-    baseUrl: `http://${params.host}:${address.port}`,
+    baseUrl: `http://${params.host.includes(":") ? `[${params.host}]` : params.host}:${address.port}`,
     async close() {
       await closeServer(server);
     },

--- a/src/servers/index.ts
+++ b/src/servers/index.ts
@@ -1,4 +1,10 @@
 import {
+  startMattermostServer,
+  type MattermostServerManifest,
+  type StartedMattermostServer,
+  type StartMattermostServerParams,
+} from "./mattermost.js";
+import {
   startSignalServer,
   type SignalServerManifest,
   type StartedSignalServer,
@@ -25,6 +31,7 @@ import {
 import { CrablineError } from "../core/errors.js";
 
 export const CRABLINE_SERVER_CHANNELS = Object.freeze([
+  "mattermost",
   "signal",
   "slack",
   "telegram",
@@ -34,18 +41,21 @@ export const CRABLINE_SERVER_CHANNELS = Object.freeze([
 export type CrablineServerChannel = (typeof CRABLINE_SERVER_CHANNELS)[number];
 
 export type CrablineServerManifest =
+  | MattermostServerManifest
   | SignalServerManifest
   | SlackServerManifest
   | TelegramServerManifest
   | WhatsAppServerManifest;
 
 export type StartedCrablineServer =
+  | StartedMattermostServer
   | StartedSignalServer
   | StartedSlackServer
   | StartedTelegramServer
   | StartedWhatsAppServer;
 
 export type StartCrablineServerParams =
+  | (StartMattermostServerParams & { channel: "mattermost" })
   | (StartSignalServerParams & { channel: "signal" })
   | (StartSlackServerParams & { channel: "slack" })
   | (StartTelegramServerParams & { channel: "telegram" })
@@ -57,6 +67,9 @@ export function isCrablineServerChannel(value: string): value is CrablineServerC
   return CRABLINE_SERVER_CHANNEL_SET.has(value);
 }
 
+export function startCrablineServer(
+  params: StartMattermostServerParams & { channel: "mattermost" },
+): Promise<StartedMattermostServer>;
 export function startCrablineServer(
   params: StartSignalServerParams & { channel: "signal" },
 ): Promise<StartedSignalServer>;
@@ -75,6 +88,9 @@ export function startCrablineServer(
 export async function startCrablineServer(
   params: StartCrablineServerParams,
 ): Promise<StartedCrablineServer> {
+  if (params.channel === "mattermost") {
+    return await startMattermostServer(params);
+  }
   if (params.channel === "signal") {
     return await startSignalServer(params);
   }

--- a/src/servers/mattermost.ts
+++ b/src/servers/mattermost.ts
@@ -24,6 +24,17 @@ type MattermostPost = {
   user_id: string;
 };
 
+type MattermostWebSocketEvent = {
+  broadcast: {
+    channel_id: string;
+    omit_users: null | Record<string, boolean>;
+    team_id: string;
+    user_id: string;
+  };
+  data: Record<string, unknown>;
+  event: string;
+};
+
 type MattermostServerState = {
   adminToken: string;
   botToken: string;
@@ -31,11 +42,11 @@ type MattermostServerState = {
   botUsername: string;
   channels: Map<string, { id: string; name: string; display_name: string; type: string }>;
   nextPost: number;
-  pendingEvents: string[];
+  pendingEvents: MattermostWebSocketEvent[];
   posts: Map<string, MattermostPost>;
   recorderPath: string;
   users: Map<string, { id: string; username: string; update_at: number }>;
-  websocketClients: Set<WebSocket>;
+  websocketClients: Map<WebSocket, number>;
 };
 
 export type MattermostServerManifest = {
@@ -82,12 +93,43 @@ async function appendEvent(state: MattermostServerState, event: ServerRequestEve
 }
 
 function authorized(request: IncomingMessage, token: string): boolean {
-  return request.headers.authorization === `Bearer ${token}`;
+  const [scheme, value] = request.headers.authorization?.trim().split(/\s+/, 2) ?? [];
+  return scheme?.toLowerCase() === "bearer" && value === token;
 }
 
-function postEvent(post: MattermostPost, senderName: string, channelType: string): string {
-  return JSON.stringify({
-    event: "posted",
+function mattermostError(message: string, status: number): Response {
+  return jsonResponse(
+    {
+      id: `api.context.${status}`,
+      message,
+      request_id: "",
+      status_code: status,
+    },
+    status,
+  );
+}
+
+function eventBroadcast(params: {
+  channelId?: string;
+  omitUsers?: Record<string, boolean>;
+  userId?: string;
+}): MattermostWebSocketEvent["broadcast"] {
+  return {
+    channel_id: params.channelId ?? "",
+    omit_users: params.omitUsers ?? null,
+    team_id: "",
+    user_id: params.userId ?? "",
+  };
+}
+
+function postEvent(
+  event: "post_deleted" | "post_edited" | "posted",
+  post: MattermostPost,
+  senderName: string,
+  channelType: string,
+): MattermostWebSocketEvent {
+  return {
+    event,
     data: {
       channel_display_name: post.channel_id,
       channel_id: post.channel_id,
@@ -96,19 +138,30 @@ function postEvent(post: MattermostPost, senderName: string, channelType: string
       post: JSON.stringify(post),
       sender_name: senderName,
     },
-    broadcast: { channel_id: post.channel_id, user_id: post.user_id },
-  });
+    broadcast: eventBroadcast({ channelId: post.channel_id, userId: post.user_id }),
+  };
 }
 
-function broadcast(state: MattermostServerState, message: string): void {
-  if (state.websocketClients.size === 0) {
-    state.pendingEvents.push(message);
+function sendEvent(
+  state: MattermostServerState,
+  client: WebSocket,
+  event: MattermostWebSocketEvent,
+) {
+  const seq = state.websocketClients.get(client);
+  if (seq === undefined || client.readyState !== WebSocket.OPEN) {
     return;
   }
-  for (const client of state.websocketClients) {
-    if (client.readyState === WebSocket.OPEN) {
-      client.send(message);
-    }
+  client.send(JSON.stringify({ ...event, seq }));
+  state.websocketClients.set(client, seq + 1);
+}
+
+function broadcast(state: MattermostServerState, event: MattermostWebSocketEvent): void {
+  if (state.websocketClients.size === 0) {
+    state.pendingEvents.push(event);
+    return;
+  }
+  for (const client of state.websocketClients.keys()) {
+    sendEvent(state, client, event);
   }
 }
 
@@ -159,7 +212,7 @@ async function handleAdminInbound(params: {
     state: params.state,
     userId: senderId,
   });
-  broadcast(params.state, postEvent(post, senderName, channelType));
+  broadcast(params.state, postEvent("posted", post, senderName, channelType));
   return jsonResponse({ ok: true, post });
 }
 
@@ -177,60 +230,103 @@ async function handleApi(params: {
   if (method === "GET" && usernameMatch?.[1]) {
     const username = decodeURIComponent(usernameMatch[1]);
     const user = [...state.users.values()].find((entry) => entry.username === username);
-    return user ? jsonResponse(user) : jsonResponse({ message: "User not found" }, 404);
+    return user ? jsonResponse(user) : mattermostError("User not found", 404);
   }
   const userMatch = /^\/users\/([^/]+)$/u.exec(apiPath);
   if (method === "GET" && userMatch?.[1]) {
     const user = state.users.get(userMatch[1]);
-    return user ? jsonResponse(user) : jsonResponse({ message: "User not found" }, 404);
+    return user ? jsonResponse(user) : mattermostError("User not found", 404);
   }
   const channelMatch = /^\/channels\/([^/]+)$/u.exec(apiPath);
   if (method === "GET" && channelMatch?.[1]) {
     const channel = state.channels.get(channelMatch[1]);
-    return channel ? jsonResponse(channel) : jsonResponse({ message: "Channel not found" }, 404);
+    return channel ? jsonResponse(channel) : mattermostError("Channel not found", 404);
   }
   if (method === "POST" && apiPath === "/channels/direct") {
     const userIds = Array.isArray(body) ? body : [];
+    if (userIds.length !== 2 || userIds.some((value) => typeof value !== "string" || !value)) {
+      return mattermostError("Two user IDs are required", 400);
+    }
     const channelId = mattermostId(`dm:${userIds.map(String).sort().join(":")}`);
     const channel = { display_name: "", id: channelId, name: channelId, type: "D" };
     state.channels.set(channelId, channel);
-    return jsonResponse(channel);
+    return jsonResponse(channel, 201);
   }
   if (method === "POST" && apiPath === "/users/me/typing") {
+    const channelId = readTrimmedString(body.channel_id);
+    if (!channelId) {
+      return mattermostError("channel_id is required", 400);
+    }
+    broadcast(state, {
+      broadcast: eventBroadcast({
+        channelId,
+        omitUsers: { [state.botUserId]: true },
+      }),
+      data: {
+        channel_id: channelId,
+        ...(readTrimmedString(body.parent_id)
+          ? { parent_id: readTrimmedString(body.parent_id) }
+          : {}),
+        user_id: state.botUserId,
+      },
+      event: "typing",
+    });
     return jsonResponse({});
   }
   if (method === "POST" && apiPath === "/posts") {
     const channelId = readTrimmedString(body.channel_id);
     const message = readTrimmedString(body.message);
     if (!channelId || !message) {
-      return jsonResponse({ message: "channel_id and message are required" }, 400);
+      return mattermostError("channel_id and message are required", 400);
     }
-    return jsonResponse(
-      createPost({
-        channelId,
-        message,
-        rootId: readTrimmedString(body.root_id),
-        state,
-        userId: state.botUserId,
-      }),
-      201,
-    );
+    const post = createPost({
+      channelId,
+      message,
+      rootId: readTrimmedString(body.root_id),
+      state,
+      userId: state.botUserId,
+    });
+    const channelType = state.channels.get(channelId)?.type ?? "O";
+    broadcast(state, postEvent("posted", post, state.botUsername, channelType));
+    return jsonResponse(post, 201);
   }
   const postMatch = /^\/posts\/([^/]+)$/u.exec(apiPath);
   if (postMatch?.[1] && method === "PUT") {
     const post = state.posts.get(postMatch[1]);
     if (!post) {
-      return jsonResponse({ message: "Post not found" }, 404);
+      return mattermostError("Post not found", 404);
     }
     const updated = { ...post, message: readTrimmedString(body.message) ?? post.message };
     state.posts.set(updated.id, updated);
+    broadcast(
+      state,
+      postEvent(
+        "post_edited",
+        updated,
+        state.botUsername,
+        state.channels.get(updated.channel_id)?.type ?? "O",
+      ),
+    );
     return jsonResponse(updated);
   }
   if (postMatch?.[1] && method === "DELETE") {
-    state.posts.delete(postMatch[1]);
+    const post = state.posts.get(postMatch[1]);
+    if (!post) {
+      return mattermostError("Post not found", 404);
+    }
+    state.posts.delete(post.id);
+    broadcast(
+      state,
+      postEvent(
+        "post_deleted",
+        post,
+        state.botUsername,
+        state.channels.get(post.channel_id)?.type ?? "O",
+      ),
+    );
     return new Response(null, { status: 204 });
   }
-  return jsonResponse({ message: "Not found" }, 404);
+  return mattermostError("Not found", 404);
 }
 
 async function handleRequest(request: IncomingMessage, state: MattermostServerState) {
@@ -255,7 +351,7 @@ async function handleRequest(request: IncomingMessage, state: MattermostServerSt
     return new Response("not found", { status: 404 });
   }
   if (!authorized(request, state.botToken)) {
-    return jsonResponse({ message: "Invalid or missing token" }, 401);
+    return mattermostError("Invalid or missing token", 401);
   }
   const body = method === "GET" || method === "DELETE" ? {} : await parseRequestBody(request);
   await appendEvent(state, {
@@ -290,25 +386,73 @@ function attachWebSocketServer(params: {
   params.server.on("upgrade", onUpgrade);
   websocketServer.on("connection", (client) => {
     client.on("message", (raw: RawData) => {
-      let message: { action?: string; data?: { token?: string }; seq?: number };
+      let message: {
+        action?: string;
+        data?: { channel_id?: string; parent_id?: string; token?: string };
+        seq?: number;
+      };
       try {
         message = JSON.parse(raw.toString()) as typeof message;
       } catch {
         client.close(1003, "invalid json");
         return;
       }
-      if (
-        message.action !== "authentication_challenge" ||
-        message.data?.token !== params.state.botToken
-      ) {
-        client.close(1008, "authentication failed");
+      const seq = message.seq ?? 0;
+      if (!params.state.websocketClients.has(client)) {
+        if (
+          message.action !== "authentication_challenge" ||
+          message.data?.token !== params.state.botToken
+        ) {
+          client.send(
+            JSON.stringify({
+              error: { id: "api.context.unauthorized", message: "Authentication failed" },
+              seq_reply: seq,
+              status: "FAIL",
+            }),
+          );
+          return;
+        }
+        params.state.websocketClients.set(client, 0);
+        client.send(JSON.stringify({ seq_reply: seq, status: "OK" }));
+        sendEvent(params.state, client, {
+          broadcast: eventBroadcast({ userId: params.state.botUserId }),
+          data: {
+            connection_id: mattermostId(`connection-${Date.now()}-${Math.random()}`),
+            server_version: "crabline-mattermost.1",
+          },
+          event: "hello",
+        });
+        for (const event of params.state.pendingEvents.splice(0)) {
+          sendEvent(params.state, client, event);
+        }
         return;
       }
-      params.state.websocketClients.add(client);
-      client.send(JSON.stringify({ seq_reply: message.seq ?? 0, status: "OK" }));
-      for (const event of params.state.pendingEvents.splice(0)) {
-        client.send(event);
+      if (message.action === "user_typing" && message.data?.channel_id) {
+        broadcast(params.state, {
+          broadcast: eventBroadcast({
+            channelId: message.data.channel_id,
+            omitUsers: { [params.state.botUserId]: true },
+          }),
+          data: {
+            parent_id: message.data.parent_id ?? "",
+            user_id: params.state.botUserId,
+          },
+          event: "typing",
+        });
+        client.send(JSON.stringify({ seq_reply: seq, status: "OK" }));
+        return;
       }
+      if (message.action === "ping") {
+        client.send(JSON.stringify({ data: { text: "pong" }, seq_reply: seq, status: "OK" }));
+        return;
+      }
+      client.send(
+        JSON.stringify({
+          error: { id: "api.websocket.invalid_action", message: "Unsupported action" },
+          seq_reply: seq,
+          status: "FAIL",
+        }),
+      );
     });
     client.once("close", () => params.state.websocketClients.delete(client));
   });
@@ -339,7 +483,7 @@ export async function startMattermostServer(
     posts: new Map(),
     recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "mattermost.jsonl"),
     users: new Map([[botUserId, { id: botUserId, update_at: Date.now(), username: botUsername }]]),
-    websocketClients: new Set(),
+    websocketClients: new Map(),
   };
   const httpServer = await startHttpJsonServer({
     handle: (request) => handleRequest(request, state),

--- a/src/servers/mattermost.ts
+++ b/src/servers/mattermost.ts
@@ -1,0 +1,375 @@
+import { createHash, randomBytes } from "node:crypto";
+import fs from "node:fs/promises";
+import type { IncomingMessage } from "node:http";
+import path from "node:path";
+import { WebSocket, WebSocketServer, type RawData } from "ws";
+import {
+  adminAuthError,
+  hasAdminToken,
+  jsonResponse,
+  parseRequestBody,
+  queryRecord,
+  readTrimmedString,
+  startHttpJsonServer,
+  type ServerRequestEvent,
+} from "./http.js";
+
+type MattermostPost = {
+  channel_id: string;
+  create_at: number;
+  id: string;
+  message: string;
+  root_id: string;
+  type: string;
+  user_id: string;
+};
+
+type MattermostServerState = {
+  adminToken: string;
+  botToken: string;
+  botUserId: string;
+  botUsername: string;
+  channels: Map<string, { id: string; name: string; display_name: string; type: string }>;
+  nextPost: number;
+  pendingEvents: string[];
+  posts: Map<string, MattermostPost>;
+  recorderPath: string;
+  users: Map<string, { id: string; username: string; update_at: number }>;
+  websocketClients: Set<WebSocket>;
+};
+
+export type MattermostServerManifest = {
+  adminToken: string;
+  baseUrl: string;
+  botToken: string;
+  botUserId: string;
+  endpoints: {
+    adminInboundUrl: string;
+    apiRoot: string;
+    websocketUrl: string;
+  };
+  env: {
+    MATTERMOST_BOT_TOKEN: string;
+    MATTERMOST_URL: string;
+  };
+  provider: "mattermost";
+  recorderPath: string;
+  version: 1;
+};
+
+export type StartedMattermostServer = {
+  close(): Promise<void>;
+  manifest: MattermostServerManifest;
+};
+
+export type StartMattermostServerParams = {
+  adminToken?: string | undefined;
+  botToken?: string | undefined;
+  botUserId?: string | undefined;
+  botUsername?: string | undefined;
+  host?: string | undefined;
+  port?: number | undefined;
+  recorderPath?: string | undefined;
+};
+
+export function mattermostId(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 26);
+}
+
+async function appendEvent(state: MattermostServerState, event: ServerRequestEvent): Promise<void> {
+  await fs.mkdir(path.dirname(state.recorderPath), { recursive: true });
+  await fs.appendFile(state.recorderPath, `${JSON.stringify(event)}\n`, "utf8");
+}
+
+function authorized(request: IncomingMessage, token: string): boolean {
+  return request.headers.authorization === `Bearer ${token}`;
+}
+
+function postEvent(post: MattermostPost, senderName: string, channelType: string): string {
+  return JSON.stringify({
+    event: "posted",
+    data: {
+      channel_display_name: post.channel_id,
+      channel_id: post.channel_id,
+      channel_name: post.channel_id,
+      channel_type: channelType,
+      post: JSON.stringify(post),
+      sender_name: senderName,
+    },
+    broadcast: { channel_id: post.channel_id, user_id: post.user_id },
+  });
+}
+
+function broadcast(state: MattermostServerState, message: string): void {
+  if (state.websocketClients.size === 0) {
+    state.pendingEvents.push(message);
+    return;
+  }
+  for (const client of state.websocketClients) {
+    if (client.readyState === WebSocket.OPEN) {
+      client.send(message);
+    }
+  }
+}
+
+function createPost(params: {
+  channelId: string;
+  message: string;
+  rootId?: string | undefined;
+  state: MattermostServerState;
+  userId: string;
+}): MattermostPost {
+  const id = mattermostId(`post-${params.state.nextPost++}`);
+  const post = {
+    channel_id: params.channelId,
+    create_at: Date.now(),
+    id,
+    message: params.message,
+    root_id: params.rootId ?? "",
+    type: "",
+    user_id: params.userId,
+  };
+  params.state.posts.set(id, post);
+  return post;
+}
+
+async function handleAdminInbound(params: {
+  body: Record<string, unknown>;
+  state: MattermostServerState;
+}): Promise<Response> {
+  const channelId = readTrimmedString(params.body.channelId ?? params.body.channel_id);
+  const senderId = readTrimmedString(params.body.senderId ?? params.body.user_id);
+  const text = readTrimmedString(params.body.text ?? params.body.message);
+  if (!channelId || !senderId || !text) {
+    return jsonResponse({ error: "channelId, senderId, and text are required", ok: false }, 400);
+  }
+  const senderName = readTrimmedString(params.body.senderName) ?? senderId;
+  const channelType = readTrimmedString(params.body.channelType) ?? "D";
+  params.state.users.set(senderId, { id: senderId, update_at: Date.now(), username: senderName });
+  params.state.channels.set(channelId, {
+    display_name: channelId,
+    id: channelId,
+    name: channelId,
+    type: channelType,
+  });
+  const post = createPost({
+    channelId,
+    message: text,
+    rootId: readTrimmedString(params.body.rootId ?? params.body.root_id),
+    state: params.state,
+    userId: senderId,
+  });
+  broadcast(params.state, postEvent(post, senderName, channelType));
+  return jsonResponse({ ok: true, post });
+}
+
+async function handleApi(params: {
+  body: Record<string, unknown>;
+  method: string;
+  path: string;
+  state: MattermostServerState;
+}): Promise<Response> {
+  const { body, method, path: apiPath, state } = params;
+  if (method === "GET" && apiPath === "/users/me") {
+    return jsonResponse(state.users.get(state.botUserId));
+  }
+  const usernameMatch = /^\/users\/username\/([^/]+)$/u.exec(apiPath);
+  if (method === "GET" && usernameMatch?.[1]) {
+    const username = decodeURIComponent(usernameMatch[1]);
+    const user = [...state.users.values()].find((entry) => entry.username === username);
+    return user ? jsonResponse(user) : jsonResponse({ message: "User not found" }, 404);
+  }
+  const userMatch = /^\/users\/([^/]+)$/u.exec(apiPath);
+  if (method === "GET" && userMatch?.[1]) {
+    const user = state.users.get(userMatch[1]);
+    return user ? jsonResponse(user) : jsonResponse({ message: "User not found" }, 404);
+  }
+  const channelMatch = /^\/channels\/([^/]+)$/u.exec(apiPath);
+  if (method === "GET" && channelMatch?.[1]) {
+    const channel = state.channels.get(channelMatch[1]);
+    return channel ? jsonResponse(channel) : jsonResponse({ message: "Channel not found" }, 404);
+  }
+  if (method === "POST" && apiPath === "/channels/direct") {
+    const userIds = Array.isArray(body) ? body : [];
+    const channelId = mattermostId(`dm:${userIds.map(String).sort().join(":")}`);
+    const channel = { display_name: "", id: channelId, name: channelId, type: "D" };
+    state.channels.set(channelId, channel);
+    return jsonResponse(channel);
+  }
+  if (method === "POST" && apiPath === "/users/me/typing") {
+    return jsonResponse({});
+  }
+  if (method === "POST" && apiPath === "/posts") {
+    const channelId = readTrimmedString(body.channel_id);
+    const message = readTrimmedString(body.message);
+    if (!channelId || !message) {
+      return jsonResponse({ message: "channel_id and message are required" }, 400);
+    }
+    return jsonResponse(
+      createPost({
+        channelId,
+        message,
+        rootId: readTrimmedString(body.root_id),
+        state,
+        userId: state.botUserId,
+      }),
+      201,
+    );
+  }
+  const postMatch = /^\/posts\/([^/]+)$/u.exec(apiPath);
+  if (postMatch?.[1] && method === "PUT") {
+    const post = state.posts.get(postMatch[1]);
+    if (!post) {
+      return jsonResponse({ message: "Post not found" }, 404);
+    }
+    const updated = { ...post, message: readTrimmedString(body.message) ?? post.message };
+    state.posts.set(updated.id, updated);
+    return jsonResponse(updated);
+  }
+  if (postMatch?.[1] && method === "DELETE") {
+    state.posts.delete(postMatch[1]);
+    return new Response(null, { status: 204 });
+  }
+  return jsonResponse({ message: "Not found" }, 404);
+}
+
+async function handleRequest(request: IncomingMessage, state: MattermostServerState) {
+  const url = new URL(request.url ?? "/", "http://localhost");
+  const method = request.method ?? "GET";
+  if (url.pathname === "/crabline/mattermost/inbound" && method === "POST") {
+    if (!hasAdminToken(request, state.adminToken)) {
+      return adminAuthError();
+    }
+    const body = await parseRequestBody(request);
+    await appendEvent(state, {
+      at: new Date().toISOString(),
+      body,
+      method,
+      path: url.pathname,
+      query: queryRecord(url),
+      type: "admin",
+    });
+    return await handleAdminInbound({ body, state });
+  }
+  if (!url.pathname.startsWith("/api/v4/")) {
+    return new Response("not found", { status: 404 });
+  }
+  if (!authorized(request, state.botToken)) {
+    return jsonResponse({ message: "Invalid or missing token" }, 401);
+  }
+  const body = method === "GET" || method === "DELETE" ? {} : await parseRequestBody(request);
+  await appendEvent(state, {
+    at: new Date().toISOString(),
+    ...(Object.keys(body).length > 0 ? { body } : {}),
+    method,
+    path: url.pathname,
+    query: queryRecord(url),
+    type: "api",
+  });
+  return await handleApi({ body, method, path: url.pathname.slice("/api/v4".length), state });
+}
+
+function attachWebSocketServer(params: {
+  state: MattermostServerState;
+  server: import("node:http").Server;
+}) {
+  const websocketServer = new WebSocketServer({ noServer: true });
+  const onUpgrade = (
+    request: IncomingMessage,
+    socket: import("node:stream").Duplex,
+    head: Buffer,
+  ) => {
+    if (new URL(request.url ?? "/", "http://localhost").pathname !== "/api/v4/websocket") {
+      socket.destroy();
+      return;
+    }
+    websocketServer.handleUpgrade(request, socket, head, (client) => {
+      websocketServer.emit("connection", client, request);
+    });
+  };
+  params.server.on("upgrade", onUpgrade);
+  websocketServer.on("connection", (client) => {
+    client.on("message", (raw: RawData) => {
+      let message: { action?: string; data?: { token?: string }; seq?: number };
+      try {
+        message = JSON.parse(raw.toString()) as typeof message;
+      } catch {
+        client.close(1003, "invalid json");
+        return;
+      }
+      if (
+        message.action !== "authentication_challenge" ||
+        message.data?.token !== params.state.botToken
+      ) {
+        client.close(1008, "authentication failed");
+        return;
+      }
+      params.state.websocketClients.add(client);
+      client.send(JSON.stringify({ seq_reply: message.seq ?? 0, status: "OK" }));
+      for (const event of params.state.pendingEvents.splice(0)) {
+        client.send(event);
+      }
+    });
+    client.once("close", () => params.state.websocketClients.delete(client));
+  });
+  return async () => {
+    params.server.off("upgrade", onUpgrade);
+    for (const client of websocketServer.clients) {
+      client.close();
+    }
+    await new Promise<void>((resolve, reject) =>
+      websocketServer.close((error) => (error ? reject(error) : resolve())),
+    );
+  };
+}
+
+export async function startMattermostServer(
+  params: StartMattermostServerParams = {},
+): Promise<StartedMattermostServer> {
+  const botUserId = params.botUserId ?? mattermostId("crabline-mattermost-bot");
+  const botUsername = params.botUsername ?? "crabline_bot";
+  const state: MattermostServerState = {
+    adminToken: params.adminToken ?? randomBytes(24).toString("base64url"),
+    botToken: params.botToken ?? "crabline-mattermost-token",
+    botUserId,
+    botUsername,
+    channels: new Map(),
+    nextPost: 1,
+    pendingEvents: [],
+    posts: new Map(),
+    recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "mattermost.jsonl"),
+    users: new Map([[botUserId, { id: botUserId, update_at: Date.now(), username: botUsername }]]),
+    websocketClients: new Set(),
+  };
+  const httpServer = await startHttpJsonServer({
+    handle: (request) => handleRequest(request, state),
+    host: params.host ?? "127.0.0.1",
+    port: params.port ?? 0,
+    serverName: "Mattermost",
+  });
+  const closeWebSocketServer = attachWebSocketServer({ server: httpServer.server, state });
+  return {
+    async close() {
+      await closeWebSocketServer();
+      await httpServer.close();
+    },
+    manifest: {
+      adminToken: state.adminToken,
+      baseUrl: httpServer.baseUrl,
+      botToken: state.botToken,
+      botUserId,
+      endpoints: {
+        adminInboundUrl: `${httpServer.baseUrl}/crabline/mattermost/inbound`,
+        apiRoot: `${httpServer.baseUrl}/api/v4`,
+        websocketUrl: `${httpServer.baseUrl.replace(/^http/u, "ws")}/api/v4/websocket`,
+      },
+      env: {
+        MATTERMOST_BOT_TOKEN: state.botToken,
+        MATTERMOST_URL: httpServer.baseUrl,
+      },
+      provider: "mattermost",
+      recorderPath: state.recorderPath,
+      version: 1,
+    },
+  };
+}

--- a/test/mattermost-server.test.ts
+++ b/test/mattermost-server.test.ts
@@ -22,6 +22,21 @@ function nextMessage(socket: WebSocket): Promise<Record<string, unknown>> {
   });
 }
 
+function nextMessages(socket: WebSocket, count: number): Promise<Record<string, unknown>[]> {
+  return new Promise((resolve, reject) => {
+    const messages: Record<string, unknown>[] = [];
+    const onMessage = (data: WebSocket.RawData) => {
+      messages.push(JSON.parse(data.toString()) as Record<string, unknown>);
+      if (messages.length === count) {
+        socket.off("message", onMessage);
+        resolve(messages);
+      }
+    };
+    socket.on("message", onMessage);
+    socket.once("error", reject);
+  });
+}
+
 describe("Mattermost local provider server", () => {
   it("serves authenticated REST and delivers admin inbound over the native WebSocket", async () => {
     const directory = await createTempDir();
@@ -50,6 +65,7 @@ describe("Mattermost local provider server", () => {
       socket.once("open", resolve);
       socket.once("error", reject);
     });
+    const authenticated = nextMessages(socket, 2);
     socket.send(
       JSON.stringify({
         action: "authentication_challenge",
@@ -57,7 +73,38 @@ describe("Mattermost local provider server", () => {
         seq: 1,
       }),
     );
-    await expect(nextMessage(socket)).resolves.toEqual({ seq_reply: 1, status: "OK" });
+    const [authResponse, hello] = await authenticated;
+    expect(authResponse).toEqual({ seq_reply: 1, status: "OK" });
+    expect(hello).toMatchObject({
+      event: "hello",
+      data: {
+        connection_id: expect.any(String),
+        server_version: expect.any(String),
+      },
+      broadcast: {
+        channel_id: "",
+        omit_users: null,
+        team_id: "",
+        user_id: server.manifest.botUserId,
+      },
+      seq: 0,
+    });
+
+    const pong = nextMessage(socket);
+    socket.send(JSON.stringify({ action: "ping", data: {}, seq: 2 }));
+    await expect(pong).resolves.toEqual({
+      data: { text: "pong" },
+      seq_reply: 2,
+      status: "OK",
+    });
+
+    const unsupported = nextMessage(socket);
+    socket.send(JSON.stringify({ action: "unsupported", data: {}, seq: 3 }));
+    await expect(unsupported).resolves.toMatchObject({
+      error: { id: "api.websocket.invalid_action" },
+      seq_reply: 3,
+      status: "FAIL",
+    });
 
     const inboundMessage = nextMessage(socket);
     const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
@@ -80,10 +127,14 @@ describe("Mattermost local provider server", () => {
       data: { channel_type: "O", sender_name: "alice" },
       broadcast: {
         channel_id: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+        omit_users: null,
+        team_id: "",
         user_id: "bbbbbbbbbbbbbbbbbbbbbbbbbb",
       },
+      seq: 1,
     });
 
+    const outboundEvent = nextMessage(socket);
     const send = await fetch(`${server.manifest.endpoints.apiRoot}/posts`, {
       body: JSON.stringify({
         channel_id: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -93,11 +144,44 @@ describe("Mattermost local provider server", () => {
       method: "POST",
     });
     expect(send.status).toBe(201);
-    await expect(send.json()).resolves.toMatchObject({
+    const sentPost = (await send.json()) as Record<string, unknown>;
+    expect(sentPost).toMatchObject({
       channel_id: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
       message: "assistant nonce-1",
       user_id: server.manifest.botUserId,
     });
+    await expect(outboundEvent).resolves.toMatchObject({
+      event: "posted",
+      data: { channel_id: "aaaaaaaaaaaaaaaaaaaaaaaaaa", sender_name: "crabline_bot" },
+      seq: 2,
+    });
+
+    const direct = await fetch(`${server.manifest.endpoints.apiRoot}/channels/direct`, {
+      body: JSON.stringify([server.manifest.botUserId, "bbbbbbbbbbbbbbbbbbbbbbbbbb"]),
+      headers: { authorization: "bearer bot-secret", "content-type": "application/json" },
+      method: "POST",
+    });
+    expect(direct.status).toBe(201);
+    await expect(direct.json()).resolves.toMatchObject({ type: "D" });
+
+    const postId = sentPost.id;
+    expect(postId).toMatch(/^[a-z0-9]{26}$/u);
+    const editedEvent = nextMessage(socket);
+    const edited = await fetch(`${server.manifest.endpoints.apiRoot}/posts/${postId}`, {
+      body: JSON.stringify({ message: "assistant edited" }),
+      headers: { authorization: "Bearer bot-secret", "content-type": "application/json" },
+      method: "PUT",
+    });
+    expect(edited.status).toBe(200);
+    await expect(editedEvent).resolves.toMatchObject({ event: "post_edited", seq: 3 });
+
+    const deletedEvent = nextMessage(socket);
+    const deleted = await fetch(`${server.manifest.endpoints.apiRoot}/posts/${postId}`, {
+      headers: { authorization: "Bearer bot-secret" },
+      method: "DELETE",
+    });
+    expect(deleted.status).toBe(204);
+    await expect(deletedEvent).resolves.toMatchObject({ event: "post_deleted", seq: 4 });
     socket.close();
 
     const recorded = await fs.readFile(recorderPath, "utf8");

--- a/test/mattermost-server.test.ts
+++ b/test/mattermost-server.test.ts
@@ -1,0 +1,107 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { WebSocket } from "ws";
+import { afterEach, describe, expect, it } from "vitest";
+import { startMattermostServer, type StartedMattermostServer } from "../src/index.js";
+import { createTempDir, disposeTempDir } from "./test-helpers.js";
+
+const servers: StartedMattermostServer[] = [];
+const directories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => server.close()));
+  await Promise.all(directories.splice(0).map(disposeTempDir));
+});
+
+function nextMessage(socket: WebSocket): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    socket.once("message", (data) =>
+      resolve(JSON.parse(data.toString()) as Record<string, unknown>),
+    );
+    socket.once("error", reject);
+  });
+}
+
+describe("Mattermost local provider server", () => {
+  it("serves authenticated REST and delivers admin inbound over the native WebSocket", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const recorderPath = path.join(directory, "mattermost.jsonl");
+    const server = await startMattermostServer({
+      adminToken: "admin-secret",
+      botToken: "bot-secret",
+      recorderPath,
+    });
+    servers.push(server);
+
+    const unauthorized = await fetch(`${server.manifest.endpoints.apiRoot}/users/me`);
+    expect(unauthorized.status).toBe(401);
+
+    const me = await fetch(`${server.manifest.endpoints.apiRoot}/users/me`, {
+      headers: { authorization: "Bearer bot-secret" },
+    });
+    await expect(me.json()).resolves.toMatchObject({
+      id: server.manifest.botUserId,
+      username: "crabline_bot",
+    });
+
+    const socket = new WebSocket(server.manifest.endpoints.websocketUrl);
+    await new Promise<void>((resolve, reject) => {
+      socket.once("open", resolve);
+      socket.once("error", reject);
+    });
+    socket.send(
+      JSON.stringify({
+        action: "authentication_challenge",
+        data: { token: "bot-secret" },
+        seq: 1,
+      }),
+    );
+    await expect(nextMessage(socket)).resolves.toEqual({ seq_reply: 1, status: "OK" });
+
+    const inboundMessage = nextMessage(socket);
+    const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({
+        channelId: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+        channelType: "O",
+        senderId: "bbbbbbbbbbbbbbbbbbbbbbbbbb",
+        senderName: "alice",
+        text: "user nonce-1",
+      }),
+      headers: {
+        "content-type": "application/json",
+        "x-crabline-admin-token": "admin-secret",
+      },
+      method: "POST",
+    });
+    expect(inbound.status).toBe(200);
+    await expect(inboundMessage).resolves.toMatchObject({
+      event: "posted",
+      data: { channel_type: "O", sender_name: "alice" },
+      broadcast: {
+        channel_id: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+        user_id: "bbbbbbbbbbbbbbbbbbbbbbbbbb",
+      },
+    });
+
+    const send = await fetch(`${server.manifest.endpoints.apiRoot}/posts`, {
+      body: JSON.stringify({
+        channel_id: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+        message: "assistant nonce-1",
+      }),
+      headers: { authorization: "Bearer bot-secret", "content-type": "application/json" },
+      method: "POST",
+    });
+    expect(send.status).toBe(201);
+    await expect(send.json()).resolves.toMatchObject({
+      channel_id: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+      message: "assistant nonce-1",
+      user_id: server.manifest.botUserId,
+    });
+    socket.close();
+
+    const recorded = await fs.readFile(recorderPath, "utf8");
+    expect(recorded).toContain('"path":"/crabline/mattermost/inbound"');
+    expect(recorded).toContain('"path":"/api/v4/posts"');
+  });
+});

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -59,6 +59,25 @@ const signalManifest: CrablineServerManifest = {
   version: 1,
 };
 
+const mattermostManifest: CrablineServerManifest = {
+  adminToken: "crabline-mattermost-admin-token",
+  baseUrl: "http://127.0.0.1:9753",
+  botToken: "crabline-mattermost-token",
+  botUserId: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+  endpoints: {
+    adminInboundUrl: "http://127.0.0.1:9753/crabline/mattermost/inbound",
+    apiRoot: "http://127.0.0.1:9753/api/v4",
+    websocketUrl: "ws://127.0.0.1:9753/api/v4/websocket",
+  },
+  env: {
+    MATTERMOST_BOT_TOKEN: "crabline-mattermost-token",
+    MATTERMOST_URL: "http://127.0.0.1:9753",
+  },
+  provider: "mattermost",
+  recorderPath: "/tmp/crabline/mattermost.jsonl",
+  version: 1,
+};
+
 const whatsappManifest: CrablineServerManifest = {
   accessToken: "crabline-whatsapp-access-token",
   adminToken: "crabline-whatsapp-admin-token",
@@ -137,8 +156,11 @@ describe("OpenClaw local provider bridge", () => {
     expect(resolveOpenClawCrablineChannelDriverSelection({ channel: " SIGNAL " })).toMatchObject({
       channel: "signal",
     });
+    expect(
+      resolveOpenClawCrablineChannelDriverSelection({ channel: " MATTERMOST " }),
+    ).toMatchObject({ channel: "mattermost" });
     expect(() => resolveOpenClawCrablineChannelDriverSelection({ channel: "discord" })).toThrow(
-      '--channel must be one of signal, slack, telegram, whatsapp for --channel-driver crabline, got "discord"',
+      '--channel must be one of mattermost, signal, slack, telegram, whatsapp for --channel-driver crabline, got "discord"',
     );
   });
 
@@ -639,6 +661,102 @@ describe("OpenClaw local provider bridge", () => {
     });
   });
 
+  it("maps Mattermost QA targets, inbound messages, and recorder events", () => {
+    const delivery = createOpenClawCrablineAgentDelivery({
+      manifest: mattermostManifest,
+      target: "dm:alice",
+    });
+    expect(delivery).toMatchObject({
+      channel: "mattermost",
+      replyChannel: "mattermost",
+    });
+    expect(delivery.to).toMatch(/^user:[a-z0-9]{26}$/u);
+
+    expect(() =>
+      createOpenClawCrablineAgentDelivery({
+        manifest: mattermostManifest,
+        target: "thread:general/parent",
+      }),
+    ).toThrow("Mattermost thread targets require OpenClaw QA thread forwarding.");
+
+    const inbound = createOpenClawCrablineInbound({
+      manifest: mattermostManifest,
+      input: {
+        conversation: { id: "alice", kind: "direct" },
+        senderId: "alice",
+        senderName: "Alice",
+        text: "hello",
+      },
+    });
+    expect(inbound).toMatchObject({
+      providerBody: {
+        channelType: "D",
+        senderName: "Alice",
+        text: "hello",
+      },
+      providerUrl: "http://127.0.0.1:9753/crabline/mattermost/inbound",
+      qaTarget: "dm:alice",
+    });
+    expect(inbound.providerBody.senderId).toBe(delivery.to.slice("user:".length));
+
+    expect(
+      createOpenClawCrablineOutboundFromRecorderEvent({
+        manifest: mattermostManifest,
+        targetByProviderTarget: new Map([[inbound.providerTargetKey, "dm:alice"]]),
+        event: {
+          body: { channel_id: inbound.providerTargetKey, message: "hello from openclaw" },
+          method: "POST",
+          path: "/api/v4/posts",
+          type: "api",
+        },
+      }),
+    ).toEqual({
+      accountId: "default",
+      senderId: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+      senderName: "OpenClaw QA",
+      text: "hello from openclaw",
+      to: "dm:alice",
+    });
+
+    const binding = createOpenClawCrablineProviderBinding(mattermostManifest);
+    expect(binding).toMatchObject({
+      channel: "mattermost",
+      requiredPluginIds: ["mattermost"],
+    });
+    expect(binding.createGatewayConfig()).toMatchObject({
+      channels: { mattermost: { chatmode: "onmessage", streaming: "off" } },
+    });
+
+    const threadInbound = createOpenClawCrablineInbound({
+      manifest: mattermostManifest,
+      input: {
+        conversation: { id: "general", kind: "group" },
+        senderId: "alice",
+        text: "thread reply",
+        threadId: "parent",
+      },
+    });
+    expect(threadInbound.providerTargetKey).toMatch(/:thread:[a-z0-9]{26}$/u);
+    expect(
+      createOpenClawCrablineOutboundFromRecorderEvent({
+        manifest: mattermostManifest,
+        targetByProviderTarget: new Map([
+          [threadInbound.providerTargetKey, "thread:general/parent"],
+        ]),
+        event: {
+          body: {
+            channel_id: threadInbound.providerBody.channelId,
+            message: "thread response",
+            root_id: threadInbound.providerBody.rootId,
+          },
+          method: "POST",
+          path: "/api/v4/posts",
+          type: "api",
+        },
+      }),
+    ).toMatchObject({ to: "thread:general/parent" });
+  });
+
   it("posts WhatsApp OpenClaw inbound with admin headers into the local provider", async () => {
     const adapter = await startOpenClawCrablineAdapter({ channel: "whatsapp" });
     try {
@@ -687,7 +805,7 @@ describe("OpenClaw local provider bridge", () => {
         result: {
           driver: "crabline",
           selectedChannel: "telegram",
-          supportedChannels: ["signal", "slack", "telegram", "whatsapp"],
+          supportedChannels: ["mattermost", "signal", "slack", "telegram", "whatsapp"],
         },
       });
       expect(result.smoke).toMatchObject({


### PR DESCRIPTION
## Summary

- add a standalone Mattermost-compatible REST and WebSocket server subset for text DM/channel roundtrips
- add the separate OpenClaw bridge, CLI registration, exports, manifests, recorder mapping, and setup docs
- deliver admin-injected messages through native Mattermost `posted` events and record outbound REST writes

## Mattermost protocol

- bearer-authenticated `/api/v4` identity, user/channel lookup, direct-channel, typing, and post create/edit/delete routes
- native WebSocket authentication response followed by a sequenced `hello` event
- Mattermost `ping`/`pong`, typing, `posted`, `post_edited`, and `post_deleted` events with provider-shaped broadcast envelopes
- Mattermost-style REST status codes and error bodies
- admin ingress is only Crabline's out-of-band test control plane; the server has no OpenClaw imports or runtime assumptions

## OpenClaw bridge

- maps the server manifest to existing Mattermost `baseUrl`/`botToken` configuration
- handles QA/native target IDs and recorder conversion outside the provider server
- disables mention gating and streaming in the generated QA binding for deterministic text assertions
- agent delivery supports DM and channel targets; thread targets wait for the OpenClaw QA wiring step to forward thread IDs separately

## Verification

- `pnpm verify` (36 files, 171 tests)
- OpenClaw's real Mattermost client and WebSocket monitor helper passed against the local server
- protocol tests cover auth, `hello`, sequencing, `ping`/`pong`, inbound/outbound posts, direct channels, edit, and delete
- autoreview: clean, no actionable findings
