### PR TITLE
Add in-process server event observers

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,11 @@ commands for `probe`, `send`, `waitForInbound`, or `watch`.
 preferred Smoke CI path because OpenClaw still uses its normal channel adapter,
 but the provider endpoint is local and deterministic.
 
+Library callers can pass `onEvent` to `startCrablineServer`, an individual
+provider server, or `startOpenClawCrablineAdapter`. Crabline awaits the callback
+after appending each API/admin event to `recorderPath`, so callers can react in
+process while retaining the JSONL artifact as durable evidence.
+
 Mattermost:
 
 ```bash

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,8 @@ export { OPENCLAW_SUPPORT_CATALOG } from "./providers/catalog.js";
 export { createRegistry } from "./providers/registry.js";
 export type { CatalogEntry } from "./providers/catalog.js";
 export type { Registry } from "./providers/registry.js";
+export type { ServerRequestEvent } from "./servers/http.js";
+export type { ServerEventObserver } from "./servers/recorder.js";
 export type {
   BuiltinAdapterId,
   FixtureDefinition,

--- a/src/openclaw.ts
+++ b/src/openclaw.ts
@@ -145,6 +145,7 @@ export async function startOpenClawCrablineAdapter(
 ): Promise<StartedOpenClawCrablineAdapter> {
   const server: StartedCrablineServer = await startCrablineServer({
     channel: params.channel,
+    onEvent: params.onEvent,
     recorderPath: params.recorderPath,
   });
   const providerAdapter = createOpenClawCrablineProviderAdapter(server.manifest);

--- a/src/openclaw/shared.ts
+++ b/src/openclaw/shared.ts
@@ -1,5 +1,6 @@
 import { ADMIN_TOKEN_HEADER } from "../servers/http.js";
 import type { CrablineServerChannel, CrablineServerManifest } from "../servers/index.js";
+import type { ServerEventObserver } from "../servers/recorder.js";
 
 export const DEFAULT_ACCOUNT_ID = "default";
 export const OPENCLAW_CRABLINE_CHANNEL_CAPABILITY_MATRIX_PATH =
@@ -73,6 +74,7 @@ export type OpenClawCrablineOutboundMessage = {
 
 export type StartOpenClawCrablineAdapterParams = {
   channel: CrablineServerChannel;
+  onEvent?: ServerEventObserver | undefined;
   openclawConfig?: Record<string, unknown> | undefined;
   recorderPath?: string | undefined;
 };

--- a/src/servers/matrix.ts
+++ b/src/servers/matrix.ts
@@ -1,5 +1,4 @@
 import { createHash, randomBytes } from "node:crypto";
-import fs from "node:fs/promises";
 import type { IncomingMessage } from "node:http";
 import path from "node:path";
 import {
@@ -13,6 +12,7 @@ import {
   startHttpJsonServer,
   type ServerRequestEvent,
 } from "./http.js";
+import { recordServerEvent, type ServerEventObserver } from "./recorder.js";
 
 type MatrixEvent = {
   content: Record<string, unknown>;
@@ -43,6 +43,7 @@ type MatrixServerState = {
   nextEvent: number;
   nextFilter: number;
   nextSequence: number;
+  onEvent: ServerEventObserver | undefined;
   recorderPath: string;
   rooms: Map<string, MatrixRoom>;
   serverName: string;
@@ -81,6 +82,7 @@ export type StartMatrixServerParams = {
   botUserId?: string | undefined;
   deviceId?: string | undefined;
   host?: string | undefined;
+  onEvent?: ServerEventObserver | undefined;
   port?: number | undefined;
   recorderPath?: string | undefined;
   roomId?: string | undefined;
@@ -93,8 +95,7 @@ function matrixId(prefix: "$" | "!", value: string, serverName: string): string 
 }
 
 async function appendEvent(state: MatrixServerState, event: ServerRequestEvent): Promise<void> {
-  await fs.mkdir(path.dirname(state.recorderPath), { recursive: true });
-  await fs.appendFile(state.recorderPath, `${JSON.stringify(event)}\n`, "utf8");
+  await recordServerEvent({ event, onEvent: state.onEvent, recorderPath: state.recorderPath });
 }
 
 function authorized(request: IncomingMessage, token: string): boolean {
@@ -451,6 +452,7 @@ export async function startMatrixServer(
     nextEvent: 1,
     nextFilter: 1,
     nextSequence: 1,
+    onEvent: params.onEvent,
     recorderPath: params.recorderPath ?? path.resolve("artifacts/crabline/matrix.jsonl"),
     rooms: new Map(),
     serverName,

--- a/src/servers/mattermost.ts
+++ b/src/servers/mattermost.ts
@@ -1,5 +1,4 @@
 import { createHash, randomBytes } from "node:crypto";
-import fs from "node:fs/promises";
 import type { IncomingMessage } from "node:http";
 import path from "node:path";
 import { WebSocket, WebSocketServer, type RawData } from "ws";
@@ -13,6 +12,7 @@ import {
   startHttpJsonServer,
   type ServerRequestEvent,
 } from "./http.js";
+import { recordServerEvent, type ServerEventObserver } from "./recorder.js";
 
 type MattermostPost = {
   channel_id: string;
@@ -42,6 +42,7 @@ type MattermostServerState = {
   botUsername: string;
   channels: Map<string, { id: string; name: string; display_name: string; type: string }>;
   nextPost: number;
+  onEvent: ServerEventObserver | undefined;
   pendingEvents: MattermostWebSocketEvent[];
   posts: Map<string, MattermostPost>;
   recorderPath: string;
@@ -79,6 +80,7 @@ export type StartMattermostServerParams = {
   botUserId?: string | undefined;
   botUsername?: string | undefined;
   host?: string | undefined;
+  onEvent?: ServerEventObserver | undefined;
   port?: number | undefined;
   recorderPath?: string | undefined;
 };
@@ -88,8 +90,7 @@ export function mattermostId(value: string): string {
 }
 
 async function appendEvent(state: MattermostServerState, event: ServerRequestEvent): Promise<void> {
-  await fs.mkdir(path.dirname(state.recorderPath), { recursive: true });
-  await fs.appendFile(state.recorderPath, `${JSON.stringify(event)}\n`, "utf8");
+  await recordServerEvent({ event, onEvent: state.onEvent, recorderPath: state.recorderPath });
 }
 
 function authorized(request: IncomingMessage, token: string): boolean {
@@ -479,6 +480,7 @@ export async function startMattermostServer(
     botUsername,
     channels: new Map(),
     nextPost: 1,
+    onEvent: params.onEvent,
     pendingEvents: [],
     posts: new Map(),
     recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "mattermost.jsonl"),

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -1,0 +1,15 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { ServerRequestEvent } from "./http.js";
+
+export type ServerEventObserver = (event: ServerRequestEvent) => void | Promise<void>;
+
+export async function recordServerEvent(params: {
+  event: ServerRequestEvent;
+  onEvent: ServerEventObserver | undefined;
+  recorderPath: string;
+}): Promise<void> {
+  await fs.mkdir(path.dirname(params.recorderPath), { recursive: true });
+  await fs.appendFile(params.recorderPath, `${JSON.stringify(params.event)}\n`, "utf8");
+  await params.onEvent?.(params.event);
+}

--- a/src/servers/signal.ts
+++ b/src/servers/signal.ts
@@ -1,5 +1,4 @@
 import { randomBytes } from "node:crypto";
-import fs from "node:fs/promises";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import path from "node:path";
 import {
@@ -14,12 +13,14 @@ import {
   type ServerRequestEvent,
   writeResponse,
 } from "./http.js";
+import { recordServerEvent, type ServerEventObserver } from "./recorder.js";
 
 type SignalServerState = {
   account: string;
   adminToken: string;
   clients: Set<ServerResponse>;
   nextTimestamp: number;
+  onEvent: ServerEventObserver | undefined;
   pendingEvents: string[];
   recorderPath: string;
 };
@@ -51,13 +52,13 @@ export type StartSignalServerParams = {
   account?: string | undefined;
   adminToken?: string | undefined;
   host?: string | undefined;
+  onEvent?: ServerEventObserver | undefined;
   port?: number | undefined;
   recorderPath?: string | undefined;
 };
 
 async function appendEvent(state: SignalServerState, event: ServerRequestEvent): Promise<void> {
-  await fs.mkdir(path.dirname(state.recorderPath), { recursive: true });
-  await fs.appendFile(state.recorderPath, `${JSON.stringify(event)}\n`, "utf8");
+  await recordServerEvent({ event, onEvent: state.onEvent, recorderPath: state.recorderPath });
 }
 
 function rpcResponse(id: unknown, result: unknown): Response {
@@ -209,6 +210,7 @@ export async function startSignalServer(
     adminToken: params.adminToken ?? randomBytes(24).toString("base64url"),
     clients: new Set(),
     nextTimestamp: Date.now(),
+    onEvent: params.onEvent,
     pendingEvents: [],
     recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "signal.jsonl"),
   };

--- a/src/servers/slack.ts
+++ b/src/servers/slack.ts
@@ -1,6 +1,5 @@
 import type { IncomingMessage } from "node:http";
 import { randomBytes } from "node:crypto";
-import fs from "node:fs/promises";
 import path from "node:path";
 import {
   adminAuthError,
@@ -19,6 +18,7 @@ import {
   SLACK_TS_RULE,
   SLACK_USER_ID_RULE,
 } from "../providers/slack-ids.js";
+import { recordServerEvent, type ServerEventObserver } from "./recorder.js";
 
 type SlackMessage = {
   attachments?: unknown;
@@ -43,6 +43,7 @@ type SlackServerState = {
   botUserId: string;
   nextDmIndex: number;
   nextTsIndex: number;
+  onEvent: ServerEventObserver | undefined;
   recorderPath: string;
   signingSecret: string;
   userDmChannels: Map<string, string>;
@@ -80,6 +81,7 @@ export type StartSlackServerParams = {
   botToken?: string | undefined;
   botUserId?: string | undefined;
   host?: string | undefined;
+  onEvent?: ServerEventObserver | undefined;
   port?: number | undefined;
   recorderPath?: string | undefined;
   signingSecret?: string | undefined;
@@ -238,8 +240,7 @@ function appendMessage(state: SlackServerState, message: SlackMessage): SlackMes
 }
 
 async function appendEvent(state: SlackServerState, event: ServerRequestEvent) {
-  await fs.mkdir(path.dirname(state.recorderPath), { recursive: true });
-  await fs.appendFile(state.recorderPath, `${JSON.stringify(event)}\n`, "utf8");
+  await recordServerEvent({ event, onEvent: state.onEvent, recorderPath: state.recorderPath });
 }
 
 function redactSlackAuthFields(value: Record<string, unknown>): Record<string, unknown> {
@@ -566,6 +567,7 @@ export async function startSlackServer(
     botUserId: params.botUserId ?? "UCRABBOT",
     nextDmIndex: 1,
     nextTsIndex: 100,
+    onEvent: params.onEvent,
     recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "slack.jsonl"),
     signingSecret: params.signingSecret ?? "crabline-slack-signing-secret",
     userDmChannels: new Map(),

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -1,9 +1,9 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { randomBytes } from "node:crypto";
-import fs from "node:fs/promises";
 import path from "node:path";
 import { CrablineError } from "../core/errors.js";
 import { adminAuthError, hasAdminToken } from "./http.js";
+import { recordServerEvent, type ServerEventObserver } from "./recorder.js";
 
 type TelegramServerEvent = {
   at: string;
@@ -21,6 +21,7 @@ type TelegramServerState = {
   botUsername: string;
   nextMessageId: number;
   nextUpdateId: number;
+  onEvent: ServerEventObserver | undefined;
   recorderPath: string;
   updates: TelegramUpdate[];
 };
@@ -105,6 +106,7 @@ export type StartTelegramServerParams = {
   botToken?: string | undefined;
   botUsername?: string | undefined;
   host?: string | undefined;
+  onEvent?: ServerEventObserver | undefined;
   port?: number | undefined;
   recorderPath?: string | undefined;
 };
@@ -232,8 +234,7 @@ function telegramChatId(value: unknown): number | string | undefined {
 }
 
 async function appendEvent(state: TelegramServerState, event: TelegramServerEvent) {
-  await fs.mkdir(path.dirname(state.recorderPath), { recursive: true });
-  await fs.appendFile(state.recorderPath, `${JSON.stringify(event)}\n`, "utf8");
+  await recordServerEvent({ event, onEvent: state.onEvent, recorderPath: state.recorderPath });
 }
 
 function createBotUser(state: TelegramServerState) {
@@ -508,6 +509,7 @@ export async function startTelegramServer(
     botUsername: params.botUsername ?? "crabline_bot",
     nextMessageId: 1,
     nextUpdateId: 1,
+    onEvent: params.onEvent,
     recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "telegram.jsonl"),
     updates: [],
   };

--- a/src/servers/whatsapp.ts
+++ b/src/servers/whatsapp.ts
@@ -1,6 +1,5 @@
 import type { IncomingMessage } from "node:http";
 import { randomBytes } from "node:crypto";
-import fs from "node:fs/promises";
 import path from "node:path";
 import {
   adminAuthError,
@@ -12,6 +11,7 @@ import {
   startHttpJsonServer,
   type ServerRequestEvent,
 } from "./http.js";
+import { recordServerEvent, type ServerEventObserver } from "./recorder.js";
 import {
   attachWhatsAppBaileysWebSocketServer,
   type WhatsAppBaileysInboundMessage,
@@ -29,6 +29,7 @@ type WhatsAppServerState = {
   displayPhoneNumber: string;
   deliverInboundMessage(message: WhatsAppBaileysInboundMessage): void;
   nextMessageId: number;
+  onEvent: ServerEventObserver | undefined;
   phoneNumberId: string;
   recorderPath: string;
   selfJid: string;
@@ -70,6 +71,7 @@ export type StartWhatsAppServerParams = {
   accessToken?: string | undefined;
   adminToken?: string | undefined;
   host?: string | undefined;
+  onEvent?: ServerEventObserver | undefined;
   port?: number | undefined;
   recorderPath?: string | undefined;
   selfJid?: string | undefined;
@@ -130,8 +132,7 @@ function graphAuthError(): Response {
 }
 
 async function appendEvent(state: WhatsAppServerState, event: ServerRequestEvent) {
-  await fs.mkdir(path.dirname(state.recorderPath), { recursive: true });
-  await fs.appendFile(state.recorderPath, `${JSON.stringify(event)}\n`, "utf8");
+  await recordServerEvent({ event, onEvent: state.onEvent, recorderPath: state.recorderPath });
 }
 
 function isWhatsAppJid(value: string): boolean {
@@ -415,6 +416,7 @@ export async function startWhatsAppServer(
     deliverInboundMessage: () => undefined,
     displayPhoneNumber: "15550000000",
     nextMessageId: 1,
+    onEvent: params.onEvent,
     phoneNumberId: "TEST_PHONE_NUMBER_ID",
     recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "whatsapp.jsonl"),
     selfJid: params.selfJid ?? "15550000000@s.whatsapp.net",

--- a/src/servers/zalo.ts
+++ b/src/servers/zalo.ts
@@ -1,5 +1,4 @@
 import { randomBytes } from "node:crypto";
-import fs from "node:fs/promises";
 import type { IncomingMessage } from "node:http";
 import path from "node:path";
 import {
@@ -12,6 +11,7 @@ import {
   startHttpJsonServer,
   type ServerRequestEvent,
 } from "./http.js";
+import { recordServerEvent, type ServerEventObserver } from "./recorder.js";
 
 type ZaloChatType = "GROUP" | "PRIVATE";
 
@@ -40,6 +40,7 @@ type ZaloServerState = {
   botName: string;
   botToken: string;
   nextMessage: number;
+  onEvent: ServerEventObserver | undefined;
   pendingRequests: PendingUpdateRequest[];
   recorderPath: string;
   updates: ZaloUpdate[];
@@ -75,13 +76,13 @@ export type StartZaloServerParams = {
   botName?: string | undefined;
   botToken?: string | undefined;
   host?: string | undefined;
+  onEvent?: ServerEventObserver | undefined;
   port?: number | undefined;
   recorderPath?: string | undefined;
 };
 
 async function appendEvent(state: ZaloServerState, event: ServerRequestEvent): Promise<void> {
-  await fs.mkdir(path.dirname(state.recorderPath), { recursive: true });
-  await fs.appendFile(state.recorderPath, `${JSON.stringify(event)}\n`, "utf8");
+  await recordServerEvent({ event, onEvent: state.onEvent, recorderPath: state.recorderPath });
 }
 
 function zaloOk(result?: unknown): Response {
@@ -332,6 +333,7 @@ export async function startZaloServer(
     botName: params.botName ?? "bot.crabline",
     botToken: params.botToken ?? "crabline-zalo-bot-token",
     nextMessage: 1,
+    onEvent: params.onEvent,
     pendingRequests: [],
     recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "zalo.jsonl"),
     updates: [],

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -449,8 +449,12 @@ describe("OpenClaw local provider bridge", () => {
   });
 
   it("starts a bound OpenClaw adapter from channel and config", async () => {
+    const observedEvents: unknown[] = [];
     const adapter = await startOpenClawCrablineAdapter({
       channel: "telegram",
+      onEvent: (event) => {
+        observedEvents.push(event);
+      },
       openclawConfig: {
         channels: {
           telegram: {
@@ -474,6 +478,13 @@ describe("OpenClaw local provider bridge", () => {
         channel: "telegram",
         to: "100001",
       });
+      if (adapter.manifest.provider !== "telegram") {
+        throw new Error("Expected Telegram local provider manifest.");
+      }
+      await fetch(`${adapter.manifest.baseUrl}/bot${adapter.manifest.botToken}/getMe`);
+      expect(observedEvents).toEqual([
+        expect.objectContaining({ method: "GET", path: "/bot<redacted>/getMe", type: "api" }),
+      ]);
     } finally {
       await adapter.close();
     }

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -230,4 +230,28 @@ describe("telegram local provider server", () => {
     expect(recordedEvents).not.toContain(botToken);
     expect(recordedEvents).toContain('"path":"/bot<redacted>/getMe"');
   });
+
+  it("notifies observers after recording each event", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const recorderPath = path.join(directory, "telegram.jsonl");
+    const observedEvents: unknown[] = [];
+    const server = await startTelegramServer({
+      botToken: "123456:fake-token",
+      onEvent: async (event) => {
+        const recordedEvents = await fs.readFile(recorderPath, "utf8");
+        expect(recordedEvents).toContain(`${JSON.stringify(event)}\n`);
+        observedEvents.push(event);
+      },
+      recorderPath,
+    });
+    servers.push(server);
+
+    const response = await fetch(`${server.manifest.baseUrl}/bot123456:fake-token/getMe`);
+    await expect(response.json()).resolves.toMatchObject({ ok: true });
+
+    expect(observedEvents).toEqual([
+      expect.objectContaining({ method: "GET", path: "/bot<redacted>/getMe", type: "api" }),
+    ]);
+  });
 });


### PR DESCRIPTION
## What Problem This Solves

Consumers currently discover local-provider traffic by repeatedly rereading Crabline JSONL recorder files. That adds avoidable latency and exposes readers to concurrent append boundaries even though Crabline already owns the complete event in memory.

## Why This Change Was Made

Add an optional `onEvent` callback to every provider server, the generic `startCrablineServer` dispatcher, and `startOpenClawCrablineAdapter`. A shared recorder helper appends the complete JSONL record first, then awaits the callback. This preserves the recorder as durable evidence while allowing deterministic in-process delivery.

## User Impact

Library consumers can react to provider API/admin traffic immediately without polling the recorder. Existing callers are unchanged because the callback is optional, and CLI/provider protocol behavior remains the same.

## Evidence

- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm test test/telegram-server.test.ts test/openclaw.test.ts` (22 tests)
- Fresh Codex autoreview: no accepted/actionable findings
