### PR TITLE
fix(servers): harden provider request ingress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Reject ambiguous fixture/config inputs and keep the published CLI, type dependencies, and README assets aligned with their public contract.
 - Poll recorder JSONL incrementally while preserving incomplete trailing records.
 - Serialize local mock and WhatsApp webhook startup and cleanup, and honor explicit public webhook URL precedence.
+- Bound Matrix, Mattermost, Signal, Slack, and WhatsApp request bodies, validate JSON object payloads with native errors, and keep rejected authentication out of recorder events.
 - Harden release packaging and retries, and make cleanup scripts portable across supported platforms.
 - Export the OpenClaw conversation type from the package root.
 - Harden CLI lifecycle cleanup, ready-file publication, run diagnostics, and config validation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Implement Telegram `getUpdates` long polling with timeout wakeups, offset confirmation, negative offsets, and shutdown cleanup.
 - Restrict releases to stable version tags and resolve workflow-dispatch inputs through exact tag refs before publication.
 - Reject ambiguous fixture/config inputs and keep the published CLI, type dependencies, and README assets aligned with their public contract.
 - Poll recorder JSONL incrementally while preserving incomplete trailing records.

--- a/src/servers/http.ts
+++ b/src/servers/http.ts
@@ -12,6 +12,7 @@ export type ServerRequestEvent = {
 };
 
 export const ADMIN_TOKEN_HEADER = "x-crabline-admin-token";
+export const DEFAULT_MAX_REQUEST_BODY_BYTES = 1024 * 1024;
 
 export class InvalidJsonBodyError extends Error {
   constructor(cause: unknown) {
@@ -20,20 +21,99 @@ export class InvalidJsonBodyError extends Error {
   }
 }
 
+export class RequestBodyTooLargeError extends Error {
+  constructor(readonly maxBytes: number) {
+    super(`Request body exceeds the ${maxBytes} byte limit.`);
+    this.name = "RequestBodyTooLargeError";
+  }
+}
+
 export function jsonResponse(value: unknown, status = 200): Response {
   return Response.json(value, { status });
 }
 
-export async function readBody(request: IncomingMessage): Promise<Buffer> {
-  const chunks: Buffer[] = [];
-  for await (const chunk of request) {
-    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-  }
-  return Buffer.concat(chunks);
+function drainRejectedRequest(request: IncomingMessage): void {
+  const ignoreError = () => {};
+  const cleanup = () => {
+    request.off("close", cleanup);
+    request.off("end", cleanup);
+    request.off("error", ignoreError);
+  };
+
+  request.on("error", ignoreError);
+  request.once("close", cleanup);
+  request.once("end", cleanup);
+  request.resume();
 }
 
-export async function parseRequestBody(request: IncomingMessage): Promise<Record<string, unknown>> {
-  const body = await readBody(request);
+export async function readBody(
+  request: IncomingMessage,
+  maxBytes = DEFAULT_MAX_REQUEST_BODY_BYTES,
+): Promise<Buffer> {
+  const contentLengthHeader = request.headers["content-length"];
+  const contentLengthValue = Array.isArray(contentLengthHeader)
+    ? contentLengthHeader[0]
+    : contentLengthHeader;
+  if (contentLengthValue && /^\d+$/u.test(contentLengthValue)) {
+    const contentLength = Number(contentLengthValue);
+    if (!Number.isSafeInteger(contentLength) || contentLength > maxBytes) {
+      drainRejectedRequest(request);
+      throw new RequestBodyTooLargeError(maxBytes);
+    }
+  }
+
+  return await new Promise<Buffer>((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let length = 0;
+    let settled = false;
+
+    const cleanup = () => {
+      request.off("aborted", onAborted);
+      request.off("data", onData);
+      request.off("end", onEnd);
+      request.off("error", onError);
+    };
+    const fail = (error: Error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      drainRejectedRequest(request);
+      cleanup();
+      reject(error);
+    };
+    const onAborted = () => fail(new Error("Request body stream was aborted."));
+    const onData = (chunk: Buffer | string) => {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      length += buffer.length;
+      if (length > maxBytes) {
+        fail(new RequestBodyTooLargeError(maxBytes));
+        return;
+      }
+      chunks.push(buffer);
+    };
+    const onEnd = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      resolve(Buffer.concat(chunks, length));
+    };
+    const onError = (error: Error) => fail(error);
+
+    request.on("aborted", onAborted);
+    request.on("data", onData);
+    request.on("end", onEnd);
+    request.on("error", onError);
+  });
+}
+
+export async function parseUnknownRequestBody(
+  request: IncomingMessage,
+  maxBytes = DEFAULT_MAX_REQUEST_BODY_BYTES,
+): Promise<unknown> {
+  const body = await readBody(request, maxBytes);
   if (body.length === 0) {
     return {};
   }
@@ -43,13 +123,24 @@ export async function parseRequestBody(request: IncomingMessage): Promise<Record
     : contentType.includes("json");
   if (includesJson) {
     try {
-      return JSON.parse(body.toString("utf8")) as Record<string, unknown>;
+      return JSON.parse(body.toString("utf8")) as unknown;
     } catch (error) {
       throw new InvalidJsonBodyError(error);
     }
   }
   const params = new URLSearchParams(body.toString("utf8"));
   return Object.fromEntries(params.entries());
+}
+
+export async function parseRequestBody(request: IncomingMessage): Promise<Record<string, unknown>> {
+  return (await parseUnknownRequestBody(request, Number.MAX_SAFE_INTEGER)) as Record<
+    string,
+    unknown
+  >;
+}
+
+export function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 export function queryRecord(url: URL): Record<string, string> {
@@ -73,13 +164,17 @@ export async function writeResponse(
 
 export function closeServer(server: Server): Promise<void> {
   return new Promise((resolve, reject) => {
+    const closeIdleInterval = setInterval(() => server.closeIdleConnections(), 25);
+    closeIdleInterval.unref();
     server.close((error) => {
+      clearInterval(closeIdleInterval);
       if (error) {
         reject(error);
         return;
       }
       resolve();
     });
+    server.closeIdleConnections();
   });
 }
 

--- a/src/servers/matrix.ts
+++ b/src/servers/matrix.ts
@@ -5,11 +5,13 @@ import {
   adminAuthError,
   hasAdminToken,
   InvalidJsonBodyError,
+  isJsonObject,
   jsonResponse,
-  parseRequestBody,
+  parseUnknownRequestBody,
   queryRecord,
   readInteger,
   readTrimmedString,
+  RequestBodyTooLargeError,
   startHttpJsonServer,
   type ServerRequestEvent,
 } from "./http.js";
@@ -489,44 +491,76 @@ export async function startMatrixServer(
   );
 
   const server = await startHttpJsonServer({
-    handleError: (error) =>
-      error instanceof InvalidJsonBodyError
-        ? matrixError("M_NOT_JSON", "Request body is not valid JSON", 400)
-        : undefined,
+    handleError: (error) => {
+      if (error instanceof InvalidJsonBodyError) {
+        return matrixError("M_NOT_JSON", "Request body is not valid JSON", 400);
+      }
+      if (error instanceof RequestBodyTooLargeError) {
+        return matrixError("M_TOO_LARGE", "Request body is too large", 413);
+      }
+      return undefined;
+    },
     host,
     port: params.port ?? 0,
     serverName: "Matrix",
     async handle(request) {
       const url = new URL(request.url ?? "/", "http://localhost");
       const method = request.method ?? "GET";
-      const body = ["POST", "PUT"].includes(method) ? await parseRequestBody(request) : {};
       const type = url.pathname === "/crabline/matrix/inbound" ? "admin" : "api";
-      await appendEvent(state, {
-        at: new Date().toISOString(),
-        ...(Object.keys(body).length > 0 ? { body } : {}),
-        method,
-        path: url.pathname,
-        query: queryRecord(url),
-        type,
-      });
       if (type === "admin") {
         if (method !== "POST") {
           return jsonResponse({ error: "Method not allowed", ok: false }, 405);
         }
-        return hasAdminToken(request, state.adminToken)
-          ? await handleAdminInbound({ body, state })
-          : adminAuthError();
+        if (!hasAdminToken(request, state.adminToken)) {
+          request.resume();
+          return adminAuthError();
+        }
+        const body = await parseUnknownRequestBody(request);
+        if (!isJsonObject(body)) {
+          return jsonResponse({ error: "Request body must be a JSON object", ok: false }, 400);
+        }
+        await appendEvent(state, {
+          at: new Date().toISOString(),
+          ...(Object.keys(body).length > 0 ? { body } : {}),
+          method,
+          path: url.pathname,
+          query: queryRecord(url),
+          type,
+        });
+        return await handleAdminInbound({ body, state });
       }
       if (url.pathname === "/_matrix/client/versions" && method === "GET") {
+        await appendEvent(state, {
+          at: new Date().toISOString(),
+          method,
+          path: url.pathname,
+          query: queryRecord(url),
+          type,
+        });
         return jsonResponse({ unstable_features: {}, versions: ["v1.11"] });
       }
       if (!url.pathname.startsWith("/_matrix/client/")) {
         return matrixError("M_UNRECOGNIZED", "Unrecognized request", 404);
       }
       if (!authorized(request, state.accessToken)) {
+        request.resume();
         return matrixError("M_UNKNOWN_TOKEN", "Invalid access token", 401);
       }
-      return await handleMatrixApi({ body, method, path: url.pathname, state, url });
+      const parsedBody = ["POST", "PUT"].includes(method)
+        ? await parseUnknownRequestBody(request)
+        : {};
+      if (!isJsonObject(parsedBody)) {
+        return matrixError("M_BAD_JSON", "Request body must be a JSON object", 400);
+      }
+      await appendEvent(state, {
+        at: new Date().toISOString(),
+        ...(Object.keys(parsedBody).length > 0 ? { body: parsedBody } : {}),
+        method,
+        path: url.pathname,
+        query: queryRecord(url),
+        type,
+      });
+      return await handleMatrixApi({ body: parsedBody, method, path: url.pathname, state, url });
     },
   });
 

--- a/src/servers/mattermost.ts
+++ b/src/servers/mattermost.ts
@@ -5,10 +5,13 @@ import { WebSocket, WebSocketServer, type RawData } from "ws";
 import {
   adminAuthError,
   hasAdminToken,
+  InvalidJsonBodyError,
+  isJsonObject,
   jsonResponse,
-  parseRequestBody,
+  parseUnknownRequestBody,
   queryRecord,
   readTrimmedString,
+  RequestBodyTooLargeError,
   startHttpJsonServer,
   type ServerRequestEvent,
 } from "./http.js";
@@ -218,7 +221,7 @@ async function handleAdminInbound(params: {
 }
 
 async function handleApi(params: {
-  body: Record<string, unknown>;
+  body: unknown;
   method: string;
   path: string;
   state: MattermostServerState;
@@ -252,6 +255,9 @@ async function handleApi(params: {
     const channel = { display_name: "", id: channelId, name: channelId, type: "D" };
     state.channels.set(channelId, channel);
     return jsonResponse(channel, 201);
+  }
+  if (!isJsonObject(body)) {
+    return mattermostError("Request body must be a JSON object", 400);
   }
   if (method === "POST" && apiPath === "/users/me/typing") {
     const channelId = readTrimmedString(body.channel_id);
@@ -337,7 +343,10 @@ async function handleRequest(request: IncomingMessage, state: MattermostServerSt
     if (!hasAdminToken(request, state.adminToken)) {
       return adminAuthError();
     }
-    const body = await parseRequestBody(request);
+    const body = await parseUnknownRequestBody(request);
+    if (!isJsonObject(body)) {
+      return jsonResponse({ error: "Request body must be a JSON object", ok: false }, 400);
+    }
     await appendEvent(state, {
       at: new Date().toISOString(),
       body,
@@ -354,10 +363,11 @@ async function handleRequest(request: IncomingMessage, state: MattermostServerSt
   if (!authorized(request, state.botToken)) {
     return mattermostError("Invalid or missing token", 401);
   }
-  const body = method === "GET" || method === "DELETE" ? {} : await parseRequestBody(request);
+  const body =
+    method === "GET" || method === "DELETE" ? {} : await parseUnknownRequestBody(request);
   await appendEvent(state, {
     at: new Date().toISOString(),
-    ...(Object.keys(body).length > 0 ? { body } : {}),
+    ...(typeof body === "object" && body !== null && Object.keys(body).length > 0 ? { body } : {}),
     method,
     path: url.pathname,
     query: queryRecord(url),
@@ -489,6 +499,15 @@ export async function startMattermostServer(
   };
   const httpServer = await startHttpJsonServer({
     handle: (request) => handleRequest(request, state),
+    handleError: (error) => {
+      if (error instanceof InvalidJsonBodyError) {
+        return mattermostError("Request body is not valid JSON", 400);
+      }
+      if (error instanceof RequestBodyTooLargeError) {
+        return mattermostError("Request body is too large", 413);
+      }
+      return undefined;
+    },
     host: params.host ?? "127.0.0.1",
     port: params.port ?? 0,
     serverName: "Mattermost",

--- a/src/servers/signal.ts
+++ b/src/servers/signal.ts
@@ -5,11 +5,14 @@ import {
   adminAuthError,
   closeServer,
   hasAdminToken,
+  InvalidJsonBodyError,
+  isJsonObject,
   jsonResponse,
-  parseRequestBody,
+  parseUnknownRequestBody,
   queryRecord,
   readInteger,
   readTrimmedString,
+  RequestBodyTooLargeError,
   type ServerRequestEvent,
   writeResponse,
 } from "./http.js";
@@ -65,6 +68,17 @@ function rpcResponse(id: unknown, result: unknown): Response {
   return jsonResponse({ id: id ?? null, jsonrpc: "2.0", result });
 }
 
+function rpcError(code: number, message: string, id: unknown = null, status = 400): Response {
+  return jsonResponse(
+    {
+      error: { code, message },
+      id: id ?? null,
+      jsonrpc: "2.0",
+    },
+    status,
+  );
+}
+
 function emitSignalEvent(state: SignalServerState, payload: unknown): void {
   const event = `event:receive\ndata:${JSON.stringify(payload)}\n\n`;
   if (state.clients.size === 0) {
@@ -109,14 +123,7 @@ async function handleRpc(params: {
 }): Promise<Response> {
   const method = readTrimmedString(params.body.method);
   if (!method) {
-    return jsonResponse(
-      {
-        error: { code: -32600, message: "Invalid Request" },
-        id: params.body.id ?? null,
-        jsonrpc: "2.0",
-      },
-      400,
-    );
+    return rpcError(-32600, "Invalid Request", params.body.id);
   }
   if (method === "version") {
     return rpcResponse(params.body.id, { version: "crabline-signal-1" });
@@ -165,7 +172,15 @@ async function handleRequest(params: {
     if (!hasAdminToken(params.request, params.state.adminToken)) {
       fetchResponse = adminAuthError();
     } else {
-      const body = await parseRequestBody(params.request);
+      const body = await parseUnknownRequestBody(params.request);
+      if (!isJsonObject(body)) {
+        fetchResponse = jsonResponse(
+          { error: "Request body must be a JSON object", ok: false },
+          400,
+        );
+        await writeResponse(params.response, fetchResponse);
+        return;
+      }
       await appendEvent(params.state, {
         at: new Date().toISOString(),
         body,
@@ -186,7 +201,11 @@ async function handleRequest(params: {
     });
     fetchResponse = new Response(null, { status: 200 });
   } else if (url.pathname === "/api/v1/rpc" && params.request.method === "POST") {
-    const body = await parseRequestBody(params.request);
+    const body = await parseUnknownRequestBody(params.request);
+    if (!isJsonObject(body)) {
+      await writeResponse(params.response, rpcError(-32600, "Invalid Request"));
+      return;
+    }
     await appendEvent(params.state, {
       at: new Date().toISOString(),
       body,
@@ -218,13 +237,24 @@ export async function startSignalServer(
   const server = createServer((request, response) => {
     void handleRequest({ request, response, state }).catch(async (error) => {
       if (!response.headersSent) {
-        await writeResponse(
-          response,
-          jsonResponse(
+        let errorResponse: Response;
+        const isAdminRequest =
+          new URL(request.url ?? "/", "http://localhost").pathname === "/crabline/signal/inbound";
+        if (error instanceof InvalidJsonBodyError) {
+          errorResponse = isAdminRequest
+            ? jsonResponse({ error: "Request body is not valid JSON", ok: false }, 400)
+            : rpcError(-32700, "Parse error");
+        } else if (error instanceof RequestBodyTooLargeError) {
+          errorResponse = isAdminRequest
+            ? jsonResponse({ error: "Request body is too large", ok: false }, 413)
+            : rpcError(-32600, "Request body is too large", null, 413);
+        } else {
+          errorResponse = jsonResponse(
             { error: error instanceof Error ? error.message : String(error), ok: false },
             500,
-          ),
-        );
+          );
+        }
+        await writeResponse(response, errorResponse);
       } else {
         response.destroy(error instanceof Error ? error : new Error(String(error)));
       }

--- a/src/servers/slack.ts
+++ b/src/servers/slack.ts
@@ -5,11 +5,13 @@ import {
   adminAuthError,
   hasAdminToken,
   InvalidJsonBodyError,
+  isJsonObject,
   jsonResponse,
-  parseRequestBody,
+  parseUnknownRequestBody,
   queryRecord,
   readInteger,
   readTrimmedString,
+  RequestBodyTooLargeError,
   startHttpJsonServer,
   type ServerRequestEvent,
 } from "./http.js";
@@ -351,14 +353,8 @@ async function deliverSlackEvent(
 async function handleSlackApi(params: {
   body: Record<string, unknown>;
   method: string;
-  request: IncomingMessage;
   state: SlackServerState;
 }): Promise<Response> {
-  const authError = requireSlackToken(params.request, params.body, params.state);
-  if (authError) {
-    return authError;
-  }
-
   switch (params.method) {
     case "auth.test":
       return slackOk({
@@ -557,9 +553,13 @@ async function handleRequest(params: { request: IncomingMessage; state: SlackSer
       return new Response("not found", { status: 404 });
     }
     if (!hasAdminToken(params.request, params.state.adminToken)) {
+      params.request.resume();
       return adminAuthError();
     }
-    const body = await parseRequestBody(params.request);
+    const body = await parseUnknownRequestBody(params.request);
+    if (!isJsonObject(body)) {
+      return slackError("invalid_json", 400);
+    }
     await appendEvent(params.state, {
       at: new Date().toISOString(),
       body,
@@ -572,17 +572,20 @@ async function handleRequest(params: { request: IncomingMessage; state: SlackSer
   }
 
   const query = queryRecord(url);
-  const body = params.request.method === "GET" ? query : await parseRequestBody(params.request);
-  await appendEvent(params.state, {
-    at: new Date().toISOString(),
-    body: redactSlackAuthFields(body),
-    method: params.request.method ?? "GET",
-    path: url.pathname,
-    query: redactSlackAuthQuery(query),
-    type: "api",
-  });
-
   if (url.pathname === "/slack/events") {
+    const body =
+      params.request.method === "GET" ? query : await parseUnknownRequestBody(params.request);
+    if (!isJsonObject(body)) {
+      return slackError("invalid_json", 400);
+    }
+    await appendEvent(params.state, {
+      at: new Date().toISOString(),
+      body: redactSlackAuthFields(body),
+      method: params.request.method ?? "GET",
+      path: url.pathname,
+      query: redactSlackAuthQuery(query),
+      type: "api",
+    });
     if (body.type === "url_verification") {
       return jsonResponse({ challenge: readTrimmedString(body.challenge) ?? "" });
     }
@@ -593,10 +596,34 @@ async function handleRequest(params: { request: IncomingMessage; state: SlackSer
   if (!methodMatch?.[1]) {
     return new Response("not found", { status: 404 });
   }
+
+  if (params.request.headers.authorization) {
+    const headerAuthError = requireSlackToken(params.request, {}, params.state);
+    if (headerAuthError) {
+      params.request.resume();
+      return headerAuthError;
+    }
+  }
+  const body =
+    params.request.method === "GET" ? query : await parseUnknownRequestBody(params.request);
+  if (!isJsonObject(body)) {
+    return slackError("json_not_object", 400);
+  }
+  const authError = requireSlackToken(params.request, body, params.state);
+  if (authError) {
+    return authError;
+  }
+  await appendEvent(params.state, {
+    at: new Date().toISOString(),
+    body: redactSlackAuthFields(body),
+    method: params.request.method ?? "GET",
+    path: url.pathname,
+    query: redactSlackAuthQuery(query),
+    type: "api",
+  });
   return await handleSlackApi({
     body,
     method: methodMatch[1],
-    request: params.request,
     state: params.state,
   });
 }
@@ -621,8 +648,15 @@ export async function startSlackServer(
   const host = params.host ?? "127.0.0.1";
   const httpServer = await startHttpJsonServer({
     handle: (request) => handleRequest({ request, state }),
-    handleError: (error) =>
-      error instanceof InvalidJsonBodyError ? slackError("invalid_json", 400) : undefined,
+    handleError: (error) => {
+      if (error instanceof InvalidJsonBodyError) {
+        return slackError("invalid_json", 400);
+      }
+      if (error instanceof RequestBodyTooLargeError) {
+        return slackError("request_too_large", 413);
+      }
+      return undefined;
+    },
     host,
     port: params.port ?? 0,
     serverName: "Slack",

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -1,9 +1,23 @@
-import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { createServer, type IncomingMessage } from "node:http";
 import { randomBytes } from "node:crypto";
 import path from "node:path";
 import { CrablineError } from "../core/errors.js";
-import { adminAuthError, formatUrlHost, hasAdminToken, InvalidJsonBodyError } from "./http.js";
+import {
+  adminAuthError,
+  closeServer,
+  formatUrlHost,
+  hasAdminToken,
+  InvalidJsonBodyError,
+  isJsonObject,
+  jsonResponse,
+  queryRecord,
+  readBody,
+  RequestBodyTooLargeError,
+  writeResponse,
+} from "./http.js";
 import { recordServerEvent, type ServerEventObserver } from "./recorder.js";
+
+const TELEGRAM_MAX_REQUEST_BODY_BYTES = 50 * 1024 * 1024;
 
 type TelegramServerEvent = {
   at: string;
@@ -19,10 +33,12 @@ type TelegramServerState = {
   botId: number;
   botToken: string;
   botUsername: string;
+  closing: boolean;
   nextMessageId: number;
   nextUpdateId: number;
   onEvent: ServerEventObserver | undefined;
   recorderPath: string;
+  updateWaiters: Set<(hasUpdate: boolean) => void>;
   updates: TelegramUpdate[];
 };
 
@@ -111,10 +127,6 @@ export type StartTelegramServerParams = {
   recorderPath?: string | undefined;
 };
 
-function jsonResponse(value: unknown, status = 200): Response {
-  return Response.json(value, { status });
-}
-
 function telegramOk(result: unknown): Response {
   return jsonResponse({ ok: true, result });
 }
@@ -123,16 +135,8 @@ function telegramError(description: string, status = 400): Response {
   return jsonResponse({ description, error_code: status, ok: false }, status);
 }
 
-async function readBody(request: IncomingMessage): Promise<Buffer> {
-  const chunks: Buffer[] = [];
-  for await (const chunk of request) {
-    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-  }
-  return Buffer.concat(chunks);
-}
-
-async function parseRequestBody(request: IncomingMessage): Promise<Record<string, unknown>> {
-  const body = await readBody(request);
+async function parseRequestBody(request: IncomingMessage): Promise<unknown> {
+  const body = await readBody(request, TELEGRAM_MAX_REQUEST_BODY_BYTES);
   if (body.length === 0) {
     return {};
   }
@@ -140,7 +144,7 @@ async function parseRequestBody(request: IncomingMessage): Promise<Record<string
   const contentTypes = Array.isArray(contentType) ? contentType : [contentType];
   if (contentTypes.some((entry) => entry.includes("json"))) {
     try {
-      return JSON.parse(body.toString("utf8")) as Record<string, unknown>;
+      return JSON.parse(body.toString("utf8")) as unknown;
     } catch (error) {
       throw new InvalidJsonBodyError(error);
     }
@@ -183,26 +187,6 @@ function parseMultipartFormDataBody(body: Buffer, contentType: string): Record<s
     fields[name] = filename && filename.length > 0 ? filename : rawContent;
   }
   return fields;
-}
-
-function closeServer(server: Server): Promise<void> {
-  return new Promise((resolve, reject) => {
-    server.close((error) => {
-      if (error) {
-        reject(error);
-        return;
-      }
-      resolve();
-    });
-  });
-}
-
-async function writeResponse(response: ServerResponse, fetchResponse: Response): Promise<void> {
-  response.statusCode = fetchResponse.status;
-  for (const [name, value] of fetchResponse.headers) {
-    response.setHeader(name, value);
-  }
-  response.end(Buffer.from(await fetchResponse.arrayBuffer()));
 }
 
 function requireTelegramBotPath(pathname: string): { method: string; token: string } | undefined {
@@ -388,13 +372,10 @@ function createInboundUpdate(
   };
 }
 
-function queryRecord(url: URL): Record<string, string> {
-  return Object.fromEntries(url.searchParams.entries());
-}
-
 async function handleTelegramApi(params: {
   body: Record<string, unknown>;
   method: string;
+  request: IncomingMessage;
   state: TelegramServerState;
 }) {
   switch (params.method) {
@@ -445,15 +426,91 @@ async function handleTelegramApi(params: {
     case "getUpdates": {
       const offset = toIntegerValue(params.body.offset);
       const limit = toIntegerValue(params.body.limit) ?? 100;
-      const updates =
-        offset === undefined
-          ? params.state.updates
-          : params.state.updates.filter((update) => update.update_id >= offset);
-      return telegramOk(updates.slice(0, limit));
+      const timeout = toIntegerValue(params.body.timeout) ?? 0;
+      if (limit < 1 || limit > 100) {
+        return telegramError("Bad Request: limit must be between 1 and 100");
+      }
+      if (timeout < 0) {
+        return telegramError("Bad Request: timeout must be non-negative");
+      }
+      let updates = takeTelegramUpdates(params.state, offset, limit);
+      const deadline = Date.now() + Math.min(timeout * 1_000, 2_147_483_647);
+      if (updates.length === 0 && timeout > 0) {
+        while (updates.length === 0) {
+          const remainingMs = deadline - Date.now();
+          if (
+            remainingMs <= 0 ||
+            !(await waitForTelegramUpdate(params.state, params.request, remainingMs))
+          ) {
+            break;
+          }
+          updates = takeTelegramUpdates(params.state, offset, limit);
+        }
+      }
+      return telegramOk(updates);
     }
     default:
       return telegramError(`Not Found: unsupported method ${params.method}`, 404);
   }
+}
+
+function takeTelegramUpdates(
+  state: TelegramServerState,
+  offset: number | undefined,
+  limit: number,
+): TelegramUpdate[] {
+  if (offset !== undefined && offset < 0) {
+    const retainedCount = Math.min(Math.abs(offset), state.updates.length);
+    state.updates.splice(0, state.updates.length - retainedCount);
+  } else if (offset !== undefined) {
+    const firstUnconfirmed = state.updates.findIndex((update) => update.update_id >= offset);
+    if (firstUnconfirmed === -1) {
+      state.updates.length = 0;
+    } else if (firstUnconfirmed > 0) {
+      state.updates.splice(0, firstUnconfirmed);
+    }
+  }
+  return state.updates.slice(0, limit);
+}
+
+function notifyTelegramUpdateWaiters(state: TelegramServerState, hasUpdate: boolean): void {
+  const waiters = [...state.updateWaiters];
+  state.updateWaiters.clear();
+  for (const resolve of waiters) {
+    resolve(hasUpdate);
+  }
+}
+
+async function waitForTelegramUpdate(
+  state: TelegramServerState,
+  request: IncomingMessage,
+  timeoutMs: number,
+): Promise<boolean> {
+  if (state.closing || request.socket.destroyed) {
+    return false;
+  }
+  return await new Promise<boolean>((resolve) => {
+    let settled = false;
+    const finish = (hasUpdate: boolean) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      request.socket.off("close", onSocketClose);
+      state.updateWaiters.delete(onUpdate);
+      resolve(hasUpdate);
+    };
+    const onUpdate = (hasUpdate: boolean) => finish(hasUpdate);
+    const onSocketClose = () => finish(false);
+    const timer = setTimeout(() => finish(false), timeoutMs);
+    timer.unref();
+    request.socket.once("close", onSocketClose);
+    state.updateWaiters.add(onUpdate);
+    if (state.closing || request.socket.destroyed) {
+      finish(false);
+    }
+  });
 }
 
 async function handleRequest(params: { request: IncomingMessage; state: TelegramServerState }) {
@@ -466,6 +523,9 @@ async function handleRequest(params: { request: IncomingMessage; state: Telegram
       return adminAuthError();
     }
     const body = await parseRequestBody(params.request);
+    if (!isJsonObject(body)) {
+      return telegramError("Bad Request: request body must be a JSON object");
+    }
     const update = createInboundUpdate(params.state, body);
     await appendEvent(params.state, {
       at: new Date().toISOString(),
@@ -479,6 +539,8 @@ async function handleRequest(params: { request: IncomingMessage; state: Telegram
       return telegramError("Bad Request: chatId and text are required");
     }
     params.state.updates.push(update);
+    params.state.updates.sort((left, right) => left.update_id - right.update_id);
+    notifyTelegramUpdateWaiters(params.state, true);
     return jsonResponse({ ok: true, update });
   }
 
@@ -488,6 +550,9 @@ async function handleRequest(params: { request: IncomingMessage; state: Telegram
   }
   const body =
     params.request.method === "GET" ? queryRecord(url) : await parseRequestBody(params.request);
+  if (!isJsonObject(body)) {
+    return telegramError("Bad Request: can't parse JSON object");
+  }
   await appendEvent(params.state, {
     at: new Date().toISOString(),
     body,
@@ -499,6 +564,7 @@ async function handleRequest(params: { request: IncomingMessage; state: Telegram
   return handleTelegramApi({
     body,
     method: botPath.method,
+    request: params.request,
     state: params.state,
   });
 }
@@ -515,6 +581,8 @@ export async function startTelegramServer(
     nextUpdateId: 1,
     onEvent: params.onEvent,
     recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "telegram.jsonl"),
+    closing: false,
+    updateWaiters: new Set(),
     updates: [],
   };
   const host = params.host ?? "127.0.0.1";
@@ -527,13 +595,15 @@ export async function startTelegramServer(
         response,
         error instanceof InvalidJsonBodyError
           ? telegramError("Bad Request: can't parse JSON object")
-          : jsonResponse(
-              {
-                error: error instanceof Error ? error.message : String(error),
-                ok: false,
-              },
-              500,
-            ),
+          : error instanceof RequestBodyTooLargeError
+            ? telegramError("Request Entity Too Large", 413)
+            : jsonResponse(
+                {
+                  error: error instanceof Error ? error.message : String(error),
+                  ok: false,
+                },
+                500,
+              ),
       );
     }
   });
@@ -553,6 +623,8 @@ export async function startTelegramServer(
   const baseUrl = `http://${formatUrlHost(host)}:${address.port}`;
   return {
     async close() {
+      state.closing = true;
+      notifyTelegramUpdateWaiters(state, false);
       await closeServer(server);
     },
     manifest: {

--- a/src/servers/whatsapp.ts
+++ b/src/servers/whatsapp.ts
@@ -5,10 +5,12 @@ import {
   adminAuthError,
   hasAdminToken,
   InvalidJsonBodyError,
+  isJsonObject,
   jsonResponse,
-  parseRequestBody,
+  parseUnknownRequestBody,
   queryRecord,
   readTrimmedString,
+  RequestBodyTooLargeError,
   startHttpJsonServer,
   type ServerRequestEvent,
 } from "./http.js";
@@ -137,10 +139,6 @@ function graphAuthError(): Response {
     message: "Invalid OAuth access token.",
     status: 401,
   });
-}
-
-function isJsonObject(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
 async function appendEvent(state: WhatsAppServerState, event: ServerRequestEvent) {
@@ -386,9 +384,16 @@ async function handleRequest(params: { request: IncomingMessage; state: WhatsApp
       return new Response("not found", { status: 404 });
     }
     if (!hasAdminToken(params.request, params.state.adminToken)) {
+      params.request.resume();
       return adminAuthError();
     }
-    const body = await parseRequestBody(params.request);
+    const body = await parseUnknownRequestBody(params.request);
+    if (!isJsonObject(body)) {
+      return graphParameterError(
+        "(#100) Invalid parameter: request body",
+        "The request body must be a JSON object.",
+      );
+    }
     const result = await handleAdminInbound({ body, state: params.state });
     if (result.response) {
       return result.response;
@@ -414,21 +419,20 @@ async function handleRequest(params: { request: IncomingMessage; state: WhatsApp
 
   const phoneNumberPath = `/${params.state.graphVersion}/${params.state.phoneNumberId}`;
   const messagesPath = `${phoneNumberPath}/messages`;
-  const body =
-    params.request.method === "GET" ? queryRecord(url) : await parseRequestBody(params.request);
-  await appendEvent(params.state, {
-    at: new Date().toISOString(),
-    body,
-    method: params.request.method ?? "GET",
-    path: url.pathname,
-    query: queryRecord(url),
-    type: "api",
-  });
-
   if (!requireAuth(params.request, params.state)) {
+    params.request.resume();
     return graphAuthError();
   }
   if (url.pathname === phoneNumberPath && params.request.method === "GET") {
+    const body = queryRecord(url);
+    await appendEvent(params.state, {
+      at: new Date().toISOString(),
+      body,
+      method: params.request.method,
+      path: url.pathname,
+      query: body,
+      type: "api",
+    });
     return jsonResponse({
       display_phone_number: params.state.displayPhoneNumber,
       id: params.state.phoneNumberId,
@@ -440,6 +444,15 @@ async function handleRequest(params: { request: IncomingMessage; state: WhatsApp
     if (params.request.method !== "POST") {
       return new Response("not found", { status: 404 });
     }
+    const body = await parseUnknownRequestBody(params.request);
+    await appendEvent(params.state, {
+      at: new Date().toISOString(),
+      body,
+      method: params.request.method,
+      path: url.pathname,
+      query: queryRecord(url),
+      type: "api",
+    });
     if (!isJsonObject(body)) {
       return graphParameterError(
         "(#100) Invalid parameter: request body",
@@ -480,13 +493,23 @@ export async function startWhatsAppServer(
   const host = params.host ?? "127.0.0.1";
   const httpServer = await startHttpJsonServer({
     handle: (request) => handleRequest({ request, state }),
-    handleError: (error) =>
-      error instanceof InvalidJsonBodyError
-        ? graphParameterError(
-            "(#100) Invalid parameter: request body",
-            "The request body must be valid JSON.",
-          )
-        : undefined,
+    handleError: (error) => {
+      if (error instanceof InvalidJsonBodyError) {
+        return graphParameterError(
+          "(#100) Invalid parameter: request body",
+          "The request body must be valid JSON.",
+        );
+      }
+      if (error instanceof RequestBodyTooLargeError) {
+        return graphError({
+          code: 100,
+          details: "The request body exceeds the supported size limit.",
+          message: "(#100) Request body is too large.",
+          status: 413,
+        });
+      }
+      return undefined;
+    },
     host,
     port: params.port ?? 0,
     serverName: "WhatsApp",

--- a/test/http-server.test.ts
+++ b/test/http-server.test.ts
@@ -1,0 +1,36 @@
+import type { IncomingMessage } from "node:http";
+import { PassThrough } from "node:stream";
+import { describe, expect, it } from "vitest";
+import { readBody, RequestBodyTooLargeError } from "../src/servers/http.js";
+
+type TestRequest = IncomingMessage & PassThrough;
+
+function createRequest(headers: IncomingMessage["headers"] = {}): TestRequest {
+  return Object.assign(new PassThrough(), { headers }) as unknown as TestRequest;
+}
+
+function expectLateErrorHandled(request: IncomingMessage): void {
+  expect(() => request.emit("error", new Error("late stream error"))).not.toThrow();
+  request.emit("close");
+  expect(request.listenerCount("error")).toBe(0);
+}
+
+describe("server HTTP body reader", () => {
+  it("keeps rejected request streams error-handled until close", async () => {
+    const aborted = createRequest();
+    const abortedRead = readBody(aborted);
+    aborted.emit("aborted");
+    await expect(abortedRead).rejects.toThrow("Request body stream was aborted");
+    expectLateErrorHandled(aborted);
+
+    const streamed = createRequest();
+    const streamedRead = readBody(streamed, 4);
+    streamed.write("12345");
+    await expect(streamedRead).rejects.toBeInstanceOf(RequestBodyTooLargeError);
+    expectLateErrorHandled(streamed);
+
+    const declared = createRequest({ "content-length": "5" });
+    await expect(readBody(declared, 4)).rejects.toBeInstanceOf(RequestBodyTooLargeError);
+    expectLateErrorHandled(declared);
+  });
+});

--- a/test/matrix-server.test.ts
+++ b/test/matrix-server.test.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { ClientEvent, createClient, RoomEvent, SyncState, type MatrixEvent } from "matrix-js-sdk";
 import { afterEach, describe, expect, it } from "vitest";
 import { startMatrixServer, type StartedMatrixServer } from "../src/index.js";
-import { createTempDir, disposeTempDir } from "./test-helpers.js";
+import { createTempDir, disposeTempDir, requestHttp } from "./test-helpers.js";
 
 const servers: StartedMatrixServer[] = [];
 const directories: string[] = [];
@@ -95,6 +95,84 @@ describe("Matrix local provider server", () => {
         type: "api",
       }),
     );
+  });
+
+  it("validates object bodies, rejects oversized payloads, and records only authenticated API calls", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const observed: unknown[] = [];
+    const server = await startMatrixServer({
+      accessToken: "test-token",
+      onEvent: (event) => {
+        observed.push(event);
+      },
+      recorderPath: path.join(directory, "matrix-ingress.jsonl"),
+      roomId: "!qa:matrix.test",
+    });
+    servers.push(server);
+    const sendUrl = `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!qa:matrix.test")}/send/m.room.message/ingress`;
+
+    const unauthorized = await fetch(sendUrl, {
+      body: JSON.stringify({ body: "untrusted matrix body", msgtype: "m.text" }),
+      headers: { ...auth("wrong-token"), "content-type": "application/json" },
+      method: "PUT",
+    });
+    expect(unauthorized.status).toBe(401);
+    const unauthorizedOversized = await requestHttp({
+      body: Buffer.alloc(1024 * 1024 + 1, 0x20),
+      headers: {
+        ...auth("wrong-token"),
+        "content-length": String(1024 * 1024 + 1),
+        "content-type": "application/json",
+      },
+      method: "PUT",
+      url: sendUrl,
+    });
+    expect(unauthorizedOversized.status).toBe(401);
+
+    for (const scalarBody of ["null", '"scalar"', "42", "true", "[]"]) {
+      const invalid = await fetch(sendUrl, {
+        body: scalarBody,
+        headers: { ...auth("test-token"), "content-type": "application/json" },
+        method: "PUT",
+      });
+      expect(invalid.status).toBe(400);
+      await expect(invalid.json()).resolves.toEqual({
+        errcode: "M_BAD_JSON",
+        error: "Request body must be a JSON object",
+      });
+    }
+
+    const oversized = await requestHttp({
+      body: Buffer.alloc(1024 * 1024 + 1, 0x20),
+      headers: {
+        ...auth("test-token"),
+        "content-length": String(1024 * 1024 + 1),
+        "content-type": "application/json",
+      },
+      method: "PUT",
+      url: sendUrl,
+    });
+    expect(oversized.status).toBe(413);
+    expect(JSON.parse(oversized.body)).toEqual({
+      errcode: "M_TOO_LARGE",
+      error: "Request body is too large",
+    });
+
+    const whoami = await fetch(`${server.manifest.endpoints.clientApiRoot}/account/whoami`, {
+      headers: auth("test-token"),
+    });
+    expect(whoami.status).toBe(200);
+
+    const recorder = await fs.readFile(server.manifest.recorderPath, "utf8");
+    expect(recorder).not.toContain("untrusted matrix body");
+    expect(observed).toEqual([
+      expect.objectContaining({
+        method: "GET",
+        path: "/_matrix/client/v3/account/whoami",
+        type: "api",
+      }),
+    ]);
   });
 
   it("works with matrix-js-sdk sync and delivers admin inbound as a room event", async () => {

--- a/test/mattermost-server.test.ts
+++ b/test/mattermost-server.test.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { WebSocket } from "ws";
 import { afterEach, describe, expect, it } from "vitest";
 import { startMattermostServer, type StartedMattermostServer } from "../src/index.js";
-import { createTempDir, disposeTempDir } from "./test-helpers.js";
+import { createTempDir, disposeTempDir, requestHttp } from "./test-helpers.js";
 
 const servers: StartedMattermostServer[] = [];
 const directories: string[] = [];
@@ -38,6 +38,57 @@ function nextMessages(socket: WebSocket, count: number): Promise<Record<string, 
 }
 
 describe("Mattermost local provider server", () => {
+  it("returns Mattermost errors for non-object and oversized request bodies", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const server = await startMattermostServer({
+      botToken: "bot-secret",
+      recorderPath: path.join(directory, "mattermost-bodies.jsonl"),
+    });
+    servers.push(server);
+    const postsUrl = `${server.manifest.endpoints.apiRoot}/posts`;
+
+    for (const scalarBody of ["null", '"scalar"', "42", "true", "[]"]) {
+      const invalid = await fetch(postsUrl, {
+        body: scalarBody,
+        headers: { authorization: "Bearer bot-secret", "content-type": "application/json" },
+        method: "POST",
+      });
+      expect(invalid.status).toBe(400);
+      await expect(invalid.json()).resolves.toMatchObject({
+        message: "Request body must be a JSON object",
+        status_code: 400,
+      });
+    }
+
+    const malformed = await fetch(postsUrl, {
+      body: "{",
+      headers: { authorization: "Bearer bot-secret", "content-type": "application/json" },
+      method: "POST",
+    });
+    expect(malformed.status).toBe(400);
+    await expect(malformed.json()).resolves.toMatchObject({
+      message: "Request body is not valid JSON",
+      status_code: 400,
+    });
+
+    const oversized = await requestHttp({
+      body: Buffer.alloc(1024 * 1024 + 1, 0x20),
+      headers: {
+        authorization: "Bearer bot-secret",
+        "content-length": String(1024 * 1024 + 1),
+        "content-type": "application/json",
+      },
+      method: "POST",
+      url: postsUrl,
+    });
+    expect(oversized.status).toBe(413);
+    expect(JSON.parse(oversized.body)).toMatchObject({
+      message: "Request body is too large",
+      status_code: 413,
+    });
+  });
+
   it("serves authenticated REST and delivers admin inbound over the native WebSocket", async () => {
     const directory = await createTempDir();
     directories.push(directory);

--- a/test/signal-server.test.ts
+++ b/test/signal-server.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { startSignalServer, type StartedSignalServer } from "../src/index.js";
-import { createTempDir, disposeTempDir } from "./test-helpers.js";
+import { createTempDir, disposeTempDir, requestHttp } from "./test-helpers.js";
 
 const servers: StartedSignalServer[] = [];
 const directories: string[] = [];
@@ -13,6 +13,71 @@ afterEach(async () => {
 });
 
 describe("signal local provider server", () => {
+  it("returns JSON-RPC errors for non-object and oversized request bodies", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const server = await startSignalServer({
+      recorderPath: path.join(directory, "signal-bodies.jsonl"),
+    });
+    servers.push(server);
+
+    for (const scalarBody of ["null", '"scalar"', "42", "true", "[]"]) {
+      const invalid = await fetch(server.manifest.endpoints.rpcUrl, {
+        body: scalarBody,
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      expect(invalid.status).toBe(400);
+      await expect(invalid.json()).resolves.toEqual({
+        error: { code: -32600, message: "Invalid Request" },
+        id: null,
+        jsonrpc: "2.0",
+      });
+    }
+
+    const malformed = await fetch(server.manifest.endpoints.rpcUrl, {
+      body: "{",
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    expect(malformed.status).toBe(400);
+    await expect(malformed.json()).resolves.toEqual({
+      error: { code: -32700, message: "Parse error" },
+      id: null,
+      jsonrpc: "2.0",
+    });
+
+    const malformedAdmin = await fetch(`${server.manifest.endpoints.adminInboundUrl}?trace=1`, {
+      body: "{",
+      headers: {
+        "content-type": "application/json",
+        "x-crabline-admin-token": server.manifest.adminToken,
+      },
+      method: "POST",
+    });
+    expect(malformedAdmin.status).toBe(400);
+    await expect(malformedAdmin.json()).resolves.toEqual({
+      error: "Request body is not valid JSON",
+      ok: false,
+    });
+
+    const oversized = await requestHttp({
+      body: Buffer.alloc(1024 * 1024 + 1, 0x20),
+      headers: {
+        "content-length": String(1024 * 1024 + 1),
+        "content-type": "application/json",
+      },
+      method: "POST",
+      url: server.manifest.endpoints.rpcUrl,
+    });
+    expect(oversized.status).toBe(413);
+    expect(JSON.parse(oversized.body)).toEqual({
+      error: { code: -32600, message: "Request body is too large" },
+      id: null,
+      jsonrpc: "2.0",
+    });
+  });
+
   it("advertises valid URLs when bound to IPv6", async () => {
     const directory = await createTempDir();
     directories.push(directory);

--- a/test/slack-server.test.ts
+++ b/test/slack-server.test.ts
@@ -8,7 +8,7 @@ import {
   type StartedSlackServer,
   type StartSlackServerParams,
 } from "../src/index.js";
-import { createTempDir, disposeTempDir } from "./test-helpers.js";
+import { createTempDir, disposeTempDir, requestHttp } from "./test-helpers.js";
 
 const servers: StartedSlackServer[] = [];
 const directories: string[] = [];
@@ -115,6 +115,96 @@ describe("slack local provider server", () => {
       },
       ok: true,
     });
+  });
+
+  it("bounds request bodies and does not record rejected API authentication", async () => {
+    const observed: unknown[] = [];
+    const server = await startTestSlackServer({
+      onEvent: (event) => {
+        observed.push(event);
+      },
+    });
+    const authUrl = `${server.manifest.endpoints.apiRoot}auth.test`;
+
+    const unauthenticated = await fetch(authUrl, {
+      body: JSON.stringify({ probe: "untrusted slack body" }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    await expect(unauthenticated.json()).resolves.toEqual({
+      error: "not_authed",
+      ok: false,
+    });
+    const invalidHeader = await requestHttp({
+      body: Buffer.alloc(1024 * 1024 + 1, 0x20),
+      headers: {
+        authorization: "Bearer wrong-token",
+        "content-length": String(1024 * 1024 + 1),
+        "content-type": "application/json",
+      },
+      method: "POST",
+      url: authUrl,
+    });
+    expect(invalidHeader.status).toBe(200);
+    expect(JSON.parse(invalidHeader.body)).toEqual({
+      error: "invalid_auth",
+      ok: false,
+    });
+
+    for (const scalarBody of ["null", '"scalar"', "42", "true", "[]"]) {
+      const invalid = await fetch(authUrl, {
+        body: scalarBody,
+        headers: {
+          authorization: "Bearer xoxb-fake",
+          "content-type": "application/json",
+        },
+        method: "POST",
+      });
+      expect(invalid.status).toBe(400);
+      await expect(invalid.json()).resolves.toEqual({ error: "json_not_object", ok: false });
+    }
+
+    const earlyRejected = await requestHttp({
+      body: Buffer.alloc(1024 * 1024 + 1, 0x20),
+      headers: {
+        authorization: "Bearer xoxb-fake",
+        "content-length": String(1024 * 1024 + 1),
+        "content-type": "application/json",
+      },
+      method: "POST",
+      url: authUrl,
+    });
+    expect(earlyRejected.status).toBe(413);
+    expect(JSON.parse(earlyRejected.body)).toEqual({
+      error: "request_too_large",
+      ok: false,
+    });
+
+    const streamed = await requestHttp({
+      body: Buffer.alloc(1024 * 1024 + 1, 0x20),
+      headers: {
+        authorization: "Bearer xoxb-fake",
+        "content-type": "application/json",
+        "transfer-encoding": "chunked",
+      },
+      method: "POST",
+      url: authUrl,
+    });
+    expect(streamed.status).toBe(413);
+    expect(JSON.parse(streamed.body)).toEqual({
+      error: "request_too_large",
+      ok: false,
+    });
+
+    await expect((await slackApi(server, "auth.test")).json()).resolves.toMatchObject({ ok: true });
+    const recorder = await fs.readFile(server.manifest.recorderPath, "utf8");
+    expect(recorder).not.toContain("untrusted slack body");
+    expect(observed).toEqual([
+      expect.objectContaining({
+        path: "/api/auth.test",
+        type: "api",
+      }),
+    ]);
   });
 
   it("posts messages and serves thread/history reads", async () => {

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -1,8 +1,9 @@
 import fs from "node:fs/promises";
+import { request as httpRequest } from "node:http";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { startTelegramServer, type StartedTelegramServer } from "../src/index.js";
-import { createTempDir, disposeTempDir } from "./test-helpers.js";
+import { createTempDir, disposeTempDir, requestHttp } from "./test-helpers.js";
 
 const servers: StartedTelegramServer[] = [];
 const directories: string[] = [];
@@ -12,6 +13,28 @@ function adminHeaders(server: StartedTelegramServer) {
     "content-type": "application/json",
     "x-crabline-admin-token": server.manifest.adminToken,
   };
+}
+
+async function injectUpdate(
+  server: StartedTelegramServer,
+  body: Record<string, unknown>,
+): Promise<Response> {
+  return await fetch(server.manifest.endpoints.adminInboundUrl, {
+    body: JSON.stringify(body),
+    headers: adminHeaders(server),
+    method: "POST",
+  });
+}
+
+async function getUpdates(
+  server: StartedTelegramServer,
+  body: Record<string, unknown>,
+): Promise<Response> {
+  return await fetch(`${server.manifest.baseUrl}/bot${server.manifest.botToken}/getUpdates`, {
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+    method: "POST",
+  });
 }
 
 afterEach(async () => {
@@ -89,6 +112,38 @@ describe("telegram local provider server", () => {
     await expect(invalidJson.json()).resolves.toEqual({
       description: "Bad Request: can't parse JSON object",
       error_code: 400,
+      ok: false,
+    });
+
+    for (const scalarBody of ["null", '"scalar"', "42", "true", "[]"]) {
+      const invalidBody = await fetch(
+        `${server.manifest.baseUrl}/bot123456:fake-token/sendMessage`,
+        {
+          body: scalarBody,
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        },
+      );
+      expect(invalidBody.status).toBe(400);
+      await expect(invalidBody.json()).resolves.toEqual({
+        description: "Bad Request: can't parse JSON object",
+        error_code: 400,
+        ok: false,
+      });
+    }
+
+    const oversized = await requestHttp({
+      headers: {
+        "content-length": String(50 * 1024 * 1024 + 1),
+        "content-type": "application/json",
+      },
+      method: "POST",
+      url: `${server.manifest.baseUrl}/bot123456:fake-token/sendMessage`,
+    });
+    expect(oversized.status).toBe(413);
+    expect(JSON.parse(oversized.body)).toEqual({
+      description: "Request Entity Too Large",
+      error_code: 413,
       ok: false,
     });
 
@@ -238,6 +293,188 @@ describe("telegram local provider server", () => {
         message: { message_id: 201 },
         update_id: 101,
       },
+    });
+  });
+
+  it("long-polls until an update arrives and returns empty on timeout", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const server = await startTelegramServer({
+      botToken: "test-token",
+      recorderPath: path.join(directory, "telegram-long-poll.jsonl"),
+    });
+    servers.push(server);
+
+    const timeoutStartedAt = Date.now();
+    const timedOut = await getUpdates(server, { timeout: 1 });
+    expect(Date.now() - timeoutStartedAt).toBeGreaterThanOrEqual(800);
+    await expect(timedOut.json()).resolves.toEqual({ ok: true, result: [] });
+
+    const pending = getUpdates(server, { offset: 100, timeout: 5 });
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    const belowOffset = await injectUpdate(server, {
+      chatId: "123",
+      text: "below the poll offset",
+      updateId: 10,
+    });
+    expect(belowOffset.status).toBe(200);
+    await expect(
+      Promise.race([
+        pending.then(() => "resolved"),
+        new Promise<string>((resolve) => setTimeout(() => resolve("waiting"), 100)),
+      ]),
+    ).resolves.toBe("waiting");
+
+    const matching = await injectUpdate(server, {
+      chatId: "123",
+      text: "wake the poll",
+      updateId: 100,
+    });
+    expect(matching.status).toBe(200);
+
+    await expect(pending.then((response) => response.json())).resolves.toMatchObject({
+      ok: true,
+      result: [{ message: { text: "wake the poll" }, update_id: 100 }],
+    });
+  });
+
+  it("confirms positive offsets and forgets updates before a negative offset", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const server = await startTelegramServer({
+      botToken: "test-token",
+      recorderPath: path.join(directory, "telegram-offsets.jsonl"),
+    });
+    servers.push(server);
+
+    for (const updateId of [10, 11, 12]) {
+      const inbound = await injectUpdate(server, {
+        chatId: "123",
+        text: `update ${updateId}`,
+        updateId,
+      });
+      expect(inbound.status).toBe(200);
+    }
+    await expect(
+      getUpdates(server, { offset: 11 }).then((response) => response.json()),
+    ).resolves.toMatchObject({
+      result: [{ update_id: 11 }, { update_id: 12 }],
+    });
+    await expect(
+      getUpdates(server, { offset: 13 }).then((response) => response.json()),
+    ).resolves.toEqual({
+      ok: true,
+      result: [],
+    });
+
+    for (const updateId of [20, 21, 22]) {
+      const inbound = await injectUpdate(server, {
+        chatId: "123",
+        text: `update ${updateId}`,
+        updateId,
+      });
+      expect(inbound.status).toBe(200);
+    }
+    await expect(
+      getUpdates(server, { offset: -2 }).then((response) => response.json()),
+    ).resolves.toMatchObject({
+      result: [{ update_id: 21 }, { update_id: 22 }],
+    });
+    await expect(getUpdates(server, {}).then((response) => response.json())).resolves.toMatchObject(
+      {
+        result: [{ update_id: 21 }, { update_id: 22 }],
+      },
+    );
+  });
+
+  it("releases pending long polls when the server closes", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const server = await startTelegramServer({
+      botToken: "test-token",
+      recorderPath: path.join(directory, "telegram-close.jsonl"),
+    });
+    servers.push(server);
+
+    const pending = getUpdates(server, { timeout: 30 });
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    const closeStartedAt = Date.now();
+    const closing = server.close();
+    const payload = await pending.then((response) => response.json());
+    await closing;
+    servers.splice(servers.indexOf(server), 1);
+    expect(Date.now() - closeStartedAt).toBeLessThan(1_000);
+    expect(payload).toEqual({
+      ok: true,
+      result: [],
+    });
+  });
+
+  it("does not register a long poll after shutdown starts", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const server = await startTelegramServer({
+      botToken: "test-token",
+      recorderPath: path.join(directory, "telegram-close-during-read.jsonl"),
+    });
+    servers.push(server);
+
+    let resolveConnected!: () => void;
+    let rejectConnected!: (error: Error) => void;
+    const connected = new Promise<void>((resolve, reject) => {
+      resolveConnected = resolve;
+      rejectConnected = reject;
+    });
+    let pendingRequest!: ReturnType<typeof httpRequest>;
+    const response = new Promise<{ body: string; status: number }>((resolve, reject) => {
+      pendingRequest = httpRequest(
+        `${server.manifest.baseUrl}/bot${server.manifest.botToken}/getUpdates`,
+        {
+          headers: {
+            "content-type": "application/json",
+            "transfer-encoding": "chunked",
+          },
+          method: "POST",
+        },
+        (incoming) => {
+          const chunks: Buffer[] = [];
+          incoming.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+          incoming.once("end", () => {
+            resolve({
+              body: Buffer.concat(chunks).toString("utf8"),
+              status: incoming.statusCode ?? 0,
+            });
+          });
+        },
+      );
+      pendingRequest.once("socket", (socket) => {
+        if (socket.connecting) {
+          socket.once("connect", resolveConnected);
+        } else {
+          resolveConnected();
+        }
+      });
+      pendingRequest.once("error", (error) => {
+        rejectConnected(error);
+        reject(error);
+      });
+      pendingRequest.write('{"timeout":30');
+    });
+
+    await connected;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    const closeStartedAt = Date.now();
+    const closing = server.close();
+    pendingRequest.end("}");
+    const result = await response;
+    await closing;
+    servers.splice(servers.indexOf(server), 1);
+
+    expect(Date.now() - closeStartedAt).toBeLessThan(1_000);
+    expect(result.status).toBe(200);
+    expect(JSON.parse(result.body)).toEqual({
+      ok: true,
+      result: [],
     });
   });
 

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -1,4 +1,5 @@
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { request as httpRequest } from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -15,6 +16,39 @@ export const writeJson = async (filePath: string, value: unknown): Promise<void>
 export const writeText = async (filePath: string, value: string): Promise<void> => {
   await writeFile(filePath, value, "utf8");
 };
+
+export async function requestHttp(params: {
+  body?: Buffer | string;
+  headers?: Record<string, string>;
+  method: string;
+  url: string;
+}): Promise<{ body: string; headers: import("node:http").IncomingHttpHeaders; status: number }> {
+  return await new Promise((resolve, reject) => {
+    const request = httpRequest(
+      params.url,
+      {
+        headers: params.headers,
+        method: params.method,
+      },
+      (response) => {
+        const chunks: Buffer[] = [];
+        response.on("data", (chunk: Buffer) => chunks.push(chunk));
+        response.once("end", () =>
+          resolve({
+            body: Buffer.concat(chunks).toString("utf8"),
+            headers: response.headers,
+            status: response.statusCode ?? 0,
+          }),
+        );
+      },
+    );
+    request.once("error", reject);
+    if (params.body !== undefined) {
+      request.write(params.body);
+    }
+    request.end();
+  });
+}
 
 export const captureWrites = (): {
   restore: () => void;

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -11,7 +11,7 @@ import {
 import { afterEach, describe, expect, it } from "vitest";
 import { WebSocket } from "ws";
 import { startWhatsAppServer, type StartedWhatsAppServer } from "../src/index.js";
-import { createTempDir, disposeTempDir } from "./test-helpers.js";
+import { createTempDir, disposeTempDir, requestHttp } from "./test-helpers.js";
 
 const servers: StartedWhatsAppServer[] = [];
 const directories: string[] = [];
@@ -368,6 +368,81 @@ describe("whatsapp local provider server", () => {
     const recorder = await fs.readFile(server.manifest.recorderPath, "utf8");
     expect(recorder).not.toContain("forged user nonce");
     expect(recorder).toContain('"path":"/_crabline/admin/whatsapp/inbound"');
+  });
+
+  it("authenticates Graph requests before reading or recording their bodies", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const observed: unknown[] = [];
+    const server = await startWhatsAppServer({
+      accessToken: "fake",
+      onEvent: (event) => {
+        observed.push(event);
+      },
+      recorderPath: path.join(directory, "whatsapp-auth.jsonl"),
+    });
+    servers.push(server);
+
+    const unauthenticated = await fetch(server.manifest.endpoints.messagesUrl, {
+      body: JSON.stringify({
+        messaging_product: "whatsapp",
+        text: { body: "untrusted whatsapp body" },
+        to: "15551234567",
+        type: "text",
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    expect(unauthenticated.status).toBe(401);
+    const unauthorizedOversized = await requestHttp({
+      body: Buffer.alloc(1024 * 1024 + 1, 0x20),
+      headers: {
+        authorization: "Bearer wrong-token",
+        "content-length": String(1024 * 1024 + 1),
+        "content-type": "application/json",
+      },
+      method: "POST",
+      url: server.manifest.endpoints.messagesUrl,
+    });
+    expect(unauthorizedOversized.status).toBe(401);
+
+    const oversized = await requestHttp({
+      body: Buffer.alloc(1024 * 1024 + 1, 0x20),
+      headers: {
+        authorization: "Bearer fake",
+        "content-length": String(1024 * 1024 + 1),
+        "content-type": "application/json",
+      },
+      method: "POST",
+      url: server.manifest.endpoints.messagesUrl,
+    });
+    expect(oversized.status).toBe(413);
+    expect(JSON.parse(oversized.body)).toMatchObject({
+      error: {
+        code: 100,
+        error_data: {
+          details: "The request body exceeds the supported size limit.",
+          messaging_product: "whatsapp",
+        },
+        message: "(#100) Request body is too large.",
+        type: "OAuthException",
+      },
+    });
+
+    const phoneNumber = await fetch(server.manifest.endpoints.phoneNumberUrl, {
+      headers: { authorization: "Bearer fake" },
+    });
+    expect(phoneNumber.status).toBe(200);
+
+    const recorder = await fs.readFile(server.manifest.recorderPath, "utf8");
+    expect(recorder).not.toContain("untrusted whatsapp body");
+    expect(observed).toEqual([
+      expect.objectContaining({
+        method: "GET",
+        path: new URL(server.manifest.endpoints.phoneNumberUrl).pathname,
+        type: "api",
+      }),
+    ]);
   });
 
   it("does not accept admin inbound messages when recorder append fails", async () => {


### PR DESCRIPTION
## Summary

- bound provider request bodies and return provider-native malformed/oversized payload errors
- authenticate before parsing or recording rejected traffic across Matrix, Mattermost, Signal, Slack, and WhatsApp
- implement Telegram getUpdates long polling, offset confirmation, wakeups, and shutdown cleanup
- keep rejected Node request streams error-handled through close

## Verification

- Crabbox `run_6c41dd67084a`: `pnpm verify` (42 files, 268 tests)
- autoreview: clean, confidence 0.91, `gpt-5.6-sol` high
- focused local server suites: 36 tests

## Release notes

- adds two Unreleased changelog entries for provider ingress hardening and Telegram polling behavior