### PR TITLE
fix(persistence): serialize shared artifact writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Serialize WhatsApp Noise frames per session and reject invalid X25519 peer keys.
+- Serialize recorder persistence and reject overlapping OpenClaw smoke artifact runs.
 - Implement Telegram `getUpdates` long polling with timeout wakeups, offset confirmation, negative offsets, and shutdown cleanup.
 - Restrict releases to stable version tags and resolve workflow-dispatch inputs through exact tag refs before publication.
 - Reject ambiguous fixture/config inputs and keep the published CLI, type dependencies, and README assets aligned with their public contract.

--- a/src/openclaw.ts
+++ b/src/openclaw.ts
@@ -69,6 +69,8 @@ const OPENCLAW_CRABLINE_PROVIDER_BRIDGE_LIST = Object.values(
   OPENCLAW_CRABLINE_PROVIDER_BRIDGES,
 ) as readonly OpenClawCrablineProviderBridge[];
 
+const activeSmokeRuns = new Map<string, { channel: CrablineServerChannel }>();
+
 function createOpenClawCrablineProviderAdapter(
   manifest: CrablineServerManifest,
 ): OpenClawCrablineProviderAdapter {
@@ -177,44 +179,61 @@ export async function runOpenClawCrablineChannelDriverSmoke(params: {
   outputDir: string;
   selection: OpenClawCrablineChannelDriverSelection;
 }): Promise<OpenClawCrablineChannelDriverSmokeResult> {
-  const manifestPath = path.join(params.outputDir, OPENCLAW_CRABLINE_MANIFEST_PATH);
-  const recorderPath = path.join(
-    params.outputDir,
-    "artifacts",
-    "crabline",
-    `${params.selection.channel}-fake-provider.jsonl`,
-  );
-  await fs.mkdir(path.dirname(recorderPath), { recursive: true });
-  const adapter = await startOpenClawCrablineAdapter({
-    channel: params.selection.channel,
-    openclawConfig: {},
-    recorderPath,
-  });
+  const outputDir = path.resolve(params.outputDir);
+  const runKey = path.join(outputDir, OPENCLAW_CRABLINE_MANIFEST_PATH);
+  const activeRun = activeSmokeRuns.get(runKey);
+  if (activeRun) {
+    throw new Error(
+      `OpenClaw Crabline smoke is already running for channel "${activeRun.channel}" in "${outputDir}"; cannot start channel "${params.selection.channel}".`,
+    );
+  }
+  const run = { channel: params.selection.channel };
+  activeSmokeRuns.set(runKey, run);
+
   try {
-    await fs.writeFile(manifestPath, `${JSON.stringify(adapter.manifest, null, 2)}\n`, "utf8");
-    const probe = await adapter.probe();
-    return {
-      capabilityReport: {
-        result: {
-          driver: "crabline",
-          selectedChannel: params.selection.channel,
-          supportedChannels: [...CRABLINE_SERVER_CHANNELS],
+    const manifestPath = path.join(outputDir, OPENCLAW_CRABLINE_MANIFEST_PATH);
+    const recorderPath = path.join(
+      outputDir,
+      "artifacts",
+      "crabline",
+      `${params.selection.channel}-fake-provider.jsonl`,
+    );
+    await fs.mkdir(path.dirname(recorderPath), { recursive: true });
+    const adapter = await startOpenClawCrablineAdapter({
+      channel: params.selection.channel,
+      openclawConfig: {},
+      recorderPath,
+    });
+    try {
+      await fs.writeFile(manifestPath, `${JSON.stringify(adapter.manifest, null, 2)}\n`, "utf8");
+      const probe = await adapter.probe();
+      return {
+        capabilityReport: {
+          result: {
+            driver: "crabline",
+            selectedChannel: params.selection.channel,
+            supportedChannels: [...CRABLINE_SERVER_CHANNELS],
+          },
         },
-      },
-      manifestPath: path.basename(manifestPath),
-      smoke: {
         manifestPath: path.basename(manifestPath),
-        result: {
-          ok: true,
-          probe,
-          provider: adapter.manifest.provider,
-          endpoints: adapter.manifest.endpoints,
-          recorderPath: path.relative(params.outputDir, adapter.manifest.recorderPath),
+        smoke: {
+          manifestPath: path.basename(manifestPath),
+          result: {
+            ok: true,
+            probe,
+            provider: adapter.manifest.provider,
+            endpoints: adapter.manifest.endpoints,
+            recorderPath: path.relative(outputDir, adapter.manifest.recorderPath),
+          },
         },
-      },
-    };
+      };
+    } finally {
+      await adapter.close();
+    }
   } finally {
-    await adapter.close();
+    if (activeSmokeRuns.get(runKey) === run) {
+      activeSmokeRuns.delete(runKey);
+    }
   }
 }
 

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -11,15 +11,31 @@ function sleep(ms: number): Promise<void> {
 }
 
 function toRecordKey(event: InboundEnvelope): string {
-  return `${event.provider}:${event.threadId}:${event.id}`;
+  return JSON.stringify([event.provider, event.threadId, event.id]);
 }
 
 const MAX_WATCH_SEEN_KEYS = 4096;
+const pendingAppends = new Map<string, Promise<void>>();
 
 type IncrementalReadState = {
   offset: number;
   pending: Buffer;
 };
+
+async function appendJsonLine(filePath: string, line: string): Promise<void> {
+  const key = path.resolve(filePath);
+  const previous = pendingAppends.get(key) ?? Promise.resolve();
+  const current = previous.catch(() => {}).then(() => appendFile(filePath, line, "utf8"));
+  pendingAppends.set(key, current);
+
+  try {
+    await current;
+  } finally {
+    if (pendingAppends.get(key) === current) {
+      pendingAppends.delete(key);
+    }
+  }
+}
 
 async function readRecordedInboundAppend(
   filePath: string,
@@ -93,7 +109,7 @@ export async function appendRecordedInbound(
     recordedAt: new Date().toISOString(),
   } satisfies RecordedInboundEnvelope;
 
-  await appendFile(filePath, `${JSON.stringify(recorded)}\n`, "utf8");
+  await appendJsonLine(filePath, `${JSON.stringify(recorded)}\n`);
   return recorded;
 }
 

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -1,15 +1,32 @@
-import fs from "node:fs/promises";
+import { appendFile, mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { ServerRequestEvent } from "./http.js";
 
 export type ServerEventObserver = (event: ServerRequestEvent) => void | Promise<void>;
+
+const pendingAppends = new Map<string, Promise<void>>();
+
+async function appendJsonLine(filePath: string, line: string): Promise<void> {
+  const key = path.resolve(filePath);
+  const previous = pendingAppends.get(key) ?? Promise.resolve();
+  const current = previous.catch(() => {}).then(() => appendFile(filePath, line, "utf8"));
+  pendingAppends.set(key, current);
+
+  try {
+    await current;
+  } finally {
+    if (pendingAppends.get(key) === current) {
+      pendingAppends.delete(key);
+    }
+  }
+}
 
 export async function recordServerEvent(params: {
   event: ServerRequestEvent;
   onEvent: ServerEventObserver | undefined;
   recorderPath: string;
 }): Promise<void> {
-  await fs.mkdir(path.dirname(params.recorderPath), { recursive: true });
-  await fs.appendFile(params.recorderPath, `${JSON.stringify(params.event)}\n`, "utf8");
+  await mkdir(path.dirname(params.recorderPath), { recursive: true });
+  await appendJsonLine(params.recorderPath, `${JSON.stringify(params.event)}\n`);
   await params.onEvent?.(params.event);
 }

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -1376,4 +1376,35 @@ describe("OpenClaw local provider bridge", () => {
       await fs.rm(outputDir, { recursive: true, force: true });
     }
   });
+
+  it("rejects overlapping smoke runs that share an output artifact set", async () => {
+    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-openclaw-overlap-"));
+    try {
+      const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
+      const first = runOpenClawCrablineChannelDriverSmoke({ outputDir, selection });
+      const overlapping = runOpenClawCrablineChannelDriverSmoke({ outputDir, selection });
+      const otherSelection = resolveOpenClawCrablineChannelDriverSelection({ channel: "slack" });
+      const otherChannel = runOpenClawCrablineChannelDriverSmoke({
+        outputDir,
+        selection: otherSelection,
+      });
+
+      await expect(overlapping).rejects.toThrow(
+        `OpenClaw Crabline smoke is already running for channel "telegram" in "${outputDir}"; cannot start channel "telegram".`,
+      );
+      await expect(otherChannel).rejects.toThrow(
+        `OpenClaw Crabline smoke is already running for channel "telegram" in "${outputDir}"; cannot start channel "slack".`,
+      );
+      await expect(first).resolves.toMatchObject({
+        smoke: { result: { ok: true, provider: "telegram" } },
+      });
+      await expect(
+        runOpenClawCrablineChannelDriverSmoke({ outputDir, selection }),
+      ).resolves.toMatchObject({
+        smoke: { result: { ok: true, provider: "telegram" } },
+      });
+    } finally {
+      await fs.rm(outputDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/test/recorder-concurrency.test.ts
+++ b/test/recorder-concurrency.test.ts
@@ -1,0 +1,105 @@
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { appendRecordedInbound } from "../src/providers/recorder.js";
+import { recordServerEvent } from "../src/servers/recorder.js";
+
+const fsMocks = vi.hoisted(() => ({
+  appendFile: vi.fn<(filePath: string, data: string, encoding: string) => Promise<void>>(),
+}));
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return { ...actual, appendFile: fsMocks.appendFile };
+});
+
+type PendingWrite = {
+  data: string;
+  resolve: () => void;
+};
+
+let pendingWrites: PendingWrite[] = [];
+
+beforeEach(() => {
+  pendingWrites = [];
+  fsMocks.appendFile.mockReset();
+  fsMocks.appendFile.mockImplementation(
+    async (_filePath, data) =>
+      await new Promise<void>((resolve) => {
+        pendingWrites.push({ data, resolve });
+      }),
+  );
+});
+
+async function expectSerializedWrites(first: Promise<unknown>, second: Promise<unknown>) {
+  await vi.waitFor(() => expect(fsMocks.appendFile).toHaveBeenCalledTimes(1));
+  expect(pendingWrites).toHaveLength(1);
+
+  pendingWrites[0]!.resolve();
+  await vi.waitFor(() => expect(fsMocks.appendFile).toHaveBeenCalledTimes(2));
+  expect(pendingWrites).toHaveLength(2);
+
+  pendingWrites[1]!.resolve();
+  await Promise.all([first, second]);
+}
+
+describe("recorder append serialization", () => {
+  it("serializes server event appends to the same JSONL file", async () => {
+    const recorderPath = path.join("/tmp", "crabline-server-recorder.jsonl");
+    const firstEvent = {
+      at: "2026-07-12T10:00:00.000Z",
+      method: "GET",
+      path: "/first",
+      query: {},
+      type: "api" as const,
+    };
+    const secondEvent = {
+      ...firstEvent,
+      path: "/second",
+    };
+
+    const first = recordServerEvent({
+      event: firstEvent,
+      onEvent: undefined,
+      recorderPath,
+    });
+    await vi.waitFor(() => expect(fsMocks.appendFile).toHaveBeenCalledTimes(1));
+    const second = recordServerEvent({
+      event: secondEvent,
+      onEvent: undefined,
+      recorderPath,
+    });
+
+    await expectSerializedWrites(first, second);
+    expect(pendingWrites.map((write) => write.data)).toEqual([
+      `${JSON.stringify(firstEvent)}\n`,
+      `${JSON.stringify(secondEvent)}\n`,
+    ]);
+  });
+
+  it("serializes provider inbound appends to the same JSONL file", async () => {
+    const recorderPath = path.join("/tmp", "crabline-provider-recorder.jsonl");
+    const firstEvent = {
+      author: "assistant" as const,
+      id: "first",
+      provider: "slack",
+      sentAt: "2026-07-12T10:00:00.000Z",
+      text: "first",
+      threadId: "slack:C123",
+    };
+    const secondEvent = {
+      ...firstEvent,
+      id: "second",
+      text: "second",
+    };
+
+    const first = appendRecordedInbound(recorderPath, firstEvent);
+    await vi.waitFor(() => expect(fsMocks.appendFile).toHaveBeenCalledTimes(1));
+    const second = appendRecordedInbound(recorderPath, secondEvent);
+
+    await expectSerializedWrites(first, second);
+    expect(pendingWrites.map((write) => JSON.parse(write.data) as { id: string })).toEqual([
+      expect.objectContaining({ id: "first" }),
+      expect.objectContaining({ id: "second" }),
+    ]);
+  });
+});

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -123,6 +123,34 @@ describe("recorder", () => {
     });
   });
 
+  it("does not collapse distinct records whose fields contain delimiters", async () => {
+    const filePath = await createRecorderPath();
+    await appendRecordedInbound(filePath, {
+      author: "assistant",
+      id: "c",
+      provider: "slack",
+      sentAt: new Date().toISOString(),
+      text: "first",
+      threadId: "a:b",
+    });
+    const expected = await appendRecordedInbound(filePath, {
+      author: "assistant",
+      id: "b:c",
+      provider: "slack",
+      sentAt: new Date().toISOString(),
+      text: "second",
+      threadId: "a",
+    });
+
+    await expect(
+      waitForRecordedInbound({
+        filePath,
+        matches: (event) => event.text === "second",
+        timeoutMs: 30,
+      }),
+    ).resolves.toEqual(expected);
+  });
+
   it("times out when no matching event arrives", async () => {
     const filePath = await createRecorderPath();
 


### PR DESCRIPTION
## Summary
- serialize concurrent JSONL appends for provider and server recorders
- prevent key collisions in the write-lock registry
- reject overlapping OpenClaw smoke runs that target the same artifact path
- add focused concurrency coverage and a changelog entry

## Verification
- Crabbox `run_0ff09cc10835`: `pnpm verify` (43 files, 272 tests)
- autoreview: clean, confidence 0.91
- local focused persistence tests, typecheck, and formatting checks passed

## Release note
Prevents concurrent recorder writes and smoke runs from corrupting shared JSONL artifacts.