### PR TITLE
fix(openclaw): validate targets and bound probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Serve WhatsApp Cloud API requests on provider-native Graph routes, queue acknowledged Baileys inbound messages until a session opens, and bound binary frame decoding.
 - Accept uint64 unknown fields in WhatsApp handshakes and bound recursive binary-node decoding.
 - Harden OpenClaw bridges for provider-level probe failures, whitespace-preserving message capture, stable symbolic Telegram IDs, and unsupported thread targets.
+- Reject invalid Telegram topic IDs in explicit OpenClaw QA targets instead of silently dropping or coercing them.
 
 ## 0.1.9 - 2026-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Accept uint64 unknown fields in WhatsApp handshakes and bound recursive binary-node decoding.
 - Harden OpenClaw bridges for provider-level probe failures, whitespace-preserving message capture, stable symbolic Telegram IDs, and unsupported thread targets.
 - Reject invalid Telegram topic IDs in explicit OpenClaw QA targets instead of silently dropping or coercing them.
+- Bound every OpenClaw provider probe to five seconds and label timeout failures.
 
 ## 0.1.9 - 2026-07-03
 

--- a/src/openclaw.ts
+++ b/src/openclaw.ts
@@ -19,6 +19,7 @@ import {
   OPENCLAW_CRABLINE_DEFAULT_CHANNEL,
   OPENCLAW_CRABLINE_MANIFEST_PATH,
   parseQaTarget,
+  runOpenClawCrablineProviderProbe,
   type OpenClawCrablineAgentDelivery,
   type OpenClawCrablineChannelDriverSelection,
   type OpenClawCrablineChannelDriverSmokeResult,
@@ -75,7 +76,11 @@ function createOpenClawCrablineProviderAdapter(
     (candidate) => candidate.provider === manifest.provider,
   );
   if (bridge) {
-    return bridge.createAdapterFromManifest(manifest);
+    const adapter = bridge.createAdapterFromManifest(manifest);
+    return {
+      ...adapter,
+      probe: () => runOpenClawCrablineProviderProbe(manifest.provider, () => adapter.probe()),
+    };
   }
   throw new Error("Unsupported OpenClaw provider binding.");
 }

--- a/src/openclaw.ts
+++ b/src/openclaw.ts
@@ -79,7 +79,8 @@ function createOpenClawCrablineProviderAdapter(
     const adapter = bridge.createAdapterFromManifest(manifest);
     return {
       ...adapter,
-      probe: () => runOpenClawCrablineProviderProbe(manifest.provider, () => adapter.probe()),
+      probe: () =>
+        runOpenClawCrablineProviderProbe(manifest.provider, (signal) => adapter.probe(signal)),
     };
   }
   throw new Error("Unsupported OpenClaw provider binding.");

--- a/src/openclaw/bridges/matrix.ts
+++ b/src/openclaw/bridges/matrix.ts
@@ -29,9 +29,10 @@ export const MATRIX_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablinePr
   provider: "matrix",
   createAdapter(matrix) {
     return {
-      async probe() {
+      async probe(signal) {
         const response = await fetch(`${matrix.endpoints.clientApiRoot}/account/whoami`, {
           headers: { authorization: `Bearer ${matrix.accessToken}` },
+          ...(signal ? { signal } : {}),
         });
         if (!response.ok) {
           throw new Error(`Crabline Matrix probe failed with HTTP ${response.status}.`);

--- a/src/openclaw/bridges/mattermost.ts
+++ b/src/openclaw/bridges/mattermost.ts
@@ -29,9 +29,10 @@ export const MATTERMOST_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabli
   provider: "mattermost",
   createAdapter(mattermost) {
     return {
-      async probe() {
+      async probe(signal) {
         const response = await fetch(`${mattermost.endpoints.apiRoot}/users/me`, {
           headers: { authorization: `Bearer ${mattermost.botToken}` },
+          ...(signal ? { signal } : {}),
         });
         if (!response.ok) {
           throw new Error(`Crabline Mattermost probe failed with HTTP ${response.status}.`);

--- a/src/openclaw/bridges/signal.ts
+++ b/src/openclaw/bridges/signal.ts
@@ -30,8 +30,10 @@ export const SIGNAL_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablinePr
   provider: "signal",
   createAdapter(signal) {
     return {
-      async probe() {
-        const response = await fetch(`${signal.baseUrl}/api/v1/check`);
+      async probe(abortSignal) {
+        const response = await fetch(`${signal.baseUrl}/api/v1/check`, {
+          ...(abortSignal ? { signal: abortSignal } : {}),
+        });
         if (!response.ok) {
           throw new Error(`Crabline Signal check probe failed with HTTP ${response.status}.`);
         }

--- a/src/openclaw/bridges/slack.ts
+++ b/src/openclaw/bridges/slack.ts
@@ -54,10 +54,11 @@ export const SLACK_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablinePro
   provider: "slack",
   createAdapter(slack) {
     return {
-      async probe() {
+      async probe(signal) {
         const response = await fetch(`${slack.endpoints.apiRoot}auth.test`, {
           headers: { authorization: `Bearer ${slack.botToken}` },
           method: "POST",
+          ...(signal ? { signal } : {}),
         });
         if (!response.ok) {
           throw new Error(`Crabline Slack auth.test probe failed with HTTP ${response.status}.`);

--- a/src/openclaw/bridges/telegram.ts
+++ b/src/openclaw/bridges/telegram.ts
@@ -36,6 +36,21 @@ function telegramTargetKey(chatId: string, threadId?: number) {
   return threadId === undefined ? chatId : `${chatId}:topic:${threadId}`;
 }
 
+function parseTelegramThreadTargetId(value: string | undefined): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!/^\d+$/u.test(trimmed)) {
+    throw new Error("Telegram thread target must be a safe non-negative integer.");
+  }
+  const threadId = Number(trimmed);
+  if (!Number.isSafeInteger(threadId)) {
+    throw new Error("Telegram thread target must be a safe non-negative integer.");
+  }
+  return threadId;
+}
+
 export const TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablineProviderBridge({
   provider: "telegram",
   createAdapter(telegram) {
@@ -100,7 +115,7 @@ export const TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
       },
       createAgentDelivery(parsed) {
         const chatId = normalizeTelegramChatId(parsed.kind, parsed.id);
-        const threadId = readInteger(parsed.threadId);
+        const threadId = parseTelegramThreadTargetId(parsed.threadId);
         const to = telegramTargetKey(chatId, threadId);
         return {
           channel: "telegram",

--- a/src/openclaw/bridges/telegram.ts
+++ b/src/openclaw/bridges/telegram.ts
@@ -55,8 +55,11 @@ export const TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
   provider: "telegram",
   createAdapter(telegram) {
     return {
-      async probe() {
-        const response = await fetch(`${telegram.endpoints.apiRoot}/bot${telegram.botToken}/getMe`);
+      async probe(signal) {
+        const response = await fetch(
+          `${telegram.endpoints.apiRoot}/bot${telegram.botToken}/getMe`,
+          signal ? { signal } : {},
+        );
         if (!response.ok) {
           throw new Error(`Crabline Telegram getMe probe failed with HTTP ${response.status}.`);
         }

--- a/src/openclaw/bridges/whatsapp.ts
+++ b/src/openclaw/bridges/whatsapp.ts
@@ -24,11 +24,12 @@ export const WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
   createAdapter(whatsapp) {
     const messagesPath = new URL(whatsapp.endpoints.messagesUrl).pathname;
     return {
-      async probe() {
+      async probe(signal) {
         const response = await fetch(whatsapp.endpoints.phoneNumberUrl, {
           headers: {
             authorization: `Bearer ${whatsapp.accessToken}`,
           },
+          ...(signal ? { signal } : {}),
         });
         if (!response.ok) {
           throw new Error(`Crabline WhatsApp probe failed with HTTP ${response.status}.`);

--- a/src/openclaw/bridges/zalo.ts
+++ b/src/openclaw/bridges/zalo.ts
@@ -20,9 +20,10 @@ export const ZALO_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablineProv
   provider: "zalo",
   createAdapter(zalo) {
     return {
-      async probe() {
+      async probe(signal) {
         const response = await fetch(`${zalo.endpoints.apiRoot}/bot${zalo.botToken}/getMe`, {
           method: "POST",
+          ...(signal ? { signal } : {}),
         });
         if (!response.ok) {
           throw new Error(`Crabline Zalo getMe probe failed with HTTP ${response.status}.`);

--- a/src/openclaw/shared.ts
+++ b/src/openclaw/shared.ts
@@ -9,6 +9,17 @@ export const OPENCLAW_CRABLINE_CHANNEL_SMOKE_PATH = "crabline-fake-provider-smok
 export const OPENCLAW_CRABLINE_MANIFEST_PATH = "crabline-fake-provider-server.json";
 export const OPENCLAW_CRABLINE_DEFAULT_CHANNEL = "telegram";
 
+const OPENCLAW_CRABLINE_PROVIDER_PROBE_TIMEOUT_MS = 5_000;
+const OPENCLAW_CRABLINE_PROVIDER_PROBE_LABELS = {
+  mattermost: "Mattermost users.me",
+  matrix: "Matrix whoami",
+  signal: "Signal check",
+  slack: "Slack auth.test",
+  telegram: "Telegram getMe",
+  whatsapp: "WhatsApp phone number",
+  zalo: "Zalo getMe",
+} satisfies Record<CrablineServerManifest["provider"], string>;
+
 export type OpenClawCrablineChannelDriverSelection = {
   channel: CrablineServerChannel;
   channelDriver: "crabline";
@@ -156,6 +167,42 @@ export function createOpenClawCrablineProviderBridge<
     provider: params.provider as ProviderManifest["provider"],
   };
   return bridge;
+}
+
+export async function runOpenClawCrablineProviderProbe<T>(
+  provider: CrablineServerManifest["provider"],
+  probe: () => Promise<T>,
+): Promise<T> {
+  const signal = AbortSignal.timeout(OPENCLAW_CRABLINE_PROVIDER_PROBE_TIMEOUT_MS);
+  const timeoutError = (cause: unknown) =>
+    new Error(
+      `Crabline ${OPENCLAW_CRABLINE_PROVIDER_PROBE_LABELS[provider]} probe timed out after ${OPENCLAW_CRABLINE_PROVIDER_PROBE_TIMEOUT_MS} ms.`,
+      { cause },
+    );
+  let onAbort: (() => void) | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    onAbort = () => reject(timeoutError(signal.reason));
+    if (signal.aborted) {
+      onAbort();
+      return;
+    }
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+  const probeResult = Promise.resolve()
+    .then(probe)
+    .catch((error: unknown) => {
+      if (signal.aborted) {
+        throw timeoutError(error);
+      }
+      throw error;
+    });
+  try {
+    return await Promise.race([probeResult, timeout]);
+  } finally {
+    if (onAbort) {
+      signal.removeEventListener("abort", onAbort);
+    }
+  }
 }
 
 export function readString(value: unknown): string | undefined {

--- a/src/openclaw/shared.ts
+++ b/src/openclaw/shared.ts
@@ -99,7 +99,7 @@ export type StartedOpenClawCrablineAdapter = OpenClawCrablineGatewayBinding & {
     targetByProviderTarget: ReadonlyMap<string, string>;
   }): OpenClawCrablineOutboundMessage | null;
   manifest: CrablineServerManifest;
-  probe(): Promise<unknown>;
+  probe(signal?: AbortSignal): Promise<unknown>;
 };
 
 export type ParsedQaTarget = {
@@ -116,7 +116,7 @@ export type OpenClawCrablineProviderAdapter = {
     event: unknown;
     targetByProviderTarget: ReadonlyMap<string, string>;
   }): OpenClawCrablineOutboundMessage | null;
-  probe(): Promise<unknown>;
+  probe(signal?: AbortSignal): Promise<unknown>;
 };
 
 export type OpenClawCrablineProviderBridge<
@@ -171,7 +171,7 @@ export function createOpenClawCrablineProviderBridge<
 
 export async function runOpenClawCrablineProviderProbe<T>(
   provider: CrablineServerManifest["provider"],
-  probe: () => Promise<T>,
+  probe: (signal: AbortSignal) => Promise<T>,
 ): Promise<T> {
   const signal = AbortSignal.timeout(OPENCLAW_CRABLINE_PROVIDER_PROBE_TIMEOUT_MS);
   const timeoutError = (cause: unknown) =>
@@ -189,7 +189,7 @@ export async function runOpenClawCrablineProviderProbe<T>(
     signal.addEventListener("abort", onAbort, { once: true });
   });
   const probeResult = Promise.resolve()
-    .then(probe)
+    .then(() => probe(signal))
     .catch((error: unknown) => {
       if (signal.aborted) {
         throw timeoutError(error);

--- a/src/openclaw/shared.ts
+++ b/src/openclaw/shared.ts
@@ -99,7 +99,7 @@ export type StartedOpenClawCrablineAdapter = OpenClawCrablineGatewayBinding & {
     targetByProviderTarget: ReadonlyMap<string, string>;
   }): OpenClawCrablineOutboundMessage | null;
   manifest: CrablineServerManifest;
-  probe(signal?: AbortSignal): Promise<unknown>;
+  probe(): Promise<unknown>;
 };
 
 export type ParsedQaTarget = {

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -197,6 +197,53 @@ describe("OpenClaw local provider bridge", () => {
     }
   });
 
+  it.each([
+    { label: "Mattermost users.me", manifest: mattermostManifest },
+    { label: "Matrix whoami", manifest: matrixManifest },
+    { label: "Signal check", manifest: signalManifest },
+    { label: "Slack auth.test", manifest: slackManifest },
+    { label: "Telegram getMe", manifest },
+    { label: "WhatsApp phone number", manifest: whatsappManifest },
+    { label: "Zalo getMe", manifest: zaloManifest },
+  ])("times out stalled $label probe headers", async ({ label, manifest: probeManifest }) => {
+    const controller = new AbortController();
+    const timeoutMock = vi.spyOn(AbortSignal, "timeout").mockReturnValue(controller.signal);
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(() => new Promise<Response>(() => {}));
+    try {
+      const probe = probeOpenClawCrablineProvider(probeManifest);
+      expect(timeoutMock).toHaveBeenCalledWith(5_000);
+      controller.abort(new DOMException("probe deadline", "TimeoutError"));
+      await expect(probe).rejects.toThrow(
+        `Crabline ${label} probe timed out after 5000 ms.`,
+      );
+    } finally {
+      fetchMock.mockRestore();
+      timeoutMock.mockRestore();
+    }
+  });
+
+  it("times out a stalled provider probe response body", async () => {
+    const controller = new AbortController();
+    const timeoutMock = vi.spyOn(AbortSignal, "timeout").mockReturnValue(controller.signal);
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      json: () => new Promise<unknown>(() => {}),
+      ok: true,
+      status: 200,
+    } as Response);
+    try {
+      const probe = probeOpenClawCrablineProvider(manifest);
+      controller.abort(new DOMException("probe deadline", "TimeoutError"));
+      await expect(probe).rejects.toThrow(
+        "Crabline Telegram getMe probe timed out after 5000 ms.",
+      );
+    } finally {
+      fetchMock.mockRestore();
+      timeoutMock.mockRestore();
+    }
+  });
+
   it("resolves channel-driver metadata through Crabline", () => {
     expect(resolveOpenClawCrablineChannelDriverSelection({})).toEqual({
       capabilityMatrixPath: OPENCLAW_CRABLINE_CHANNEL_CAPABILITY_MATRIX_PATH,

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -215,9 +215,7 @@ describe("OpenClaw local provider bridge", () => {
       const probe = probeOpenClawCrablineProvider(probeManifest);
       expect(timeoutMock).toHaveBeenCalledWith(5_000);
       controller.abort(new DOMException("probe deadline", "TimeoutError"));
-      await expect(probe).rejects.toThrow(
-        `Crabline ${label} probe timed out after 5000 ms.`,
-      );
+      await expect(probe).rejects.toThrow(`Crabline ${label} probe timed out after 5000 ms.`);
     } finally {
       fetchMock.mockRestore();
       timeoutMock.mockRestore();
@@ -235,9 +233,7 @@ describe("OpenClaw local provider bridge", () => {
     try {
       const probe = probeOpenClawCrablineProvider(manifest);
       controller.abort(new DOMException("probe deadline", "TimeoutError"));
-      await expect(probe).rejects.toThrow(
-        "Crabline Telegram getMe probe timed out after 5000 ms.",
-      );
+      await expect(probe).rejects.toThrow("Crabline Telegram getMe probe timed out after 5000 ms.");
     } finally {
       fetchMock.mockRestore();
       timeoutMock.mockRestore();

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -208,9 +208,12 @@ describe("OpenClaw local provider bridge", () => {
   ])("times out stalled $label probe headers", async ({ label, manifest: probeManifest }) => {
     const controller = new AbortController();
     const timeoutMock = vi.spyOn(AbortSignal, "timeout").mockReturnValue(controller.signal);
-    const fetchMock = vi
-      .spyOn(globalThis, "fetch")
-      .mockImplementation(() => new Promise<Response>(() => {}));
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation((_input, init) => {
+      expect(init?.signal).toBe(controller.signal);
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
+      });
+    });
     try {
       const probe = probeOpenClawCrablineProvider(probeManifest);
       expect(timeoutMock).toHaveBeenCalledWith(5_000);
@@ -225,11 +228,19 @@ describe("OpenClaw local provider bridge", () => {
   it("times out a stalled provider probe response body", async () => {
     const controller = new AbortController();
     const timeoutMock = vi.spyOn(AbortSignal, "timeout").mockReturnValue(controller.signal);
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue({
-      json: () => new Promise<unknown>(() => {}),
-      ok: true,
-      status: 200,
-    } as Response);
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation((_input, init) => {
+      expect(init?.signal).toBe(controller.signal);
+      return Promise.resolve({
+        json: () =>
+          new Promise<unknown>((_resolve, reject) => {
+            init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), {
+              once: true,
+            });
+          }),
+        ok: true,
+        status: 200,
+      } as Response);
+    });
     try {
       const probe = probeOpenClawCrablineProvider(manifest);
       controller.abort(new DOMException("probe deadline", "TimeoutError"));

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -657,6 +657,37 @@ describe("OpenClaw local provider bridge", () => {
     });
   });
 
+  it("validates explicit Telegram thread target ids", () => {
+    const symbolicGroup = createOpenClawCrablineAgentDelivery({
+      manifest,
+      target: "group:alice",
+    }).to;
+
+    for (const threadId of ["0", "42", String(Number.MAX_SAFE_INTEGER)]) {
+      expect(
+        createOpenClawCrablineAgentDelivery({
+          manifest,
+          target: `thread:alice/${threadId}`,
+        }).to,
+      ).toBe(`${symbolicGroup}:topic:${threadId}`);
+    }
+
+    for (const threadId of [
+      "",
+      "not-a-number",
+      "-1",
+      String(Number.MAX_SAFE_INTEGER + 1),
+      "9".repeat(400),
+    ]) {
+      expect(() =>
+        createOpenClawCrablineAgentDelivery({
+          manifest,
+          target: `thread:alice/${threadId}`,
+        }),
+      ).toThrow("Telegram thread target must be a safe non-negative integer.");
+    }
+  });
+
   it("maps WhatsApp QA targets, inbound messages, and recorder events", () => {
     expect(
       createOpenClawCrablineAgentDelivery({


### PR DESCRIPTION
## Summary

- reject malformed explicit Telegram topic targets
- bound all OpenClaw provider probes to five seconds
- abort the underlying fetch and body read on deadline
- keep cancellation internal to the bridge contract

## Verification

- Crabbox `run_6024952a1be0`: `pnpm verify` (40 files, 251 tests)
- autoreview: `gpt-5.6-sol` high, clean after two accepted fixes (0.97)
- focused OpenClaw tests: 27 passed
