### PR TITLE
fix(servers): harden provider protocol fidelity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Harden CLI lifecycle cleanup, ready-file publication, run diagnostics, and config validation.
 - Harden script provider subprocess limits and result validation, recorder polling and JSONL parsing, and local webhook startup and IPv6 URLs.
 - Fix provider normalization for loopback pagination and thread codecs, Telegram edited channel posts, Feishu and Matrix thread roots, and complete WhatsApp webhook batches.
+- Harden provider server fidelity with idempotent Matrix send transactions, valid Telegram IPv6 URLs, provider-native malformed JSON errors, signed Slack Events API delivery, and bounded Zalo webhook delivery.
 
 ## 0.1.9 - 2026-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Harden script provider subprocess limits and result validation, recorder polling and JSONL parsing, and local webhook startup and IPv6 URLs.
 - Fix provider normalization for loopback pagination and thread codecs, Telegram edited channel posts, Feishu and Matrix thread roots, and complete WhatsApp webhook batches.
 - Harden provider server fidelity with idempotent Matrix send transactions, valid Telegram IPv6 URLs, provider-native malformed JSON errors, signed Slack Events API delivery, and bounded Zalo webhook delivery.
+- Serve WhatsApp Cloud API requests on provider-native Graph routes, queue acknowledged Baileys inbound messages until a session opens, and bound binary frame decoding.
 
 ## 0.1.9 - 2026-07-03
 

--- a/README.md
+++ b/README.md
@@ -257,29 +257,29 @@ crabline --json serve whatsapp --ready-file .crabline/whatsapp-server.json
 
 The JSON manifest contains:
 
-- `endpoints.apiRoot`: Crabline WhatsApp local provider API root
+- `endpoints.apiRoot`: versioned WhatsApp Graph API root
+- `endpoints.phoneNumberUrl`: provider-native phone-number resource
 - `endpoints.baileysWebSocketUrl`: Baileys-compatible WebSocket URL for
   `waWebSocketUrl`, including the local provider access token query parameter
 - `accessToken`: bearer token for local provider requests
 - `adminToken`: send this as the `X-Crabline-Admin-Token` header when posting
   test user messages
 - `selfJid`: local authenticated WhatsApp user JID
-- `env.CRABLINE_WHATSAPP_ACCESS_TOKEN`: same value as `accessToken`
-- `env.CRABLINE_WHATSAPP_API_ROOT`: same value as `endpoints.apiRoot`
-- `env.CRABLINE_WHATSAPP_BAILEYS_WEB_SOCKET_URL`: same value as
-  `endpoints.baileysWebSocketUrl`
-- `env.CRABLINE_WHATSAPP_RECORDER_PATH`: recorder file for HTTP traffic and
-  Baileys WebSocket stanzas
-- `env.CRABLINE_WHATSAPP_SELF_JID`: local authenticated WhatsApp user JID
+- `env.CLOUD_API_ACCESS_TOKEN`: same value as `accessToken`
+- `env.CLOUD_API_VERSION`: Graph API version used by the local server
+- `env.WA_BASE_URL`: local Graph API origin
+- `env.WA_PHONE_NUMBER_ID`: local sender phone-number resource ID
 - `endpoints.adminInboundUrl`: authenticated POST endpoint for test user
   messages using the WhatsApp Business webhook payload shape
-- `endpoints.messagesUrl`: local text send endpoint for Graph-style callers
-- `endpoints.presenceUrl`: local presence endpoint for Graph-style callers
+- `endpoints.messagesUrl`: provider-native Cloud API message and status endpoint
+- `endpoints.statusUrl`: alias for the same provider-native status endpoint
 - `recorderPath`: JSONL file of local provider API/admin traffic and Baileys
   WebSocket stanzas
 
 Pass `endpoints.baileysWebSocketUrl` to Baileys as `waWebSocketUrl` when a
-runtime needs to connect through the local provider. The local server completes
+runtime needs to connect through the local provider. Cloud API-compatible
+clients can send text messages through
+`POST /v25.0/<phone-number-id>/messages` with a bearer token. The local server completes
 the Baileys Noise handshake, serves bootstrap/device/prekey queries, and records
 encrypted outbound WebSocket stanzas. The WebSocket endpoint rejects clients
 that do not present the access token embedded in the manifest URL. The admin

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -233,28 +233,28 @@ crabline --json serve whatsapp --ready-file .crabline/whatsapp-server.json
 
 Manifest fields:
 
-- `endpoints.apiRoot`: Crabline WhatsApp local provider API root
+- `endpoints.apiRoot`: versioned WhatsApp Graph API root
+- `endpoints.phoneNumberUrl`: provider-native phone-number resource
 - `endpoints.baileysWebSocketUrl`: Baileys-compatible WebSocket URL for
   `waWebSocketUrl`, including the local provider access token query parameter
 - `accessToken`: bearer token for local provider requests
 - `adminToken`: value for the `X-Crabline-Admin-Token` header on admin ingress
 - `selfJid`: local authenticated WhatsApp user JID
-- `env.CRABLINE_WHATSAPP_ACCESS_TOKEN`: same value as `accessToken`
-- `env.CRABLINE_WHATSAPP_API_ROOT`: same value as `endpoints.apiRoot`
-- `env.CRABLINE_WHATSAPP_BAILEYS_WEB_SOCKET_URL`: same value as
-  `endpoints.baileysWebSocketUrl`
-- `env.CRABLINE_WHATSAPP_RECORDER_PATH`: recorder file for HTTP traffic and
-  Baileys WebSocket stanzas
-- `env.CRABLINE_WHATSAPP_SELF_JID`: local authenticated WhatsApp user JID
+- `env.CLOUD_API_ACCESS_TOKEN`: same value as `accessToken`
+- `env.CLOUD_API_VERSION`: Graph API version used by the local server
+- `env.WA_BASE_URL`: local Graph API origin
+- `env.WA_PHONE_NUMBER_ID`: local sender phone-number resource ID
 - `endpoints.adminInboundUrl`: authenticated admin ingress for test user
   messages using the WhatsApp Business webhook payload shape
-- `endpoints.messagesUrl`: text send endpoint for Graph-style callers
-- `endpoints.presenceUrl`: presence endpoint for Graph-style callers
+- `endpoints.messagesUrl`: provider-native Cloud API message and status endpoint
+- `endpoints.statusUrl`: alias for the same provider-native status endpoint
 - `recorderPath`: JSONL provider traffic recorder for HTTP traffic and Baileys
   WebSocket stanzas
 
 Pass `endpoints.baileysWebSocketUrl` to Baileys as `waWebSocketUrl` when a
-runtime needs to connect through the local provider. The local server completes
+runtime needs to connect through the local provider. Cloud API-compatible
+clients can send text messages through
+`POST /v25.0/<phone-number-id>/messages` with a bearer token. The local server completes
 the Baileys Noise handshake, serves bootstrap/device/prekey queries, and records
 encrypted outbound WebSocket stanzas. The WebSocket endpoint rejects clients
 that do not present the access token embedded in the manifest URL. The admin

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -461,7 +461,8 @@ function renderServeProviderFields(manifest: CrablineServerManifest): string[] |
       `  accessToken: ${manifest.accessToken}`,
       `  baileysWebSocket: ${manifest.endpoints.baileysWebSocketUrl}`,
       `  messages: ${manifest.endpoints.messagesUrl}`,
-      `  presence: ${manifest.endpoints.presenceUrl}`,
+      `  phoneNumber: ${manifest.endpoints.phoneNumberUrl}`,
+      `  status: ${manifest.endpoints.statusUrl}`,
       `  selfJid: ${manifest.selfJid}`,
     ];
   }

--- a/src/openclaw/bridges/whatsapp.ts
+++ b/src/openclaw/bridges/whatsapp.ts
@@ -18,14 +18,23 @@ function requireWhatsAppJid(value: string, label: string): string {
   return trimmed;
 }
 
+function readMessageText(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
 export const WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablineProviderBridge({
   provider: "whatsapp",
   createAdapter(whatsapp) {
+    const messagesPath = new URL(whatsapp.endpoints.messagesUrl).pathname;
     return {
       async probe() {
-        const response = await fetch(`${whatsapp.endpoints.apiRoot}/health`);
+        const response = await fetch(whatsapp.endpoints.phoneNumberUrl, {
+          headers: {
+            authorization: `Bearer ${whatsapp.accessToken}`,
+          },
+        });
         if (!response.ok) {
-          throw new Error(`Crabline WhatsApp health probe failed with HTTP ${response.status}.`);
+          throw new Error(`Crabline WhatsApp probe failed with HTTP ${response.status}.`);
         }
         return await response.json();
       },
@@ -103,21 +112,22 @@ export const WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
         if (!isRecord(event) || event.type !== "api" || typeof event.path !== "string") {
           return null;
         }
-        if (!event.path.endsWith("/crabline/whatsapp/messages") || !isRecord(event.body)) {
+        if (event.path !== messagesPath || !isRecord(event.body)) {
           return null;
         }
-        const to = readString(event.body.to ?? event.body.jid);
+        const to = readString(event.body.to);
         const textPayload = event.body.text;
-        const text = isRecord(textPayload) ? readString(textPayload.body) : readString(textPayload);
+        const text = isRecord(textPayload) ? readMessageText(textPayload.body) : undefined;
         if (!to || !text) {
           return null;
         }
+        const providerTarget = /^\d{7,15}$/u.test(to) ? `${to}@s.whatsapp.net` : to;
         return {
           accountId: DEFAULT_ACCOUNT_ID,
           senderId: "openclaw",
           senderName: "OpenClaw QA",
           text,
-          to: targetByProviderTarget.get(to) ?? to,
+          to: targetByProviderTarget.get(providerTarget) ?? providerTarget,
         };
       },
     };

--- a/src/servers/http.ts
+++ b/src/servers/http.ts
@@ -13,6 +13,13 @@ export type ServerRequestEvent = {
 
 export const ADMIN_TOKEN_HEADER = "x-crabline-admin-token";
 
+export class InvalidJsonBodyError extends Error {
+  constructor(cause: unknown) {
+    super("Request body is not valid JSON.", { cause });
+    this.name = "InvalidJsonBodyError";
+  }
+}
+
 export function jsonResponse(value: unknown, status = 200): Response {
   return Response.json(value, { status });
 }
@@ -35,7 +42,11 @@ export async function parseRequestBody(request: IncomingMessage): Promise<Record
     ? contentType.some((entry) => entry.includes("json"))
     : contentType.includes("json");
   if (includesJson) {
-    return JSON.parse(body.toString("utf8")) as Record<string, unknown>;
+    try {
+      return JSON.parse(body.toString("utf8")) as Record<string, unknown>;
+    } catch (error) {
+      throw new InvalidJsonBodyError(error);
+    }
   }
   const params = new URLSearchParams(body.toString("utf8"));
   return Object.fromEntries(params.entries());
@@ -74,6 +85,7 @@ export function closeServer(server: Server): Promise<void> {
 
 export async function startHttpJsonServer(params: {
   handle: (request: IncomingMessage) => Promise<Response>;
+  handleError?: (error: unknown, request: IncomingMessage) => Response | undefined;
   host: string;
   port: number;
   serverName: string;
@@ -82,15 +94,17 @@ export async function startHttpJsonServer(params: {
     try {
       await writeResponse(response, await params.handle(request));
     } catch (error) {
+      const handled = params.handleError?.(error, request);
       await writeResponse(
         response,
-        jsonResponse(
-          {
-            error: error instanceof Error ? error.message : String(error),
-            ok: false,
-          },
-          500,
-        ),
+        handled ??
+          jsonResponse(
+            {
+              error: error instanceof Error ? error.message : String(error),
+              ok: false,
+            },
+            500,
+          ),
       );
     }
   });

--- a/src/servers/http.ts
+++ b/src/servers/http.ts
@@ -45,6 +45,10 @@ export function queryRecord(url: URL): Record<string, string> {
   return Object.fromEntries(url.searchParams.entries());
 }
 
+export function formatUrlHost(host: string): string {
+  return host.includes(":") ? `[${host}]` : host;
+}
+
 export async function writeResponse(
   response: ServerResponse,
   fetchResponse: Response,
@@ -104,7 +108,7 @@ export async function startHttpJsonServer(params: {
     });
   }
   return {
-    baseUrl: `http://${params.host.includes(":") ? `[${params.host}]` : params.host}:${address.port}`,
+    baseUrl: `http://${formatUrlHost(params.host)}:${address.port}`,
     async close() {
       await closeServer(server);
     },

--- a/src/servers/matrix.ts
+++ b/src/servers/matrix.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import {
   adminAuthError,
   hasAdminToken,
+  InvalidJsonBodyError,
   jsonResponse,
   parseRequestBody,
   queryRecord,
@@ -480,6 +481,10 @@ export async function startMatrixServer(
   );
 
   const server = await startHttpJsonServer({
+    handleError: (error) =>
+      error instanceof InvalidJsonBodyError
+        ? matrixError("M_NOT_JSON", "Request body is not valid JSON", 400)
+        : undefined,
     host,
     port: params.port ?? 0,
     serverName: "Matrix",

--- a/src/servers/matrix.ts
+++ b/src/servers/matrix.ts
@@ -48,6 +48,7 @@ type MatrixServerState = {
   rooms: Map<string, MatrixRoom>;
   serverName: string;
   syncWaiters: Set<() => void>;
+  transactions: Map<string, string>;
 };
 
 export type MatrixServerManifest = {
@@ -413,6 +414,11 @@ async function handleMatrixApi(params: {
     if (!room) {
       return matrixError("M_NOT_FOUND", "Unknown room", 404);
     }
+    const transactionKey = relativePath;
+    const existingEventId = params.state.transactions.get(transactionKey);
+    if (existingEventId) {
+      return jsonResponse({ event_id: existingEventId });
+    }
     const event = createEvent({
       content: params.body,
       roomId: room.id,
@@ -422,6 +428,7 @@ async function handleMatrixApi(params: {
       type: decodeURIComponent(match[2]!),
     });
     room.timeline.push({ event, sequence: params.state.nextSequence++ });
+    params.state.transactions.set(transactionKey, event.event_id);
     notifySyncWaiters(params.state);
     return jsonResponse({ event_id: event.event_id });
   }
@@ -457,6 +464,7 @@ export async function startMatrixServer(
     rooms: new Map(),
     serverName,
     syncWaiters: new Set(),
+    transactions: new Map(),
   };
   const roomId = params.roomId ?? matrixId("!", "default-room", serverName);
   state.rooms.set(

--- a/src/servers/matrix.ts
+++ b/src/servers/matrix.ts
@@ -35,6 +35,11 @@ type MatrixRoom = {
   users: Map<string, { avatar_url?: string; display_name?: string }>;
 };
 
+type MatrixTransactionResponse = {
+  body: Record<string, unknown>;
+  status: number;
+};
+
 type MatrixServerState = {
   accessToken: string;
   adminToken: string;
@@ -49,7 +54,7 @@ type MatrixServerState = {
   rooms: Map<string, MatrixRoom>;
   serverName: string;
   syncWaiters: Set<() => void>;
-  transactions: Map<string, string>;
+  transactions: Map<string, MatrixTransactionResponse>;
 };
 
 export type MatrixServerManifest = {
@@ -411,14 +416,16 @@ async function handleMatrixApi(params: {
 
   match = /^\/rooms\/([^/]+)\/send\/([^/]+)\/([^/]+)$/u.exec(relativePath);
   if (params.method === "PUT" && match) {
+    const transactionKey = relativePath;
+    const existingResponse = params.state.transactions.get(transactionKey);
+    if (existingResponse) {
+      return jsonResponse(existingResponse.body, existingResponse.status);
+    }
     const room = findRoom(params.state, match[1]!);
     if (!room) {
-      return matrixError("M_NOT_FOUND", "Unknown room", 404);
-    }
-    const transactionKey = relativePath;
-    const existingEventId = params.state.transactions.get(transactionKey);
-    if (existingEventId) {
-      return jsonResponse({ event_id: existingEventId });
+      const body = { errcode: "M_NOT_FOUND", error: "Unknown room" };
+      params.state.transactions.set(transactionKey, { body, status: 404 });
+      return jsonResponse(body, 404);
     }
     const event = createEvent({
       content: params.body,
@@ -429,9 +436,10 @@ async function handleMatrixApi(params: {
       type: decodeURIComponent(match[2]!),
     });
     room.timeline.push({ event, sequence: params.state.nextSequence++ });
-    params.state.transactions.set(transactionKey, event.event_id);
+    const body = { event_id: event.event_id };
+    params.state.transactions.set(transactionKey, { body, status: 200 });
     notifySyncWaiters(params.state);
-    return jsonResponse({ event_id: event.event_id });
+    return jsonResponse(body);
   }
 
   match = /^\/rooms\/([^/]+)\/typing\/([^/]+)$/u.exec(relativePath);

--- a/src/servers/slack.ts
+++ b/src/servers/slack.ts
@@ -532,19 +532,21 @@ async function handleAdminInbound(params: {
   if (ts instanceof Response) {
     return ts;
   }
-  const message = createSlackMessage(params.state, {
-    channel,
-    text,
-    threadTs,
-    ts,
-    user,
-  });
+  const message = appendMessage(
+    params.state,
+    createSlackMessage(params.state, {
+      channel,
+      text,
+      threadTs,
+      ts,
+      user,
+    }),
+  );
   const event = asSlackEventCallback(message);
   const deliveryError = await deliverSlackEvent(params.state, event);
   if (deliveryError) {
     return deliveryError;
   }
-  appendMessage(params.state, message);
   return slackOk({ event, message });
 }
 

--- a/src/servers/slack.ts
+++ b/src/servers/slack.ts
@@ -1,5 +1,5 @@
 import type { IncomingMessage } from "node:http";
-import { randomBytes } from "node:crypto";
+import { createHmac, randomBytes } from "node:crypto";
 import path from "node:path";
 import {
   adminAuthError,
@@ -42,6 +42,7 @@ type SlackServerState = {
   botId: string;
   botToken: string;
   botUserId: string;
+  eventsRequestUrl: string | undefined;
   nextDmIndex: number;
   nextTsIndex: number;
   onEvent: ServerEventObserver | undefined;
@@ -81,6 +82,7 @@ export type StartSlackServerParams = {
   botId?: string | undefined;
   botToken?: string | undefined;
   botUserId?: string | undefined;
+  eventsRequestUrl?: string | undefined;
   host?: string | undefined;
   onEvent?: ServerEventObserver | undefined;
   port?: number | undefined;
@@ -310,6 +312,42 @@ function asSlackEventCallback(message: SlackMessage) {
   };
 }
 
+function slackRequestSignature(signingSecret: string, timestamp: string, body: string): string {
+  const digest = createHmac("sha256", signingSecret)
+    .update(`v0:${timestamp}:${body}`)
+    .digest("hex");
+  return `v0=${digest}`;
+}
+
+async function deliverSlackEvent(
+  state: SlackServerState,
+  event: ReturnType<typeof asSlackEventCallback>,
+): Promise<Response | undefined> {
+  if (!state.eventsRequestUrl) {
+    return undefined;
+  }
+  const body = JSON.stringify(event);
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  try {
+    const response = await fetch(state.eventsRequestUrl, {
+      body,
+      headers: {
+        "content-type": "application/json",
+        "x-slack-request-timestamp": timestamp,
+        "x-slack-signature": slackRequestSignature(state.signingSecret, timestamp, body),
+      },
+      method: "POST",
+      signal: AbortSignal.timeout(3_000),
+    });
+    if (!response.ok) {
+      return slackError("event_delivery_failed", 502);
+    }
+  } catch {
+    return slackError("event_delivery_failed", 502);
+  }
+  return undefined;
+}
+
 async function handleSlackApi(params: {
   body: Record<string, unknown>;
   method: string;
@@ -494,17 +532,20 @@ async function handleAdminInbound(params: {
   if (ts instanceof Response) {
     return ts;
   }
-  const message = appendMessage(
-    params.state,
-    createSlackMessage(params.state, {
-      channel,
-      text,
-      threadTs,
-      ts,
-      user,
-    }),
-  );
-  return slackOk({ event: asSlackEventCallback(message), message });
+  const message = createSlackMessage(params.state, {
+    channel,
+    text,
+    threadTs,
+    ts,
+    user,
+  });
+  const event = asSlackEventCallback(message);
+  const deliveryError = await deliverSlackEvent(params.state, event);
+  if (deliveryError) {
+    return deliveryError;
+  }
+  appendMessage(params.state, message);
+  return slackOk({ event, message });
 }
 
 async function handleRequest(params: { request: IncomingMessage; state: SlackServerState }) {
@@ -566,6 +607,7 @@ export async function startSlackServer(
     botId: params.botId ?? "BCRABLINE",
     botToken: params.botToken ?? "xoxb-crabline-slack-token",
     botUserId: params.botUserId ?? "UCRABBOT",
+    eventsRequestUrl: params.eventsRequestUrl,
     nextDmIndex: 1,
     nextTsIndex: 100,
     onEvent: params.onEvent,

--- a/src/servers/slack.ts
+++ b/src/servers/slack.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import {
   adminAuthError,
   hasAdminToken,
+  InvalidJsonBodyError,
   jsonResponse,
   parseRequestBody,
   queryRecord,
@@ -576,6 +577,8 @@ export async function startSlackServer(
   const host = params.host ?? "127.0.0.1";
   const httpServer = await startHttpJsonServer({
     handle: (request) => handleRequest({ request, state }),
+    handleError: (error) =>
+      error instanceof InvalidJsonBodyError ? slackError("invalid_json", 400) : undefined,
     host,
     port: params.port ?? 0,
     serverName: "Slack",

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -2,7 +2,12 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import { randomBytes } from "node:crypto";
 import path from "node:path";
 import { CrablineError } from "../core/errors.js";
-import { adminAuthError, formatUrlHost, hasAdminToken } from "./http.js";
+import {
+  adminAuthError,
+  formatUrlHost,
+  hasAdminToken,
+  InvalidJsonBodyError,
+} from "./http.js";
 import { recordServerEvent, type ServerEventObserver } from "./recorder.js";
 
 type TelegramServerEvent = {
@@ -139,7 +144,11 @@ async function parseRequestBody(request: IncomingMessage): Promise<Record<string
   const contentType = request.headers["content-type"] ?? "";
   const contentTypes = Array.isArray(contentType) ? contentType : [contentType];
   if (contentTypes.some((entry) => entry.includes("json"))) {
-    return JSON.parse(body.toString("utf8")) as Record<string, unknown>;
+    try {
+      return JSON.parse(body.toString("utf8")) as Record<string, unknown>;
+    } catch (error) {
+      throw new InvalidJsonBodyError(error);
+    }
   }
   const multipartType = contentTypes.find((entry) => entry.includes("multipart/form-data"));
   if (multipartType) {
@@ -521,13 +530,15 @@ export async function startTelegramServer(
     } catch (error) {
       await writeResponse(
         response,
-        jsonResponse(
-          {
-            error: error instanceof Error ? error.message : String(error),
-            ok: false,
-          },
-          500,
-        ),
+        error instanceof InvalidJsonBodyError
+          ? telegramError("Bad Request: can't parse JSON object")
+          : jsonResponse(
+              {
+                error: error instanceof Error ? error.message : String(error),
+                ok: false,
+              },
+              500,
+            ),
       );
     }
   });

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -2,7 +2,7 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import { randomBytes } from "node:crypto";
 import path from "node:path";
 import { CrablineError } from "../core/errors.js";
-import { adminAuthError, hasAdminToken } from "./http.js";
+import { adminAuthError, formatUrlHost, hasAdminToken } from "./http.js";
 import { recordServerEvent, type ServerEventObserver } from "./recorder.js";
 
 type TelegramServerEvent = {
@@ -544,7 +544,7 @@ export async function startTelegramServer(
       kind: "connectivity",
     });
   }
-  const baseUrl = `http://${host}:${address.port}`;
+  const baseUrl = `http://${formatUrlHost(host)}:${address.port}`;
   return {
     async close() {
       await closeServer(server);

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -2,12 +2,7 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 import { randomBytes } from "node:crypto";
 import path from "node:path";
 import { CrablineError } from "../core/errors.js";
-import {
-  adminAuthError,
-  formatUrlHost,
-  hasAdminToken,
-  InvalidJsonBodyError,
-} from "./http.js";
+import { adminAuthError, formatUrlHost, hasAdminToken, InvalidJsonBodyError } from "./http.js";
 import { recordServerEvent, type ServerEventObserver } from "./recorder.js";
 
 type TelegramServerEvent = {

--- a/src/servers/whatsapp-baileys-websocket.ts
+++ b/src/servers/whatsapp-baileys-websocket.ts
@@ -585,12 +585,14 @@ export function attachWhatsAppBaileysWebSocketServer(
       });
     },
     deliverInboundMessage(message) {
-      if (pendingMessages.length === 0) {
-        for (const session of sessions) {
-          if (session.deliverInboundMessage(message)) {
-            return "delivered";
-          }
+      let delivered = false;
+      for (const session of sessions) {
+        if (session.deliverInboundMessage(message)) {
+          delivered = true;
         }
+      }
+      if (delivered) {
+        return "delivered";
       }
       enqueuePendingMessage(message);
       return "queued";

--- a/src/servers/whatsapp-baileys-websocket.ts
+++ b/src/servers/whatsapp-baileys-websocket.ts
@@ -29,6 +29,7 @@ import type { ServerRequestEvent } from "./http.js";
 // as a black-box client to verify this narrow WhatsApp Web wire subset.
 const EMPTY_BUFFER = Buffer.alloc(0);
 const IV_LENGTH = 12;
+const MAX_PENDING_INBOUND_MESSAGES = 1_000;
 type NodeBuffer = Buffer<ArrayBufferLike>;
 const WHATSAPP_NOISE_CERT_CHAIN = Buffer.from(
   "CncKMwjjAhADGiCRKg7Kg1iu4CSulwLBaxX51Tefw6VXGgZqcr5OEbXIRiDQ04bOBijQjZ/TBhJA34Bj82jAHhLpCWBNVBlGnFDieamd8+138S57uMt9ke9mrn5r4+VepwBPKEgHjob6bR70rlCmWDkxZv+CfVjIAxJ2CjIIAxAAGiAcUamsMDmUxsjQuS6hh4pTNHZZnMWZ++o1mX2aqQzOYiCAka6+Bij/3rfcBhJAJw8pRkhTn+1IcOJQVN1OlZg6uikYnCumyO7acFVVX3U3QPXsGSq2TCbCbWrebSC593Su43EgprIDlfU8ZgWFBw==",
@@ -37,7 +38,7 @@ const WHATSAPP_NOISE_CERT_CHAIN = Buffer.from(
 
 export type WhatsAppBaileysWebSocketServer = {
   close(): Promise<void>;
-  deliverInboundMessage(message: WhatsAppBaileysInboundMessage): void;
+  deliverInboundMessage(message: WhatsAppBaileysInboundMessage): "delivered" | "queued";
 };
 
 export type WhatsAppBaileysWebSocketServerParams = {
@@ -260,10 +261,15 @@ class WhatsAppBaileysWebSocketSession {
     private readonly params: {
       appendEvent(event: ServerRequestEvent): Promise<void>;
       path: string;
+      onOpen(session: WhatsAppBaileysWebSocketSession): void;
       selfJid: string;
       signalBundles: Map<string, MockSignalBundle>;
     },
   ) {}
+
+  get isOpen(): boolean {
+    return this.#handshakeState === "open" && this.socket.readyState === WebSocket.OPEN;
+  }
 
   handleMessage(data: RawData): void {
     void this.#handleMessage(data).catch((error: unknown) => {
@@ -271,11 +277,12 @@ class WhatsAppBaileysWebSocketSession {
     });
   }
 
-  deliverInboundMessage(message: WhatsAppBaileysInboundMessage): void {
-    if (this.#handshakeState !== "open" || this.socket.readyState !== WebSocket.OPEN) {
-      return;
+  deliverInboundMessage(message: WhatsAppBaileysInboundMessage): boolean {
+    if (!this.isOpen) {
+      return false;
     }
     this.#sendNode(createInboundMessageNode(message));
+    return true;
   }
 
   async #handleMessage(data: RawData): Promise<void> {
@@ -300,6 +307,7 @@ class WhatsAppBaileysWebSocketSession {
           content: [{ attrs: { count: "0" }, tag: "offline" }],
           tag: "ib",
         });
+        this.params.onOpen(this);
         continue;
       }
       await this.#handleNode(await this.#noise.decodeTransportNode(frame));
@@ -512,7 +520,23 @@ export function attachWhatsAppBaileysWebSocketServer(
 ): WhatsAppBaileysWebSocketServer {
   const signalBundles = new Map<string, MockSignalBundle>();
   const sessions = new Set<WhatsAppBaileysWebSocketSession>();
+  const pendingMessages: WhatsAppBaileysInboundMessage[] = [];
   const wss = new WebSocketServer({ noServer: true });
+  const flushPendingMessages = (session: WhatsAppBaileysWebSocketSession) => {
+    while (pendingMessages.length > 0) {
+      const message = pendingMessages[0];
+      if (!message || !session.deliverInboundMessage(message)) {
+        return;
+      }
+      pendingMessages.shift();
+    }
+  };
+  const enqueuePendingMessage = (message: WhatsAppBaileysInboundMessage) => {
+    if (pendingMessages.length >= MAX_PENDING_INBOUND_MESSAGES) {
+      throw new Error(`WhatsApp inbound queue is full (${MAX_PENDING_INBOUND_MESSAGES} messages).`);
+    }
+    pendingMessages.push(message);
+  };
   const handleUpgrade = (request: IncomingMessage, socket: Duplex, head: Buffer) => {
     const url = new URL(request.url ?? "/", "http://127.0.0.1");
     if (url.pathname !== params.path) {
@@ -532,6 +556,9 @@ export function attachWhatsAppBaileysWebSocketServer(
   wss.on("connection", (socket: WebSocket) => {
     const session = new WhatsAppBaileysWebSocketSession(socket, {
       appendEvent: params.appendEvent,
+      onOpen: (openSession) => {
+        setImmediate(() => flushPendingMessages(openSession));
+      },
       path: params.path,
       selfJid: params.selfJid,
       signalBundles,
@@ -546,6 +573,7 @@ export function attachWhatsAppBaileysWebSocketServer(
       for (const client of wss.clients) {
         client.close();
       }
+      pendingMessages.length = 0;
       await new Promise<void>((resolve, reject) => {
         wss.close((error) => {
           if (error) {
@@ -557,9 +585,15 @@ export function attachWhatsAppBaileysWebSocketServer(
       });
     },
     deliverInboundMessage(message) {
-      for (const session of sessions) {
-        session.deliverInboundMessage(message);
+      if (pendingMessages.length === 0) {
+        for (const session of sessions) {
+          if (session.deliverInboundMessage(message)) {
+            return "delivered";
+          }
+        }
       }
+      enqueuePendingMessage(message);
+      return "queued";
     },
   };
 }

--- a/src/servers/whatsapp-wire/binary-node.ts
+++ b/src/servers/whatsapp-wire/binary-node.ts
@@ -8,7 +8,13 @@ export type BinaryNode = {
   tag: string;
 };
 
-const inflateAsync = promisify(inflate);
+export const WHATSAPP_BINARY_NODE_MAX_COMPRESSED_BYTES = 1024 * 1024;
+export const WHATSAPP_BINARY_NODE_MAX_DECOMPRESSED_BYTES = 8 * 1024 * 1024;
+
+const inflateAsync = promisify(inflate) as (
+  buffer: Uint8Array,
+  options: { maxOutputLength: number },
+) => Promise<Buffer>;
 
 const TAGS = {
   AD_JID: 247,
@@ -84,11 +90,13 @@ const SINGLE_BYTE_TOKENS: Readonly<Record<number, string>> = {
   155: "true",
   156: "identity",
   158: "key",
+  160: "background",
   169: "auth",
   173: "registration",
   189: "ttl",
   194: "w:m",
   197: "token",
+  198: "inactive",
   203: "encrypt",
   212: "signature",
   217: "trusted_contact",
@@ -131,14 +139,36 @@ async function decompressIfRequired(buffer: Buffer): Promise<Buffer> {
   }
   const flag = buffer.readUInt8();
   if ((flag & 2) !== 0) {
-    return await inflateAsync(buffer.subarray(1));
+    if (buffer.length > WHATSAPP_BINARY_NODE_MAX_COMPRESSED_BYTES) {
+      throw new Error(`Compressed WhatsApp binary node frame is too large: ${buffer.length}.`);
+    }
+    try {
+      return await inflateAsync(buffer.subarray(1), {
+        maxOutputLength: WHATSAPP_BINARY_NODE_MAX_DECOMPRESSED_BYTES,
+      });
+    } catch (error) {
+      if (
+        error instanceof RangeError ||
+        (error instanceof Error && (error as NodeJS.ErrnoException).code === "ERR_BUFFER_TOO_LARGE")
+      ) {
+        throw new Error(
+          `WhatsApp binary node expands beyond ${WHATSAPP_BINARY_NODE_MAX_DECOMPRESSED_BYTES} bytes.`,
+          { cause: error },
+        );
+      }
+      throw error;
+    }
   }
-  return buffer.subarray(1);
+  const payload = buffer.subarray(1);
+  if (payload.length > WHATSAPP_BINARY_NODE_MAX_DECOMPRESSED_BYTES) {
+    throw new Error(`WhatsApp binary node payload is too large: ${payload.length}.`);
+  }
+  return payload;
 }
 
 function decodeDecompressedBinaryNode(buffer: Buffer, indexRef = { index: 0 }): BinaryNode {
   const checkEOS = (length: number) => {
-    if (indexRef.index + length > buffer.length) {
+    if (!Number.isSafeInteger(length) || length < 0 || length > buffer.length - indexRef.index) {
       throw new Error("Unexpected end of WhatsApp binary node.");
     }
   };
@@ -164,8 +194,8 @@ function decodeDecompressedBinaryNode(buffer: Buffer, indexRef = { index: 0 }): 
     checkEOS(length);
     let value = 0;
     for (let index = 0; index < length; index += 1) {
-      const shift = littleEndian ? index : length - 1 - index;
-      value |= next() << (shift * 8);
+      const byte = next();
+      value = littleEndian ? value + byte * 256 ** index : value * 256 + byte;
     }
     return value;
   };
@@ -431,6 +461,9 @@ function writeString(buffer: number[], value: string): void {
 }
 
 function writeListStart(buffer: number[], size: number): void {
+  if (!Number.isSafeInteger(size) || size < 0 || size > 0xffff) {
+    throw new Error(`WhatsApp binary node list is too large: ${size}.`);
+  }
   if (size === 0) {
     pushByte(buffer, TAGS.LIST_EMPTY);
     return;

--- a/src/servers/whatsapp.ts
+++ b/src/servers/whatsapp.ts
@@ -21,13 +21,16 @@ const WHATSAPP_USER_JID_RE = /^\d{7,15}(?::\d+)?@s\.whatsapp\.net$/iu;
 const WHATSAPP_LEGACY_USER_JID_RE = /^\d{7,15}@c\.us$/iu;
 const WHATSAPP_GROUP_JID_RE = /^\d{5,}@g\.us$/iu;
 const WHATSAPP_LID_RE = /^\d{7,15}@lid$/iu;
+const WHATSAPP_CLOUD_RECIPIENT_RE = /^\d{7,15}$/u;
+const WHATSAPP_GRAPH_VERSION_RE = /^v\d+\.\d+$/u;
+const DEFAULT_GRAPH_VERSION = "v25.0";
 
 type WhatsAppServerState = {
   accessToken: string;
   adminToken: string;
-  apiRoot: string;
   displayPhoneNumber: string;
-  deliverInboundMessage(message: WhatsAppBaileysInboundMessage): void;
+  deliverInboundMessage(message: WhatsAppBaileysInboundMessage): "delivered" | "queued";
+  graphVersion: string;
   nextMessageId: number;
   onEvent: ServerEventObserver | undefined;
   phoneNumberId: string;
@@ -46,16 +49,17 @@ export type WhatsAppServerManifest = {
     apiRoot: string;
     baileysWebSocketUrl: string;
     messagesUrl: string;
-    presenceUrl: string;
+    phoneNumberUrl: string;
+    statusUrl: string;
   };
   env: {
-    CRABLINE_WHATSAPP_ADMIN_TOKEN: string;
-    CRABLINE_WHATSAPP_ACCESS_TOKEN: string;
-    CRABLINE_WHATSAPP_API_ROOT: string;
-    CRABLINE_WHATSAPP_BAILEYS_WEB_SOCKET_URL: string;
-    CRABLINE_WHATSAPP_RECORDER_PATH: string;
-    CRABLINE_WHATSAPP_SELF_JID: string;
+    CLOUD_API_ACCESS_TOKEN: string;
+    CLOUD_API_VERSION: string;
+    WA_BASE_URL: string;
+    WA_PHONE_NUMBER_ID: string;
   };
+  graphVersion: string;
+  phoneNumberId: string;
   provider: "whatsapp";
   recorderPath: string;
   selfJid: string;
@@ -70,8 +74,11 @@ export type StartedWhatsAppServer = {
 export type StartWhatsAppServerParams = {
   accessToken?: string | undefined;
   adminToken?: string | undefined;
+  displayPhoneNumber?: string | undefined;
+  graphVersion?: string | undefined;
   host?: string | undefined;
   onEvent?: ServerEventObserver | undefined;
+  phoneNumberId?: string | undefined;
   port?: number | undefined;
   recorderPath?: string | undefined;
   selfJid?: string | undefined;
@@ -79,7 +86,8 @@ export type StartWhatsAppServerParams = {
 
 type WhatsAppAdminInboundResult = {
   message?: WhatsAppBaileysMessage | undefined;
-  response: Response;
+  response?: Response | undefined;
+  webhook?: Record<string, unknown> | undefined;
 };
 
 type WhatsAppRecorderEvent = ServerRequestEvent & {
@@ -113,7 +121,6 @@ function graphError(params: {
         message: params.message,
         type: params.type ?? "OAuthException",
       },
-      ok: false,
     },
     params.status ?? 400,
   );
@@ -155,6 +162,17 @@ function requireWhatsAppJid(value: unknown, label: string): string | Response {
   return stringValue;
 }
 
+function requireCloudRecipient(value: unknown): string | Response {
+  const recipient = readTrimmedString(value);
+  if (!recipient || !WHATSAPP_CLOUD_RECIPIENT_RE.test(recipient)) {
+    return graphParameterError(
+      "(#100) Invalid parameter: to",
+      "to must be a WhatsApp phone number in international format without punctuation.",
+    );
+  }
+  return recipient;
+}
+
 function requireAuth(request: IncomingMessage, state: WhatsAppServerState): boolean {
   const authorization = request.headers.authorization;
   return (
@@ -172,7 +190,7 @@ function waIdFromJid(jid: string): string {
 
 function requireMessagingProduct(body: Record<string, unknown>): Response | undefined {
   const messagingProduct = readTrimmedString(body.messaging_product);
-  if (messagingProduct && messagingProduct !== "whatsapp") {
+  if (messagingProduct !== "whatsapp") {
     return graphParameterError(
       "(#100) Invalid parameter: messaging_product",
       'messaging_product must be "whatsapp".',
@@ -190,17 +208,11 @@ function readTextMessageBody(body: Record<string, unknown>): string | Response {
     );
   }
   const textPayload = body.text;
-  const textBody =
+  const text =
     textPayload && typeof textPayload === "object"
-      ? readTrimmedString((textPayload as Record<string, unknown>).body)
-      : readTrimmedString(textPayload);
-  const content = body.content;
-  const contentText =
-    content && typeof content === "object"
-      ? readTrimmedString((content as Record<string, unknown>).text)
+      ? readMessageText((textPayload as Record<string, unknown>).body)
       : undefined;
-  const text = textBody ?? contentText;
-  if (!text) {
+  if (text === undefined) {
     return graphParameterError(
       "(#100) Missing required parameter: text.body",
       "A WhatsApp text send requires text.body.",
@@ -240,7 +252,14 @@ async function handleSendMessage(params: {
   if (productError) {
     return productError;
   }
-  const to = requireWhatsAppJid(params.body.to ?? params.body.jid, "to");
+  const recipientType = readTrimmedString(params.body.recipient_type);
+  if (recipientType && recipientType !== "individual") {
+    return graphParameterError(
+      "(#100) Invalid parameter: recipient_type",
+      'recipient_type must be "individual".',
+    );
+  }
+  const to = requireCloudRecipient(params.body.to);
   if (to instanceof Response) {
     return to;
   }
@@ -251,24 +270,39 @@ async function handleSendMessage(params: {
   const message = createWhatsAppMessage({
     fromMe: true,
     id: nextMessageId(params.state),
-    remoteJid: to,
+    remoteJid: `${to}@s.whatsapp.net`,
     text,
   });
-  const waId = waIdFromJid(to);
-  return whatsappOk({
+  return jsonResponse({
     contacts: [
       {
         input: to,
-        wa_id: waId,
+        wa_id: to,
       },
     ],
-    key: message.key,
-    message,
-    messageId: message.key.id,
     messages: [{ id: message.key.id }],
     messaging_product: "whatsapp",
-    toJid: to,
   });
+}
+
+function handleMessageStatus(body: Record<string, unknown>): Response {
+  const productError = requireMessagingProduct(body);
+  if (productError) {
+    return productError;
+  }
+  if (readTrimmedString(body.status) !== "read") {
+    return graphParameterError(
+      "(#100) Invalid parameter: status",
+      'status must be "read" for message status updates.',
+    );
+  }
+  if (!readTrimmedString(body.message_id)) {
+    return graphParameterError(
+      "(#100) Missing required parameter: message_id",
+      "A message status update requires message_id.",
+    );
+  }
+  return jsonResponse({ success: true });
 }
 
 async function handleAdminInbound(params: {
@@ -283,8 +317,8 @@ async function handleAdminInbound(params: {
   if (senderJid instanceof Response) {
     return { response: senderJid };
   }
-  const text = readTrimmedString(params.body.text);
-  if (!text) {
+  const text = readMessageText(params.body.text);
+  if (text === undefined) {
     return {
       response: graphParameterError(
         "(#100) Missing required parameter: text",
@@ -336,17 +370,13 @@ async function handleAdminInbound(params: {
     ],
     object: "whatsapp_business_account",
   };
-  return { message, response: whatsappOk({ message, webhook }) };
+  return { message, webhook };
 }
 
 async function handleRequest(params: { request: IncomingMessage; state: WhatsAppServerState }) {
   const url = new URL(params.request.url ?? "/", "http://127.0.0.1");
 
-  if (url.pathname === "/crabline/whatsapp/health") {
-    return whatsappOk({ selfJid: params.state.selfJid });
-  }
-
-  if (url.pathname === "/crabline/whatsapp/inbound") {
+  if (url.pathname === "/_crabline/admin/whatsapp/inbound") {
     if (params.request.method !== "POST") {
       return new Response("not found", { status: 404 });
     }
@@ -355,6 +385,9 @@ async function handleRequest(params: { request: IncomingMessage; state: WhatsApp
     }
     const body = await parseRequestBody(params.request);
     const result = await handleAdminInbound({ body, state: params.state });
+    if (result.response) {
+      return result.response;
+    }
     const event: WhatsAppRecorderEvent = {
       at: new Date().toISOString(),
       body,
@@ -368,11 +401,14 @@ async function handleRequest(params: { request: IncomingMessage; state: WhatsApp
     }
     await appendEvent(params.state, event);
     if (result.message) {
-      params.state.deliverInboundMessage(result.message);
+      const delivery = params.state.deliverInboundMessage(result.message);
+      return whatsappOk({ delivery, message: result.message, webhook: result.webhook });
     }
-    return result.response;
+    return graphParameterError("(#100) Invalid inbound WhatsApp event");
   }
 
+  const phoneNumberPath = `/${params.state.graphVersion}/${params.state.phoneNumberId}`;
+  const messagesPath = `${phoneNumberPath}/messages`;
   const body =
     params.request.method === "GET" ? queryRecord(url) : await parseRequestBody(params.request);
   await appendEvent(params.state, {
@@ -387,21 +423,22 @@ async function handleRequest(params: { request: IncomingMessage; state: WhatsApp
   if (!requireAuth(params.request, params.state)) {
     return graphAuthError();
   }
-  if (url.pathname === "/crabline/whatsapp/messages") {
+  if (url.pathname === phoneNumberPath && params.request.method === "GET") {
+    return jsonResponse({
+      display_phone_number: params.state.displayPhoneNumber,
+      id: params.state.phoneNumberId,
+      quality_rating: "GREEN",
+      verified_name: "Crabline Test Bot",
+    });
+  }
+  if (url.pathname === messagesPath) {
     if (params.request.method !== "POST") {
       return new Response("not found", { status: 404 });
     }
-    return await handleSendMessage({ body, state: params.state });
-  }
-  if (url.pathname === "/crabline/whatsapp/presence") {
-    const presence = readTrimmedString(body.presence) ?? "composing";
-    if (!["available", "composing", "paused", "unavailable"].includes(presence)) {
-      return graphParameterError(
-        "(#100) Invalid parameter: presence",
-        "presence must be available, composing, paused, or unavailable.",
-      );
+    if ("status" in body || "message_id" in body) {
+      return handleMessageStatus(body);
     }
-    return whatsappOk({ presence });
+    return await handleSendMessage({ body, state: params.state });
   }
   return new Response("not found", { status: 404 });
 }
@@ -409,15 +446,23 @@ async function handleRequest(params: { request: IncomingMessage; state: WhatsApp
 export async function startWhatsAppServer(
   params: StartWhatsAppServerParams = {},
 ): Promise<StartedWhatsAppServer> {
+  const graphVersion = params.graphVersion ?? DEFAULT_GRAPH_VERSION;
+  if (!WHATSAPP_GRAPH_VERSION_RE.test(graphVersion)) {
+    throw new Error(`Invalid WhatsApp Graph API version: ${graphVersion}.`);
+  }
+  const phoneNumberId = params.phoneNumberId ?? "100000000000000";
+  if (!/^\d+$/u.test(phoneNumberId)) {
+    throw new Error("WhatsApp phoneNumberId must contain only digits.");
+  }
   const state: WhatsAppServerState = {
     accessToken: params.accessToken ?? "crabline-whatsapp-access-token",
     adminToken: params.adminToken ?? randomBytes(24).toString("hex"),
-    apiRoot: "",
-    deliverInboundMessage: () => undefined,
-    displayPhoneNumber: "15550000000",
+    deliverInboundMessage: () => "queued",
+    displayPhoneNumber: params.displayPhoneNumber ?? "15550000000",
+    graphVersion,
     nextMessageId: 1,
     onEvent: params.onEvent,
-    phoneNumberId: "TEST_PHONE_NUMBER_ID",
+    phoneNumberId,
     recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "whatsapp.jsonl"),
     selfJid: params.selfJid ?? "15550000000@s.whatsapp.net",
   };
@@ -429,17 +474,18 @@ export async function startWhatsAppServer(
     serverName: "WhatsApp",
   });
   const baseUrl = httpServer.baseUrl;
-  const apiRoot = `${baseUrl}/crabline/whatsapp`;
+  const apiRoot = `${baseUrl}/${state.graphVersion}`;
+  const phoneNumberUrl = `${apiRoot}/${state.phoneNumberId}`;
+  const messagesUrl = `${phoneNumberUrl}/messages`;
   const baileysWebSocketUrl = `${baseUrl.replace(
     /^http/u,
     "ws",
-  )}/crabline/whatsapp/ws/chat?access_token=${encodeURIComponent(state.accessToken)}`;
-  state.apiRoot = apiRoot;
+  )}/ws/chat?access_token=${encodeURIComponent(state.accessToken)}`;
   const baileysWebSocketServer = attachWhatsAppBaileysWebSocketServer({
     accessToken: state.accessToken,
     appendEvent: (event) => appendEvent(state, event),
     httpServer: httpServer.server,
-    path: "/crabline/whatsapp/ws/chat",
+    path: "/ws/chat",
     selfJid: state.selfJid,
   });
   state.deliverInboundMessage = (message) => baileysWebSocketServer.deliverInboundMessage(message);
@@ -453,24 +499,29 @@ export async function startWhatsAppServer(
       adminToken: state.adminToken,
       baseUrl,
       endpoints: {
-        adminInboundUrl: `${apiRoot}/inbound`,
+        adminInboundUrl: `${baseUrl}/_crabline/admin/whatsapp/inbound`,
         apiRoot,
         baileysWebSocketUrl,
-        messagesUrl: `${apiRoot}/messages`,
-        presenceUrl: `${apiRoot}/presence`,
+        messagesUrl,
+        phoneNumberUrl,
+        statusUrl: messagesUrl,
       },
       env: {
-        CRABLINE_WHATSAPP_ADMIN_TOKEN: state.adminToken,
-        CRABLINE_WHATSAPP_ACCESS_TOKEN: state.accessToken,
-        CRABLINE_WHATSAPP_API_ROOT: apiRoot,
-        CRABLINE_WHATSAPP_BAILEYS_WEB_SOCKET_URL: baileysWebSocketUrl,
-        CRABLINE_WHATSAPP_RECORDER_PATH: state.recorderPath,
-        CRABLINE_WHATSAPP_SELF_JID: state.selfJid,
+        CLOUD_API_ACCESS_TOKEN: state.accessToken,
+        CLOUD_API_VERSION: state.graphVersion,
+        WA_BASE_URL: baseUrl,
+        WA_PHONE_NUMBER_ID: state.phoneNumberId,
       },
+      graphVersion: state.graphVersion,
+      phoneNumberId: state.phoneNumberId,
       provider: "whatsapp",
       recorderPath: state.recorderPath,
       selfJid: state.selfJid,
       version: 1,
     },
   };
+}
+
+function readMessageText(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
 }

--- a/src/servers/whatsapp.ts
+++ b/src/servers/whatsapp.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import {
   adminAuthError,
   hasAdminToken,
+  InvalidJsonBodyError,
   jsonResponse,
   parseRequestBody,
   queryRecord,
@@ -479,6 +480,13 @@ export async function startWhatsAppServer(
   const host = params.host ?? "127.0.0.1";
   const httpServer = await startHttpJsonServer({
     handle: (request) => handleRequest({ request, state }),
+    handleError: (error) =>
+      error instanceof InvalidJsonBodyError
+        ? graphParameterError(
+            "(#100) Invalid parameter: request body",
+            "The request body must be valid JSON.",
+          )
+        : undefined,
     host,
     port: params.port ?? 0,
     serverName: "WhatsApp",

--- a/src/servers/whatsapp.ts
+++ b/src/servers/whatsapp.ts
@@ -138,6 +138,10 @@ function graphAuthError(): Response {
   });
 }
 
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
 async function appendEvent(state: WhatsAppServerState, event: ServerRequestEvent) {
   await recordServerEvent({ event, onEvent: state.onEvent, recorderPath: state.recorderPath });
 }
@@ -434,6 +438,12 @@ async function handleRequest(params: { request: IncomingMessage; state: WhatsApp
   if (url.pathname === messagesPath) {
     if (params.request.method !== "POST") {
       return new Response("not found", { status: 404 });
+    }
+    if (!isJsonObject(body)) {
+      return graphParameterError(
+        "(#100) Invalid parameter: request body",
+        "The request body must be a JSON object.",
+      );
     }
     if ("status" in body || "message_id" in body) {
       return handleMessageStatus(body);

--- a/src/servers/zalo.ts
+++ b/src/servers/zalo.ts
@@ -16,6 +16,9 @@ import { recordServerEvent, type ServerEventObserver } from "./recorder.js";
 
 type ZaloChatType = "GROUP" | "PRIVATE";
 
+const DEFAULT_WEBHOOK_DELIVERY_TIMEOUT_MS = 5_000;
+const MAX_WEBHOOK_DELIVERY_TIMEOUT_MS = 30_000;
+
 type ZaloMessage = {
   chat: { chat_type: ZaloChatType; id: string };
   date: number;
@@ -46,6 +49,7 @@ type ZaloServerState = {
   recorderPath: string;
   updates: ZaloUpdate[];
   webhook: { secretToken: string; updatedAt: number; url: string } | undefined;
+  webhookDeliveryTimeoutMs: number;
 };
 
 export type ZaloServerManifest = {
@@ -80,6 +84,7 @@ export type StartZaloServerParams = {
   onEvent?: ServerEventObserver | undefined;
   port?: number | undefined;
   recorderPath?: string | undefined;
+  webhookDeliveryTimeoutMs?: number | undefined;
 };
 
 async function appendEvent(state: ZaloServerState, event: ServerRequestEvent): Promise<void> {
@@ -123,6 +128,13 @@ function firstError(...values: Array<string | Response>): Response | undefined {
   return values.find((value): value is Response => value instanceof Response);
 }
 
+function webhookDeliveryTimeoutMs(value: number | undefined): number {
+  if (value === undefined || !Number.isFinite(value)) {
+    return DEFAULT_WEBHOOK_DELIVERY_TIMEOUT_MS;
+  }
+  return Math.max(1, Math.min(Math.floor(value), MAX_WEBHOOK_DELIVERY_TIMEOUT_MS));
+}
+
 function nextUpdate(state: ZaloServerState): Response | undefined {
   const update = state.updates.shift();
   return update ? zaloOk(update) : undefined;
@@ -164,6 +176,7 @@ function deliverPollingUpdate(state: ZaloServerState, update: ZaloUpdate): void 
 async function deliverWebhookUpdate(
   webhook: NonNullable<ZaloServerState["webhook"]>,
   update: ZaloUpdate,
+  timeoutMs: number,
 ): Promise<Response | undefined> {
   try {
     const response = await fetch(webhook.url, {
@@ -173,11 +186,15 @@ async function deliverWebhookUpdate(
         "x-bot-api-secret-token": webhook.secretToken,
       },
       method: "POST",
+      signal: AbortSignal.timeout(timeoutMs),
     });
     if (!response.ok) {
       return zaloError(`Webhook delivery failed with HTTP ${response.status}`, 502);
     }
   } catch (error) {
+    if (error instanceof DOMException && error.name === "TimeoutError") {
+      return zaloError(`Webhook delivery timed out after ${timeoutMs}ms`, 502);
+    }
     return zaloError(
       `Webhook delivery failed: ${error instanceof Error ? error.message : String(error)}`,
       502,
@@ -224,7 +241,7 @@ async function handleAdminInbound(
     type: "admin",
   });
   if (state.webhook?.url) {
-    const error = await deliverWebhookUpdate(state.webhook, update);
+    const error = await deliverWebhookUpdate(state.webhook, update, state.webhookDeliveryTimeoutMs);
     if (error) {
       return error;
     }
@@ -339,6 +356,7 @@ export async function startZaloServer(
     recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "zalo.jsonl"),
     updates: [],
     webhook: undefined,
+    webhookDeliveryTimeoutMs: webhookDeliveryTimeoutMs(params.webhookDeliveryTimeoutMs),
   };
   const httpServer = await startHttpJsonServer({
     handle: async (request) => {

--- a/src/servers/zalo.ts
+++ b/src/servers/zalo.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import {
   adminAuthError,
   hasAdminToken,
+  InvalidJsonBodyError,
   jsonResponse,
   parseRequestBody,
   queryRecord,
@@ -354,6 +355,10 @@ export async function startZaloServer(
       }
       return await handleZaloMethod(request, state, url, match[2] ?? "");
     },
+    handleError: (error) =>
+      error instanceof InvalidJsonBodyError
+        ? zaloError("Bad Request: can't parse JSON object", 400)
+        : undefined,
     host,
     port: params.port ?? 0,
     serverName: "Zalo",

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -466,25 +466,31 @@ describe("cli", () => {
         baileysWebSocketUrl?: string;
         messagesUrl?: string;
       };
-      env?: { CRABLINE_WHATSAPP_BAILEYS_WEB_SOCKET_URL?: string };
+      env?: {
+        CLOUD_API_ACCESS_TOKEN?: string;
+        CLOUD_API_VERSION?: string;
+        WA_PHONE_NUMBER_ID?: string;
+      };
       provider?: string;
     };
     expect(manifest.provider).toBe("whatsapp");
     expect(manifest.accessToken).toBe("test-whatsapp-access-token");
     expect(manifest.adminToken).toBe("test-whatsapp-admin-token");
-    expect(manifest.endpoints?.apiRoot).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/crabline\/whatsapp$/u);
+    expect(manifest.endpoints?.apiRoot).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/v25\.0$/u);
     expect(manifest.endpoints?.adminInboundUrl).toMatch(
-      /^http:\/\/127\.0\.0\.1:\d+\/crabline\/whatsapp\/inbound$/u,
+      /^http:\/\/127\.0\.0\.1:\d+\/_crabline\/admin\/whatsapp\/inbound$/u,
     );
     expect(manifest.endpoints?.messagesUrl).toMatch(
-      /^http:\/\/127\.0\.0\.1:\d+\/crabline\/whatsapp\/messages$/u,
+      /^http:\/\/127\.0\.0\.1:\d+\/v25\.0\/100000000000000\/messages$/u,
     );
     expect(manifest.endpoints?.baileysWebSocketUrl).toMatch(
-      /^ws:\/\/127\.0\.0\.1:\d+\/crabline\/whatsapp\/ws\/chat\?access_token=test-whatsapp-access-token$/u,
+      /^ws:\/\/127\.0\.0\.1:\d+\/ws\/chat\?access_token=test-whatsapp-access-token$/u,
     );
-    expect(manifest.env?.CRABLINE_WHATSAPP_BAILEYS_WEB_SOCKET_URL).toBe(
-      manifest.endpoints?.baileysWebSocketUrl,
-    );
+    expect(manifest.env).toMatchObject({
+      CLOUD_API_ACCESS_TOKEN: "test-whatsapp-access-token",
+      CLOUD_API_VERSION: "v25.0",
+      WA_PHONE_NUMBER_ID: "100000000000000",
+    });
     await expect(fs.readFile(readyFile, "utf8")).resolves.toContain('"provider": "whatsapp"');
   });
 

--- a/test/matrix-server.test.ts
+++ b/test/matrix-server.test.ts
@@ -206,7 +206,7 @@ describe("Matrix local provider server", () => {
         };
       };
       const retryEvents = retrySyncBody.rooms.join[dynamicRoomId]?.timeline.events.filter(
-        (event) => event.event_id === firstRetry.event_id,
+        (timelineEvent) => timelineEvent.event_id === firstRetry.event_id,
       );
       expect(retryEvents).toHaveLength(1);
       expect(retryEvents?.[0]?.content).toMatchObject({ body: "idempotent send" });

--- a/test/matrix-server.test.ts
+++ b/test/matrix-server.test.ts
@@ -215,6 +215,61 @@ describe("Matrix local provider server", () => {
     }
   });
 
+  it("replays a transaction room error after the room is created", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const server = await startMatrixServer({
+      recorderPath: path.join(directory, "matrix-transaction-error.jsonl"),
+    });
+    servers.push(server);
+    const roomId = "!later:matrix.test";
+    const transactionUrl = `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent(roomId)}/send/m.room.message/stable-error`;
+
+    const firstAttempt = await fetch(transactionUrl, {
+      body: JSON.stringify({ body: "room does not exist yet", msgtype: "m.text" }),
+      headers: { ...auth(server.manifest.accessToken), "content-type": "application/json" },
+      method: "PUT",
+    });
+    expect(firstAttempt.status).toBe(404);
+    const firstBody = await firstAttempt.json();
+    expect(firstBody).toEqual({
+      errcode: "M_NOT_FOUND",
+      error: "Unknown room",
+    });
+
+    const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({
+        roomId,
+        senderId: "@alice:matrix.test",
+        text: "create the room",
+      }),
+      headers: {
+        "content-type": "application/json",
+        "x-crabline-admin-token": server.manifest.adminToken,
+      },
+      method: "POST",
+    });
+    expect(inbound.status).toBe(200);
+
+    const retry = await fetch(transactionUrl, {
+      body: JSON.stringify({ body: "must not be sent", msgtype: "m.text" }),
+      headers: { ...auth(server.manifest.accessToken), "content-type": "application/json" },
+      method: "PUT",
+    });
+    expect(retry.status).toBe(firstAttempt.status);
+    await expect(retry.json()).resolves.toEqual(firstBody);
+
+    const nextTransaction = await fetch(`${transactionUrl}-next`, {
+      body: JSON.stringify({ body: "new transaction succeeds", msgtype: "m.text" }),
+      headers: { ...auth(server.manifest.accessToken), "content-type": "application/json" },
+      method: "PUT",
+    });
+    expect(nextTransaction.status).toBe(200);
+    await expect(nextTransaction.json()).resolves.toMatchObject({
+      event_id: expect.stringMatching(/^\$/u),
+    });
+  });
+
   it("provisions direct rooms with native Matrix membership evidence", async () => {
     const directory = await createTempDir();
     directories.push(directory);

--- a/test/matrix-server.test.ts
+++ b/test/matrix-server.test.ts
@@ -160,6 +160,42 @@ describe("Matrix local provider server", () => {
 
       const sent = await client.sendTextMessage(dynamicRoomId, "hello from the SDK");
       expect(sent.event_id).toMatch(/^\$/u);
+
+      const firstRetry = await client.sendTextMessage(
+        dynamicRoomId,
+        "idempotent send",
+        "stable-transaction",
+      );
+      const replayClient = createClient({
+        accessToken: server.manifest.accessToken,
+        baseUrl: server.manifest.baseUrl,
+        deviceId: server.manifest.deviceId,
+        userId: server.manifest.botUserId,
+        useAuthorizationHeader: true,
+      });
+      const secondRetry = await replayClient.sendTextMessage(
+        dynamicRoomId,
+        "changed body is ignored on retry",
+        "stable-transaction",
+      );
+      expect(secondRetry.event_id).toBe(firstRetry.event_id);
+
+      const retrySync = await fetch(`${server.manifest.endpoints.syncUrl}?timeout=0`, {
+        headers: auth("matrix-token"),
+      });
+      const retrySyncBody = (await retrySync.json()) as {
+        rooms: {
+          join: Record<
+            string,
+            { timeline: { events: Array<{ content: Record<string, unknown>; event_id: string }> } }
+          >;
+        };
+      };
+      const retryEvents = retrySyncBody.rooms.join[dynamicRoomId]?.timeline.events.filter(
+        (event) => event.event_id === firstRetry.event_id,
+      );
+      expect(retryEvents).toHaveLength(1);
+      expect(retryEvents?.[0]?.content).toMatchObject({ body: "idempotent send" });
     } finally {
       client.stopClient();
     }

--- a/test/matrix-server.test.ts
+++ b/test/matrix-server.test.ts
@@ -37,6 +37,20 @@ describe("Matrix local provider server", () => {
       error: "Invalid access token",
     });
 
+    const invalidJson = await fetch(
+      `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!qa:matrix.test")}/send/m.room.message/invalid-json`,
+      {
+        body: "{",
+        headers: { ...auth("matrix-token"), "content-type": "application/json" },
+        method: "PUT",
+      },
+    );
+    expect(invalidJson.status).toBe(400);
+    await expect(invalidJson.json()).resolves.toEqual({
+      errcode: "M_NOT_JSON",
+      error: "Request body is not valid JSON",
+    });
+
     const whoami = await fetch(`${server.manifest.endpoints.clientApiRoot}/account/whoami`, {
       headers: auth("matrix-token"),
     });

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -105,22 +105,21 @@ const whatsappManifest: CrablineServerManifest = {
   adminToken: "crabline-whatsapp-admin-token",
   baseUrl: "http://127.0.0.1:5678",
   endpoints: {
-    adminInboundUrl: "http://127.0.0.1:5678/crabline/whatsapp/inbound",
-    apiRoot: "http://127.0.0.1:5678/crabline/whatsapp",
-    baileysWebSocketUrl:
-      "ws://127.0.0.1:5678/crabline/whatsapp/ws/chat?access_token=crabline-whatsapp-access-token",
-    messagesUrl: "http://127.0.0.1:5678/crabline/whatsapp/messages",
-    presenceUrl: "http://127.0.0.1:5678/crabline/whatsapp/presence",
+    adminInboundUrl: "http://127.0.0.1:5678/_crabline/admin/whatsapp/inbound",
+    apiRoot: "http://127.0.0.1:5678/v25.0",
+    baileysWebSocketUrl: "ws://127.0.0.1:5678/ws/chat?access_token=crabline-whatsapp-access-token",
+    messagesUrl: "http://127.0.0.1:5678/v25.0/100000000000000/messages",
+    phoneNumberUrl: "http://127.0.0.1:5678/v25.0/100000000000000",
+    statusUrl: "http://127.0.0.1:5678/v25.0/100000000000000/messages",
   },
   env: {
-    CRABLINE_WHATSAPP_ADMIN_TOKEN: "crabline-whatsapp-admin-token",
-    CRABLINE_WHATSAPP_ACCESS_TOKEN: "crabline-whatsapp-access-token",
-    CRABLINE_WHATSAPP_API_ROOT: "http://127.0.0.1:5678/crabline/whatsapp",
-    CRABLINE_WHATSAPP_BAILEYS_WEB_SOCKET_URL:
-      "ws://127.0.0.1:5678/crabline/whatsapp/ws/chat?access_token=crabline-whatsapp-access-token",
-    CRABLINE_WHATSAPP_RECORDER_PATH: "/tmp/crabline/whatsapp.jsonl",
-    CRABLINE_WHATSAPP_SELF_JID: "15550000000@s.whatsapp.net",
+    CLOUD_API_ACCESS_TOKEN: "crabline-whatsapp-access-token",
+    CLOUD_API_VERSION: "v25.0",
+    WA_BASE_URL: "http://127.0.0.1:5678",
+    WA_PHONE_NUMBER_ID: "100000000000000",
   },
+  graphVersion: "v25.0",
+  phoneNumberId: "100000000000000",
   provider: "whatsapp",
   recorderPath: "/tmp/crabline/whatsapp.jsonl",
   selfJid: "15550000000@s.whatsapp.net",
@@ -410,7 +409,7 @@ describe("OpenClaw local provider bridge", () => {
       CRABLINE_WHATSAPP_RECORDER_PATH: "/tmp/crabline/whatsapp.jsonl",
       CRABLINE_WHATSAPP_SELF_JID: "15550000000@s.whatsapp.net",
       OPENCLAW_WHATSAPP_WEB_SOCKET_URL:
-        "ws://127.0.0.1:5678/crabline/whatsapp/ws/chat?access_token=crabline-whatsapp-access-token",
+        "ws://127.0.0.1:5678/ws/chat?access_token=crabline-whatsapp-access-token",
     });
   });
 
@@ -613,7 +612,7 @@ describe("OpenClaw local provider bridge", () => {
         "x-crabline-admin-token": "crabline-whatsapp-admin-token",
       },
       providerTargetKey: "120363001234567890@g.us",
-      providerUrl: "http://127.0.0.1:5678/crabline/whatsapp/inbound",
+      providerUrl: "http://127.0.0.1:5678/_crabline/admin/whatsapp/inbound",
       qaTarget: "group:120363001234567890@g.us",
       stateConversation: {
         id: "120363001234567890@g.us",
@@ -627,9 +626,9 @@ describe("OpenClaw local provider bridge", () => {
         targetByProviderTarget: new Map([["15551234567@s.whatsapp.net", "dm:alice"]]),
         event: {
           type: "api",
-          path: "/crabline/whatsapp/messages",
+          path: "/v25.0/100000000000000/messages",
           body: {
-            to: "15551234567@s.whatsapp.net",
+            to: "15551234567",
             text: { body: "hello from openclaw" },
           },
         },
@@ -981,6 +980,10 @@ describe("OpenClaw local provider bridge", () => {
       if (adapter.manifest.provider !== "whatsapp") {
         throw new Error("Expected WhatsApp local provider manifest.");
       }
+      await expect(probeOpenClawCrablineProvider(adapter.manifest)).resolves.toMatchObject({
+        id: adapter.manifest.phoneNumberId,
+        quality_rating: "GREEN",
+      });
 
       const inbound = adapter.createInbound({
         input: {

--- a/test/slack-server.test.ts
+++ b/test/slack-server.test.ts
@@ -67,6 +67,17 @@ describe("slack local provider server", () => {
       ok: false,
     });
 
+    const invalidJson = await fetch(`${server.manifest.endpoints.apiRoot}chat.postMessage`, {
+      body: "{",
+      headers: {
+        authorization: "Bearer xoxb-fake",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+    expect(invalidJson.status).toBe(400);
+    await expect(invalidJson.json()).resolves.toEqual({ error: "invalid_json", ok: false });
+
     await expect(
       (
         await slackApi(server, "conversations.open", {

--- a/test/slack-server.test.ts
+++ b/test/slack-server.test.ts
@@ -1,7 +1,13 @@
-import path from "node:path";
+import { createHmac } from "node:crypto";
 import fs from "node:fs/promises";
+import { createServer } from "node:http";
+import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { startSlackServer, type StartedSlackServer } from "../src/index.js";
+import {
+  startSlackServer,
+  type StartedSlackServer,
+  type StartSlackServerParams,
+} from "../src/index.js";
 import { createTempDir, disposeTempDir } from "./test-helpers.js";
 
 const servers: StartedSlackServer[] = [];
@@ -12,12 +18,15 @@ afterEach(async () => {
   await Promise.all(directories.splice(0).map(disposeTempDir));
 });
 
-async function startTestSlackServer(): Promise<StartedSlackServer> {
+async function startTestSlackServer(
+  params: StartSlackServerParams = {},
+): Promise<StartedSlackServer> {
   const directory = await createTempDir();
   directories.push(directory);
   const server = await startSlackServer({
-    adminToken: "admin-token",
-    botToken: "xoxb-fake",
+    ...params,
+    adminToken: params.adminToken ?? "admin-token",
+    botToken: params.botToken ?? "xoxb-fake",
     recorderPath: path.join(directory, "slack.jsonl"),
   });
   servers.push(server);
@@ -163,8 +172,44 @@ describe("slack local provider server", () => {
     });
   });
 
-  it("accepts authenticated admin inbound messages", async () => {
-    const server = await startTestSlackServer();
+  it("delivers authenticated admin inbound through signed Slack Events API requests", async () => {
+    type DeliveredEvent = {
+      body: string;
+      signature: string | undefined;
+      timestamp: string | undefined;
+    };
+    let resolveDelivered: (event: DeliveredEvent) => void = () => undefined;
+    const delivered = new Promise<DeliveredEvent>((resolve) => {
+      resolveDelivered = resolve;
+    });
+    const eventsReceiver = createServer(async (request, response) => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of request) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+      resolveDelivered({
+        body: Buffer.concat(chunks).toString("utf8"),
+        signature:
+          typeof request.headers["x-slack-signature"] === "string"
+            ? request.headers["x-slack-signature"]
+            : undefined,
+        timestamp:
+          typeof request.headers["x-slack-request-timestamp"] === "string"
+            ? request.headers["x-slack-request-timestamp"]
+            : undefined,
+      });
+      response.statusCode = 200;
+      response.end();
+    });
+    await new Promise<void>((resolve) => eventsReceiver.listen(0, "127.0.0.1", resolve));
+    const address = eventsReceiver.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Unable to resolve Slack Events API receiver address.");
+    }
+    const server = await startTestSlackServer({
+      eventsRequestUrl: `http://127.0.0.1:${address.port}/slack/events`,
+      signingSecret: "test-signing-secret",
+    });
     const parent = await postMessage(server, {
       channel: "C1234567890",
       text: "hello fake slack",
@@ -182,21 +227,36 @@ describe("slack local provider server", () => {
     });
     expect(rejected.status).toBe(401);
 
-    const accepted = await fetch(server.manifest.endpoints.adminInboundUrl, {
-      body: JSON.stringify({
-        channel: "C1234567890",
-        text: "user nonce-1",
-        threadTs: parent.ts,
-        user: "U1234567890",
-      }),
-      headers: {
-        "content-type": "application/json",
-        "x-crabline-admin-token": "admin-token",
-      },
-      method: "POST",
-    });
-    await expect(accepted.json()).resolves.toMatchObject({
-      event: {
+    try {
+      const accepted = await fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({
+          channel: "C1234567890",
+          text: "user nonce-1",
+          threadTs: parent.ts,
+          user: "U1234567890",
+        }),
+        headers: {
+          "content-type": "application/json",
+          "x-crabline-admin-token": "admin-token",
+        },
+        method: "POST",
+      });
+      await expect(accepted.json()).resolves.toMatchObject({
+        event: {
+          event: {
+            channel: "C1234567890",
+            text: "user nonce-1",
+            thread_ts: parent.ts,
+            user: "U1234567890",
+          },
+          type: "event_callback",
+        },
+        ok: true,
+      });
+
+      const callback = await delivered;
+      const callbackBody = JSON.parse(callback.body) as Record<string, unknown>;
+      expect(callbackBody).toMatchObject({
         event: {
           channel: "C1234567890",
           text: "user nonce-1",
@@ -204,21 +264,30 @@ describe("slack local provider server", () => {
           user: "U1234567890",
         },
         type: "event_callback",
-      },
-      ok: true,
-    });
+      });
+      expect(callback.timestamp).toMatch(/^\d+$/u);
+      expect(callback.signature).toBe(
+        `v0=${createHmac("sha256", "test-signing-secret")
+          .update(`v0:${callback.timestamp}:${callback.body}`)
+          .digest("hex")}`,
+      );
 
-    await expect(
-      (
-        await slackApi(server, "conversations.replies", {
-          channel: "C1234567890",
-          ts: parent.ts,
-        })
-      ).json(),
-    ).resolves.toMatchObject({
-      messages: [{ text: "hello fake slack" }, { text: "user nonce-1" }],
-      ok: true,
-    });
+      await expect(
+        (
+          await slackApi(server, "conversations.replies", {
+            channel: "C1234567890",
+            ts: parent.ts,
+          })
+        ).json(),
+      ).resolves.toMatchObject({
+        messages: [{ text: "hello fake slack" }, { text: "user nonce-1" }],
+        ok: true,
+      });
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        eventsReceiver.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
   });
 
   it("redacts body/query tokens and skips rejected admin inbound recording", async () => {

--- a/test/slack-server.test.ts
+++ b/test/slack-server.test.ts
@@ -175,9 +175,11 @@ describe("slack local provider server", () => {
   it("delivers authenticated admin inbound through signed Slack Events API requests", async () => {
     type DeliveredEvent = {
       body: string;
+      history: Array<{ text?: string }>;
       signature: string | undefined;
       timestamp: string | undefined;
     };
+    let slackServer: StartedSlackServer | undefined;
     let resolveDelivered: (event: DeliveredEvent) => void = () => undefined;
     const delivered = new Promise<DeliveredEvent>((resolve) => {
       resolveDelivered = resolve;
@@ -187,8 +189,20 @@ describe("slack local provider server", () => {
       for await (const chunk of request) {
         chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
       }
+      if (!slackServer) {
+        response.statusCode = 500;
+        response.end("Slack server is not ready.");
+        return;
+      }
+      const historyResponse = await slackApi(slackServer, "conversations.history", {
+        channel: "C1234567890",
+      });
+      const history = (await historyResponse.json()) as {
+        messages?: Array<{ text?: string }>;
+      };
       resolveDelivered({
         body: Buffer.concat(chunks).toString("utf8"),
+        history: history.messages ?? [],
         signature:
           typeof request.headers["x-slack-signature"] === "string"
             ? request.headers["x-slack-signature"]
@@ -206,10 +220,11 @@ describe("slack local provider server", () => {
     if (!address || typeof address === "string") {
       throw new Error("Unable to resolve Slack Events API receiver address.");
     }
-    const server = await startTestSlackServer({
+    slackServer = await startTestSlackServer({
       eventsRequestUrl: `http://127.0.0.1:${address.port}/slack/events`,
       signingSecret: "test-signing-secret",
     });
+    const server = slackServer;
     const parent = await postMessage(server, {
       channel: "C1234567890",
       text: "hello fake slack",
@@ -271,6 +286,11 @@ describe("slack local provider server", () => {
           .update(`v0:${callback.timestamp}:${callback.body}`)
           .digest("hex")}`,
       );
+      expect(callback.history).toContainEqual(
+        expect.objectContaining({
+          text: "user nonce-1",
+        }),
+      );
 
       await expect(
         (
@@ -281,6 +301,57 @@ describe("slack local provider server", () => {
         ).json(),
       ).resolves.toMatchObject({
         messages: [{ text: "hello fake slack" }, { text: "user nonce-1" }],
+        ok: true,
+      });
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        eventsReceiver.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+
+  it("retains inbound message state when Events API delivery is rejected", async () => {
+    const eventsReceiver = createServer((_request, response) => {
+      response.statusCode = 503;
+      response.end();
+    });
+    await new Promise<void>((resolve) => eventsReceiver.listen(0, "127.0.0.1", resolve));
+    const address = eventsReceiver.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Unable to resolve Slack Events API receiver address.");
+    }
+    const server = await startTestSlackServer({
+      eventsRequestUrl: `http://127.0.0.1:${address.port}/slack/events`,
+      signingSecret: "test-signing-secret",
+    });
+
+    try {
+      const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({
+          channel: "C1234567890",
+          text: "retained after callback failure",
+          user: "U1234567890",
+        }),
+        headers: {
+          "content-type": "application/json",
+          "x-crabline-admin-token": "admin-token",
+        },
+        method: "POST",
+      });
+      expect(inbound.status).toBe(502);
+      await expect(inbound.json()).resolves.toEqual({
+        error: "event_delivery_failed",
+        ok: false,
+      });
+
+      await expect(
+        (
+          await slackApi(server, "conversations.history", {
+            channel: "C1234567890",
+          })
+        ).json(),
+      ).resolves.toMatchObject({
+        messages: [{ text: "retained after callback failure" }],
         ok: true,
       });
     } finally {

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -20,6 +20,20 @@ afterEach(async () => {
 });
 
 describe("telegram local provider server", () => {
+  it("advertises valid URLs when bound to IPv6", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const server = await startTelegramServer({
+      host: "::1",
+      recorderPath: path.join(directory, "telegram-ipv6.jsonl"),
+    });
+    servers.push(server);
+
+    expect(new URL(server.manifest.baseUrl).hostname).toBe("[::1]");
+    const getMe = await fetch(`${server.manifest.baseUrl}/bot${server.manifest.botToken}/getMe`);
+    expect(getMe.status).toBe(200);
+  });
+
   it("distinguishes ordinary groups from supergroups", async () => {
     const directory = await createTempDir();
     directories.push(directory);

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -80,6 +80,21 @@ describe("telegram local provider server", () => {
       },
     });
 
+    const invalidJson = await fetch(
+      `${server.manifest.baseUrl}/bot123456:fake-token/sendMessage`,
+      {
+        body: "{",
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      },
+    );
+    expect(invalidJson.status).toBe(400);
+    await expect(invalidJson.json()).resolves.toEqual({
+      description: "Bad Request: can't parse JSON object",
+      error_code: 400,
+      ok: false,
+    });
+
     const sendMessage = await fetch(`${server.manifest.baseUrl}/bot123456:fake-token/sendMessage`, {
       body: JSON.stringify({
         chat_id: "-1001234567890",

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -80,14 +80,11 @@ describe("telegram local provider server", () => {
       },
     });
 
-    const invalidJson = await fetch(
-      `${server.manifest.baseUrl}/bot123456:fake-token/sendMessage`,
-      {
-        body: "{",
-        headers: { "content-type": "application/json" },
-        method: "POST",
-      },
-    );
+    const invalidJson = await fetch(`${server.manifest.baseUrl}/bot123456:fake-token/sendMessage`, {
+      body: "{",
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
     expect(invalidJson.status).toBe(400);
     await expect(invalidJson.json()).resolves.toEqual({
       description: "Bad Request: can't parse JSON object",

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -129,7 +129,7 @@ afterEach(async () => {
 });
 
 describe("whatsapp local provider server", () => {
-  it("serves Graph-style sends and injected inbound webhook payloads", async () => {
+  it("serves Cloud API sends and injected inbound webhook payloads", async () => {
     const directory = await createTempDir();
     directories.push(directory);
     const server = await startWhatsAppServer({
@@ -142,14 +142,18 @@ describe("whatsapp local provider server", () => {
     const baileysWebSocketUrl = new URL(server.manifest.endpoints.baileysWebSocketUrl);
     expect(baileysWebSocketUrl).toMatchObject({
       hostname: "127.0.0.1",
-      pathname: "/crabline/whatsapp/ws/chat",
+      pathname: "/ws/chat",
       protocol: "ws:",
     });
     expect(baileysWebSocketUrl.searchParams.get("access_token")).toBe("fake-whatsapp-token");
-    const health = await fetch(`${server.manifest.endpoints.apiRoot}/health`);
-    await expect(health.json()).resolves.toMatchObject({
-      ok: true,
-      selfJid: "15550000000@s.whatsapp.net",
+    expect(server.manifest.endpoints.messagesUrl).toMatch(/\/v25\.0\/100000000000000\/messages$/u);
+    const phoneNumber = await fetch(server.manifest.endpoints.phoneNumberUrl, {
+      headers: { authorization: "Bearer fake-whatsapp-token" },
+    });
+    await expect(phoneNumber.json()).resolves.toMatchObject({
+      display_phone_number: "15550000000",
+      id: "100000000000000",
+      quality_rating: "GREEN",
     });
 
     const unauthenticated = await fetch(server.manifest.endpoints.messagesUrl, {
@@ -167,14 +171,13 @@ describe("whatsapp local provider server", () => {
         message: "Invalid OAuth access token.",
         type: "OAuthException",
       },
-      ok: false,
     });
 
     const sent = await fetch(server.manifest.endpoints.messagesUrl, {
       body: JSON.stringify({
         messaging_product: "whatsapp",
         text: { body: "hello fake whatsapp" },
-        to: "15551234567@s.whatsapp.net",
+        to: "15551234567",
         type: "text",
       }),
       headers: {
@@ -184,27 +187,16 @@ describe("whatsapp local provider server", () => {
       method: "POST",
     });
     await expect(sent.json()).resolves.toMatchObject({
-      contacts: [{ input: "15551234567@s.whatsapp.net", wa_id: "15551234567" }],
-      key: {
-        fromMe: true,
-        remoteJid: "15551234567@s.whatsapp.net",
-      },
-      message: {
-        message: {
-          conversation: "hello fake whatsapp",
-        },
-      },
+      contacts: [{ input: "15551234567", wa_id: "15551234567" }],
       messages: [{ id: expect.stringMatching(/^wamid\.FAKE/u) }],
       messaging_product: "whatsapp",
-      ok: true,
-      toJid: "15551234567@s.whatsapp.net",
     });
 
     const invalidProduct = await fetch(server.manifest.endpoints.messagesUrl, {
       body: JSON.stringify({
         messaging_product: "messenger",
         text: { body: "hello fake whatsapp" },
-        to: "15551234567@s.whatsapp.net",
+        to: "15551234567",
         type: "text",
       }),
       headers: {
@@ -222,12 +214,13 @@ describe("whatsapp local provider server", () => {
         },
         type: "OAuthException",
       },
-      ok: false,
     });
 
-    const presence = await fetch(server.manifest.endpoints.presenceUrl, {
+    const status = await fetch(server.manifest.endpoints.statusUrl, {
       body: JSON.stringify({
-        presence: "paused",
+        message_id: "wamid.FAKE00000001",
+        messaging_product: "whatsapp",
+        status: "read",
       }),
       headers: {
         authorization: "Bearer fake-whatsapp-token",
@@ -235,10 +228,7 @@ describe("whatsapp local provider server", () => {
       },
       method: "POST",
     });
-    await expect(presence.json()).resolves.toMatchObject({
-      ok: true,
-      presence: "paused",
-    });
+    await expect(status.json()).resolves.toEqual({ success: true });
 
     const unauthenticatedInbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
       body: JSON.stringify({
@@ -304,7 +294,7 @@ describe("whatsapp local provider server", () => {
     });
     const recorder = await fs.readFile(server.manifest.recorderPath, "utf8");
     expect(recorder).not.toContain("forged user nonce");
-    expect(recorder).toContain('"path":"/crabline/whatsapp/inbound"');
+    expect(recorder).toContain('"path":"/_crabline/admin/whatsapp/inbound"');
   });
 
   it("does not accept admin inbound messages when recorder append fails", async () => {
@@ -362,6 +352,28 @@ describe("whatsapp local provider server", () => {
       selfJid: "15550000001:0@s.whatsapp.net",
     });
     servers.push(server);
+    const queuedInbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({
+        chatJid: "120363001234567890@g.us",
+        pushName: "Fake Sender",
+        senderJid: "15551234567@s.whatsapp.net",
+        text: "hello from queued admin inbound",
+      }),
+      headers: {
+        "content-type": "application/json",
+        "x-crabline-admin-token": server.manifest.adminToken,
+      },
+      method: "POST",
+    });
+    await expect(queuedInbound.json()).resolves.toMatchObject({
+      delivery: "queued",
+      message: {
+        message: {
+          conversation: "hello from queued admin inbound",
+        },
+      },
+      ok: true,
+    });
     const creds: AuthenticationCreds = {
       ...initAuthCreds(),
       me: {
@@ -422,34 +434,6 @@ describe("whatsapp local provider server", () => {
       expect(recorder).toContain('"tag":"message"');
       expect(recorder).toContain('"to":"15551234567@s.whatsapp.net"');
 
-      const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
-        body: JSON.stringify({
-          chatJid: "120363001234567890@g.us",
-          pushName: "Fake Sender",
-          senderJid: "15551234567@s.whatsapp.net",
-          text: "hello from admin inbound",
-        }),
-        headers: {
-          "content-type": "application/json",
-          "x-crabline-admin-token": server.manifest.adminToken,
-        },
-        method: "POST",
-      });
-      await expect(inbound.json()).resolves.toMatchObject({
-        message: {
-          key: {
-            fromMe: false,
-            participant: "15551234567@s.whatsapp.net",
-            remoteJid: "120363001234567890@g.us",
-          },
-          message: {
-            conversation: "hello from admin inbound",
-          },
-          pushName: "Fake Sender",
-        },
-        ok: true,
-      });
-
       await waitForCondition(
         () =>
           messageUpserts
@@ -458,26 +442,26 @@ describe("whatsapp local provider server", () => {
               (message) =>
                 message.key?.remoteJid === "120363001234567890@g.us" &&
                 message.key.participant === "15551234567@s.whatsapp.net" &&
-                message.message?.conversation === "hello from admin inbound",
+                message.message?.conversation === "hello from queued admin inbound",
             ),
-        "Baileys inbound messages.upsert",
+        "queued Baileys inbound messages.upsert",
       );
-      expect(
-        messageUpserts
-          .flatMap((event) => event.messages)
-          .find(
-            (message) =>
-              message.key?.remoteJid === "120363001234567890@g.us" &&
-              message.message?.conversation === "hello from admin inbound",
-          ),
-      ).toMatchObject({
+      const queuedMessages = messageUpserts
+        .flatMap((event) => event.messages)
+        .filter(
+          (message) =>
+            message.key?.remoteJid === "120363001234567890@g.us" &&
+            message.message?.conversation === "hello from queued admin inbound",
+        );
+      expect(queuedMessages).toHaveLength(1);
+      expect(queuedMessages[0]).toMatchObject({
         key: {
           fromMe: false,
           participant: "15551234567@s.whatsapp.net",
           remoteJid: "120363001234567890@g.us",
         },
         message: {
-          conversation: "hello from admin inbound",
+          conversation: "hello from queued admin inbound",
         },
         pushName: "Fake Sender",
       });

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -82,6 +82,33 @@ function createMemorySignalStore(): MemorySignalStore {
   };
 }
 
+function createBaileysTestSocket(server: StartedWhatsAppServer) {
+  const creds: AuthenticationCreds = {
+    ...initAuthCreds(),
+    me: {
+      id: "15550000001:0@s.whatsapp.net",
+      name: "Crabline Test Bot",
+    },
+  };
+  return makeWASocket({
+    auth: {
+      creds,
+      keys: makeCacheableSignalKeyStore(createMemorySignalStore(), silentLogger),
+    },
+    browser: ["crabline", "test", "1.0"],
+    connectTimeoutMs: 2_000,
+    defaultQueryTimeoutMs: 750,
+    fireInitQueries: false,
+    keepAliveIntervalMs: 10_000,
+    logger: silentLogger,
+    markOnlineOnConnect: false,
+    printQRInTerminal: false,
+    syncFullHistory: false,
+    waWebSocketUrl: server.manifest.endpoints.baileysWebSocketUrl,
+    version: [2, 3000, 1035194821],
+  });
+}
+
 async function waitForCondition(
   predicate: () => boolean | Promise<boolean>,
   label: string,
@@ -215,6 +242,30 @@ describe("whatsapp local provider server", () => {
         type: "OAuthException",
       },
     });
+
+    for (const scalarBody of ["null", '"scalar"', "42", "true", "[]"]) {
+      const invalidBody = await fetch(server.manifest.endpoints.messagesUrl, {
+        body: scalarBody,
+        headers: {
+          authorization: "Bearer fake-whatsapp-token",
+          "content-type": "application/json",
+        },
+        method: "POST",
+      });
+      expect(invalidBody.status).toBe(400);
+      await expect(invalidBody.json()).resolves.toEqual({
+        error: {
+          code: 100,
+          error_data: {
+            details: "The request body must be a JSON object.",
+            messaging_product: "whatsapp",
+          },
+          fbtrace_id: "A1B2C3D4E5F",
+          message: "(#100) Invalid parameter: request body",
+          type: "OAuthException",
+        },
+      });
+    }
 
     const status = await fetch(server.manifest.endpoints.statusUrl, {
       body: JSON.stringify({
@@ -374,30 +425,7 @@ describe("whatsapp local provider server", () => {
       },
       ok: true,
     });
-    const creds: AuthenticationCreds = {
-      ...initAuthCreds(),
-      me: {
-        id: "15550000001:0@s.whatsapp.net",
-        name: "Crabline Test Bot",
-      },
-    };
-    const socket = makeWASocket({
-      auth: {
-        creds,
-        keys: makeCacheableSignalKeyStore(createMemorySignalStore(), silentLogger),
-      },
-      browser: ["crabline", "test", "1.0"],
-      connectTimeoutMs: 2_000,
-      defaultQueryTimeoutMs: 750,
-      fireInitQueries: false,
-      keepAliveIntervalMs: 10_000,
-      logger: silentLogger,
-      markOnlineOnConnect: false,
-      printQRInTerminal: false,
-      syncFullHistory: false,
-      waWebSocketUrl: server.manifest.endpoints.baileysWebSocketUrl,
-      version: [2, 3000, 1035194821],
-    });
+    const socket = createBaileysTestSocket(server);
     const connectionUpdates: unknown[] = [];
     socket.ev.on("connection.update", (update) => {
       connectionUpdates.push(update);
@@ -467,6 +495,93 @@ describe("whatsapp local provider server", () => {
       });
     } finally {
       socket.end(undefined);
+    }
+  });
+
+  it("fans admin inbound messages out to every open Baileys session", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const server = await startWhatsAppServer({
+      recorderPath: path.join(directory, "whatsapp-multi-session.jsonl"),
+      selfJid: "15550000001:0@s.whatsapp.net",
+    });
+    servers.push(server);
+    const sockets = [createBaileysTestSocket(server), createBaileysTestSocket(server)];
+    const connectionUpdates: unknown[][] = sockets.map(() => []);
+    const messageUpserts: BaileysMessagesUpsertEvent[][] = sockets.map(() => []);
+    sockets.forEach((socket, index) => {
+      socket.ev.on("connection.update", (update) => {
+        connectionUpdates[index]?.push(update);
+      });
+      socket.ev.on("messages.upsert", (event) => {
+        messageUpserts[index]?.push(event);
+      });
+    });
+
+    try {
+      await Promise.all(
+        connectionUpdates.map((updates, index) =>
+          waitForCondition(
+            () =>
+              updates.some(
+                (update) =>
+                  !!update &&
+                  typeof update === "object" &&
+                  (update as { connection?: unknown }).connection === "open",
+              ),
+            `Baileys connection ${index + 1} open`,
+          ),
+        ),
+      );
+
+      const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({
+          chatJid: "120363001234567890@g.us",
+          pushName: "Fake Sender",
+          senderJid: "15551234567@s.whatsapp.net",
+          text: "hello to every Baileys session",
+        }),
+        headers: {
+          "content-type": "application/json",
+          "x-crabline-admin-token": server.manifest.adminToken,
+        },
+        method: "POST",
+      });
+      await expect(inbound.json()).resolves.toMatchObject({
+        delivery: "delivered",
+        ok: true,
+      });
+
+      await Promise.all(
+        messageUpserts.map((upserts, index) =>
+          waitForCondition(
+            () =>
+              upserts
+                .flatMap((event) => event.messages)
+                .some(
+                  (message) =>
+                    message.key?.remoteJid === "120363001234567890@g.us" &&
+                    message.message?.conversation === "hello to every Baileys session",
+                ),
+            `Baileys session ${index + 1} inbound messages.upsert`,
+          ),
+        ),
+      );
+      for (const upserts of messageUpserts) {
+        expect(
+          upserts
+            .flatMap((event) => event.messages)
+            .filter(
+              (message) =>
+                message.key?.remoteJid === "120363001234567890@g.us" &&
+                message.message?.conversation === "hello to every Baileys session",
+            ),
+        ).toHaveLength(1);
+      }
+    } finally {
+      for (const socket of sockets) {
+        socket.end(undefined);
+      }
     }
   });
 });

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -267,6 +267,28 @@ describe("whatsapp local provider server", () => {
       });
     }
 
+    const malformedBody = await fetch(server.manifest.endpoints.messagesUrl, {
+      body: "{",
+      headers: {
+        authorization: "Bearer fake-whatsapp-token",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+    expect(malformedBody.status).toBe(400);
+    await expect(malformedBody.json()).resolves.toEqual({
+      error: {
+        code: 100,
+        error_data: {
+          details: "The request body must be valid JSON.",
+          messaging_product: "whatsapp",
+        },
+        fbtrace_id: "A1B2C3D4E5F",
+        message: "(#100) Invalid parameter: request body",
+        type: "OAuthException",
+      },
+    });
+
     const status = await fetch(server.manifest.endpoints.statusUrl, {
       body: JSON.stringify({
         message_id: "wamid.FAKE00000001",

--- a/test/whatsapp-wire.test.ts
+++ b/test/whatsapp-wire.test.ts
@@ -1,0 +1,37 @@
+import { deflateSync } from "node:zlib";
+import { describe, expect, it } from "vitest";
+import {
+  decodeBinaryNode,
+  encodeBinaryNode,
+  WHATSAPP_BINARY_NODE_MAX_DECOMPRESSED_BYTES,
+  type BinaryNode,
+} from "../src/servers/whatsapp-wire/binary-node.js";
+
+describe("WhatsApp binary nodes", () => {
+  it("rejects BINARY_32 lengths that exceed the remaining frame", async () => {
+    const malformed = Buffer.from([0, 248, 2, 252, 1, "x".charCodeAt(0), 254, 0x80, 0, 0, 0]);
+
+    await expect(decodeBinaryNode(malformed)).rejects.toThrow(
+      "Unexpected end of WhatsApp binary node.",
+    );
+  });
+
+  it("rejects compressed nodes that expand past the frame limit", async () => {
+    const compressed = deflateSync(Buffer.alloc(WHATSAPP_BINARY_NODE_MAX_DECOMPRESSED_BYTES + 1));
+
+    await expect(decodeBinaryNode(Buffer.concat([Buffer.from([2]), compressed]))).rejects.toThrow(
+      "WhatsApp binary node expands beyond",
+    );
+  });
+
+  it("rejects child lists that cannot be represented by LIST_16", () => {
+    const child: BinaryNode = { attrs: {}, tag: "child" };
+    const node: BinaryNode = {
+      attrs: {},
+      content: Array<BinaryNode>(0x10000).fill(child),
+      tag: "root",
+    };
+
+    expect(() => encodeBinaryNode(node)).toThrow("WhatsApp binary node list is too large: 65536.");
+  });
+});

--- a/test/zalo-server.test.ts
+++ b/test/zalo-server.test.ts
@@ -171,6 +171,54 @@ describe("Zalo local provider server", () => {
     }
   });
 
+  it("bounds webhook delivery time for admin ingress", async () => {
+    const webhook = createServer(() => undefined);
+    await new Promise<void>((resolve) => webhook.listen(0, "127.0.0.1", resolve));
+    const address = webhook.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Unable to resolve webhook test server address.");
+    }
+
+    const directory = await createTempDir();
+    directories.push(directory);
+    const server = await startZaloServer({
+      botToken: "zalo-token",
+      recorderPath: path.join(directory, "zalo-webhook-timeout.jsonl"),
+      webhookDeliveryTimeoutMs: 25,
+    });
+    servers.push(server);
+    try {
+      const setWebhook = await fetch(`${server.manifest.baseUrl}/botzalo-token/setWebhook`, {
+        body: JSON.stringify({
+          secret_token: "webhook-secret",
+          url: `http://127.0.0.1:${address.port}/zalo`,
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      expect(setWebhook.ok).toBe(true);
+
+      const startedAt = Date.now();
+      const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({ chatId: "chat-1", senderId: "user-1", text: "hello" }),
+        headers: adminHeaders(server),
+        method: "POST",
+      });
+      expect(Date.now() - startedAt).toBeLessThan(500);
+      expect(inbound.status).toBe(502);
+      await expect(inbound.json()).resolves.toMatchObject({
+        description: "Webhook delivery timed out after 25ms",
+        error_code: 502,
+        ok: false,
+      });
+    } finally {
+      webhook.closeAllConnections();
+      await new Promise<void>((resolve, reject) =>
+        webhook.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+
   it("rejects invalid bot tokens and unauthenticated admin ingress", async () => {
     const server = await startZaloServer({ botToken: "zalo-token" });
     servers.push(server);

--- a/test/zalo-server.test.ts
+++ b/test/zalo-server.test.ts
@@ -41,6 +41,18 @@ describe("Zalo local provider server", () => {
       },
     });
 
+    const invalidJson = await fetch(`${server.manifest.baseUrl}/botzalo-token/sendMessage`, {
+      body: "{",
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    expect(invalidJson.status).toBe(400);
+    await expect(invalidJson.json()).resolves.toEqual({
+      description: "Bad Request: can't parse JSON object",
+      error_code: 400,
+      ok: false,
+    });
+
     const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
       body: JSON.stringify({
         chatId: "group-1",


### PR DESCRIPTION
## Summary

- return provider-native JSON errors, preserve Matrix transaction idempotency, and harden Telegram, Slack, and Zalo transport behavior
- serve WhatsApp Cloud API on native Graph routes, queue Baileys inbound delivery, and bound binary decoding
- align the OpenClaw WhatsApp bridge plus setup documentation and changelog entries

## Verification

- Crabbox `corepack pnpm verify`: 40 files, 231 tests passed
- autoreview: `gpt-5.6-sol` high, clean, confidence 0.91