### PR TITLE
fix(cli): preserve failure and packaging contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Serialize WhatsApp Noise frames per session and reject invalid X25519 peer keys.
 - Serialize recorder persistence and reject overlapping OpenClaw smoke artifact runs.
+- Make CLI failures machine-readable, preserve stage-specific failure contracts, validate fixture provider references, redact script commands, and verify production-only tarball installs.
 - Implement Telegram `getUpdates` long polling with timeout wakeups, offset confirmation, negative offsets, and shutdown cleanup.
 - Restrict releases to stable version tags and resolve workflow-dispatch inputs through exact tag refs before publication.
 - Reject ambiguous fixture/config inputs and keep the published CLI, type dependencies, and README assets aligned with their public contract.

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -582,7 +582,13 @@ export async function runCli(argv: string[]): Promise<number> {
     return exitCode;
   } catch (error) {
     const errorExitCode =
-      error instanceof CrablineError || error instanceof CommanderError ? error.exitCode : 1;
+      error instanceof CommanderError
+        ? error.code === "commander.help" && error.exitCode !== 0
+          ? 1
+          : error.exitCode
+        : error instanceof CrablineError
+          ? error.exitCode
+          : 1;
     if (error instanceof CommanderError && errorExitCode === 0) {
       return 0;
     }

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -1,4 +1,4 @@
-import { Command } from "commander";
+import { Command, CommanderError } from "commander";
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import nodePath from "node:path";
@@ -126,6 +126,7 @@ export function createProgram(
   const startServer = dependencies.startServer ?? startCrablineServer;
 
   program
+    .exitOverride()
     .name("crabline")
     .description("Deterministic CLI harness for messaging provider E2E tests")
     .option("-c, --config <path>", "Config file path")
@@ -568,15 +569,40 @@ export async function runCli(argv: string[]): Promise<number> {
   const program = createProgram((code) => {
     exitCode = code;
   });
+  const json = argv.slice(2).includes("--json");
+  if (json) {
+    const configureJsonOutput = (command: Command): void => {
+      command.configureOutput({ writeErr: () => undefined });
+      for (const child of command.commands) {
+        configureJsonOutput(child);
+      }
+    };
+    configureJsonOutput(program);
+  }
   try {
     await program.parseAsync(argv);
     return exitCode;
   } catch (error) {
-    const message = ensureErrorMessage(error);
-    process.stderr.write(`${message}\n`);
-    if (error instanceof CrablineError) {
-      return error.exitCode;
+    const errorExitCode =
+      error instanceof CrablineError || error instanceof CommanderError ? error.exitCode : 1;
+    if (error instanceof CommanderError && errorExitCode === 0) {
+      return 0;
     }
-    return 1;
+    if (json) {
+      process.stderr.write(
+        `${formatJson({
+          error: {
+            ...(error instanceof CommanderError ? { code: error.code } : {}),
+            exitCode: errorExitCode,
+            ...(error instanceof CrablineError && error.kind ? { kind: error.kind } : {}),
+            message: ensureErrorMessage(error),
+          },
+          ok: false,
+        })}\n`,
+      );
+    } else if (!(error instanceof CommanderError)) {
+      process.stderr.write(`${ensureErrorMessage(error)}\n`);
+    }
+    return errorExitCode;
   }
 }

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -569,16 +569,14 @@ export async function runCli(argv: string[]): Promise<number> {
   const program = createProgram((code) => {
     exitCode = code;
   });
-  const json = argv.slice(2).includes("--json");
-  if (json) {
-    const configureJsonOutput = (command: Command): void => {
-      command.configureOutput({ writeErr: () => undefined });
-      for (const child of command.commands) {
-        configureJsonOutput(child);
-      }
-    };
-    configureJsonOutput(program);
-  }
+  const parserErrors: string[] = [];
+  const bufferParserErrors = (command: Command): void => {
+    command.configureOutput({ writeErr: (message) => parserErrors.push(message) });
+    for (const child of command.commands) {
+      bufferParserErrors(child);
+    }
+  };
+  bufferParserErrors(program);
   try {
     await program.parseAsync(argv);
     return exitCode;
@@ -588,6 +586,7 @@ export async function runCli(argv: string[]): Promise<number> {
     if (error instanceof CommanderError && errorExitCode === 0) {
       return 0;
     }
+    const json = program.opts().json === true;
     if (json) {
       process.stderr.write(
         `${formatJson({
@@ -595,12 +594,17 @@ export async function runCli(argv: string[]): Promise<number> {
             ...(error instanceof CommanderError ? { code: error.code } : {}),
             exitCode: errorExitCode,
             ...(error instanceof CrablineError && error.kind ? { kind: error.kind } : {}),
-            message: ensureErrorMessage(error),
+            message:
+              error instanceof CommanderError && error.code === "commander.help"
+                ? "No command specified."
+                : ensureErrorMessage(error),
           },
           ok: false,
         })}\n`,
       );
-    } else if (!(error instanceof CommanderError)) {
+    } else if (error instanceof CommanderError) {
+      process.stderr.write(parserErrors.join(""));
+    } else {
       process.stderr.write(`${ensureErrorMessage(error)}\n`);
     }
     return errorExitCode;

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -627,6 +627,14 @@ const StrictManifestSchema = z
         });
       }
       seenFixtureIds.add(fixture.id);
+
+      if (!Object.hasOwn(manifest.providers, fixture.provider)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `fixture ${fixture.id} references unknown provider ${fixture.provider}`,
+          path: ["fixtures", index, "provider"],
+        });
+      }
     }
   });
 

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -91,7 +91,7 @@ export async function runFixtureCommand(params: {
           providerId: fixture.provider,
         });
       } catch (error) {
-        return (result = toFailure(fixture.id, fixture.provider, mode, error));
+        return (result = toFailure(fixture.id, fixture.provider, mode, error, "connectivity"));
       }
     }
 
@@ -106,12 +106,18 @@ export async function runFixtureCommand(params: {
       try {
         const outboundText = createOutboundText({ ...fixture, mode }, nonce);
         const since = new Date().toISOString();
-        const accepted = await provider.send({
-          ...contextBase,
-          mode,
-          nonce,
-          text: outboundText,
-        });
+        let accepted;
+        try {
+          accepted = await provider.send({
+            ...contextBase,
+            mode,
+            nonce,
+            text: outboundText,
+          });
+        } catch (error) {
+          lastFailure = toFailure(fixture.id, fixture.provider, mode, error, "outbound", nonce);
+          continue;
+        }
         diagnostics.push(`accepted message ${accepted.messageId}`);
 
         if (mode === "send") {
@@ -125,13 +131,19 @@ export async function runFixtureCommand(params: {
           });
         }
 
-        const inbound = await provider.waitForInbound({
-          ...contextBase,
-          nonce,
-          since,
-          threadId: accepted.threadId,
-          timeoutMs: fixture.timeoutMs,
-        });
+        let inbound;
+        try {
+          inbound = await provider.waitForInbound({
+            ...contextBase,
+            nonce,
+            since,
+            threadId: accepted.threadId,
+            timeoutMs: fixture.timeoutMs,
+          });
+        } catch (error) {
+          lastFailure = toFailure(fixture.id, fixture.provider, mode, error, "inbound", nonce);
+          continue;
+        }
         if (!inbound) {
           lastFailure = {
             diagnostics: [
@@ -172,7 +184,7 @@ export async function runFixtureCommand(params: {
           providerId: fixture.provider,
         });
       } catch (error) {
-        lastFailure = toFailure(fixture.id, fixture.provider, mode, error, nonce);
+        lastFailure = toFailure(fixture.id, fixture.provider, mode, error, "assertion", nonce);
       }
     }
 
@@ -278,6 +290,7 @@ function toFailure(
   providerId: string,
   mode: string,
   error: unknown,
+  fallbackKind: FailureKind,
   nonce?: string,
 ): CommandRunResult {
   const diagnostics = [ensureErrorMessage(error)];
@@ -296,7 +309,7 @@ function toFailure(
 
   return {
     diagnostics,
-    failureKind: "assertion",
+    failureKind: fallbackKind,
     fixtureId,
     mode,
     nonce,

--- a/src/providers/builtin/script.ts
+++ b/src/providers/builtin/script.ts
@@ -80,8 +80,18 @@ function formatValidationError(error: z.ZodError): string {
     .join("; ");
 }
 
+const sensitiveCommandValuePattern =
+  /(?:^|[\s;&|])(?:[A-Za-z_][A-Za-z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|PASS|PRIVATE|CREDENTIAL|AUTH)[A-Za-z0-9_]*\s*=|--(?:api[-_]?key|auth|credential|pass(?:word)?|private[-_]?key|secret|token)(?:=|\s))/iu;
+
 function formatScriptError(summary: string, detail: string, command: string): string {
-  const redacted = detail.split(command).join("[configured script command]").trim();
+  const trimmed = detail.trim();
+  if (!trimmed) {
+    return summary;
+  }
+  if (sensitiveCommandValuePattern.test(command)) {
+    return `${summary}\n[script diagnostics redacted]`;
+  }
+  const redacted = trimmed.split(command).join("[configured script command]").trim();
   return redacted ? `${summary}\n${redacted}` : summary;
 }
 

--- a/src/providers/builtin/script.ts
+++ b/src/providers/builtin/script.ts
@@ -80,13 +80,22 @@ function formatValidationError(error: z.ZodError): string {
     .join("; ");
 }
 
+function formatScriptError(summary: string, detail: string, command: string): string {
+  const redacted = detail.split(command).join("[configured script command]").trim();
+  return redacted ? `${summary}\n${redacted}` : summary;
+}
+
 function parseScriptJson<T>(params: { command: string; output: string; schema: z.ZodType<T> }): T {
   let parsed: unknown;
   try {
     parsed = JSON.parse(params.output);
   } catch (error) {
     throw new CrablineError(
-      `Script command did not return valid JSON: ${params.command}\n${ensureErrorMessage(error)}`,
+      formatScriptError(
+        "Script command did not return valid JSON.",
+        ensureErrorMessage(error),
+        params.command,
+      ),
       { kind: "config" },
     );
   }
@@ -94,7 +103,7 @@ function parseScriptJson<T>(params: { command: string; output: string; schema: z
   const result = params.schema.safeParse(parsed);
   if (!result.success) {
     throw new CrablineError(
-      `Script command returned invalid result: ${params.command}\n${formatValidationError(result.error)}`,
+      `Script command returned invalid result.\n${formatValidationError(result.error)}`,
       { kind: "config" },
     );
   }
@@ -141,10 +150,9 @@ function runScript<T>(params: {
       finish(() => {
         terminateChild(child);
         reject(
-          new CrablineError(
-            `Script command exceeded ${MAX_SCRIPT_OUTPUT_BYTES} bytes of output: ${params.command}`,
-            { kind: "connectivity" },
-          ),
+          new CrablineError(`Script command exceeded ${MAX_SCRIPT_OUTPUT_BYTES} bytes of output.`, {
+            kind: "connectivity",
+          }),
         );
       });
     };
@@ -176,8 +184,12 @@ function runScript<T>(params: {
       finish(() => {
         reject(
           new CrablineError(
-            `Script command failed to start: ${params.command}\n${ensureErrorMessage(error)}`,
-            { cause: error, kind: "connectivity" },
+            formatScriptError(
+              "Script command failed to start.",
+              ensureErrorMessage(error),
+              params.command,
+            ),
+            { kind: "connectivity" },
           ),
         );
       });
@@ -189,9 +201,11 @@ function runScript<T>(params: {
         if (code !== 0) {
           reject(
             new CrablineError(
-              `Script command failed: ${params.command}${
-                signal ? ` (${signal})` : ""
-              }\n${stderrText.trim() || stdoutText.trim()}`,
+              formatScriptError(
+                `Script command failed${signal ? ` (${signal})` : ""}.`,
+                stderrText || stdoutText,
+                params.command,
+              ),
               { kind: "connectivity" },
             ),
           );
@@ -206,10 +220,9 @@ function runScript<T>(params: {
           });
           if (deadlineExceeded && !params.acceptResultDuringTimeoutGrace?.(result)) {
             reject(
-              new CrablineError(
-                `Script command timed out after ${params.timeoutMs}ms: ${params.command}`,
-                { kind: "timeout" },
-              ),
+              new CrablineError(`Script command timed out after ${params.timeoutMs}ms.`, {
+                kind: "timeout",
+              }),
             );
             return;
           }
@@ -224,10 +237,9 @@ function runScript<T>(params: {
       finish(() => {
         terminateChild(child);
         reject(
-          new CrablineError(
-            `Script command timed out after ${params.timeoutMs}ms: ${params.command}`,
-            { kind: "timeout" },
-          ),
+          new CrablineError(`Script command timed out after ${params.timeoutMs}ms.`, {
+            kind: "timeout",
+          }),
         );
       });
     };
@@ -397,7 +409,7 @@ export class ScriptProviderAdapter implements ProviderAdapter {
       stderr += chunk;
       if (Buffer.byteLength(stderr) > MAX_SCRIPT_OUTPUT_BYTES) {
         outputLimitError = new CrablineError(
-          `Script watch command exceeded ${MAX_SCRIPT_OUTPUT_BYTES} bytes of stderr: ${command}`,
+          `Script watch command exceeded ${MAX_SCRIPT_OUTPUT_BYTES} bytes of stderr.`,
           { kind: "connectivity" },
         );
         terminateChild(child);
@@ -430,7 +442,7 @@ export class ScriptProviderAdapter implements ProviderAdapter {
         buffer += chunk;
         if (Buffer.byteLength(buffer) > MAX_SCRIPT_OUTPUT_BYTES && !buffer.includes("\n")) {
           throw new CrablineError(
-            `Script watch command exceeded ${MAX_SCRIPT_OUTPUT_BYTES} bytes without a newline: ${command}`,
+            `Script watch command exceeded ${MAX_SCRIPT_OUTPUT_BYTES} bytes without a newline.`,
             { kind: "config" },
           );
         }
@@ -442,7 +454,7 @@ export class ScriptProviderAdapter implements ProviderAdapter {
           }
           if (Buffer.byteLength(line) > MAX_SCRIPT_OUTPUT_BYTES) {
             throw new CrablineError(
-              `Script watch command emitted a JSON line larger than ${MAX_SCRIPT_OUTPUT_BYTES} bytes: ${command}`,
+              `Script watch command emitted a JSON line larger than ${MAX_SCRIPT_OUTPUT_BYTES} bytes.`,
               { kind: "config" },
             );
           }
@@ -476,15 +488,21 @@ export class ScriptProviderAdapter implements ProviderAdapter {
       }
       if (childError) {
         throw new CrablineError(
-          `Script watch command failed to start: ${command}\n${ensureErrorMessage(childError)}`,
-          { cause: childError, kind: "connectivity" },
+          formatScriptError(
+            "Script watch command failed to start.",
+            ensureErrorMessage(childError),
+            command,
+          ),
+          { kind: "connectivity" },
         );
       }
       if (exit.code !== 0) {
         throw new CrablineError(
-          `Script watch command failed: ${command}${
-            exit.signal ? ` (${exit.signal})` : ""
-          }\n${stderr.trim()}`,
+          formatScriptError(
+            `Script watch command failed${exit.signal ? ` (${exit.signal})` : ""}.`,
+            stderr,
+            command,
+          ),
           { kind: "connectivity" },
         );
       }
@@ -494,8 +512,12 @@ export class ScriptProviderAdapter implements ProviderAdapter {
       }
       if (childError) {
         throw new CrablineError(
-          `Script watch command failed to start: ${command}\n${ensureErrorMessage(childError)}`,
-          { cause: childError, kind: "connectivity" },
+          formatScriptError(
+            "Script watch command failed to start.",
+            ensureErrorMessage(childError),
+            command,
+          ),
+          { kind: "connectivity" },
         );
       }
       throw error;

--- a/src/providers/builtin/script.ts
+++ b/src/providers/builtin/script.ts
@@ -203,7 +203,7 @@ function runScript<T>(params: {
             new CrablineError(
               formatScriptError(
                 `Script command failed${signal ? ` (${signal})` : ""}.`,
-                stderrText || stdoutText,
+                stderrText.trim() || stdoutText.trim(),
                 params.command,
               ),
               { kind: "connectivity" },

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -238,6 +238,28 @@ describe("cli", () => {
     });
   });
 
+  it("normalizes missing-command exit codes independently of process state", async () => {
+    process.exitCode = 10;
+    const captured = captureWrites();
+
+    let exitCode: number;
+    try {
+      exitCode = await runCli(["node", "crabline", "--json"]);
+    } finally {
+      captured.restore();
+    }
+
+    expect(exitCode!).toBe(1);
+    expect(JSON.parse(captured.stderr.join(""))).toEqual({
+      error: {
+        code: "commander.help",
+        exitCode: 1,
+        message: "No command specified.",
+      },
+      ok: false,
+    });
+  });
+
   it("does not treat --json option values or positional arguments as the global flag", async () => {
     const configPath = await createConfig();
     const captured = captureWrites();

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -216,6 +216,47 @@ describe("cli", () => {
     });
   });
 
+  it("reports a useful JSON error when no command is specified", async () => {
+    const captured = captureWrites();
+
+    let exitCode: number;
+    try {
+      exitCode = await runCli(["node", "crabline", "--json"]);
+    } finally {
+      captured.restore();
+    }
+
+    expect(exitCode!).toBe(1);
+    expect(captured.stdout).toEqual([]);
+    expect(JSON.parse(captured.stderr.join(""))).toEqual({
+      error: {
+        code: "commander.help",
+        exitCode: 1,
+        message: "No command specified.",
+      },
+      ok: false,
+    });
+  });
+
+  it("does not treat --json option values or positional arguments as the global flag", async () => {
+    const configPath = await createConfig();
+    const captured = captureWrites();
+
+    try {
+      expect(await runCli(["node", "crabline", "--config", "--json", "doctor"])).toBe(10);
+      expect(
+        await runCli(["node", "crabline", "--config", configPath, "probe", "--", "--json"]),
+      ).toBe(10);
+    } finally {
+      captured.restore();
+    }
+
+    const stderr = captured.stderr.join("");
+    expect(stderr).toMatch(/Unable to load config file ".*\/--json"/u);
+    expect(stderr).toContain("Unknown fixture: --json");
+    expect(() => JSON.parse(stderr)).toThrow(SyntaxError);
+  });
+
   it("documents probe as a fixture-only command", () => {
     const probe = createProgram().commands.find((command) => command.name() === "probe");
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -122,6 +122,100 @@ describe("cli", () => {
     expect(captured.stderr.join("")).toContain("Unknown fixture");
   });
 
+  it("reports JSON failures as one machine-readable document", async () => {
+    const configPath = await createConfig();
+    const captured = captureWrites();
+
+    let exitCode: number;
+    try {
+      exitCode = await runCli([
+        "node",
+        "crabline",
+        "--json",
+        "--config",
+        configPath,
+        "probe",
+        "missing",
+      ]);
+    } finally {
+      captured.restore();
+    }
+
+    expect(exitCode!).toBe(10);
+    expect(captured.stdout).toEqual([]);
+    expect(JSON.parse(captured.stderr.join(""))).toEqual({
+      error: {
+        exitCode: 10,
+        kind: "config",
+        message: "Unknown fixture: missing",
+      },
+      ok: false,
+    });
+  });
+
+  it("keeps Commander exits inside runCli without duplicate output", async () => {
+    const exit = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit must not be called");
+    });
+    const captured = captureWrites();
+
+    try {
+      expect(await runCli(["node", "crabline", "not-a-command"])).toBe(1);
+      expect(await runCli(["node", "crabline", "--help"])).toBe(0);
+    } finally {
+      captured.restore();
+      exit.mockRestore();
+    }
+
+    expect(exit).not.toHaveBeenCalled();
+    expect(captured.stderr.join("").match(/unknown command 'not-a-command'/gu)).toHaveLength(1);
+    expect(captured.stdout.join("")).toContain("Usage: crabline");
+  });
+
+  it("serializes Commander failures when JSON output is requested", async () => {
+    const captured = captureWrites();
+
+    let exitCode: number;
+    try {
+      exitCode = await runCli(["node", "crabline", "--json", "not-a-command"]);
+    } finally {
+      captured.restore();
+    }
+
+    expect(exitCode!).toBe(1);
+    expect(captured.stdout).toEqual([]);
+    expect(JSON.parse(captured.stderr.join(""))).toEqual({
+      error: {
+        code: "commander.unknownCommand",
+        exitCode: 1,
+        message: "error: unknown command 'not-a-command'",
+      },
+      ok: false,
+    });
+  });
+
+  it("suppresses subcommand parser output in JSON mode", async () => {
+    const captured = captureWrites();
+
+    let exitCode: number;
+    try {
+      exitCode = await runCli(["node", "crabline", "--json", "probe"]);
+    } finally {
+      captured.restore();
+    }
+
+    expect(exitCode!).toBe(1);
+    expect(captured.stdout).toEqual([]);
+    expect(JSON.parse(captured.stderr.join(""))).toEqual({
+      error: {
+        code: "commander.missingArgument",
+        exitCode: 1,
+        message: "error: missing required argument 'fixtureId'",
+      },
+      ok: false,
+    });
+  });
+
   it("documents probe as a fixture-only command", () => {
     const probe = createProgram().commands.find((command) => command.name() === "probe");
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -54,6 +54,23 @@ describe("manifest schema", () => {
     ).toThrow(/duplicate fixture id: duplicate/u);
   });
 
+  it("rejects fixtures that reference unknown providers", () => {
+    expect(() =>
+      ManifestSchema.parse({
+        configVersion: 1,
+        fixtures: [
+          {
+            id: "missing-provider",
+            mode: "send",
+            provider: "missing",
+            target: { id: "sink" },
+          },
+        ],
+        providers: {},
+      }),
+    ).toThrow(/fixture missing-provider references unknown provider missing/u);
+  });
+
   it("parses a valid loopback fixture", () => {
     const manifest = ManifestSchema.parse({
       configVersion: 1,

--- a/test/package-production.test.ts
+++ b/test/package-production.test.ts
@@ -28,6 +28,7 @@ describe("production package", () => {
       optionalDependencies?: Record<string, string>;
       peerDependencies?: Record<string, string>;
       types?: string;
+      version?: string;
     };
 
     expect(pkg.dependencies?.["@types/node"]).toBeDefined();
@@ -77,7 +78,70 @@ describe("production package", () => {
         }
       }),
     );
-  }, 30_000);
+
+    const installRoot = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-production-install-"));
+    const packDirectory = path.join(installRoot, "pack");
+    const consumerDirectory = path.join(installRoot, "consumer");
+    try {
+      await Promise.all([
+        fs.mkdir(packDirectory, { recursive: true }),
+        fs.mkdir(consumerDirectory, { recursive: true }),
+      ]);
+      const packed = await npmPack(root, packDirectory);
+      const tarballPath = path.join(packDirectory, packed.filename);
+      await fs.writeFile(
+        path.join(consumerDirectory, "package.json"),
+        JSON.stringify({ name: "crabline-production-consumer", private: true }),
+      );
+      await execFileAsync(
+        "npm",
+        [
+          "install",
+          "--ignore-scripts",
+          "--no-audit",
+          "--no-fund",
+          "--no-package-lock",
+          "--omit=dev",
+          tarballPath,
+        ],
+        {
+          cwd: consumerDirectory,
+          maxBuffer: 10 * 1024 * 1024,
+        },
+      );
+
+      const installedRoot = path.join(consumerDirectory, "node_modules", "@openclaw", "crabline");
+      const installedPackage = JSON.parse(
+        await fs.readFile(path.join(installedRoot, "package.json"), "utf8"),
+      ) as typeof pkg;
+      expect(installedPackage.version).toBe(pkg.version);
+      for (const packageName of DEV_ONLY_RUNTIME_PACKAGES) {
+        await expect(
+          fs.stat(path.join(consumerDirectory, "node_modules", packageName)),
+        ).rejects.toMatchObject({ code: "ENOENT" });
+      }
+
+      const { stdout: importOutput } = await execFileAsync(
+        process.execPath,
+        [
+          "--input-type=module",
+          "--eval",
+          'const pkg = await import("@openclaw/crabline"); console.log(typeof pkg.startCrablineServer);',
+        ],
+        { cwd: consumerDirectory },
+      );
+      expect(importOutput.trim()).toBe("function");
+
+      const installedCliPath = path.join(installedRoot, cliPath!);
+      const { stdout: installedCliHelp } = await execFileAsync(process.execPath, [
+        installedCliPath,
+        "--help",
+      ]);
+      expect(installedCliHelp).toContain("Usage: crabline");
+    } finally {
+      await fs.rm(installRoot, { force: true, recursive: true });
+    }
+  }, 120_000);
 
   it("uses portable cleanup scripts", async () => {
     const root = process.cwd();
@@ -119,6 +183,7 @@ describe("production package", () => {
 
   it("extracts pack metadata around lifecycle output", () => {
     const pack: NpmPackMetadata = {
+      filename: "openclaw-crabline-0.1.9.tgz",
       files: [{ path: "dist/src/bin/crabline.js" }],
     };
     const outputs = [
@@ -133,6 +198,7 @@ describe("production package", () => {
 });
 
 type NpmPackMetadata = {
+  filename: string;
   files: Array<{ mode?: number; path: string; size?: number }>;
 };
 
@@ -141,6 +207,18 @@ async function npmPackDryRun(root: string): Promise<NpmPackMetadata> {
     cwd: root,
     maxBuffer: 10 * 1024 * 1024,
   });
+  return parseNpmPackOutput(stdout);
+}
+
+async function npmPack(root: string, destination: string): Promise<NpmPackMetadata> {
+  const { stdout } = await execFileAsync(
+    "npm",
+    ["pack", "--json", "--pack-destination", destination],
+    {
+      cwd: root,
+      maxBuffer: 10 * 1024 * 1024,
+    },
+  );
   return parseNpmPackOutput(stdout);
 }
 
@@ -219,7 +297,10 @@ function findJsonDocumentEnd(output: string, start: number): number {
 
 function isNpmPackMetadata(value: unknown): value is NpmPackMetadata {
   return (
-    Boolean(value) && typeof value === "object" && Array.isArray((value as NpmPackMetadata).files)
+    Boolean(value) &&
+    typeof value === "object" &&
+    typeof (value as NpmPackMetadata).filename === "string" &&
+    Array.isArray((value as NpmPackMetadata).files)
   );
 }
 

--- a/test/run.behavior.test.ts
+++ b/test/run.behavior.test.ts
@@ -154,7 +154,46 @@ describe("run behavior", () => {
       manifestPath: "/tmp/crabline.yaml",
       registry: buildRegistry(provider),
     });
-    expect(roundtrip.failureKind).toBe("assertion");
+    expect(roundtrip.failureKind).toBe("outbound");
+  });
+
+  it("classifies plain provider failures by execution stage", async () => {
+    let stage: "probe" | "send" | "wait" = "probe";
+    const provider: ProviderAdapter = {
+      id: "mock",
+      platform: "loopback",
+      status: "ready",
+      supports: ["probe", "send", "roundtrip", "agent"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      probe: async () => {
+        throw new Error("probe exploded");
+      },
+      send: async () => {
+        if (stage === "send") {
+          throw new Error("send exploded");
+        }
+        return { accepted: true, messageId: "sent", threadId: "thread" };
+      },
+      waitForInbound: async () => {
+        throw new Error("wait exploded");
+      },
+    };
+    const run = (modeOverride?: "probe") =>
+      runFixtureCommand({
+        fixtureId: "fixture",
+        manifest: withAllCapabilities(manifest),
+        manifestPath: "/tmp/crabline.yaml",
+        ...(modeOverride ? { modeOverride } : {}),
+        registry: buildRegistry(provider),
+      });
+
+    expect((await run("probe")).failureKind).toBe("connectivity");
+    stage = "send";
+    expect((await run()).failureKind).toBe("outbound");
+    stage = "wait";
+    expect((await run()).failureKind).toBe("inbound");
   });
 
   it("fails an otherwise successful fixture when cleanup fails", async () => {

--- a/test/script-provider.test.ts
+++ b/test/script-provider.test.ts
@@ -469,6 +469,26 @@ describe("script provider", () => {
     expect(ensureErrorMessage(watchError)).not.toContain(sentinel);
   });
 
+  it("uses stdout diagnostics when stderr is only whitespace", async () => {
+    const context = await createContext();
+    const failingScript = path.join(path.dirname(context.manifestPath), "send-stdout-error.mjs");
+    await writeText(
+      failingScript,
+      'process.stderr.write("\\n");process.stdout.write("useful failure");process.exitCode=7;',
+    );
+    context.config.script!.commands.send = `node ${JSON.stringify(failingScript)}`;
+    const provider = new ScriptProviderAdapter(context);
+
+    await expect(
+      provider.send({
+        ...context,
+        mode: "send",
+        nonce: "nonce",
+        text: "payload",
+      }),
+    ).rejects.toThrow(/useful failure/u);
+  });
+
   it("fails when required commands are missing", async () => {
     const context = await createContext();
     const provider = new ScriptProviderAdapter({

--- a/test/script-provider.test.ts
+++ b/test/script-provider.test.ts
@@ -431,7 +431,10 @@ describe("script provider", () => {
     const context = await createContext();
     const sentinel = "redact-me";
     const failingScript = path.join(path.dirname(context.manifestPath), "send-secret.mjs");
-    await writeText(failingScript, 'process.stderr.write("failed");process.exitCode=7;');
+    await writeText(
+      failingScript,
+      "process.stderr.write(process.env.CRABLINE_PRIVATE_VALUE);process.exitCode=7;",
+    );
     const command = `CRABLINE_PRIVATE_VALUE=${sentinel} node ${JSON.stringify(failingScript)}`;
     context.config.script!.commands.send = command;
     const provider = new ScriptProviderAdapter(context);
@@ -449,11 +452,15 @@ describe("script provider", () => {
     }
 
     expect(ensureErrorMessage(sendError)).toContain("Script command failed");
+    expect(ensureErrorMessage(sendError)).toContain("[script diagnostics redacted]");
     expect(ensureErrorMessage(sendError)).not.toContain(command);
     expect(ensureErrorMessage(sendError)).not.toContain(sentinel);
 
     const watchScript = path.join(path.dirname(context.manifestPath), "watch-secret.mjs");
-    await writeText(watchScript, 'process.stderr.write("watch failed");process.exitCode=8;');
+    await writeText(
+      watchScript,
+      "process.stderr.write(process.env.CRABLINE_PRIVATE_VALUE);process.exitCode=8;",
+    );
     const watchCommand = `CRABLINE_PRIVATE_VALUE=${sentinel} node ${JSON.stringify(watchScript)}`;
     context.config.script!.commands.watch = watchCommand;
 
@@ -465,6 +472,7 @@ describe("script provider", () => {
     }
 
     expect(ensureErrorMessage(watchError)).toContain("Script watch command failed");
+    expect(ensureErrorMessage(watchError)).toContain("[script diagnostics redacted]");
     expect(ensureErrorMessage(watchError)).not.toContain(watchCommand);
     expect(ensureErrorMessage(watchError)).not.toContain(sentinel);
   });

--- a/test/script-provider.test.ts
+++ b/test/script-provider.test.ts
@@ -1,5 +1,7 @@
 import path from "node:path";
+import { inspect } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
+import { ensureErrorMessage } from "../src/core/errors.js";
 import { ScriptProviderAdapter } from "../src/providers/builtin/script.js";
 import type { ProviderContext } from "../src/providers/types.js";
 import { createTempDir, disposeTempDir, writeText } from "./test-helpers.js";
@@ -381,10 +383,33 @@ describe("script provider", () => {
 
   it("reports watch subprocess spawn failures without crashing", async () => {
     const context = await createContext();
+    const sentinel = "redact-me";
+    const command = `CRABLINE_PRIVATE_VALUE=${sentinel} node watch.mjs`;
+    context.config.script!.commands.send = command;
+    context.config.script!.commands.watch = command;
     context.config.script!.shell = path.join(path.dirname(context.manifestPath), "missing-shell");
     const provider = new ScriptProviderAdapter(context);
 
-    await expect(provider.watch(context).next()).rejects.toThrow(/failed to start/u);
+    for (const operation of [
+      () =>
+        provider.send({
+          ...context,
+          mode: "send" as const,
+          nonce: "nonce",
+          text: "payload",
+        }),
+      () => provider.watch(context).next(),
+    ]) {
+      let failure: unknown;
+      try {
+        await operation();
+      } catch (error) {
+        failure = error;
+      }
+      expect(ensureErrorMessage(failure)).toMatch(/failed to start/u);
+      expect(inspect(failure, { depth: null })).not.toContain(command);
+      expect(inspect(failure, { depth: null })).not.toContain(sentinel);
+    }
   });
 
   it("validates watched JSON message contracts", async () => {
@@ -400,6 +425,48 @@ describe("script provider", () => {
     await expect(provider.watch(context).next()).rejects.toThrow(
       /returned invalid result.*author/isu,
     );
+  });
+
+  it("redacts configured command text from script errors", async () => {
+    const context = await createContext();
+    const sentinel = "redact-me";
+    const failingScript = path.join(path.dirname(context.manifestPath), "send-secret.mjs");
+    await writeText(failingScript, 'process.stderr.write("failed");process.exitCode=7;');
+    const command = `CRABLINE_PRIVATE_VALUE=${sentinel} node ${JSON.stringify(failingScript)}`;
+    context.config.script!.commands.send = command;
+    const provider = new ScriptProviderAdapter(context);
+
+    let sendError: unknown;
+    try {
+      await provider.send({
+        ...context,
+        mode: "send",
+        nonce: "nonce",
+        text: "payload",
+      });
+    } catch (error) {
+      sendError = error;
+    }
+
+    expect(ensureErrorMessage(sendError)).toContain("Script command failed");
+    expect(ensureErrorMessage(sendError)).not.toContain(command);
+    expect(ensureErrorMessage(sendError)).not.toContain(sentinel);
+
+    const watchScript = path.join(path.dirname(context.manifestPath), "watch-secret.mjs");
+    await writeText(watchScript, 'process.stderr.write("watch failed");process.exitCode=8;');
+    const watchCommand = `CRABLINE_PRIVATE_VALUE=${sentinel} node ${JSON.stringify(watchScript)}`;
+    context.config.script!.commands.watch = watchCommand;
+
+    let watchError: unknown;
+    try {
+      await provider.watch(context).next();
+    } catch (error) {
+      watchError = error;
+    }
+
+    expect(ensureErrorMessage(watchError)).toContain("Script watch command failed");
+    expect(ensureErrorMessage(watchError)).not.toContain(watchCommand);
+    expect(ensureErrorMessage(watchError)).not.toContain(sentinel);
   });
 
   it("fails when required commands are missing", async () => {


### PR DESCRIPTION
## Summary
- emit one machine-readable JSON error document and keep Commander exits inside `runCli`
- preserve stage-specific failure classification and validate fixture provider references
- redact configured script commands and suppress diagnostics for secret-bearing commands
- verify production-only tarball installation and public entry points
- add regression coverage and a changelog entry

## Verification
- Crabbox `run_94e055ac9248`: `pnpm verify` (43 files, 287 tests)
- autoreview: clean, confidence 0.93
- local focused CLI/script tests and full lint passed

## Release note
Hardens CLI failure output, script error redaction, configuration validation, and production package verification.