### PR TITLE
fix(servers): enforce provider-native contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Pin privileged release workflow actions to immutable revisions.
 - Redact inherited secret-named environment values from script diagnostics.
 - Verify production tarballs through their installed npm command shims.
+- Enforce Telegram method and long-poll contracts, hide shared server exception details, and return native Matrix filter and internal errors.
 - Serialize WhatsApp Noise frames per session and reject invalid X25519 peer keys.
 - Serialize recorder persistence and reject overlapping OpenClaw smoke artifact runs.
 - Make CLI failures machine-readable, preserve stage-specific failure contracts, validate fixture provider references, redact script commands, and verify production-only tarball installs.

--- a/src/servers/http.ts
+++ b/src/servers/http.ts
@@ -198,7 +198,7 @@ export async function startHttpJsonServer(params: {
         handled ??
           jsonResponse(
             {
-              error: error instanceof Error ? error.message : String(error),
+              error: "internal server error",
               ok: false,
             },
             500,

--- a/src/servers/matrix.ts
+++ b/src/servers/matrix.ts
@@ -379,6 +379,10 @@ async function handleMatrixApi(params: {
 
   match = /^\/user\/([^/]+)\/filter\/([^/]+)$/u.exec(relativePath);
   if (params.method === "GET" && match) {
+    const userId = decodeURIComponent(match[1]!);
+    if (userId !== params.state.botUserId) {
+      return matrixError("M_FORBIDDEN", "Cannot get filters for another user", 403);
+    }
     const filter = params.state.filters.get(decodeURIComponent(match[2]!));
     return filter ? jsonResponse(filter) : matrixError("M_NOT_FOUND", "Unknown filter", 404);
   }
@@ -498,7 +502,7 @@ export async function startMatrixServer(
       if (error instanceof RequestBodyTooLargeError) {
         return matrixError("M_TOO_LARGE", "Request body is too large", 413);
       }
-      return undefined;
+      return matrixError("M_UNKNOWN", "Internal server error", 500);
     },
     host,
     port: params.port ?? 0,

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -49,6 +49,11 @@ type TelegramUpdatePoll = {
 
 type TelegramUpdatePollResult = "conflict" | "shutdown" | "timeout" | "update";
 
+type TelegramGetUpdatesState = Pick<
+  TelegramServerState,
+  "activeUpdatePoll" | "closing" | "updates"
+>;
+
 type TelegramMessage = {
   chat: {
     id: number | string;
@@ -447,51 +452,61 @@ async function handleTelegramApi(params: {
         ? telegramOk(message)
         : telegramError(`Bad Request: chat_id and ${mediaKind} are required`);
     }
-    case "getupdates": {
-      const offset = toIntegerValue(params.body.offset);
-      const limit = toIntegerValue(params.body.limit) ?? 100;
-      const timeout = toIntegerValue(params.body.timeout) ?? 0;
-      if (limit < 1 || limit > 100) {
-        return telegramError("Bad Request: limit must be between 1 and 100");
-      }
-      if (timeout < 0) {
-        return telegramError("Bad Request: timeout must be non-negative");
-      }
-      let updates = takeTelegramUpdates(params.state, offset, limit);
-      const deadline = Date.now() + Math.min(timeout * 1_000, 2_147_483_647);
-      if (updates.length === 0 && timeout > 0) {
-        while (updates.length === 0) {
-          const remainingMs = deadline - Date.now();
-          if (remainingMs <= 0) {
-            break;
-          }
-          const pollResult = await waitForTelegramUpdate(
-            params.state,
-            params.request,
-            remainingMs,
-            () => hasTelegramUpdates(params.state, offset),
-          );
-          if (pollResult === "conflict") {
-            return telegramError(
-              "Conflict: terminated by other getUpdates request; make sure that only one bot instance is running",
-              409,
-            );
-          }
-          if (pollResult !== "update") {
-            break;
-          }
-          updates = takeTelegramUpdates(params.state, offset, limit);
-        }
-      }
-      return telegramOk(updates);
-    }
+    case "getupdates":
+      return await handleTelegramGetUpdates(params);
     default:
       return telegramError(`Not Found: unsupported method ${params.method}`, 404);
   }
 }
 
+/** @internal */
+export async function handleTelegramGetUpdates(params: {
+  body: Record<string, unknown>;
+  request: IncomingMessage;
+  state: TelegramGetUpdatesState;
+}): Promise<Response> {
+  const offset = toIntegerValue(params.body.offset);
+  const limit = toIntegerValue(params.body.limit) ?? 100;
+  const timeout = toIntegerValue(params.body.timeout) ?? 0;
+  if (limit < 1 || limit > 100) {
+    return telegramError("Bad Request: limit must be between 1 and 100");
+  }
+  if (timeout < 0) {
+    return telegramError("Bad Request: timeout must be non-negative");
+  }
+
+  finishTelegramUpdatePoll(params.state, "conflict");
+  let updates = takeTelegramUpdates(params.state, offset, limit);
+  const deadline = Date.now() + Math.min(timeout * 1_000, 2_147_483_647);
+  if (updates.length === 0 && timeout > 0) {
+    while (updates.length === 0) {
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) {
+        break;
+      }
+      const pollResult = await waitForTelegramUpdate(
+        params.state,
+        params.request,
+        remainingMs,
+        () => hasTelegramUpdates(params.state, offset),
+      );
+      if (pollResult === "conflict") {
+        return telegramError(
+          "Conflict: terminated by other getUpdates request; make sure that only one bot instance is running",
+          409,
+        );
+      }
+      if (pollResult !== "update") {
+        break;
+      }
+      updates = takeTelegramUpdates(params.state, offset, limit);
+    }
+  }
+  return telegramOk(updates);
+}
+
 function takeTelegramUpdates(
-  state: TelegramServerState,
+  state: TelegramGetUpdatesState,
   offset: number | undefined,
   limit: number,
 ): TelegramUpdate[] {
@@ -509,7 +524,7 @@ function takeTelegramUpdates(
   return state.updates.slice(0, limit);
 }
 
-function hasTelegramUpdates(state: TelegramServerState, offset: number | undefined): boolean {
+function hasTelegramUpdates(state: TelegramGetUpdatesState, offset: number | undefined): boolean {
   if (offset === undefined || offset < 0) {
     return state.updates.length > 0;
   }
@@ -517,14 +532,14 @@ function hasTelegramUpdates(state: TelegramServerState, offset: number | undefin
 }
 
 function finishTelegramUpdatePoll(
-  state: TelegramServerState,
+  state: TelegramGetUpdatesState,
   result: TelegramUpdatePollResult,
 ): void {
   state.activeUpdatePoll?.finish(result);
 }
 
 async function waitForTelegramUpdate(
-  state: TelegramServerState,
+  state: TelegramGetUpdatesState,
   request: IncomingMessage,
   timeoutMs: number,
   hasUpdate: () => boolean,

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -30,6 +30,7 @@ type TelegramServerEvent = {
 };
 
 type TelegramServerState = {
+  activeUpdatePoll: TelegramUpdatePoll | undefined;
   adminToken: string;
   botId: number;
   botToken: string;
@@ -39,9 +40,14 @@ type TelegramServerState = {
   nextUpdateId: number;
   onEvent: ServerEventObserver | undefined;
   recorderPath: string;
-  updateWaiters: Set<(hasUpdate: boolean) => void>;
   updates: TelegramUpdate[];
 };
+
+type TelegramUpdatePoll = {
+  finish(result: TelegramUpdatePollResult): void;
+};
+
+type TelegramUpdatePollResult = "conflict" | "shutdown" | "timeout" | "update";
 
 type TelegramMessage = {
   chat: {
@@ -391,45 +397,46 @@ async function handleTelegramApi(params: {
   request: IncomingMessage;
   state: TelegramServerState;
 }) {
-  switch (params.method) {
-    case "getMe":
+  const method = params.method.toLowerCase();
+  switch (method) {
+    case "getme":
       return telegramOk(createBotUser(params.state));
-    case "deleteWebhook":
-    case "setWebhook":
-    case "setMyCommands":
-    case "deleteMyCommands":
-    case "sendChatAction":
-    case "answerCallbackQuery":
-    case "deleteMessage":
-    case "pinChatMessage":
-    case "unpinChatMessage":
-    case "setMessageReaction":
-    case "editForumTopic":
+    case "deletewebhook":
+    case "setwebhook":
+    case "setmycommands":
+    case "deletemycommands":
+    case "sendchataction":
+    case "answercallbackquery":
+    case "deletemessage":
+    case "pinchatmessage":
+    case "unpinchatmessage":
+    case "setmessagereaction":
+    case "editforumtopic":
       return telegramOk(true);
-    case "createForumTopic":
+    case "createforumtopic":
       return telegramOk({
         icon_color: 0x6fb9f0,
         message_thread_id: params.state.nextMessageId++,
         name: toStringValue(params.body.name) ?? "Crabline Topic",
       });
-    case "editMessageText": {
+    case "editmessagetext": {
       const message = createEditedMessage(params.state, params.body);
       return message
         ? telegramOk(message)
         : telegramError("Bad Request: chat_id, message_id, and text are required");
     }
-    case "sendMessage": {
+    case "sendmessage": {
       const message = createOutboundMessage(params.state, params.body);
       return message
         ? telegramOk(message)
         : telegramError("Bad Request: chat_id and text are required");
     }
-    case "sendAnimation":
-    case "sendAudio":
-    case "sendDocument":
-    case "sendPhoto":
-    case "sendVideo": {
-      const mediaKind = params.method.slice("send".length).toLowerCase() as
+    case "sendanimation":
+    case "sendaudio":
+    case "senddocument":
+    case "sendphoto":
+    case "sendvideo": {
+      const mediaKind = method.slice("send".length) as
         | "animation"
         | "audio"
         | "document"
@@ -440,7 +447,7 @@ async function handleTelegramApi(params: {
         ? telegramOk(message)
         : telegramError(`Bad Request: chat_id and ${mediaKind} are required`);
     }
-    case "getUpdates": {
+    case "getupdates": {
       const offset = toIntegerValue(params.body.offset);
       const limit = toIntegerValue(params.body.limit) ?? 100;
       const timeout = toIntegerValue(params.body.timeout) ?? 0;
@@ -455,10 +462,22 @@ async function handleTelegramApi(params: {
       if (updates.length === 0 && timeout > 0) {
         while (updates.length === 0) {
           const remainingMs = deadline - Date.now();
-          if (
-            remainingMs <= 0 ||
-            !(await waitForTelegramUpdate(params.state, params.request, remainingMs))
-          ) {
+          if (remainingMs <= 0) {
+            break;
+          }
+          const pollResult = await waitForTelegramUpdate(
+            params.state,
+            params.request,
+            remainingMs,
+            () => hasTelegramUpdates(params.state, offset),
+          );
+          if (pollResult === "conflict") {
+            return telegramError(
+              "Conflict: terminated by other getUpdates request; make sure that only one bot instance is running",
+              409,
+            );
+          }
+          if (pollResult !== "update") {
             break;
           }
           updates = takeTelegramUpdates(params.state, offset, limit);
@@ -490,44 +509,64 @@ function takeTelegramUpdates(
   return state.updates.slice(0, limit);
 }
 
-function notifyTelegramUpdateWaiters(state: TelegramServerState, hasUpdate: boolean): void {
-  const waiters = [...state.updateWaiters];
-  state.updateWaiters.clear();
-  for (const resolve of waiters) {
-    resolve(hasUpdate);
+function hasTelegramUpdates(state: TelegramServerState, offset: number | undefined): boolean {
+  if (offset === undefined || offset < 0) {
+    return state.updates.length > 0;
   }
+  return state.updates.some((update) => update.update_id >= offset);
+}
+
+function finishTelegramUpdatePoll(
+  state: TelegramServerState,
+  result: TelegramUpdatePollResult,
+): void {
+  state.activeUpdatePoll?.finish(result);
 }
 
 async function waitForTelegramUpdate(
   state: TelegramServerState,
   request: IncomingMessage,
   timeoutMs: number,
-): Promise<boolean> {
+  hasUpdate: () => boolean,
+): Promise<TelegramUpdatePollResult> {
   if (state.closing || request.socket.destroyed) {
-    return false;
+    return "shutdown";
   }
-  return await new Promise<boolean>((resolve) => {
+  return await new Promise<TelegramUpdatePollResult>((resolve) => {
     let settled = false;
-    const finish = (hasUpdate: boolean) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      clearTimeout(timer);
-      request.socket.off("close", onSocketClose);
-      state.updateWaiters.delete(onUpdate);
-      resolve(hasUpdate);
+    const poll: TelegramUpdatePoll = {
+      finish(result) {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timer);
+        request.socket.off("close", onSocketClose);
+        if (state.activeUpdatePoll === poll) {
+          state.activeUpdatePoll = undefined;
+        }
+        resolve(result);
+      },
     };
-    const onUpdate = (hasUpdate: boolean) => finish(hasUpdate);
-    const onSocketClose = () => finish(false);
-    const timer = setTimeout(() => finish(false), timeoutMs);
+    const onSocketClose = () => poll.finish("shutdown");
+    const timer = setTimeout(() => poll.finish("timeout"), timeoutMs);
     timer.unref();
+    const previousPoll = state.activeUpdatePoll;
+    state.activeUpdatePoll = poll;
+    previousPoll?.finish("conflict");
     request.socket.once("close", onSocketClose);
-    state.updateWaiters.add(onUpdate);
     if (state.closing || request.socket.destroyed) {
-      finish(false);
+      poll.finish("shutdown");
+    } else if (hasUpdate()) {
+      poll.finish("update");
     }
   });
+}
+
+function telegramMethodNotAllowed(): Response {
+  const response = telegramError("Method Not Allowed", 405);
+  response.headers.set("allow", "GET, POST");
+  return response;
 }
 
 async function handleRequest(params: { request: IncomingMessage; state: TelegramServerState }) {
@@ -558,7 +597,7 @@ async function handleRequest(params: { request: IncomingMessage; state: Telegram
     }
     params.state.updates.push(update);
     params.state.updates.sort((left, right) => left.update_id - right.update_id);
-    notifyTelegramUpdateWaiters(params.state, true);
+    finishTelegramUpdatePoll(params.state, "update");
     return jsonResponse({ ok: true, update });
   }
 
@@ -567,15 +606,19 @@ async function handleRequest(params: { request: IncomingMessage; state: Telegram
     drainRequestBody(params.request);
     return new Response("not found", { status: 404 });
   }
-  const body =
-    params.request.method === "GET" ? queryRecord(url) : await parseRequestBody(params.request);
+  const requestMethod = params.request.method ?? "GET";
+  if (requestMethod !== "GET" && requestMethod !== "POST") {
+    drainRequestBody(params.request);
+    return telegramMethodNotAllowed();
+  }
+  const body = requestMethod === "GET" ? queryRecord(url) : await parseRequestBody(params.request);
   if (!isJsonObject(body)) {
     return telegramError("Bad Request: can't parse JSON object");
   }
   await appendEvent(params.state, {
     at: new Date().toISOString(),
     body,
-    method: params.request.method ?? "GET",
+    method: requestMethod,
     path: `/bot<redacted>/${botPath.method}`,
     query: queryRecord(url),
     type: "api",
@@ -592,6 +635,7 @@ export async function startTelegramServer(
   params: StartTelegramServerParams = {},
 ): Promise<StartedTelegramServer> {
   const state: TelegramServerState = {
+    activeUpdatePoll: undefined,
     adminToken: params.adminToken ?? randomBytes(24).toString("hex"),
     botId: params.botId ?? 424242,
     botToken: params.botToken ?? "424242:crabline-telegram-token",
@@ -601,7 +645,6 @@ export async function startTelegramServer(
     onEvent: params.onEvent,
     recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "telegram.jsonl"),
     closing: false,
-    updateWaiters: new Set(),
     updates: [],
   };
   const host = params.host ?? "127.0.0.1";
@@ -643,7 +686,7 @@ export async function startTelegramServer(
   return {
     async close() {
       state.closing = true;
-      notifyTelegramUpdateWaiters(state, false);
+      finishTelegramUpdatePoll(state, "shutdown");
       await closeServer(server);
     },
     manifest: {

--- a/test/http-server.test.ts
+++ b/test/http-server.test.ts
@@ -1,7 +1,7 @@
 import type { IncomingMessage } from "node:http";
 import { PassThrough } from "node:stream";
 import { describe, expect, it } from "vitest";
-import { readBody, RequestBodyTooLargeError } from "../src/servers/http.js";
+import { readBody, RequestBodyTooLargeError, startHttpJsonServer } from "../src/servers/http.js";
 
 type TestRequest = IncomingMessage & PassThrough;
 
@@ -32,5 +32,27 @@ describe("server HTTP body reader", () => {
     const declared = createRequest({ "content-length": "5" });
     await expect(readBody(declared, 4)).rejects.toBeInstanceOf(RequestBodyTooLargeError);
     expectLateErrorHandled(declared);
+  });
+
+  it("does not expose unexpected exception details", async () => {
+    const server = await startHttpJsonServer({
+      async handle() {
+        throw new Error("sensitive shared server detail");
+      },
+      host: "127.0.0.1",
+      port: 0,
+      serverName: "test",
+    });
+
+    try {
+      const response = await fetch(server.baseUrl);
+      expect(response.status).toBe(500);
+      await expect(response.json()).resolves.toEqual({
+        error: "internal server error",
+        ok: false,
+      });
+    } finally {
+      await server.close();
+    }
   });
 });

--- a/test/matrix-server.test.ts
+++ b/test/matrix-server.test.ts
@@ -176,7 +176,12 @@ describe("Matrix local provider server", () => {
   });
 
   it("returns filters only through their owning user URL", async () => {
-    const server = await startMatrixServer({ accessToken: "matrix-token" });
+    const directory = await createTempDir();
+    directories.push(directory);
+    const server = await startMatrixServer({
+      accessToken: "matrix-token",
+      recorderPath: path.join(directory, "matrix-filter-owner.jsonl"),
+    });
     servers.push(server);
     const filter = { room: { timeline: { limit: 10 } } };
     const created = await fetch(

--- a/test/matrix-server.test.ts
+++ b/test/matrix-server.test.ts
@@ -175,6 +175,59 @@ describe("Matrix local provider server", () => {
     ]);
   });
 
+  it("returns filters only through their owning user URL", async () => {
+    const server = await startMatrixServer({ accessToken: "matrix-token" });
+    servers.push(server);
+    const filter = { room: { timeline: { limit: 10 } } };
+    const created = await fetch(
+      `${server.manifest.endpoints.clientApiRoot}/user/${encodeURIComponent(server.manifest.botUserId)}/filter`,
+      {
+        body: JSON.stringify(filter),
+        headers: { ...auth("matrix-token"), "content-type": "application/json" },
+        method: "POST",
+      },
+    );
+    const createdBody = (await created.json()) as { filter_id: string };
+
+    const owned = await fetch(
+      `${server.manifest.endpoints.clientApiRoot}/user/${encodeURIComponent(server.manifest.botUserId)}/filter/${createdBody.filter_id}`,
+      { headers: auth("matrix-token") },
+    );
+    await expect(owned.json()).resolves.toEqual(filter);
+
+    const forged = await fetch(
+      `${server.manifest.endpoints.clientApiRoot}/user/${encodeURIComponent("@other:matrix.test")}/filter/${createdBody.filter_id}`,
+      { headers: auth("matrix-token") },
+    );
+    expect(forged.status).toBe(403);
+    await expect(forged.json()).resolves.toEqual({
+      errcode: "M_FORBIDDEN",
+      error: "Cannot get filters for another user",
+    });
+  });
+
+  it("returns provider-native internal errors without exception details", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const server = await startMatrixServer({
+      accessToken: "matrix-token",
+      onEvent() {
+        throw new Error("sensitive Matrix observer detail");
+      },
+      recorderPath: path.join(directory, "matrix-internal-error.jsonl"),
+    });
+    servers.push(server);
+
+    const response = await fetch(`${server.manifest.endpoints.clientApiRoot}/account/whoami`, {
+      headers: auth("matrix-token"),
+    });
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      errcode: "M_UNKNOWN",
+      error: "Internal server error",
+    });
+  });
+
   it("works with matrix-js-sdk sync and delivers admin inbound as a room event", async () => {
     const directory = await createTempDir();
     directories.push(directory);

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -1,8 +1,9 @@
 import fs from "node:fs/promises";
-import { Agent, request as httpRequest } from "node:http";
+import { Agent, request as httpRequest, type IncomingMessage } from "node:http";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { startTelegramServer, type StartedTelegramServer } from "../src/index.js";
+import { handleTelegramGetUpdates } from "../src/servers/telegram.js";
 import { createTempDir, disposeTempDir, requestHttp } from "./test-helpers.js";
 
 const servers: StartedTelegramServer[] = [];
@@ -473,6 +474,60 @@ describe("telegram local provider server", () => {
     await expect(replacementPoll.then((response) => response.json())).resolves.toMatchObject({
       ok: true,
       result: [{ message: { text: "replacement poll remains active" }, update_id: 100 }],
+    });
+  });
+
+  it("supersedes an active long poll with a timeout-zero replacement", async () => {
+    const server = await startTelegramServer({ botToken: "test-token" });
+    servers.push(server);
+
+    const firstPoll = getUpdates(server, { offset: 100, timeout: 30 });
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    const replacement = await getUpdates(server, { offset: 100, timeout: 0 });
+
+    expect(replacement.status).toBe(200);
+    await expect(replacement.json()).resolves.toEqual({ ok: true, result: [] });
+    const conflicted = await firstPoll;
+    expect(conflicted.status).toBe(409);
+    await expect(conflicted.json()).resolves.toMatchObject({
+      description:
+        "Conflict: terminated by other getUpdates request; make sure that only one bot instance is running",
+      error_code: 409,
+      ok: false,
+    });
+  });
+
+  it("supersedes an active long poll before returning queued updates", async () => {
+    const pollResults: string[] = [];
+    const response = await handleTelegramGetUpdates({
+      body: { timeout: 30 },
+      request: {} as IncomingMessage,
+      state: {
+        activeUpdatePoll: {
+          finish(result) {
+            pollResults.push(result);
+          },
+        },
+        closing: false,
+        updates: [
+          {
+            message: {
+              chat: { id: 123, type: "private" },
+              date: 1,
+              from: { first_name: "QA User", id: 100001, is_bot: false },
+              message_id: 1,
+              text: "already queued",
+            },
+            update_id: 1,
+          },
+        ],
+      },
+    });
+
+    expect(pollResults).toEqual(["conflict"]);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      result: [{ message: { text: "already queued" }, update_id: 1 }],
     });
   });
 

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -43,6 +43,37 @@ afterEach(async () => {
 });
 
 describe("telegram local provider server", () => {
+  it("accepts only GET and POST and resolves Bot API methods case-insensitively", async () => {
+    const server = await startTelegramServer({ botToken: "test-token" });
+    servers.push(server);
+    const apiRoot = `${server.manifest.baseUrl}/bottest-token`;
+
+    const getMe = await fetch(`${apiRoot}/gEtMe`);
+    await expect(getMe.json()).resolves.toMatchObject({
+      ok: true,
+      result: { is_bot: true },
+    });
+
+    const sent = await fetch(`${apiRoot}/sEnDmEsSaGe`, {
+      body: JSON.stringify({ chat_id: "123", text: "case-insensitive" }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    await expect(sent.json()).resolves.toMatchObject({
+      ok: true,
+      result: { text: "case-insensitive" },
+    });
+
+    const rejected = await fetch(`${apiRoot}/getMe`, { method: "PUT" });
+    expect(rejected.status).toBe(405);
+    expect(rejected.headers.get("allow")).toBe("GET, POST");
+    await expect(rejected.json()).resolves.toEqual({
+      description: "Method Not Allowed",
+      error_code: 405,
+      ok: false,
+    });
+  });
+
   it("advertises valid URLs when bound to IPv6", async () => {
     const directory = await createTempDir();
     directories.push(directory);
@@ -413,6 +444,35 @@ describe("telegram local provider server", () => {
     await expect(pending.then((response) => response.json())).resolves.toMatchObject({
       ok: true,
       result: [{ message: { text: "wake the poll" }, update_id: 100 }],
+    });
+  });
+
+  it("supersedes an active long poll with a Telegram conflict response", async () => {
+    const server = await startTelegramServer({ botToken: "test-token" });
+    servers.push(server);
+
+    const firstPoll = getUpdates(server, { offset: 100, timeout: 30 });
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    const replacementPoll = getUpdates(server, { offset: 100, timeout: 30 });
+
+    const conflicted = await firstPoll;
+    expect(conflicted.status).toBe(409);
+    await expect(conflicted.json()).resolves.toEqual({
+      description:
+        "Conflict: terminated by other getUpdates request; make sure that only one bot instance is running",
+      error_code: 409,
+      ok: false,
+    });
+
+    const inbound = await injectUpdate(server, {
+      chatId: "123",
+      text: "replacement poll remains active",
+      updateId: 100,
+    });
+    expect(inbound.status).toBe(200);
+    await expect(replacementPoll.then((response) => response.json())).resolves.toMatchObject({
+      ok: true,
+      result: [{ message: { text: "replacement poll remains active" }, update_id: 100 }],
     });
   });
 


### PR DESCRIPTION
## Summary
- enforce Telegram Bot API method, polling, and supersession contracts
- hide unexpected shared HTTP server errors
- return native Matrix filter and internal error payloads

## Verification
- autoreview: gpt-5.6-sol high, clean (0.93)
- Crabbox: `run_42b5a131d8f7`
- `pnpm verify`: 43 files, 302 tests passed

## Release note
- updated `CHANGELOG.md`