### PR TITLE
fix(providers): harden runtime and normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Export the OpenClaw conversation type from the package root.
 - Harden CLI lifecycle cleanup, ready-file publication, run diagnostics, and config validation.
 - Harden script provider subprocess limits and result validation, recorder polling and JSONL parsing, and local webhook startup and IPv6 URLs.
+- Fix provider normalization for loopback pagination and thread codecs, Telegram edited channel posts, Feishu and Matrix thread roots, and complete WhatsApp webhook batches.
 
 ## 0.1.9 - 2026-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Harden release packaging and retries, and make cleanup scripts portable across supported platforms.
 - Export the OpenClaw conversation type from the package root.
 - Harden CLI lifecycle cleanup, ready-file publication, run diagnostics, and config validation.
+- Harden script provider subprocess limits and result validation, recorder polling and JSONL parsing, and local webhook startup and IPv6 URLs.
 
 ## 0.1.9 - 2026-07-03
 

--- a/src/providers/builtin/feishu.ts
+++ b/src/providers/builtin/feishu.ts
@@ -62,7 +62,7 @@ export class FeishuProviderAdapter extends LocalMockProviderAdapter implements P
   }
 }
 
-function normalizeFeishuWebhookPayload(payload: unknown) {
+export function normalizeFeishuWebhookPayload(payload: unknown) {
   if (!isRecord(payload)) {
     throw new CrablineError("Feishu webhook payload must be an object", { kind: "inbound" });
   }
@@ -79,6 +79,7 @@ function normalizeFeishuWebhookPayload(payload: unknown) {
 
   const chatId = optionalString(message, "chat_id");
   const messageId = optionalString(message, "message_id");
+  const rootId = optionalString(message, "root_id");
   const rawContent = optionalString(message, "content");
   const text = parseFeishuText(rawContent);
   if (!chatId || !text) {
@@ -94,8 +95,8 @@ function normalizeFeishuWebhookPayload(payload: unknown) {
       : {}),
     raw: payload,
     text,
-    threadId: messageId
-      ? requireNativeInboundId(messageId, FEISHU_MESSAGE_ID_RULE, "Feishu message_id")
+    threadId: rootId
+      ? requireNativeInboundId(rootId, FEISHU_MESSAGE_ID_RULE, "Feishu root_id")
       : requireNativeInboundId(chatId, FEISHU_CHAT_ID_RULE, "Feishu chat_id"),
   };
 }

--- a/src/providers/builtin/loopback.ts
+++ b/src/providers/builtin/loopback.ts
@@ -54,13 +54,27 @@ export class LoopbackChatAdapter {
 
   decodeThreadId(threadId: string): ThreadAddress {
     const [address = threadId, rawThreadId] = threadId.split("::");
-    const [, channelId = address, id = address] = address.split(":");
-    const decoded: ThreadAddress = { id };
-    if (channelId) {
-      decoded.channelId = channelId;
+    const [platform, rawChannelOrId, rawId] = address.split(":");
+    if (platform !== "loopback+v2" || !rawChannelOrId) {
+      const [, channelId = address, id = address] = address.split(":");
+      const decoded: ThreadAddress = { id };
+      if (channelId) {
+        decoded.channelId = channelId;
+      }
+      if (rawThreadId) {
+        decoded.threadId = rawThreadId;
+      }
+      return decoded;
+    }
+
+    const decoded: ThreadAddress = {
+      id: decodeURIComponent(rawId ?? rawChannelOrId),
+    };
+    if (rawId) {
+      decoded.channelId = decodeURIComponent(rawChannelOrId);
     }
     if (rawThreadId) {
-      decoded.threadId = rawThreadId;
+      decoded.threadId = decodeURIComponent(rawThreadId);
     }
     return decoded;
   }
@@ -95,8 +109,12 @@ export class LoopbackChatAdapter {
   }
 
   encodeThreadId(platformData: ThreadAddress): string {
-    const channelId = platformData.channelId ?? `loopback:${platformData.id}`;
-    return platformData.threadId ? `${channelId}::${platformData.threadId}` : channelId;
+    const address = platformData.channelId
+      ? `loopback+v2:${encodeURIComponent(platformData.channelId)}:${encodeURIComponent(platformData.id)}`
+      : `loopback+v2:${encodeURIComponent(platformData.id)}`;
+    return platformData.threadId
+      ? `${address}::${encodeURIComponent(platformData.threadId)}`
+      : address;
   }
 
   fetchMessages(
@@ -106,9 +124,13 @@ export class LoopbackChatAdapter {
     const messages = [...(this.#messages.get(threadId) ?? [])];
     const limit = options?.limit ?? messages.length;
     if (!options?.cursor) {
-      return Promise.resolve({
+      const result: { messages: LoopbackMessage[]; nextCursor?: string } = {
         messages: messages.slice(-limit),
-      });
+      };
+      if (messages.length - limit > 0) {
+        result.nextCursor = String(messages.length - limit);
+      }
+      return Promise.resolve(result);
     }
 
     const offset = Number(options.cursor);

--- a/src/providers/builtin/loopback.ts
+++ b/src/providers/builtin/loopback.ts
@@ -48,8 +48,11 @@ export class LoopbackChatAdapter {
   }
 
   channelIdFromThreadId(threadId: string): string {
-    const [channelId = threadId] = threadId.split("::");
-    return channelId;
+    const [address = threadId] = threadId.split("::");
+    if (!address.startsWith("loopback+v2:")) {
+      return address;
+    }
+    return this.decodeThreadId(threadId).channelId ?? address;
   }
 
   decodeThreadId(threadId: string): ThreadAddress {

--- a/src/providers/builtin/matrix.ts
+++ b/src/providers/builtin/matrix.ts
@@ -69,7 +69,7 @@ export class MatrixProviderAdapter extends LocalMockProviderAdapter implements P
   }
 }
 
-function normalizeMatrixWebhookPayload(payload: unknown) {
+export function normalizeMatrixWebhookPayload(payload: unknown) {
   if (!isRecord(payload)) {
     throw new CrablineError("Matrix webhook payload must be an object", { kind: "inbound" });
   }
@@ -92,6 +92,12 @@ function normalizeMatrixWebhookPayload(payload: unknown) {
     });
   }
 
+  const relation = content ? optionalRecord(content, "m.relates_to") : undefined;
+  const threadRootId =
+    relation && optionalString(relation, "rel_type") === "m.thread"
+      ? optionalString(relation, "event_id")
+      : undefined;
+
   return {
     author: authorFromBotFlag(false),
     ...(eventId
@@ -99,8 +105,8 @@ function normalizeMatrixWebhookPayload(payload: unknown) {
       : {}),
     raw: payload,
     text,
-    threadId: eventId
-      ? requireNativeInboundId(eventId, MATRIX_EVENT_ID_RULE, "Matrix event_id")
+    threadId: threadRootId
+      ? requireNativeInboundId(threadRootId, MATRIX_EVENT_ID_RULE, "Matrix thread root event_id")
       : requireNativeInboundId(roomId, MATRIX_ROOM_ID_RULE, "Matrix room_id"),
   };
 }

--- a/src/providers/builtin/script.ts
+++ b/src/providers/builtin/script.ts
@@ -11,6 +11,7 @@ import type {
 } from "../types.js";
 
 const MAX_SCRIPT_OUTPUT_BYTES = 1024 * 1024;
+const SCRIPT_WAIT_EXIT_GRACE_MS = 250;
 
 type ScriptPayload = {
   fixture: ProviderContext["fixture"];
@@ -101,11 +102,13 @@ function parseScriptJson<T>(params: { command: string; output: string; schema: z
 }
 
 function runScript<T>(params: {
+  acceptResultDuringTimeoutGrace?: ((result: T) => boolean) | undefined;
   command: string;
   cwd?: string | undefined;
   payload: unknown;
   schema: z.ZodType<T>;
   shell?: string | undefined;
+  timeoutGraceMs?: number | undefined;
   timeoutMs: number;
 }): Promise<T> {
   return new Promise((resolve, reject) => {
@@ -119,8 +122,10 @@ function runScript<T>(params: {
 
     const stdout: Buffer[] = [];
     const stderr: Buffer[] = [];
+    let deadlineExceeded = false;
     let outputBytes = 0;
     let settled = false;
+    let timeoutGrace: NodeJS.Timeout | undefined;
 
     const finish = (callback: () => void) => {
       if (settled) {
@@ -128,6 +133,7 @@ function runScript<T>(params: {
       }
       settled = true;
       clearTimeout(timeout);
+      clearTimeout(timeoutGrace);
       callback();
     };
 
@@ -193,20 +199,28 @@ function runScript<T>(params: {
         }
 
         try {
-          resolve(
-            parseScriptJson({
-              command: params.command,
-              output: stdoutText,
-              schema: params.schema,
-            }),
-          );
+          const result = parseScriptJson({
+            command: params.command,
+            output: stdoutText,
+            schema: params.schema,
+          });
+          if (deadlineExceeded && !params.acceptResultDuringTimeoutGrace?.(result)) {
+            reject(
+              new CrablineError(
+                `Script command timed out after ${params.timeoutMs}ms: ${params.command}`,
+                { kind: "timeout" },
+              ),
+            );
+            return;
+          }
+          resolve(result);
         } catch (error) {
           reject(error);
         }
       });
     });
 
-    const timeout = setTimeout(() => {
+    const failForTimeout = () => {
       finish(() => {
         terminateChild(child);
         reject(
@@ -216,6 +230,16 @@ function runScript<T>(params: {
           ),
         );
       });
+    };
+    const timeout = setTimeout(() => {
+      const timeoutGraceMs = params.timeoutGraceMs ?? 0;
+      if (timeoutGraceMs <= 0) {
+        failForTimeout();
+        return;
+      }
+      deadlineExceeded = true;
+      timeoutGrace = setTimeout(failForTimeout, timeoutGraceMs);
+      timeoutGrace.unref();
     }, params.timeoutMs);
     timeout.unref();
 
@@ -313,6 +337,7 @@ export class ScriptProviderAdapter implements ProviderAdapter {
     }
 
     const result = await runScript({
+      acceptResultDuringTimeoutGrace: (candidate) => candidate.timeout === true,
       command,
       cwd: this.#config.cwd,
       payload: {
@@ -326,6 +351,7 @@ export class ScriptProviderAdapter implements ProviderAdapter {
       },
       schema: ScriptInboundResultSchema,
       shell: this.#config.shell,
+      timeoutGraceMs: SCRIPT_WAIT_EXIT_GRACE_MS,
       timeoutMs: context.timeoutMs,
     });
 

--- a/src/providers/builtin/script.ts
+++ b/src/providers/builtin/script.ts
@@ -1,5 +1,6 @@
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 import path from "node:path";
+import { z } from "zod";
 import { CrablineError, ensureErrorMessage } from "../../core/errors.js";
 import type {
   ProviderAdapter,
@@ -8,6 +9,8 @@ import type {
   WaitContext,
   WatchContext,
 } from "../types.js";
+
+const MAX_SCRIPT_OUTPUT_BYTES = 1024 * 1024;
 
 type ScriptPayload = {
   fixture: ProviderContext["fixture"];
@@ -18,76 +21,201 @@ type ScriptPayload = {
   };
 };
 
-type ScriptProbeResult = {
-  details?: string[];
-  healthy: boolean;
-};
+const ScriptMessageSchema = z.object({
+  author: z.enum(["assistant", "system", "user"]),
+  id: z.string().min(1),
+  raw: z.unknown().optional(),
+  sentAt: z.string().min(1),
+  text: z.string(),
+  threadId: z.string().min(1),
+});
 
-type ScriptSendResult = {
-  accepted: boolean;
-  messageId: string;
-  threadId: string;
-};
+const ScriptProbeResultSchema = z.object({
+  details: z.array(z.string()).optional(),
+  healthy: z.boolean(),
+});
 
-type ScriptInboundResult = {
-  message?: {
-    author: "assistant" | "system" | "user";
-    id: string;
-    raw?: unknown;
-    sentAt: string;
-    text: string;
-    threadId: string;
-  };
-  timeout?: boolean;
-};
+const ScriptSendResultSchema = z.object({
+  accepted: z.boolean(),
+  messageId: z.string().min(1),
+  threadId: z.string().min(1),
+});
 
-function runScript<T>(command: string, payload: unknown, cwd?: string, shell?: string): Promise<T> {
+const ScriptInboundResultSchema = z
+  .object({
+    message: ScriptMessageSchema.optional(),
+    timeout: z.boolean().optional(),
+  })
+  .refine(
+    (result) =>
+      (result.timeout === true && result.message === undefined) ||
+      (result.timeout !== true && result.message !== undefined),
+    { message: "result must contain either a message or timeout: true" },
+  );
+
+function terminateChild(child: ChildProcess): void {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+
+  if (process.platform !== "win32" && child.pid) {
+    try {
+      process.kill(-child.pid, "SIGKILL");
+      return;
+    } catch {
+      // The process group may have exited with the shell.
+    }
+  }
+  child.kill("SIGKILL");
+}
+
+function formatValidationError(error: z.ZodError): string {
+  return error.issues
+    .map((issue) => `${issue.path.length > 0 ? issue.path.join(".") : "result"}: ${issue.message}`)
+    .join("; ");
+}
+
+function parseScriptJson<T>(params: { command: string; output: string; schema: z.ZodType<T> }): T {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(params.output);
+  } catch (error) {
+    throw new CrablineError(
+      `Script command did not return valid JSON: ${params.command}\n${ensureErrorMessage(error)}`,
+      { kind: "config" },
+    );
+  }
+
+  const result = params.schema.safeParse(parsed);
+  if (!result.success) {
+    throw new CrablineError(
+      `Script command returned invalid result: ${params.command}\n${formatValidationError(result.error)}`,
+      { kind: "config" },
+    );
+  }
+  return result.data;
+}
+
+function runScript<T>(params: {
+  command: string;
+  cwd?: string | undefined;
+  payload: unknown;
+  schema: z.ZodType<T>;
+  shell?: string | undefined;
+  timeoutMs: number;
+}): Promise<T> {
   return new Promise((resolve, reject) => {
-    const child = spawn(command, {
-      cwd: cwd ? path.resolve(cwd) : process.cwd(),
+    const child = spawn(params.command, {
+      cwd: params.cwd ? path.resolve(params.cwd) : process.cwd(),
       env: process.env,
-      shell: shell ?? true,
+      shell: params.shell ?? true,
+      detached: process.platform !== "win32",
       stdio: ["pipe", "pipe", "pipe"],
     });
 
-    let stdout = "";
-    let stderr = "";
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    let outputBytes = 0;
+    let settled = false;
+
+    const finish = (callback: () => void) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      callback();
+    };
+
+    const failForOutputLimit = () => {
+      finish(() => {
+        terminateChild(child);
+        reject(
+          new CrablineError(
+            `Script command exceeded ${MAX_SCRIPT_OUTPUT_BYTES} bytes of output: ${params.command}`,
+            { kind: "connectivity" },
+          ),
+        );
+      });
+    };
 
     child.stdout.on("data", (chunk) => {
-      stdout += String(chunk);
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      outputBytes += buffer.length;
+      if (outputBytes > MAX_SCRIPT_OUTPUT_BYTES) {
+        failForOutputLimit();
+        return;
+      }
+      stdout.push(buffer);
     });
 
     child.stderr.on("data", (chunk) => {
-      stderr += String(chunk);
-    });
-
-    child.on("error", reject);
-    child.on("close", (code) => {
-      if (code !== 0) {
-        reject(
-          new CrablineError(
-            `Script command failed: ${command}\n${stderr.trim() || stdout.trim()}`,
-            {
-              kind: "connectivity",
-            },
-          ),
-        );
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      outputBytes += buffer.length;
+      if (outputBytes > MAX_SCRIPT_OUTPUT_BYTES) {
+        failForOutputLimit();
         return;
       }
-
-      try {
-        resolve(JSON.parse(stdout) as T);
-      } catch (error) {
-        reject(
-          new CrablineError(
-            `Script command did not return valid JSON: ${command}\n${ensureErrorMessage(error)}`,
-            { kind: "config" },
-          ),
-        );
-      }
+      stderr.push(buffer);
     });
 
-    child.stdin.end(JSON.stringify(payload));
+    child.stdin.on("error", () => {
+      // Child closure is reported through the process error/close handlers.
+    });
+    child.once("error", (error) => {
+      finish(() => {
+        reject(
+          new CrablineError(
+            `Script command failed to start: ${params.command}\n${ensureErrorMessage(error)}`,
+            { cause: error, kind: "connectivity" },
+          ),
+        );
+      });
+    });
+    child.once("close", (code, signal) => {
+      finish(() => {
+        const stdoutText = Buffer.concat(stdout).toString("utf8");
+        const stderrText = Buffer.concat(stderr).toString("utf8");
+        if (code !== 0) {
+          reject(
+            new CrablineError(
+              `Script command failed: ${params.command}${
+                signal ? ` (${signal})` : ""
+              }\n${stderrText.trim() || stdoutText.trim()}`,
+              { kind: "connectivity" },
+            ),
+          );
+          return;
+        }
+
+        try {
+          resolve(
+            parseScriptJson({
+              command: params.command,
+              output: stdoutText,
+              schema: params.schema,
+            }),
+          );
+        } catch (error) {
+          reject(error);
+        }
+      });
+    });
+
+    const timeout = setTimeout(() => {
+      finish(() => {
+        terminateChild(child);
+        reject(
+          new CrablineError(
+            `Script command timed out after ${params.timeoutMs}ms: ${params.command}`,
+            { kind: "timeout" },
+          ),
+        );
+      });
+    }, params.timeoutMs);
+    timeout.unref();
+
+    child.stdin.end(JSON.stringify(params.payload));
   });
 }
 
@@ -134,12 +262,14 @@ export class ScriptProviderAdapter implements ProviderAdapter {
       };
     }
 
-    const result = await runScript<ScriptProbeResult>(
+    const result = await runScript({
       command,
-      createPayload(context),
-      this.#config.cwd,
-      this.#config.shell,
-    );
+      cwd: this.#config.cwd,
+      payload: createPayload(context),
+      schema: ScriptProbeResultSchema,
+      shell: this.#config.shell,
+      timeoutMs: context.fixture.timeoutMs,
+    });
     return {
       details: result.details ?? [],
       healthy: result.healthy,
@@ -154,9 +284,10 @@ export class ScriptProviderAdapter implements ProviderAdapter {
       });
     }
 
-    return runScript<ScriptSendResult>(
+    return runScript({
       command,
-      {
+      cwd: this.#config.cwd,
+      payload: {
         ...createPayload(context),
         outbound: {
           mode: context.mode,
@@ -165,9 +296,10 @@ export class ScriptProviderAdapter implements ProviderAdapter {
           text: context.text,
         },
       },
-      this.#config.cwd,
-      this.#config.shell,
-    );
+      schema: ScriptSendResultSchema,
+      shell: this.#config.shell,
+      timeoutMs: context.fixture.timeoutMs,
+    });
   }
 
   async waitForInbound(context: WaitContext) {
@@ -176,9 +308,10 @@ export class ScriptProviderAdapter implements ProviderAdapter {
       return null;
     }
 
-    const result = await runScript<ScriptInboundResult>(
+    const result = await runScript({
       command,
-      {
+      cwd: this.#config.cwd,
+      payload: {
         ...createPayload(context),
         wait: {
           nonce: context.nonce,
@@ -187,9 +320,10 @@ export class ScriptProviderAdapter implements ProviderAdapter {
           timeoutMs: context.timeoutMs,
         },
       },
-      this.#config.cwd,
-      this.#config.shell,
-    );
+      schema: ScriptInboundResultSchema,
+      shell: this.#config.shell,
+      timeoutMs: context.timeoutMs,
+    });
 
     if (result.timeout || !result.message) {
       return null;
@@ -214,8 +348,41 @@ export class ScriptProviderAdapter implements ProviderAdapter {
       env: process.env,
       shell: this.#config.shell ?? true,
       detached: process.platform !== "win32",
-      stdio: ["pipe", "pipe", "inherit"],
+      stdio: ["pipe", "pipe", "pipe"],
     });
+
+    let buffer = "";
+    let stderr = "";
+    let childError: unknown;
+    let outputLimitError: CrablineError | undefined;
+    child.stdin.on("error", () => {
+      // Child closure is reported through the process error/close handlers.
+    });
+    child.stderr.on("data", (chunk) => {
+      if (outputLimitError) {
+        return;
+      }
+      stderr += String(chunk);
+      if (Buffer.byteLength(stderr) > MAX_SCRIPT_OUTPUT_BYTES) {
+        outputLimitError = new CrablineError(
+          `Script watch command exceeded ${MAX_SCRIPT_OUTPUT_BYTES} bytes of stderr: ${command}`,
+          { kind: "connectivity" },
+        );
+        terminateChild(child);
+      }
+    });
+    child.once("error", (error) => {
+      childError = error;
+    });
+    const childClosed = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+      (resolve) => {
+        if (child.exitCode !== null || child.signalCode !== null) {
+          resolve({ code: child.exitCode, signal: child.signalCode });
+          return;
+        }
+        child.once("close", (code, signal) => resolve({ code, signal }));
+      },
+    );
     child.stdin.end(
       JSON.stringify({
         ...createPayload(context),
@@ -226,28 +393,32 @@ export class ScriptProviderAdapter implements ProviderAdapter {
       }),
     );
 
-    let buffer = "";
-    const childClosed = new Promise<void>((resolve) => {
-      if (child.exitCode !== null || child.signalCode !== null) {
-        resolve();
-        return;
-      }
-      child.once("close", () => resolve());
-    });
-
     try {
       for await (const chunk of child.stdout) {
         buffer += String(chunk);
+        if (Buffer.byteLength(buffer) > MAX_SCRIPT_OUTPUT_BYTES && !buffer.includes("\n")) {
+          throw new CrablineError(
+            `Script watch command exceeded ${MAX_SCRIPT_OUTPUT_BYTES} bytes without a newline: ${command}`,
+            { kind: "config" },
+          );
+        }
         const lines = buffer.split("\n");
         buffer = lines.pop() ?? "";
         for (const line of lines) {
           if (!line.trim()) {
             continue;
           }
-          const parsed = JSON.parse(line) as ScriptInboundResult["message"];
-          if (!parsed) {
-            continue;
+          if (Buffer.byteLength(line) > MAX_SCRIPT_OUTPUT_BYTES) {
+            throw new CrablineError(
+              `Script watch command emitted a JSON line larger than ${MAX_SCRIPT_OUTPUT_BYTES} bytes: ${command}`,
+              { kind: "config" },
+            );
           }
+          const parsed = parseScriptJson({
+            command,
+            output: line,
+            schema: ScriptMessageSchema,
+          });
           yield {
             ...parsed,
             provider: this.id,
@@ -256,25 +427,50 @@ export class ScriptProviderAdapter implements ProviderAdapter {
       }
 
       if (buffer.trim()) {
-        const parsed = JSON.parse(buffer) as ScriptInboundResult["message"];
-        if (parsed) {
-          yield {
-            ...parsed,
-            provider: this.id,
-          };
-        }
+        const parsed = parseScriptJson({
+          command,
+          output: buffer,
+          schema: ScriptMessageSchema,
+        });
+        yield {
+          ...parsed,
+          provider: this.id,
+        };
       }
+
+      const exit = await childClosed;
+      if (outputLimitError) {
+        throw outputLimitError;
+      }
+      if (childError) {
+        throw new CrablineError(
+          `Script watch command failed to start: ${command}\n${ensureErrorMessage(childError)}`,
+          { cause: childError, kind: "connectivity" },
+        );
+      }
+      if (exit.code !== 0) {
+        throw new CrablineError(
+          `Script watch command failed: ${command}${
+            exit.signal ? ` (${exit.signal})` : ""
+          }\n${stderr.trim()}`,
+          { kind: "connectivity" },
+        );
+      }
+    } catch (error) {
+      if (outputLimitError) {
+        throw outputLimitError;
+      }
+      if (childError) {
+        throw new CrablineError(
+          `Script watch command failed to start: ${command}\n${ensureErrorMessage(childError)}`,
+          { cause: childError, kind: "connectivity" },
+        );
+      }
+      throw error;
     } finally {
       child.stdin.destroy();
       if (child.exitCode === null && child.signalCode === null) {
-        child.kill();
-        if (process.platform !== "win32" && child.pid) {
-          try {
-            process.kill(-child.pid, "SIGKILL");
-          } catch {
-            // The process group may have already exited with the shell.
-          }
-        }
+        terminateChild(child);
       }
       await childClosed;
     }

--- a/src/providers/builtin/script.ts
+++ b/src/providers/builtin/script.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcess } from "node:child_process";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import path from "node:path";
 import { z } from "zod";
 import { CrablineError, ensureErrorMessage } from "../../core/errors.js";
@@ -54,19 +54,23 @@ const ScriptInboundResultSchema = z
   );
 
 function terminateChild(child: ChildProcess): void {
-  if (child.exitCode !== null || child.signalCode !== null) {
-    return;
-  }
-
-  if (process.platform !== "win32" && child.pid) {
+  if (process.platform === "win32" && child.pid) {
+    spawnSync("taskkill.exe", ["/PID", String(child.pid), "/T", "/F"], {
+      stdio: "ignore",
+      timeout: 5000,
+      windowsHide: true,
+    });
+  } else if (child.pid) {
     try {
       process.kill(-child.pid, "SIGKILL");
-      return;
     } catch {
       // The process group may have exited with the shell.
     }
   }
-  child.kill("SIGKILL");
+
+  if (child.exitCode === null && child.signalCode === null) {
+    child.kill("SIGKILL");
+  }
 }
 
 function formatValidationError(error: z.ZodError): string {
@@ -374,13 +378,13 @@ export class ScriptProviderAdapter implements ProviderAdapter {
     child.once("error", (error) => {
       childError = error;
     });
+    let childCloseObserved = false;
     const childClosed = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
       (resolve) => {
-        if (child.exitCode !== null || child.signalCode !== null) {
-          resolve({ code: child.exitCode, signal: child.signalCode });
-          return;
-        }
-        child.once("close", (code, signal) => resolve({ code, signal }));
+        child.once("close", (code, signal) => {
+          childCloseObserved = true;
+          resolve({ code, signal });
+        });
       },
     );
     child.stdin.end(
@@ -469,7 +473,7 @@ export class ScriptProviderAdapter implements ProviderAdapter {
       throw error;
     } finally {
       child.stdin.destroy();
-      if (child.exitCode === null && child.signalCode === null) {
+      if (!childCloseObserved) {
         terminateChild(child);
       }
       await childClosed;

--- a/src/providers/builtin/telegram.ts
+++ b/src/providers/builtin/telegram.ts
@@ -101,7 +101,8 @@ export function normalizeTelegramWebhookPayload(payload: unknown) {
   const message =
     optionalRecord(payload, "message") ??
     optionalRecord(payload, "edited_message") ??
-    optionalRecord(payload, "channel_post");
+    optionalRecord(payload, "channel_post") ??
+    optionalRecord(payload, "edited_channel_post");
   if (!message) {
     return genericMockPayloadWithNativeThread({
       channelRule: TELEGRAM_CHAT_ID_RULE,

--- a/src/providers/builtin/whatsapp.ts
+++ b/src/providers/builtin/whatsapp.ts
@@ -21,6 +21,7 @@ import {
   createNativeTargetCodec,
   genericMockPayloadWithNativeThread,
   isRecord,
+  normalizeAuthor,
   optionalRecord,
   optionalString,
   requireNativeInboundId,
@@ -283,13 +284,69 @@ export function normalizeWhatsAppWebhookPayload(
     return [];
   }
 
-  return [
-    genericMockPayloadWithNativeThread({
-      channelRule: WHATSAPP_WA_ID_RULE,
-      payload,
-      threadRule: WHATSAPP_WA_ID_RULE,
-    }),
-  ];
+  const fallback = genericMockPayloadWithNativeThread({
+    channelRule: WHATSAPP_WA_ID_RULE,
+    payload,
+    threadRule: WHATSAPP_WA_ID_RULE,
+  }) as Record<string, unknown>;
+  return [normalizeWhatsAppFallback(fallback)];
+}
+
+function normalizeWhatsAppFallback(
+  fallback: Record<string, unknown>,
+): NormalizedWhatsAppWebhookMessage {
+  const normalized: NormalizedWhatsAppWebhookMessage = {
+    raw: fallback.raw ?? fallback,
+  };
+  const author = normalizeAuthor(fallback.author);
+  if (author) {
+    normalized.author = author;
+  }
+  if (typeof fallback.authorIsBot === "boolean") {
+    normalized.authorIsBot = fallback.authorIsBot;
+  }
+  const id = optionalString(fallback, "id");
+  if (id) {
+    normalized.id = id;
+  }
+  const text = optionalString(fallback, "text");
+  if (text) {
+    normalized.text = text;
+  }
+  const threadId = optionalString(fallback, "threadId");
+  if (threadId) {
+    normalized.threadId = threadId;
+  }
+
+  const message = optionalRecord(fallback, "message");
+  if (message) {
+    const normalizedMessage: NonNullable<NormalizedWhatsAppWebhookMessage["message"]> = {};
+    const messageAuthor = normalizeAuthor(message.author);
+    if (messageAuthor) {
+      normalizedMessage.author = messageAuthor;
+    }
+    if (typeof message.authorIsBot === "boolean") {
+      normalizedMessage.authorIsBot = message.authorIsBot;
+    }
+    const messageId = optionalString(message, "id");
+    if (messageId) {
+      normalizedMessage.id = messageId;
+    }
+    if (message.raw !== undefined) {
+      normalizedMessage.raw = message.raw;
+    }
+    const messageText = optionalString(message, "text");
+    if (messageText) {
+      normalizedMessage.text = messageText;
+    }
+    const messageThreadId = optionalString(message, "threadId");
+    if (messageThreadId) {
+      normalizedMessage.threadId = messageThreadId;
+    }
+    normalized.message = normalizedMessage;
+  }
+
+  return normalized;
 }
 
 function normalizeWhatsAppMessage(
@@ -310,9 +367,10 @@ function normalizeWhatsAppMessage(
     });
   }
 
+  const messageId = optionalString(message, "id");
   return {
     author: authorFromBotFlag(false),
-    ...(optionalString(message, "id") ? { id: optionalString(message, "id") } : {}),
+    ...(messageId ? { id: messageId } : {}),
     raw: payload,
     text: body,
     threadId: requireNativeInboundId(from, WHATSAPP_WA_ID_RULE, "WhatsApp messages[].from"),

--- a/src/providers/builtin/whatsapp.ts
+++ b/src/providers/builtin/whatsapp.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { CrablineError, ensureErrorMessage } from "../../core/errors.js";
+import { matchesInbound } from "../../core/matcher.js";
 import type { ProviderConfig } from "../../config/schema.js";
 import { LocalMockProviderAdapter, type LocalMockWebhookConfig } from "../local-mock.js";
 import {
@@ -104,7 +105,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
   }
 
   override async probe(context: ProviderContext): Promise<ProbeResult> {
-    const server = await this.#ensureWebhookServer(true);
+    const server = await this.#ensureWebhookServer();
     const target = this.normalizeTarget(context.fixture.target);
     const details = [
       "whatsapp local mock ready",
@@ -125,7 +126,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
   }
 
   override async waitForInbound(context: WaitContext): Promise<InboundEnvelope | null> {
-    await this.#ensureWebhookServer(true);
+    await this.#ensureWebhookServer();
     const target = this.normalizeTarget(context.fixture.target);
     return await waitForRecordedInbound({
       filePath: this.#recorderPath,
@@ -142,7 +143,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
   }
 
   override async *watch(context: WatchContext): AsyncIterable<InboundEnvelope> {
-    await this.#ensureWebhookServer(false);
+    await this.#ensureWebhookServer();
     const target = this.normalizeTarget(context.fixture.target);
     for await (const event of watchRecordedInbound({
       filePath: this.#recorderPath,
@@ -205,7 +206,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
     );
   }
 
-  async #ensureWebhookServer(allowExisting: boolean): Promise<StartedWebhookServer> {
+  async #ensureWebhookServer(): Promise<StartedWebhookServer> {
     if (this.#server) {
       return this.#server;
     }
@@ -222,13 +223,6 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
       });
       return this.#server;
     } catch (error) {
-      const code = (error as NodeJS.ErrnoException).code;
-      if (allowExisting && code === "EADDRINUSE") {
-        return {
-          async close() {},
-          endpointUrl: `http://${host}:${port}${webhookPath}`,
-        };
-      }
       throw new CrablineError(
         `whatsapp local mock webhook server failed: ${ensureErrorMessage(error)}`,
         { cause: error, kind: "connectivity" },
@@ -398,6 +392,9 @@ function isAddressInChannel(threadId: string, channelId?: string): boolean {
 
 function matchesWaitCandidate(event: InboundEnvelope, context: WaitContext): boolean {
   const config = context.fixture.inboundMatch;
+  if (config.nonce === "exact") {
+    return matchesInbound(event, config, context.nonce);
+  }
   if (config.author !== "any" && event.author !== config.author) {
     return false;
   }

--- a/src/providers/builtin/whatsapp.ts
+++ b/src/providers/builtin/whatsapp.ts
@@ -1,8 +1,21 @@
 import path from "node:path";
-import { CrablineError } from "../../core/errors.js";
+import { CrablineError, ensureErrorMessage } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
-import { LocalMockProviderAdapter } from "../local-mock.js";
-import type { ProviderAdapter } from "../types.js";
+import { LocalMockProviderAdapter, type LocalMockWebhookConfig } from "../local-mock.js";
+import {
+  appendRecordedInbound,
+  waitForRecordedInbound,
+  watchRecordedInbound,
+} from "../recorder.js";
+import type {
+  InboundEnvelope,
+  ProbeResult,
+  ProviderAdapter,
+  ProviderContext,
+  WaitContext,
+  WatchContext,
+} from "../types.js";
+import { startWebhookServer, type StartedWebhookServer } from "../webhook-server.js";
 import {
   authorFromBotFlag,
   createNativeTargetCodec,
@@ -14,11 +27,34 @@ import {
   type NativeIdRule,
 } from "./native-local-mock.js";
 
+type NormalizedWhatsAppWebhookMessage = {
+  author?: "assistant" | "system" | "user";
+  authorIsBot?: boolean;
+  id?: string;
+  message?: {
+    author?: "assistant" | "system" | "user";
+    authorIsBot?: boolean;
+    id?: string;
+    raw?: unknown;
+    text?: string;
+    threadId?: string;
+  };
+  raw?: unknown;
+  text?: string;
+  threadId?: string;
+};
+
 const WHATSAPP_WA_ID_RULE: NativeIdRule = {
   example: "15551234567",
   name: "WhatsApp wa_id",
   pattern: /^\d{7,15}$/u,
 };
+
+const DEFAULT_WHATSAPP_WEBHOOK = {
+  host: "127.0.0.1",
+  path: "/whatsapp/webhook",
+  port: 8789,
+} as const;
 
 export function resolveWhatsAppAdapterConfig(
   config: ProviderConfig,
@@ -34,6 +70,11 @@ export function resolveWhatsAppAdapterConfig(
 }
 
 export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
+  readonly #publicUrl: string | undefined;
+  readonly #recorderPath: string;
+  readonly #webhook: LocalMockWebhookConfig | undefined;
+  #server: StartedWebhookServer | null = null;
+
   constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
     super({
       codec: createNativeTargetCodec({
@@ -43,7 +84,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
       config,
       id,
       options: {
-        defaultWebhook: { host: "127.0.0.1", path: "/whatsapp/webhook", port: 8789 },
+        defaultWebhook: DEFAULT_WHATSAPP_WEBHOOK,
         endpointLabel: "webhook endpoint",
         normalizeWebhookPayload: normalizeWhatsAppWebhookPayload,
         platform: "whatsapp",
@@ -54,15 +95,156 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
         webhook: config.whatsapp?.webhook,
       },
     });
+    this.#publicUrl = config.whatsapp?.webhook.publicUrl;
+    this.#recorderPath = config.whatsapp?.recorder.path
+      ? path.resolve(config.whatsapp.recorder.path)
+      : path.resolve(".crabline", "recorders", `${id}.jsonl`);
+    this.#webhook = config.whatsapp?.webhook;
+  }
+
+  override async probe(context: ProviderContext): Promise<ProbeResult> {
+    const server = await this.#ensureWebhookServer(true);
+    const target = this.normalizeTarget(context.fixture.target);
+    const details = [
+      "whatsapp local mock ready",
+      `recorder path ${this.#recorderPath}`,
+      `webhook endpoint ${server.endpointUrl}`,
+    ];
+    if (this.#publicUrl) {
+      details.push(`public webhook ${this.#publicUrl}`);
+    }
+    if (target.threadId) {
+      details.push(`thread reachable ${target.threadId}`);
+    } else if (target.channelId) {
+      details.push(`channel reachable ${target.channelId}`);
+    } else {
+      details.push(`dm reachable ${target.id}`);
+    }
+    return { details, healthy: true };
+  }
+
+  override async waitForInbound(context: WaitContext): Promise<InboundEnvelope | null> {
+    await this.#ensureWebhookServer(true);
+    const target = this.normalizeTarget(context.fixture.target);
+    return await waitForRecordedInbound({
+      filePath: this.#recorderPath,
+      matches: (event) =>
+        event.provider === this.id &&
+        isAddressInChannel(
+          event.threadId,
+          context.threadId ?? target.threadId ?? target.channelId ?? target.id,
+        ) &&
+        matchesWaitCandidate(event, context),
+      since: context.since,
+      timeoutMs: context.timeoutMs,
+    });
+  }
+
+  override async *watch(context: WatchContext): AsyncIterable<InboundEnvelope> {
+    await this.#ensureWebhookServer(false);
+    const target = this.normalizeTarget(context.fixture.target);
+    for await (const event of watchRecordedInbound({
+      filePath: this.#recorderPath,
+      matches: (entry) =>
+        entry.provider === this.id &&
+        isAddressInChannel(entry.threadId, target.threadId ?? target.channelId ?? target.id),
+      since: context.since,
+    })) {
+      yield event;
+    }
+  }
+
+  override async cleanup(): Promise<void> {
+    if (this.#server) {
+      await this.#server.close();
+      this.#server = null;
+    }
+    await super.cleanup();
+  }
+
+  async #handleWebhook(request: Request): Promise<Response> {
+    if (!request.headers.get("content-type")?.includes("application/json")) {
+      return new Response("expected application/json", { status: 415 });
+    }
+
+    let messages: NormalizedWhatsAppWebhookMessage[];
+    try {
+      messages = normalizeWhatsAppWebhookPayload(await request.json());
+    } catch (error) {
+      return new Response(ensureErrorMessage(error), { status: 400 });
+    }
+
+    const ids: string[] = [];
+    for (const message of messages) {
+      const id = message.message?.id ?? message.id ?? createMessageId();
+      const threadId = message.message?.threadId ?? message.threadId;
+      const text = message.message?.text ?? message.text;
+      if (!threadId || !text) {
+        return new Response("payload requires message.threadId and message.text", { status: 400 });
+      }
+
+      await appendRecordedInbound(this.#recorderPath, {
+        author: authorFromPayload(message),
+        id,
+        provider: this.id,
+        raw: message.message?.raw ?? message.raw ?? message,
+        sentAt: new Date().toISOString(),
+        text,
+        threadId,
+      });
+      ids.push(id);
+    }
+
+    return new Response(
+      JSON.stringify(ids.length === 1 ? { id: ids[0], ok: true } : { ids, ok: true }),
+      {
+        headers: { "content-type": "application/json" },
+        status: 200,
+      },
+    );
+  }
+
+  async #ensureWebhookServer(allowExisting: boolean): Promise<StartedWebhookServer> {
+    if (this.#server) {
+      return this.#server;
+    }
+
+    const host = this.#webhook?.host ?? DEFAULT_WHATSAPP_WEBHOOK.host;
+    const port = this.#webhook?.port ?? DEFAULT_WHATSAPP_WEBHOOK.port;
+    const webhookPath = this.#webhook?.path ?? DEFAULT_WHATSAPP_WEBHOOK.path;
+    try {
+      this.#server = await startWebhookServer({
+        handle: (request) => this.#handleWebhook(request),
+        host,
+        path: webhookPath,
+        port,
+      });
+      return this.#server;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (allowExisting && code === "EADDRINUSE") {
+        return {
+          async close() {},
+          endpointUrl: `http://${host}:${port}${webhookPath}`,
+        };
+      }
+      throw new CrablineError(
+        `whatsapp local mock webhook server failed: ${ensureErrorMessage(error)}`,
+        { cause: error, kind: "connectivity" },
+      );
+    }
   }
 }
 
-export function normalizeWhatsAppWebhookPayload(payload: unknown) {
+export function normalizeWhatsAppWebhookPayload(
+  payload: unknown,
+): NormalizedWhatsAppWebhookMessage[] {
   if (!isRecord(payload)) {
     throw new CrablineError("WhatsApp webhook payload must be an object", { kind: "inbound" });
   }
 
-  let message: Record<string, unknown> | undefined;
+  const normalized: NormalizedWhatsAppWebhookMessage[] = [];
+  let firstMalformedMessageError: unknown;
   if (Array.isArray(payload.entry)) {
     for (const entry of payload.entry) {
       if (!isRecord(entry) || !Array.isArray(entry.changes)) {
@@ -73,24 +255,50 @@ export function normalizeWhatsAppWebhookPayload(payload: unknown) {
           continue;
         }
         const value = optionalRecord(change, "value");
-        const candidate =
-          value && Array.isArray(value.messages) ? value.messages.find(isRecord) : undefined;
-        if (candidate) {
-          message = candidate;
-          break;
+        if (!value || !Array.isArray(value.messages)) {
+          continue;
+        }
+        for (const message of value.messages) {
+          if (!isRecord(message)) {
+            continue;
+          }
+          try {
+            const normalizedMessage = normalizeWhatsAppMessage(message, payload);
+            if (normalizedMessage) {
+              normalized.push(normalizedMessage);
+            }
+          } catch (error) {
+            firstMalformedMessageError ??= error;
+          }
         }
       }
-      if (message) {
-        break;
-      }
     }
+
+    if (normalized.length > 0) {
+      return normalized;
+    }
+    if (firstMalformedMessageError) {
+      throw firstMalformedMessageError;
+    }
+    return [];
   }
-  if (!message) {
-    return genericMockPayloadWithNativeThread({
+
+  return [
+    genericMockPayloadWithNativeThread({
       channelRule: WHATSAPP_WA_ID_RULE,
       payload,
       threadRule: WHATSAPP_WA_ID_RULE,
-    });
+    }),
+  ];
+}
+
+function normalizeWhatsAppMessage(
+  message: Record<string, unknown>,
+  payload: Record<string, unknown>,
+): NormalizedWhatsAppWebhookMessage | null {
+  const messageType = optionalString(message, "type");
+  if (messageType && messageType !== "text") {
+    return null;
   }
 
   const text = optionalRecord(message, "text");
@@ -109,4 +317,43 @@ export function normalizeWhatsAppWebhookPayload(payload: unknown) {
     text: body,
     threadId: requireNativeInboundId(from, WHATSAPP_WA_ID_RULE, "WhatsApp messages[].from"),
   };
+}
+
+function authorFromPayload(payload: NormalizedWhatsAppWebhookMessage): InboundEnvelope["author"] {
+  const explicit = payload.message?.author ?? payload.author;
+  if (explicit) {
+    return explicit;
+  }
+  return (payload.message?.authorIsBot ?? payload.authorIsBot ?? true) ? "assistant" : "user";
+}
+
+function createMessageId(): string {
+  return `whatsapp-mock-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function isAddressInChannel(threadId: string, channelId?: string): boolean {
+  if (!channelId) {
+    return true;
+  }
+  return threadId === channelId || threadId.startsWith(`${channelId}:`);
+}
+
+function matchesWaitCandidate(event: InboundEnvelope, context: WaitContext): boolean {
+  const config = context.fixture.inboundMatch;
+  if (config.author !== "any" && event.author !== config.author) {
+    return false;
+  }
+  if (config.nonce !== "ignore" && !event.text.includes(context.nonce)) {
+    return false;
+  }
+  if (!config.pattern) {
+    return true;
+  }
+  if (config.strategy === "exact") {
+    return event.text === config.pattern;
+  }
+  if (config.strategy === "regex") {
+    return new RegExp(config.pattern, "u").test(event.text);
+  }
+  return event.text.includes(config.pattern);
 }

--- a/src/providers/builtin/whatsapp.ts
+++ b/src/providers/builtin/whatsapp.ts
@@ -136,7 +136,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
           event.threadId,
           context.threadId ?? target.threadId ?? target.channelId ?? target.id,
         ) &&
-        matchesWaitCandidate(event, context),
+        matchesInbound(event, context.fixture.inboundMatch, context.nonce),
       since: context.since,
       timeoutMs: context.timeoutMs,
     });
@@ -258,7 +258,7 @@ export function normalizeWhatsAppWebhookPayload(
             continue;
           }
           try {
-            const normalizedMessage = normalizeWhatsAppMessage(message, payload);
+            const normalizedMessage = normalizeWhatsAppMessage(message);
             if (normalizedMessage) {
               normalized.push(normalizedMessage);
             }
@@ -345,7 +345,6 @@ function normalizeWhatsAppFallback(
 
 function normalizeWhatsAppMessage(
   message: Record<string, unknown>,
-  payload: Record<string, unknown>,
 ): NormalizedWhatsAppWebhookMessage | null {
   const messageType = optionalString(message, "type");
   if (messageType && messageType !== "text") {
@@ -365,7 +364,7 @@ function normalizeWhatsAppMessage(
   return {
     author: authorFromBotFlag(false),
     ...(messageId ? { id: messageId } : {}),
-    raw: payload,
+    raw: message,
     text: body,
     threadId: requireNativeInboundId(from, WHATSAPP_WA_ID_RULE, "WhatsApp messages[].from"),
   };
@@ -388,27 +387,4 @@ function isAddressInChannel(threadId: string, channelId?: string): boolean {
     return true;
   }
   return threadId === channelId || threadId.startsWith(`${channelId}:`);
-}
-
-function matchesWaitCandidate(event: InboundEnvelope, context: WaitContext): boolean {
-  const config = context.fixture.inboundMatch;
-  if (config.nonce === "exact") {
-    return matchesInbound(event, config, context.nonce);
-  }
-  if (config.author !== "any" && event.author !== config.author) {
-    return false;
-  }
-  if (config.nonce !== "ignore" && !event.text.includes(context.nonce)) {
-    return false;
-  }
-  if (!config.pattern) {
-    return true;
-  }
-  if (config.strategy === "exact") {
-    return event.text === config.pattern;
-  }
-  if (config.strategy === "regex") {
-    return new RegExp(config.pattern, "u").test(event.text);
-  }
-  return event.text.includes(config.pattern);
 }

--- a/src/providers/local-mock.ts
+++ b/src/providers/local-mock.ts
@@ -156,7 +156,7 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
   }
 
   async probe(context: ProviderContext): Promise<ProbeResult> {
-    const server = await this.#ensureWebhookServer(true);
+    const server = await this.#ensureWebhookServer();
     const target = this.normalizeTarget(context.fixture.target);
     const details = [
       `${this.platform} local mock ready`,
@@ -218,7 +218,7 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
   }
 
   async waitForInbound(context: WaitContext): Promise<InboundEnvelope | null> {
-    await this.#ensureWebhookServer(true);
+    await this.#ensureWebhookServer();
     const target = this.normalizeTarget(context.fixture.target);
     const expectedAuthor = context.fixture.inboundMatch.author;
     return await waitForRecordedInbound({
@@ -233,7 +233,7 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
   }
 
   async *watch(context: WatchContext): AsyncIterable<InboundEnvelope> {
-    await this.#ensureWebhookServer(false);
+    await this.#ensureWebhookServer();
     const target = this.normalizeTarget(context.fixture.target);
     for await (const event of watchRecordedInbound({
       filePath: this.#recorderPath,
@@ -292,7 +292,7 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
     });
   }
 
-  async #ensureWebhookServer(allowExisting: boolean): Promise<StartedWebhookServer> {
+  async #ensureWebhookServer(): Promise<StartedWebhookServer> {
     if (this.#server) {
       return this.#server;
     }
@@ -310,13 +310,6 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
       });
       return this.#server;
     } catch (error) {
-      const code = (error as NodeJS.ErrnoException).code;
-      if (allowExisting && code === "EADDRINUSE") {
-        return {
-          async close() {},
-          endpointUrl: `http://${host}:${port}${webhookPath}`,
-        };
-      }
       throw new CrablineError(
         `${this.platform} local mock webhook server failed: ${ensureErrorMessage(error)}`,
         { cause: error, kind: "connectivity" },

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -73,15 +73,8 @@ async function readRecordedInboundAppend(
       .split("\n")
       .filter((line) => line.trim().length > 0);
     const events: RecordedInboundEnvelope[] = [];
-    for (const [index, line] of lines.entries()) {
-      try {
-        events.push(JSON.parse(line) as RecordedInboundEnvelope);
-      } catch (error) {
-        if (index === lines.length - 1 && state.pending.length === 0) {
-          continue;
-        }
-        throw error;
-      }
+    for (const line of lines) {
+      events.push(JSON.parse(line) as RecordedInboundEnvelope);
     }
     return events;
   } finally {
@@ -119,12 +112,13 @@ export async function readRecordedInbound(filePath: string): Promise<RecordedInb
 
   const lines = raw.split("\n").filter((line) => line.trim().length > 0);
   const events: RecordedInboundEnvelope[] = [];
+  const hasUnterminatedTail = !raw.endsWith("\n");
 
   for (const [index, line] of lines.entries()) {
     try {
       events.push(JSON.parse(line) as RecordedInboundEnvelope);
     } catch (error) {
-      if (index === lines.length - 1) {
+      if (hasUnterminatedTail && index === lines.length - 1) {
         continue;
       }
       throw error;
@@ -162,7 +156,11 @@ export async function waitForRecordedInbound(params: {
       }
     }
 
-    await sleep(params.pollMs ?? 200);
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) {
+      return null;
+    }
+    await sleep(Math.min(params.pollMs ?? 200, remainingMs));
   }
 
   return null;

--- a/src/providers/webhook-server.ts
+++ b/src/providers/webhook-server.ts
@@ -100,6 +100,10 @@ function closeServer(server: Server): Promise<void> {
   });
 }
 
+function formatUrlHost(host: string): string {
+  return host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
+}
+
 export async function startWebhookServer(params: {
   handle(request: Request): Promise<Response>;
   host: string;
@@ -147,6 +151,6 @@ export async function startWebhookServer(params: {
     async close() {
       await closeServer(server);
     },
-    endpointUrl: `http://${params.host}:${address.port}${params.path}`,
+    endpointUrl: `http://${formatUrlHost(params.host)}:${address.port}${params.path}`,
   };
 }

--- a/test/discord-provider.test.ts
+++ b/test/discord-provider.test.ts
@@ -250,7 +250,7 @@ describe("discord provider", () => {
     expect(next.value?.id).toBe("evt-2");
   });
 
-  it("reuses an existing interactions listener during probe", async () => {
+  it("rejects a secondary probe when the interactions listener is occupied", async () => {
     const config = await createDiscordConfig(await resolveFreePort());
     const primary = new DiscordProviderAdapter(
       "discord-primary",
@@ -281,23 +281,26 @@ describe("discord provider", () => {
     providers.push(secondary);
 
     const primaryProbe = await primary.probe(createContext(config));
-    const secondaryProbe = await secondary.probe(
-      createContext({
-        ...config,
-        discord: {
-          ...config.discord!,
-          recorder: {
-            path: config.discord!.recorder.path?.replace(
-              "discord.jsonl",
-              "discord-secondary.jsonl",
-            ),
-          },
-        },
-      }),
-    );
-
     expect(primaryProbe.healthy).toBe(true);
-    expect(secondaryProbe.healthy).toBe(true);
+
+    await expect(
+      secondary.probe(
+        createContext({
+          ...config,
+          discord: {
+            ...config.discord!,
+            recorder: {
+              path: config.discord!.recorder.path?.replace(
+                "discord.jsonl",
+                "discord-secondary.jsonl",
+              ),
+            },
+          },
+        }),
+      ),
+    ).rejects.toThrow(/EADDRINUSE/u);
+
+    await expect(primary.probe(createContext(config))).resolves.toMatchObject({ healthy: true });
   });
 
   it("returns channel-like webhook errors for malformed interaction events", async () => {

--- a/test/feishu-provider.test.ts
+++ b/test/feishu-provider.test.ts
@@ -1,5 +1,46 @@
-import { FeishuProviderAdapter } from "../src/providers/builtin/feishu.js";
+import { describe, expect, it } from "vitest";
+import {
+  FeishuProviderAdapter,
+  normalizeFeishuWebhookPayload,
+} from "../src/providers/builtin/feishu.js";
 import { runLocalMockProviderContract } from "./local-mock-provider-helpers.js";
+
+describe("Feishu webhook normalizer", () => {
+  it("uses the chat for ordinary messages and preserves message_id as the event id", () => {
+    const payload = {
+      event: {
+        message: {
+          chat_id: "oc_abc123",
+          content: JSON.stringify({ text: "hello" }),
+          message_id: "om_message123",
+        },
+      },
+    };
+
+    expect(normalizeFeishuWebhookPayload(payload)).toMatchObject({
+      id: "om_message123",
+      threadId: "oc_abc123",
+    });
+  });
+
+  it("uses root_id for topic replies", () => {
+    const payload = {
+      event: {
+        message: {
+          chat_id: "oc_abc123",
+          content: JSON.stringify({ text: "topic reply" }),
+          message_id: "om_reply123",
+          root_id: "om_root123",
+        },
+      },
+    };
+
+    expect(normalizeFeishuWebhookPayload(payload)).toMatchObject({
+      id: "om_reply123",
+      threadId: "om_root123",
+    });
+  });
+});
 
 runLocalMockProviderContract({
   Adapter: FeishuProviderAdapter,
@@ -24,5 +65,5 @@ runLocalMockProviderContract({
       },
     },
   },
-  webhookThreadId: "om_abc123",
+  webhookThreadId: "oc_abc123",
 });

--- a/test/local-mock-provider-helpers.ts
+++ b/test/local-mock-provider-helpers.ts
@@ -19,6 +19,13 @@ type ContractOptions = {
   expectedChannelId: string;
   expectedThreadId?: string | undefined;
   invalidTargets?: ProviderContext["fixture"]["target"][] | undefined;
+  nonces?:
+    | {
+        reply?: string | undefined;
+        user?: string | undefined;
+        webhook?: string | undefined;
+      }
+    | undefined;
   target: ProviderContext["fixture"]["target"];
   threadTarget?: ProviderContext["fixture"]["target"] | undefined;
   webhookExpected: {
@@ -131,6 +138,7 @@ export function runLocalMockProviderContract(options: ContractOptions): void {
       const provider = new options.Adapter(options.platform, config, "crabline");
       providers.push(provider);
       const context = createProviderContext(options.platform, config, options.target);
+      const nonce = options.nonces?.reply ?? "nonce-1";
 
       const probe = await provider.probe(context);
       expect(probe.healthy).toBe(true);
@@ -141,8 +149,8 @@ export function runLocalMockProviderContract(options: ContractOptions): void {
       const result = await provider.send({
         ...context,
         mode: "agent",
-        nonce: "nonce-1",
-        text: "hello nonce-1",
+        nonce,
+        text: `hello ${nonce}`,
       });
       expect(result.accepted).toBe(true);
       expect(result.threadId).toBe(options.expectedChannelId);
@@ -150,14 +158,14 @@ export function runLocalMockProviderContract(options: ContractOptions): void {
       await expect(
         provider.waitForInbound({
           ...context,
-          nonce: "nonce-1",
+          nonce,
           since,
           threadId: result.threadId,
           timeoutMs: 500,
         }),
       ).resolves.toMatchObject({
         author: "assistant",
-        text: `[${options.platform} mock] hello nonce-1`,
+        text: `[${options.platform} mock] hello ${nonce}`,
         threadId: result.threadId,
       });
     });
@@ -171,6 +179,7 @@ export function runLocalMockProviderContract(options: ContractOptions): void {
       const provider = new options.Adapter(options.platform, config, "crabline");
       providers.push(provider);
       const context = createProviderContext(options.platform, config, options.target);
+      const nonce = options.nonces?.webhook ?? "nonce-2";
       context.fixture.inboundMatch = {
         author: options.webhookExpected.author ?? "any",
         nonce: "contains",
@@ -196,7 +205,7 @@ export function runLocalMockProviderContract(options: ContractOptions): void {
       await expect(
         provider.waitForInbound({
           ...context,
-          nonce: "nonce-2",
+          nonce,
           since,
           threadId: options.webhookThreadId,
           timeoutMs: 500,
@@ -215,6 +224,7 @@ export function runLocalMockProviderContract(options: ContractOptions): void {
       const provider = new options.Adapter(options.platform, config, "crabline");
       providers.push(provider);
       const context = createProviderContext(options.platform, config, options.target);
+      const nonce = options.nonces?.user ?? "nonce-3";
       context.fixture.inboundMatch = {
         author: "user",
         nonce: "contains",
@@ -228,7 +238,7 @@ export function runLocalMockProviderContract(options: ContractOptions): void {
           message: {
             author: "user",
             id: `${options.platform}-user-inbound`,
-            text: "user nonce-3",
+            text: `user ${nonce}`,
             threadId: options.expectedChannelId,
           },
         }),
@@ -240,7 +250,7 @@ export function runLocalMockProviderContract(options: ContractOptions): void {
       await expect(
         provider.waitForInbound({
           ...context,
-          nonce: "nonce-3",
+          nonce,
           since,
           threadId: options.expectedChannelId,
           timeoutMs: 500,
@@ -248,7 +258,7 @@ export function runLocalMockProviderContract(options: ContractOptions): void {
       ).resolves.toMatchObject({
         author: "user",
         id: `${options.platform}-user-inbound`,
-        text: "user nonce-3",
+        text: `user ${nonce}`,
       });
     });
   });

--- a/test/local-mock-provider.test.ts
+++ b/test/local-mock-provider.test.ts
@@ -1,20 +1,29 @@
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ProviderConfig } from "../src/config/schema.js";
 import { SlackProviderAdapter } from "../src/providers/builtin/slack.js";
 import { appendRecordedInbound } from "../src/providers/recorder.js";
 import type { ProviderContext } from "../src/providers/types.js";
 import { createTempDir, disposeTempDir } from "./test-helpers.js";
 
+const webhookMocks = vi.hoisted(() => ({
+  startWebhookServer: vi.fn(),
+}));
+
 vi.mock("../src/providers/webhook-server.js", () => ({
-  startWebhookServer: async () => ({
-    async close() {},
-    endpointUrl: "http://127.0.0.1:0/slack/events",
-  }),
+  startWebhookServer: webhookMocks.startWebhookServer,
 }));
 
 const directories: string[] = [];
 const providers: SlackProviderAdapter[] = [];
+
+beforeEach(() => {
+  webhookMocks.startWebhookServer.mockReset();
+  webhookMocks.startWebhookServer.mockResolvedValue({
+    async close() {},
+    endpointUrl: "http://127.0.0.1:0/slack/events",
+  });
+});
 
 afterEach(async () => {
   await Promise.all(providers.splice(0).map((provider) => provider.cleanup()));
@@ -26,6 +35,50 @@ function sleep(ms: number): Promise<void> {
 }
 
 describe("local mock provider", () => {
+  it("does not treat an occupied webhook port as a healthy server", async () => {
+    const addressInUse = Object.assign(new Error("listen EADDRINUSE: address already in use"), {
+      code: "EADDRINUSE",
+    });
+    webhookMocks.startWebhookServer.mockRejectedValueOnce(addressInUse);
+    const config: ProviderConfig = {
+      adapter: "slack",
+      capabilities: ["probe"],
+      env: [],
+      platform: "slack",
+      slack: {
+        recorder: {},
+        webhook: {
+          host: "127.0.0.1",
+          path: "/slack/events",
+          port: 8787,
+        },
+      },
+      status: "active",
+    };
+    const provider = new SlackProviderAdapter("provider-a", config, "crabline");
+    providers.push(provider);
+
+    await expect(
+      provider.probe({
+        config,
+        fixture: {
+          env: [],
+          id: "slack-probe",
+          inboundMatch: { author: "assistant", nonce: "contains", strategy: "contains" },
+          mode: "probe",
+          provider: "provider-a",
+          retries: 0,
+          tags: [],
+          target: { id: "C1234567890", metadata: {} },
+          timeoutMs: 500,
+        },
+        manifestPath: "/tmp/crabline.yaml",
+        providerId: "provider-a",
+        userName: "crabline",
+      }),
+    ).rejects.toThrow(/EADDRINUSE/u);
+  });
+
   it("does not watch events from another provider sharing its recorder", async () => {
     const directory = await createTempDir();
     directories.push(directory);

--- a/test/loopback-adapter.test.ts
+++ b/test/loopback-adapter.test.ts
@@ -41,7 +41,7 @@ describe("loopback chat adapter", () => {
     expect(latest.nextCursor).toBe("1");
 
     const previous = await adapter.fetchMessages(threadId, {
-      cursor: latest.nextCursor,
+      ...(latest.nextCursor ? { cursor: latest.nextCursor } : {}),
       limit: 2,
     });
     expect(previous.messages.map((message) => message.text)).toEqual(["first"]);

--- a/test/loopback-adapter.test.ts
+++ b/test/loopback-adapter.test.ts
@@ -8,6 +8,46 @@ afterEach(() => {
 });
 
 describe("loopback chat adapter", () => {
+  it("round-trips direct and channel thread addresses", () => {
+    adapter = new LoopbackChatAdapter("crabline");
+
+    for (const address of [
+      { id: "user:1", threadId: "dm::1" },
+      { channelId: "channel:1", id: "user:1", threadId: "topic::1" },
+    ]) {
+      expect(adapter.decodeThreadId(adapter.encodeThreadId(address))).toEqual(address);
+    }
+  });
+
+  it("preserves legacy percent-encoded-looking thread ids", () => {
+    adapter = new LoopbackChatAdapter("crabline");
+
+    expect(adapter.decodeThreadId("loopback:user%2F::topic%2F")).toEqual({
+      channelId: "user%2F",
+      id: "loopback:user%2F",
+      threadId: "topic%2F",
+    });
+  });
+
+  it("returns a cursor with the initial limited page", async () => {
+    adapter = new LoopbackChatAdapter("crabline");
+    const threadId = adapter.encodeThreadId({ id: "user-1" });
+    adapter.ingestUserMessage(threadId, "first");
+    adapter.ingestUserMessage(threadId, "second");
+    adapter.ingestUserMessage(threadId, "third");
+
+    const latest = await adapter.fetchMessages(threadId, { limit: 2 });
+    expect(latest.messages.map((message) => message.text)).toEqual(["second", "third"]);
+    expect(latest.nextCursor).toBe("1");
+
+    const previous = await adapter.fetchMessages(threadId, {
+      cursor: latest.nextCursor,
+      limit: 2,
+    });
+    expect(previous.messages.map((message) => message.text)).toEqual(["first"]);
+    expect(previous.nextCursor).toBeUndefined();
+  });
+
   it("supports direct adapter operations", async () => {
     adapter = new LoopbackChatAdapter("crabline");
 

--- a/test/loopback-adapter.test.ts
+++ b/test/loopback-adapter.test.ts
@@ -19,6 +19,23 @@ describe("loopback chat adapter", () => {
     }
   });
 
+  it("recovers delimiter-containing v2 channel ids for thread metadata", async () => {
+    adapter = new LoopbackChatAdapter("crabline");
+    const address = {
+      channelId: "channel:west::1",
+      id: "user:east::2",
+      threadId: "topic:north::3",
+    };
+    const threadId = adapter.encodeThreadId(address);
+
+    expect(adapter.channelIdFromThreadId(threadId)).toBe(address.channelId);
+    await expect(adapter.fetchThread(threadId)).resolves.toMatchObject({
+      channelId: address.channelId,
+      id: threadId,
+    });
+    expect(adapter.channelIdFromThreadId("loopback:legacy::topic")).toBe("loopback:legacy");
+  });
+
   it("preserves legacy percent-encoded-looking thread ids", () => {
     adapter = new LoopbackChatAdapter("crabline");
 

--- a/test/matrix-provider.test.ts
+++ b/test/matrix-provider.test.ts
@@ -1,5 +1,46 @@
-import { MatrixProviderAdapter } from "../src/providers/builtin/matrix.js";
+import { describe, expect, it } from "vitest";
+import {
+  MatrixProviderAdapter,
+  normalizeMatrixWebhookPayload,
+} from "../src/providers/builtin/matrix.js";
 import { runLocalMockProviderContract } from "./local-mock-provider-helpers.js";
+
+describe("Matrix webhook normalizer", () => {
+  it("uses the room for main-timeline events", () => {
+    const payload = {
+      content: { body: "hello", msgtype: "m.text" },
+      event_id: "$event123:matrix.org",
+      room_id: "!abc123:matrix.org",
+      type: "m.room.message",
+    };
+
+    expect(normalizeMatrixWebhookPayload(payload)).toMatchObject({
+      id: "$event123:matrix.org",
+      threadId: "!abc123:matrix.org",
+    });
+  });
+
+  it("uses the m.thread root event for threaded events", () => {
+    const payload = {
+      content: {
+        body: "thread reply",
+        "m.relates_to": {
+          event_id: "$root123:matrix.org",
+          rel_type: "m.thread",
+        },
+        msgtype: "m.text",
+      },
+      event_id: "$reply123:matrix.org",
+      room_id: "!abc123:matrix.org",
+      type: "m.room.message",
+    };
+
+    expect(normalizeMatrixWebhookPayload(payload)).toMatchObject({
+      id: "$reply123:matrix.org",
+      threadId: "$root123:matrix.org",
+    });
+  });
+});
 
 runLocalMockProviderContract({
   Adapter: MatrixProviderAdapter,
@@ -22,5 +63,5 @@ runLocalMockProviderContract({
     sender: "@user:matrix.org",
     type: "m.room.message",
   },
-  webhookThreadId: "$event123:matrix.org",
+  webhookThreadId: "!abc123:matrix.org",
 });

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -77,6 +77,27 @@ describe("recorder", () => {
     });
   });
 
+  it("rejects a malformed final record once it is newline terminated", async () => {
+    const filePath = await createRecorderPath();
+    await appendFile(filePath, '{"id":"malformed"} trailing\n', "utf8");
+
+    await expect(readRecordedInbound(filePath)).rejects.toThrow(SyntaxError);
+    await expect(
+      waitForRecordedInbound({
+        filePath,
+        matches: () => true,
+        timeoutMs: 30,
+      }),
+    ).rejects.toThrow(SyntaxError);
+
+    const iterator = watchRecordedInbound({
+      filePath,
+      matches: () => true,
+      pollMs: 10,
+    })[Symbol.asyncIterator]();
+    await expect(iterator.next()).rejects.toThrow(SyntaxError);
+  });
+
   it("waits for a matching inbound event", async () => {
     const filePath = await createRecorderPath();
     const waitPromise = waitForRecordedInbound({
@@ -122,6 +143,22 @@ describe("recorder", () => {
         timeoutMs: 30,
       }),
     ).resolves.toBeNull();
+  });
+
+  it("does not sleep past the polling timeout", async () => {
+    const filePath = await createRecorderPath();
+    const startedAt = Date.now();
+
+    await expect(
+      waitForRecordedInbound({
+        filePath,
+        matches: () => false,
+        pollMs: 1000,
+        timeoutMs: 40,
+      }),
+    ).resolves.toBeNull();
+
+    expect(Date.now() - startedAt).toBeLessThan(500);
   });
 
   it("streams new inbound events", async () => {

--- a/test/script-provider.test.ts
+++ b/test/script-provider.test.ts
@@ -236,10 +236,7 @@ describe("script provider", () => {
 
   it("reports watch subprocess spawn failures without crashing", async () => {
     const context = await createContext();
-    context.config.script!.shell = path.join(
-      path.dirname(context.manifestPath),
-      "missing-shell",
-    );
+    context.config.script!.shell = path.join(path.dirname(context.manifestPath), "missing-shell");
     const provider = new ScriptProviderAdapter(context);
 
     await expect(provider.watch(context).next()).rejects.toThrow(/failed to start/u);

--- a/test/script-provider.test.ts
+++ b/test/script-provider.test.ts
@@ -240,6 +240,46 @@ describe("script provider", () => {
     ).rejects.toThrow(/timed out after 100ms/u);
   });
 
+  it("allows wait commands to report timeout at their documented deadline", async () => {
+    const context = await createContext();
+    const waitScript = path.join(path.dirname(context.manifestPath), "wait-timeout.mjs");
+    await writeText(
+      waitScript,
+      'let raw="";process.stdin.on("data",(chunk)=>raw+=chunk);process.stdin.on("end",()=>{const input=JSON.parse(raw);setTimeout(()=>process.stdout.write(JSON.stringify({timeout:true})),input.wait.timeoutMs);});',
+    );
+    context.config.script!.commands.waitForInbound = `node ${waitScript}`;
+    const provider = new ScriptProviderAdapter(context);
+
+    await expect(
+      provider.waitForInbound({
+        ...context,
+        nonce: "nonce",
+        since: new Date().toISOString(),
+        timeoutMs: 50,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("rejects inbound messages returned during the wait exit grace", async () => {
+    const context = await createContext();
+    const waitScript = path.join(path.dirname(context.manifestPath), "wait-late-message.mjs");
+    await writeText(
+      waitScript,
+      'let raw="";process.stdin.on("data",(chunk)=>raw+=chunk);process.stdin.on("end",()=>{const input=JSON.parse(raw);setTimeout(()=>process.stdout.write(JSON.stringify({message:{author:"assistant",id:"late-inbound",sentAt:new Date().toISOString(),text:`ACK ${input.wait.nonce}`,threadId:input.wait.target.id}})),input.wait.timeoutMs+50);});',
+    );
+    context.config.script!.commands.waitForInbound = `node ${waitScript}`;
+    const provider = new ScriptProviderAdapter(context);
+
+    await expect(
+      provider.waitForInbound({
+        ...context,
+        nonce: "nonce",
+        since: new Date().toISOString(),
+        timeoutMs: 50,
+      }),
+    ).rejects.toThrow(/timed out after 50ms/u);
+  });
+
   it("rejects commands that exceed the output limit", async () => {
     const context = await createContext();
     const sendScript = path.join(path.dirname(context.manifestPath), "send-noisy.mjs");

--- a/test/script-provider.test.ts
+++ b/test/script-provider.test.ts
@@ -10,6 +10,19 @@ afterEach(async () => {
   await Promise.all(directories.splice(0).map(disposeTempDir));
 });
 
+async function waitForProcessExit(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  return false;
+}
+
 const createContext = async (watchTrailingNewline = true): Promise<ProviderContext> => {
   const directory = await createTempDir();
   directories.push(directory);
@@ -148,6 +161,66 @@ describe("script provider", () => {
     }
     throw new Error(`watch subprocess ${pid} is still running`);
   });
+
+  it.skipIf(process.platform === "win32")(
+    "stops descendants that hold watch pipes after the leader exits",
+    async () => {
+      const context = await createContext();
+      const watchScript = path.join(path.dirname(context.manifestPath), "watch-descendant.mjs");
+      await writeText(
+        watchScript,
+        'import {spawn} from "node:child_process";const descendant=spawn(process.execPath,["-e","setInterval(()=>{},1000)"],{stdio:["ignore","inherit","ignore"]});descendant.unref();process.stdout.write(JSON.stringify({author:"assistant",id:String(descendant.pid),raw:{leaderPid:process.pid},sentAt:new Date().toISOString(),text:"watch payload",threadId:"thread-1"})+"\\n");',
+      );
+      context.config.script!.commands.watch = `exec node ${JSON.stringify(watchScript)}`;
+      const provider = new ScriptProviderAdapter(context);
+      const iterator = provider.watch(context)[Symbol.asyncIterator]();
+      let descendantPid = 0;
+      let descendantExited = false;
+      try {
+        const watched = await iterator.next();
+        descendantPid = Number(watched.value?.id);
+        const leaderPid = Number(
+          (watched.value?.raw as { leaderPid?: number } | undefined)?.leaderPid,
+        );
+        expect(Number.isInteger(descendantPid)).toBe(true);
+        expect(Number.isInteger(leaderPid)).toBe(true);
+        await expect(waitForProcessExit(leaderPid, 2000)).resolves.toBe(true);
+
+        const returnPromise = iterator.return();
+        let timeout: NodeJS.Timeout | undefined;
+        const stopped = await Promise.race([
+          returnPromise.then(() => true),
+          new Promise<false>((resolve) => {
+            timeout = setTimeout(() => resolve(false), 1000);
+          }),
+        ]);
+        if (timeout) {
+          clearTimeout(timeout);
+        }
+        if (!stopped) {
+          try {
+            process.kill(descendantPid, "SIGKILL");
+          } catch {
+            // The descendant may have exited at the timeout boundary.
+          }
+          await returnPromise;
+          throw new Error("watch cleanup waited for a descendant-held pipe");
+        }
+
+        descendantExited = await waitForProcessExit(descendantPid, 2000);
+        expect(descendantExited).toBe(true);
+      } finally {
+        if (descendantPid > 0 && !descendantExited) {
+          try {
+            process.kill(descendantPid, "SIGKILL");
+          } catch {
+            // The expected cleanup path already stopped the descendant.
+          }
+        }
+        await iterator.return();
+      }
+    },
+  );
 
   it("enforces command deadlines in the parent process", async () => {
     const context = await createContext();

--- a/test/script-provider.test.ts
+++ b/test/script-provider.test.ts
@@ -149,6 +149,117 @@ describe("script provider", () => {
     throw new Error(`watch subprocess ${pid} is still running`);
   });
 
+  it("enforces command deadlines in the parent process", async () => {
+    const context = await createContext();
+    const sendScript = path.join(path.dirname(context.manifestPath), "send-hanging.mjs");
+    await writeText(sendScript, "process.stdin.resume();setInterval(()=>{},1000);");
+    context.fixture.timeoutMs = 100;
+    context.config.script!.commands.send = `node ${sendScript}`;
+    const provider = new ScriptProviderAdapter(context);
+
+    await expect(
+      provider.send({
+        ...context,
+        mode: "send",
+        nonce: "nonce",
+        text: "payload",
+      }),
+    ).rejects.toThrow(/timed out after 100ms/u);
+  });
+
+  it("rejects commands that exceed the output limit", async () => {
+    const context = await createContext();
+    const sendScript = path.join(path.dirname(context.manifestPath), "send-noisy.mjs");
+    await writeText(
+      sendScript,
+      'process.stdin.resume();process.stdout.write("x".repeat(1024*1024+1));',
+    );
+    context.config.script!.commands.send = `node ${sendScript}`;
+    const provider = new ScriptProviderAdapter(context);
+
+    await expect(
+      provider.send({
+        ...context,
+        mode: "send",
+        nonce: "nonce",
+        text: "payload",
+      }),
+    ).rejects.toThrow(/exceeded 1048576 bytes of output/u);
+  });
+
+  it("validates script JSON result contracts at runtime", async () => {
+    const context = await createContext();
+    const probeScript = path.join(path.dirname(context.manifestPath), "probe-invalid.mjs");
+    await writeText(
+      probeScript,
+      'process.stdin.resume();process.stdin.on("end",()=>process.stdout.write(JSON.stringify({healthy:"yes"})));',
+    );
+    context.config.script!.commands.probe = `node ${probeScript}`;
+    const provider = new ScriptProviderAdapter(context);
+
+    await expect(provider.probe(context)).rejects.toThrow(/returned invalid result.*healthy/isu);
+
+    const waitScript = path.join(path.dirname(context.manifestPath), "wait-invalid.mjs");
+    await writeText(
+      waitScript,
+      'process.stdin.resume();process.stdin.on("end",()=>process.stdout.write("{}"));',
+    );
+    context.config.script!.commands.waitForInbound = `node ${waitScript}`;
+
+    await expect(
+      provider.waitForInbound({
+        ...context,
+        nonce: "nonce",
+        since: new Date().toISOString(),
+        timeoutMs: 1000,
+      }),
+    ).rejects.toThrow(/either a message or timeout: true/u);
+  });
+
+  it("reports watch subprocess failures after emitted messages", async () => {
+    const context = await createContext();
+    const watchScript = path.join(path.dirname(context.manifestPath), "watch-failing.mjs");
+    await writeText(
+      watchScript,
+      'process.stdout.write(JSON.stringify({author:"assistant",id:"watch-before-failure",sentAt:new Date().toISOString(),text:"watch payload",threadId:"thread-1"})+"\\n");process.stderr.write("watch exploded");process.exitCode=7;',
+    );
+    context.config.script!.commands.watch = `node ${watchScript}`;
+    const provider = new ScriptProviderAdapter(context);
+    const iterator = provider.watch(context)[Symbol.asyncIterator]();
+
+    await expect(iterator.next()).resolves.toMatchObject({
+      done: false,
+      value: { id: "watch-before-failure" },
+    });
+    await expect(iterator.next()).rejects.toThrow(/watch exploded/u);
+  });
+
+  it("reports watch subprocess spawn failures without crashing", async () => {
+    const context = await createContext();
+    context.config.script!.shell = path.join(
+      path.dirname(context.manifestPath),
+      "missing-shell",
+    );
+    const provider = new ScriptProviderAdapter(context);
+
+    await expect(provider.watch(context).next()).rejects.toThrow(/failed to start/u);
+  });
+
+  it("validates watched JSON message contracts", async () => {
+    const context = await createContext();
+    const watchScript = path.join(path.dirname(context.manifestPath), "watch-invalid.mjs");
+    await writeText(
+      watchScript,
+      'process.stdout.write(JSON.stringify({author:"bot",id:"watch-1",sentAt:new Date().toISOString(),text:"watch payload",threadId:"thread-1"})+"\\n");',
+    );
+    context.config.script!.commands.watch = `node ${watchScript}`;
+    const provider = new ScriptProviderAdapter(context);
+
+    await expect(provider.watch(context).next()).rejects.toThrow(
+      /returned invalid result.*author/isu,
+    );
+  });
+
   it("fails when required commands are missing", async () => {
     const context = await createContext();
     const provider = new ScriptProviderAdapter({

--- a/test/telegram-provider.test.ts
+++ b/test/telegram-provider.test.ts
@@ -139,6 +139,25 @@ describe("telegram provider", () => {
     expect(firstThreadId).not.toBe(secondThreadId);
   });
 
+  it("normalizes edited channel posts", () => {
+    const payload = {
+      edited_channel_post: {
+        caption: "edited caption",
+        chat: { id: -1001234567890 },
+        message_id: 42,
+      },
+      update_id: 99,
+    };
+
+    expect(normalizeTelegramWebhookPayload(payload)).toEqual({
+      author: "user",
+      id: "42",
+      raw: payload,
+      text: "edited caption",
+      threadId: "-1001234567890",
+    });
+  });
+
   it("probes and sends through the local mock service", async () => {
     const config = await createTelegramConfig(0);
     const provider = new TelegramProviderAdapter("telegram", config, "crabline");

--- a/test/webhook-server.test.ts
+++ b/test/webhook-server.test.ts
@@ -8,6 +8,20 @@ afterEach(async () => {
 });
 
 describe("webhook server", () => {
+  it("advertises a valid URL when bound to IPv6", async () => {
+    const server = await startWebhookServer({
+      handle: async () => new Response("ok"),
+      host: "::1",
+      path: "/slack/events",
+      port: 0,
+    });
+    cleanups.push(() => server.close());
+
+    expect(new URL(server.endpointUrl).hostname).toBe("[::1]");
+    const response = await fetch(server.endpointUrl, { method: "POST" });
+    expect(response.status).toBe(200);
+  });
+
   it("serves the configured POST path", async () => {
     const server = await startWebhookServer({
       async handle(request) {

--- a/test/whatsapp-provider.test.ts
+++ b/test/whatsapp-provider.test.ts
@@ -3,7 +3,11 @@ import {
   normalizeWhatsAppWebhookPayload,
   WhatsAppProviderAdapter,
 } from "../src/providers/builtin/whatsapp.js";
-import { runLocalMockProviderContract } from "./local-mock-provider-helpers.js";
+import {
+  createLocalMockConfig,
+  createProviderContext,
+  runLocalMockProviderContract,
+} from "./local-mock-provider-helpers.js";
 
 describe("WhatsApp webhook normalizer", () => {
   it("normalizes text messages with the provider message id", () => {
@@ -27,13 +31,15 @@ describe("WhatsApp webhook normalizer", () => {
       ],
     };
 
-    expect(normalizeWhatsAppWebhookPayload(payload)).toEqual({
-      author: "user",
-      id: "wamid.abc123",
-      raw: payload,
-      text: "hello",
-      threadId: "15551234567",
-    });
+    expect(normalizeWhatsAppWebhookPayload(payload)).toEqual([
+      {
+        author: "user",
+        id: "wamid.abc123",
+        raw: payload,
+        text: "hello",
+        threadId: "15551234567",
+      },
+    ]);
   });
 
   it.each([
@@ -67,13 +73,117 @@ describe("WhatsApp webhook normalizer", () => {
       threadId: "15551234567",
     };
 
-    expect(normalizeWhatsAppWebhookPayload(payload)).toEqual({
-      authorIsBot: false,
-      id: "fallback-message",
-      raw: payload,
-      text: "fallback text",
-      threadId: "15551234567",
+    expect(normalizeWhatsAppWebhookPayload(payload)).toEqual([
+      {
+        authorIsBot: false,
+        id: "fallback-message",
+        raw: payload,
+        text: "fallback text",
+        threadId: "15551234567",
+      },
+    ]);
+  });
+
+  it("preserves all valid messages after malformed and unsupported batch items", async () => {
+    const config = await createLocalMockConfig("whatsapp", "/whatsapp/webhook");
+    const provider = new WhatsAppProviderAdapter("whatsapp", config, "crabline");
+    const context = createProviderContext("whatsapp", config, {
+      id: "15551234567",
+      metadata: {},
     });
+    context.fixture.inboundMatch = { author: "user", nonce: "contains", strategy: "contains" };
+    const nonce = "mp-whatsapp-batch-abc-1234abcd";
+
+    try {
+      const probe = await provider.probe(context);
+      const endpoint = probe.details
+        .find((detail) => detail.startsWith("webhook endpoint "))
+        ?.replace("webhook endpoint ", "");
+      expect(endpoint).toBeDefined();
+      const since = new Date(Date.now() - 1000).toISOString();
+
+      const response = await fetch(endpoint!, {
+        body: JSON.stringify({
+          entry: [
+            {
+              changes: [
+                {
+                  value: {
+                    messages: [
+                      { from: "invalid-id", text: { body: "malformed" }, type: "text" },
+                      { from: "15550000000", image: { id: "image-1" }, type: "image" },
+                      {
+                        from: "15551234567",
+                        id: "wamid.unrelated",
+                        text: { body: "unrelated valid" },
+                        type: "text",
+                      },
+                      {
+                        from: "15551234567",
+                        id: "wamid.first",
+                        text: { body: `first valid ${nonce}` },
+                        type: "text",
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+            {
+              changes: [
+                {
+                  value: {
+                    messages: [
+                      { from: "15550000001", text: {}, type: "text" },
+                      {
+                        from: "15557654321",
+                        id: "wamid.second",
+                        text: { body: `second valid ${nonce}` },
+                        type: "text",
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({
+        ids: ["wamid.unrelated", "wamid.first", "wamid.second"],
+        ok: true,
+      });
+      await expect(
+        provider.waitForInbound({
+          ...context,
+          nonce,
+          since,
+          threadId: "15551234567",
+          timeoutMs: 500,
+        }),
+      ).resolves.toMatchObject({
+        id: "wamid.first",
+        text: `first valid ${nonce}`,
+      });
+      await expect(
+        provider.waitForInbound({
+          ...context,
+          nonce,
+          since,
+          threadId: "15557654321",
+          timeoutMs: 500,
+        }),
+      ).resolves.toMatchObject({
+        id: "wamid.second",
+        text: `second valid ${nonce}`,
+      });
+    } finally {
+      await provider.cleanup();
+    }
   });
 });
 

--- a/test/whatsapp-provider.test.ts
+++ b/test/whatsapp-provider.test.ts
@@ -12,19 +12,18 @@ import {
 
 describe("WhatsApp webhook normalizer", () => {
   it("normalizes text messages with the provider message id", () => {
+    const message = {
+      from: "15551234567",
+      id: "wamid.abc123",
+      text: { body: "hello" },
+    };
     const payload = {
       entry: [
         {
           changes: [
             {
               value: {
-                messages: [
-                  {
-                    from: "15551234567",
-                    id: "wamid.abc123",
-                    text: { body: "hello" },
-                  },
-                ],
+                messages: [message],
               },
             },
           ],
@@ -36,11 +35,34 @@ describe("WhatsApp webhook normalizer", () => {
       {
         author: "user",
         id: "wamid.abc123",
-        raw: payload,
+        raw: message,
         text: "hello",
         threadId: "15551234567",
       },
     ]);
+  });
+
+  it("keeps native raw data scoped to each message in a batch", () => {
+    const first = {
+      from: "15551234567",
+      id: "wamid.first",
+      text: { body: "first" },
+      type: "text",
+    };
+    const second = {
+      from: "15557654321",
+      id: "wamid.second",
+      text: { body: "second" },
+      type: "text",
+    };
+    const payload = {
+      entry: [{ changes: [{ value: { messages: [first, second] } }] }],
+    };
+
+    const normalized = normalizeWhatsAppWebhookPayload(payload);
+
+    expect(normalized.map((message) => message.raw)).toEqual([first, second]);
+    expect(normalized.every((message) => message.raw !== payload)).toBe(true);
   });
 
   it.each([
@@ -267,15 +289,73 @@ describe("WhatsApp webhook normalizer", () => {
       await provider.cleanup();
     }
   });
+
+  it("skips an earlier malformed nonce substring in contains mode", async () => {
+    const config = await createLocalMockConfig("whatsapp", "/whatsapp/webhook");
+    const provider = new WhatsAppProviderAdapter("whatsapp", config, "crabline");
+    const context = createProviderContext("whatsapp", config, {
+      id: "15551234567",
+      metadata: {},
+    });
+    context.fixture.inboundMatch = { author: "user", nonce: "contains", strategy: "contains" };
+    const nonce = "mp-whatsapp-contains-abc-1234abcd";
+    const recorderPath = config.whatsapp!.recorder.path!;
+    const since = new Date(Date.now() - 1000).toISOString();
+
+    try {
+      await appendRecordedInbound(recorderPath, {
+        author: "user",
+        id: "malformed-substring",
+        provider: "whatsapp",
+        sentAt: new Date().toISOString(),
+        text: `reply ${nonce}0`,
+        threadId: "15551234567",
+      });
+      await appendRecordedInbound(recorderPath, {
+        author: "user",
+        id: "valid-contains",
+        provider: "whatsapp",
+        sentAt: new Date().toISOString(),
+        text: `reply ${nonce}`,
+        threadId: "15551234567",
+      });
+
+      await expect(
+        provider.waitForInbound({
+          ...context,
+          nonce,
+          since,
+          threadId: "15551234567",
+          timeoutMs: 500,
+        }),
+      ).resolves.toMatchObject({
+        id: "valid-contains",
+        text: `reply ${nonce}`,
+      });
+    } finally {
+      await provider.cleanup();
+    }
+  });
 });
+
+const contractNonces = {
+  reply: "mp-whatsapp-reply-abc-11111111",
+  user: "mp-whatsapp-user-abc-33333333",
+  webhook: "mp-whatsapp-webhook-abc-22222222",
+};
 
 runLocalMockProviderContract({
   Adapter: WhatsAppProviderAdapter,
   endpointPath: "/whatsapp/webhook",
   expectedChannelId: "15551234567",
+  nonces: contractNonces,
   platform: "whatsapp",
   target: { id: "15551234567", metadata: {} },
-  webhookExpected: { author: "user", id: "wamid.abc123", text: "reply nonce-2" },
+  webhookExpected: {
+    author: "user",
+    id: "wamid.abc123",
+    text: `reply ${contractNonces.webhook}`,
+  },
   webhookPayload: {
     entry: [
       {
@@ -295,7 +375,7 @@ runLocalMockProviderContract({
                 {
                   from: "15551234567",
                   id: "wamid.abc123",
-                  text: { body: "reply nonce-2" },
+                  text: { body: `reply ${contractNonces.webhook}` },
                 },
               ],
             },

--- a/test/whatsapp-provider.test.ts
+++ b/test/whatsapp-provider.test.ts
@@ -3,6 +3,7 @@ import {
   normalizeWhatsAppWebhookPayload,
   WhatsAppProviderAdapter,
 } from "../src/providers/builtin/whatsapp.js";
+import { appendRecordedInbound } from "../src/providers/recorder.js";
 import {
   createLocalMockConfig,
   createProviderContext,
@@ -180,6 +181,87 @@ describe("WhatsApp webhook normalizer", () => {
       ).resolves.toMatchObject({
         id: "wamid.second",
         text: `second valid ${nonce}`,
+      });
+    } finally {
+      await provider.cleanup();
+    }
+  });
+
+  it("rejects a secondary probe when the webhook listener is occupied", async () => {
+    const primaryConfig = await createLocalMockConfig("whatsapp", "/whatsapp/webhook");
+    const primary = new WhatsAppProviderAdapter("whatsapp-primary", primaryConfig, "crabline");
+    const primaryContext = createProviderContext("whatsapp", primaryConfig, {
+      id: "15551234567",
+      metadata: {},
+    });
+    let secondary: WhatsAppProviderAdapter | undefined;
+
+    try {
+      const primaryProbe = await primary.probe(primaryContext);
+      expect(primaryProbe.healthy).toBe(true);
+      const endpoint = primaryProbe.details
+        .find((detail) => detail.startsWith("webhook endpoint "))
+        ?.replace("webhook endpoint ", "");
+      expect(endpoint).toBeDefined();
+
+      const secondaryConfig = await createLocalMockConfig("whatsapp", "/whatsapp/webhook");
+      secondaryConfig.whatsapp!.webhook.port = Number(new URL(endpoint!).port);
+      secondary = new WhatsAppProviderAdapter("whatsapp-secondary", secondaryConfig, "crabline");
+      const secondaryContext = createProviderContext("whatsapp", secondaryConfig, {
+        id: "15551234567",
+        metadata: {},
+      });
+
+      await expect(secondary.probe(secondaryContext)).rejects.toThrow(/EADDRINUSE/u);
+      await expect(primary.probe(primaryContext)).resolves.toMatchObject({ healthy: true });
+    } finally {
+      await secondary?.cleanup();
+      await primary.cleanup();
+    }
+  });
+
+  it("skips an earlier wrong extracted nonce in exact mode", async () => {
+    const config = await createLocalMockConfig("whatsapp", "/whatsapp/webhook");
+    const provider = new WhatsAppProviderAdapter("whatsapp", config, "crabline");
+    const context = createProviderContext("whatsapp", config, {
+      id: "15551234567",
+      metadata: {},
+    });
+    context.fixture.inboundMatch = { author: "user", nonce: "exact", strategy: "contains" };
+    const expectedNonce = "mp-whatsapp-exact-abc-1234abcd";
+    const wrongNonce = "mp-whatsapp-wrong-abc-87654321";
+    const recorderPath = config.whatsapp!.recorder.path!;
+    const since = new Date(Date.now() - 1000).toISOString();
+
+    try {
+      await appendRecordedInbound(recorderPath, {
+        author: "user",
+        id: "wrong-nonce",
+        provider: "whatsapp",
+        sentAt: new Date().toISOString(),
+        text: `forwarded ${wrongNonce}; expected ${expectedNonce}`,
+        threadId: "15551234567",
+      });
+      await appendRecordedInbound(recorderPath, {
+        author: "user",
+        id: "valid-nonce",
+        provider: "whatsapp",
+        sentAt: new Date().toISOString(),
+        text: `reply ${expectedNonce}`,
+        threadId: "15551234567",
+      });
+
+      await expect(
+        provider.waitForInbound({
+          ...context,
+          nonce: expectedNonce,
+          since,
+          threadId: "15551234567",
+          timeoutMs: 500,
+        }),
+      ).resolves.toMatchObject({
+        id: "valid-nonce",
+        text: `reply ${expectedNonce}`,
       });
     } finally {
       await provider.cleanup();


### PR DESCRIPTION
## Summary

- harden script subprocess limits, deadlines, process-tree cleanup, and webhook startup
- normalize provider thread metadata and preserve loopback pagination/codec behavior
- process complete WhatsApp webhook batches with bounded per-message recorder data and canonical nonce matching

## Verification

- Crabbox: `pnpm verify` (39 files, 223 tests)
- autoreview: `gpt-5.6-sol` high, clean (0.88 confidence)
- changelog updated under `Unreleased`
