### PR TITLE
fix(whatsapp): bound wire decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix provider normalization for loopback pagination and thread codecs, Telegram edited channel posts, Feishu and Matrix thread roots, and complete WhatsApp webhook batches.
 - Harden provider server fidelity with idempotent Matrix send transactions, valid Telegram IPv6 URLs, provider-native malformed JSON errors, signed Slack Events API delivery, and bounded Zalo webhook delivery.
 - Serve WhatsApp Cloud API requests on provider-native Graph routes, queue acknowledged Baileys inbound messages until a session opens, and bound binary frame decoding.
+- Accept uint64 unknown fields in WhatsApp handshakes and bound recursive binary-node decoding.
 - Harden OpenClaw bridges for provider-level probe failures, whitespace-preserving message capture, stable symbolic Telegram IDs, and unsupported thread targets.
 
 ## 0.1.9 - 2026-07-03

--- a/src/servers/whatsapp-wire/binary-node.ts
+++ b/src/servers/whatsapp-wire/binary-node.ts
@@ -10,6 +10,7 @@ export type BinaryNode = {
 
 export const WHATSAPP_BINARY_NODE_MAX_COMPRESSED_BYTES = 1024 * 1024;
 export const WHATSAPP_BINARY_NODE_MAX_DECOMPRESSED_BYTES = 8 * 1024 * 1024;
+export const WHATSAPP_BINARY_NODE_MAX_DEPTH = 128;
 
 const inflateAsync = promisify(inflate) as (
   buffer: Uint8Array,
@@ -166,7 +167,14 @@ async function decompressIfRequired(buffer: Buffer): Promise<Buffer> {
   return payload;
 }
 
-function decodeDecompressedBinaryNode(buffer: Buffer, indexRef = { index: 0 }): BinaryNode {
+function decodeDecompressedBinaryNode(
+  buffer: Buffer,
+  indexRef = { index: 0 },
+  depth = 1,
+): BinaryNode {
+  if (depth > WHATSAPP_BINARY_NODE_MAX_DEPTH) {
+    throw new Error(`WhatsApp binary node nesting exceeds ${WHATSAPP_BINARY_NODE_MAX_DEPTH}.`);
+  }
   const checkEOS = (length: number) => {
     if (!Number.isSafeInteger(length) || length < 0 || length > buffer.length - indexRef.index) {
       throw new Error("Unexpected end of WhatsApp binary node.");
@@ -307,7 +315,7 @@ function decodeDecompressedBinaryNode(buffer: Buffer, indexRef = { index: 0 }): 
     const items: BinaryNode[] = [];
     const size = readListSize(tag);
     for (let index = 0; index < size; index += 1) {
-      items.push(decodeDecompressedBinaryNode(buffer, indexRef));
+      items.push(decodeDecompressedBinaryNode(buffer, indexRef, depth + 1));
     }
     return items;
   };

--- a/src/servers/whatsapp-wire/handshake.ts
+++ b/src/servers/whatsapp-wire/handshake.ts
@@ -107,7 +107,7 @@ class ProtoReader {
 
   skip(wireType: number): void {
     if (wireType === 0) {
-      this.uint32();
+      this.#skipVarint();
       return;
     }
     if (wireType === 1) {
@@ -144,6 +144,21 @@ class ProtoReader {
         return value >>> 0;
       }
       shift += 7;
+    }
+    throw new Error("Invalid WhatsApp handshake varint.");
+  }
+
+  #skipVarint(): void {
+    for (let index = 0; index < 10; index += 1) {
+      this.#require(1);
+      const byte = this.#buffer[this.#offset];
+      this.#offset += 1;
+      if (byte === undefined || (index === 9 && byte > 1)) {
+        throw new Error("Invalid WhatsApp handshake varint.");
+      }
+      if ((byte & 0x80) === 0) {
+        return;
+      }
     }
     throw new Error("Invalid WhatsApp handshake varint.");
   }

--- a/test/whatsapp-wire.test.ts
+++ b/test/whatsapp-wire.test.ts
@@ -3,9 +3,41 @@ import { describe, expect, it } from "vitest";
 import {
   decodeBinaryNode,
   encodeBinaryNode,
+  WHATSAPP_BINARY_NODE_MAX_DEPTH,
   WHATSAPP_BINARY_NODE_MAX_DECOMPRESSED_BYTES,
   type BinaryNode,
 } from "../src/servers/whatsapp-wire/binary-node.js";
+import { decodeHandshakeMessage } from "../src/servers/whatsapp-wire/handshake.js";
+
+describe("WhatsApp handshake protobufs", () => {
+  it("skips unknown ten-byte uint64 varints", () => {
+    const message = decodeHandshakeMessage(
+      Buffer.from([
+        0x28, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x01, 0x12, 0x03, 0x0a, 0x01,
+        0x2a,
+      ]),
+    );
+
+    expect(message.clientHello?.ephemeral).toEqual(Buffer.from([0x2a]));
+  });
+
+  it("keeps Baileys field-number dispatch for known fields", () => {
+    expect(decodeHandshakeMessage(Buffer.from([0x10, 0x00]))).toEqual({
+      clientHello: {},
+    });
+  });
+
+  it("keeps handshake tags and lengths bounded to uint32 varints", () => {
+    const oversizedUint32s = [
+      Buffer.from([0x80, 0x80, 0x80, 0x80, 0x80, 0x00]),
+      Buffer.from([0x12, 0x80, 0x80, 0x80, 0x80, 0x80, 0x00]),
+    ];
+
+    for (const message of oversizedUint32s) {
+      expect(() => decodeHandshakeMessage(message)).toThrow("Invalid WhatsApp handshake varint.");
+    }
+  });
+});
 
 describe("WhatsApp binary nodes", () => {
   it("rejects BINARY_32 lengths that exceed the remaining frame", async () => {
@@ -34,4 +66,27 @@ describe("WhatsApp binary nodes", () => {
 
     expect(() => encodeBinaryNode(node)).toThrow("WhatsApp binary node list is too large: 65536.");
   });
+
+  it("decodes nodes at the nesting limit while ignoring trailing bytes", async () => {
+    const node = nestedNode(WHATSAPP_BINARY_NODE_MAX_DEPTH);
+    const frame = Buffer.concat([encodeBinaryNode(node), Buffer.from([0xff])]);
+
+    await expect(decodeBinaryNode(frame)).resolves.toEqual(node);
+  });
+
+  it("rejects nodes beyond the nesting limit", async () => {
+    const node = nestedNode(WHATSAPP_BINARY_NODE_MAX_DEPTH + 1);
+
+    await expect(decodeBinaryNode(encodeBinaryNode(node))).rejects.toThrow(
+      `WhatsApp binary node nesting exceeds ${WHATSAPP_BINARY_NODE_MAX_DEPTH}.`,
+    );
+  });
 });
+
+function nestedNode(depth: number): BinaryNode {
+  let node: BinaryNode = { attrs: {}, tag: "leaf" };
+  for (let level = 1; level < depth; level += 1) {
+    node = { attrs: {}, content: [node], tag: "node" };
+  }
+  return node;
+}


### PR DESCRIPTION
## Summary

- skip legal ten-byte protobuf varints in unknown fields
- cap recursive binary-node decoding depth
- preserve Baileys-compatible trailing-frame behavior

## Verification

- Crabbox `run_bdacef01fd20`: `pnpm verify` (40 files, 242 tests)
- autoreview: `gpt-5.6-sol` high, clean (0.98)
- focused wire tests: 8 passed
