### PR TITLE
Document provider server fidelity rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,27 @@
 # AGENTS.md
 
+## Provider Server Fidelity
+
+- Provider servers under `src/servers/` must emulate the real provider's public
+  protocol as faithfully as practical for the supported subset. Implement
+  provider-native routes, authentication, status codes, errors, payloads,
+  event ordering, connection behavior, and state transitions. Do not implement
+  an OpenClaw-shaped shortcut merely because it satisfies one current caller.
+- A provider server must remain independently usable by any compatible client.
+  Its production code must not import OpenClaw code or contain OpenClaw-specific
+  configuration, target syntax, QA assumptions, or conditional behavior.
+- OpenClaw integration may live in this repository only under OpenClaw-specific
+  bridge code such as `src/openclaw/bridges/`. Gateway configuration, QA target
+  translation, recorder normalization, and OpenClaw capability limitations
+  belong there or in the OpenClaw repository, never in the provider server.
+- Admin ingress is Crabline's out-of-band test control plane. It must translate
+  injected state into the provider's normal inbound transport and observable
+  behavior rather than exposing a QA-only path to provider clients.
+- Verify new provider behavior against authoritative provider documentation or
+  source and, when practical, an actual client implementation. Tests that only
+  prove OpenClaw accepts the mock are not sufficient evidence of protocol
+  fidelity.
+
 ## Documentation
 
 - Keep `docs/channel-setup.md` current whenever provider/channel support,


### PR DESCRIPTION
## Summary

- require provider servers to emulate provider-native protocols rather than caller-specific shortcuts
- require provider servers to remain independently usable by compatible clients
- isolate OpenClaw configuration, QA target mapping, and recorder normalization to OpenClaw-specific bridge code or the OpenClaw repository
- require admin ingress to translate into normal provider behavior and verification against authoritative provider docs/source

Documentation-only contributor guidance; no runtime behavior changes.
