### PR TITLE
fix(runtime): preserve recorder and nonce correctness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Redact inherited secret-named environment values from script diagnostics.
 - Verify production tarballs through their installed npm command shims.
 - Enforce Telegram method and long-poll contracts, hide shared server exception details, and return native Matrix filter and internal errors.
+- Preserve recorder continuity across file replacement, keep fixture waits on one outbound until a match, and require canonical nonce tokens.
 - Serialize WhatsApp Noise frames per session and reject invalid X25519 peer keys.
 - Serialize recorder persistence and reject overlapping OpenClaw smoke artifact runs.
 - Make CLI failures machine-readable, preserve stage-specific failure contracts, validate fixture provider references, redact script commands, and verify production-only tarball installs.

--- a/src/core/matcher.ts
+++ b/src/core/matcher.ts
@@ -1,4 +1,4 @@
-import { extractNonce } from "./nonces.js";
+import { extractNonces } from "./nonces.js";
 import type { InboundEnvelope, InboundMatchConfig } from "../providers/types.js";
 
 export function matchesInbound(
@@ -11,18 +11,18 @@ export function matchesInbound(
   }
 
   const text = envelope.text ?? "";
-  const extractedNonce = extractNonce(text);
+  const extractedNonces = extractNonces(text);
 
   if (config.nonce !== "ignore") {
-    if (!extractedNonce) {
+    if (extractedNonces.length === 0) {
       return false;
     }
 
-    if (config.nonce === "exact" && extractedNonce !== nonce) {
+    if (config.nonce === "exact" && extractedNonces[0] !== nonce) {
       return false;
     }
 
-    if (config.nonce === "contains" && !text.includes(nonce)) {
+    if (config.nonce === "contains" && !extractedNonces.includes(nonce)) {
       return false;
     }
   }

--- a/src/core/nonces.ts
+++ b/src/core/nonces.ts
@@ -6,7 +6,10 @@ export function createNonce(fixtureId: string): string {
   return `mp-${fixtureId}-${timestamp}-${entropy}`;
 }
 
+export function extractNonces(text: string): string[] {
+  return text.match(/\bmp-[a-z0-9-]+-[a-z0-9]+-[a-f0-9]{8}\b/gi) ?? [];
+}
+
 export function extractNonce(text: string): string | null {
-  const match = text.match(/\bmp-[a-z0-9-]+-[a-z0-9]+-[a-f0-9]{8}\b/i);
-  return match?.[0] ?? null;
+  return extractNonces(text)[0] ?? null;
 }

--- a/src/core/nonces.ts
+++ b/src/core/nonces.ts
@@ -7,7 +7,7 @@ export function createNonce(fixtureId: string): string {
 }
 
 export function extractNonces(text: string): string[] {
-  return text.match(/\bmp-[a-z0-9-]+-[a-z0-9]+-[a-f0-9]{8}\b/gi) ?? [];
+  return text.match(/(?<![a-z0-9-])mp-[a-z0-9-]+-[a-z0-9]+-[a-f0-9]{8}(?![a-z0-9-])/gi) ?? [];
 }
 
 export function extractNonce(text: string): string | null {

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -131,15 +131,35 @@ export async function runFixtureCommand(params: {
           });
         }
 
+        const inboundDeadline = Date.now() + fixture.timeoutMs;
+        const seenInbound = new Set<string>();
         let inbound;
         try {
-          inbound = await provider.waitForInbound({
-            ...contextBase,
-            nonce,
-            since,
-            threadId: accepted.threadId,
-            timeoutMs: fixture.timeoutMs,
-          });
+          while (Date.now() < inboundDeadline) {
+            const timeoutMs = inboundDeadline - Date.now();
+            const candidate = await provider.waitForInbound({
+              ...contextBase,
+              nonce,
+              since,
+              threadId: accepted.threadId,
+              timeoutMs,
+            });
+            if (!candidate) {
+              break;
+            }
+
+            const key = JSON.stringify([candidate.provider, candidate.threadId, candidate.id]);
+            if (seenInbound.has(key)) {
+              await sleep(Math.min(10, Math.max(0, inboundDeadline - Date.now())));
+              continue;
+            }
+            seenInbound.add(key);
+
+            if (matchesInbound(candidate, fixture.inboundMatch, nonce)) {
+              inbound = candidate;
+              break;
+            }
+          }
         } catch (error) {
           lastFailure = toFailure(fixture.id, fixture.provider, mode, error, "inbound", nonce);
           continue;
@@ -151,20 +171,6 @@ export async function runFixtureCommand(params: {
               `timed out waiting for inbound after ${fixture.timeoutMs}ms`,
             ],
             failureKind: "timeout",
-            fixtureId: fixture.id,
-            mode,
-            nonce,
-            ok: false,
-            providerId: fixture.provider,
-          };
-          await sleep(50);
-          continue;
-        }
-
-        if (!matchesInbound(inbound, fixture.inboundMatch, nonce)) {
-          lastFailure = {
-            diagnostics: [...diagnostics, `received non-matching inbound message ${inbound.id}`],
-            failureKind: "assertion",
             fixtureId: fixture.id,
             mode,
             nonce,

--- a/src/providers/local-mock.ts
+++ b/src/providers/local-mock.ts
@@ -1,7 +1,13 @@
 import path from "node:path";
 import { CrablineError, ensureErrorMessage } from "../core/errors.js";
 import type { ProviderConfig, ProviderPlatform } from "../config/schema.js";
-import { appendRecordedInbound, waitForRecordedInbound, watchRecordedInbound } from "./recorder.js";
+import {
+  appendRecordedInbound,
+  createRecordedInboundCursor,
+  waitForRecordedInbound,
+  watchRecordedInbound,
+  type RecordedInboundCursor,
+} from "./recorder.js";
 import type {
   InboundEnvelope,
   NormalizedTarget,
@@ -136,6 +142,7 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
   readonly #options: LocalMockAdapterOptions;
   readonly #publicUrl: string | undefined;
   readonly #recorderPath: string;
+  readonly #waitCursors = new Map<string, RecordedInboundCursor>();
   #server: StartedWebhookServer | null = null;
   #serverClosing: Promise<void> | null = null;
   #serverStarting: Promise<StartedWebhookServer> | null = null;
@@ -225,15 +232,30 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
     await this.#ensureWebhookServer();
     const target = this.normalizeTarget(context.fixture.target);
     const expectedAuthor = context.fixture.inboundMatch.author;
-    return await waitForRecordedInbound({
-      filePath: this.#recorderPath,
-      matches: (event) =>
-        event.provider === this.id &&
-        (expectedAuthor === "any" || event.author === expectedAuthor) &&
-        isAddressInChannel(event.threadId, context.threadId ?? target.threadId ?? target.channelId),
-      since: context.since,
-      timeoutMs: context.timeoutMs,
-    });
+    const channelId = context.threadId ?? target.threadId ?? target.channelId;
+    const cursorKey = JSON.stringify([context.nonce, context.since, channelId]);
+    const cursor = this.#waitCursors.get(cursorKey) ?? createRecordedInboundCursor();
+    this.#waitCursors.set(cursorKey, cursor);
+
+    try {
+      const event = await waitForRecordedInbound({
+        cursor,
+        filePath: this.#recorderPath,
+        matches: (candidate) =>
+          candidate.provider === this.id &&
+          (expectedAuthor === "any" || candidate.author === expectedAuthor) &&
+          isAddressInChannel(candidate.threadId, channelId),
+        since: context.since,
+        timeoutMs: context.timeoutMs,
+      });
+      if (!event) {
+        this.#waitCursors.delete(cursorKey);
+      }
+      return event;
+    } catch (error) {
+      this.#waitCursors.delete(cursorKey);
+      throw error;
+    }
   }
 
   async *watch(context: WatchContext): AsyncIterable<InboundEnvelope> {
@@ -251,6 +273,7 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
   }
 
   async cleanup(): Promise<void> {
+    this.#waitCursors.clear();
     if (this.#serverClosing) {
       await this.#serverClosing;
       return;

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -18,9 +18,43 @@ const MAX_WATCH_SEEN_KEYS = 4096;
 const pendingAppends = new Map<string, Promise<void>>();
 
 type IncrementalReadState = {
+  continuity: Buffer;
+  identity:
+    | {
+        dev: number;
+        ino: number;
+      }
+    | undefined;
   offset: number;
   pending: Buffer;
 };
+
+const CONTINUITY_BYTES = 4096;
+
+function resetIncrementalReadState(state: IncrementalReadState): void {
+  state.continuity = Buffer.alloc(0);
+  state.offset = 0;
+  state.pending = Buffer.alloc(0);
+}
+
+async function readBufferAt(
+  handle: Awaited<ReturnType<typeof open>>,
+  length: number,
+  position: number,
+): Promise<Buffer> {
+  const buffer = Buffer.alloc(length);
+  let bytesRead = 0;
+
+  while (bytesRead < length) {
+    const result = await handle.read(buffer, bytesRead, length - bytesRead, position + bytesRead);
+    if (result.bytesRead === 0) {
+      break;
+    }
+    bytesRead += result.bytesRead;
+  }
+
+  return buffer.subarray(0, bytesRead);
+}
 
 async function appendJsonLine(filePath: string, line: string): Promise<void> {
   const key = path.resolve(filePath);
@@ -48,24 +82,37 @@ async function readRecordedInboundAppend(
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code;
     if (code === "ENOENT") {
-      state.offset = 0;
-      state.pending = Buffer.alloc(0);
+      resetIncrementalReadState(state);
+      state.identity = undefined;
       return [];
     }
     throw error;
   }
 
   try {
-    const size = (await handle.stat()).size;
-    if (size < state.offset) {
-      state.offset = 0;
-      state.pending = Buffer.alloc(0);
+    const stats = await handle.stat();
+    const identity = { dev: stats.dev, ino: stats.ino };
+    const sameFile = state.identity?.dev === identity.dev && state.identity.ino === identity.ino;
+    let hasContinuity = sameFile && stats.size >= state.offset;
+
+    if (hasContinuity && state.continuity.length > 0) {
+      const actual = await readBufferAt(
+        handle,
+        state.continuity.length,
+        state.offset - state.continuity.length,
+      );
+      hasContinuity = actual.equals(state.continuity);
     }
+
+    if (!hasContinuity) {
+      resetIncrementalReadState(state);
+    }
+    state.identity = identity;
 
     const chunks: Buffer[] = [];
     let position = state.offset;
-    while (position < size) {
-      const chunk = Buffer.alloc(Math.min(64 * 1024, size - position));
+    while (position < stats.size) {
+      const chunk = Buffer.alloc(Math.min(64 * 1024, stats.size - position));
       const { bytesRead } = await handle.read(chunk, 0, chunk.length, position);
       if (bytesRead === 0) {
         break;
@@ -74,6 +121,7 @@ async function readRecordedInboundAppend(
       position += bytesRead;
     }
     state.offset = position;
+    state.continuity = Buffer.concat([state.continuity, ...chunks]).subarray(-CONTINUITY_BYTES);
 
     const raw = Buffer.concat([state.pending, ...chunks]);
     const lastNewline = raw.lastIndexOf(0x0a);
@@ -153,6 +201,8 @@ export async function waitForRecordedInbound(params: {
 }): Promise<RecordedInboundEnvelope | null> {
   const deadline = Date.now() + params.timeoutMs;
   const state: IncrementalReadState = {
+    continuity: Buffer.alloc(0),
+    identity: undefined,
     offset: 0,
     pending: Buffer.alloc(0),
   };
@@ -193,6 +243,8 @@ export async function* watchRecordedInbound(params: {
   since?: string | undefined;
 }): AsyncIterable<RecordedInboundEnvelope> {
   const state: IncrementalReadState = {
+    continuity: Buffer.alloc(0),
+    identity: undefined,
     offset: 0,
     pending: Buffer.alloc(0),
   };

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -29,7 +29,30 @@ type IncrementalReadState = {
   pending: Buffer;
 };
 
+export type RecordedInboundCursor = {
+  buffered: RecordedInboundEnvelope[];
+  readState: IncrementalReadState;
+  seen: Set<string>;
+};
+
 const CONTINUITY_BYTES = 4096;
+
+function createIncrementalReadState(): IncrementalReadState {
+  return {
+    continuity: Buffer.alloc(0),
+    identity: undefined,
+    offset: 0,
+    pending: Buffer.alloc(0),
+  };
+}
+
+export function createRecordedInboundCursor(): RecordedInboundCursor {
+  return {
+    buffered: [],
+    readState: createIncrementalReadState(),
+    seen: new Set(),
+  };
+}
 
 function resetIncrementalReadState(state: IncrementalReadState): void {
   state.continuity = Buffer.alloc(0);
@@ -193,6 +216,7 @@ export async function readRecordedInbound(filePath: string): Promise<RecordedInb
 }
 
 export async function waitForRecordedInbound(params: {
+  cursor?: RecordedInboundCursor | undefined;
   filePath: string;
   matches: (event: RecordedInboundEnvelope) => boolean;
   pollMs?: number;
@@ -200,28 +224,26 @@ export async function waitForRecordedInbound(params: {
   timeoutMs: number;
 }): Promise<RecordedInboundEnvelope | null> {
   const deadline = Date.now() + params.timeoutMs;
-  const state: IncrementalReadState = {
-    continuity: Buffer.alloc(0),
-    identity: undefined,
-    offset: 0,
-    pending: Buffer.alloc(0),
-  };
-  const seen = new Set<string>();
+  const cursor = params.cursor ?? createRecordedInboundCursor();
 
   while (Date.now() <= deadline) {
-    const events = await readRecordedInboundAppend(params.filePath, state);
-    for (const event of events) {
+    const events =
+      cursor.buffered.length > 0
+        ? cursor.buffered.splice(0)
+        : await readRecordedInboundAppend(params.filePath, cursor.readState);
+    for (const [index, event] of events.entries()) {
       const key = toRecordKey(event);
-      if (seen.has(key)) {
+      if (cursor.seen.has(key)) {
         continue;
       }
-      seen.add(key);
+      cursor.seen.add(key);
 
       if (params.since && new Date(event.sentAt).getTime() < new Date(params.since).getTime()) {
         continue;
       }
 
       if (params.matches(event)) {
+        cursor.buffered.push(...events.slice(index + 1));
         return event;
       }
     }
@@ -242,12 +264,7 @@ export async function* watchRecordedInbound(params: {
   pollMs?: number;
   since?: string | undefined;
 }): AsyncIterable<RecordedInboundEnvelope> {
-  const state: IncrementalReadState = {
-    continuity: Buffer.alloc(0),
-    identity: undefined,
-    offset: 0,
-    pending: Buffer.alloc(0),
-  };
+  const state = createIncrementalReadState();
   const seen = new Set<string>();
 
   while (true) {

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -116,9 +116,11 @@ async function readRecordedInboundAppend(
     const stats = await handle.stat();
     const identity = { dev: stats.dev, ino: stats.ino };
     const sameFile = state.identity?.dev === identity.dev && state.identity.ino === identity.ino;
-    let hasContinuity = sameFile && stats.size >= state.offset;
+    let hasContinuity = stats.size >= state.offset;
 
-    if (hasContinuity && state.continuity.length > 0) {
+    if (hasContinuity && state.offset > 0 && state.continuity.length === 0) {
+      hasContinuity = sameFile;
+    } else if (hasContinuity && state.continuity.length > 0) {
       const actual = await readBufferAt(
         handle,
         state.continuity.length,

--- a/test/local-mock-provider.test.ts
+++ b/test/local-mock-provider.test.ts
@@ -1,12 +1,15 @@
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { ProviderConfig } from "../src/config/schema.js";
+import type { ManifestDefinition, ProviderConfig } from "../src/config/schema.js";
+import { runFixtureCommand } from "../src/core/run.js";
 import { SlackProviderAdapter } from "../src/providers/builtin/slack.js";
+import { OPENCLAW_SUPPORT_CATALOG } from "../src/providers/catalog.js";
 import {
   createGenericLocalMockTargetCodec,
   LocalMockProviderAdapter,
 } from "../src/providers/local-mock.js";
 import { appendRecordedInbound } from "../src/providers/recorder.js";
+import type { Registry } from "../src/providers/registry.js";
 import type { ProviderAdapter, ProviderContext } from "../src/providers/types.js";
 import { createTempDir, disposeTempDir } from "./test-helpers.js";
 
@@ -275,5 +278,58 @@ describe("local mock provider", () => {
       },
     });
     await iterator.return?.();
+  });
+
+  it("runs past an earlier unrelated recorder event to the matching reply", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const recorderPath = path.join(directory, "slack.jsonl");
+    const config = createConfig();
+    config.slack!.recorder.path = recorderPath;
+    const provider = new SlackProviderAdapter("provider-a", config, "crabline");
+    providers.push(provider);
+    const fixture: ManifestDefinition["fixtures"][number] = {
+      env: [],
+      id: "slack-roundtrip",
+      inboundMatch: { author: "assistant", nonce: "contains", strategy: "contains" },
+      mode: "roundtrip",
+      provider: "provider-a",
+      retries: 0,
+      tags: [],
+      target: { behavior: "echo", id: "C1234567890", metadata: {} },
+      timeoutMs: 100,
+    };
+    const manifest: ManifestDefinition = {
+      configVersion: 1,
+      fixtures: [fixture],
+      providers: { "provider-a": config },
+      userName: "crabline",
+    };
+    const registry: Registry = {
+      catalog: OPENCLAW_SUPPORT_CATALOG,
+      resolve() {
+        return provider;
+      },
+    };
+
+    await appendRecordedInbound(recorderPath, {
+      author: "assistant",
+      id: "unrelated",
+      provider: "provider-a",
+      sentAt: new Date(Date.now() + 60_000).toISOString(),
+      text: "unrelated canonical-free message",
+      threadId: "C1234567890",
+    });
+
+    await expect(
+      runFixtureCommand({
+        fixtureId: fixture.id,
+        manifest,
+        manifestPath: "/tmp/crabline.yaml",
+        registry,
+      }),
+    ).resolves.toMatchObject({
+      ok: true,
+    });
   });
 });

--- a/test/matcher.test.ts
+++ b/test/matcher.test.ts
@@ -30,6 +30,36 @@ describe("nonce + matcher", () => {
     ).toBe(true);
   });
 
+  it("matches contains mode only against canonical nonce tokens", () => {
+    const nonce = "mp-demo-abc-1234abcd";
+    const otherNonce = "mp-other-def-8765dcba";
+    const envelope = {
+      author: "assistant" as const,
+      id: "1",
+      provider: "loopback",
+      sentAt: new Date().toISOString(),
+      text: `ACK ${otherNonce} then ${nonce}`,
+      threadId: "loopback:echo",
+    };
+    const config = {
+      author: "assistant" as const,
+      nonce: "contains" as const,
+      strategy: "contains" as const,
+    };
+
+    expect(matchesInbound(envelope, config, nonce)).toBe(true);
+    expect(
+      matchesInbound(
+        {
+          ...envelope,
+          text: `ACK ${otherNonce} then malformed ${nonce}0`,
+        },
+        config,
+        nonce,
+      ),
+    ).toBe(false);
+  });
+
   it("covers exact, regex, and ignore-nonce branches", () => {
     const baseMessage = {
       author: "assistant" as const,

--- a/test/matcher.test.ts
+++ b/test/matcher.test.ts
@@ -8,6 +8,14 @@ describe("nonce + matcher", () => {
     expect(extractNonce(`hello ${nonce}`)).toBe(nonce);
   });
 
+  it("requires boundaries outside the nonce alphabet", () => {
+    const nonce = "mp-demo-abc-1234abcd";
+
+    expect(extractNonce(`(${nonce})`)).toBe(nonce);
+    expect(extractNonce(`prefix-${nonce}`)).toBeNull();
+    expect(extractNonce(`${nonce}-suffix`)).toBeNull();
+  });
+
   it("matches inbound messages with nonce", () => {
     const nonce = "mp-demo-abc-1234abcd";
     expect(
@@ -52,7 +60,7 @@ describe("nonce + matcher", () => {
       matchesInbound(
         {
           ...envelope,
-          text: `ACK ${otherNonce} then malformed ${nonce}0`,
+          text: `ACK ${otherNonce} then malformed ${nonce}-suffix`,
         },
         config,
         nonce,

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   appendRecordedInbound,
+  createRecordedInboundCursor,
   readRecordedInbound,
   waitForRecordedInbound,
   watchRecordedInbound,
@@ -121,6 +122,44 @@ describe("recorder", () => {
       id: "evt-2",
       text: "match me",
     });
+  });
+
+  it("retains unread events when a cursor returns an earlier match", async () => {
+    const filePath = await createRecorderPath();
+    const cursor = createRecordedInboundCursor();
+    const first = await appendRecordedInbound(filePath, {
+      author: "assistant",
+      id: "first",
+      provider: "slack",
+      sentAt: new Date().toISOString(),
+      text: "first",
+      threadId: "slack:C123",
+    });
+    const second = await appendRecordedInbound(filePath, {
+      author: "assistant",
+      id: "second",
+      provider: "slack",
+      sentAt: new Date().toISOString(),
+      text: "second",
+      threadId: "slack:C123",
+    });
+
+    await expect(
+      waitForRecordedInbound({
+        cursor,
+        filePath,
+        matches: () => true,
+        timeoutMs: 30,
+      }),
+    ).resolves.toEqual(first);
+    await expect(
+      waitForRecordedInbound({
+        cursor,
+        filePath,
+        matches: () => true,
+        timeoutMs: 30,
+      }),
+    ).resolves.toEqual(second);
   });
 
   it("does not collapse distinct records whose fields contain delimiters", async () => {

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -344,6 +344,55 @@ describe("recorder", () => {
     });
   });
 
+  it("preserves the offset when atomic replacement retains recorder history", async () => {
+    const filePath = await createRecorderPath();
+    const now = new Date().toISOString();
+    const history = Array.from(
+      { length: 4097 },
+      (_, index) =>
+        `${JSON.stringify({
+          author: "assistant",
+          id: `history-${index}`,
+          provider: "slack",
+          recordedAt: now,
+          sentAt: now,
+          text: "history",
+          threadId: "slack:C123",
+        })}\n`,
+    ).join("");
+    await writeFile(filePath, history, "utf8");
+
+    const iterator = watchRecordedInbound({
+      filePath,
+      matches: (event) => event.id === "history-4096" || event.id === "after-history-replacement",
+      pollMs: 10,
+    })[Symbol.asyncIterator]();
+    await expect(iterator.next()).resolves.toMatchObject({
+      value: { id: "history-4096" },
+    });
+
+    const replacementPath = `${filePath}.replacement`;
+    await writeFile(
+      replacementPath,
+      `${history}${JSON.stringify({
+        author: "assistant",
+        id: "after-history-replacement",
+        provider: "slack",
+        recordedAt: now,
+        sentAt: now,
+        text: "new tail",
+        threadId: "slack:C123",
+      })}\n`,
+      "utf8",
+    );
+    await rename(replacementPath, filePath);
+
+    await expect(iterator.next()).resolves.toMatchObject({
+      value: { id: "after-history-replacement" },
+    });
+    await iterator.return?.();
+  });
+
   it("resets partial state when a recorder is truncated and regrown past the offset", async () => {
     const filePath = await createRecorderPath();
     const now = new Date().toISOString();

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -1,4 +1,4 @@
-import { appendFile, open, type FileHandle } from "node:fs/promises";
+import { appendFile, open, rename, writeFile, type FileHandle } from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -256,6 +256,99 @@ describe("recorder", () => {
     } finally {
       fileHandlePrototype.read = originalRead;
     }
+  });
+
+  it("resets incremental reads when the recorder is atomically replaced", async () => {
+    const filePath = await createRecorderPath();
+    const now = new Date().toISOString();
+    await writeFile(
+      filePath,
+      `${JSON.stringify({
+        author: "user",
+        id: "before-replacement",
+        provider: "slack",
+        recordedAt: now,
+        sentAt: now,
+        text: "old recorder",
+        threadId: "slack:C999",
+      })}\n`,
+      "utf8",
+    );
+
+    const waitPromise = waitForRecordedInbound({
+      filePath,
+      matches: (event) => event.id === "after-replacement",
+      pollMs: 10,
+      timeoutMs: 500,
+    });
+
+    setTimeout(() => {
+      const replacementPath = `${filePath}.replacement`;
+      void writeFile(
+        replacementPath,
+        `${JSON.stringify({
+          author: "assistant",
+          id: "after-replacement",
+          provider: "slack",
+          recordedAt: now,
+          sentAt: now,
+          text: "new recorder".repeat(20),
+          threadId: "slack:C123",
+        })}\n`,
+        "utf8",
+      ).then(() => rename(replacementPath, filePath));
+    }, 25);
+
+    await expect(waitPromise).resolves.toMatchObject({
+      id: "after-replacement",
+      threadId: "slack:C123",
+    });
+  });
+
+  it("resets partial state when a recorder is truncated and regrown past the offset", async () => {
+    const filePath = await createRecorderPath();
+    const now = new Date().toISOString();
+    await writeFile(
+      filePath,
+      `${JSON.stringify({
+        author: "user",
+        id: "before-truncate",
+        provider: "slack",
+        recordedAt: now,
+        sentAt: now,
+        text: "old recorder",
+        threadId: "slack:C999",
+      })}\n{"id":"stale-partial"`,
+      "utf8",
+    );
+
+    const waitPromise = waitForRecordedInbound({
+      filePath,
+      matches: (event) => event.id === "after-truncate",
+      pollMs: 10,
+      timeoutMs: 500,
+    });
+
+    setTimeout(() => {
+      void writeFile(
+        filePath,
+        `${JSON.stringify({
+          author: "assistant",
+          id: "after-truncate",
+          provider: "slack",
+          recordedAt: now,
+          sentAt: now,
+          text: "regrown recorder".repeat(20),
+          threadId: "slack:C123",
+        })}\n`,
+        "utf8",
+      );
+    }, 25);
+
+    await expect(waitPromise).resolves.toMatchObject({
+      id: "after-truncate",
+      threadId: "slack:C123",
+    });
   });
 
   it("streams new inbound events", async () => {

--- a/test/run.behavior.test.ts
+++ b/test/run.behavior.test.ts
@@ -196,6 +196,120 @@ describe("run behavior", () => {
     expect((await run()).failureKind).toBe("inbound");
   });
 
+  it("keeps waiting through unrelated inbound messages without resending", async () => {
+    let sendCalls = 0;
+    let waitCalls = 0;
+    let unrelated:
+      | {
+          author: "assistant";
+          id: string;
+          provider: string;
+          sentAt: string;
+          text: string;
+          threadId: string;
+        }
+      | undefined;
+    const provider: ProviderAdapter = {
+      id: "mock",
+      platform: "loopback",
+      status: "ready",
+      supports: ["probe", "send", "roundtrip", "agent"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      probe: async () => ({ details: [], healthy: true }),
+      send: async () => {
+        sendCalls += 1;
+        return { accepted: true, messageId: "sent", threadId: "thread" };
+      },
+      waitForInbound: async (context) => {
+        waitCalls += 1;
+        unrelated ??= {
+          author: "assistant",
+          id: "unrelated",
+          provider: "mock",
+          sentAt: new Date().toISOString(),
+          text: "not the requested nonce",
+          threadId: "thread",
+        };
+        if (waitCalls <= 2) {
+          return unrelated;
+        }
+        return {
+          author: "assistant",
+          id: "matched",
+          provider: "mock",
+          sentAt: new Date().toISOString(),
+          text: `ACK ${context.nonce}`,
+          threadId: "thread",
+        };
+      },
+    };
+    const retryingManifest = withAllCapabilities({
+      ...manifest,
+      fixtures: [{ ...manifest.fixtures[0]!, retries: 1, timeoutMs: 100 }],
+    });
+
+    const result = await runFixtureCommand({
+      fixtureId: "fixture",
+      manifest: retryingManifest,
+      manifestPath: "/tmp/crabline.yaml",
+      registry: buildRegistry(provider),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.diagnostics).toContain("matched inbound matched");
+    expect(sendCalls).toBe(1);
+    expect(waitCalls).toBe(3);
+  });
+
+  it("bounds repeated inbound envelopes by the fixture deadline", async () => {
+    let sendCalls = 0;
+    let waitCalls = 0;
+    const repeated = {
+      author: "assistant" as const,
+      id: "repeated",
+      provider: "mock",
+      sentAt: new Date().toISOString(),
+      text: "not the requested nonce",
+      threadId: "thread",
+    };
+    const provider: ProviderAdapter = {
+      id: "mock",
+      platform: "loopback",
+      status: "ready",
+      supports: ["probe", "send", "roundtrip", "agent"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      probe: async () => ({ details: [], healthy: true }),
+      send: async () => {
+        sendCalls += 1;
+        return { accepted: true, messageId: "sent", threadId: "thread" };
+      },
+      waitForInbound: async () => {
+        waitCalls += 1;
+        return repeated;
+      },
+    };
+    const boundedManifest = withAllCapabilities({
+      ...manifest,
+      fixtures: [{ ...manifest.fixtures[0]!, timeoutMs: 35 }],
+    });
+
+    const result = await runFixtureCommand({
+      fixtureId: "fixture",
+      manifest: boundedManifest,
+      manifestPath: "/tmp/crabline.yaml",
+      registry: buildRegistry(provider),
+    });
+
+    expect(result.failureKind).toBe("timeout");
+    expect(sendCalls).toBe(1);
+    expect(waitCalls).toBeGreaterThan(1);
+    expect(waitCalls).toBeLessThan(10);
+  });
+
   it("fails an otherwise successful fixture when cleanup fails", async () => {
     const provider: ProviderAdapter = {
       id: "mock",


### PR DESCRIPTION
## Summary
- preserve recorder continuity across rotation and copied history
- keep recorder-backed waits advancing until the matching inbound event
- enforce canonical nonce tokens and alphabet boundaries

## Verification
- autoreview: gpt-5.6-sol high, clean (0.90)
- Crabbox: `run_13738ba04dda`
- `pnpm verify`: 43 files, 311 tests passed

## Release note
- updated `CHANGELOG.md`