### PR TITLE
fix(core): harden release and package contracts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,14 +31,14 @@ jobs:
         run: |
           set -euo pipefail
           tag="${INPUT_TAG:-${GITHUB_REF_NAME}}"
-          [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z]+)*$ ]]
+          [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
-          ref: ${{ steps.release.outputs.tag }}
+          ref: refs/tags/${{ steps.release.outputs.tag }}
       - name: Verify release metadata
         env:
           RELEASE_VERSION: ${{ steps.release.outputs.version }}

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,4 +1,6 @@
 {
   "$schema": "./node_modules/oxfmt/configuration_schema.json",
-  "ignorePatterns": []
+  "ignorePatterns": [],
+  "tabWidth": 2,
+  "useTabs": false
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Restrict releases to stable version tags and resolve workflow-dispatch inputs through exact tag refs before publication.
+- Reject ambiguous fixture/config inputs and keep the published CLI, type dependencies, and README assets aligned with their public contract.
 - Harden release packaging and retries, and make cleanup scripts portable across supported platforms.
 - Export the OpenClaw conversation type from the package root.
 - Harden CLI lifecycle cleanup, ready-file publication, run diagnostics, and config validation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Restrict releases to stable version tags and resolve workflow-dispatch inputs through exact tag refs before publication.
 - Harden release packaging and retries, and make cleanup scripts portable across supported platforms.
 - Export the OpenClaw conversation type from the package root.
 - Harden CLI lifecycle cleanup, ready-file publication, run diagnostics, and config validation.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "crabline": "dist/src/bin/crabline.js"
   },
   "files": [
+    "assets/crabline-banner.svg",
     "dist/src",
     "README.md",
     "docs/channel-setup.md",
@@ -49,6 +50,7 @@
     "check": "pnpm verify"
   },
   "dependencies": {
+    "@types/node": "^26.1.0",
     "commander": "^15.0.0",
     "curve25519-js": "^0.0.4",
     "picocolors": "^1.1.1",
@@ -57,7 +59,6 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@types/node": "^26.1.0",
     "@types/ws": "^8.18.1",
     "@typescript/native": "npm:typescript@^7.0.2",
     "@vitest/coverage-v8": "^4.1.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     dependencies:
+      '@types/node':
+        specifier: ^26.1.0
+        version: 26.1.0
       commander:
         specifier: ^15.0.0
         version: 15.0.0
@@ -30,9 +33,6 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
-      '@types/node':
-        specifier: ^26.1.0
-        version: 26.1.0
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -171,16 +171,14 @@ export function createProgram(
     });
 
   program
-    .command("probe <fixtureOrProvider>")
-    .description("Probe provider readiness using a fixture or provider id")
-    .action(async (fixtureOrProvider) => {
+    .command("probe <fixtureId>")
+    .description("Probe provider readiness using a fixture")
+    .action(async (fixtureId) => {
       const options = program.opts() as GlobalOptions;
       const { manifest, path } = await loadManifest(options.config);
-      const fixture =
-        manifest.fixtures.find((entry) => entry.id === fixtureOrProvider) ??
-        manifest.fixtures.find((entry) => entry.provider === fixtureOrProvider);
+      const fixture = manifest.fixtures.find((entry) => entry.id === fixtureId);
       if (!fixture) {
-        throw new CrablineError(`No fixture found for "${fixtureOrProvider}"`, { kind: "config" });
+        throw new CrablineError(`Unknown fixture: ${fixtureId}`, { kind: "config" });
       }
       const registry = createRegistry(manifest, path);
       const result = await runFixtureCommand({

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -1,4 +1,4 @@
-import { access, readFile } from "node:fs/promises";
+import { readFile, stat } from "node:fs/promises";
 import path from "node:path";
 import YAML from "yaml";
 import { CrablineError, ensureErrorMessage } from "../core/errors.js";
@@ -14,8 +14,9 @@ export async function resolveConfigPath(explicitPath?: string): Promise<string> 
   for (const candidate of DEFAULT_CONFIG_CANDIDATES) {
     const resolved = path.resolve(candidate);
     try {
-      await access(resolved);
-      return resolved;
+      if ((await stat(resolved)).isFile()) {
+        return resolved;
+      }
     } catch (error) {
       if (
         typeof error === "object" &&

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -609,12 +609,26 @@ function omitManifestExtensions(value: unknown): unknown {
   return manifestEntries.length === entries.length ? value : Object.fromEntries(manifestEntries);
 }
 
-const StrictManifestSchema = z.strictObject({
-  configVersion: z.literal(1).default(1),
-  fixtures: z.array(FixtureSchema).default([]),
-  providers: z.record(z.string(), ProviderConfigSchema).default({}),
-  userName: z.string().min(1).default("crabline"),
-});
+const StrictManifestSchema = z
+  .strictObject({
+    configVersion: z.literal(1).default(1),
+    fixtures: z.array(FixtureSchema).default([]),
+    providers: z.record(z.string(), ProviderConfigSchema).default({}),
+    userName: z.string().min(1).default("crabline"),
+  })
+  .superRefine((manifest, ctx) => {
+    const seenFixtureIds = new Set<string>();
+    for (const [index, fixture] of manifest.fixtures.entries()) {
+      if (seenFixtureIds.has(fixture.id)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `duplicate fixture id: ${fixture.id}`,
+          path: ["fixtures", index, "id"],
+        });
+      }
+      seenFixtureIds.add(fixture.id);
+    }
+  });
 
 export const ManifestSchema = z.preprocess(omitManifestExtensions, StrictManifestSchema);
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -119,7 +119,14 @@ describe("cli", () => {
     }
 
     expect(exitCode!).toBe(10);
-    expect(captured.stderr.join("")).toContain("No fixture found");
+    expect(captured.stderr.join("")).toContain("Unknown fixture");
+  });
+
+  it("documents probe as a fixture-only command", () => {
+    const probe = createProgram().commands.find((command) => command.name() === "probe");
+
+    expect(probe?.usage()).toBe("[options] <fixtureId>");
+    expect(probe?.description()).toBe("Probe provider readiness using a fixture");
   });
 
   it("isolates exit codes across repeated invocations", async () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -26,6 +26,34 @@ describe("manifest schema", () => {
     }
   });
 
+  it("rejects duplicate fixture ids", () => {
+    expect(() =>
+      ManifestSchema.parse({
+        configVersion: 1,
+        fixtures: [
+          {
+            id: "duplicate",
+            mode: "send",
+            provider: "local",
+            target: { id: "first" },
+          },
+          {
+            id: "duplicate",
+            mode: "send",
+            provider: "local",
+            target: { id: "second" },
+          },
+        ],
+        providers: {
+          local: {
+            adapter: "loopback",
+            platform: "loopback",
+          },
+        },
+      }),
+    ).toThrow(/duplicate fixture id: duplicate/u);
+  });
+
   it("parses a valid loopback fixture", () => {
     const manifest = ManifestSchema.parse({
       configVersion: 1,

--- a/test/load.test.ts
+++ b/test/load.test.ts
@@ -1,12 +1,12 @@
 import path from "node:path";
-import { realpath, access } from "node:fs/promises";
+import { mkdir, realpath, stat } from "node:fs/promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { loadManifest, resolveConfigPath } from "../src/config/load.js";
 import { createTempDir, disposeTempDir, writeJson, writeText } from "./test-helpers.js";
 
 vi.mock("node:fs/promises", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs/promises")>();
-  return { ...actual, access: vi.fn(actual.access) };
+  return { ...actual, stat: vi.fn(actual.stat) };
 });
 
 const directories: string[] = [];
@@ -116,6 +116,22 @@ describe("config load", () => {
     }
   });
 
+  it("skips config-name directories during discovery", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    await mkdir(path.join(directory, "crabline.yaml"));
+    const configPath = path.join(directory, "crabline.yml");
+    await writeText(configPath, "configVersion: 1\nproviders: {}\nfixtures: []\n");
+    const originalCwd = process.cwd();
+
+    process.chdir(directory);
+    try {
+      expect(await realpath(await resolveConfigPath())).toBe(await realpath(configPath));
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
   it("fails when no config file exists", async () => {
     const directory = await createTempDir();
     directories.push(directory);
@@ -131,7 +147,7 @@ describe("config load", () => {
 
   it("surfaces non-missing filesystem errors during discovery", async () => {
     const error = Object.assign(new Error("permission denied"), { code: "EACCES" });
-    vi.mocked(access).mockRejectedValueOnce(error);
+    vi.mocked(stat).mockRejectedValueOnce(error);
 
     await expect(resolveConfigPath()).rejects.toBe(error);
   });

--- a/test/package-production.test.ts
+++ b/test/package-production.test.ts
@@ -30,6 +30,9 @@ describe("production package", () => {
       types?: string;
     };
 
+    expect(pkg.dependencies?.["@types/node"]).toBeDefined();
+    expect(pkg.devDependencies?.["@types/node"]).toBeUndefined();
+
     for (const packageName of DEV_ONLY_RUNTIME_PACKAGES) {
       expect(pkg.dependencies?.[packageName]).toBeUndefined();
       expect(pkg.optionalDependencies?.[packageName]).toBeUndefined();
@@ -52,6 +55,7 @@ describe("production package", () => {
     expect(files).toContain(cliPath);
     expect(files).toContain(mainPath);
     expect(files).toContain(typesPath);
+    expect(files).toContain("assets/crabline-banner.svg");
     expect(files.some((file) => file.startsWith("node_modules/"))).toBe(false);
     expect(files.some((file) => file.startsWith("test/"))).toBe(false);
     expect(files.some((file) => /(^|\/)baileys(\/|$)/u.test(file))).toBe(false);

--- a/test/release-workflow.test.ts
+++ b/test/release-workflow.test.ts
@@ -41,8 +41,8 @@ describe("release workflow", () => {
       tag: "v1.2.3",
       version: "1.2.3",
     });
-    await expect(runResolveTag(resolveStep, "v1.2.3-beta.1")).rejects.toThrow();
-    await expect(runResolveTag(resolveStep, "v1.2.3.preview")).rejects.toThrow();
+    await expect(runResolveTag(resolveStep, "v1.2.3-beta.1")).rejects.toThrow(/Command failed/u);
+    await expect(runResolveTag(resolveStep, "v1.2.3.preview")).rejects.toThrow(/Command failed/u);
     expect(checkoutStep?.with?.ref).toBe("refs/tags/${{ steps.release.outputs.tag }}");
   });
 

--- a/test/release-workflow.test.ts
+++ b/test/release-workflow.test.ts
@@ -14,6 +14,8 @@ type WorkflowStep = {
   id?: string;
   name?: string;
   run?: string;
+  uses?: string;
+  with?: Record<string, unknown>;
 };
 
 type ReleaseWorkflow = {
@@ -29,6 +31,21 @@ type ReleaseWorkflow = {
 };
 
 describe("release workflow", () => {
+  it("only accepts stable tags and checks out the exact tag ref", async () => {
+    const workflow = await readWorkflow();
+    const steps = workflow.jobs?.release?.steps ?? [];
+    const resolveStep = steps.find((step) => step.name === "Resolve release tag")?.run;
+    const checkoutStep = steps.find((step) => step.uses?.startsWith("actions/checkout@"));
+
+    await expect(runResolveTag(resolveStep, "v1.2.3")).resolves.toEqual({
+      tag: "v1.2.3",
+      version: "1.2.3",
+    });
+    await expect(runResolveTag(resolveStep, "v1.2.3-beta.1")).rejects.toThrow();
+    await expect(runResolveTag(resolveStep, "v1.2.3.preview")).rejects.toThrow();
+    expect(checkoutStep?.with?.ref).toBe("refs/tags/${{ steps.release.outputs.tag }}");
+  });
+
   it("pins tooling and makes package and GitHub publication retry-safe", async () => {
     const workflow = await readWorkflow();
     const steps = workflow.jobs?.release?.steps ?? [];
@@ -161,6 +178,35 @@ async function runMetadataCheck(script: string, changelog: string): Promise<void
         RELEASE_VERSION: "1.2.3",
       },
     });
+  } finally {
+    await fs.rm(tempDir, { force: true, recursive: true });
+  }
+}
+
+async function runResolveTag(
+  script: string | undefined,
+  tag: string,
+): Promise<Record<string, string>> {
+  if (!script) {
+    throw new Error("Release workflow is missing its tag resolution step.");
+  }
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-release-tag-"));
+  const outputPath = path.join(tempDir, "outputs");
+  try {
+    await execFileWithOutput("bash", ["-c", script], {
+      env: {
+        ...process.env,
+        GITHUB_OUTPUT: outputPath,
+        GITHUB_REF_NAME: tag,
+        INPUT_TAG: tag,
+      },
+    });
+    return Object.fromEntries(
+      (await fs.readFile(outputPath, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => line.split("=", 2)),
+    );
   } finally {
     await fs.rm(tempDir, { force: true, recursive: true });
   }


### PR DESCRIPTION
## Summary

- require exact stable tag refs before npm publication
- reject duplicate fixtures and non-file config candidates
- align fixture-only probe help, published type dependencies, and packaged README assets
- pin formatter indentation so linked worktrees are deterministic

## Verification

- Crabbox `run_a8db9a350259`: `pnpm verify` (40 files, 237 tests)
- autoreview: `gpt-5.6-sol` high, clean (0.96)
- focused local tests: 50 passed
