### PR TITLE
fix(providers): serialize local runtime lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Restrict releases to stable version tags and resolve workflow-dispatch inputs through exact tag refs before publication.
 - Reject ambiguous fixture/config inputs and keep the published CLI, type dependencies, and README assets aligned with their public contract.
+- Serialize local mock and WhatsApp webhook startup and cleanup, and honor explicit public webhook URL precedence.
 - Harden release packaging and retries, and make cleanup scripts portable across supported platforms.
 - Export the OpenClaw conversation type from the package root.
 - Harden CLI lifecycle cleanup, ready-file publication, run diagnostics, and config validation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Restrict releases to stable version tags and resolve workflow-dispatch inputs through exact tag refs before publication.
 - Reject ambiguous fixture/config inputs and keep the published CLI, type dependencies, and README assets aligned with their public contract.
+- Poll recorder JSONL incrementally while preserving incomplete trailing records.
 - Serialize local mock and WhatsApp webhook startup and cleanup, and honor explicit public webhook URL precedence.
 - Harden release packaging and retries, and make cleanup scripts portable across supported platforms.
 - Export the OpenClaw conversation type from the package root.

--- a/src/providers/builtin/whatsapp.ts
+++ b/src/providers/builtin/whatsapp.ts
@@ -76,6 +76,8 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
   readonly #recorderPath: string;
   readonly #webhook: LocalMockWebhookConfig | undefined;
   #server: StartedWebhookServer | null = null;
+  #serverClosing: Promise<void> | null = null;
+  #serverStarting: Promise<StartedWebhookServer> | null = null;
 
   constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
     super({
@@ -157,9 +159,18 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
   }
 
   override async cleanup(): Promise<void> {
-    if (this.#server) {
-      await this.#server.close();
-      this.#server = null;
+    if (this.#serverClosing) {
+      await this.#serverClosing;
+    } else {
+      const closing = this.#closeWebhookServer();
+      this.#serverClosing = closing;
+      try {
+        await closing;
+      } finally {
+        if (this.#serverClosing === closing) {
+          this.#serverClosing = null;
+        }
+      }
     }
     await super.cleanup();
   }
@@ -207,27 +218,64 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
   }
 
   async #ensureWebhookServer(): Promise<StartedWebhookServer> {
+    if (this.#serverClosing) {
+      await this.#serverClosing;
+    }
     if (this.#server) {
       return this.#server;
+    }
+    if (this.#serverStarting) {
+      return await this.#serverStarting;
     }
 
     const host = this.#webhook?.host ?? DEFAULT_WHATSAPP_WEBHOOK.host;
     const port = this.#webhook?.port ?? DEFAULT_WHATSAPP_WEBHOOK.port;
     const webhookPath = this.#webhook?.path ?? DEFAULT_WHATSAPP_WEBHOOK.path;
+    const starting = (async () => {
+      try {
+        return await startWebhookServer({
+          handle: (request) => this.#handleWebhook(request),
+          host,
+          path: webhookPath,
+          port,
+        });
+      } catch (error) {
+        throw new CrablineError(
+          `whatsapp local mock webhook server failed: ${ensureErrorMessage(error)}`,
+          { cause: error, kind: "connectivity" },
+        );
+      }
+    })();
+    this.#serverStarting = starting;
+
     try {
-      this.#server = await startWebhookServer({
-        handle: (request) => this.#handleWebhook(request),
-        host,
-        path: webhookPath,
-        port,
-      });
-      return this.#server;
-    } catch (error) {
-      throw new CrablineError(
-        `whatsapp local mock webhook server failed: ${ensureErrorMessage(error)}`,
-        { cause: error, kind: "connectivity" },
-      );
+      const server = await starting;
+      this.#server = server;
+      return server;
+    } finally {
+      if (this.#serverStarting === starting) {
+        this.#serverStarting = null;
+      }
     }
+  }
+
+  async #closeWebhookServer(): Promise<void> {
+    let server = this.#server;
+    if (!server && this.#serverStarting) {
+      try {
+        server = await this.#serverStarting;
+      } catch {
+        return;
+      }
+    }
+    if (!server) {
+      return;
+    }
+
+    if (this.#server === server) {
+      this.#server = null;
+    }
+    await server.close();
   }
 }
 

--- a/src/providers/local-mock.ts
+++ b/src/providers/local-mock.ts
@@ -134,8 +134,11 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
   readonly #codec: LocalMockTargetCodec;
   readonly #config: ProviderConfig;
   readonly #options: LocalMockAdapterOptions;
+  readonly #publicUrl: string | undefined;
   readonly #recorderPath: string;
   #server: StartedWebhookServer | null = null;
+  #serverClosing: Promise<void> | null = null;
+  #serverStarting: Promise<StartedWebhookServer> | null = null;
 
   constructor(params: {
     codec: LocalMockTargetCodec;
@@ -148,6 +151,7 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
     this.#codec = params.codec;
     this.#config = params.config;
     this.#options = params.options;
+    this.#publicUrl = params.options.publicUrl ?? params.options.webhook?.publicUrl;
     this.#recorderPath = toRecorderPath(params.id, params.options.recorderPath);
   }
 
@@ -163,8 +167,8 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
       `recorder path ${this.#recorderPath}`,
       `${this.#options.endpointLabel} ${server.endpointUrl}`,
     ];
-    if (this.#options.publicUrl) {
-      details.push(`public webhook ${this.#options.publicUrl}`);
+    if (this.#publicUrl) {
+      details.push(`public webhook ${this.#publicUrl}`);
     }
     if (target.threadId) {
       details.push(`thread reachable ${target.threadId}`);
@@ -247,11 +251,20 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
   }
 
   async cleanup(): Promise<void> {
-    if (!this.#server) {
+    if (this.#serverClosing) {
+      await this.#serverClosing;
       return;
     }
-    await this.#server.close();
-    this.#server = null;
+
+    const closing = this.#closeWebhookServer();
+    this.#serverClosing = closing;
+    try {
+      await closing;
+    } finally {
+      if (this.#serverClosing === closing) {
+        this.#serverClosing = null;
+      }
+    }
   }
 
   async #handleWebhook(request: Request): Promise<Response> {
@@ -293,27 +306,64 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
   }
 
   async #ensureWebhookServer(): Promise<StartedWebhookServer> {
+    if (this.#serverClosing) {
+      await this.#serverClosing;
+    }
     if (this.#server) {
       return this.#server;
+    }
+    if (this.#serverStarting) {
+      return await this.#serverStarting;
     }
 
     const webhook = this.#options.webhook;
     const host = webhook?.host ?? this.#options.defaultWebhook.host;
     const port = webhook?.port ?? this.#options.defaultWebhook.port;
     const webhookPath = webhook?.path ?? this.#options.defaultWebhook.path;
+    const starting = (async () => {
+      try {
+        return await startWebhookServer({
+          handle: (request) => this.#handleWebhook(request),
+          host,
+          path: webhookPath,
+          port,
+        });
+      } catch (error) {
+        throw new CrablineError(
+          `${this.platform} local mock webhook server failed: ${ensureErrorMessage(error)}`,
+          { cause: error, kind: "connectivity" },
+        );
+      }
+    })();
+    this.#serverStarting = starting;
+
     try {
-      this.#server = await startWebhookServer({
-        handle: (request) => this.#handleWebhook(request),
-        host,
-        path: webhookPath,
-        port,
-      });
-      return this.#server;
-    } catch (error) {
-      throw new CrablineError(
-        `${this.platform} local mock webhook server failed: ${ensureErrorMessage(error)}`,
-        { cause: error, kind: "connectivity" },
-      );
+      const server = await starting;
+      this.#server = server;
+      return server;
+    } finally {
+      if (this.#serverStarting === starting) {
+        this.#serverStarting = null;
+      }
     }
+  }
+
+  async #closeWebhookServer(): Promise<void> {
+    let server = this.#server;
+    if (!server && this.#serverStarting) {
+      try {
+        server = await this.#serverStarting;
+      } catch {
+        return;
+      }
+    }
+    if (!server) {
+      return;
+    }
+
+    if (this.#server === server) {
+      this.#server = null;
+    }
+    await server.close();
   }
 }

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -136,10 +136,14 @@ export async function waitForRecordedInbound(params: {
   timeoutMs: number;
 }): Promise<RecordedInboundEnvelope | null> {
   const deadline = Date.now() + params.timeoutMs;
+  const state: IncrementalReadState = {
+    offset: 0,
+    pending: Buffer.alloc(0),
+  };
   const seen = new Set<string>();
 
   while (Date.now() <= deadline) {
-    const events = await readRecordedInbound(params.filePath);
+    const events = await readRecordedInboundAppend(params.filePath, state);
     for (const event of events) {
       const key = toRecordKey(event);
       if (seen.has(key)) {

--- a/test/local-mock-provider.test.ts
+++ b/test/local-mock-provider.test.ts
@@ -2,8 +2,12 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ProviderConfig } from "../src/config/schema.js";
 import { SlackProviderAdapter } from "../src/providers/builtin/slack.js";
+import {
+  createGenericLocalMockTargetCodec,
+  LocalMockProviderAdapter,
+} from "../src/providers/local-mock.js";
 import { appendRecordedInbound } from "../src/providers/recorder.js";
-import type { ProviderContext } from "../src/providers/types.js";
+import type { ProviderAdapter, ProviderContext } from "../src/providers/types.js";
 import { createTempDir, disposeTempDir } from "./test-helpers.js";
 
 const webhookMocks = vi.hoisted(() => ({
@@ -15,7 +19,7 @@ vi.mock("../src/providers/webhook-server.js", () => ({
 }));
 
 const directories: string[] = [];
-const providers: SlackProviderAdapter[] = [];
+const providers: ProviderAdapter[] = [];
 
 beforeEach(() => {
   webhookMocks.startWebhookServer.mockReset();
@@ -26,12 +30,50 @@ beforeEach(() => {
 });
 
 afterEach(async () => {
-  await Promise.all(providers.splice(0).map((provider) => provider.cleanup()));
+  await Promise.all(providers.splice(0).map((provider) => provider.cleanup?.()));
   await Promise.all(directories.splice(0).map(disposeTempDir));
 });
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function createConfig(): ProviderConfig {
+  return {
+    adapter: "slack",
+    capabilities: ["probe", "send", "roundtrip", "agent"],
+    env: [],
+    platform: "slack",
+    slack: {
+      recorder: {},
+      webhook: {
+        host: "127.0.0.1",
+        path: "/slack/events",
+        port: 0,
+      },
+    },
+    status: "active",
+  };
+}
+
+function createContext(config: ProviderConfig): ProviderContext {
+  return {
+    config,
+    fixture: {
+      env: [],
+      id: "slack-probe",
+      inboundMatch: { author: "assistant", nonce: "contains", strategy: "contains" },
+      mode: "probe",
+      provider: "provider-a",
+      retries: 0,
+      tags: [],
+      target: { id: "C1234567890", metadata: {} },
+      timeoutMs: 500,
+    },
+    manifestPath: "/tmp/crabline.yaml",
+    providerId: "provider-a",
+    userName: "crabline",
+  };
 }
 
 describe("local mock provider", () => {
@@ -77,6 +119,83 @@ describe("local mock provider", () => {
         userName: "crabline",
       }),
     ).rejects.toThrow(/EADDRINUSE/u);
+  });
+
+  it("shares one listener across concurrent probes and closes it once", async () => {
+    let resolveStart:
+      | ((server: { close(): Promise<void>; endpointUrl: string }) => void)
+      | undefined;
+    const close = vi.fn(async () => undefined);
+    webhookMocks.startWebhookServer.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveStart = resolve;
+      }),
+    );
+    const config = createConfig();
+    const provider = new SlackProviderAdapter("provider-a", config, "crabline");
+    providers.push(provider);
+    const context = createContext(config);
+
+    const firstProbe = provider.probe(context);
+    const secondProbe = provider.probe(context);
+    await vi.waitFor(() => expect(webhookMocks.startWebhookServer).toHaveBeenCalledTimes(1));
+
+    resolveStart?.({
+      close,
+      endpointUrl: "http://127.0.0.1:43210/slack/events",
+    });
+
+    await expect(Promise.all([firstProbe, secondProbe])).resolves.toEqual([
+      expect.objectContaining({ healthy: true }),
+      expect.objectContaining({ healthy: true }),
+    ]);
+    expect(webhookMocks.startWebhookServer).toHaveBeenCalledTimes(1);
+
+    await Promise.all([provider.cleanup(), provider.cleanup()]);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the webhook public URL and gives the top-level option precedence", async () => {
+    const config = createConfig();
+    const context = createContext(config);
+    const createProvider = (publicUrl?: string) =>
+      new LocalMockProviderAdapter({
+        codec: createGenericLocalMockTargetCodec("slack"),
+        config,
+        id: "provider-a",
+        options: {
+          defaultWebhook: {
+            host: "127.0.0.1",
+            path: "/slack/events",
+            port: 0,
+          },
+          endpointLabel: "webhook endpoint",
+          platform: "slack",
+          publicUrl,
+          webhook: {
+            host: "127.0.0.1",
+            path: "/slack/events",
+            port: 0,
+            publicUrl: "https://webhook.example.test/slack/events",
+          },
+        },
+      });
+
+    const fallbackProvider = createProvider();
+    providers.push(fallbackProvider);
+    await expect(fallbackProvider.probe(context)).resolves.toMatchObject({
+      details: expect.arrayContaining(["public webhook https://webhook.example.test/slack/events"]),
+    });
+
+    const preferredProvider = createProvider("https://top-level.example.test/slack/events");
+    providers.push(preferredProvider);
+    const preferredProbe = await preferredProvider.probe(context);
+    expect(preferredProbe.details).toContain(
+      "public webhook https://top-level.example.test/slack/events",
+    );
+    expect(preferredProbe.details).not.toContain(
+      "public webhook https://webhook.example.test/slack/events",
+    );
   });
 
   it("does not watch events from another provider sharing its recorder", async () => {

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -161,6 +161,75 @@ describe("recorder", () => {
     expect(Date.now() - startedAt).toBeLessThan(500);
   });
 
+  it("reads only appended bytes while waiting and preserves a partial record", async () => {
+    const filePath = await createRecorderPath();
+    const now = new Date().toISOString();
+    const history = Array.from(
+      { length: 1000 },
+      (_, index) =>
+        `${JSON.stringify({
+          author: "user",
+          id: `history-${index}`,
+          provider: "slack",
+          recordedAt: now,
+          sentAt: now,
+          text: "history",
+          threadId: "slack:C999",
+        })}\n`,
+    ).join("");
+    const tail = JSON.stringify({
+      author: "assistant",
+      id: "evt-tail",
+      provider: "slack",
+      recordedAt: now,
+      sentAt: now,
+      text: "completed tail",
+      threadId: "slack:C123",
+    });
+    const splitAt = Math.floor(tail.length / 2);
+    await appendFile(filePath, history + tail.slice(0, splitAt), "utf8");
+
+    const probeHandle = await open(filePath, "r");
+    const fileHandlePrototype = Object.getPrototypeOf(probeHandle);
+    await probeHandle.close();
+    const originalRead = fileHandlePrototype.read;
+    let bytesRead = 0;
+    fileHandlePrototype.read = async function (
+      this: FileHandle,
+      buffer: Uint8Array,
+      offset?: number | null,
+      length?: number | null,
+      position?: number | null,
+    ) {
+      const result = await originalRead.call(this, buffer, offset, length, position);
+      bytesRead += result.bytesRead;
+      return result;
+    };
+
+    try {
+      const waitPromise = waitForRecordedInbound({
+        filePath,
+        matches: (event) => event.id === "evt-tail",
+        pollMs: 10,
+        timeoutMs: 500,
+      });
+
+      setTimeout(() => {
+        void appendFile(filePath, `${tail.slice(splitAt)}\n`, "utf8");
+      }, 25);
+
+      await expect(waitPromise).resolves.toMatchObject({
+        id: "evt-tail",
+        text: "completed tail",
+      });
+      const fileSize = Buffer.byteLength(`${history}${tail}\n`);
+      expect(bytesRead).toBeGreaterThanOrEqual(fileSize);
+      expect(bytesRead).toBeLessThan(fileSize * 2);
+    } finally {
+      fileHandlePrototype.read = originalRead;
+    }
+  });
+
   it("streams new inbound events", async () => {
     const filePath = await createRecorderPath();
     const iterator = watchRecordedInbound({

--- a/test/whatsapp-provider-lifecycle.test.ts
+++ b/test/whatsapp-provider-lifecycle.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProviderConfig } from "../src/config/schema.js";
+import { WhatsAppProviderAdapter } from "../src/providers/builtin/whatsapp.js";
+import type { ProviderContext } from "../src/providers/types.js";
+
+const webhookMocks = vi.hoisted(() => ({
+  startWebhookServer: vi.fn(),
+}));
+
+vi.mock("../src/providers/webhook-server.js", () => ({
+  startWebhookServer: webhookMocks.startWebhookServer,
+}));
+
+beforeEach(() => {
+  webhookMocks.startWebhookServer.mockReset();
+});
+
+function createConfig(): ProviderConfig {
+  return {
+    adapter: "whatsapp",
+    capabilities: ["probe", "send", "roundtrip", "agent"],
+    env: [],
+    platform: "whatsapp",
+    status: "active",
+    whatsapp: {
+      recorder: {},
+      webhook: {
+        host: "127.0.0.1",
+        path: "/whatsapp/webhook",
+        port: 0,
+      },
+    },
+  };
+}
+
+function createContext(config: ProviderConfig): ProviderContext {
+  return {
+    config,
+    fixture: {
+      env: [],
+      id: "whatsapp-probe",
+      inboundMatch: { author: "assistant", nonce: "contains", strategy: "contains" },
+      mode: "probe",
+      provider: "whatsapp",
+      retries: 0,
+      tags: [],
+      target: { id: "15551234567", metadata: {} },
+      timeoutMs: 500,
+    },
+    manifestPath: "/tmp/crabline.yaml",
+    providerId: "whatsapp",
+    userName: "crabline",
+  };
+}
+
+describe("WhatsApp provider lifecycle", () => {
+  it("shares one listener across concurrent probes and closes it once", async () => {
+    let resolveStart:
+      | ((server: { close(): Promise<void>; endpointUrl: string }) => void)
+      | undefined;
+    const close = vi.fn(async () => undefined);
+    webhookMocks.startWebhookServer.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveStart = resolve;
+      }),
+    );
+    const config = createConfig();
+    const provider = new WhatsAppProviderAdapter("whatsapp", config, "crabline");
+    const context = createContext(config);
+
+    const firstProbe = provider.probe(context);
+    const secondProbe = provider.probe(context);
+    await vi.waitFor(() => expect(webhookMocks.startWebhookServer).toHaveBeenCalledTimes(1));
+
+    resolveStart?.({
+      close,
+      endpointUrl: "http://127.0.0.1:43210/whatsapp/webhook",
+    });
+
+    await expect(Promise.all([firstProbe, secondProbe])).resolves.toEqual([
+      expect.objectContaining({ healthy: true }),
+      expect.objectContaining({ healthy: true }),
+    ]);
+    expect(webhookMocks.startWebhookServer).toHaveBeenCalledTimes(1);
+
+    await Promise.all([provider.cleanup(), provider.cleanup()]);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- coalesce concurrent local mock and WhatsApp listener startup
- make cleanup close in-flight listeners exactly once
- honor nested public webhook URL fallback and precedence
- poll recorder JSONL incrementally

## Verification

- Crabbox `run_7f2ffae7c3aa`: `pnpm verify` (41 files, 241 tests)
- autoreview: `gpt-5.6-sol` high, clean (0.94)
- focused runtime tests: 66 passed
