### PR TITLE
fix(core): harden release and CLI lifecycle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,13 +87,9 @@ jobs:
           import fs from "node:fs";
           import path from "node:path";
 
-          const metadata = JSON.parse(fs.readFileSync(`${process.env.RUNNER_TEMP}/npm-pack.json`, "utf8"));
-          const packs = Array.isArray(metadata) ? metadata : Object.values(metadata);
-          if (packs.length !== 1 || !packs[0]) {
-            throw new Error(`Expected one packed artifact, received ${packs.length}.`);
-          }
-
-          const pack = packs[0];
+          const pack = extractPackMetadata(
+            fs.readFileSync(`${process.env.RUNNER_TEMP}/npm-pack.json`, "utf8"),
+          );
           const packageJson = JSON.parse(fs.readFileSync("package.json", "utf8"));
           const cliPath = packageJson.bin?.crabline?.replace(/^\.\//u, "");
           if (!cliPath || !pack.files?.some((file) => file.path === cliPath)) {
@@ -122,6 +118,75 @@ jobs:
               .map(([key, value]) => `${key}=${value}\n`)
               .join(""),
           );
+
+          function extractPackMetadata(output) {
+            let pack;
+            for (let start = 0; start < output.length; start += 1) {
+              if (!isJsonDocumentStart(output, start)) {
+                continue;
+              }
+              const end = findJsonDocumentEnd(output, start);
+              if (end === -1) {
+                continue;
+              }
+              try {
+                const metadata = JSON.parse(output.slice(start, end));
+                const packs = Array.isArray(metadata) ? metadata : Object.values(metadata);
+                if (packs.length === 1 && Array.isArray(packs[0]?.files)) {
+                  pack = packs[0];
+                }
+              } catch {
+                // Lifecycle output may contain JSON-like text before the metadata document.
+              }
+              start = end - 1;
+            }
+            if (!pack) {
+              throw new Error("npm pack did not return package metadata.");
+            }
+            return pack;
+          }
+
+          function isJsonDocumentStart(output, index) {
+            if (output[index] !== "{" && output[index] !== "[") {
+              return false;
+            }
+            const lineStart = output.lastIndexOf("\n", index - 1) + 1;
+            return output.slice(lineStart, index).trim() === "";
+          }
+
+          function findJsonDocumentEnd(output, start) {
+            const closingTokens = [];
+            let escaped = false;
+            let inString = false;
+            for (let index = start; index < output.length; index += 1) {
+              const token = output[index];
+              if (inString) {
+                if (escaped) {
+                  escaped = false;
+                } else if (token === "\\") {
+                  escaped = true;
+                } else if (token === '"') {
+                  inString = false;
+                }
+                continue;
+              }
+              if (token === '"') {
+                inString = true;
+              } else if (token === "{") {
+                closingTokens.push("}");
+              } else if (token === "[") {
+                closingTokens.push("]");
+              } else if (token === "}" || token === "]") {
+                if (closingTokens.pop() !== token) {
+                  return -1;
+                }
+                if (closingTokens.length === 0) {
+                  return index + 1;
+                }
+              }
+            }
+            return -1;
+          }
           NODE
       - name: Publish package with npm provenance
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: release-${{ inputs.tag_name || github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -40,8 +44,26 @@ jobs:
           RELEASE_VERSION: ${{ steps.release.outputs.version }}
         run: |
           set -euo pipefail
-          test "$(node -p 'require("./package.json").version')" = "$RELEASE_VERSION"
-          grep -q "^## $RELEASE_VERSION" CHANGELOG.md
+          node --input-type=module <<'NODE'
+          import fs from "node:fs";
+
+          const version = process.env.RELEASE_VERSION;
+          const packageJson = JSON.parse(fs.readFileSync("package.json", "utf8"));
+          if (packageJson.version !== version) {
+            throw new Error(
+              `package.json version ${packageJson.version} does not match release ${version}.`,
+            );
+          }
+
+          const headingPrefix = `## ${version} - `;
+          const headings = fs
+            .readFileSync("CHANGELOG.md", "utf8")
+            .split(/\r?\n/u)
+            .filter((line) => line.startsWith(headingPrefix));
+          if (headings.length !== 1 || !/^\d{4}-\d{2}-\d{2}$/u.test(headings[0].slice(headingPrefix.length))) {
+            throw new Error(`CHANGELOG.md must contain exactly one "${headingPrefix}YYYY-MM-DD" heading.`);
+          }
+          NODE
       - uses: pnpm/action-setup@v4
         with:
           version: 10.32.1
@@ -50,13 +72,118 @@ jobs:
           node-version: 24
           cache: pnpm
           registry-url: https://registry.npmjs.org
-      - run: npm install -g npm@latest
+      - run: npm install -g npm@12.0.1
       - run: pnpm install --frozen-lockfile
       - run: pnpm verify
+      - name: Pack and verify release artifact
+        id: package
+        env:
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          metadata_path="$RUNNER_TEMP/npm-pack.json"
+          npm pack --json --pack-destination "$RUNNER_TEMP" > "$metadata_path"
+          node --input-type=module <<'NODE'
+          import fs from "node:fs";
+          import path from "node:path";
+
+          const metadata = JSON.parse(fs.readFileSync(`${process.env.RUNNER_TEMP}/npm-pack.json`, "utf8"));
+          const packs = Array.isArray(metadata) ? metadata : Object.values(metadata);
+          if (packs.length !== 1 || !packs[0]) {
+            throw new Error(`Expected one packed artifact, received ${packs.length}.`);
+          }
+
+          const pack = packs[0];
+          const packageJson = JSON.parse(fs.readFileSync("package.json", "utf8"));
+          const cliPath = packageJson.bin?.crabline?.replace(/^\.\//u, "");
+          if (!cliPath || !pack.files?.some((file) => file.path === cliPath)) {
+            throw new Error(`Packed artifact is missing the crabline CLI at ${cliPath ?? "<unset>"}.`);
+          }
+          if (!fs.readFileSync(cliPath, "utf8").startsWith("#!/usr/bin/env node\n")) {
+            throw new Error(`Packed CLI ${cliPath} is missing its Node shebang.`);
+          }
+          if (pack.version !== process.env.RELEASE_VERSION) {
+            throw new Error(
+              `Packed version ${pack.version} does not match release ${process.env.RELEASE_VERSION}.`,
+            );
+          }
+          if (!pack.integrity || !pack.filename) {
+            throw new Error("npm pack did not report artifact integrity and filename.");
+          }
+
+          const outputs = {
+            integrity: pack.integrity,
+            name: packageJson.name,
+            tarball: path.join(process.env.RUNNER_TEMP, pack.filename),
+          };
+          fs.appendFileSync(
+            process.env.GITHUB_OUTPUT,
+            Object.entries(outputs)
+              .map(([key, value]) => `${key}=${value}\n`)
+              .join(""),
+          );
+          NODE
       - name: Publish package with npm provenance
-        run: npm publish --access public --provenance
+        env:
+          PACKAGE_INTEGRITY: ${{ steps.package.outputs.integrity }}
+          PACKAGE_NAME: ${{ steps.package.outputs.name }}
+          PACKAGE_TARBALL: ${{ steps.package.outputs.tarball }}
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          check_existing_package() {
+            local actual_integrity
+            if ! actual_integrity="$(npm view "$PACKAGE_NAME@$RELEASE_VERSION" dist.integrity 2>/dev/null)"; then
+              return 1
+            fi
+            if [[ "$actual_integrity" != "$PACKAGE_INTEGRITY" ]]; then
+              echo "::error::Published $PACKAGE_NAME@$RELEASE_VERSION has integrity $actual_integrity, expected $PACKAGE_INTEGRITY."
+              return 2
+            fi
+            return 0
+          }
+
+          if check_existing_package; then
+            echo "$PACKAGE_NAME@$RELEASE_VERSION is already published with the expected integrity."
+            exit 0
+          else
+            existing_status=$?
+            if [[ "$existing_status" -eq 2 ]]; then
+              exit 1
+            fi
+          fi
+
+          if npm publish "$PACKAGE_TARBALL" --access public --provenance; then
+            exit 0
+          else
+            publish_status=$?
+          fi
+
+          for delay in 2 4 8 16; do
+            sleep "$delay"
+            if check_existing_package; then
+              echo "$PACKAGE_NAME@$RELEASE_VERSION was published despite the prior client error."
+              exit 0
+            else
+              existing_status=$?
+              if [[ "$existing_status" -eq 2 ]]; then
+                exit 1
+              fi
+            fi
+          done
+          exit "$publish_status"
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
-        run: gh release create "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --generate-notes
+        run: |
+          set -euo pipefail
+          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "GitHub release $RELEASE_TAG already exists."
+            exit 0
+          fi
+          gh release create "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --generate-notes \
+            --verify-tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Harden release packaging and retries, and make cleanup scripts portable across supported platforms.
 - Export the OpenClaw conversation type from the package root.
+- Harden CLI lifecycle cleanup, ready-file publication, run diagnostics, and config validation.
 
 ## 0.1.9 - 2026-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Harden release packaging and retries, and make cleanup scripts portable across supported platforms.
+- Export the OpenClaw conversation type from the package root.
 
 ## 0.1.9 - 2026-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Harden release packaging and retries, and make cleanup scripts portable across supported platforms.
+
 ## 0.1.9 - 2026-07-03
 
 - Add in-process provider event observers while retaining JSONL recorder artifacts.

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     }
   },
   "scripts": {
-    "prebuild": "rm -rf dist",
+    "prebuild": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\"",
     "build": "tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist coverage",
+    "clean": "node -e \"const fs = require('node:fs'); for (const path of ['dist', 'coverage']) fs.rmSync(path, { recursive: true, force: true })\"",
     "dev": "tsx src/bin/crabline.ts",
     "doctor": "tsx src/bin/crabline.ts doctor",
     "fixtures": "tsx src/bin/crabline.ts fixtures",

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -1,4 +1,5 @@
 import { Command } from "commander";
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import nodePath from "node:path";
 import { loadManifest } from "../config/load.js";
@@ -12,6 +13,7 @@ import {
   type CrablineServerChannel,
   type CrablineServerManifest,
   type StartCrablineServerParams,
+  type StartedCrablineServer,
 } from "../servers/index.js";
 
 type GlobalOptions = {
@@ -20,6 +22,11 @@ type GlobalOptions = {
 };
 
 type SetExitCode = (code: number) => void;
+
+type ProgramDependencies = {
+  publishReadyFile?: (filePath: string, contents: string) => Promise<void>;
+  startServer?: (params: StartCrablineServerParams) => Promise<StartedCrablineServer>;
+};
 
 type ServeSharedOptions = {
   host: string;
@@ -112,8 +119,11 @@ export function createProgram(
   setExitCode: SetExitCode = (code) => {
     process.exitCode = code;
   },
+  dependencies: ProgramDependencies = {},
 ): Command {
   const program = new Command();
+  const publish = dependencies.publishReadyFile ?? publishReadyFile;
+  const startServer = dependencies.startServer ?? startCrablineServer;
 
   program
     .name("crabline")
@@ -298,7 +308,10 @@ export function createProgram(
           kind: "config",
         });
       }
-      const server = await startCrablineServer(
+      if (commandOptions.readyFile) {
+        await prepareReadyFile(commandOptions.readyFile);
+      }
+      const server = await startServer(
         factory(
           {
             host: commandOptions.host,
@@ -308,17 +321,19 @@ export function createProgram(
           commandOptions,
         ),
       );
-      const payload = formatJson(server.manifest);
-      if (commandOptions.readyFile) {
-        await fs.mkdir(nodePath.dirname(commandOptions.readyFile), { recursive: true });
-        await fs.writeFile(commandOptions.readyFile, `${payload}\n`, "utf8");
+      const close = onceAsync(() => server.close());
+      try {
+        const payload = formatJson(server.manifest);
+        if (commandOptions.readyFile) {
+          await publish(commandOptions.readyFile, `${payload}\n`);
+        }
+        print(options.json ? payload : renderServeText(server.manifest));
+        if (!commandOptions.once) {
+          await waitForShutdown(close);
+        }
+      } finally {
+        await close();
       }
-      print(options.json ? payload : renderServeText(server.manifest));
-      if (commandOptions.once) {
-        await server.close();
-        return;
-      }
-      await waitForShutdown(server.close);
     });
 
   program
@@ -337,13 +352,60 @@ export function createProgram(
   return program;
 }
 
-function waitForShutdown(close: () => Promise<void>): Promise<void> {
+type ShutdownSignal = "SIGINT" | "SIGTERM";
+
+type SignalTarget = {
+  once(event: ShutdownSignal, listener: () => void): unknown;
+  removeListener(event: ShutdownSignal, listener: () => void): unknown;
+};
+
+function onceAsync(action: () => Promise<void>): () => Promise<void> {
+  let result: Promise<void> | undefined;
+  return () => (result ??= Promise.resolve().then(action));
+}
+
+async function prepareReadyFile(filePath: string): Promise<void> {
+  await fs.mkdir(nodePath.dirname(filePath), { recursive: true });
+  await fs.rm(filePath, { force: true });
+}
+
+export async function publishReadyFile(filePath: string, contents: string): Promise<void> {
+  const temporaryPath = nodePath.join(
+    nodePath.dirname(filePath),
+    `.${nodePath.basename(filePath)}.${process.pid}.${randomUUID()}.tmp`,
+  );
+  try {
+    await fs.writeFile(temporaryPath, contents, {
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600,
+    });
+    await fs.rename(temporaryPath, filePath);
+  } finally {
+    await fs.rm(temporaryPath, { force: true }).catch(() => undefined);
+  }
+}
+
+export function waitForShutdown(
+  close: () => Promise<void>,
+  signalTarget: SignalTarget = process,
+): Promise<void> {
   return new Promise((resolve, reject) => {
-    const shutdown = () => {
-      close().then(resolve, reject);
+    let shuttingDown = false;
+    const removeListeners = () => {
+      signalTarget.removeListener("SIGINT", shutdown);
+      signalTarget.removeListener("SIGTERM", shutdown);
     };
-    process.once("SIGINT", shutdown);
-    process.once("SIGTERM", shutdown);
+    const shutdown = () => {
+      if (shuttingDown) {
+        return;
+      }
+      shuttingDown = true;
+      removeListeners();
+      void Promise.resolve().then(close).then(resolve, reject);
+    };
+    signalTarget.once("SIGINT", shutdown);
+    signalTarget.once("SIGTERM", shutdown);
   });
 }
 
@@ -477,16 +539,26 @@ function diagnose(manifest: Awaited<ReturnType<typeof loadManifest>>["manifest"]
       }
     }
 
-    if (provider.adapter === "script") {
-      if (!provider.script?.commands.send) {
+    if (provider.adapter === "script" && provider.status === "active") {
+      const commands = provider.script?.commands;
+      if (provider.capabilities.includes("probe") && !commands?.probe) {
+        findings.push(`provider ${providerId} missing script.commands.probe`);
+      }
+      if (
+        provider.capabilities.some((capability) =>
+          ["agent", "roundtrip", "send"].includes(capability),
+        ) &&
+        !commands?.send
+      ) {
         findings.push(`provider ${providerId} missing script.commands.send`);
       }
-      if (!provider.script?.commands.waitForInbound) {
+      if (
+        provider.capabilities.some((capability) => ["agent", "roundtrip"].includes(capability)) &&
+        !commands?.waitForInbound
+      ) {
         findings.push(`provider ${providerId} missing script.commands.waitForInbound`);
       }
     }
-
-    void providerId;
   }
 
   return findings;

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -41,7 +41,9 @@ export async function loadManifest(
   const resolvedPath = await resolveConfigPath(configPath);
   try {
     const raw = await readFile(resolvedPath, "utf8");
-    const parsed = resolvedPath.endsWith(".json") ? JSON.parse(raw) : YAML.parse(raw, { merge: true });
+    const parsed = resolvedPath.endsWith(".json")
+      ? JSON.parse(raw)
+      : YAML.parse(raw, { merge: true });
     const manifest = ManifestSchema.parse(parsed);
     return { manifest, path: resolvedPath };
   } catch (error) {

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -41,7 +41,7 @@ export async function loadManifest(
   const resolvedPath = await resolveConfigPath(configPath);
   try {
     const raw = await readFile(resolvedPath, "utf8");
-    const parsed = resolvedPath.endsWith(".json") ? JSON.parse(raw) : YAML.parse(raw);
+    const parsed = resolvedPath.endsWith(".json") ? JSON.parse(raw) : YAML.parse(raw, { merge: true });
     const manifest = ManifestSchema.parse(parsed);
     return { manifest, path: resolvedPath };
   } catch (error) {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -597,12 +597,26 @@ export const FixtureSchema = z.strictObject({
   timeoutMs: z.number().int().min(100).default(30_000),
 });
 
-export const ManifestSchema = z.strictObject({
+const MANIFEST_EXTENSION_KEY_PATTERN = /^x-[a-z0-9][a-z0-9._-]*$/u;
+
+function omitManifestExtensions(value: unknown): unknown {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return value;
+  }
+
+  const entries = Object.entries(value);
+  const manifestEntries = entries.filter(([key]) => !MANIFEST_EXTENSION_KEY_PATTERN.test(key));
+  return manifestEntries.length === entries.length ? value : Object.fromEntries(manifestEntries);
+}
+
+const StrictManifestSchema = z.strictObject({
   configVersion: z.literal(1).default(1),
   fixtures: z.array(FixtureSchema).default([]),
   providers: z.record(z.string(), ProviderConfigSchema).default({}),
   userName: z.string().min(1).default("crabline"),
 });
+
+export const ManifestSchema = z.preprocess(omitManifestExtensions, StrictManifestSchema);
 
 export type BuiltinAdapterId = BuiltinAdapterName;
 export type FixtureDefinition = z.infer<typeof FixtureSchema>;

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -57,7 +57,7 @@ function inferProviderPlatform(adapter: BuiltinAdapterName): ProviderPlatformNam
   return adapter;
 }
 
-const TargetSchema = z.object({
+const TargetSchema = z.strictObject({
   id: z.string().min(1),
   channelId: z.string().min(1).optional(),
   threadId: z.string().min(1).optional(),
@@ -65,42 +65,57 @@ const TargetSchema = z.object({
   metadata: z.record(z.string(), z.string()).default({}),
 });
 
-const InboundMatchSchema = z.object({
-  author: z.enum(INBOUND_AUTHORS).default("assistant"),
-  nonce: z.enum(INBOUND_NONCE_MODES).default("contains"),
-  pattern: z.string().min(1).optional(),
-  strategy: z.enum(INBOUND_STRATEGIES).default("contains"),
-});
+const InboundMatchSchema = z
+  .strictObject({
+    author: z.enum(INBOUND_AUTHORS).default("assistant"),
+    nonce: z.enum(INBOUND_NONCE_MODES).default("contains"),
+    pattern: z.string().min(1).optional(),
+    strategy: z.enum(INBOUND_STRATEGIES).default("contains"),
+  })
+  .superRefine((value, ctx) => {
+    if (value.strategy !== "regex" || !value.pattern) {
+      return;
+    }
+    try {
+      RegExp(value.pattern, "u");
+    } catch {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "inboundMatch.pattern must be a valid Unicode regular expression",
+        path: ["pattern"],
+      });
+    }
+  });
 
-const ScriptCommandsSchema = z.object({
+const ScriptCommandsSchema = z.strictObject({
   probe: z.string().min(1).optional(),
   send: z.string().min(1).optional(),
   waitForInbound: z.string().min(1).optional(),
   watch: z.string().min(1).optional(),
 });
 
-const LoopbackConfigSchema = z.object({
+const LoopbackConfigSchema = z.strictObject({
   delayMs: z.number().int().min(0).default(25),
 });
 
-const ScriptConfigSchema = z.object({
+const ScriptConfigSchema = z.strictObject({
   commands: ScriptCommandsSchema,
   cwd: z.string().min(1).optional(),
   shell: z.string().min(1).optional(),
 });
 
-const SlackRecorderSchema = z.object({
+const SlackRecorderSchema = z.strictObject({
   path: z.string().min(1).optional(),
 });
 
-const SlackWebhookSchema = z.object({
+const SlackWebhookSchema = z.strictObject({
   host: z.string().min(1).default("127.0.0.1"),
   path: z.string().min(1).default("/slack/events"),
   port: z.number().int().min(0).max(65_535).default(8787),
   publicUrl: z.string().url().optional(),
 });
 
-const SlackConfigSchema = z.object({
+const SlackConfigSchema = z.strictObject({
   recorder: SlackRecorderSchema.default({}),
   webhook: SlackWebhookSchema.default({
     host: "127.0.0.1",
@@ -109,18 +124,18 @@ const SlackConfigSchema = z.object({
   }),
 });
 
-const DiscordRecorderSchema = z.object({
+const DiscordRecorderSchema = z.strictObject({
   path: z.string().min(1).optional(),
 });
 
-const DiscordWebhookSchema = z.object({
+const DiscordWebhookSchema = z.strictObject({
   host: z.string().min(1).default("127.0.0.1"),
   path: z.string().min(1).default("/discord/interactions"),
   port: z.number().int().min(0).max(65_535).default(8788),
   publicUrl: z.string().url().optional(),
 });
 
-const DiscordConfigSchema = z.object({
+const DiscordConfigSchema = z.strictObject({
   applicationId: z.string().min(1).optional(),
   botToken: z.string().min(1).optional(),
   gatewayDurationMs: z.number().int().min(1000).default(180_000),
@@ -134,18 +149,18 @@ const DiscordConfigSchema = z.object({
   }),
 });
 
-const WhatsAppRecorderSchema = z.object({
+const WhatsAppRecorderSchema = z.strictObject({
   path: z.string().min(1).optional(),
 });
 
-const WhatsAppWebhookSchema = z.object({
+const WhatsAppWebhookSchema = z.strictObject({
   host: z.string().min(1).default("127.0.0.1"),
   path: z.string().min(1).default("/whatsapp/webhook"),
   port: z.number().int().min(0).max(65_535).default(8789),
   publicUrl: z.string().url().optional(),
 });
 
-const WhatsAppConfigSchema = z.object({
+const WhatsAppConfigSchema = z.strictObject({
   accessToken: z.string().min(1).optional(),
   apiUrl: z.string().url().optional(),
   apiVersion: z.string().min(1).optional(),
@@ -161,23 +176,23 @@ const WhatsAppConfigSchema = z.object({
   }),
 });
 
-const MsTeamsFederatedSchema = z.object({
+const MsTeamsFederatedSchema = z.strictObject({
   clientAudience: z.string().min(1).optional(),
   clientId: z.string().min(1),
 });
 
-const MsTeamsRecorderSchema = z.object({
+const MsTeamsRecorderSchema = z.strictObject({
   path: z.string().min(1).optional(),
 });
 
-const MsTeamsWebhookSchema = z.object({
+const MsTeamsWebhookSchema = z.strictObject({
   host: z.string().min(1).default("127.0.0.1"),
   path: z.string().min(1).default("/msteams/webhook"),
   port: z.number().int().min(0).max(65_535).default(8791),
   publicUrl: z.string().url().optional(),
 });
 
-const MsTeamsConfigSchema = z.object({
+const MsTeamsConfigSchema = z.strictObject({
   apiUrl: z.string().url().optional(),
   appId: z.string().min(1).optional(),
   appPassword: z.string().min(1).optional(),
@@ -202,18 +217,18 @@ const GoogleChatCredentialsSchema = z
   })
   .passthrough();
 
-const GoogleChatRecorderSchema = z.object({
+const GoogleChatRecorderSchema = z.strictObject({
   path: z.string().min(1).optional(),
 });
 
-const GoogleChatWebhookSchema = z.object({
+const GoogleChatWebhookSchema = z.strictObject({
   host: z.string().min(1).default("127.0.0.1"),
   path: z.string().min(1).default("/googlechat/webhook"),
   port: z.number().int().min(0).max(65_535).default(8792),
   publicUrl: z.string().url().optional(),
 });
 
-const GoogleChatConfigSchema = z.object({
+const GoogleChatConfigSchema = z.strictObject({
   apiUrl: z.string().url().optional(),
   credentials: GoogleChatCredentialsSchema.optional(),
   disableSignatureVerification: z.boolean().optional(),
@@ -232,7 +247,7 @@ const GoogleChatConfigSchema = z.object({
   }),
 });
 
-const TelegramLongPollingSchema = z.object({
+const TelegramLongPollingSchema = z.strictObject({
   allowedUpdates: z.array(z.string().min(1)).optional(),
   deleteWebhook: z.boolean().optional(),
   dropPendingUpdates: z.boolean().optional(),
@@ -241,18 +256,18 @@ const TelegramLongPollingSchema = z.object({
   timeout: z.number().int().min(0).optional(),
 });
 
-const TelegramRecorderSchema = z.object({
+const TelegramRecorderSchema = z.strictObject({
   path: z.string().min(1).optional(),
 });
 
-const TelegramWebhookSchema = z.object({
+const TelegramWebhookSchema = z.strictObject({
   host: z.string().min(1).default("127.0.0.1"),
   path: z.string().min(1).default("/telegram/webhook"),
   port: z.number().int().min(0).max(65_535).default(8790),
   publicUrl: z.string().url().optional(),
 });
 
-const TelegramConfigSchema = z.object({
+const TelegramConfigSchema = z.strictObject({
   apiUrl: z.string().url().optional(),
   botToken: z.string().min(1).optional(),
   longPolling: TelegramLongPollingSchema.optional(),
@@ -267,13 +282,13 @@ const TelegramConfigSchema = z.object({
   }),
 });
 
-const FeishuConfigSchema = z.object({
+const FeishuConfigSchema = z.strictObject({
   appId: z.string().min(1).optional(),
   appSecret: z.string().min(1).optional(),
-  recorder: z.object({ path: z.string().min(1).optional() }).default({}),
+  recorder: z.strictObject({ path: z.string().min(1).optional() }).default({}),
   userName: z.string().min(1).optional(),
   webhook: z
-    .object({
+    .strictObject({
       host: z.string().min(1).default("127.0.0.1"),
       path: z.string().min(1).default("/feishu/webhook"),
       port: z.number().int().min(0).max(65_535).default(8795),
@@ -286,24 +301,24 @@ const FeishuConfigSchema = z.object({
     }),
 });
 
-const MattermostRecorderSchema = z.object({
+const MattermostRecorderSchema = z.strictObject({
   path: z.string().min(1).optional(),
 });
 
-const MattermostWebhookSchema = z.object({
+const MattermostWebhookSchema = z.strictObject({
   host: z.string().min(1).default("127.0.0.1"),
   path: z.string().min(1).default("/mattermost/webhook"),
   port: z.number().int().min(0).max(65_535).default(8793),
   publicUrl: z.string().url().optional(),
 });
 
-const MattermostWebsocketSchema = z.object({
+const MattermostWebsocketSchema = z.strictObject({
   enabled: z.boolean().optional(),
   maxReconnectDelayMs: z.number().int().min(0).optional(),
   reconnectDelayMs: z.number().int().min(0).optional(),
 });
 
-const MattermostConfigSchema = z.object({
+const MattermostConfigSchema = z.strictObject({
   baseUrl: z.string().url().optional(),
   botToken: z.string().min(1).optional(),
   callbackUrl: z.string().url().optional(),
@@ -317,18 +332,18 @@ const MattermostConfigSchema = z.object({
   websocket: MattermostWebsocketSchema.optional(),
 });
 
-const ZaloRecorderSchema = z.object({
+const ZaloRecorderSchema = z.strictObject({
   path: z.string().min(1).optional(),
 });
 
-const ZaloWebhookSchema = z.object({
+const ZaloWebhookSchema = z.strictObject({
   host: z.string().min(1).default("127.0.0.1"),
   path: z.string().min(1).default("/zalo/webhook"),
   port: z.number().int().min(0).max(65_535).default(8794),
   publicUrl: z.string().url().optional(),
 });
 
-const ZaloConfigSchema = z.object({
+const ZaloConfigSchema = z.strictObject({
   botToken: z.string().min(1).optional(),
   recorder: ZaloRecorderSchema.default({}),
   userName: z.string().min(1).optional(),
@@ -340,28 +355,28 @@ const ZaloConfigSchema = z.object({
   webhookSecret: z.string().min(1).optional(),
 });
 
-const MatrixAccessTokenAuthSchema = z.object({
+const MatrixAccessTokenAuthSchema = z.strictObject({
   accessToken: z.string().min(1),
   type: z.literal("accessToken"),
   userID: z.string().min(1).optional(),
 });
 
-const MatrixPasswordAuthSchema = z.object({
+const MatrixPasswordAuthSchema = z.strictObject({
   password: z.string().min(1),
   type: z.literal("password"),
   userID: z.string().min(1).optional(),
   username: z.string().min(1),
 });
 
-const MatrixConfigSchema = z.object({
+const MatrixConfigSchema = z.strictObject({
   auth: z.union([MatrixAccessTokenAuthSchema, MatrixPasswordAuthSchema]).optional(),
   baseURL: z.string().url().optional(),
   commandPrefix: z.string().min(1).optional(),
-  recorder: z.object({ path: z.string().min(1).optional() }).default({}),
+  recorder: z.strictObject({ path: z.string().min(1).optional() }).default({}),
   recoveryKey: z.string().min(1).optional(),
   roomAllowlist: z.array(z.string().min(1)).optional(),
   webhook: z
-    .object({
+    .strictObject({
       host: z.string().min(1).default("127.0.0.1"),
       path: z.string().min(1).default("/matrix/webhook"),
       port: z.number().int().min(0).max(65_535).default(8797),
@@ -374,14 +389,14 @@ const MatrixConfigSchema = z.object({
     }),
 });
 
-const IMessageConfigSchema = z.object({
+const IMessageConfigSchema = z.strictObject({
   apiKey: z.string().min(1).optional(),
   gatewayDurationMs: z.number().int().min(1000).default(180_000),
   local: z.boolean().optional(),
-  recorder: z.object({ path: z.string().min(1).optional() }).default({}),
+  recorder: z.strictObject({ path: z.string().min(1).optional() }).default({}),
   serverUrl: z.string().url().optional(),
   webhook: z
-    .object({
+    .strictObject({
       host: z.string().min(1).default("127.0.0.1"),
       path: z.string().min(1).default("/imessage/webhook"),
       port: z.number().int().min(0).max(65_535).default(8796),
@@ -395,7 +410,7 @@ const IMessageConfigSchema = z.object({
 });
 
 export const ProviderConfigSchema = z
-  .object({
+  .strictObject({
     adapter: z.enum(BUILTIN_ADAPTERS),
     capabilities: z.array(z.enum(FIXTURE_MODES)).default(["probe", "send", "roundtrip", "agent"]),
     discord: DiscordConfigSchema.optional(),
@@ -561,7 +576,7 @@ export const ProviderConfigSchema = z
     platform: value.platform ?? inferProviderPlatform(value.adapter) ?? "loopback",
   }));
 
-export const FixtureSchema = z.object({
+export const FixtureSchema = z.strictObject({
   accountId: z.string().min(1).optional(),
   env: z.array(z.string().min(1)).default([]),
   id: z
@@ -582,7 +597,7 @@ export const FixtureSchema = z.object({
   timeoutMs: z.number().int().min(100).default(30_000),
 });
 
-export const ManifestSchema = z.object({
+export const ManifestSchema = z.strictObject({
   configVersion: z.literal(1).default(1),
   fixtures: z.array(FixtureSchema).default([]),
   providers: z.record(z.string(), ProviderConfigSchema).default({}),

--- a/src/core/reporters.ts
+++ b/src/core/reporters.ts
@@ -5,7 +5,10 @@ export function formatRunResultText(result: CommandRunResult | SuiteRunResult): 
   if ("results" in result) {
     const lines = [
       `${pc.bold("suite")} ${result.totalPassed}/${result.results.length} passed`,
-      ...result.results.map((entry) => formatCaseLine(entry)),
+      ...result.results.flatMap((entry) => [
+        formatCaseLine(entry),
+        ...entry.diagnostics.map((diagnostic) => `  - ${diagnostic}`),
+      ]),
     ];
     return lines.join("\n");
   }

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -2,11 +2,13 @@ import { matchesInbound } from "./matcher.js";
 import { createOutboundText } from "./message-template.js";
 import { createNonce } from "./nonces.js";
 import { type FailureKind, CrablineError, ensureErrorMessage } from "./errors.js";
+import { EXIT_CODES, type ExitCode } from "./exit-codes.js";
 import type { ManifestDefinition } from "../config/schema.js";
 import type { Registry } from "../providers/registry.js";
 
 export type CommandRunResult = {
   diagnostics: string[];
+  exitCode?: ExitCode | undefined;
   failureKind?: FailureKind | undefined;
   fixtureId: string;
   mode: string;
@@ -189,9 +191,15 @@ export async function runFixtureCommand(params: {
       const diagnostic = `cleanup failed: ${ensureErrorMessage(error)}`;
       if (result) {
         result.diagnostics.push(diagnostic);
+        if (result.ok) {
+          result.exitCode = EXIT_CODES.ASSERTION;
+          result.failureKind = "assertion";
+          result.ok = false;
+        }
       } else {
         result = {
           diagnostics: [...diagnostics, diagnostic],
+          exitCode: EXIT_CODES.ASSERTION,
           failureKind: "assertion",
           fixtureId: fixture.id,
           mode,
@@ -241,6 +249,10 @@ export function computeExitCode(result: CommandRunResult | SuiteRunResult): numb
     return 0;
   }
 
+  if (result.exitCode !== undefined) {
+    return result.exitCode;
+  }
+
   switch (result.failureKind) {
     case "auth":
       return 11;
@@ -272,6 +284,7 @@ function toFailure(
   if (error instanceof CrablineError) {
     return {
       diagnostics,
+      exitCode: error.exitCode,
       failureKind: error.kind,
       fixtureId,
       mode,

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,6 +134,7 @@ export type {
   OpenClawCrablineAgentDelivery,
   OpenClawCrablineChannelDriverSelection,
   OpenClawCrablineChannelDriverSmokeResult,
+  OpenClawCrablineConversation,
   OpenClawCrablineGatewayBinding,
   OpenClawCrablineInbound,
   OpenClawCrablineInboundInput,

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,7 +1,9 @@
+import { EventEmitter } from "node:events";
 import path from "node:path";
 import fs from "node:fs/promises";
-import { afterEach, describe, expect, it } from "vitest";
-import { runCli } from "../src/cli/program.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createProgram, runCli, waitForShutdown } from "../src/cli/program.js";
+import type { StartedCrablineServer } from "../src/servers/index.js";
 import { captureWrites, createTempDir, disposeTempDir, writeText } from "./test-helpers.js";
 
 const directories: string[] = [];
@@ -195,10 +197,96 @@ describe("cli", () => {
     expect(captured.stderr.join("")).toContain(`Unable to load config file "${configPath}"`);
   });
 
+  it("closes once and removes both shutdown listeners", async () => {
+    const signals = new EventEmitter();
+    const close = vi.fn(async () => undefined);
+    const shutdown = waitForShutdown(close, signals);
+
+    signals.emit("SIGINT");
+    signals.emit("SIGTERM");
+    await shutdown;
+
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(signals.listenerCount("SIGINT")).toBe(0);
+    expect(signals.listenerCount("SIGTERM")).toBe(0);
+  });
+
+  it("removes a stale ready file before starting the server", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const readyFile = path.join(directory, "server.json");
+    await writeText(readyFile, "stale\n");
+    const startError = new Error("start exploded");
+    const program = createProgram(() => undefined, {
+      startServer: async () => {
+        throw startError;
+      },
+    });
+
+    await expect(
+      program.parseAsync([
+        "node",
+        "crabline",
+        "--json",
+        "serve",
+        "telegram",
+        "--ready-file",
+        readyFile,
+      ]),
+    ).rejects.toBe(startError);
+    await expect(fs.readFile(readyFile, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("closes the server once when ready-file publication fails after startup", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const close = vi.fn(async () => undefined);
+    const publishError = new Error("publish exploded");
+    const server = {
+      close,
+      manifest: {
+        adminToken: "admin",
+        baseUrl: "http://127.0.0.1:12345",
+        botToken: "424242:token",
+        endpoints: {
+          adminInboundUrl: "http://127.0.0.1:12345/crabline/telegram/inbound",
+          apiRoot: "http://127.0.0.1:12345",
+        },
+        env: {
+          TELEGRAM_BOT_TOKEN: "424242:token",
+        },
+        provider: "telegram",
+        recorderPath: path.join(directory, "telegram.jsonl"),
+        version: 1,
+      },
+    } satisfies StartedCrablineServer;
+    const program = createProgram(() => undefined, {
+      publishReadyFile: async () => {
+        throw publishError;
+      },
+      startServer: async () => server,
+    });
+
+    await expect(
+      program.parseAsync([
+        "node",
+        "crabline",
+        "--json",
+        "serve",
+        "telegram",
+        "--ready-file",
+        path.join(directory, "server.json"),
+      ]),
+    ).rejects.toBe(publishError);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
   it("prints a Telegram server runtime manifest", async () => {
     const directory = await createTempDir();
     directories.push(directory);
     const readyFile = path.join(directory, ".crabline", "telegram-server.json");
+    await fs.mkdir(path.dirname(readyFile), { recursive: true });
+    await fs.writeFile(readyFile, "stale\n", { mode: 0o644 });
     const captured = captureWrites();
 
     try {
@@ -236,6 +324,8 @@ describe("cli", () => {
     );
     expect(manifest.botToken).toBe("424242:crabline-telegram-token");
     await expect(fs.readFile(readyFile, "utf8")).resolves.toContain('"provider": "telegram"');
+    expect((await fs.stat(readyFile)).mode & 0o777).toBe(0o600);
+    expect(await fs.readdir(path.dirname(readyFile))).toEqual([path.basename(readyFile)]);
   });
 
   it("prints a Zalo server runtime manifest", async () => {
@@ -553,6 +643,43 @@ describe("cli", () => {
     }
 
     expect(exitCode!).toBe(0);
+    expect(captured.stdout.join("")).toContain("doctor ok");
+  });
+
+  it("doctor accepts script providers with capability-scoped commands", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const configPath = path.join(directory, "crabline.yaml");
+    await writeText(
+      configPath,
+      [
+        "configVersion: 1",
+        "providers:",
+        "  probe-only:",
+        "    adapter: script",
+        "    platform: signal",
+        "    capabilities: [probe]",
+        "    script:",
+        "      commands:",
+        '        probe: "printf ok"',
+        "  send-only:",
+        "    adapter: script",
+        "    platform: irc",
+        "    capabilities: [send]",
+        "    script:",
+        "      commands:",
+        '        send: "printf ok"',
+        "fixtures: []",
+      ].join("\n"),
+    );
+    const captured = captureWrites();
+
+    try {
+      expect(await runCli(["node", "crabline", "--config", configPath, "doctor"])).toBe(0);
+    } finally {
+      captured.restore();
+    }
+
     expect(captured.stdout.join("")).toContain("doctor ok");
   });
 });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -49,6 +49,83 @@ describe("manifest schema", () => {
     expect(manifest.fixtures[0]?.inboundMatch.author).toBe("assistant");
   });
 
+  it("rejects unknown keys throughout user-authored config", () => {
+    const base = {
+      configVersion: 1,
+      fixtures: [
+        {
+          id: "loopback-send",
+          mode: "send",
+          provider: "local",
+          target: { id: "sink-bot" },
+        },
+      ],
+      providers: {
+        local: {
+          adapter: "loopback",
+          loopback: {},
+        },
+      },
+    };
+    const candidates = [
+      { ...base, typo: true },
+      {
+        ...base,
+        providers: {
+          local: {
+            ...base.providers.local,
+            typo: true,
+          },
+        },
+      },
+      {
+        ...base,
+        fixtures: [
+          {
+            ...base.fixtures[0],
+            target: {
+              ...base.fixtures[0]!.target,
+              typo: true,
+            },
+          },
+        ],
+      },
+    ];
+
+    const issueCodes = candidates.map((candidate) => {
+      const result = ManifestSchema.safeParse(candidate);
+      return result.success ? [] : result.error.issues.map((issue) => issue.code);
+    });
+    expect(issueCodes).toEqual([
+      ["unrecognized_keys"],
+      ["unrecognized_keys"],
+      ["unrecognized_keys"],
+    ]);
+  });
+
+  it("allows provider-defined fields in Google credential payloads", () => {
+    const manifest = ManifestSchema.parse({
+      configVersion: 1,
+      fixtures: [],
+      providers: {
+        googlechat: {
+          adapter: "googlechat",
+          googlechat: {
+            credentials: {
+              client_email: "bot@example.com",
+              private_key: "secret",
+              private_key_id: "provider-defined",
+            },
+          },
+        },
+      },
+    });
+
+    expect(manifest.providers.googlechat?.googlechat?.credentials).toMatchObject({
+      private_key_id: "provider-defined",
+    });
+  });
+
   it("rejects script providers without script config", () => {
     expect(() =>
       ManifestSchema.parse({

--- a/test/load.test.ts
+++ b/test/load.test.ts
@@ -55,6 +55,33 @@ describe("config load", () => {
     expect(loaded.path).toBe(configPath);
   });
 
+  it("rejects invalid inbound regular expressions during config load", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const configPath = path.join(directory, "crabline.yaml");
+    await writeText(
+      configPath,
+      [
+        "configVersion: 1",
+        "providers:",
+        "  local:",
+        "    adapter: loopback",
+        "fixtures:",
+        "  - id: fixture",
+        "    provider: local",
+        "    mode: roundtrip",
+        "    inboundMatch:",
+        "      nonce: ignore",
+        '      pattern: "["',
+        "      strategy: regex",
+        "    target:",
+        "      id: echo-bot",
+      ].join("\n"),
+    );
+
+    await expect(loadManifest(configPath)).rejects.toThrow(/valid Unicode regular expression/u);
+  });
+
   it("resolves default config names from cwd", async () => {
     const directory = await createTempDir();
     directories.push(directory);

--- a/test/load.test.ts
+++ b/test/load.test.ts
@@ -55,6 +55,25 @@ describe("config load", () => {
     expect(loaded.path).toBe(configPath);
   });
 
+  it("loads the shipped OpenClaw bridge fixture with YAML anchors", async () => {
+    const configPath = path.resolve("fixtures/examples/openclaw-bridge.yaml");
+
+    const loaded = await loadManifest(configPath);
+
+    expect(loaded.manifest.providers["slack-openclaw"]).toMatchObject({
+      adapter: "script",
+      platform: "slack",
+      script: {
+        commands: {
+          probe: "node ./scripts/openclaw-bridge-probe.mjs",
+          send: "node ./scripts/openclaw-bridge-send.mjs",
+          waitForInbound: "node ./scripts/openclaw-bridge-wait.mjs",
+        },
+      },
+    });
+    expect(loaded.manifest).not.toHaveProperty("x-openclaw-bridge");
+  });
+
   it("rejects invalid inbound regular expressions during config load", async () => {
     const directory = await createTempDir();
     directories.push(directory);

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -25,6 +25,7 @@ import {
   startOpenClawCrablineAdapter,
   type CrablineFakeProviderManifest,
   type CrablineServerManifest,
+  type OpenClawCrablineConversation,
 } from "../src/index.js";
 
 const manifest: CrablineServerManifest = {
@@ -167,6 +168,10 @@ const zaloManifest: CrablineServerManifest = {
 describe("OpenClaw local provider bridge", () => {
   it("keeps legacy fake-provider root aliases", () => {
     const legacyManifest: CrablineFakeProviderManifest = manifest;
+    const conversation: OpenClawCrablineConversation = {
+      id: "alice",
+      kind: "direct",
+    };
 
     expect(CRABLINE_FAKE_PROVIDER_CHANNELS).toBe(CRABLINE_SERVER_CHANNELS);
     expect(isCrablineFakeProviderChannel).toBe(isCrablineServerChannel);
@@ -174,6 +179,7 @@ describe("OpenClaw local provider bridge", () => {
     expect(createOpenClawCrablineFakeProviderBinding).toBe(createOpenClawCrablineProviderBinding);
     expect(probeOpenClawCrablineFakeProvider).toBe(probeOpenClawCrablineProvider);
     expect(legacyManifest.provider).toBe("telegram");
+    expect(conversation).toEqual({ id: "alice", kind: "direct" });
   });
 
   it("resolves channel-driver metadata through Crabline", () => {

--- a/test/package-production.test.ts
+++ b/test/package-production.test.ts
@@ -215,9 +215,7 @@ function findJsonDocumentEnd(output: string, start: number): number {
 
 function isNpmPackMetadata(value: unknown): value is NpmPackMetadata {
   return (
-    Boolean(value) &&
-    typeof value === "object" &&
-    Array.isArray((value as NpmPackMetadata).files)
+    Boolean(value) && typeof value === "object" && Array.isArray((value as NpmPackMetadata).files)
   );
 }
 

--- a/test/package-production.test.ts
+++ b/test/package-production.test.ts
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
@@ -15,15 +16,18 @@ const IMPORT_PATTERNS = DEV_ONLY_RUNTIME_PACKAGES.map(
 );
 
 describe("production package", () => {
-  it("does not ship dev-only dependencies in the runtime package", async () => {
+  it("ships its public entry points and CLI without dev-only dependencies", async () => {
     const root = process.cwd();
     const pkg = JSON.parse(await fs.readFile(path.join(root, "package.json"), "utf8")) as {
+      bin?: Record<string, string>;
       bundleDependencies?: string[];
       bundledDependencies?: string[];
       dependencies?: Record<string, string>;
       devDependencies?: Record<string, string>;
+      main?: string;
       optionalDependencies?: Record<string, string>;
       peerDependencies?: Record<string, string>;
+      types?: string;
     };
 
     for (const packageName of DEV_ONLY_RUNTIME_PACKAGES) {
@@ -37,10 +41,28 @@ describe("production package", () => {
 
     const pack = await npmPackDryRun(root);
     const files = pack.files.map((file) => file.path);
+    const cliPath = pkg.bin?.crabline?.replace(/^\.\//u, "");
+    const mainPath = pkg.main?.replace(/^\.\//u, "");
+    const typesPath = pkg.types?.replace(/^\.\//u, "");
+
+    expect(cliPath).toBe("dist/src/bin/crabline.js");
+    expect(mainPath).toBeDefined();
+    expect(typesPath).toBeDefined();
     expect(files).toContain("package.json");
+    expect(files).toContain(cliPath);
+    expect(files).toContain(mainPath);
+    expect(files).toContain(typesPath);
     expect(files.some((file) => file.startsWith("node_modules/"))).toBe(false);
     expect(files.some((file) => file.startsWith("test/"))).toBe(false);
     expect(files.some((file) => /(^|\/)baileys(\/|$)/u.test(file))).toBe(false);
+
+    const cliContents = await fs.readFile(path.join(root, cliPath!), "utf8");
+    expect(cliContents).toMatch(/^#!\/usr\/bin\/env node\r?\n/u);
+    const { stdout: cliHelp } = await execFileAsync(process.execPath, [
+      path.join(root, cliPath!),
+      "--help",
+    ]);
+    expect(cliHelp).toContain("Usage: crabline");
 
     const runtimeFiles = files.filter((file) => file.startsWith("dist/") && file.endsWith(".js"));
     await Promise.all(
@@ -52,20 +74,61 @@ describe("production package", () => {
       }),
     );
   }, 30_000);
+
+  it("uses portable cleanup scripts", async () => {
+    const root = process.cwd();
+    const pkg = JSON.parse(await fs.readFile(path.join(root, "package.json"), "utf8")) as {
+      scripts?: Record<string, string>;
+    };
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-package-scripts-"));
+
+    try {
+      await fs.writeFile(
+        path.join(tempDir, "package.json"),
+        JSON.stringify({
+          private: true,
+          scripts: {
+            clean: pkg.scripts?.clean,
+            prebuild: pkg.scripts?.prebuild,
+          },
+        }),
+      );
+      await Promise.all([
+        fs.mkdir(path.join(tempDir, "coverage"), { recursive: true }),
+        fs.mkdir(path.join(tempDir, "dist"), { recursive: true }),
+      ]);
+
+      await execFileAsync("npm", ["run", "prebuild"], { cwd: tempDir });
+      await expect(fs.stat(path.join(tempDir, "dist"))).rejects.toMatchObject({ code: "ENOENT" });
+      expect(await fs.stat(path.join(tempDir, "coverage"))).toBeDefined();
+
+      await fs.mkdir(path.join(tempDir, "dist"), { recursive: true });
+      await execFileAsync("npm", ["run", "clean"], { cwd: tempDir });
+      await expect(fs.stat(path.join(tempDir, "dist"))).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.stat(path.join(tempDir, "coverage"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    } finally {
+      await fs.rm(tempDir, { force: true, recursive: true });
+    }
+  });
 });
 
-async function npmPackDryRun(root: string): Promise<{ files: Array<{ path: string }> }> {
+type NpmPackMetadata = {
+  files: Array<{ mode?: number; path: string; size?: number }>;
+};
+
+async function npmPackDryRun(root: string): Promise<NpmPackMetadata> {
   const { stdout } = await execFileAsync("npm", ["pack", "--dry-run", "--json"], {
     cwd: root,
     maxBuffer: 10 * 1024 * 1024,
   });
-  const jsonStart = stdout.lastIndexOf("\n[");
-  const jsonText = stdout.slice(jsonStart >= 0 ? jsonStart + 1 : stdout.indexOf("[")).trim();
-  const [pack] = JSON.parse(jsonText) as Array<{ files: Array<{ path: string }> }>;
-  if (!pack) {
+  const result = JSON.parse(stdout) as NpmPackMetadata[] | Record<string, NpmPackMetadata>;
+  const packs = Array.isArray(result) ? result : Object.values(result);
+  if (packs.length !== 1 || !packs[0]) {
     throw new Error("npm pack --dry-run returned no package metadata.");
   }
-  return pack;
+  return packs[0];
 }
 
 function escapeRegex(value: string): string {

--- a/test/package-production.test.ts
+++ b/test/package-production.test.ts
@@ -112,6 +112,20 @@ describe("production package", () => {
       await fs.rm(tempDir, { force: true, recursive: true });
     }
   });
+
+  it("extracts pack metadata around lifecycle output", () => {
+    const pack: NpmPackMetadata = {
+      files: [{ path: "dist/src/bin/crabline.js" }],
+    };
+    const outputs = [
+      `> @openclaw/crabline prepare\n${JSON.stringify([pack], null, 2)}\n> prepare complete`,
+      `npm notice run prepare\n${JSON.stringify({ "@openclaw/crabline": pack }, null, 2)}\nnpm notice complete`,
+    ];
+
+    for (const output of outputs) {
+      expect(parseNpmPackOutput(output)).toEqual(pack);
+    }
+  });
 });
 
 type NpmPackMetadata = {
@@ -123,12 +137,88 @@ async function npmPackDryRun(root: string): Promise<NpmPackMetadata> {
     cwd: root,
     maxBuffer: 10 * 1024 * 1024,
   });
-  const result = JSON.parse(stdout) as NpmPackMetadata[] | Record<string, NpmPackMetadata>;
-  const packs = Array.isArray(result) ? result : Object.values(result);
-  if (packs.length !== 1 || !packs[0]) {
+  return parseNpmPackOutput(stdout);
+}
+
+function parseNpmPackOutput(output: string): NpmPackMetadata {
+  let pack: NpmPackMetadata | undefined;
+  for (let start = 0; start < output.length; start += 1) {
+    if (!isJsonDocumentStart(output, start)) {
+      continue;
+    }
+    const end = findJsonDocumentEnd(output, start);
+    if (end === -1) {
+      continue;
+    }
+    try {
+      const metadata = JSON.parse(output.slice(start, end)) as unknown;
+      const packs = Array.isArray(metadata)
+        ? metadata
+        : metadata && typeof metadata === "object"
+          ? Object.values(metadata)
+          : [];
+      if (packs.length === 1 && isNpmPackMetadata(packs[0])) {
+        pack = packs[0];
+      }
+    } catch {
+      // Lifecycle output may contain JSON-like text before the metadata document.
+    }
+    start = end - 1;
+  }
+  if (!pack) {
     throw new Error("npm pack --dry-run returned no package metadata.");
   }
-  return packs[0];
+  return pack;
+}
+
+function isJsonDocumentStart(output: string, index: number): boolean {
+  if (output[index] !== "{" && output[index] !== "[") {
+    return false;
+  }
+  const lineStart = output.lastIndexOf("\n", index - 1) + 1;
+  return output.slice(lineStart, index).trim() === "";
+}
+
+function findJsonDocumentEnd(output: string, start: number): number {
+  const closingTokens: string[] = [];
+  let escaped = false;
+  let inString = false;
+  for (let index = start; index < output.length; index += 1) {
+    const token = output[index];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (token === "\\") {
+        escaped = true;
+      } else if (token === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (token === '"') {
+      inString = true;
+    } else if (token === "{") {
+      closingTokens.push("}");
+    } else if (token === "[") {
+      closingTokens.push("]");
+    } else if (token === "}" || token === "]") {
+      if (closingTokens.pop() !== token) {
+        return -1;
+      }
+      if (closingTokens.length === 0) {
+        return index + 1;
+      }
+    }
+  }
+  return -1;
+}
+
+function isNpmPackMetadata(value: unknown): value is NpmPackMetadata {
+  return (
+    Boolean(value) &&
+    typeof value === "object" &&
+    Array.isArray((value as NpmPackMetadata).files)
+  );
 }
 
 function escapeRegex(value: string): string {

--- a/test/release-workflow.test.ts
+++ b/test/release-workflow.test.ts
@@ -72,6 +72,31 @@ describe("release workflow", () => {
     );
   });
 
+  it("extracts pack metadata around lifecycle output", async () => {
+    const workflow = await readWorkflow();
+    const packageStep = workflow.jobs?.release?.steps?.find((step) => step.id === "package")?.run;
+    const script = extractNodeHeredoc(packageStep);
+    const pack = {
+      filename: "openclaw-crabline-1.2.3.tgz",
+      files: [{ path: "dist/src/bin/crabline.js" }],
+      integrity: "sha512-expected",
+      version: "1.2.3",
+    };
+
+    for (const metadata of [[pack], { "@openclaw/crabline": pack }]) {
+      await expect(
+        runPackageMetadataCheck(
+          script,
+          `> @openclaw/crabline prepare\n${JSON.stringify(metadata, null, 2)}\n> prepare complete`,
+        ),
+      ).resolves.toEqual({
+        integrity: "sha512-expected",
+        name: "@openclaw/crabline",
+        tarball: expect.stringMatching(/openclaw-crabline-1\.2\.3\.tgz$/u),
+      });
+    }
+  });
+
   it("skips matching packages, rejects drift, and recovers after publish races", async () => {
     const workflow = await readWorkflow();
     const publishStep = workflow.jobs?.release?.steps?.find(
@@ -117,7 +142,7 @@ async function readWorkflow(): Promise<ReleaseWorkflow> {
 function extractNodeHeredoc(run: string | undefined): string {
   const match = /node --input-type=module <<'NODE'\n(?<script>[\s\S]*?)\nNODE/u.exec(run ?? "");
   if (!match?.groups?.script) {
-    throw new Error("Release metadata step is missing its Node validation script.");
+    throw new Error("Workflow step is missing its Node validation script.");
   }
   return match.groups.script;
 }
@@ -136,6 +161,48 @@ async function runMetadataCheck(script: string, changelog: string): Promise<void
         RELEASE_VERSION: "1.2.3",
       },
     });
+  } finally {
+    await fs.rm(tempDir, { force: true, recursive: true });
+  }
+}
+
+async function runPackageMetadataCheck(
+  script: string,
+  packOutput: string,
+): Promise<Record<string, string>> {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-release-package-"));
+  const outputPath = path.join(tempDir, "outputs");
+  try {
+    await fs.mkdir(path.join(tempDir, "dist/src/bin"), { recursive: true });
+    await Promise.all([
+      fs.writeFile(path.join(tempDir, "npm-pack.json"), packOutput),
+      fs.writeFile(
+        path.join(tempDir, "package.json"),
+        JSON.stringify({
+          bin: { crabline: "dist/src/bin/crabline.js" },
+          name: "@openclaw/crabline",
+        }),
+      ),
+      fs.writeFile(
+        path.join(tempDir, "dist/src/bin/crabline.js"),
+        "#!/usr/bin/env node\nconsole.log('crabline');\n",
+      ),
+    ]);
+    await execFileWithOutput(process.execPath, ["--input-type=module", "--eval", script], {
+      cwd: tempDir,
+      env: {
+        ...process.env,
+        GITHUB_OUTPUT: outputPath,
+        RELEASE_VERSION: "1.2.3",
+        RUNNER_TEMP: tempDir,
+      },
+    });
+    return Object.fromEntries(
+      (await fs.readFile(outputPath, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => line.split("=", 2)),
+    );
   } finally {
     await fs.rm(tempDir, { force: true, recursive: true });
   }

--- a/test/release-workflow.test.ts
+++ b/test/release-workflow.test.ts
@@ -7,6 +7,8 @@ import { describe, expect, it } from "vitest";
 import { parse } from "yaml";
 
 const execFileAsync = promisify(execFile);
+const CHANGELOG_HEADING_ERROR =
+  'CHANGELOG.md must contain exactly one "## 1.2.3 - YYYY-MM-DD" heading.';
 
 type WorkflowStep = {
   id?: string;
@@ -59,9 +61,15 @@ describe("release workflow", () => {
     const script = extractNodeHeredoc(verifyStep);
 
     await expect(runMetadataCheck(script, "## 1.2.3 - 2026-07-12\n")).resolves.toBeUndefined();
-    await expect(runMetadataCheck(script, "## 1.2.30 - 2026-07-12\n")).rejects.toThrow();
-    await expect(runMetadataCheck(script, "## 1x2x3 - 2026-07-12\n")).rejects.toThrow();
-    await expect(runMetadataCheck(script, "## 1.2.3-beta - 2026-07-12\n")).rejects.toThrow();
+    await expect(runMetadataCheck(script, "## 1.2.30 - 2026-07-12\n")).rejects.toThrow(
+      CHANGELOG_HEADING_ERROR,
+    );
+    await expect(runMetadataCheck(script, "## 1x2x3 - 2026-07-12\n")).rejects.toThrow(
+      CHANGELOG_HEADING_ERROR,
+    );
+    await expect(runMetadataCheck(script, "## 1.2.3-beta - 2026-07-12\n")).rejects.toThrow(
+      CHANGELOG_HEADING_ERROR,
+    );
   });
 
   it("skips matching packages, rejects drift, and recovers after publish races", async () => {
@@ -82,7 +90,9 @@ describe("release workflow", () => {
       runPublishStep(publishStep, {
         MOCK_VIEW_RESULT: "mismatch",
       }),
-    ).rejects.toThrow();
+    ).rejects.toThrow(
+      "::error::Published @openclaw/crabline@1.2.3 has integrity sha512-different, expected sha512-expected.",
+    );
 
     const racedCalls = await runPublishStep(publishStep, {
       MOCK_PUBLISH_STATUS: "1",
@@ -119,7 +129,7 @@ async function runMetadataCheck(script: string, changelog: string): Promise<void
       fs.writeFile(path.join(tempDir, "CHANGELOG.md"), changelog),
       fs.writeFile(path.join(tempDir, "package.json"), JSON.stringify({ version: "1.2.3" })),
     ]);
-    await execFileAsync(process.execPath, ["--input-type=module", "--eval", script], {
+    await execFileWithOutput(process.execPath, ["--input-type=module", "--eval", script], {
       cwd: tempDir,
       env: {
         ...process.env,
@@ -174,7 +184,7 @@ esac
       writeExecutable(path.join(binDir, "sleep"), "#!/usr/bin/env bash\nexit 0\n"),
     ]);
 
-    await execFileAsync("bash", ["-c", script], {
+    await execFileWithOutput("bash", ["-c", script], {
       cwd: tempDir,
       env: {
         ...process.env,
@@ -196,4 +206,21 @@ esac
 
 async function writeExecutable(filePath: string, contents: string): Promise<void> {
   await fs.writeFile(filePath, contents, { mode: 0o755 });
+}
+
+async function execFileWithOutput(
+  file: string,
+  args: string[],
+  options: Parameters<typeof execFileAsync>[2],
+): Promise<void> {
+  try {
+    await execFileAsync(file, args, options);
+  } catch (error) {
+    const failure = error as Error & {
+      stderr?: string;
+      stdout?: string;
+    };
+    const output = [failure.stdout, failure.stderr].filter(Boolean).join("\n").trim();
+    throw new Error(output || failure.message, { cause: error });
+  }
 }

--- a/test/release-workflow.test.ts
+++ b/test/release-workflow.test.ts
@@ -1,0 +1,199 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+const execFileAsync = promisify(execFile);
+
+type WorkflowStep = {
+  id?: string;
+  name?: string;
+  run?: string;
+};
+
+type ReleaseWorkflow = {
+  concurrency?: {
+    "cancel-in-progress"?: boolean;
+    group?: string;
+  };
+  jobs?: {
+    release?: {
+      steps?: WorkflowStep[];
+    };
+  };
+};
+
+describe("release workflow", () => {
+  it("pins tooling and makes package and GitHub publication retry-safe", async () => {
+    const workflow = await readWorkflow();
+    const steps = workflow.jobs?.release?.steps ?? [];
+    const commands = steps.map((step) => step.run).filter((run): run is string => Boolean(run));
+    const packageStep = steps.find((step) => step.id === "package")?.run;
+    const publishStep = steps.find(
+      (step) => step.name === "Publish package with npm provenance",
+    )?.run;
+    const releaseStep = steps.find((step) => step.name === "Create GitHub release")?.run;
+
+    expect(workflow.concurrency).toEqual({
+      "cancel-in-progress": false,
+      group: "release-${{ inputs.tag_name || github.ref_name }}",
+    });
+    expect(commands).toContain("npm install -g npm@12.0.1");
+    expect(commands.some((command) => command.includes("npm@latest"))).toBe(false);
+    expect(packageStep).toContain('npm pack --json --pack-destination "$RUNNER_TEMP"');
+    expect(packageStep).toContain("Packed artifact is missing the crabline CLI");
+    expect(publishStep).toContain('npm view "$PACKAGE_NAME@$RELEASE_VERSION" dist.integrity');
+    expect(publishStep).toContain('npm publish "$PACKAGE_TARBALL" --access public --provenance');
+    expect(releaseStep).toContain('gh release view "$RELEASE_TAG"');
+    expect(releaseStep).toContain("--verify-tag");
+  });
+
+  it("requires an exact changelog version heading", async () => {
+    const workflow = await readWorkflow();
+    const verifyStep = workflow.jobs?.release?.steps?.find(
+      (step) => step.name === "Verify release metadata",
+    )?.run;
+    const script = extractNodeHeredoc(verifyStep);
+
+    await expect(runMetadataCheck(script, "## 1.2.3 - 2026-07-12\n")).resolves.toBeUndefined();
+    await expect(runMetadataCheck(script, "## 1.2.30 - 2026-07-12\n")).rejects.toThrow();
+    await expect(runMetadataCheck(script, "## 1x2x3 - 2026-07-12\n")).rejects.toThrow();
+    await expect(runMetadataCheck(script, "## 1.2.3-beta - 2026-07-12\n")).rejects.toThrow();
+  });
+
+  it("skips matching packages, rejects drift, and recovers after publish races", async () => {
+    const workflow = await readWorkflow();
+    const publishStep = workflow.jobs?.release?.steps?.find(
+      (step) => step.name === "Publish package with npm provenance",
+    )?.run;
+    if (!publishStep) {
+      throw new Error("Release workflow is missing its npm publish step.");
+    }
+
+    const matchingCalls = await runPublishStep(publishStep, {
+      MOCK_VIEW_RESULT: "matching",
+    });
+    expect(matchingCalls).toEqual(["view @openclaw/crabline@1.2.3 dist.integrity"]);
+
+    await expect(
+      runPublishStep(publishStep, {
+        MOCK_VIEW_RESULT: "mismatch",
+      }),
+    ).rejects.toThrow();
+
+    const racedCalls = await runPublishStep(publishStep, {
+      MOCK_PUBLISH_STATUS: "1",
+      MOCK_VIEW_RESULT: "after-publish",
+    });
+    expect(racedCalls).toEqual([
+      "view @openclaw/crabline@1.2.3 dist.integrity",
+      "publish /tmp/crabline-1.2.3.tgz --access public --provenance",
+      "view @openclaw/crabline@1.2.3 dist.integrity",
+    ]);
+  });
+});
+
+async function readWorkflow(): Promise<ReleaseWorkflow> {
+  const contents = await fs.readFile(
+    path.join(process.cwd(), ".github/workflows/release.yml"),
+    "utf8",
+  );
+  return parse(contents) as ReleaseWorkflow;
+}
+
+function extractNodeHeredoc(run: string | undefined): string {
+  const match = /node --input-type=module <<'NODE'\n(?<script>[\s\S]*?)\nNODE/u.exec(run ?? "");
+  if (!match?.groups?.script) {
+    throw new Error("Release metadata step is missing its Node validation script.");
+  }
+  return match.groups.script;
+}
+
+async function runMetadataCheck(script: string, changelog: string): Promise<void> {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-release-metadata-"));
+  try {
+    await Promise.all([
+      fs.writeFile(path.join(tempDir, "CHANGELOG.md"), changelog),
+      fs.writeFile(path.join(tempDir, "package.json"), JSON.stringify({ version: "1.2.3" })),
+    ]);
+    await execFileAsync(process.execPath, ["--input-type=module", "--eval", script], {
+      cwd: tempDir,
+      env: {
+        ...process.env,
+        RELEASE_VERSION: "1.2.3",
+      },
+    });
+  } finally {
+    await fs.rm(tempDir, { force: true, recursive: true });
+  }
+}
+
+async function runPublishStep(
+  script: string,
+  overrides: Record<string, string>,
+): Promise<string[]> {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-release-publish-"));
+  const binDir = path.join(tempDir, "bin");
+  const logPath = path.join(tempDir, "npm.log");
+  const viewCountPath = path.join(tempDir, "view-count");
+
+  try {
+    await fs.mkdir(binDir);
+    await Promise.all([
+      writeExecutable(
+        path.join(binDir, "npm"),
+        `#!/usr/bin/env bash
+set -euo pipefail
+echo "$*" >> "$MOCK_LOG"
+if [[ "$1" == "publish" ]]; then
+  exit "\${MOCK_PUBLISH_STATUS:-0}"
+fi
+count=0
+if [[ -f "$MOCK_VIEW_COUNT" ]]; then
+  count="$(cat "$MOCK_VIEW_COUNT")"
+fi
+count=$((count + 1))
+echo "$count" > "$MOCK_VIEW_COUNT"
+case "\${MOCK_VIEW_RESULT:-missing}" in
+  matching) echo "$PACKAGE_INTEGRITY" ;;
+  mismatch) echo "sha512-different" ;;
+  after-publish)
+    if [[ "$count" -gt 1 ]]; then
+      echo "$PACKAGE_INTEGRITY"
+    else
+      exit 1
+    fi
+    ;;
+  *) exit 1 ;;
+esac
+`,
+      ),
+      writeExecutable(path.join(binDir, "sleep"), "#!/usr/bin/env bash\nexit 0\n"),
+    ]);
+
+    await execFileAsync("bash", ["-c", script], {
+      cwd: tempDir,
+      env: {
+        ...process.env,
+        ...overrides,
+        MOCK_LOG: logPath,
+        MOCK_VIEW_COUNT: viewCountPath,
+        PACKAGE_INTEGRITY: "sha512-expected",
+        PACKAGE_NAME: "@openclaw/crabline",
+        PACKAGE_TARBALL: "/tmp/crabline-1.2.3.tgz",
+        PATH: `${binDir}:${process.env.PATH}`,
+        RELEASE_VERSION: "1.2.3",
+      },
+    });
+    return (await fs.readFile(logPath, "utf8")).trim().split("\n");
+  } finally {
+    await fs.rm(tempDir, { force: true, recursive: true });
+  }
+}
+
+async function writeExecutable(filePath: string, contents: string): Promise<void> {
+  await fs.writeFile(filePath, contents, { mode: 0o755 });
+}

--- a/test/reporters-errors.test.ts
+++ b/test/reporters-errors.test.ts
@@ -26,7 +26,7 @@ describe("errors and reporters", () => {
     const suite = formatRunResultText({
       results: [
         {
-          diagnostics: [],
+          diagnostics: ["accepted"],
           fixtureId: "fixture",
           mode: "send",
           ok: true,
@@ -38,6 +38,7 @@ describe("errors and reporters", () => {
 
     expect(stripAnsi(single)).toContain("PASS");
     expect(stripAnsi(suite)).toContain("suite 1/1 passed");
+    expect(stripAnsi(suite)).toContain("  - accepted");
     expect(formatJson({ ok: true })).toContain('"ok": true');
     expect(formatJson(undefined)).toBe("null");
   });

--- a/test/run.behavior.test.ts
+++ b/test/run.behavior.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { CrablineError } from "../src/core/errors.js";
+import { EXIT_CODES } from "../src/core/exit-codes.js";
 import { computeExitCode, runFixtureCommand, runSuite } from "../src/core/run.js";
 import type { ManifestDefinition } from "../src/config/schema.js";
 import { OPENCLAW_SUPPORT_CATALOG } from "../src/providers/catalog.js";
@@ -156,7 +157,7 @@ describe("run behavior", () => {
     expect(roundtrip.failureKind).toBe("assertion");
   });
 
-  it("preserves the fixture result when cleanup fails", async () => {
+  it("fails an otherwise successful fixture when cleanup fails", async () => {
     const provider: ProviderAdapter = {
       id: "mock",
       platform: "loopback",
@@ -187,8 +188,10 @@ describe("run behavior", () => {
       registry: buildRegistry(provider),
     });
 
-    expect(result.ok).toBe(true);
+    expect(result.ok).toBe(false);
+    expect(result.failureKind).toBe("assertion");
     expect(result.diagnostics).toContain("cleanup failed: cleanup exploded");
+    expect(computeExitCode(result)).toBe(EXIT_CODES.ASSERTION);
   });
 
   it("preserves captured failures when cleanup fails", async () => {
@@ -222,6 +225,37 @@ describe("run behavior", () => {
       ok: false,
     });
     expect(result.diagnostics).toEqual(["send failed", "cleanup failed: cleanup exploded"]);
+  });
+
+  it("preserves explicit CrablineError exit codes", async () => {
+    const provider: ProviderAdapter = {
+      id: "mock",
+      platform: "loopback",
+      status: "ready",
+      supports: ["probe", "send", "roundtrip", "agent"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      probe: async () => ({ details: [], healthy: true }),
+      send: async () => {
+        throw new CrablineError("custom failure", {
+          exitCode: EXIT_CODES.AUTH,
+          kind: "outbound",
+        });
+      },
+      waitForInbound: async () => null,
+    };
+
+    const result = await runFixtureCommand({
+      fixtureId: "fixture",
+      manifest: withAllCapabilities(manifest),
+      manifestPath: "/tmp/crabline.yaml",
+      registry: buildRegistry(provider),
+    });
+
+    expect(result.failureKind).toBe("outbound");
+    expect(result.exitCode).toBe(EXIT_CODES.AUTH);
+    expect(computeExitCode(result)).toBe(EXIT_CODES.AUTH);
   });
 
   it("computes suite exit codes", async () => {


### PR DESCRIPTION
## Summary

- make npm publication retry-safe and validate production package entry points
- harden CLI cleanup, ready-file publication, diagnostics, and exit behavior
- keep manifest loading strict while supporting YAML anchors and validated `x-*` extensions

## Verification

- Crabbox: `pnpm verify` (39 files, 196 tests)
- autoreview: `gpt-5.6-sol` high, clean (0.91 confidence)
- changelog updated under `Unreleased`
