### PR TITLE
Prepare Crabline 0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.9 - 2026-07-03
+
+- Add in-process provider event observers while retaining JSONL recorder artifacts.
+
 ## 0.1.8 - 2026-07-03
 
 - Add the Zalo provider server with an isolated OpenClaw bridge.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/crabline",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Standalone CLI for deterministic messaging provider E2E tests",
   "homepage": "https://github.com/openclaw/crabline#readme",
   "bugs": {


### PR DESCRIPTION
## Summary

- bump `@openclaw/crabline` to 0.1.9
- document the in-process provider event observer API added in #38

After this merges, tag `v0.1.9` to trigger the release workflow.

## Verification

- `pnpm verify` (38 files, 181 tests passed)
- Fresh Codex autoreview: no accepted/actionable findings
