### PR TITLE
Add Matrix provider server

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ provider APIs that OpenClaw live adapters can target during deterministic QA.
   `whatsapp`, and `zalo`
 - a `script` bridge for channels that are still exercised by external commands
 - per-provider local webhook endpoints for inbound events
-- local provider servers for live-adapter smoke tests for Signal, Slack,
-  Telegram, and WhatsApp
+- local provider servers for live-adapter smoke tests for Mattermost, Matrix,
+  Signal, Slack, Telegram, and WhatsApp
 - JSONL recorder files for deterministic wait/watch behavior
 - nonce-based `send`, `roundtrip`, `agent`, `probe`, `run`, `watch`, and
   `doctor` commands
@@ -146,6 +146,30 @@ roundtrips, including REST authentication/status codes, WebSocket
 authentication and `hello`, sequenced events, typing, and post
 create/edit/delete events. Admin ingress is only the test control plane;
 injected messages are delivered to clients as native `posted` events.
+
+Matrix:
+
+```bash
+crabline --json serve matrix --ready-file .crabline/matrix-server.json
+```
+
+The JSON manifest contains:
+
+- `baseUrl`: OpenClaw `channels.matrix.homeserver`
+- `accessToken`: OpenClaw `channels.matrix.accessToken`
+- `botUserId`: OpenClaw `channels.matrix.userId`
+- `endpoints.clientApiRoot`: Matrix Client-Server API root
+- `adminToken`: send this as the `X-Crabline-Admin-Token` header when posting
+  test user messages
+- `endpoints.adminInboundUrl`: authenticated POST control endpoint for inbound
+  messages
+- `recorderPath`: JSONL file of local provider API/admin traffic
+
+The server implements an unencrypted Matrix Client-Server API subset including
+`whoami`, filters, push rules, joined rooms and members, room state, `/sync`,
+room event sends, typing, and read receipts. Admin ingress is only the test
+control plane; injected messages are delivered to clients as native
+`m.room.message` events through `/sync`.
 
 Slack:
 

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -72,8 +72,8 @@ execution.
 
 ## Local Provider Servers
 
-Server-backed channels currently include Mattermost, Signal, Slack, Telegram,
-and WhatsApp.
+Server-backed channels currently include Mattermost, Matrix, Signal, Slack,
+Telegram, and WhatsApp.
 
 ### Mattermost
 
@@ -100,9 +100,36 @@ implements Mattermost REST error/status behavior plus WebSocket authentication,
 subset. OpenClaw configuration and QA target mapping remain in the separate
 OpenClaw bridge.
 
-Local provider servers sit below OpenClaw's normal channel adapters. QA starts the
-server, writes the emitted runtime manifest into OpenClaw config/env, and then
-OpenClaw talks to the local provider instead of the public provider.
+### Matrix
+
+Start the server:
+
+```bash
+crabline --json serve matrix --ready-file .crabline/matrix-server.json
+```
+
+Use the manifest's `baseUrl`, `accessToken`, and `botUserId` as OpenClaw's
+Matrix homeserver, access token, and user ID. Set encryption to `false` and,
+because the server is loopback HTTP, enable
+`channels.matrix.network.dangerouslyAllowPrivateNetwork`. The OpenClaw bridge
+applies those settings automatically.
+
+Admin inbound accepts native `roomId`, `senderId`, and `text` fields plus
+optional `senderName` and `threadId`. It queues a native `m.room.message` event
+for delivery through Matrix `/sync`. Outbound room sends through
+`PUT /_matrix/client/v3/rooms/:roomId/send/:eventType/:txnId` are written to the
+manifest recorder.
+
+The provider server implements the unencrypted Client-Server API subset needed
+by the normal Matrix SDK: versions, `whoami`, filters, push rules, joined rooms
+and members, room state, `/sync`, room sends, typing, and read receipts. The
+`/crabline/matrix/inbound` endpoint is a test control plane and is not part of
+the Matrix API. OpenClaw configuration and QA target mapping remain in the
+separate OpenClaw bridge.
+
+Local provider servers sit below OpenClaw's normal channel adapters. QA starts
+the server, writes the emitted runtime manifest into OpenClaw config/env, and
+then OpenClaw talks to the local provider instead of the public provider.
 
 Slack:
 

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@typescript/native-preview": "7.0.0-dev.20260630.1",
     "@vitest/coverage-v8": "^4.1.9",
     "baileys": "7.0.0-rc13",
+    "matrix-js-sdk": "41.6.0",
     "oxfmt": "^0.56.0",
     "oxlint": "^1.69.0",
     "oxlint-tsgolint": "^0.23.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       baileys:
         specifier: 7.0.0-rc13
         version: 7.0.0-rc13(sharp@0.35.2)
+      matrix-js-sdk:
+        specifier: 41.6.0
+        version: 41.6.0
       oxfmt:
         specifier: ^0.56.0
         version: 0.56.0
@@ -78,6 +81,10 @@ packages:
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
@@ -454,6 +461,10 @@ packages:
 
   '@keyv/serialize@1.1.1':
     resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
+
+  '@matrix-org/matrix-sdk-crypto-wasm@18.3.1':
+    resolution: {integrity: sha512-VRjWhE1UgHnPpJ3b9B5+8z71ZC/HICFngPPFIN6ktzmUBKI5RusPujzbAQUoB3CgZ0yU58L99AfSQS4YTztSWw==}
+    engines: {node: '>= 18'}
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -888,6 +899,9 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/events@3.0.3':
+    resolution: {integrity: sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g==}
+
   '@types/node@26.0.1':
     resolution: {integrity: sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==}
 
@@ -979,6 +993,9 @@ packages:
   '@vitest/utils@4.1.9':
     resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
 
+  another-json@0.2.0:
+    resolution: {integrity: sha512-/Ndrl68UQLhnCdsAzEXLMFuOR546o2qbYRqCglaNHbjXrwG1ayTcdwr3zkSGOGtGXDyR5X9nCFfnyG2AFJIsqg==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -1009,6 +1026,12 @@ packages:
       link-preview-js:
         optional: true
 
+  base-x@5.0.1:
+    resolution: {integrity: sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==}
+
+  bs58@6.0.0:
+    resolution: {integrity: sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==}
+
   cacheable@2.3.5:
     resolution: {integrity: sha512-EQfaKe09tl615iNvq/TBRWTFf1AKJNXYQSsMx0Z3EI0nA+pVsVPS8wJhnRlkbdacKPh1d0qVIhwTc2zsQNFEEg==}
 
@@ -1019,6 +1042,10 @@ packages:
   commander@15.0.0:
     resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
     engines: {node: '>=22.12.0'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
 
   content-type@2.0.0:
     resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
@@ -1056,6 +1083,10 @@ packages:
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
 
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
@@ -1099,6 +1130,10 @@ packages:
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
+  is-network-error@1.3.2:
+    resolution: {integrity: sha512-PhBY86zaxNZUuWP6h13Vu5oFe0XY6/UlKzQnYFELzGVHygP3MxmvTfYSG7GN3aIab/iWudSMgjSnG9Dq+nHrgA==}
+    engines: {node: '>=16'}
+
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
@@ -1113,6 +1148,10 @@ packages:
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
+  jwt-decode@4.0.0:
+    resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
+    engines: {node: '>=18'}
 
   keyv@5.6.0:
     resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
@@ -1194,6 +1233,10 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  loglevel@1.9.2:
+    resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
+    engines: {node: '>= 0.6.0'}
+
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
@@ -1210,6 +1253,16 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
+
+  matrix-events-sdk@0.0.1:
+    resolution: {integrity: sha512-1QEOsXO+bhyCroIe2/A5OwaxHvBm7EsSQ46DEDn8RBIfQwN5HWBpFvyWWR4QY0KHPPnnJdI99wgRiAl7Ad5qaA==}
+
+  matrix-js-sdk@41.6.0:
+    resolution: {integrity: sha512-FOEQBE9i3I+yRymMzKdDO5ptonawqrbtwxSqlkkpqaiFRnsA5zplaPZozdukt+IjBTuE2KceFY+bjFXiNi/+Eg==}
+    engines: {node: '>=22.0.0'}
+
+  matrix-widget-api@1.17.0:
+    resolution: {integrity: sha512-5FHoo3iEP3Bdlv5jsYPWOqj+pGdFQNLWnJLiB0V7Ygne7bb+Gsj3ibyFyHWC6BVw+Z+tSW4ljHpO17I9TwStwQ==}
 
   media-typer@2.0.0:
     resolution: {integrity: sha512-kOy3OxT2HH39N70UnKgu4NWDZjLOz8W/mfyvniHjRH/DrL3f2pOfvWQ4p60offbbtDAnXWp0v9LfMIqMec269Q==}
@@ -1230,6 +1283,10 @@ packages:
   obug@2.1.3:
     resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
     engines: {node: '>=12.20.0'}
+
+  oidc-client-ts@3.5.0:
+    resolution: {integrity: sha512-l2q8l9CTCTOlbX+AnK4p3M+4CEpKpyQhle6blQkdFhm0IsBqsxm15bYaSa11G7pWdsYr6epdsRZxJpCyCRbT8A==}
+    engines: {node: '>=18'}
 
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
@@ -1268,6 +1325,10 @@ packages:
   p-queue@9.3.0:
     resolution: {integrity: sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==}
     engines: {node: '>=20'}
+
+  p-retry@8.0.0:
+    resolution: {integrity: sha512-kFVqH1HxOHp8LupNsOys7bSV09VYTRLxarH/mokO4Rqhk6wGi70E0jh4VzvVGXfEVNggHoHLAMWsQqHyU1Ey9A==}
+    engines: {node: '>=22'}
 
   p-timeout@7.0.1:
     resolution: {integrity: sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==}
@@ -1323,6 +1384,10 @@ packages:
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
+
+  sdp-transform@3.0.0:
+    resolution: {integrity: sha512-gfYVRGxjHkGF2NPeUWHw5u6T/KGFtS5/drPms73gaSuMaVHKCY3lpLnGDfswVQO0kddeePoti09AwhYP4zA8dQ==}
+    hasBin: true
 
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
@@ -1406,6 +1471,9 @@ packages:
 
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
+  unhomoglyph@1.0.6:
+    resolution: {integrity: sha512-7uvcWI3hWshSADBu4JpnyYbTVc7YlhF5GDW/oPD5AxIxl34k4wXR3WDkPnzLxkN32LiTCTKMQLtKVZiwki3zGg==}
 
   vite@8.0.16:
     resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
@@ -1531,6 +1599,8 @@ snapshots:
   '@babel/parser@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
+
+  '@babel/runtime@7.29.7': {}
 
   '@babel/types@7.29.7':
     dependencies:
@@ -1787,6 +1857,8 @@ snapshots:
 
   '@keyv/serialize@1.1.1': {}
 
+  '@matrix-org/matrix-sdk-crypto-wasm@18.3.1': {}
+
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
@@ -2026,6 +2098,8 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
+  '@types/events@3.0.3': {}
+
   '@types/node@26.0.1':
     dependencies:
       undici-types: 8.3.0
@@ -2120,6 +2194,8 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  another-json@0.2.0: {}
+
   assertion-error@2.0.1: {}
 
   ast-v8-to-istanbul@1.0.4:
@@ -2153,6 +2229,12 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  base-x@5.0.1: {}
+
+  bs58@6.0.0:
+    dependencies:
+      base-x: 5.0.1
+
   cacheable@2.3.5:
     dependencies:
       '@cacheable/memory': 2.0.9
@@ -2164,6 +2246,8 @@ snapshots:
   chai@6.2.2: {}
 
   commander@15.0.0: {}
+
+  content-type@1.0.5: {}
 
   content-type@2.0.0: {}
 
@@ -2214,6 +2298,8 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
+  events@3.3.0: {}
+
   expect-type@1.4.0: {}
 
   fdir@6.5.0(picomatch@4.0.4):
@@ -2246,6 +2332,8 @@ snapshots:
 
   ieee754@1.2.1: {}
 
+  is-network-error@1.3.2: {}
+
   istanbul-lib-coverage@3.2.2: {}
 
   istanbul-lib-report@3.0.1:
@@ -2260,6 +2348,8 @@ snapshots:
       istanbul-lib-report: 3.0.1
 
   js-tokens@10.0.0: {}
+
+  jwt-decode@4.0.0: {}
 
   keyv@5.6.0:
     dependencies:
@@ -2319,6 +2409,8 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  loglevel@1.9.2: {}
+
   long@5.3.2: {}
 
   lru-cache@11.5.1: {}
@@ -2336,6 +2428,29 @@ snapshots:
   make-dir@4.0.0:
     dependencies:
       semver: 7.8.5
+
+  matrix-events-sdk@0.0.1: {}
+
+  matrix-js-sdk@41.6.0:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@matrix-org/matrix-sdk-crypto-wasm': 18.3.1
+      another-json: 0.2.0
+      bs58: 6.0.0
+      content-type: 1.0.5
+      jwt-decode: 4.0.0
+      loglevel: 1.9.2
+      matrix-events-sdk: 0.0.1
+      matrix-widget-api: 1.17.0
+      oidc-client-ts: 3.5.0
+      p-retry: 8.0.0
+      sdp-transform: 3.0.0
+      unhomoglyph: 1.0.6
+
+  matrix-widget-api@1.17.0:
+    dependencies:
+      '@types/events': 3.0.3
+      events: 3.3.0
 
   media-typer@2.0.0: {}
 
@@ -2359,6 +2474,10 @@ snapshots:
   nanoid@3.3.15: {}
 
   obug@2.1.3: {}
+
+  oidc-client-ts@3.5.0:
+    dependencies:
+      jwt-decode: 4.0.0
 
   on-exit-leak-free@2.1.2: {}
 
@@ -2422,6 +2541,10 @@ snapshots:
     dependencies:
       eventemitter3: 5.0.4
       p-timeout: 7.0.1
+
+  p-retry@8.0.0:
+    dependencies:
+      is-network-error: 1.3.2
 
   p-timeout@7.0.1: {}
 
@@ -2503,6 +2626,8 @@ snapshots:
       '@rolldown/binding-win32-x64-msvc': 1.0.3
 
   safe-stable-stringify@2.5.0: {}
+
+  sdp-transform@3.0.0: {}
 
   semver@7.8.5: {}
 
@@ -2596,6 +2721,8 @@ snapshots:
   uint8array-extras@1.5.0: {}
 
   undici-types@8.3.0: {}
+
+  unhomoglyph@1.0.6: {}
 
   vite@8.0.16(@types/node@26.0.1)(esbuild@0.28.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -55,6 +55,12 @@ const SERVE_PARAM_FACTORIES = {
     botUsername: commandOptions.botUsername,
     channel: "mattermost",
   }),
+  matrix: (shared, commandOptions) => ({
+    ...shared,
+    accessToken: commandOptions.accessToken,
+    adminToken: commandOptions.adminToken,
+    channel: "matrix",
+  }),
   signal: (shared, commandOptions) => ({
     ...shared,
     account: commandOptions.account,
@@ -254,7 +260,7 @@ export function createProgram(
     .option("--port <port>", "Bind port", "0")
     .option("--admin-token <token>", "Admin token for inbound test messages")
     .option("--account <number>", "Signal account number")
-    .option("--access-token <token>", "WhatsApp access token")
+    .option("--access-token <token>", "Matrix or WhatsApp access token")
     .option("--bot-token <token>", "Mattermost, Telegram, or Slack bot token")
     .option("--bot-username <username>", "Mattermost or Telegram bot username", "crabline_bot")
     .option("--recorder <path>", "JSONL recorder path")
@@ -333,7 +339,7 @@ function waitForShutdown(close: () => Promise<void>): Promise<void> {
 function renderServeText(manifest: CrablineServerManifest) {
   const lines = [
     `${manifest.provider} local server ready`,
-    `  apiRoot: ${manifest.endpoints.apiRoot}`,
+    `  apiRoot: ${manifest.provider === "matrix" ? manifest.endpoints.clientApiRoot : manifest.endpoints.apiRoot}`,
     `  inbound: ${manifest.endpoints.adminInboundUrl}`,
     `  recorder: ${manifest.recorderPath}`,
   ];
@@ -353,6 +359,14 @@ function renderServeProviderFields(manifest: CrablineServerManifest): string[] |
       `  adminToken: ${manifest.adminToken}`,
       `  botToken: ${manifest.botToken}`,
       `  websocket: ${manifest.endpoints.websocketUrl}`,
+    ];
+  }
+  if (manifest.provider === "matrix") {
+    return [
+      `  adminToken: ${manifest.adminToken}`,
+      `  accessToken: ${manifest.accessToken}`,
+      `  botUserId: ${manifest.botUserId}`,
+      `  sync: ${manifest.endpoints.syncUrl}`,
     ];
   }
   if (manifest.provider === "signal") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export { resolveTelegramAdapterConfig } from "./providers/builtin/telegram.js";
 export { resolveWhatsAppAdapterConfig } from "./providers/builtin/whatsapp.js";
 export { startMattermostServer } from "./servers/mattermost.js";
+export { startMatrixServer } from "./servers/matrix.js";
 export { startSignalServer } from "./servers/signal.js";
 export { startSlackServer, startSlackServer as startSlackFakeServer } from "./servers/slack.js";
 export {
@@ -76,6 +77,11 @@ export type {
   StartedMattermostServer,
   StartMattermostServerParams,
 } from "./servers/mattermost.js";
+export type {
+  MatrixServerManifest,
+  StartedMatrixServer,
+  StartMatrixServerParams,
+} from "./servers/matrix.js";
 export type {
   SignalServerManifest,
   StartedSignalServer,

--- a/src/openclaw.ts
+++ b/src/openclaw.ts
@@ -8,6 +8,7 @@ import {
 } from "./servers/index.js";
 import { SLACK_OPENCLAW_CRABLINE_PROVIDER_BRIDGE } from "./openclaw/bridges/slack.js";
 import { MATTERMOST_OPENCLAW_CRABLINE_PROVIDER_BRIDGE } from "./openclaw/bridges/mattermost.js";
+import { MATRIX_OPENCLAW_CRABLINE_PROVIDER_BRIDGE } from "./openclaw/bridges/matrix.js";
 import { SIGNAL_OPENCLAW_CRABLINE_PROVIDER_BRIDGE } from "./openclaw/bridges/signal.js";
 import { TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE } from "./openclaw/bridges/telegram.js";
 import { WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE } from "./openclaw/bridges/whatsapp.js";
@@ -54,6 +55,7 @@ export type {
 
 const OPENCLAW_CRABLINE_PROVIDER_BRIDGES = {
   mattermost: MATTERMOST_OPENCLAW_CRABLINE_PROVIDER_BRIDGE,
+  matrix: MATRIX_OPENCLAW_CRABLINE_PROVIDER_BRIDGE,
   signal: SIGNAL_OPENCLAW_CRABLINE_PROVIDER_BRIDGE,
   slack: SLACK_OPENCLAW_CRABLINE_PROVIDER_BRIDGE,
   telegram: TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE,

--- a/src/openclaw/bridges/matrix.ts
+++ b/src/openclaw/bridges/matrix.ts
@@ -1,0 +1,148 @@
+import {
+  createAdminInboundRequest,
+  createOpenClawCrablineProviderBridge,
+  DEFAULT_ACCOUNT_ID,
+  isRecord,
+  qaTargetForInbound,
+  readString,
+} from "../shared.js";
+
+function matrixRoomId(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("!") || !trimmed.includes(":")) {
+    throw new Error("Matrix targets must be native room IDs.");
+  }
+  return trimmed;
+}
+
+function targetKey(roomId: string, threadId?: string): string {
+  return threadId ? `${roomId}:thread:${threadId}` : roomId;
+}
+
+function eventThreadId(content: Record<string, unknown>): string | undefined {
+  const relation = isRecord(content["m.relates_to"]) ? content["m.relates_to"] : undefined;
+  return relation?.rel_type === "m.thread" ? readString(relation.event_id) : undefined;
+}
+
+export const MATRIX_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablineProviderBridge({
+  provider: "matrix",
+  createAdapter(matrix) {
+    return {
+      async probe() {
+        const response = await fetch(`${matrix.endpoints.clientApiRoot}/account/whoami`, {
+          headers: { authorization: `Bearer ${matrix.accessToken}` },
+        });
+        if (!response.ok) {
+          throw new Error(`Crabline Matrix probe failed with HTTP ${response.status}.`);
+        }
+        return await response.json();
+      },
+      createBinding() {
+        return {
+          accountId: DEFAULT_ACCOUNT_ID,
+          channel: "matrix",
+          createChannelDriverSmokeEnv: (env) => ({ ...env, ...matrix.env }),
+          createGatewayConfig: (openclawConfig = {}) => {
+            const channels = isRecord(openclawConfig.channels) ? openclawConfig.channels : {};
+            const matrixConfig = isRecord(channels.matrix) ? channels.matrix : {};
+            const dmConfig = isRecord(matrixConfig.dm) ? matrixConfig.dm : {};
+            return {
+              ...openclawConfig,
+              channels: {
+                ...channels,
+                matrix: {
+                  ...matrixConfig,
+                  accessToken: matrix.accessToken,
+                  blockStreaming: false,
+                  dm: {
+                    ...dmConfig,
+                    allowFrom: ["*"],
+                    policy: "open",
+                  },
+                  enabled: true,
+                  encryption: false,
+                  groupAllowFrom: ["*"],
+                  groupPolicy: "open",
+                  homeserver: matrix.baseUrl,
+                  network: { dangerouslyAllowPrivateNetwork: true },
+                  streaming: "off",
+                  userId: matrix.botUserId,
+                },
+              },
+            };
+          },
+          requiredPluginIds: ["matrix"],
+        };
+      },
+      createAgentDelivery(parsed) {
+        if (parsed.threadId) {
+          throw new Error("Matrix thread targets require OpenClaw QA thread forwarding.");
+        }
+        const roomId = matrixRoomId(parsed.id);
+        const to = `room:${roomId}`;
+        return {
+          channel: "matrix",
+          replyChannel: "matrix",
+          replyTo: to,
+          to,
+        };
+      },
+      createInbound(input) {
+        const roomId = matrixRoomId(input.conversation.id);
+        const threadId = input.threadId?.trim() || undefined;
+        const direct = input.conversation.kind === "direct";
+        return {
+          ...createAdminInboundRequest(matrix),
+          providerBody: {
+            roomId,
+            direct,
+            senderId: input.senderId,
+            ...(input.senderName ? { senderName: input.senderName } : {}),
+            text: input.text,
+            ...(threadId ? { threadId } : {}),
+          },
+          providerTargetKey: targetKey(roomId, threadId),
+          qaTarget: qaTargetForInbound(input),
+          stateConversation: {
+            id: input.conversation.id,
+            kind: direct ? "direct" : "group",
+          },
+          ...(threadId ? { threadId } : {}),
+        };
+      },
+      createOutboundFromRecorderEvent({ event, targetByProviderTarget }) {
+        if (
+          !isRecord(event) ||
+          event.type !== "api" ||
+          event.method !== "PUT" ||
+          !isRecord(event.body)
+        ) {
+          return null;
+        }
+        const match = /^\/_matrix\/client\/(?:v3|r0)\/rooms\/([^/]+)\/send\/([^/]+)\/[^/]+$/u.exec(
+          readString(event.path) ?? "",
+        );
+        if (!match) {
+          return null;
+        }
+        const roomId = decodeURIComponent(match[1]!);
+        const eventType = decodeURIComponent(match[2]!);
+        if (eventType !== "m.room.message") {
+          return null;
+        }
+        const text = readString(event.body.body);
+        if (!text) {
+          return null;
+        }
+        const threadId = eventThreadId(event.body);
+        return {
+          accountId: DEFAULT_ACCOUNT_ID,
+          senderId: matrix.botUserId,
+          senderName: "OpenClaw QA",
+          text,
+          to: targetByProviderTarget.get(targetKey(roomId, threadId)) ?? roomId,
+        };
+      },
+    };
+  },
+});

--- a/src/servers/index.ts
+++ b/src/servers/index.ts
@@ -5,6 +5,12 @@ import {
   type StartMattermostServerParams,
 } from "./mattermost.js";
 import {
+  startMatrixServer,
+  type MatrixServerManifest,
+  type StartedMatrixServer,
+  type StartMatrixServerParams,
+} from "./matrix.js";
+import {
   startSignalServer,
   type SignalServerManifest,
   type StartedSignalServer,
@@ -32,6 +38,7 @@ import { CrablineError } from "../core/errors.js";
 
 export const CRABLINE_SERVER_CHANNELS = Object.freeze([
   "mattermost",
+  "matrix",
   "signal",
   "slack",
   "telegram",
@@ -42,6 +49,7 @@ export type CrablineServerChannel = (typeof CRABLINE_SERVER_CHANNELS)[number];
 
 export type CrablineServerManifest =
   | MattermostServerManifest
+  | MatrixServerManifest
   | SignalServerManifest
   | SlackServerManifest
   | TelegramServerManifest
@@ -49,6 +57,7 @@ export type CrablineServerManifest =
 
 export type StartedCrablineServer =
   | StartedMattermostServer
+  | StartedMatrixServer
   | StartedSignalServer
   | StartedSlackServer
   | StartedTelegramServer
@@ -56,6 +65,7 @@ export type StartedCrablineServer =
 
 export type StartCrablineServerParams =
   | (StartMattermostServerParams & { channel: "mattermost" })
+  | (StartMatrixServerParams & { channel: "matrix" })
   | (StartSignalServerParams & { channel: "signal" })
   | (StartSlackServerParams & { channel: "slack" })
   | (StartTelegramServerParams & { channel: "telegram" })
@@ -70,6 +80,9 @@ export function isCrablineServerChannel(value: string): value is CrablineServerC
 export function startCrablineServer(
   params: StartMattermostServerParams & { channel: "mattermost" },
 ): Promise<StartedMattermostServer>;
+export function startCrablineServer(
+  params: StartMatrixServerParams & { channel: "matrix" },
+): Promise<StartedMatrixServer>;
 export function startCrablineServer(
   params: StartSignalServerParams & { channel: "signal" },
 ): Promise<StartedSignalServer>;
@@ -90,6 +103,9 @@ export async function startCrablineServer(
 ): Promise<StartedCrablineServer> {
   if (params.channel === "mattermost") {
     return await startMattermostServer(params);
+  }
+  if (params.channel === "matrix") {
+    return await startMatrixServer(params);
   }
   if (params.channel === "signal") {
     return await startSignalServer(params);

--- a/src/servers/matrix.ts
+++ b/src/servers/matrix.ts
@@ -26,6 +26,7 @@ type MatrixEvent = {
 };
 
 type MatrixRoom = {
+  createdSequence: number;
   id: string;
   name: string;
   state: MatrixEvent[];
@@ -153,6 +154,7 @@ function createEvent(params: {
 
 function createRoom(params: {
   botUserId: string;
+  createdSequence: number;
   direct?: boolean;
   id: string;
   name: string;
@@ -160,6 +162,7 @@ function createRoom(params: {
   state: MatrixServerState;
 }): MatrixRoom {
   const room: MatrixRoom = {
+    createdSequence: params.createdSequence,
     id: params.id,
     name: params.name,
     state: [],
@@ -206,7 +209,7 @@ function syncRoom(room: MatrixRoom, since: number | undefined) {
   return {
     account_data: { events: [] },
     ephemeral: { events: [] },
-    state: { events: since === undefined ? room.state : [] },
+    state: { events: since === undefined || room.createdSequence > since ? room.state : [] },
     timeline: { events, limited: false, prev_batch: `s${since ?? 0}` },
     unread_notifications: { highlight_count: 0, notification_count: 0 },
   };
@@ -262,6 +265,7 @@ async function handleAdminInbound(params: {
     params.state.rooms.get(roomId) ??
     createRoom({
       botUserId: params.state.botUserId,
+      createdSequence: params.state.nextSequence++,
       direct,
       id: roomId,
       name: readTrimmedString(params.body.roomName) ?? roomId,
@@ -457,6 +461,7 @@ export async function startMatrixServer(
     roomId,
     createRoom({
       botUserId: state.botUserId,
+      createdSequence: 0,
       id: roomId,
       name: params.roomName ?? "Crabline Matrix Room",
       serverName,

--- a/src/servers/matrix.ts
+++ b/src/servers/matrix.ts
@@ -1,0 +1,529 @@
+import { createHash, randomBytes } from "node:crypto";
+import fs from "node:fs/promises";
+import type { IncomingMessage } from "node:http";
+import path from "node:path";
+import {
+  adminAuthError,
+  hasAdminToken,
+  jsonResponse,
+  parseRequestBody,
+  queryRecord,
+  readInteger,
+  readTrimmedString,
+  startHttpJsonServer,
+  type ServerRequestEvent,
+} from "./http.js";
+
+type MatrixEvent = {
+  content: Record<string, unknown>;
+  event_id: string;
+  origin_server_ts: number;
+  room_id: string;
+  sender: string;
+  state_key?: string;
+  type: string;
+  unsigned?: { transaction_id: string };
+};
+
+type MatrixRoom = {
+  id: string;
+  name: string;
+  state: MatrixEvent[];
+  timeline: Array<{ sequence: number; event: MatrixEvent }>;
+  users: Map<string, { avatar_url?: string; display_name?: string }>;
+};
+
+type MatrixServerState = {
+  accessToken: string;
+  adminToken: string;
+  botUserId: string;
+  deviceId: string;
+  filters: Map<string, Record<string, unknown>>;
+  nextEvent: number;
+  nextFilter: number;
+  nextSequence: number;
+  recorderPath: string;
+  rooms: Map<string, MatrixRoom>;
+  serverName: string;
+  syncWaiters: Set<() => void>;
+};
+
+export type MatrixServerManifest = {
+  accessToken: string;
+  adminToken: string;
+  baseUrl: string;
+  botUserId: string;
+  deviceId: string;
+  endpoints: {
+    adminInboundUrl: string;
+    clientApiRoot: string;
+    syncUrl: string;
+  };
+  env: {
+    MATRIX_ACCESS_TOKEN: string;
+    MATRIX_BASE_URL: string;
+    MATRIX_USER_ID: string;
+  };
+  provider: "matrix";
+  recorderPath: string;
+  version: 1;
+};
+
+export type StartedMatrixServer = {
+  close(): Promise<void>;
+  manifest: MatrixServerManifest;
+};
+
+export type StartMatrixServerParams = {
+  accessToken?: string | undefined;
+  adminToken?: string | undefined;
+  botUserId?: string | undefined;
+  deviceId?: string | undefined;
+  host?: string | undefined;
+  port?: number | undefined;
+  recorderPath?: string | undefined;
+  roomId?: string | undefined;
+  roomName?: string | undefined;
+  serverName?: string | undefined;
+};
+
+function matrixId(prefix: "$" | "!", value: string, serverName: string): string {
+  return `${prefix}${createHash("sha256").update(value).digest("hex").slice(0, 16)}:${serverName}`;
+}
+
+async function appendEvent(state: MatrixServerState, event: ServerRequestEvent): Promise<void> {
+  await fs.mkdir(path.dirname(state.recorderPath), { recursive: true });
+  await fs.appendFile(state.recorderPath, `${JSON.stringify(event)}\n`, "utf8");
+}
+
+function authorized(request: IncomingMessage, token: string): boolean {
+  const [scheme, value] = request.headers.authorization?.trim().split(/\s+/, 2) ?? [];
+  return scheme?.toLowerCase() === "bearer" && value === token;
+}
+
+function matrixError(errcode: string, error: string, status: number): Response {
+  return jsonResponse({ errcode, error }, status);
+}
+
+function eventId(state: MatrixServerState): string {
+  return matrixId("$", `event-${state.nextEvent++}`, state.serverName);
+}
+
+function notifySyncWaiters(state: MatrixServerState): void {
+  for (const resolve of state.syncWaiters) {
+    resolve();
+  }
+  state.syncWaiters.clear();
+}
+
+async function waitForSyncEvent(state: MatrixServerState, timeout: number): Promise<void> {
+  await new Promise<void>((resolve) => {
+    const timer = setTimeout(() => {
+      state.syncWaiters.delete(onEvent);
+      resolve();
+    }, timeout);
+    const onEvent = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    state.syncWaiters.add(onEvent);
+  });
+}
+
+function createEvent(params: {
+  content: Record<string, unknown>;
+  roomId: string;
+  sender: string;
+  state: MatrixServerState;
+  stateKey?: string;
+  transactionId?: string;
+  type: string;
+}): MatrixEvent {
+  return {
+    content: params.content,
+    event_id: eventId(params.state),
+    origin_server_ts: Date.now(),
+    room_id: params.roomId,
+    sender: params.sender,
+    ...(params.stateKey !== undefined ? { state_key: params.stateKey } : {}),
+    type: params.type,
+    ...(params.transactionId ? { unsigned: { transaction_id: params.transactionId } } : {}),
+  };
+}
+
+function createRoom(params: {
+  botUserId: string;
+  direct?: boolean;
+  id: string;
+  name: string;
+  serverName: string;
+  state: MatrixServerState;
+}): MatrixRoom {
+  const room: MatrixRoom = {
+    id: params.id,
+    name: params.name,
+    state: [],
+    timeline: [],
+    users: new Map([[params.botUserId, { display_name: "OpenClaw QA" }]]),
+  };
+  room.state.push(
+    createEvent({
+      content: { creator: params.botUserId, room_version: "10" },
+      roomId: room.id,
+      sender: params.botUserId,
+      state: params.state,
+      stateKey: "",
+      type: "m.room.create",
+    }),
+    createEvent({
+      content: {
+        membership: "join",
+        displayname: "OpenClaw QA",
+        ...(params.direct ? { is_direct: true } : {}),
+      },
+      roomId: room.id,
+      sender: params.botUserId,
+      state: params.state,
+      stateKey: params.botUserId,
+      type: "m.room.member",
+    }),
+    createEvent({
+      content: { name: room.name },
+      roomId: room.id,
+      sender: params.botUserId,
+      state: params.state,
+      stateKey: "",
+      type: "m.room.name",
+    }),
+  );
+  return room;
+}
+
+function syncRoom(room: MatrixRoom, since: number | undefined) {
+  const events = room.timeline
+    .filter((entry) => since === undefined || entry.sequence > since)
+    .map((entry) => entry.event);
+  return {
+    account_data: { events: [] },
+    ephemeral: { events: [] },
+    state: { events: since === undefined ? room.state : [] },
+    timeline: { events, limited: false, prev_batch: `s${since ?? 0}` },
+    unread_notifications: { highlight_count: 0, notification_count: 0 },
+  };
+}
+
+function parseSyncToken(value: string | null): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const match = /^s(\d+)$/u.exec(value);
+  return match ? Number(match[1]) : undefined;
+}
+
+async function handleSync(url: URL, state: MatrixServerState): Promise<Response> {
+  const since = parseSyncToken(url.searchParams.get("since"));
+  const timeout = Math.min(readInteger(url.searchParams.get("timeout")) ?? 0, 1_000);
+  const hasNewEvents = [...state.rooms.values()].some((room) =>
+    room.timeline.some((entry) => since === undefined || entry.sequence > since),
+  );
+  if (since !== undefined && !hasNewEvents && timeout > 0) {
+    await waitForSyncEvent(state, timeout);
+  }
+  const join = Object.fromEntries(
+    [...state.rooms.values()].map((room) => [room.id, syncRoom(room, since)]),
+  );
+  return jsonResponse({
+    account_data: { events: [] },
+    device_lists: { changed: [], left: [] },
+    device_one_time_keys_count: {},
+    next_batch: `s${state.nextSequence - 1}`,
+    presence: { events: [] },
+    rooms: { invite: {}, join, knock: {}, leave: {} },
+    to_device: { events: [] },
+  });
+}
+
+function findRoom(state: MatrixServerState, encodedRoomId: string): MatrixRoom | undefined {
+  return state.rooms.get(decodeURIComponent(encodedRoomId));
+}
+
+async function handleAdminInbound(params: {
+  body: Record<string, unknown>;
+  state: MatrixServerState;
+}): Promise<Response> {
+  const roomId = readTrimmedString(params.body.roomId);
+  const sender = readTrimmedString(params.body.sender ?? params.body.senderId);
+  const text = readTrimmedString(params.body.text);
+  if (!roomId || !sender || !text) {
+    return jsonResponse({ error: "roomId, senderId, and text are required", ok: false }, 400);
+  }
+  const direct = params.body.direct === true;
+  const room =
+    params.state.rooms.get(roomId) ??
+    createRoom({
+      botUserId: params.state.botUserId,
+      direct,
+      id: roomId,
+      name: readTrimmedString(params.body.roomName) ?? roomId,
+      serverName: params.state.serverName,
+      state: params.state,
+    });
+  params.state.rooms.set(roomId, room);
+  const senderName = readTrimmedString(params.body.senderName);
+  if (!room.users.has(sender)) {
+    room.users.set(sender, senderName ? { display_name: senderName } : {});
+    const membership = createEvent({
+      content: {
+        membership: "join",
+        ...(senderName ? { displayname: senderName } : {}),
+      },
+      roomId,
+      sender,
+      state: params.state,
+      stateKey: sender,
+      type: "m.room.member",
+    });
+    room.state.push(membership);
+    room.timeline.push({ event: membership, sequence: params.state.nextSequence++ });
+  } else if (senderName) {
+    room.users.set(sender, { display_name: senderName });
+  }
+  const content: Record<string, unknown> = { body: text, msgtype: "m.text" };
+  const threadId = readTrimmedString(params.body.threadId);
+  if (threadId) {
+    content["m.relates_to"] = {
+      event_id: threadId,
+      is_falling_back: true,
+      rel_type: "m.thread",
+      "m.in_reply_to": { event_id: threadId },
+    };
+  }
+  const event = createEvent({
+    content,
+    roomId,
+    sender,
+    state: params.state,
+    type: "m.room.message",
+  });
+  room.timeline.push({ event, sequence: params.state.nextSequence++ });
+  notifySyncWaiters(params.state);
+  return jsonResponse({ event, ok: true });
+}
+
+async function handleMatrixApi(params: {
+  body: Record<string, unknown>;
+  method: string;
+  path: string;
+  state: MatrixServerState;
+  url: URL;
+}): Promise<Response> {
+  const relativePath = params.path.replace(/^\/_matrix\/client\/(?:v3|r0)/u, "");
+  if (params.method === "GET" && relativePath === "/account/whoami") {
+    return jsonResponse({
+      device_id: params.state.deviceId,
+      is_guest: false,
+      user_id: params.state.botUserId,
+    });
+  }
+  if (params.method === "GET" && relativePath === "/joined_rooms") {
+    return jsonResponse({ joined_rooms: [...params.state.rooms.keys()] });
+  }
+  if (params.method === "GET" && relativePath === "/capabilities") {
+    return jsonResponse({ capabilities: {} });
+  }
+  let match = /^\/profile\/([^/]+)$/u.exec(relativePath);
+  if (params.method === "GET" && match) {
+    const userId = decodeURIComponent(match[1]!);
+    const member = [...params.state.rooms.values()]
+      .map((room) => room.users.get(userId))
+      .find((profile) => profile !== undefined);
+    return member
+      ? jsonResponse({
+          ...(member.avatar_url ? { avatar_url: member.avatar_url } : {}),
+          ...(member.display_name ? { displayname: member.display_name } : {}),
+        })
+      : matrixError("M_NOT_FOUND", "Unknown user", 404);
+  }
+  if (params.method === "GET" && relativePath === "/pushrules/") {
+    const empty = { content: [], override: [], room: [], sender: [], underride: [] };
+    return jsonResponse({ global: empty });
+  }
+  if (params.method === "GET" && relativePath === "/sync") {
+    return await handleSync(params.url, params.state);
+  }
+
+  match = /^\/user\/([^/]+)\/filter$/u.exec(relativePath);
+  if (params.method === "POST" && match) {
+    const userId = decodeURIComponent(match[1]!);
+    if (userId !== params.state.botUserId) {
+      return matrixError("M_FORBIDDEN", "Cannot create a filter for another user", 403);
+    }
+    const filterId = String(params.state.nextFilter++);
+    params.state.filters.set(filterId, params.body);
+    return jsonResponse({ filter_id: filterId });
+  }
+
+  match = /^\/user\/([^/]+)\/filter\/([^/]+)$/u.exec(relativePath);
+  if (params.method === "GET" && match) {
+    const filter = params.state.filters.get(decodeURIComponent(match[2]!));
+    return filter ? jsonResponse(filter) : matrixError("M_NOT_FOUND", "Unknown filter", 404);
+  }
+
+  match = /^\/rooms\/([^/]+)\/joined_members$/u.exec(relativePath);
+  if (params.method === "GET" && match) {
+    const room = findRoom(params.state, match[1]!);
+    return room
+      ? jsonResponse({ joined: Object.fromEntries(room.users) })
+      : matrixError("M_NOT_FOUND", "Unknown room", 404);
+  }
+
+  match = /^\/rooms\/([^/]+)\/state\/([^/]+)(?:\/(.*))?$/u.exec(relativePath);
+  if (params.method === "GET" && match) {
+    const room = findRoom(params.state, match[1]!);
+    if (!room) {
+      return matrixError("M_NOT_FOUND", "Unknown room", 404);
+    }
+    const eventType = decodeURIComponent(match[2]!);
+    const stateKey = decodeURIComponent(match[3] ?? "");
+    if (eventType === "m.room.name" && stateKey === "") {
+      return jsonResponse({ name: room.name });
+    }
+    if (eventType === "m.room.canonical_alias" && stateKey === "") {
+      return matrixError("M_NOT_FOUND", "Unknown state event", 404);
+    }
+    if (eventType === "m.room.member") {
+      const membership = [...room.state]
+        .reverse()
+        .find((event) => event.type === "m.room.member" && event.state_key === stateKey);
+      return membership
+        ? jsonResponse(membership.content)
+        : matrixError("M_NOT_FOUND", "Unknown room member", 404);
+    }
+    return matrixError("M_NOT_FOUND", "Unknown state event", 404);
+  }
+
+  match = /^\/rooms\/([^/]+)\/send\/([^/]+)\/([^/]+)$/u.exec(relativePath);
+  if (params.method === "PUT" && match) {
+    const room = findRoom(params.state, match[1]!);
+    if (!room) {
+      return matrixError("M_NOT_FOUND", "Unknown room", 404);
+    }
+    const event = createEvent({
+      content: params.body,
+      roomId: room.id,
+      sender: params.state.botUserId,
+      state: params.state,
+      transactionId: decodeURIComponent(match[3]!),
+      type: decodeURIComponent(match[2]!),
+    });
+    room.timeline.push({ event, sequence: params.state.nextSequence++ });
+    notifySyncWaiters(params.state);
+    return jsonResponse({ event_id: event.event_id });
+  }
+
+  match = /^\/rooms\/([^/]+)\/typing\/([^/]+)$/u.exec(relativePath);
+  if (params.method === "PUT" && match) {
+    return jsonResponse({});
+  }
+  match = /^\/rooms\/([^/]+)\/receipt\/m\.read\/([^/]+)$/u.exec(relativePath);
+  if (params.method === "POST" && match) {
+    return jsonResponse({});
+  }
+
+  return matrixError("M_UNRECOGNIZED", "Unrecognized request", 404);
+}
+
+export async function startMatrixServer(
+  params: StartMatrixServerParams = {},
+): Promise<StartedMatrixServer> {
+  const host = params.host ?? "127.0.0.1";
+  const serverName = params.serverName ?? "matrix.test";
+  const state: MatrixServerState = {
+    accessToken: params.accessToken ?? `syt_crabline_${randomBytes(12).toString("hex")}`,
+    adminToken: params.adminToken ?? randomBytes(24).toString("hex"),
+    botUserId: params.botUserId ?? `@openclaw:${serverName}`,
+    deviceId: params.deviceId ?? "CRABLINE",
+    filters: new Map(),
+    nextEvent: 1,
+    nextFilter: 1,
+    nextSequence: 1,
+    recorderPath: params.recorderPath ?? path.resolve("artifacts/crabline/matrix.jsonl"),
+    rooms: new Map(),
+    serverName,
+    syncWaiters: new Set(),
+  };
+  const roomId = params.roomId ?? matrixId("!", "default-room", serverName);
+  state.rooms.set(
+    roomId,
+    createRoom({
+      botUserId: state.botUserId,
+      id: roomId,
+      name: params.roomName ?? "Crabline Matrix Room",
+      serverName,
+      state,
+    }),
+  );
+
+  const server = await startHttpJsonServer({
+    host,
+    port: params.port ?? 0,
+    serverName: "Matrix",
+    async handle(request) {
+      const url = new URL(request.url ?? "/", "http://localhost");
+      const method = request.method ?? "GET";
+      const body = ["POST", "PUT"].includes(method) ? await parseRequestBody(request) : {};
+      const type = url.pathname === "/crabline/matrix/inbound" ? "admin" : "api";
+      await appendEvent(state, {
+        at: new Date().toISOString(),
+        ...(Object.keys(body).length > 0 ? { body } : {}),
+        method,
+        path: url.pathname,
+        query: queryRecord(url),
+        type,
+      });
+      if (type === "admin") {
+        if (method !== "POST") {
+          return jsonResponse({ error: "Method not allowed", ok: false }, 405);
+        }
+        return hasAdminToken(request, state.adminToken)
+          ? await handleAdminInbound({ body, state })
+          : adminAuthError();
+      }
+      if (url.pathname === "/_matrix/client/versions" && method === "GET") {
+        return jsonResponse({ unstable_features: {}, versions: ["v1.11"] });
+      }
+      if (!url.pathname.startsWith("/_matrix/client/")) {
+        return matrixError("M_UNRECOGNIZED", "Unrecognized request", 404);
+      }
+      if (!authorized(request, state.accessToken)) {
+        return matrixError("M_UNKNOWN_TOKEN", "Invalid access token", 401);
+      }
+      return await handleMatrixApi({ body, method, path: url.pathname, state, url });
+    },
+  });
+
+  const clientApiRoot = `${server.baseUrl}/_matrix/client/v3`;
+  return {
+    close: server.close,
+    manifest: {
+      accessToken: state.accessToken,
+      adminToken: state.adminToken,
+      baseUrl: server.baseUrl,
+      botUserId: state.botUserId,
+      deviceId: state.deviceId,
+      endpoints: {
+        adminInboundUrl: `${server.baseUrl}/crabline/matrix/inbound`,
+        clientApiRoot,
+        syncUrl: `${clientApiRoot}/sync`,
+      },
+      env: {
+        MATRIX_ACCESS_TOKEN: state.accessToken,
+        MATRIX_BASE_URL: server.baseUrl,
+        MATRIX_USER_ID: state.botUserId,
+      },
+      provider: "matrix",
+      recorderPath: state.recorderPath,
+      version: 1,
+    },
+  };
+}

--- a/test/matrix-server.test.ts
+++ b/test/matrix-server.test.ts
@@ -112,44 +112,57 @@ describe("Matrix local provider server", () => {
       });
     });
     client.startClient({ initialSyncLimit: 10 });
-    await ready;
+    try {
+      await ready;
 
-    const inbound = new Promise<MatrixEvent>((resolve) => {
-      client.on(RoomEvent.Timeline, (event) => {
-        if (event.getSender() === "@alice:matrix.test" && event.getType() === "m.room.message") {
-          resolve(event);
-        }
+      const dynamicRoomId = "!dynamic:matrix.test";
+      const inbound = new Promise<MatrixEvent>((resolve) => {
+        client.on(RoomEvent.Timeline, (event) => {
+          if (event.getSender() === "@alice:matrix.test" && event.getType() === "m.room.message") {
+            resolve(event);
+          }
+        });
       });
-    });
-    const response = await fetch(server.manifest.endpoints.adminInboundUrl, {
-      body: JSON.stringify({
-        roomId: "!qa:matrix.test",
-        senderId: "@alice:matrix.test",
-        senderName: "Alice",
-        text: "hello from Alice",
-      }),
-      headers: {
-        "content-type": "application/json",
-        "x-crabline-admin-token": "admin-secret",
-      },
-      method: "POST",
-    });
-    expect(response.status).toBe(200);
+      const response = await fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({
+          roomId: dynamicRoomId,
+          roomName: "Dynamic QA Room",
+          senderId: "@alice:matrix.test",
+          senderName: "Alice",
+          text: "hello from Alice",
+        }),
+        headers: {
+          "content-type": "application/json",
+          "x-crabline-admin-token": "admin-secret",
+        },
+        method: "POST",
+      });
+      expect(response.status).toBe(200);
 
-    const event = await inbound;
-    expect(event.getRoomId()).toBe("!qa:matrix.test");
-    expect(event.getType()).toBe("m.room.message");
-    expect(event.getContent()).toMatchObject({ body: "hello from Alice", msgtype: "m.text" });
-    expect(client.getRoom("!qa:matrix.test")?.getMember("@alice:matrix.test")?.membership).toBe(
-      "join",
-    );
+      const event = await inbound;
+      expect(event.getRoomId()).toBe(dynamicRoomId);
+      expect(event.getType()).toBe("m.room.message");
+      expect(event.getContent()).toMatchObject({ body: "hello from Alice", msgtype: "m.text" });
+      await expect
+        .poll(() =>
+          client
+            .getRoom(dynamicRoomId)
+            ?.currentState.getStateEvents("m.room.name", "")
+            ?.getContent(),
+        )
+        .toEqual({ name: "Dynamic QA Room" });
+      const room = client.getRoom(dynamicRoomId);
+      expect(room?.getMember(server.manifest.botUserId)?.membership).toBe("join");
+      expect(room?.getMember("@alice:matrix.test")?.membership).toBe("join");
 
-    const profile = await client.getProfileInfo("@alice:matrix.test");
-    expect(profile).toEqual({ displayname: "Alice" });
+      const profile = await client.getProfileInfo("@alice:matrix.test");
+      expect(profile).toEqual({ displayname: "Alice" });
 
-    const sent = await client.sendTextMessage("!qa:matrix.test", "hello from the SDK");
-    expect(sent.event_id).toMatch(/^\$/u);
-    client.stopClient();
+      const sent = await client.sendTextMessage(dynamicRoomId, "hello from the SDK");
+      expect(sent.event_id).toMatch(/^\$/u);
+    } finally {
+      client.stopClient();
+    }
   });
 
   it("provisions direct rooms with native Matrix membership evidence", async () => {

--- a/test/matrix-server.test.ts
+++ b/test/matrix-server.test.ts
@@ -1,0 +1,201 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { ClientEvent, createClient, RoomEvent, SyncState, type MatrixEvent } from "matrix-js-sdk";
+import { afterEach, describe, expect, it } from "vitest";
+import { startMatrixServer, type StartedMatrixServer } from "../src/index.js";
+import { createTempDir, disposeTempDir } from "./test-helpers.js";
+
+const servers: StartedMatrixServer[] = [];
+const directories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => server.close()));
+  await Promise.all(directories.splice(0).map(disposeTempDir));
+});
+
+function auth(token: string) {
+  return { authorization: `Bearer ${token}` };
+}
+
+describe("Matrix local provider server", () => {
+  it("serves the native client-server API and records room sends", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const recorderPath = path.join(directory, "matrix.jsonl");
+    const server = await startMatrixServer({
+      accessToken: "matrix-token",
+      adminToken: "admin-secret",
+      recorderPath,
+      roomId: "!qa:matrix.test",
+    });
+    servers.push(server);
+
+    const unauthorized = await fetch(`${server.manifest.endpoints.clientApiRoot}/account/whoami`);
+    expect(unauthorized.status).toBe(401);
+    await expect(unauthorized.json()).resolves.toEqual({
+      errcode: "M_UNKNOWN_TOKEN",
+      error: "Invalid access token",
+    });
+
+    const whoami = await fetch(`${server.manifest.endpoints.clientApiRoot}/account/whoami`, {
+      headers: auth("matrix-token"),
+    });
+    await expect(whoami.json()).resolves.toMatchObject({
+      device_id: "CRABLINE",
+      user_id: server.manifest.botUserId,
+    });
+
+    const sent = await fetch(
+      `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!qa:matrix.test")}/send/m.room.message/txn-1`,
+      {
+        body: JSON.stringify({ body: "hello Matrix", msgtype: "m.text" }),
+        headers: { ...auth("matrix-token"), "content-type": "application/json" },
+        method: "PUT",
+      },
+    );
+    await expect(sent.json()).resolves.toMatchObject({ event_id: expect.stringMatching(/^\$/u) });
+
+    const sync = await fetch(`${server.manifest.endpoints.syncUrl}?timeout=0`, {
+      headers: auth("matrix-token"),
+    });
+    const syncBody = (await sync.json()) as {
+      rooms: { join: Record<string, { timeline: { events: unknown[] } }> };
+    };
+    expect(syncBody.rooms.join["!qa:matrix.test"]?.timeline.events).toContainEqual(
+      expect.objectContaining({
+        content: { body: "hello Matrix", msgtype: "m.text" },
+        sender: server.manifest.botUserId,
+        type: "m.room.message",
+      }),
+    );
+
+    const records = (await fs.readFile(recorderPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(records).toContainEqual(
+      expect.objectContaining({
+        body: { body: "hello Matrix", msgtype: "m.text" },
+        method: "PUT",
+        path: "/_matrix/client/v3/rooms/!qa%3Amatrix.test/send/m.room.message/txn-1",
+        type: "api",
+      }),
+    );
+  });
+
+  it("works with matrix-js-sdk sync and delivers admin inbound as a room event", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const server = await startMatrixServer({
+      accessToken: "matrix-token",
+      adminToken: "admin-secret",
+      recorderPath: path.join(directory, "matrix-sdk.jsonl"),
+      roomId: "!qa:matrix.test",
+    });
+    servers.push(server);
+
+    const client = createClient({
+      accessToken: server.manifest.accessToken,
+      baseUrl: server.manifest.baseUrl,
+      deviceId: server.manifest.deviceId,
+      userId: server.manifest.botUserId,
+      useAuthorizationHeader: true,
+    });
+    const ready = new Promise<void>((resolve, reject) => {
+      client.on(ClientEvent.Sync, (state) => {
+        if (state === SyncState.Prepared || state === SyncState.Syncing) {
+          resolve();
+        }
+        if (state === SyncState.Error) {
+          reject(new Error("Matrix SDK entered an error sync state"));
+        }
+      });
+    });
+    client.startClient({ initialSyncLimit: 10 });
+    await ready;
+
+    const inbound = new Promise<MatrixEvent>((resolve) => {
+      client.on(RoomEvent.Timeline, (event) => {
+        if (event.getSender() === "@alice:matrix.test" && event.getType() === "m.room.message") {
+          resolve(event);
+        }
+      });
+    });
+    const response = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({
+        roomId: "!qa:matrix.test",
+        senderId: "@alice:matrix.test",
+        senderName: "Alice",
+        text: "hello from Alice",
+      }),
+      headers: {
+        "content-type": "application/json",
+        "x-crabline-admin-token": "admin-secret",
+      },
+      method: "POST",
+    });
+    expect(response.status).toBe(200);
+
+    const event = await inbound;
+    expect(event.getRoomId()).toBe("!qa:matrix.test");
+    expect(event.getType()).toBe("m.room.message");
+    expect(event.getContent()).toMatchObject({ body: "hello from Alice", msgtype: "m.text" });
+    expect(client.getRoom("!qa:matrix.test")?.getMember("@alice:matrix.test")?.membership).toBe(
+      "join",
+    );
+
+    const profile = await client.getProfileInfo("@alice:matrix.test");
+    expect(profile).toEqual({ displayname: "Alice" });
+
+    const sent = await client.sendTextMessage("!qa:matrix.test", "hello from the SDK");
+    expect(sent.event_id).toMatch(/^\$/u);
+    client.stopClient();
+  });
+
+  it("provisions direct rooms with native Matrix membership evidence", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const server = await startMatrixServer({
+      accessToken: "matrix-token",
+      adminToken: "admin-secret",
+      recorderPath: path.join(directory, "matrix-direct.jsonl"),
+    });
+    servers.push(server);
+
+    const roomId = "!direct:matrix.test";
+    const response = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({
+        direct: true,
+        roomId,
+        senderId: "@alice:matrix.test",
+        text: "direct hello",
+      }),
+      headers: {
+        "content-type": "application/json",
+        "x-crabline-admin-token": "admin-secret",
+      },
+      method: "POST",
+    });
+    expect(response.status).toBe(200);
+
+    const members = await fetch(
+      `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent(roomId)}/joined_members`,
+      { headers: auth("matrix-token") },
+    );
+    await expect(members.json()).resolves.toEqual({
+      joined: {
+        "@alice:matrix.test": {},
+        [server.manifest.botUserId]: { display_name: "OpenClaw QA" },
+      },
+    });
+    const botMembership = await fetch(
+      `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent(roomId)}/state/m.room.member/${encodeURIComponent(server.manifest.botUserId)}`,
+      { headers: auth("matrix-token") },
+    );
+    await expect(botMembership.json()).resolves.toMatchObject({
+      displayname: "OpenClaw QA",
+      is_direct: true,
+      membership: "join",
+    });
+  });
+});

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -78,6 +78,27 @@ const mattermostManifest: CrablineServerManifest = {
   version: 1,
 };
 
+const matrixManifest: CrablineServerManifest = {
+  accessToken: "syt_crabline_matrix_token",
+  adminToken: "crabline-matrix-admin-token",
+  baseUrl: "http://127.0.0.1:8642",
+  botUserId: "@openclaw:matrix.test",
+  deviceId: "CRABLINE",
+  endpoints: {
+    adminInboundUrl: "http://127.0.0.1:8642/crabline/matrix/inbound",
+    clientApiRoot: "http://127.0.0.1:8642/_matrix/client/v3",
+    syncUrl: "http://127.0.0.1:8642/_matrix/client/v3/sync",
+  },
+  env: {
+    MATRIX_ACCESS_TOKEN: "syt_crabline_matrix_token",
+    MATRIX_BASE_URL: "http://127.0.0.1:8642",
+    MATRIX_USER_ID: "@openclaw:matrix.test",
+  },
+  provider: "matrix",
+  recorderPath: "/tmp/crabline/matrix.jsonl",
+  version: 1,
+};
+
 const whatsappManifest: CrablineServerManifest = {
   accessToken: "crabline-whatsapp-access-token",
   adminToken: "crabline-whatsapp-admin-token",
@@ -159,8 +180,11 @@ describe("OpenClaw local provider bridge", () => {
     expect(
       resolveOpenClawCrablineChannelDriverSelection({ channel: " MATTERMOST " }),
     ).toMatchObject({ channel: "mattermost" });
+    expect(resolveOpenClawCrablineChannelDriverSelection({ channel: " MATRIX " })).toMatchObject({
+      channel: "matrix",
+    });
     expect(() => resolveOpenClawCrablineChannelDriverSelection({ channel: "discord" })).toThrow(
-      '--channel must be one of mattermost, signal, slack, telegram, whatsapp for --channel-driver crabline, got "discord"',
+      '--channel must be one of mattermost, matrix, signal, slack, telegram, whatsapp for --channel-driver crabline, got "discord"',
     );
   });
 
@@ -757,6 +781,86 @@ describe("OpenClaw local provider bridge", () => {
     ).toMatchObject({ to: "thread:general/parent" });
   });
 
+  it("maps Matrix native rooms, inbound messages, and recorder events", () => {
+    const roomId = "!qa:matrix.test";
+    expect(
+      createOpenClawCrablineAgentDelivery({
+        manifest: matrixManifest,
+        target: `channel:${roomId}`,
+      }),
+    ).toEqual({
+      channel: "matrix",
+      replyChannel: "matrix",
+      replyTo: `room:${roomId}`,
+      to: `room:${roomId}`,
+    });
+    expect(() =>
+      createOpenClawCrablineAgentDelivery({ manifest: matrixManifest, target: "channel:general" }),
+    ).toThrow("Matrix targets must be native room IDs.");
+    expect(() =>
+      createOpenClawCrablineAgentDelivery({
+        manifest: matrixManifest,
+        target: `thread:${roomId}/$parent:matrix.test`,
+      }),
+    ).toThrow("Matrix thread targets require OpenClaw QA thread forwarding.");
+
+    const inbound = createOpenClawCrablineInbound({
+      manifest: matrixManifest,
+      input: {
+        conversation: { id: roomId, kind: "group" },
+        senderId: "@alice:matrix.test",
+        senderName: "Alice",
+        text: "hello Matrix",
+      },
+    });
+    expect(inbound).toMatchObject({
+      providerBody: {
+        direct: false,
+        roomId,
+        senderId: "@alice:matrix.test",
+        senderName: "Alice",
+        text: "hello Matrix",
+      },
+      providerTargetKey: roomId,
+      providerUrl: "http://127.0.0.1:8642/crabline/matrix/inbound",
+      qaTarget: `group:${roomId}`,
+    });
+
+    expect(
+      createOpenClawCrablineOutboundFromRecorderEvent({
+        manifest: matrixManifest,
+        targetByProviderTarget: new Map([[roomId, `group:${roomId}`]]),
+        event: {
+          body: { body: "hello from OpenClaw", msgtype: "m.text" },
+          method: "PUT",
+          path: `/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/send/m.room.message/txn-1`,
+          type: "api",
+        },
+      }),
+    ).toEqual({
+      accountId: "default",
+      senderId: "@openclaw:matrix.test",
+      senderName: "OpenClaw QA",
+      text: "hello from OpenClaw",
+      to: `group:${roomId}`,
+    });
+
+    const binding = createOpenClawCrablineProviderBinding(matrixManifest);
+    expect(binding).toMatchObject({ channel: "matrix", requiredPluginIds: ["matrix"] });
+    expect(binding.createGatewayConfig()).toMatchObject({
+      channels: {
+        matrix: {
+          accessToken: "syt_crabline_matrix_token",
+          dm: { allowFrom: ["*"], policy: "open" },
+          encryption: false,
+          homeserver: "http://127.0.0.1:8642",
+          network: { dangerouslyAllowPrivateNetwork: true },
+          userId: "@openclaw:matrix.test",
+        },
+      },
+    });
+  });
+
   it("posts WhatsApp OpenClaw inbound with admin headers into the local provider", async () => {
     const adapter = await startOpenClawCrablineAdapter({ channel: "whatsapp" });
     try {
@@ -805,7 +909,7 @@ describe("OpenClaw local provider bridge", () => {
         result: {
           driver: "crabline",
           selectedChannel: "telegram",
-          supportedChannels: ["mattermost", "signal", "slack", "telegram", "whatsapp"],
+          supportedChannels: ["mattermost", "matrix", "signal", "slack", "telegram", "whatsapp"],
         },
       });
       expect(result.smoke).toMatchObject({


### PR DESCRIPTION
## Summary

- add an unencrypted Matrix Client-Server API implementation for Crabline live-adapter QA
- deliver admin-injected messages as native room membership and `m.room.message` events through `/sync`
- add an isolated OpenClaw bridge for Matrix homeserver credentials, native room targets, and recorder mapping
- expose Matrix through `crabline serve matrix` and document the supported protocol subset

## Matrix protocol coverage

The server implements the Matrix surfaces exercised by the normal SDK path:

- client versions, capabilities, `whoami`, profiles, filters, and push rules
- joined rooms, joined members, and room state
- initial and incremental `/sync` with stable batch tokens and event-aware long polling
- room event sends, typing, and read receipts
- native membership state for provisioned group and direct rooms

The `/crabline/matrix/inbound` endpoint is only the authenticated test control plane. Provider clients receive standard Matrix events and the provider server contains no OpenClaw imports or target syntax.

## Scope

- unencrypted rooms only
- no login, registration, federation, media, E2EE, device trust, or key backup
- thread events can be injected and recorded, but QA agent thread delivery fails explicitly until OpenClaw forwards thread IDs through the shared delivery contract

## Verification

- `pnpm verify` (37 files, 175 tests)
- `pnpm vitest run test/package-production.test.ts`
- compatibility test starts the real `matrix-js-sdk@41.6.0`, completes sync, receives admin inbound, reads native membership/profile state, and sends a room message
- `matrix-js-sdk` is a dev dependency only and is excluded from the production package

## Review

The repo-local autoreview instructions were followed, but the packaged autoreview helper executable is absent from this checkout and the configured global locations. Manual closeout review found and fixed capabilities probing, event-aware sync wakeup, native membership ordering/state, direct-room evidence, invalid Matrix config fields, and silent thread flattening.
