### PR TITLE
fix(providers): preserve native inbound fidelity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Export the OpenClaw conversation type from the package root.
 - Harden CLI lifecycle cleanup, ready-file publication, run diagnostics, and config validation.
 - Harden script provider subprocess limits and result validation, recorder polling and JSONL parsing, and local webhook startup and IPv6 URLs.
+- Fix built-in runtime fidelity for Discord component interactions, split UTF-8 script output, and opaque Microsoft Teams conversation IDs.
 - Fix provider normalization for loopback pagination and thread codecs, Telegram edited channel posts, Feishu and Matrix thread roots, and complete WhatsApp webhook batches.
 - Harden provider server fidelity with idempotent Matrix send transactions, valid Telegram IPv6 URLs, provider-native malformed JSON errors, signed Slack Events API delivery, and bounded Zalo webhook delivery.
 - Serve WhatsApp Cloud API requests on provider-native Graph routes, queue acknowledged Baileys inbound messages until a session opens, and bound binary frame decoding.

--- a/src/providers/builtin/discord.ts
+++ b/src/providers/builtin/discord.ts
@@ -65,7 +65,8 @@ function normalizeDiscordWebhookPayload(payload: unknown) {
     throw new CrablineError("Discord webhook payload must be an object", { kind: "inbound" });
   }
 
-  if (optionalRecord(payload, "message")) {
+  const message = optionalRecord(payload, "message");
+  if (message && ("text" in message || "threadId" in message)) {
     return genericMockPayloadWithNativeThread({
       channelRule: DISCORD_SNOWFLAKE_RULE,
       payload,
@@ -78,7 +79,12 @@ function normalizeDiscordWebhookPayload(payload: unknown) {
   const channelId = optionalString(payload, "channel_id");
   const text =
     optionalString(payload, "content") ??
-    (data ? (optionalString(data, "content") ?? optionalString(data, "name")) : undefined);
+    (data
+      ? (optionalString(data, "content") ??
+        optionalString(data, "name") ??
+        optionalString(data, "custom_id"))
+      : undefined) ??
+    (message ? optionalString(message, "content") : undefined);
   if (!channelId || !text) {
     throw new CrablineError("Discord event payload requires channel_id and content", {
       kind: "inbound",

--- a/src/providers/builtin/msteams.ts
+++ b/src/providers/builtin/msteams.ts
@@ -15,9 +15,9 @@ import {
 } from "./native-local-mock.js";
 
 const MSTEAMS_CONVERSATION_ID_RULE: NativeIdRule = {
-  example: "19:meeting_abc@thread.v2",
+  example: "a:opaque-conversation-id",
   name: "Microsoft Teams conversation id",
-  pattern: /^19:[^@]+@thread\.[A-Za-z0-9.]+$/u,
+  pattern: /^.+$/su,
 };
 
 export function resolveMsTeamsAdapterConfig(

--- a/src/providers/builtin/script.ts
+++ b/src/providers/builtin/script.ts
@@ -385,6 +385,8 @@ export class ScriptProviderAdapter implements ProviderAdapter {
     let stderr = "";
     let childError: unknown;
     let outputLimitError: CrablineError | undefined;
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
     child.stdin.on("error", () => {
       // Child closure is reported through the process error/close handlers.
     });
@@ -392,7 +394,7 @@ export class ScriptProviderAdapter implements ProviderAdapter {
       if (outputLimitError) {
         return;
       }
-      stderr += String(chunk);
+      stderr += chunk;
       if (Buffer.byteLength(stderr) > MAX_SCRIPT_OUTPUT_BYTES) {
         outputLimitError = new CrablineError(
           `Script watch command exceeded ${MAX_SCRIPT_OUTPUT_BYTES} bytes of stderr: ${command}`,
@@ -425,7 +427,7 @@ export class ScriptProviderAdapter implements ProviderAdapter {
 
     try {
       for await (const chunk of child.stdout) {
-        buffer += String(chunk);
+        buffer += chunk;
         if (Buffer.byteLength(buffer) > MAX_SCRIPT_OUTPUT_BYTES && !buffer.includes("\n")) {
           throw new CrablineError(
             `Script watch command exceeded ${MAX_SCRIPT_OUTPUT_BYTES} bytes without a newline: ${command}`,

--- a/test/discord-provider.test.ts
+++ b/test/discord-provider.test.ts
@@ -216,6 +216,67 @@ describe("discord provider", () => {
     });
   });
 
+  it("records native component interactions that include a Discord message", async () => {
+    const config = await createDiscordConfig(0);
+    const provider = new DiscordProviderAdapter("discord", config, "crabline");
+    providers.push(provider);
+
+    const probe = await provider.probe(createContext(config));
+    const endpoint = probe.details.find((detail) => detail.startsWith("interactions endpoint "));
+    expect(endpoint).toBeDefined();
+
+    const context = createContext(config);
+    context.fixture.inboundMatch = {
+      author: "user",
+      nonce: "contains",
+      strategy: "contains",
+    };
+    const since = new Date(Date.now() - 1000).toISOString();
+    const response = await fetch(endpoint!.replace("interactions endpoint ", ""), {
+      body: JSON.stringify({
+        channel_id: "123456789012345678",
+        data: {
+          component_type: 2,
+          custom_id: "approve:nonce-3",
+        },
+        id: "444456789012345678",
+        member: {
+          user: {
+            bot: false,
+            id: "555456789012345678",
+          },
+        },
+        message: {
+          author: {
+            bot: true,
+            id: "666456789012345678",
+          },
+          content: "Choose an action",
+          id: "777456789012345678",
+        },
+        type: 3,
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(
+      provider.waitForInbound({
+        ...context,
+        nonce: "nonce-3",
+        since,
+        threadId: "123456789012345678",
+        timeoutMs: 500,
+      }),
+    ).resolves.toMatchObject({
+      author: "user",
+      id: "444456789012345678",
+      text: "approve:nonce-3",
+      threadId: "123456789012345678",
+    });
+  });
+
   it("streams watched interaction events", async () => {
     const config = await createDiscordConfig(0);
     const provider = new DiscordProviderAdapter("discord", config, "crabline");

--- a/test/msteams-provider.test.ts
+++ b/test/msteams-provider.test.ts
@@ -1,18 +1,21 @@
 import { MsTeamsProviderAdapter } from "../src/providers/builtin/msteams.js";
 import { runLocalMockProviderContract } from "./local-mock-provider-helpers.js";
 
+const conversationId = "a:opaque-conversation-id";
+
 runLocalMockProviderContract({
   Adapter: MsTeamsProviderAdapter,
   endpointPath: "/msteams/webhook",
-  expectedChannelId: "19:meeting_abc123@thread.v2",
+  expectedChannelId: conversationId,
+  invalidTargets: [{ id: "", metadata: {} }],
   platform: "msteams",
-  target: { id: "19:meeting_abc123@thread.v2", metadata: {} },
+  target: { id: conversationId, metadata: {} },
   webhookExpected: { author: "user", id: "teams-activity-1", text: "reply nonce-2" },
   webhookPayload: {
-    conversation: { id: "19:meeting_abc123@thread.v2" },
+    conversation: { id: conversationId },
     from: { role: "user" },
     id: "teams-activity-1",
     text: "reply nonce-2",
   },
-  webhookThreadId: "19:meeting_abc123@thread.v2",
+  webhookThreadId: conversationId,
 });

--- a/test/script-provider.test.ts
+++ b/test/script-provider.test.ts
@@ -147,7 +147,7 @@ describe("script provider", () => {
     const watchScript = path.join(path.dirname(context.manifestPath), "watch-split-stderr.mjs");
     await writeText(
       watchScript,
-      'process.stderr.write(Buffer.from([0xf0,0x9f]));setTimeout(()=>{process.stderr.write(Buffer.from([0xa6,0x8a]));process.exitCode=7;},25);',
+      "process.stderr.write(Buffer.from([0xf0,0x9f]));setTimeout(()=>{process.stderr.write(Buffer.from([0xa6,0x8a]));process.exitCode=7;},25);",
     );
     context.config.script!.commands.watch = `node ${watchScript}`;
     const provider = new ScriptProviderAdapter(context);

--- a/test/script-provider.test.ts
+++ b/test/script-provider.test.ts
@@ -123,6 +123,38 @@ describe("script provider", () => {
     expect(watched?.value?.id).toBe("watch-1");
   });
 
+  it("preserves UTF-8 code points split across watch stdout chunks", async () => {
+    const context = await createContext();
+    const watchScript = path.join(path.dirname(context.manifestPath), "watch-split-utf8.mjs");
+    await writeText(
+      watchScript,
+      'const line=Buffer.from(JSON.stringify({author:"assistant",id:"watch-split",sentAt:new Date().toISOString(),text:"split \\u{1f98a} output",threadId:"thread-1"})+"\\n");const split=line.indexOf(0xf0)+2;process.stdout.write(line.subarray(0,split));setTimeout(()=>process.stdout.write(line.subarray(split)),25);',
+    );
+    context.config.script!.commands.watch = `node ${watchScript}`;
+    const provider = new ScriptProviderAdapter(context);
+
+    await expect(provider.watch(context).next()).resolves.toMatchObject({
+      done: false,
+      value: {
+        id: "watch-split",
+        text: "split \u{1f98a} output",
+      },
+    });
+  });
+
+  it("preserves UTF-8 code points split across watch stderr chunks", async () => {
+    const context = await createContext();
+    const watchScript = path.join(path.dirname(context.manifestPath), "watch-split-stderr.mjs");
+    await writeText(
+      watchScript,
+      'process.stderr.write(Buffer.from([0xf0,0x9f]));setTimeout(()=>{process.stderr.write(Buffer.from([0xa6,0x8a]));process.exitCode=7;},25);',
+    );
+    context.config.script!.commands.watch = `node ${watchScript}`;
+    const provider = new ScriptProviderAdapter(context);
+
+    await expect(provider.watch(context).next()).rejects.toThrow(/\u{1f98a}/u);
+  });
+
   it("stops the watch subprocess when iteration ends early", async () => {
     const context = await createContext();
     const watchScript = path.join(path.dirname(context.manifestPath), "watch-leaking.mjs");


### PR DESCRIPTION
## Summary

- distinguish native Discord component interactions from synthetic envelopes
- preserve split UTF-8 output from script provider subprocesses
- accept opaque Microsoft Teams conversation IDs

## Verification

- Crabbox `run_c02dfed6fefe`: `pnpm verify` (40 files, 240 tests)
- autoreview: `gpt-5.6-sol` high, clean (0.95)
- focused provider tests: 28 passed
