### PR TITLE
fix(whatsapp): harden Noise frame processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Serialize WhatsApp Noise frames per session and reject invalid X25519 peer keys.
 - Implement Telegram `getUpdates` long polling with timeout wakeups, offset confirmation, negative offsets, and shutdown cleanup.
 - Restrict releases to stable version tags and resolve workflow-dispatch inputs through exact tag refs before publication.
 - Reject ambiguous fixture/config inputs and keep the published CLI, type dependencies, and README assets aligned with their public contract.

--- a/src/servers/whatsapp-baileys-websocket.ts
+++ b/src/servers/whatsapp-baileys-websocket.ts
@@ -71,6 +71,28 @@ type MockSignalBundle = {
   signedPreKey: SignedKeyPair;
 };
 
+export function createSerializedMessageHandler<T>(
+  processMessage: (message: T) => Promise<void>,
+  onError: (error: unknown) => void,
+): (message: T) => Promise<void> {
+  let failed = false;
+  let pending = Promise.resolve();
+  return (message) => {
+    const next = pending.then(async () => {
+      if (!failed) {
+        await processMessage(message);
+      }
+    });
+    pending = next.catch((error: unknown) => {
+      if (!failed) {
+        failed = true;
+        onError(error);
+      }
+    });
+    return pending;
+  };
+}
+
 class TransportState {
   #readCounter = 0;
   #writeCounter = 0;
@@ -254,6 +276,7 @@ class BaileysNoiseServer {
 
 class WhatsAppBaileysWebSocketSession {
   #handshakeState: "client-finish" | "client-hello" | "open" = "client-hello";
+  readonly #handleSerializedMessage: (data: RawData) => Promise<void>;
   readonly #noise = new BaileysNoiseServer();
 
   constructor(
@@ -265,16 +288,21 @@ class WhatsAppBaileysWebSocketSession {
       selfJid: string;
       signalBundles: Map<string, MockSignalBundle>;
     },
-  ) {}
+  ) {
+    this.#handleSerializedMessage = createSerializedMessageHandler(
+      (data) => this.#handleMessage(data),
+      (error) => {
+        this.socket.close(1011, error instanceof Error ? error.message : String(error));
+      },
+    );
+  }
 
   get isOpen(): boolean {
     return this.#handshakeState === "open" && this.socket.readyState === WebSocket.OPEN;
   }
 
   handleMessage(data: RawData): void {
-    void this.#handleMessage(data).catch((error: unknown) => {
-      this.socket.close(1011, error instanceof Error ? error.message : String(error));
-    });
+    void this.#handleSerializedMessage(data);
   }
 
   deliverInboundMessage(message: WhatsAppBaileysInboundMessage): boolean {

--- a/src/servers/whatsapp-wire/crypto.ts
+++ b/src/servers/whatsapp-wire/crypto.ts
@@ -67,21 +67,20 @@ export const Curve = {
 
   sharedKey(privateKey: Uint8Array, publicKey: Uint8Array): Buffer {
     const rawPublicKey = scrubSignalPublicKey(publicKey);
-    try {
-      const nodePrivateKey = createPrivateKey({
-        format: "der",
-        key: Buffer.concat([PRIVATE_KEY_DER_PREFIX, Buffer.from(privateKey)]),
-        type: "pkcs8",
-      });
-      const nodePublicKey = createPublicKey({
-        format: "der",
-        key: Buffer.concat([PUBLIC_KEY_DER_PREFIX, rawPublicKey]),
-        type: "spki",
-      });
-      return diffieHellman({ privateKey: nodePrivateKey, publicKey: nodePublicKey });
-    } catch {
+    if (typeof diffieHellman !== "function") {
       return Buffer.from(curve25519.sharedKey(Buffer.from(privateKey), rawPublicKey));
     }
+    const nodePrivateKey = createPrivateKey({
+      format: "der",
+      key: Buffer.concat([PRIVATE_KEY_DER_PREFIX, Buffer.from(privateKey)]),
+      type: "pkcs8",
+    });
+    const nodePublicKey = createPublicKey({
+      format: "der",
+      key: Buffer.concat([PUBLIC_KEY_DER_PREFIX, rawPublicKey]),
+      type: "spki",
+    });
+    return diffieHellman({ privateKey: nodePrivateKey, publicKey: nodePublicKey });
   },
 
   sign(privateKey: Uint8Array, message: Uint8Array): Buffer {

--- a/test/whatsapp-wire.test.ts
+++ b/test/whatsapp-wire.test.ts
@@ -8,6 +8,48 @@ import {
   type BinaryNode,
 } from "../src/servers/whatsapp-wire/binary-node.js";
 import { decodeHandshakeMessage } from "../src/servers/whatsapp-wire/handshake.js";
+import { createSerializedMessageHandler } from "../src/servers/whatsapp-baileys-websocket.js";
+
+describe("WhatsApp WebSocket message processing", () => {
+  it("serializes concurrent frames within one session", async () => {
+    const events: string[] = [];
+    let activeHandlers = 0;
+    let releaseFirstFrame: () => void = () => undefined;
+    let markFirstFrameStarted: () => void = () => undefined;
+    const firstFrameBlocked = new Promise<void>((resolve) => {
+      releaseFirstFrame = resolve;
+    });
+    const firstFrameStarted = new Promise<void>((resolve) => {
+      markFirstFrameStarted = resolve;
+    });
+    const handleMessage = createSerializedMessageHandler<Buffer>(
+      async (frame) => {
+        activeHandlers += 1;
+        events.push(`start:${frame[0]}`);
+        expect(activeHandlers).toBe(1);
+        if (frame[0] === 1) {
+          markFirstFrameStarted();
+          await firstFrameBlocked;
+        }
+        events.push(`end:${frame[0]}`);
+        activeHandlers -= 1;
+      },
+      (error) => {
+        throw error;
+      },
+    );
+
+    const first = handleMessage(Buffer.from([1]));
+    const second = handleMessage(Buffer.from([2]));
+    await firstFrameStarted;
+
+    expect(events).toEqual(["start:1"]);
+    releaseFirstFrame();
+    await Promise.all([first, second]);
+
+    expect(events).toEqual(["start:1", "end:1", "start:2", "end:2"]);
+  });
+});
 
 describe("WhatsApp handshake protobufs", () => {
   it("skips unknown ten-byte uint64 varints", () => {

--- a/test/whatsapp-wire.test.ts
+++ b/test/whatsapp-wire.test.ts
@@ -1,4 +1,5 @@
 import { deflateSync } from "node:zlib";
+import { Curve as BaileysCurve } from "baileys";
 import { describe, expect, it } from "vitest";
 import {
   decodeBinaryNode,
@@ -7,8 +8,48 @@ import {
   WHATSAPP_BINARY_NODE_MAX_DECOMPRESSED_BYTES,
   type BinaryNode,
 } from "../src/servers/whatsapp-wire/binary-node.js";
+import { Curve } from "../src/servers/whatsapp-wire/crypto.js";
 import { decodeHandshakeMessage } from "../src/servers/whatsapp-wire/handshake.js";
 import { createSerializedMessageHandler } from "../src/servers/whatsapp-baileys-websocket.js";
+
+const RFC_7748_ALICE_PRIVATE = Buffer.from(
+  "77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a",
+  "hex",
+);
+const RFC_7748_BOB_PUBLIC = Buffer.from(
+  "de9edb7d7b7dc1b4d35b61c2ece435373f8343c85b78674dadfc7e146f882b4f",
+  "hex",
+);
+const RFC_7748_SHARED_SECRET = Buffer.from(
+  "4a5d9d5ba4ce2de1728e3bf480350f25e07e21c947d19e3376f09b3c1e161742",
+  "hex",
+);
+
+describe("WhatsApp X25519 agreement", () => {
+  it("matches the RFC 7748 vector and bundled Baileys Curve", () => {
+    expect(Curve.sharedKey(RFC_7748_ALICE_PRIVATE, RFC_7748_BOB_PUBLIC)).toEqual(
+      RFC_7748_SHARED_SECRET,
+    );
+    expect(BaileysCurve.sharedKey(RFC_7748_ALICE_PRIVATE, RFC_7748_BOB_PUBLIC)).toEqual(
+      RFC_7748_SHARED_SECRET,
+    );
+  });
+
+  it("rejects invalid peer key lengths", () => {
+    expect(() => Curve.sharedKey(RFC_7748_ALICE_PRIVATE, Buffer.alloc(31))).toThrow(
+      "Invalid Signal public key length: 31.",
+    );
+  });
+
+  it("propagates Node rejection of an all-zero peer key", () => {
+    expect(() => Curve.sharedKey(RFC_7748_ALICE_PRIVATE, Buffer.alloc(32))).toThrow(
+      "failed during derivation",
+    );
+    expect(() => BaileysCurve.sharedKey(RFC_7748_ALICE_PRIVATE, Buffer.alloc(32))).toThrow(
+      "failed during derivation",
+    );
+  });
+});
 
 describe("WhatsApp WebSocket message processing", () => {
   it("serializes concurrent frames within one session", async () => {


### PR DESCRIPTION
## Summary
- serialize inbound Noise frame handling so concurrent websocket messages cannot race cipher state
- reject invalid X25519 peer keys instead of silently substituting a fallback secret
- add regression coverage and a changelog entry

## Verification
- Crabbox `run_f7563f92267c`: `pnpm verify` (42 files, 272 tests)
- autoreview: clean, confidence 0.95
- local focused WhatsApp wire tests, typecheck, and formatting checks passed

## Release note
Prevents WhatsApp Noise session corruption under concurrent traffic and rejects malformed peer keys.