### PR TITLE
fix(ci): harden release and package verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -64,10 +64,10 @@ jobs:
             throw new Error(`CHANGELOG.md must contain exactly one "${headingPrefix}YYYY-MM-DD" heading.`);
           }
           NODE
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10.32.1
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: pnpm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Pin privileged release workflow actions to immutable revisions.
 - Redact inherited secret-named environment values from script diagnostics.
+- Verify production tarballs through their installed npm command shims.
 - Serialize WhatsApp Noise frames per session and reject invalid X25519 peer keys.
 - Serialize recorder persistence and reject overlapping OpenClaw smoke artifact runs.
 - Make CLI failures machine-readable, preserve stage-specific failure contracts, validate fixture provider references, redact script commands, and verify production-only tarball installs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Pin privileged release workflow actions to immutable revisions.
 - Serialize WhatsApp Noise frames per session and reject invalid X25519 peer keys.
 - Serialize recorder persistence and reject overlapping OpenClaw smoke artifact runs.
 - Make CLI failures machine-readable, preserve stage-specific failure contracts, validate fixture provider references, redact script commands, and verify production-only tarball installs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Pin privileged release workflow actions to immutable revisions.
+- Redact inherited secret-named environment values from script diagnostics.
 - Serialize WhatsApp Noise frames per session and reject invalid X25519 peer keys.
 - Serialize recorder persistence and reject overlapping OpenClaw smoke artifact runs.
 - Make CLI failures machine-readable, preserve stage-specific failure contracts, validate fixture provider references, redact script commands, and verify production-only tarball installs.

--- a/src/providers/builtin/script.ts
+++ b/src/providers/builtin/script.ts
@@ -80,18 +80,59 @@ function formatValidationError(error: z.ZodError): string {
     .join("; ");
 }
 
-const sensitiveCommandValuePattern =
-  /(?:^|[\s;&|])(?:[A-Za-z_][A-Za-z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|PASS|PRIVATE|CREDENTIAL|AUTH)[A-Za-z0-9_]*\s*=|--(?:api[-_]?key|auth|credential|pass(?:word)?|private[-_]?key|secret|token)(?:=|\s))/iu;
+const sensitiveEnvironmentNameFragmentPattern =
+  /(?:AUTH|BEARER|CREDENTIAL|KEY|PASS|PRIVATE|SECRET|TOKEN)/iu;
+const nonSensitiveWorkingDirectoryNames = new Set(["PWD", "OLDPWD"]);
+
+function isSensitiveEnvironmentName(name: string): boolean {
+  const upperName = name.toUpperCase();
+  return (
+    sensitiveEnvironmentNameFragmentPattern.test(upperName) ||
+    (!nonSensitiveWorkingDirectoryNames.has(upperName) && upperName.includes("PWD")) ||
+    /PAT(?!H)/u.test(upperName)
+  );
+}
+
+function commandContainsSensitiveValue(command: string): boolean {
+  const assignments = [
+    ...command.matchAll(/(?:^|[\s;&|])["']?([A-Za-z_][A-Za-z0-9_]*)\s*\+?=/gu),
+    ...command.matchAll(/\$env:([A-Za-z_][A-Za-z0-9_]*)\s*\+?=/giu),
+    ...command.matchAll(/\$\{env:([A-Za-z_][A-Za-z0-9_]*)\}\s*\+?=/giu),
+  ];
+  if (assignments.some((match) => isSensitiveEnvironmentName(match[1] ?? ""))) {
+    return true;
+  }
+  return [...command.matchAll(/(?:^|[\s;&|])["']?--([A-Za-z0-9][A-Za-z0-9_-]*)(?:=|\s)/gu)].some(
+    (match) => isSensitiveEnvironmentName((match[1] ?? "").replaceAll("-", "_")),
+  );
+}
+
+function redactSensitiveEnvironmentValues(detail: string): string {
+  let redacted = detail;
+  const values = Object.entries(process.env)
+    .filter(
+      ([name, value]) =>
+        isSensitiveEnvironmentName(name) && value !== undefined && value.length > 0,
+    )
+    .map(([, value]) => value!)
+    .sort((left, right) => right.length - left.length);
+
+  for (const value of new Set(values)) {
+    redacted = redacted.split(value).join("[redacted environment value]");
+  }
+  return redacted;
+}
 
 function formatScriptError(summary: string, detail: string, command: string): string {
-  const trimmed = detail.trim();
-  if (!trimmed) {
+  if (!detail.trim()) {
     return summary;
   }
-  if (sensitiveCommandValuePattern.test(command)) {
+  if (commandContainsSensitiveValue(command)) {
     return `${summary}\n[script diagnostics redacted]`;
   }
-  const redacted = trimmed.split(command).join("[configured script command]").trim();
+  const redacted = redactSensitiveEnvironmentValues(
+    detail.split(command).join("[configured script command]"),
+  ).trim();
   return redacted ? `${summary}\n${redacted}` : summary;
 }
 
@@ -213,7 +254,7 @@ function runScript<T>(params: {
             new CrablineError(
               formatScriptError(
                 `Script command failed${signal ? ` (${signal})` : ""}.`,
-                stderrText.trim() || stdoutText.trim(),
+                stderrText.trim() ? stderrText : stdoutText,
                 params.command,
               ),
               { kind: "connectivity" },

--- a/test/package-production.test.ts
+++ b/test/package-production.test.ts
@@ -132,11 +132,21 @@ describe("production package", () => {
       );
       expect(importOutput.trim()).toBe("function");
 
-      const installedCliPath = path.join(installedRoot, cliPath!);
-      const { stdout: installedCliHelp } = await execFileAsync(process.execPath, [
-        installedCliPath,
-        "--help",
-      ]);
+      const cliShim = path.join(
+        consumerDirectory,
+        "node_modules",
+        ".bin",
+        process.platform === "win32" ? "crabline.cmd" : "crabline",
+      );
+      await expect(fs.stat(cliShim)).resolves.toBeDefined();
+      const { stdout: installedCliHelp } =
+        process.platform === "win32"
+          ? await execFileAsync(
+              process.env.ComSpec ?? "cmd.exe",
+              ["/d", "/s", "/c", `"${cliShim}" --help`],
+              { cwd: consumerDirectory },
+            )
+          : await execFileAsync(cliShim, ["--help"], { cwd: consumerDirectory });
       expect(installedCliHelp).toContain("Usage: crabline");
     } finally {
       await fs.rm(installRoot, { force: true, recursive: true });

--- a/test/release-workflow.test.ts
+++ b/test/release-workflow.test.ts
@@ -70,6 +70,19 @@ describe("release workflow", () => {
     expect(releaseStep).toContain("--verify-tag");
   });
 
+  it("pins privileged release actions to immutable revisions", async () => {
+    const workflow = await readWorkflow();
+    const steps = workflow.jobs?.release?.steps ?? [];
+    const actionRefs = steps
+      .map((step) => step.uses)
+      .filter((uses): uses is string => uses !== undefined);
+
+    expect(actionRefs).not.toEqual([]);
+    for (const actionRef of actionRefs) {
+      expect(actionRef).toMatch(/^[^@]+@[0-9a-f]{40}$/u);
+    }
+  });
+
   it("requires an exact changelog version heading", async () => {
     const workflow = await readWorkflow();
     const verifyStep = workflow.jobs?.release?.steps?.find(

--- a/test/script-provider.test.ts
+++ b/test/script-provider.test.ts
@@ -430,12 +430,13 @@ describe("script provider", () => {
   it("redacts configured command text from script errors", async () => {
     const context = await createContext();
     const sentinel = "redact-me";
+    const inlineEnvName = ["DB", "PWD"].join("");
     const failingScript = path.join(path.dirname(context.manifestPath), "send-secret.mjs");
     await writeText(
       failingScript,
-      "process.stderr.write(process.env.CRABLINE_PRIVATE_VALUE);process.exitCode=7;",
+      'process.stderr.write(process.env[["DB","PWD"].join("")]);process.exitCode=7;',
     );
-    const command = `CRABLINE_PRIVATE_VALUE=${sentinel} node ${JSON.stringify(failingScript)}`;
+    const command = `${inlineEnvName}+=${sentinel} node ${JSON.stringify(failingScript)}`;
     context.config.script!.commands.send = command;
     const provider = new ScriptProviderAdapter(context);
 
@@ -457,11 +458,8 @@ describe("script provider", () => {
     expect(ensureErrorMessage(sendError)).not.toContain(sentinel);
 
     const watchScript = path.join(path.dirname(context.manifestPath), "watch-secret.mjs");
-    await writeText(
-      watchScript,
-      "process.stderr.write(process.env.CRABLINE_PRIVATE_VALUE);process.exitCode=8;",
-    );
-    const watchCommand = `CRABLINE_PRIVATE_VALUE=${sentinel} node ${JSON.stringify(watchScript)}`;
+    await writeText(watchScript, "process.stderr.write(process.argv[2]);process.exitCode=8;");
+    const watchCommand = `node ${JSON.stringify(watchScript)} "--access-token=${sentinel}"`;
     context.config.script!.commands.watch = watchCommand;
 
     let watchError: unknown;
@@ -475,6 +473,105 @@ describe("script provider", () => {
     expect(ensureErrorMessage(watchError)).toContain("[script diagnostics redacted]");
     expect(ensureErrorMessage(watchError)).not.toContain(watchCommand);
     expect(ensureErrorMessage(watchError)).not.toContain(sentinel);
+
+    const powershellCommand =
+      `node ${JSON.stringify(watchScript)} ${sentinel} ` +
+      `'${"${env:"}${inlineEnvName}}=${sentinel}'`;
+    context.config.script!.commands.watch = powershellCommand;
+
+    let powershellError: unknown;
+    try {
+      await provider.watch(context).next();
+    } catch (error) {
+      powershellError = error;
+    }
+
+    expect(ensureErrorMessage(powershellError)).toContain("[script diagnostics redacted]");
+    expect(ensureErrorMessage(powershellError)).not.toContain(sentinel);
+  });
+
+  it("redacts inherited secret values from script diagnostics", async () => {
+    const context = await createContext();
+    const sentinel = "fixture-redaction-value\nsecond-line\n";
+    const envName = ["GITHUB", "PAT"].join("");
+    const keySentinel = "fixture-key-value";
+    const keyEnvName = ["SIGNING", "KEY"].join("_");
+    const compoundSentinel = "fixture-compound-value";
+    const compoundEnvName = ["ACCESS", "TOKEN"].join("");
+    const shortSentinel = "123";
+    const shortEnvName = ["DB", "PWD"].join("_");
+    const originalValues = new Map([
+      [envName, process.env[envName]],
+      [keyEnvName, process.env[keyEnvName]],
+      [compoundEnvName, process.env[compoundEnvName]],
+      [shortEnvName, process.env[shortEnvName]],
+    ]);
+    process.env[envName] = sentinel;
+    process.env[keyEnvName] = keySentinel;
+    process.env[compoundEnvName] = compoundSentinel;
+    process.env[shortEnvName] = shortSentinel;
+
+    try {
+      const failingScript = path.join(path.dirname(context.manifestPath), "send-env-secret.mjs");
+      await writeText(
+        failingScript,
+        'process.stderr.write(`failed: ${process.env[["GITHUB","PAT"].join("")]} ${process.env[["SIGNING","KEY"].join("_")]} ${process.env[["ACCESS","TOKEN"].join("")]} ${process.env[["DB","PWD"].join("_")]}`);process.exitCode=7;',
+      );
+      context.config.script!.commands.send = `node ${JSON.stringify(failingScript)}`;
+      const provider = new ScriptProviderAdapter(context);
+
+      let sendError: unknown;
+      try {
+        await provider.send({
+          ...context,
+          mode: "send",
+          nonce: "nonce",
+          text: "payload",
+        });
+      } catch (error) {
+        sendError = error;
+      }
+
+      expect(ensureErrorMessage(sendError)).toContain(
+        "failed: [redacted environment value] [redacted environment value] [redacted environment value] [redacted environment value]",
+      );
+      expect(ensureErrorMessage(sendError)).not.toContain("fixture-redaction-value");
+      expect(ensureErrorMessage(sendError)).not.toContain("second-line");
+      expect(ensureErrorMessage(sendError)).not.toContain(keySentinel);
+      expect(ensureErrorMessage(sendError)).not.toContain(compoundSentinel);
+      expect(ensureErrorMessage(sendError)).not.toContain(shortSentinel);
+
+      const watchScript = path.join(path.dirname(context.manifestPath), "watch-env-secret.mjs");
+      await writeText(
+        watchScript,
+        'process.stderr.write(`watch: ${process.env[["GITHUB","PAT"].join("")]} ${process.env[["SIGNING","KEY"].join("_")]} ${process.env[["ACCESS","TOKEN"].join("")]} ${process.env[["DB","PWD"].join("_")]}`);process.exitCode=8;',
+      );
+      context.config.script!.commands.watch = `node ${JSON.stringify(watchScript)}`;
+
+      let watchError: unknown;
+      try {
+        await provider.watch(context).next();
+      } catch (error) {
+        watchError = error;
+      }
+
+      expect(ensureErrorMessage(watchError)).toContain(
+        "watch: [redacted environment value] [redacted environment value] [redacted environment value] [redacted environment value]",
+      );
+      expect(ensureErrorMessage(watchError)).not.toContain("fixture-redaction-value");
+      expect(ensureErrorMessage(watchError)).not.toContain("second-line");
+      expect(ensureErrorMessage(watchError)).not.toContain(keySentinel);
+      expect(ensureErrorMessage(watchError)).not.toContain(compoundSentinel);
+      expect(ensureErrorMessage(watchError)).not.toContain(shortSentinel);
+    } finally {
+      for (const [name, originalValue] of originalValues) {
+        if (originalValue === undefined) {
+          delete process.env[name];
+        } else {
+          process.env[name] = originalValue;
+        }
+      }
+    }
   });
 
   it("uses stdout diagnostics when stderr is only whitespace", async () => {
@@ -495,6 +592,50 @@ describe("script provider", () => {
         text: "payload",
       }),
     ).rejects.toThrow(/useful failure/u);
+  });
+
+  it("preserves inherited path values in script diagnostics", async () => {
+    const context = await createContext();
+    const envName = ["GO", "PATH"].join("");
+    const pathValue = "/tmp/crabline-go-path";
+    const extensionEnvName = ["PATH", "EXT"].join("");
+    const extensionValue = ".COM;.EXE";
+    const previousDirectoryEnvName = ["OLD", "PWD"].join("");
+    const originalValues = new Map([
+      [envName, process.env[envName]],
+      [extensionEnvName, process.env[extensionEnvName]],
+    ]);
+    process.env[envName] = pathValue;
+    process.env[extensionEnvName] = extensionValue;
+
+    try {
+      const failingScript = path.join(path.dirname(context.manifestPath), "send-path-error.mjs");
+      await writeText(
+        failingScript,
+        'process.stderr.write(`path: ${process.env[["GO","PATH"].join("")]} ${process.env[["PATH","EXT"].join("")]}`);process.exitCode=7;',
+      );
+      context.config.script!.commands.send =
+        `${previousDirectoryEnvName}=/tmp/previous-directory ` +
+        `node ${JSON.stringify(failingScript)} "--path-prefix=/tmp"`;
+      const provider = new ScriptProviderAdapter(context);
+
+      await expect(
+        provider.send({
+          ...context,
+          mode: "send",
+          nonce: "nonce",
+          text: "payload",
+        }),
+      ).rejects.toThrow(`path: ${pathValue} ${extensionValue}`);
+    } finally {
+      for (const [name, originalValue] of originalValues) {
+        if (originalValue === undefined) {
+          delete process.env[name];
+        } else {
+          process.env[name] = originalValue;
+        }
+      }
+    }
   });
 
   it("fails when required commands are missing", async () => {


### PR DESCRIPTION
## Summary
- pin privileged release actions to immutable revisions
- redact inherited credential values from script diagnostics without hiding path state
- execute the installed CLI shim in production package verification

## Verification
- autoreview: gpt-5.6-sol high, clean (0.94)
- Crabbox: `run_4c60297286c8`
- `pnpm verify`: 43 files, 295 tests passed

## Release note
- updated `CHANGELOG.md`