### PR TITLE
fix(openclaw): harden provider bridge validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix provider normalization for loopback pagination and thread codecs, Telegram edited channel posts, Feishu and Matrix thread roots, and complete WhatsApp webhook batches.
 - Harden provider server fidelity with idempotent Matrix send transactions, valid Telegram IPv6 URLs, provider-native malformed JSON errors, signed Slack Events API delivery, and bounded Zalo webhook delivery.
 - Serve WhatsApp Cloud API requests on provider-native Graph routes, queue acknowledged Baileys inbound messages until a session opens, and bound binary frame decoding.
+- Harden OpenClaw bridges for provider-level probe failures, whitespace-preserving message capture, stable symbolic Telegram IDs, and unsupported thread targets.
 
 ## 0.1.9 - 2026-07-03
 

--- a/src/openclaw/bridges/matrix.ts
+++ b/src/openclaw/bridges/matrix.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_ACCOUNT_ID,
   isRecord,
   qaTargetForInbound,
+  readNonBlankString,
   readString,
 } from "../shared.js";
 
@@ -130,7 +131,7 @@ export const MATRIX_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablinePr
         if (eventType !== "m.room.message") {
           return null;
         }
-        const text = readString(event.body.body);
+        const text = readNonBlankString(event.body.body);
         if (!text) {
           return null;
         }

--- a/src/openclaw/bridges/mattermost.ts
+++ b/src/openclaw/bridges/mattermost.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_ACCOUNT_ID,
   isRecord,
   qaTargetForInbound,
+  readNonBlankString,
   readString,
 } from "../shared.js";
 import { mattermostId } from "../../servers/mattermost.js";
@@ -112,7 +113,7 @@ export const MATTERMOST_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabli
         }
         const channelId = readString(event.body.channel_id);
         const rootId = readString(event.body.root_id);
-        const text = readString(event.body.message);
+        const text = readNonBlankString(event.body.message);
         if (!channelId || !text) {
           return null;
         }

--- a/src/openclaw/bridges/signal.ts
+++ b/src/openclaw/bridges/signal.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_ACCOUNT_ID,
   isRecord,
   qaTargetForInbound,
+  readNonBlankString,
   readString,
 } from "../shared.js";
 
@@ -67,10 +68,16 @@ export const SIGNAL_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablinePr
         };
       },
       createAgentDelivery(parsed) {
+        if (parsed.threadId !== undefined) {
+          throw new Error("Signal does not support thread targets.");
+        }
         const to = signalTarget(parsed.kind, parsed.id);
         return { channel: "signal", replyChannel: "signal", replyTo: to, to };
       },
       createInbound(input) {
+        if (input.threadId !== undefined) {
+          throw new Error("Signal does not support thread targets.");
+        }
         const kind = input.conversation.kind === "direct" ? "direct" : "group";
         const conversationId = input.conversation.id.trim();
         const senderId = input.senderId.trim();
@@ -102,7 +109,7 @@ export const SIGNAL_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablinePr
         ) {
           return null;
         }
-        const text = readString(event.body.params.message);
+        const text = readNonBlankString(event.body.params.message);
         const groupId = readString(event.body.params.groupId);
         const recipients = event.body.params.recipient;
         const recipient = Array.isArray(recipients) ? readString(recipients[0]) : undefined;

--- a/src/openclaw/bridges/slack.ts
+++ b/src/openclaw/bridges/slack.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_ACCOUNT_ID,
   isRecord,
   qaTargetForInbound,
+  readNonBlankString,
   readString,
 } from "../shared.js";
 import {
@@ -61,7 +62,12 @@ export const SLACK_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablinePro
         if (!response.ok) {
           throw new Error(`Crabline Slack auth.test probe failed with HTTP ${response.status}.`);
         }
-        return await response.json();
+        const result: unknown = await response.json();
+        if (!isRecord(result) || result.ok !== true) {
+          const error = isRecord(result) ? readString(result.error) : undefined;
+          throw new Error(`Crabline Slack auth.test probe failed: ${error ?? "unknown_error"}.`);
+        }
+        return result;
       },
       createBinding() {
         return {
@@ -147,10 +153,7 @@ export const SLACK_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablinePro
           return null;
         }
         const channel = readString(event.body.channel);
-        const text =
-          typeof event.body.text === "string" && event.body.text.trim()
-            ? event.body.text
-            : undefined;
+        const text = readNonBlankString(event.body.text);
         if (!channel || !text) {
           return null;
         }

--- a/src/openclaw/bridges/telegram.ts
+++ b/src/openclaw/bridges/telegram.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import {
   createAdminInboundRequest,
   createOpenClawCrablineProviderBridge,
@@ -5,21 +6,28 @@ import {
   isRecord,
   qaTargetForInbound,
   readInteger,
+  readNonBlankString,
   readString,
 } from "../shared.js";
 
-const TELEGRAM_DIRECT_CHAT_ID = "100001";
-const TELEGRAM_GROUP_CHAT_ID = "-1001234567890";
-const TELEGRAM_DEFAULT_SENDER_ID = 100001;
+const TELEGRAM_SYMBOLIC_CHAT_ID_BASE = 1n << 51n;
+const TELEGRAM_SYMBOLIC_CHAT_ID_MASK = TELEGRAM_SYMBOLIC_CHAT_ID_BASE - 1n;
 const TELEGRAM_OUTBOUND_METHOD_RE =
   /\/(sendAnimation|sendDocument|sendMessage|sendPhoto|sendVideo)$/u;
 
-function normalizeTelegramChatId(kind: "direct" | "group", id: string) {
-  return /^-?\d+$/u.test(id.trim())
-    ? id.trim()
-    : kind === "group"
-      ? TELEGRAM_GROUP_CHAT_ID
-      : TELEGRAM_DIRECT_CHAT_ID;
+function normalizeTelegramChatId(kind: "direct" | "group", id: string): string {
+  const value = id.trim();
+  if (!value) {
+    throw new Error("Telegram target is required.");
+  }
+  if (/^-?\d+$/u.test(value)) {
+    return value;
+  }
+  const hash =
+    createHash("sha256").update(`${kind}:${value}`).digest().readBigUInt64BE() &
+    TELEGRAM_SYMBOLIC_CHAT_ID_MASK;
+  const numericId = TELEGRAM_SYMBOLIC_CHAT_ID_BASE + hash;
+  return String(kind === "group" ? -numericId : numericId);
 }
 
 function telegramTargetKey(chatId: string, threadId?: number) {
@@ -107,7 +115,7 @@ export const TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
           ...createAdminInboundRequest(telegram),
           providerBody: {
             chatId,
-            fromId: readInteger(input.senderId) ?? TELEGRAM_DEFAULT_SENDER_ID,
+            fromId: Number(normalizeTelegramChatId("direct", input.senderId)),
             fromName: input.senderName ?? input.senderId,
             ...(threadId !== undefined ? { messageThreadId: threadId } : {}),
             ...(input.nativeCommand
@@ -142,9 +150,9 @@ export const TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
         }
         const chatId = readString(event.body.chat_id);
         const text =
-          method === "sendMessage" && typeof event.body.text === "string" && event.body.text.trim()
-            ? event.body.text
-            : readString(event.body.caption);
+          method === "sendMessage"
+            ? readNonBlankString(event.body.text)
+            : readNonBlankString(event.body.caption);
         if (!chatId || !text) {
           return null;
         }

--- a/src/openclaw/bridges/telegram.ts
+++ b/src/openclaw/bridges/telegram.ts
@@ -10,8 +10,10 @@ import {
   readString,
 } from "../shared.js";
 
-const TELEGRAM_SYMBOLIC_CHAT_ID_BASE = 1n << 51n;
-const TELEGRAM_SYMBOLIC_CHAT_ID_MASK = TELEGRAM_SYMBOLIC_CHAT_ID_BASE - 1n;
+const TELEGRAM_SYMBOLIC_DIRECT_ID_BASE = 1n << 51n;
+const TELEGRAM_SYMBOLIC_DIRECT_ID_MASK = TELEGRAM_SYMBOLIC_DIRECT_ID_BASE - 1n;
+const TELEGRAM_SYMBOLIC_GROUP_ID_BASE = 1_000_000_000_000n;
+const TELEGRAM_SYMBOLIC_GROUP_ID_RANGE = 10_000_000_000n;
 const TELEGRAM_OUTBOUND_METHOD_RE =
   /\/(sendAnimation|sendDocument|sendMessage|sendPhoto|sendVideo)$/u;
 
@@ -23,11 +25,11 @@ function normalizeTelegramChatId(kind: "direct" | "group", id: string): string {
   if (/^-?\d+$/u.test(value)) {
     return value;
   }
-  const hash =
-    createHash("sha256").update(`${kind}:${value}`).digest().readBigUInt64BE() &
-    TELEGRAM_SYMBOLIC_CHAT_ID_MASK;
-  const numericId = TELEGRAM_SYMBOLIC_CHAT_ID_BASE + hash;
-  return String(kind === "group" ? -numericId : numericId);
+  const hash = createHash("sha256").update(`${kind}:${value}`).digest().readBigUInt64BE();
+  if (kind === "group") {
+    return String(-(TELEGRAM_SYMBOLIC_GROUP_ID_BASE + (hash % TELEGRAM_SYMBOLIC_GROUP_ID_RANGE)));
+  }
+  return String(TELEGRAM_SYMBOLIC_DIRECT_ID_BASE + (hash & TELEGRAM_SYMBOLIC_DIRECT_ID_MASK));
 }
 
 function telegramTargetKey(chatId: string, threadId?: number) {

--- a/src/openclaw/bridges/whatsapp.ts
+++ b/src/openclaw/bridges/whatsapp.ts
@@ -118,11 +118,9 @@ export const WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
         if (event.path !== messagesPath || !isRecord(event.body)) {
           return null;
         }
-        const to = readString(event.body.to ?? event.body.jid);
+        const to = readString(event.body.to);
         const textPayload = event.body.text;
-        const text = isRecord(textPayload)
-          ? readNonBlankString(textPayload.body)
-          : readNonBlankString(textPayload);
+        const text = isRecord(textPayload) ? readNonBlankString(textPayload.body) : undefined;
         if (!to || !text) {
           return null;
         }

--- a/src/openclaw/bridges/whatsapp.ts
+++ b/src/openclaw/bridges/whatsapp.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_ACCOUNT_ID,
   isRecord,
   qaTargetForInbound,
+  readNonBlankString,
   readString,
 } from "../shared.js";
 
@@ -16,10 +17,6 @@ function requireWhatsAppJid(value: string, label: string): string {
     throw new Error(`${label} must be a native WhatsApp JID.`);
   }
   return trimmed;
-}
-
-function readMessageText(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value : undefined;
 }
 
 export const WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablineProviderBridge({
@@ -81,6 +78,9 @@ export const WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
         };
       },
       createAgentDelivery(parsed) {
+        if (parsed.threadId !== undefined) {
+          throw new Error("WhatsApp does not support thread targets.");
+        }
         const to = requireWhatsAppJid(parsed.id, "WhatsApp target");
         return {
           channel: "whatsapp",
@@ -90,6 +90,9 @@ export const WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
         };
       },
       createInbound(input) {
+        if (input.threadId !== undefined) {
+          throw new Error("WhatsApp does not support thread targets.");
+        }
         const chatJid = requireWhatsAppJid(input.conversation.id, "WhatsApp conversation");
         const senderJid = requireWhatsAppJid(input.senderId, "WhatsApp sender");
         return {
@@ -115,9 +118,11 @@ export const WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
         if (event.path !== messagesPath || !isRecord(event.body)) {
           return null;
         }
-        const to = readString(event.body.to);
+        const to = readString(event.body.to ?? event.body.jid);
         const textPayload = event.body.text;
-        const text = isRecord(textPayload) ? readMessageText(textPayload.body) : undefined;
+        const text = isRecord(textPayload)
+          ? readNonBlankString(textPayload.body)
+          : readNonBlankString(textPayload);
         if (!to || !text) {
           return null;
         }

--- a/src/openclaw/bridges/zalo.ts
+++ b/src/openclaw/bridges/zalo.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_ACCOUNT_ID,
   isRecord,
   qaTargetForInbound,
+  readNonBlankString,
   readString,
 } from "../shared.js";
 
@@ -95,8 +96,8 @@ export const ZALO_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablineProv
         const chatId = readString(event.body.chat_id);
         const text =
           event.path === "/bot<redacted>/sendMessage"
-            ? readString(event.body.text)
-            : readString(event.body.caption);
+            ? readNonBlankString(event.body.text)
+            : readNonBlankString(event.body.caption);
         if (!chatId || !text) {
           return null;
         }

--- a/src/openclaw/shared.ts
+++ b/src/openclaw/shared.ts
@@ -131,15 +131,27 @@ export function createOpenClawCrablineProviderBridge<
   provider: TProvider;
 }): OpenClawCrablineProviderBridge<Extract<CrablineServerManifest, { provider: TProvider }>> {
   type ProviderManifest = Extract<CrablineServerManifest, { provider: TProvider }>;
+  const createAdapter = (manifest: ProviderManifest): OpenClawCrablineProviderAdapter => {
+    const adapter = params.createAdapter(manifest);
+    return {
+      ...adapter,
+      createInbound(input) {
+        if (!readNonBlankString(input.text)) {
+          throw new Error("OpenClaw Crabline inbound message text is required.");
+        }
+        return adapter.createInbound(input);
+      },
+    };
+  };
   const bridge: OpenClawCrablineProviderBridge<ProviderManifest> = {
-    createAdapter: params.createAdapter,
+    createAdapter,
     createAdapterFromManifest(manifest) {
       if (manifest.provider !== params.provider) {
         throw new Error(
           `Unsupported OpenClaw provider binding: expected ${params.provider}, got ${manifest.provider}.`,
         );
       }
-      return params.createAdapter(manifest as ProviderManifest);
+      return createAdapter(manifest as ProviderManifest);
     },
     provider: params.provider as ProviderManifest["provider"],
   };
@@ -154,6 +166,10 @@ export function readString(value: unknown): string | undefined {
     return String(value);
   }
   return undefined;
+}
+
+export function readNonBlankString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
 }
 
 export function isRecord(value: unknown): value is Record<string, unknown> {

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -736,6 +736,22 @@ describe("OpenClaw local provider bridge", () => {
       text: "hello from openclaw",
       to: "dm:alice",
     });
+    for (const body of [
+      { jid: "15551234567@s.whatsapp.net", text: "rejected legacy shape" },
+      { text: "rejected flat text", to: "15551234567" },
+    ]) {
+      expect(
+        createOpenClawCrablineOutboundFromRecorderEvent({
+          manifest: whatsappManifest,
+          targetByProviderTarget: new Map(),
+          event: {
+            type: "api",
+            path: "/v25.0/100000000000000/messages",
+            body,
+          },
+        }),
+      ).toBeNull();
+    }
   });
 
   it("maps Slack QA targets, inbound messages, and recorder events", () => {

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -529,9 +529,18 @@ describe("OpenClaw local provider bridge", () => {
     expect(createOpenClawCrablineAgentDelivery({ manifest, target: "dm:bob" }).to).not.toBe(
       symbolicDelivery.to,
     );
-    expect(createOpenClawCrablineAgentDelivery({ manifest, target: "group:alice" }).to).toMatch(
-      /^-\d+$/u,
-    );
+    const symbolicGroupDelivery = createOpenClawCrablineAgentDelivery({
+      manifest,
+      target: "group:alice",
+    });
+    expect(symbolicGroupDelivery.to).toMatch(/^-100\d+$/u);
+    expect(Number.isSafeInteger(Number(symbolicGroupDelivery.to))).toBe(true);
+    expect(
+      createOpenClawCrablineAgentDelivery({
+        manifest,
+        target: "thread:alice/42",
+      }).to,
+    ).toBe(`${symbolicGroupDelivery.to}:topic:42`);
     expect(createOpenClawCrablineAgentDelivery({ manifest, target: "dm:42424242" }).to).toBe(
       "42424242",
     );
@@ -565,6 +574,21 @@ describe("OpenClaw local provider bridge", () => {
         id: symbolicDelivery.to,
         kind: "direct",
       },
+    });
+
+    expect(
+      createOpenClawCrablineInbound({
+        manifest,
+        input: {
+          conversation: { id: "alice", kind: "group" },
+          senderId: "alice",
+          text: "topic message",
+          threadId: "42",
+        },
+      }).providerBody,
+    ).toMatchObject({
+      chatId: expect.stringMatching(/^-100\d+$/u),
+      messageThreadId: 42,
     });
 
     const paddedText = "  hello from qa\n";

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   CRABLINE_FAKE_PROVIDER_CHANNELS,
   CRABLINE_SERVER_CHANNELS,
@@ -179,6 +179,22 @@ describe("OpenClaw local provider bridge", () => {
     expect(probeOpenClawCrablineFakeProvider).toBe(probeOpenClawCrablineProvider);
     expect(legacyManifest.provider).toBe("telegram");
     expect(conversation).toEqual({ id: "alice", kind: "direct" });
+  });
+
+  it("rejects Slack application errors returned with HTTP 200", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "invalid_auth", ok: false }), {
+        headers: { "content-type": "application/json" },
+        status: 200,
+      }),
+    );
+    try {
+      await expect(probeOpenClawCrablineProvider(slackManifest)).rejects.toThrow(
+        "Crabline Slack auth.test probe failed: invalid_auth.",
+      );
+    } finally {
+      fetchMock.mockRestore();
+    }
   });
 
   it("resolves channel-driver metadata through Crabline", () => {
@@ -481,7 +497,7 @@ describe("OpenClaw local provider bridge", () => {
       });
       expect(adapter.createAgentDelivery({ target: "dm:alice" })).toMatchObject({
         channel: "telegram",
-        to: "100001",
+        to: expect.stringMatching(/^\d+$/u),
       });
       if (adapter.manifest.provider !== "telegram") {
         throw new Error("Expected Telegram local provider manifest.");
@@ -496,12 +512,29 @@ describe("OpenClaw local provider bridge", () => {
   });
 
   it("maps QA targets, inbound messages, and recorder events", () => {
-    expect(createOpenClawCrablineAgentDelivery({ manifest, target: "dm:alice" })).toEqual({
-      channel: "telegram",
-      to: "100001",
-      replyChannel: "telegram",
-      replyTo: "100001",
+    const symbolicDelivery = createOpenClawCrablineAgentDelivery({
+      manifest,
+      target: "dm:alice",
     });
+    expect(symbolicDelivery).toEqual({
+      channel: "telegram",
+      to: expect.stringMatching(/^\d+$/u),
+      replyChannel: "telegram",
+      replyTo: symbolicDelivery.to,
+    });
+    expect(BigInt(symbolicDelivery.to)).toBeLessThan(1n << 52n);
+    expect(createOpenClawCrablineAgentDelivery({ manifest, target: "dm:alice" }).to).toBe(
+      symbolicDelivery.to,
+    );
+    expect(createOpenClawCrablineAgentDelivery({ manifest, target: "dm:bob" }).to).not.toBe(
+      symbolicDelivery.to,
+    );
+    expect(createOpenClawCrablineAgentDelivery({ manifest, target: "group:alice" }).to).toMatch(
+      /^-\d+$/u,
+    );
+    expect(createOpenClawCrablineAgentDelivery({ manifest, target: "dm:42424242" }).to).toBe(
+      "42424242",
+    );
 
     const inbound = createOpenClawCrablineInbound({
       manifest,
@@ -515,8 +548,8 @@ describe("OpenClaw local provider bridge", () => {
     });
     expect(inbound).toEqual({
       providerBody: {
-        chatId: "100001",
-        fromId: 100001,
+        chatId: symbolicDelivery.to,
+        fromId: Number(symbolicDelivery.to),
         fromName: "Alice",
         entities: [{ length: 5, offset: 0, type: "bot_command" }],
         text: "/stop",
@@ -525,14 +558,36 @@ describe("OpenClaw local provider bridge", () => {
         "content-type": "application/json",
         "x-crabline-admin-token": "crabline-admin-token",
       },
-      providerTargetKey: "100001",
+      providerTargetKey: symbolicDelivery.to,
       providerUrl: "http://127.0.0.1:1234/crabline/telegram/inbound",
       qaTarget: "dm:alice",
       stateConversation: {
-        id: "100001",
+        id: symbolicDelivery.to,
         kind: "direct",
       },
     });
+
+    const paddedText = "  hello from qa\n";
+    expect(
+      createOpenClawCrablineInbound({
+        manifest,
+        input: {
+          conversation: { id: "alice", kind: "direct" },
+          senderId: "alice",
+          text: paddedText,
+        },
+      }).providerBody,
+    ).toMatchObject({ text: paddedText });
+    expect(() =>
+      createOpenClawCrablineInbound({
+        manifest,
+        input: {
+          conversation: { id: "alice", kind: "direct" },
+          senderId: "alice",
+          text: " \n\t",
+        },
+      }),
+    ).toThrow("OpenClaw Crabline inbound message text is required.");
 
     expect(
       createOpenClawCrablineOutboundFromRecorderEvent({
@@ -590,6 +645,23 @@ describe("OpenClaw local provider bridge", () => {
       replyChannel: "whatsapp",
       replyTo: "15551234567@s.whatsapp.net",
     });
+    expect(() =>
+      createOpenClawCrablineAgentDelivery({
+        manifest: whatsappManifest,
+        target: "thread:120363001234567890@g.us/message-1",
+      }),
+    ).toThrow("WhatsApp does not support thread targets.");
+    expect(() =>
+      createOpenClawCrablineInbound({
+        manifest: whatsappManifest,
+        input: {
+          conversation: { id: "120363001234567890@g.us", kind: "group" },
+          senderId: "15551234567@s.whatsapp.net",
+          text: "hello",
+          threadId: "message-1",
+        },
+      }),
+    ).toThrow("WhatsApp does not support thread targets.");
 
     const inbound = createOpenClawCrablineInbound({
       manifest: whatsappManifest,
@@ -721,6 +793,23 @@ describe("OpenClaw local provider bridge", () => {
       replyTo: "group:group-1",
       to: "group:group-1",
     });
+    expect(() =>
+      createOpenClawCrablineAgentDelivery({
+        manifest: signalManifest,
+        target: "thread:group-1/1700000000001",
+      }),
+    ).toThrow("Signal does not support thread targets.");
+    expect(() =>
+      createOpenClawCrablineInbound({
+        manifest: signalManifest,
+        input: {
+          conversation: { id: "group-1", kind: "group" },
+          senderId: "+15551234567",
+          text: "hello",
+          threadId: "1700000000001",
+        },
+      }),
+    ).toThrow("Signal does not support thread targets.");
 
     const directDelivery = createOpenClawCrablineAgentDelivery({
       manifest: signalManifest,
@@ -796,6 +885,102 @@ describe("OpenClaw local provider bridge", () => {
       text: "hello from openclaw",
       to: "group:qa",
     });
+  });
+
+  it("preserves non-blank recorder message whitespace across bridges", () => {
+    const cases: Array<{
+      event: (text: string) => unknown;
+      manifest: CrablineServerManifest;
+      name: string;
+    }> = [
+      {
+        name: "Telegram",
+        manifest,
+        event: (text) => ({
+          body: { caption: text, chat_id: "100001", photo: "fixture.png" },
+          path: "/botTOKEN/sendPhoto",
+          type: "api",
+        }),
+      },
+      {
+        name: "WhatsApp",
+        manifest: whatsappManifest,
+        event: (text) => ({
+          body: { text: { body: text }, to: "15551234567@s.whatsapp.net" },
+          path: new URL(whatsappManifest.endpoints.messagesUrl).pathname,
+          type: "api",
+        }),
+      },
+      {
+        name: "Slack",
+        manifest: slackManifest,
+        event: (text) => ({
+          body: { channel: "C1234567890", text },
+          path: "/api/chat.postMessage",
+          type: "api",
+        }),
+      },
+      {
+        name: "Signal",
+        manifest: signalManifest,
+        event: (text) => ({
+          body: {
+            method: "send",
+            params: { message: text, recipient: ["+15551234567"] },
+          },
+          path: "/api/v1/rpc",
+          type: "api",
+        }),
+      },
+      {
+        name: "Mattermost",
+        manifest: mattermostManifest,
+        event: (text) => ({
+          body: { channel_id: "aaaaaaaaaaaaaaaaaaaaaaaaaa", message: text },
+          method: "POST",
+          path: "/api/v4/posts",
+          type: "api",
+        }),
+      },
+      {
+        name: "Matrix",
+        manifest: matrixManifest,
+        event: (text) => ({
+          body: { body: text },
+          method: "PUT",
+          path: "/_matrix/client/v3/rooms/!room%3Amatrix.test/send/m.room.message/txn-1",
+          type: "api",
+        }),
+      },
+      {
+        name: "Zalo",
+        manifest: zaloManifest,
+        event: (text) => ({
+          body: { chat_id: "1459232241454765289", text },
+          method: "POST",
+          path: "/bot<redacted>/sendMessage",
+          type: "api",
+        }),
+      },
+    ];
+
+    for (const testCase of cases) {
+      const text = `  ${testCase.name} reply\n`;
+      expect(
+        createOpenClawCrablineOutboundFromRecorderEvent({
+          event: testCase.event(text),
+          manifest: testCase.manifest,
+          targetByProviderTarget: new Map(),
+        }),
+      ).toMatchObject({ text });
+      expect(
+        createOpenClawCrablineOutboundFromRecorderEvent({
+          event: testCase.event(" \n\t"),
+          manifest: testCase.manifest,
+          targetByProviderTarget: new Map(),
+        }),
+      ).toBeNull();
+    }
   });
 
   it("maps Mattermost QA targets, inbound messages, and recorder events", () => {


### PR DESCRIPTION
## Summary

- reject unsupported provider thread targets and preserve meaningful inbound and recorder whitespace
- validate Slack application-level probe failures and generate stable provider-valid Telegram IDs
- keep WhatsApp recorder normalization aligned with accepted Cloud API payloads

## Verification

- Crabbox `corepack pnpm verify`: 40 files, 233 tests passed
- focused OpenClaw tests: 18 passed
- autoreview: `gpt-5.6-sol` high, clean, confidence 0.91