### PR TITLE
fix(providers): harden wire-level fidelity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Serialize recorder persistence and reject overlapping OpenClaw smoke artifact runs.
 - Make CLI failures machine-readable, preserve stage-specific failure contracts, validate fixture provider references, redact script commands, and verify production-only tarball installs.
 - Normalize provider bridge thread IDs and round-trip canonical Telegram topic targets.
+- Drain authentication-rejected provider bodies, bound Zalo parsing, and enforce Telegram media fields.
 - Implement Telegram `getUpdates` long polling with timeout wakeups, offset confirmation, negative offsets, and shutdown cleanup.
 - Restrict releases to stable version tags and resolve workflow-dispatch inputs through exact tag refs before publication.
 - Reject ambiguous fixture/config inputs and keep the published CLI, type dependencies, and README assets aligned with their public contract.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Serialize WhatsApp Noise frames per session and reject invalid X25519 peer keys.
 - Serialize recorder persistence and reject overlapping OpenClaw smoke artifact runs.
 - Make CLI failures machine-readable, preserve stage-specific failure contracts, validate fixture provider references, redact script commands, and verify production-only tarball installs.
+- Normalize provider bridge thread IDs and round-trip canonical Telegram topic targets.
 - Implement Telegram `getUpdates` long polling with timeout wakeups, offset confirmation, negative offsets, and shutdown cleanup.
 - Restrict releases to stable version tags and resolve workflow-dispatch inputs through exact tag refs before publication.
 - Reject ambiguous fixture/config inputs and keep the published CLI, type dependencies, and README assets aligned with their public contract.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Make CLI failures machine-readable, preserve stage-specific failure contracts, validate fixture provider references, redact script commands, and verify production-only tarball installs.
 - Normalize provider bridge thread IDs and round-trip canonical Telegram topic targets.
 - Drain authentication-rejected provider bodies, bound Zalo parsing, and enforce Telegram media fields.
+- Hide webhook handler exception details from public 500 responses.
 - Implement Telegram `getUpdates` long polling with timeout wakeups, offset confirmation, negative offsets, and shutdown cleanup.
 - Restrict releases to stable version tags and resolve workflow-dispatch inputs through exact tag refs before publication.
 - Reject ambiguous fixture/config inputs and keep the published CLI, type dependencies, and README assets aligned with their public contract.

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ provided. The inbound endpoint rejects requests without the matching admin
 header (or `Authorization: Bearer <token>`).
 
 Implemented Telegram Bot API endpoints include `getMe`, `sendMessage`,
-`sendPhoto`, `sendDocument`, `sendVideo`, `sendAnimation`, `editMessageText`,
+`sendPhoto`, `sendDocument`, `sendVideo`, `sendAudio`, `sendAnimation`, `editMessageText`,
 `deleteMessage`, `setMessageReaction`, `createForumTopic`, `editForumTopic`,
 `pinChatMessage`, `unpinChatMessage`, `getUpdates`, `deleteWebhook`,
 `setWebhook`, `setMyCommands`, `deleteMyCommands`, `sendChatAction`, and

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -223,7 +223,7 @@ The admin ingress accepts JSON like:
 
 OpenClaw consumes that message through Telegram `getUpdates`; outbound adapter
 sends are recorded through Telegram `sendMessage` and the media send endpoints
-`sendPhoto`, `sendDocument`, `sendVideo`, and `sendAnimation`.
+`sendPhoto`, `sendDocument`, `sendVideo`, `sendAudio`, and `sendAnimation`.
 
 WhatsApp:
 

--- a/src/openclaw/bridges/mattermost.ts
+++ b/src/openclaw/bridges/mattermost.ts
@@ -99,7 +99,7 @@ export const MATTERMOST_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabli
           providerTargetKey: targetKey(channelId, rootId),
           qaTarget: qaTargetForInbound(input),
           stateConversation: { id: input.conversation.id, kind },
-          ...(input.threadId ? { threadId: input.threadId } : {}),
+          ...(rootId ? { threadId: rootId } : {}),
         };
       },
       createOutboundFromRecorderEvent({ event, targetByProviderTarget }) {

--- a/src/openclaw/bridges/telegram.ts
+++ b/src/openclaw/bridges/telegram.ts
@@ -5,7 +5,6 @@ import {
   DEFAULT_ACCOUNT_ID,
   isRecord,
   qaTargetForInbound,
-  readInteger,
   readNonBlankString,
   readString,
 } from "../shared.js";
@@ -15,7 +14,7 @@ const TELEGRAM_SYMBOLIC_DIRECT_ID_MASK = TELEGRAM_SYMBOLIC_DIRECT_ID_BASE - 1n;
 const TELEGRAM_SYMBOLIC_GROUP_ID_BASE = 1_000_000_000_000n;
 const TELEGRAM_SYMBOLIC_GROUP_ID_RANGE = 10_000_000_000n;
 const TELEGRAM_OUTBOUND_METHOD_RE =
-  /\/(sendAnimation|sendDocument|sendMessage|sendPhoto|sendVideo)$/u;
+  /\/(sendAnimation|sendAudio|sendDocument|sendMessage|sendPhoto|sendVideo)$/u;
 
 function normalizeTelegramChatId(kind: "direct" | "group", id: string): string {
   const value = id.trim();
@@ -36,12 +35,12 @@ function telegramTargetKey(chatId: string, threadId?: number) {
   return threadId === undefined ? chatId : `${chatId}:topic:${threadId}`;
 }
 
-function parseTelegramThreadTargetId(value: string | undefined): number | undefined {
+function parseTelegramThreadTargetId(value: unknown): number | undefined {
   if (value === undefined) {
     return undefined;
   }
-  const trimmed = value.trim();
-  if (!/^\d+$/u.test(trimmed)) {
+  const trimmed = readString(value);
+  if (!trimmed || !/^\d+$/u.test(trimmed)) {
     throw new Error("Telegram thread target must be a safe non-negative integer.");
   }
   const threadId = Number(trimmed);
@@ -130,7 +129,7 @@ export const TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
       createInbound(input) {
         const kind = input.conversation.kind === "direct" ? "direct" : "group";
         const chatId = normalizeTelegramChatId(kind, input.conversation.id);
-        const threadId = readInteger(input.threadId);
+        const threadId = parseTelegramThreadTargetId(input.threadId);
         return {
           ...createAdminInboundRequest(telegram),
           providerBody: {
@@ -176,7 +175,12 @@ export const TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
         if (!chatId || !text) {
           return null;
         }
-        const threadId = readInteger(event.body.message_thread_id);
+        let threadId: number | undefined;
+        try {
+          threadId = parseTelegramThreadTargetId(event.body.message_thread_id);
+        } catch {
+          return null;
+        }
         const providerTargetKey = telegramTargetKey(chatId, threadId);
         return {
           accountId: DEFAULT_ACCOUNT_ID,

--- a/src/providers/builtin/telegram.ts
+++ b/src/providers/builtin/telegram.ts
@@ -70,15 +70,29 @@ const TELEGRAM_BASE_CODEC = createNativeTargetCodec({
 
 const TELEGRAM_CODEC = {
   normalize(target: Parameters<typeof TELEGRAM_BASE_CODEC.normalize>[0]) {
+    const canonicalTopic = target.threadId
+      ? parseCanonicalTelegramTopic(target.threadId)
+      : undefined;
+    const targetChatId = target.channelId ?? target.id;
+    if (
+      canonicalTopic &&
+      requireNativeId(targetChatId, TELEGRAM_CHAT_ID_RULE, "Telegram chat_id") !==
+        canonicalTopic.chatId
+    ) {
+      throw new CrablineError("Telegram canonical topic chat_id must match the target chat_id.", {
+        kind: "config",
+      });
+    }
     const normalized = TELEGRAM_BASE_CODEC.normalize({
       ...target,
+      ...(canonicalTopic ? { channelId: canonicalTopic.chatId } : {}),
       threadId: undefined,
     });
     if (!target.threadId) {
       return normalized;
     }
     const topicId = requireNativeId(
-      target.threadId,
+      canonicalTopic?.topicId ?? target.threadId,
       TELEGRAM_MESSAGE_THREAD_ID_RULE,
       "Telegram message_thread_id",
     );
@@ -93,6 +107,70 @@ const TELEGRAM_CODEC = {
   },
 };
 
+function parseCanonicalTelegramTopic(
+  value: string,
+): { chatId: string; topicId: string } | undefined {
+  const separator = value.lastIndexOf(":");
+  if (separator <= 0) {
+    return undefined;
+  }
+  const chatId = value.slice(0, separator);
+  const topicId = value.slice(separator + 1);
+  if (
+    !TELEGRAM_CHAT_ID_RULE.pattern.test(chatId) ||
+    !TELEGRAM_MESSAGE_THREAD_ID_RULE.pattern.test(topicId)
+  ) {
+    return undefined;
+  }
+  return { chatId, topicId };
+}
+
+function normalizeGenericTelegramPayload(payload: Record<string, unknown>) {
+  const message = optionalRecord(payload, "message");
+  const threadId = message
+    ? optionalString(message, "threadId")
+    : optionalString(payload, "threadId");
+  const canonicalTopic = threadId ? parseCanonicalTelegramTopic(threadId) : undefined;
+  const genericPayload = canonicalTopic
+    ? message
+      ? {
+          ...payload,
+          message: {
+            ...message,
+            threadId: canonicalTopic.topicId,
+          },
+        }
+      : {
+          ...payload,
+          threadId: canonicalTopic.topicId,
+        }
+    : payload;
+  const normalized = genericMockPayloadWithNativeThread({
+    channelRule: TELEGRAM_CHAT_ID_RULE,
+    payload: genericPayload,
+    threadRule: TELEGRAM_MESSAGE_THREAD_ID_RULE,
+  });
+  if (!canonicalTopic) {
+    return normalized;
+  }
+  const normalizedRecord = normalized as Record<string, unknown>;
+  const raw = payload.raw ?? payload;
+  return message
+    ? {
+        ...normalizedRecord,
+        raw,
+        message: {
+          ...(isRecord(normalizedRecord.message) ? normalizedRecord.message : {}),
+          threadId: `${canonicalTopic.chatId}:${canonicalTopic.topicId}`,
+        },
+      }
+    : {
+        ...normalizedRecord,
+        raw,
+        threadId: `${canonicalTopic.chatId}:${canonicalTopic.topicId}`,
+      };
+}
+
 export function normalizeTelegramWebhookPayload(payload: unknown) {
   if (!isRecord(payload)) {
     throw new CrablineError("Telegram webhook payload must be an object", { kind: "inbound" });
@@ -103,12 +181,8 @@ export function normalizeTelegramWebhookPayload(payload: unknown) {
     optionalRecord(payload, "edited_message") ??
     optionalRecord(payload, "channel_post") ??
     optionalRecord(payload, "edited_channel_post");
-  if (!message) {
-    return genericMockPayloadWithNativeThread({
-      channelRule: TELEGRAM_CHAT_ID_RULE,
-      payload,
-      threadRule: TELEGRAM_MESSAGE_THREAD_ID_RULE,
-    });
+  if (!message || optionalString(message, "threadId")) {
+    return normalizeGenericTelegramPayload(payload);
   }
 
   const chat = optionalRecord(message, "chat");

--- a/src/providers/webhook-server.ts
+++ b/src/providers/webhook-server.ts
@@ -109,6 +109,7 @@ export async function startWebhookServer(params: {
   host: string;
   maxBodyBytes?: number;
   methods?: readonly string[] | undefined;
+  onError?: ((error: unknown) => void) | undefined;
   path: string;
   port: number;
 }): Promise<StartedWebhookServer> {
@@ -125,11 +126,19 @@ export async function startWebhookServer(params: {
 
       await writeFetchResponse(response, await params.handle(fetchRequest));
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
       const status = error instanceof RequestBodyTooLargeError ? 413 : 500;
+      if (status === 500) {
+        try {
+          params.onError?.(error);
+        } catch {
+          // Error reporting must not change the public response.
+        }
+      }
       await writeFetchResponse(
         response,
-        new Response(status === 413 ? "request body too large" : message, { status }),
+        new Response(status === 413 ? "request body too large" : "internal server error", {
+          status,
+        }),
       );
     }
   });

--- a/src/servers/http.ts
+++ b/src/servers/http.ts
@@ -32,7 +32,10 @@ export function jsonResponse(value: unknown, status = 200): Response {
   return Response.json(value, { status });
 }
 
-function drainRejectedRequest(request: IncomingMessage): void {
+export function drainRequestBody(request: IncomingMessage): void {
+  if (request.destroyed || request.readableEnded) {
+    return;
+  }
   const ignoreError = () => {};
   const cleanup = () => {
     request.off("close", cleanup);
@@ -57,7 +60,7 @@ export async function readBody(
   if (contentLengthValue && /^\d+$/u.test(contentLengthValue)) {
     const contentLength = Number(contentLengthValue);
     if (!Number.isSafeInteger(contentLength) || contentLength > maxBytes) {
-      drainRejectedRequest(request);
+      drainRequestBody(request);
       throw new RequestBodyTooLargeError(maxBytes);
     }
   }
@@ -78,7 +81,7 @@ export async function readBody(
         return;
       }
       settled = true;
-      drainRejectedRequest(request);
+      drainRequestBody(request);
       cleanup();
       reject(error);
     };

--- a/src/servers/mattermost.ts
+++ b/src/servers/mattermost.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { WebSocket, WebSocketServer, type RawData } from "ws";
 import {
   adminAuthError,
+  drainRequestBody,
   hasAdminToken,
   InvalidJsonBodyError,
   isJsonObject,
@@ -341,6 +342,7 @@ async function handleRequest(request: IncomingMessage, state: MattermostServerSt
   const method = request.method ?? "GET";
   if (url.pathname === "/crabline/mattermost/inbound" && method === "POST") {
     if (!hasAdminToken(request, state.adminToken)) {
+      drainRequestBody(request);
       return adminAuthError();
     }
     const body = await parseUnknownRequestBody(request);
@@ -361,6 +363,7 @@ async function handleRequest(request: IncomingMessage, state: MattermostServerSt
     return new Response("not found", { status: 404 });
   }
   if (!authorized(request, state.botToken)) {
+    drainRequestBody(request);
     return mattermostError("Invalid or missing token", 401);
   }
   const body =

--- a/src/servers/signal.ts
+++ b/src/servers/signal.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import {
   adminAuthError,
   closeServer,
+  drainRequestBody,
   hasAdminToken,
   InvalidJsonBodyError,
   isJsonObject,
@@ -170,6 +171,7 @@ async function handleRequest(params: {
   let fetchResponse: Response;
   if (url.pathname === "/crabline/signal/inbound" && params.request.method === "POST") {
     if (!hasAdminToken(params.request, params.state.adminToken)) {
+      drainRequestBody(params.request);
       fetchResponse = adminAuthError();
     } else {
       const body = await parseUnknownRequestBody(params.request);

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -5,6 +5,7 @@ import { CrablineError } from "../core/errors.js";
 import {
   adminAuthError,
   closeServer,
+  drainRequestBody,
   formatUrlHost,
   hasAdminToken,
   InvalidJsonBodyError,
@@ -57,6 +58,13 @@ type TelegramMessage = {
   caption?: string;
   date: number;
   document?: {
+    file_id: string;
+    file_name?: string;
+    file_unique_id: string;
+    mime_type?: string;
+  };
+  audio?: {
+    duration: number;
     file_id: string;
     file_name?: string;
     file_unique_id: string;
@@ -274,18 +282,19 @@ function createOutboundMessage(
 function createOutboundMediaMessage(
   state: TelegramServerState,
   body: Record<string, unknown>,
-  mediaKind: "animation" | "document" | "photo" | "video",
+  mediaKind: "animation" | "audio" | "document" | "photo" | "video",
 ): TelegramMessage | undefined {
   const chatId = telegramChatId(body.chat_id);
-  if (chatId === undefined) {
+  const fileName = toStringValue(body[mediaKind]);
+  if (chatId === undefined || !fileName) {
     return undefined;
   }
   const threadId = toIntegerValue(body.message_thread_id);
   const caption = toStringValue(body.caption);
-  const fileName = toStringValue(body[mediaKind]);
+  const duration = Math.max(0, toIntegerValue(body.duration) ?? 0);
   const media = {
     file_id: `crabline-${mediaKind}-${state.nextMessageId}`,
-    ...(fileName ? { file_name: fileName } : {}),
+    file_name: fileName,
     file_unique_id: `crabline-${mediaKind}-unique-${state.nextMessageId}`,
   };
   return {
@@ -296,7 +305,11 @@ function createOutboundMediaMessage(
     [mediaKind]:
       mediaKind === "photo"
         ? [{ ...media, height: 1, width: 1 }]
-        : { ...media, mime_type: "application/octet-stream" },
+        : {
+            ...media,
+            ...(mediaKind === "audio" ? { duration } : {}),
+            mime_type: "application/octet-stream",
+          },
     message_id: state.nextMessageId++,
     ...(threadId !== undefined ? { message_thread_id: threadId } : {}),
   };
@@ -412,16 +425,20 @@ async function handleTelegramApi(params: {
         : telegramError("Bad Request: chat_id and text are required");
     }
     case "sendAnimation":
+    case "sendAudio":
     case "sendDocument":
     case "sendPhoto":
     case "sendVideo": {
       const mediaKind = params.method.slice("send".length).toLowerCase() as
         | "animation"
+        | "audio"
         | "document"
         | "photo"
         | "video";
       const message = createOutboundMediaMessage(params.state, params.body, mediaKind);
-      return message ? telegramOk(message) : telegramError("Bad Request: chat_id is required");
+      return message
+        ? telegramOk(message)
+        : telegramError(`Bad Request: chat_id and ${mediaKind} are required`);
     }
     case "getUpdates": {
       const offset = toIntegerValue(params.body.offset);
@@ -520,6 +537,7 @@ async function handleRequest(params: { request: IncomingMessage; state: Telegram
       return new Response("not found", { status: 404 });
     }
     if (!hasAdminToken(params.request, params.state.adminToken)) {
+      drainRequestBody(params.request);
       return adminAuthError();
     }
     const body = await parseRequestBody(params.request);
@@ -546,6 +564,7 @@ async function handleRequest(params: { request: IncomingMessage; state: Telegram
 
   const botPath = requireTelegramBotPath(url.pathname);
   if (!botPath || botPath.token !== params.state.botToken) {
+    drainRequestBody(params.request);
     return new Response("not found", { status: 404 });
   }
   const body =

--- a/src/servers/zalo.ts
+++ b/src/servers/zalo.ts
@@ -3,12 +3,15 @@ import type { IncomingMessage } from "node:http";
 import path from "node:path";
 import {
   adminAuthError,
+  drainRequestBody,
   hasAdminToken,
   InvalidJsonBodyError,
+  isJsonObject,
   jsonResponse,
-  parseRequestBody,
+  parseUnknownRequestBody,
   queryRecord,
   readTrimmedString,
+  RequestBodyTooLargeError,
   startHttpJsonServer,
   type ServerRequestEvent,
 } from "./http.js";
@@ -209,9 +212,14 @@ async function handleAdminInbound(
   url: URL,
 ): Promise<Response> {
   if (!hasAdminToken(request, state.adminToken)) {
+    drainRequestBody(request);
     return adminAuthError();
   }
-  const body = await parseRequestBody(request);
+  const parsedBody = await parseUnknownRequestBody(request);
+  if (!isJsonObject(parsedBody)) {
+    return zaloError("Bad Request: can't parse JSON object", 400);
+  }
+  const body = parsedBody;
   const chatId = requireParam(body, "chatId");
   const senderId = requireParam(body, "senderId");
   const text = requireParam(body, "text");
@@ -257,7 +265,11 @@ async function handleZaloMethod(
   url: URL,
   method: string,
 ): Promise<Response> {
-  const body = requestParams(url, await parseRequestBody(request));
+  const parsedBody = await parseUnknownRequestBody(request);
+  if (!isJsonObject(parsedBody)) {
+    return zaloError("Bad Request: can't parse JSON object", 400);
+  }
+  const body = requestParams(url, parsedBody);
   await appendEvent(state, {
     at: new Date().toISOString(),
     ...(Object.keys(body).length > 0 ? { body: redactParams(body) } : {}),
@@ -369,14 +381,20 @@ export async function startZaloServer(
         return zaloError("Not found", 404);
       }
       if (match[1] !== state.botToken) {
+        drainRequestBody(request);
         return zaloError("Unauthorized", 401);
       }
       return await handleZaloMethod(request, state, url, match[2] ?? "");
     },
-    handleError: (error) =>
-      error instanceof InvalidJsonBodyError
-        ? zaloError("Bad Request: can't parse JSON object", 400)
-        : undefined,
+    handleError: (error) => {
+      if (error instanceof InvalidJsonBodyError) {
+        return zaloError("Bad Request: can't parse JSON object", 400);
+      }
+      if (error instanceof RequestBodyTooLargeError) {
+        return zaloError("Request Entity Too Large", 413);
+      }
+      return undefined;
+    },
     host,
     port: params.port ?? 0,
     serverName: "Zalo",

--- a/test/mattermost-server.test.ts
+++ b/test/mattermost-server.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { Agent } from "node:http";
 import { WebSocket } from "ws";
 import { afterEach, describe, expect, it } from "vitest";
 import { startMattermostServer, type StartedMattermostServer } from "../src/index.js";
@@ -238,5 +239,44 @@ describe("Mattermost local provider server", () => {
     const recorded = await fs.readFile(recorderPath, "utf8");
     expect(recorded).toContain('"path":"/crabline/mattermost/inbound"');
     expect(recorded).toContain('"path":"/api/v4/posts"');
+  });
+
+  it("drains request bodies rejected by REST and admin authentication", async () => {
+    const server = await startMattermostServer({
+      adminToken: "admin",
+      botToken: "bot-secret",
+    });
+    servers.push(server);
+
+    for (const url of [
+      `${server.manifest.endpoints.apiRoot}/posts`,
+      server.manifest.endpoints.adminInboundUrl,
+    ]) {
+      const agent = new Agent({ keepAlive: true, maxSockets: 1 });
+      try {
+        const body = JSON.stringify({ rejected: true });
+        const rejected = await requestHttp({
+          agent,
+          body,
+          headers: {
+            "content-length": String(Buffer.byteLength(body)),
+            "content-type": "application/json",
+          },
+          method: "POST",
+          url,
+        });
+        expect(rejected.status).toBe(401);
+
+        const accepted = await requestHttp({
+          agent,
+          headers: { authorization: "Bearer bot-secret" },
+          method: "GET",
+          url: `${server.manifest.endpoints.apiRoot}/users/me`,
+        });
+        expect(accepted.status).toBe(200);
+      } finally {
+        agent.destroy();
+      }
+    }
   });
 });

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -644,6 +644,20 @@ describe("OpenClaw local provider bridge", () => {
       chatId: expect.stringMatching(/^-100\d+$/u),
       messageThreadId: 42,
     });
+    const normalizedTopicInbound = createOpenClawCrablineInbound({
+      manifest,
+      input: {
+        conversation: { id: "alice", kind: "group" },
+        senderId: "alice",
+        text: "normalized topic",
+        threadId: " 42 ",
+      },
+    });
+    expect(normalizedTopicInbound).toMatchObject({
+      providerBody: { messageThreadId: 42 },
+      providerTargetKey: `${symbolicGroupDelivery.to}:topic:42`,
+      threadId: "42",
+    });
 
     const paddedText = "  hello from qa\n";
     expect(
@@ -709,6 +723,25 @@ describe("OpenClaw local provider bridge", () => {
       text: "media caption",
       to: "dm:alice",
     });
+
+    expect(
+      createOpenClawCrablineOutboundFromRecorderEvent({
+        manifest,
+        targetByProviderTarget: new Map([["100001", "dm:alice"]]),
+        event: {
+          type: "api",
+          path: "/botTOKEN/sendAudio",
+          body: {
+            audio: "fixture.mp3",
+            caption: "audio caption",
+            chat_id: "100001",
+          },
+        },
+      }),
+    ).toMatchObject({
+      text: "audio caption",
+      to: "dm:alice",
+    });
   });
 
   it("validates explicit Telegram thread target ids", () => {
@@ -737,6 +770,20 @@ describe("OpenClaw local provider bridge", () => {
         createOpenClawCrablineAgentDelivery({
           manifest,
           target: `thread:alice/${threadId}`,
+        }),
+      ).toThrow("Telegram thread target must be a safe non-negative integer.");
+    }
+
+    for (const threadId of ["-1", "not-a-number", String(Number.MAX_SAFE_INTEGER + 1)]) {
+      expect(() =>
+        createOpenClawCrablineInbound({
+          manifest,
+          input: {
+            conversation: { id: "alice", kind: "group" },
+            senderId: "alice",
+            text: "invalid topic",
+            threadId,
+          },
         }),
       ).toThrow("Telegram thread target must be a safe non-negative integer.");
     }
@@ -1184,6 +1231,7 @@ describe("OpenClaw local provider bridge", () => {
       },
     });
     expect(threadInbound.providerTargetKey).toMatch(/:thread:[a-z0-9]{26}$/u);
+    expect(threadInbound.threadId).toBe(threadInbound.providerBody.rootId);
     expect(
       createOpenClawCrablineOutboundFromRecorderEvent({
         manifest: mattermostManifest,

--- a/test/signal-server.test.ts
+++ b/test/signal-server.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import { Agent } from "node:http";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { startSignalServer, type StartedSignalServer } from "../src/index.js";
@@ -154,5 +155,34 @@ describe("signal local provider server", () => {
     const recorded = await fs.readFile(recorderPath, "utf8");
     expect(recorded).toContain('"method":"send"');
     expect(recorded).toContain('"path":"/crabline/signal/inbound"');
+  });
+
+  it("drains unauthenticated admin request bodies", async () => {
+    const server = await startSignalServer({ adminToken: "admin" });
+    servers.push(server);
+    const agent = new Agent({ keepAlive: true, maxSockets: 1 });
+    try {
+      const body = JSON.stringify({ sourceNumber: "+15557654321", text: "rejected" });
+      const rejected = await requestHttp({
+        agent,
+        body,
+        headers: {
+          "content-length": String(Buffer.byteLength(body)),
+          "content-type": "application/json",
+        },
+        method: "POST",
+        url: server.manifest.endpoints.adminInboundUrl,
+      });
+      expect(rejected.status).toBe(401);
+
+      const check = await requestHttp({
+        agent,
+        method: "GET",
+        url: `${server.manifest.baseUrl}/api/v1/check`,
+      });
+      expect(check.status).toBe(200);
+    } finally {
+      agent.destroy();
+    }
   });
 });

--- a/test/telegram-provider.test.ts
+++ b/test/telegram-provider.test.ts
@@ -111,6 +111,32 @@ describe("telegram provider", () => {
       channelId: "-100123",
       threadId: "-100123:42",
     });
+    expect(() =>
+      provider.normalizeTarget({
+        channelId: "-100999",
+        id: "topic",
+        metadata: {},
+        threadId: "-100123:42",
+      }),
+    ).toThrow("Telegram canonical topic chat_id must match the target chat_id.");
+    expect(() =>
+      provider.normalizeTarget({
+        id: "-100999",
+        metadata: {},
+        threadId: "-100123:42",
+      }),
+    ).toThrow("Telegram canonical topic chat_id must match the target chat_id.");
+    expect(
+      provider.normalizeTarget({
+        channelId: "-100123",
+        id: "topic",
+        metadata: {},
+        threadId: "-100123:42",
+      }),
+    ).toMatchObject({
+      channelId: "-100123",
+      threadId: "-100123:42",
+    });
     expect(() => provider.normalizeTarget({ id: "telegram:-100123", metadata: {} })).toThrow(
       /Telegram chat_id/u,
     );
@@ -137,6 +163,38 @@ describe("telegram provider", () => {
     expect(firstThreadId).toBe("-1001:42");
     expect(secondThreadId).toBe("-1002:42");
     expect(firstThreadId).not.toBe(secondThreadId);
+  });
+
+  it("round-trips canonical topic ids through generic ingress", () => {
+    const topLevel = {
+      authorIsBot: true,
+      id: "generic-1",
+      text: "generic topic reply",
+      threadId: "-100123:42",
+    };
+    expect(normalizeTelegramWebhookPayload(topLevel)).toMatchObject({
+      id: "generic-1",
+      raw: topLevel,
+      text: "generic topic reply",
+      threadId: "-100123:42",
+    });
+
+    const nested = {
+      message: {
+        authorIsBot: true,
+        id: "generic-2",
+        text: "nested topic reply",
+        threadId: "-100123:42",
+      },
+    };
+    expect(normalizeTelegramWebhookPayload(nested)).toMatchObject({
+      raw: nested,
+      message: {
+        id: "generic-2",
+        text: "nested topic reply",
+        threadId: "-100123:42",
+      },
+    });
   });
 
   it("normalizes edited channel posts", () => {

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs/promises";
-import { request as httpRequest } from "node:http";
+import { Agent, request as httpRequest } from "node:http";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { startTelegramServer, type StartedTelegramServer } from "../src/index.js";
@@ -184,6 +184,46 @@ describe("telegram local provider server", () => {
       },
     });
 
+    for (const [method, field] of [
+      ["sendPhoto", "photo"],
+      ["sendVideo", "video"],
+      ["sendDocument", "document"],
+      ["sendAudio", "audio"],
+    ] as const) {
+      const missingMedia = await fetch(
+        `${server.manifest.baseUrl}/bot123456:fake-token/${method}`,
+        {
+          body: JSON.stringify({ chat_id: "-1001234567890" }),
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        },
+      );
+      expect(missingMedia.status).toBe(400);
+      await expect(missingMedia.json()).resolves.toEqual({
+        description: `Bad Request: chat_id and ${field} are required`,
+        error_code: 400,
+        ok: false,
+      });
+    }
+
+    const sendAudio = await fetch(`${server.manifest.baseUrl}/bot123456:fake-token/sendAudio`, {
+      body: JSON.stringify({
+        audio: "fixture.mp3",
+        caption: "hello fake telegram audio",
+        chat_id: "-1001234567890",
+        duration: 7,
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    await expect(sendAudio.json()).resolves.toMatchObject({
+      ok: true,
+      result: {
+        audio: { duration: 7, file_name: "fixture.mp3" },
+        caption: "hello fake telegram audio",
+      },
+    });
+
     const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
       body: JSON.stringify({
         chatId: "-1001234567890",
@@ -252,6 +292,44 @@ describe("telegram local provider server", () => {
       ok: true,
       update: { message: { text: "accepted" } },
     });
+  });
+
+  it("drains request bodies rejected by admin and bot authentication", async () => {
+    const server = await startTelegramServer({
+      adminToken: "admin",
+      botToken: "123:fake",
+    });
+    servers.push(server);
+
+    for (const url of [
+      server.manifest.endpoints.adminInboundUrl,
+      `${server.manifest.baseUrl}/botwrong-token/sendMessage`,
+    ]) {
+      const agent = new Agent({ keepAlive: true, maxSockets: 1 });
+      try {
+        const body = JSON.stringify({ chat_id: "123", text: "rejected" });
+        const rejected = await requestHttp({
+          agent,
+          body,
+          headers: {
+            "content-length": String(Buffer.byteLength(body)),
+            "content-type": "application/json",
+          },
+          method: "POST",
+          url,
+        });
+        expect([401, 404]).toContain(rejected.status);
+
+        const accepted = await requestHttp({
+          agent,
+          method: "GET",
+          url: `${server.manifest.baseUrl}/bot123:fake/getMe`,
+        });
+        expect(accepted.status).toBe(200);
+      } finally {
+        agent.destroy();
+      }
+    }
   });
 
   it("keeps generated inbound IDs above explicit IDs", async () => {

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -18,15 +18,18 @@ export const writeText = async (filePath: string, value: string): Promise<void> 
 };
 
 export async function requestHttp(params: {
+  agent?: import("node:http").Agent;
   body?: Buffer | string;
   headers?: Record<string, string>;
   method: string;
+  timeoutMs?: number;
   url: string;
 }): Promise<{ body: string; headers: import("node:http").IncomingHttpHeaders; status: number }> {
   return await new Promise((resolve, reject) => {
     const request = httpRequest(
       params.url,
       {
+        agent: params.agent,
         headers: params.headers,
         method: params.method,
       },
@@ -43,6 +46,9 @@ export async function requestHttp(params: {
       },
     );
     request.once("error", reject);
+    request.setTimeout(params.timeoutMs ?? 2_000, () => {
+      request.destroy(new Error(`HTTP request timed out after ${params.timeoutMs ?? 2_000} ms.`));
+    });
     if (params.body !== undefined) {
       request.write(params.body);
     }

--- a/test/webhook-server.test.ts
+++ b/test/webhook-server.test.ts
@@ -93,11 +93,13 @@ describe("webhook server", () => {
   });
 
   it("returns 500 when the handler throws", async () => {
+    const observedErrors: unknown[] = [];
     const server = await startWebhookServer({
       async handle() {
-        throw new Error("boom");
+        throw new Error("sensitive internal detail");
       },
       host: "127.0.0.1",
+      onError: (error) => observedErrors.push(error),
       path: "/slack/events",
       port: 0,
     });
@@ -106,7 +108,10 @@ describe("webhook server", () => {
     const response = await fetch(server.endpointUrl, { method: "POST" });
 
     expect(response.status).toBe(500);
-    await expect(response.text()).resolves.toContain("boom");
+    await expect(response.text()).resolves.toBe("internal server error");
+    expect(observedErrors).toEqual([
+      expect.objectContaining({ message: "sensitive internal detail" }),
+    ]);
   });
 
   it("returns 413 for oversized request bodies without invoking the handler", async () => {

--- a/test/zalo-server.test.ts
+++ b/test/zalo-server.test.ts
@@ -1,9 +1,9 @@
-import { createServer } from "node:http";
+import { Agent, createServer } from "node:http";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { startZaloServer, type StartedZaloServer } from "../src/index.js";
-import { createTempDir, disposeTempDir } from "./test-helpers.js";
+import { createTempDir, disposeTempDir, requestHttp } from "./test-helpers.js";
 
 const servers: StartedZaloServer[] = [];
 const directories: string[] = [];
@@ -48,6 +48,47 @@ describe("Zalo local provider server", () => {
     });
     expect(invalidJson.status).toBe(400);
     await expect(invalidJson.json()).resolves.toEqual({
+      description: "Bad Request: can't parse JSON object",
+      error_code: 400,
+      ok: false,
+    });
+
+    for (const scalarBody of ["null", '"scalar"', "42", "true", "[]"]) {
+      const invalidBody = await fetch(`${server.manifest.baseUrl}/botzalo-token/sendMessage`, {
+        body: scalarBody,
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      expect(invalidBody.status).toBe(400);
+      await expect(invalidBody.json()).resolves.toEqual({
+        description: "Bad Request: can't parse JSON object",
+        error_code: 400,
+        ok: false,
+      });
+    }
+
+    const oversized = await requestHttp({
+      headers: {
+        "content-length": String(1024 * 1024 + 1),
+        "content-type": "application/json",
+      },
+      method: "POST",
+      url: `${server.manifest.baseUrl}/botzalo-token/sendMessage`,
+    });
+    expect(oversized.status).toBe(413);
+    expect(JSON.parse(oversized.body)).toEqual({
+      description: "Request Entity Too Large",
+      error_code: 413,
+      ok: false,
+    });
+
+    const invalidAdminBody = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: "[]",
+      headers: adminHeaders(server),
+      method: "POST",
+    });
+    expect(invalidAdminBody.status).toBe(400);
+    await expect(invalidAdminBody.json()).resolves.toEqual({
       description: "Bad Request: can't parse JSON object",
       error_code: 400,
       ok: false,
@@ -233,5 +274,43 @@ describe("Zalo local provider server", () => {
       method: "POST",
     });
     expect(inbound.status).toBe(401);
+  });
+
+  it("drains request bodies rejected by admin and bot authentication", async () => {
+    const server = await startZaloServer({
+      adminToken: "admin",
+      botToken: "zalo-token",
+    });
+    servers.push(server);
+
+    for (const url of [
+      server.manifest.endpoints.adminInboundUrl,
+      `${server.manifest.baseUrl}/botwrong/sendMessage`,
+    ]) {
+      const agent = new Agent({ keepAlive: true, maxSockets: 1 });
+      try {
+        const body = JSON.stringify({ chat_id: "chat-1", text: "rejected" });
+        const rejected = await requestHttp({
+          agent,
+          body,
+          headers: {
+            "content-length": String(Buffer.byteLength(body)),
+            "content-type": "application/json",
+          },
+          method: "POST",
+          url,
+        });
+        expect(rejected.status).toBe(401);
+
+        const accepted = await requestHttp({
+          agent,
+          method: "GET",
+          url: `${server.manifest.baseUrl}/botzalo-token/getMe`,
+        });
+        expect(accepted.status).toBe(200);
+      } finally {
+        agent.destroy();
+      }
+    }
   });
 });


### PR DESCRIPTION
## Summary
- normalize Mattermost and Telegram thread targets while preserving canonical Telegram topics
- bound and validate provider request bodies, drain rejected auth bodies, and hide webhook exception details
- preserve Telegram media fields and required audio metadata
- add provider-native regression coverage and align README/channel setup documentation
- include changelog entries for the user-visible fidelity changes

## Verification
- Crabbox `run_6cfe47ff4d98`: `pnpm verify` (43 files, 292 tests)
- autoreview: clean, confidence 0.93
- local focused provider tests, typecheck, and formatting checks passed

## Release note
Improves provider protocol fidelity for thread targets, request validation, authentication rejection, Telegram media responses, and webhook failures.