### PR TITLE
feat: support Telegram native command ingress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.7 - 2026-07-01
+
+- Add Telegram native command entities to OpenClaw admin inbound injection.
+
 ## 0.1.6 - 2026-06-29
 
 - Add Telegram media send support to the local server for `sendPhoto`, `sendDocument`, `sendVideo`, and `sendAnimation`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/crabline",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Standalone CLI for deterministic messaging provider E2E tests",
   "homepage": "https://github.com/openclaw/crabline#readme",
   "bugs": {

--- a/src/openclaw/bridges/telegram.ts
+++ b/src/openclaw/bridges/telegram.ts
@@ -110,6 +110,17 @@ export const TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
             fromId: readInteger(input.senderId) ?? TELEGRAM_DEFAULT_SENDER_ID,
             fromName: input.senderName ?? input.senderId,
             ...(threadId !== undefined ? { messageThreadId: threadId } : {}),
+            ...(input.nativeCommand
+              ? {
+                  entities: [
+                    {
+                      length: input.nativeCommand.name.length + 1,
+                      offset: 0,
+                      type: "bot_command",
+                    },
+                  ],
+                }
+              : {}),
             text: input.text,
           },
           providerTargetKey: telegramTargetKey(chatId, threadId),

--- a/src/openclaw/shared.ts
+++ b/src/openclaw/shared.ts
@@ -50,6 +50,7 @@ export type OpenClawCrablineInboundInput = {
   senderName?: string | undefined;
   text: string;
   threadId?: string | undefined;
+  nativeCommand?: { name: string } | undefined;
 };
 
 export type OpenClawCrablineInbound = {

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -45,6 +45,11 @@ type TelegramMessage = {
     file_unique_id: string;
     mime_type?: string;
   };
+  entities?: Array<{
+    length: number;
+    offset: number;
+    type: string;
+  }>;
   from: {
     first_name: string;
     id: number;
@@ -343,6 +348,16 @@ function createInboundUpdate(
   const fromUsername = toStringValue(body.fromUsername ?? body.from_username);
   const messageId = toIntegerValue(body.messageId ?? body.message_id);
   const updateId = toIntegerValue(body.updateId ?? body.update_id);
+  const entities = Array.isArray(body.entities)
+    ? body.entities.filter(
+        (entry): entry is { length: number; offset: number; type: string } =>
+          typeof entry === "object" &&
+          entry !== null &&
+          typeof (entry as { length?: unknown }).length === "number" &&
+          typeof (entry as { offset?: unknown }).offset === "number" &&
+          typeof (entry as { type?: unknown }).type === "string",
+      )
+    : undefined;
   if (messageId !== undefined) {
     state.nextMessageId = Math.max(state.nextMessageId, messageId + 1);
   }
@@ -360,6 +375,7 @@ function createInboundUpdate(
         ...(fromUsername ? { username: fromUsername } : {}),
       },
       message_id: messageId ?? state.nextMessageId++,
+      ...(entities && entities.length > 0 ? { entities } : {}),
       ...(threadId !== undefined ? { message_thread_id: threadId } : {}),
       text,
     },

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -396,9 +396,10 @@ describe("OpenClaw local provider bridge", () => {
       manifest,
       input: {
         conversation: { id: "alice", kind: "direct" },
+        nativeCommand: { name: "stop" },
         senderId: "alice",
         senderName: "Alice",
-        text: "hello",
+        text: "/stop",
       },
     });
     expect(inbound).toEqual({
@@ -406,7 +407,8 @@ describe("OpenClaw local provider bridge", () => {
         chatId: "100001",
         fromId: 100001,
         fromName: "Alice",
-        text: "hello",
+        entities: [{ length: 5, offset: 0, type: "bot_command" }],
+        text: "/stop",
       },
       providerHeaders: {
         "content-type": "application/json",

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -108,6 +108,7 @@ describe("telegram local provider server", () => {
         chatId: "-1001234567890",
         fromId: 100001,
         messageThreadId: 42,
+        entities: [{ length: 5, offset: 0, type: "bot_command" }],
         text: "user nonce-1",
       }),
       headers: adminHeaders(server),
@@ -119,6 +120,7 @@ describe("telegram local provider server", () => {
         message: {
           chat: { id: -1001234567890 },
           from: { id: 100001, is_bot: false },
+          entities: [{ length: 5, offset: 0, type: "bot_command" }],
           message_thread_id: 42,
           text: "user nonce-1",
         },


### PR DESCRIPTION
## What Problem This Solves

OpenClaw QA scenarios can inject ordinary Telegram messages through Crabline, but cannot currently express a provider-native Telegram command. A plain `/stop` message lacks Telegram's `bot_command` entity, so it exercises text command parsing instead of native command routing.

## Why This Change Was Made

This adds an explicit `nativeCommand` field to Crabline's OpenClaw inbound contract and translates it at the Telegram provider boundary into the same `MessageEntity` shape Telegram sends. The generic admin ingress remains provider-faithful and does not learn OpenClaw command semantics.

The package is prepared as `0.1.7` so the existing tag-triggered release workflow can publish it after merge.

## User Impact

OpenClaw QA Lab can run the same native-command scenario through QA Channel and Crabline Telegram while proving the real Telegram native-command path.

## Evidence

- `pnpm lint`
- `pnpm exec vitest run test/telegram-server.test.ts test/openclaw.test.ts`
  - 2 files, 20 tests passed.
- OpenClaw `native-command-session-target` scenario passed end to end through Crabline Telegram using this branch's built package.
