### PR TITLE
fix(providers): enforce lifecycle and config contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Verify production tarballs through their installed npm command shims.
 - Enforce Telegram method and long-poll contracts, hide shared server exception details, and return native Matrix filter and internal errors.
 - Preserve recorder continuity across file replacement, keep fixture waits on one outbound until a match, and require canonical nonce tokens.
+- Enforce provider capability and adapter-config contracts, share native target normalization across lazy adapters, and make WhatsApp cleanup terminal.
 - Serialize WhatsApp Noise frames per session and reject invalid X25519 peer keys.
 - Serialize recorder persistence and reject overlapping OpenClaw smoke artifact runs.
 - Make CLI failures machine-readable, preserve stage-specific failure contracts, validate fixture provider references, redact script commands, and verify production-only tarball installs.

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -32,6 +32,11 @@ Built-in adapters infer `platform` from `adapter`. `platform` is required only
 for `adapter: script`, where Crabline needs to know which OpenClaw channel the
 bridge profile represents.
 
+Each provider selects exactly one adapter and may include only that adapter's
+config block. For example, `adapter: slack` may use `slack:`, but it cannot also
+contain `telegram:` or `script:`. When migrating an older mixed provider entry,
+remove stale config blocks or split them into separate provider ids.
+
 ## Built-In Local Mocks
 
 | Adapter      | Default Webhook Path    | Default Port |
@@ -69,6 +74,32 @@ providers:
 Provider credential fields such as `botToken`, `accessToken`, `baseURL`, or
 `serverUrl` are optional mock metadata. They are not required for local mock
 execution.
+
+## Script Bridge Config
+
+Script providers use only the `script:` config block. Their required `platform`
+labels the OpenClaw channel represented by the bridge; it does not allow the
+matching built-in block such as `slack:` or `telegram:`. Move any behavior from
+those blocks into the commands or command environment when migrating:
+
+```yaml
+providers:
+  slack-openclaw:
+    adapter: script
+    platform: slack
+    capabilities: [probe, send, roundtrip]
+    env:
+      - OPENCLAW_URL
+      - OPENCLAW_TOKEN
+    script:
+      commands:
+        probe: node ./scripts/openclaw-bridge-probe.mjs
+        send: node ./scripts/openclaw-bridge-send.mjs
+        waitForInbound: node ./scripts/openclaw-bridge-wait.mjs
+```
+
+The complete multi-channel script fixture is available in
+`fixtures/examples/openclaw-bridge.yaml`.
 
 ## Local Provider Servers
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -434,6 +434,21 @@ export const ProviderConfigSchema = z
   .superRefine((value, ctx) => {
     const platform = value.platform ?? inferProviderPlatform(value.adapter);
 
+    for (const adapterConfigKey of BUILTIN_ADAPTERS) {
+      if (adapterConfigKey === value.adapter || value[adapterConfigKey] === undefined) {
+        continue;
+      }
+
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          value.adapter === "script"
+            ? `script adapter cannot use ${adapterConfigKey} configuration; configure provider behavior through script.commands`
+            : `${adapterConfigKey} configuration requires adapter=${adapterConfigKey}, got adapter=${value.adapter}`,
+        path: [adapterConfigKey],
+      });
+    }
+
     if (value.adapter === "script" && !value.script) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
@@ -633,6 +648,16 @@ const StrictManifestSchema = z
           code: z.ZodIssueCode.custom,
           message: `fixture ${fixture.id} references unknown provider ${fixture.provider}`,
           path: ["fixtures", index, "provider"],
+        });
+        continue;
+      }
+
+      const provider = manifest.providers[fixture.provider]!;
+      if (!provider.capabilities.includes(fixture.mode)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `fixture ${fixture.id} uses mode ${fixture.mode}, but provider ${fixture.provider} declares capabilities ${provider.capabilities.join(", ") || "(none)"}`,
+          path: ["fixtures", index, "mode"],
         });
       }
     }

--- a/src/providers/builtin/discord.ts
+++ b/src/providers/builtin/discord.ts
@@ -3,15 +3,14 @@ import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
 import { LocalMockProviderAdapter } from "../local-mock.js";
 import type { ProviderAdapter } from "../types.js";
+import { DISCORD_SNOWFLAKE_RULE, getBuiltinTargetCodec } from "../target-normalizers.js";
 import {
   authorFromBotFlag,
-  createNativeTargetCodec,
   genericMockPayloadWithNativeThread,
   isRecord,
   optionalRecord,
   optionalString,
   requireNativeInboundId,
-  type NativeIdRule,
 } from "./native-local-mock.js";
 
 type DiscordEnvironment = Partial<
@@ -46,19 +45,6 @@ function toRecorderPath(providerId: string, config: ProviderConfig): string {
     ? path.resolve(configuredPath)
     : path.resolve(".crabline", "recorders", `${providerId}.jsonl`);
 }
-
-const DISCORD_SNOWFLAKE_RULE: NativeIdRule = {
-  example: "123456789012345678",
-  name: "Discord snowflake id",
-  pattern: /^\d{17,20}$/u,
-};
-
-const DISCORD_CODEC = createNativeTargetCodec({
-  channel: DISCORD_SNOWFLAKE_RULE,
-  channelLabel: "Discord channel_id",
-  thread: DISCORD_SNOWFLAKE_RULE,
-  threadLabel: "Discord thread id",
-});
 
 function normalizeDiscordWebhookPayload(payload: unknown) {
   if (!isRecord(payload)) {
@@ -105,7 +91,7 @@ function normalizeDiscordWebhookPayload(payload: unknown) {
 export class DiscordProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string) {
     super({
-      codec: DISCORD_CODEC,
+      codec: getBuiltinTargetCodec("discord"),
       config,
       id,
       options: {

--- a/src/providers/builtin/feishu.ts
+++ b/src/providers/builtin/feishu.ts
@@ -4,27 +4,18 @@ import type { ProviderConfig } from "../../config/schema.js";
 import { LocalMockProviderAdapter } from "../local-mock.js";
 import type { ProviderAdapter } from "../types.js";
 import {
+  FEISHU_CHAT_ID_RULE,
+  FEISHU_MESSAGE_ID_RULE,
+  getBuiltinTargetCodec,
+} from "../target-normalizers.js";
+import {
   authorFromBotFlag,
-  createNativeTargetCodec,
   genericMockPayloadWithNativeThread,
   isRecord,
   optionalRecord,
   optionalString,
   requireNativeInboundId,
-  type NativeIdRule,
 } from "./native-local-mock.js";
-
-const FEISHU_CHAT_ID_RULE: NativeIdRule = {
-  example: "oc_abc123",
-  name: "Feishu chat_id",
-  pattern: /^oc_[A-Za-z0-9_-]+$/u,
-};
-
-const FEISHU_MESSAGE_ID_RULE: NativeIdRule = {
-  example: "om_abc123",
-  name: "Feishu message_id",
-  pattern: /^om_[A-Za-z0-9_-]+$/u,
-};
 
 export function resolveFeishuAdapterConfig(
   config: ProviderConfig,
@@ -39,12 +30,7 @@ export function resolveFeishuAdapterConfig(
 export class FeishuProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
     super({
-      codec: createNativeTargetCodec({
-        channel: FEISHU_CHAT_ID_RULE,
-        channelLabel: "Feishu chat_id",
-        thread: FEISHU_MESSAGE_ID_RULE,
-        threadLabel: "Feishu message_id",
-      }),
+      codec: getBuiltinTargetCodec("feishu"),
       config,
       id,
       options: {

--- a/src/providers/builtin/googlechat.ts
+++ b/src/providers/builtin/googlechat.ts
@@ -4,27 +4,18 @@ import type { ProviderConfig } from "../../config/schema.js";
 import { LocalMockProviderAdapter } from "../local-mock.js";
 import type { ProviderAdapter } from "../types.js";
 import {
+  getBuiltinTargetCodec,
+  GOOGLE_CHAT_SPACE_RULE,
+  GOOGLE_CHAT_THREAD_RULE,
+} from "../target-normalizers.js";
+import {
   authorFromBotFlag,
-  createNativeTargetCodec,
   genericMockPayloadWithNativeThread,
   isRecord,
   optionalRecord,
   optionalString,
   requireNativeInboundId,
-  type NativeIdRule,
 } from "./native-local-mock.js";
-
-const GOOGLE_CHAT_SPACE_RULE: NativeIdRule = {
-  example: "spaces/AAAABbbbCCC",
-  name: "Google Chat space name",
-  pattern: /^spaces\/[A-Za-z0-9_-]+$/u,
-};
-
-const GOOGLE_CHAT_THREAD_RULE: NativeIdRule = {
-  example: "spaces/AAAABbbbCCC/threads/BBBBccccDDD",
-  name: "Google Chat thread name",
-  pattern: /^spaces\/[A-Za-z0-9_-]+\/threads\/[A-Za-z0-9_-]+$/u,
-};
 
 export function resolveGoogleChatAdapterConfig(
   config: ProviderConfig,
@@ -40,12 +31,7 @@ export function resolveGoogleChatAdapterConfig(
 export class GoogleChatProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
     super({
-      codec: createNativeTargetCodec({
-        channel: GOOGLE_CHAT_SPACE_RULE,
-        channelLabel: "Google Chat space.name",
-        thread: GOOGLE_CHAT_THREAD_RULE,
-        threadLabel: "Google Chat thread.name",
-      }),
+      codec: getBuiltinTargetCodec("googlechat"),
       config,
       id,
       options: {

--- a/src/providers/builtin/imessage.ts
+++ b/src/providers/builtin/imessage.ts
@@ -3,23 +3,15 @@ import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
 import { LocalMockProviderAdapter } from "../local-mock.js";
 import type { ProviderAdapter } from "../types.js";
+import { getBuiltinTargetCodec, IMESSAGE_THREAD_RULE } from "../target-normalizers.js";
 import {
   authorFromBotFlag,
-  createNativeTargetCodec,
   genericMockPayloadWithNativeThread,
   isRecord,
   optionalRecord,
   optionalString,
   requireNativeInboundId,
-  type NativeIdRule,
 } from "./native-local-mock.js";
-
-const IMESSAGE_THREAD_RULE: NativeIdRule = {
-  example: "+15551234567, user@example.com, or iMessage;-;chat-guid",
-  name: "iMessage recipient or chat GUID",
-  pattern:
-    /^(?:\+[1-9]\d{6,14}|[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}|(?:iMessage|SMS);[+-];.+)$/u,
-};
 
 export function resolveIMessageAdapterConfig(
   config: ProviderConfig,
@@ -35,10 +27,7 @@ export function resolveIMessageAdapterConfig(
 export class IMessageProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
     super({
-      codec: createNativeTargetCodec({
-        channel: IMESSAGE_THREAD_RULE,
-        channelLabel: "iMessage recipient or chat GUID",
-      }),
+      codec: getBuiltinTargetCodec("imessage"),
       config,
       id,
       options: {

--- a/src/providers/builtin/loopback.ts
+++ b/src/providers/builtin/loopback.ts
@@ -1,6 +1,7 @@
 import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
-import { createGenericLocalMockTargetCodec, LocalMockProviderAdapter } from "../local-mock.js";
+import { LocalMockProviderAdapter } from "../local-mock.js";
+import { getBuiltinTargetCodec } from "../target-normalizers.js";
 import type { LoopbackMessage, LoopbackRawMessage, ProviderAdapter } from "../types.js";
 
 type ThreadAddress = {
@@ -242,7 +243,7 @@ export class LoopbackChatAdapter {
 export class LoopbackProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string) {
     super({
-      codec: createGenericLocalMockTargetCodec("loopback"),
+      codec: getBuiltinTargetCodec("loopback"),
       config,
       id,
       options: {

--- a/src/providers/builtin/matrix.ts
+++ b/src/providers/builtin/matrix.ts
@@ -4,27 +4,18 @@ import type { ProviderConfig } from "../../config/schema.js";
 import { LocalMockProviderAdapter } from "../local-mock.js";
 import type { ProviderAdapter } from "../types.js";
 import {
+  getBuiltinTargetCodec,
+  MATRIX_EVENT_ID_RULE,
+  MATRIX_ROOM_ID_RULE,
+} from "../target-normalizers.js";
+import {
   authorFromBotFlag,
-  createNativeTargetCodec,
   genericMockPayloadWithNativeThread,
   isRecord,
   optionalRecord,
   optionalString,
   requireNativeInboundId,
-  type NativeIdRule,
 } from "./native-local-mock.js";
-
-const MATRIX_ROOM_ID_RULE: NativeIdRule = {
-  example: "!abcdef:matrix.org",
-  name: "Matrix room id",
-  pattern: /^![^:\s]+:[^\s]+$/u,
-};
-
-const MATRIX_EVENT_ID_RULE: NativeIdRule = {
-  example: "$eventid:matrix.org",
-  name: "Matrix event id",
-  pattern: /^\$[^\s]+(?::[^\s]+)?$/u,
-};
 
 export function resolveMatrixAdapterConfig(
   config: ProviderConfig,
@@ -46,12 +37,7 @@ export function resolveMatrixAdapterConfig(
 export class MatrixProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
     super({
-      codec: createNativeTargetCodec({
-        channel: MATRIX_ROOM_ID_RULE,
-        channelLabel: "Matrix room_id",
-        thread: MATRIX_EVENT_ID_RULE,
-        threadLabel: "Matrix event_id",
-      }),
+      codec: getBuiltinTargetCodec("matrix"),
       config,
       id,
       options: {

--- a/src/providers/builtin/mattermost.ts
+++ b/src/providers/builtin/mattermost.ts
@@ -3,22 +3,15 @@ import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
 import { LocalMockProviderAdapter } from "../local-mock.js";
 import type { ProviderAdapter } from "../types.js";
+import { getBuiltinTargetCodec, MATTERMOST_ID_RULE } from "../target-normalizers.js";
 import {
   authorFromBotFlag,
-  createNativeTargetCodec,
   genericMockPayloadWithNativeThread,
   isRecord,
   optionalRecord,
   optionalString,
   requireNativeInboundId,
-  type NativeIdRule,
 } from "./native-local-mock.js";
-
-const MATTERMOST_ID_RULE: NativeIdRule = {
-  example: "abcdefghijklmnopqrstuvwx12",
-  name: "Mattermost id",
-  pattern: /^[a-z0-9]{26}$/u,
-};
 
 export function resolveMattermostAdapterConfig(
   config: ProviderConfig,
@@ -34,10 +27,7 @@ export function resolveMattermostAdapterConfig(
 export class MattermostProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
     super({
-      codec: createNativeTargetCodec({
-        channel: MATTERMOST_ID_RULE,
-        channelLabel: "Mattermost channel_id",
-      }),
+      codec: getBuiltinTargetCodec("mattermost"),
       config,
       id,
       options: {

--- a/src/providers/builtin/msteams.ts
+++ b/src/providers/builtin/msteams.ts
@@ -3,22 +3,15 @@ import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
 import { LocalMockProviderAdapter } from "../local-mock.js";
 import type { ProviderAdapter } from "../types.js";
+import { getBuiltinTargetCodec, MSTEAMS_CONVERSATION_ID_RULE } from "../target-normalizers.js";
 import {
   authorFromBotFlag,
-  createNativeTargetCodec,
   genericMockPayloadWithNativeThread,
   isRecord,
   optionalRecord,
   optionalString,
   requireNativeInboundId,
-  type NativeIdRule,
 } from "./native-local-mock.js";
-
-const MSTEAMS_CONVERSATION_ID_RULE: NativeIdRule = {
-  example: "a:opaque-conversation-id",
-  name: "Microsoft Teams conversation id",
-  pattern: /^.+$/su,
-};
 
 export function resolveMsTeamsAdapterConfig(
   config: ProviderConfig,
@@ -36,10 +29,7 @@ export function resolveMsTeamsAdapterConfig(
 export class MsTeamsProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
     super({
-      codec: createNativeTargetCodec({
-        channel: MSTEAMS_CONVERSATION_ID_RULE,
-        channelLabel: "Microsoft Teams conversation.id",
-      }),
+      codec: getBuiltinTargetCodec("msteams"),
       config,
       id,
       options: {

--- a/src/providers/builtin/native-local-mock.ts
+++ b/src/providers/builtin/native-local-mock.ts
@@ -1,7 +1,6 @@
 import { CrablineError } from "../../core/errors.js";
-import type { LocalMockTargetCodec } from "../local-mock.js";
 import type { NativeIdRule } from "../native-ids.js";
-import type { InboundEnvelope, NormalizedTarget, ProviderContext } from "../types.js";
+import type { InboundEnvelope } from "../types.js";
 
 export type { NativeIdRule } from "../native-ids.js";
 
@@ -38,15 +37,6 @@ export function normalizeAuthor(value: unknown): "assistant" | "system" | "user"
   return value === "assistant" || value === "system" || value === "user" ? value : undefined;
 }
 
-export function requireNativeId(value: string, rule: NativeIdRule, label: string): string {
-  if (!rule.pattern.test(value)) {
-    throw new CrablineError(`${label} must be a native ${rule.name} such as ${rule.example}.`, {
-      kind: "config",
-    });
-  }
-  return value;
-}
-
 export function requireNativeInboundId(value: string, rule: NativeIdRule, label: string): string {
   if (!rule.pattern.test(value)) {
     throw new CrablineError(`${label} must be a native ${rule.name} such as ${rule.example}.`, {
@@ -54,40 +44,6 @@ export function requireNativeInboundId(value: string, rule: NativeIdRule, label:
     });
   }
   return value;
-}
-
-export function createNativeTargetCodec(options: {
-  channel: NativeIdRule;
-  channelLabel?: string | undefined;
-  thread?: NativeIdRule | undefined;
-  threadLabel?: string | undefined;
-}): LocalMockTargetCodec {
-  const channelLabel = options.channelLabel ?? "channelId";
-  const threadLabel = options.threadLabel ?? "threadId";
-  const threadRule = options.thread ?? options.channel;
-
-  return {
-    normalize(target: ProviderContext["fixture"]["target"]): NormalizedTarget {
-      const channelId = requireNativeId(
-        target.channelId ?? target.id,
-        options.channel,
-        channelLabel,
-      );
-      const normalized: NormalizedTarget = {
-        channelId,
-        id: target.id,
-        metadata: target.metadata,
-      };
-      if (target.threadId) {
-        normalized.threadId = requireNativeId(target.threadId, threadRule, threadLabel);
-      }
-      return normalized;
-    },
-    resolveThreadId(target) {
-      const normalized = this.normalize(target);
-      return normalized.threadId ?? normalized.channelId ?? normalized.id;
-    },
-  };
 }
 
 export function genericMockPayloadWithNativeThread(params: {

--- a/src/providers/builtin/slack.ts
+++ b/src/providers/builtin/slack.ts
@@ -1,38 +1,15 @@
 import path from "node:path";
 import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
-import { LocalMockProviderAdapter, type LocalMockTargetCodec } from "../local-mock.js";
-import type {
-  InboundEnvelope,
-  NormalizedTarget,
-  ProviderAdapter,
-  ProviderContext,
-} from "../types.js";
+import { LocalMockProviderAdapter } from "../local-mock.js";
+import { SLACK_CHANNEL_ID_RULE, SLACK_TS_RULE } from "../slack-ids.js";
+import { getBuiltinTargetCodec } from "../target-normalizers.js";
+import type { InboundEnvelope, ProviderAdapter } from "../types.js";
 import {
   genericMockPayloadWithNativeThread,
   isRecord,
   requireNativeInboundId,
 } from "./native-local-mock.js";
-import { SLACK_CHANNEL_ID_RULE, SLACK_TS_RULE } from "../slack-ids.js";
-
-function requireSlackChannelId(value: string, label: string): string {
-  if (!SLACK_CHANNEL_ID_RULE.pattern.test(value)) {
-    throw new CrablineError(
-      `Slack ${label} must be a native Slack conversation id such as C1234567890, G1234567890, or D1234567890.`,
-      { kind: "config" },
-    );
-  }
-  return value;
-}
-
-function requireSlackThreadTs(value: string, label: string): string {
-  if (!SLACK_TS_RULE.pattern.test(value)) {
-    throw new CrablineError(`Slack ${label} must be a Slack timestamp such as 1700000000.000100.`, {
-      kind: "config",
-    });
-  }
-  return value;
-}
 
 function slackAuthorFromEvent(event: Record<string, unknown>): InboundEnvelope["author"] {
   if (typeof event.bot_id === "string" || event.subtype === "bot_message") {
@@ -78,29 +55,10 @@ function normalizeSlackEventsPayload(payload: unknown) {
   });
 }
 
-const SLACK_CODEC: LocalMockTargetCodec = {
-  normalize(target: ProviderContext["fixture"]["target"]): NormalizedTarget {
-    const channelId = requireSlackChannelId(target.channelId ?? target.id, "channelId");
-    const normalized: NormalizedTarget = {
-      channelId,
-      id: target.id,
-      metadata: target.metadata,
-    };
-    if (target.threadId) {
-      normalized.threadId = requireSlackThreadTs(target.threadId, "threadId");
-    }
-    return normalized;
-  },
-  resolveThreadId(target) {
-    const normalized = this.normalize(target);
-    return normalized.threadId ?? normalized.channelId ?? normalized.id;
-  },
-};
-
 export class SlackProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
     super({
-      codec: SLACK_CODEC,
+      codec: getBuiltinTargetCodec("slack"),
       config,
       id,
       options: {

--- a/src/providers/builtin/telegram.ts
+++ b/src/providers/builtin/telegram.ts
@@ -2,18 +2,21 @@ import path from "node:path";
 import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
 import { LocalMockProviderAdapter } from "../local-mock.js";
+import {
+  getBuiltinTargetCodec,
+  parseCanonicalTelegramTopic,
+  TELEGRAM_CHAT_ID_RULE,
+  TELEGRAM_MESSAGE_THREAD_ID_RULE,
+} from "../target-normalizers.js";
 import type { ProviderAdapter } from "../types.js";
 import {
   authorFromBotFlag,
-  createNativeTargetCodec,
   genericMockPayloadWithNativeThread,
   isRecord,
   optionalRecord,
   optionalString,
   optionalStringish,
-  requireNativeId,
   requireNativeInboundId,
-  type NativeIdRule,
 } from "./native-local-mock.js";
 
 type TelegramEnvironment = Partial<
@@ -47,82 +50,6 @@ function toRecorderPath(providerId: string, config: ProviderConfig): string {
   return configuredPath
     ? path.resolve(configuredPath)
     : path.resolve(".crabline", "recorders", `${providerId}.jsonl`);
-}
-
-const TELEGRAM_CHAT_ID_RULE: NativeIdRule = {
-  example: "-1001234567890 or @channelusername",
-  name: "Telegram chat id",
-  pattern: /^(?:-?\d+|@[A-Za-z][A-Za-z0-9_]{4,31})$/u,
-};
-
-const TELEGRAM_MESSAGE_THREAD_ID_RULE: NativeIdRule = {
-  example: "42",
-  name: "Telegram message_thread_id",
-  pattern: /^\d+$/u,
-};
-
-const TELEGRAM_BASE_CODEC = createNativeTargetCodec({
-  channel: TELEGRAM_CHAT_ID_RULE,
-  channelLabel: "Telegram chat_id",
-  thread: TELEGRAM_MESSAGE_THREAD_ID_RULE,
-  threadLabel: "Telegram message_thread_id",
-});
-
-const TELEGRAM_CODEC = {
-  normalize(target: Parameters<typeof TELEGRAM_BASE_CODEC.normalize>[0]) {
-    const canonicalTopic = target.threadId
-      ? parseCanonicalTelegramTopic(target.threadId)
-      : undefined;
-    const targetChatId = target.channelId ?? target.id;
-    if (
-      canonicalTopic &&
-      requireNativeId(targetChatId, TELEGRAM_CHAT_ID_RULE, "Telegram chat_id") !==
-        canonicalTopic.chatId
-    ) {
-      throw new CrablineError("Telegram canonical topic chat_id must match the target chat_id.", {
-        kind: "config",
-      });
-    }
-    const normalized = TELEGRAM_BASE_CODEC.normalize({
-      ...target,
-      ...(canonicalTopic ? { channelId: canonicalTopic.chatId } : {}),
-      threadId: undefined,
-    });
-    if (!target.threadId) {
-      return normalized;
-    }
-    const topicId = requireNativeId(
-      canonicalTopic?.topicId ?? target.threadId,
-      TELEGRAM_MESSAGE_THREAD_ID_RULE,
-      "Telegram message_thread_id",
-    );
-    return {
-      ...normalized,
-      threadId: `${normalized.channelId}:${topicId}`,
-    };
-  },
-  resolveThreadId(target: Parameters<typeof TELEGRAM_BASE_CODEC.resolveThreadId>[0]) {
-    const normalized = this.normalize(target);
-    return normalized.threadId ?? normalized.channelId ?? normalized.id;
-  },
-};
-
-function parseCanonicalTelegramTopic(
-  value: string,
-): { chatId: string; topicId: string } | undefined {
-  const separator = value.lastIndexOf(":");
-  if (separator <= 0) {
-    return undefined;
-  }
-  const chatId = value.slice(0, separator);
-  const topicId = value.slice(separator + 1);
-  if (
-    !TELEGRAM_CHAT_ID_RULE.pattern.test(chatId) ||
-    !TELEGRAM_MESSAGE_THREAD_ID_RULE.pattern.test(topicId)
-  ) {
-    return undefined;
-  }
-  return { chatId, topicId };
 }
 
 function normalizeGenericTelegramPayload(payload: Record<string, unknown>) {
@@ -223,7 +150,7 @@ export function normalizeTelegramWebhookPayload(payload: unknown) {
 export class TelegramProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string) {
     super({
-      codec: TELEGRAM_CODEC,
+      codec: getBuiltinTargetCodec("telegram"),
       config,
       id,
       options: {

--- a/src/providers/builtin/whatsapp.ts
+++ b/src/providers/builtin/whatsapp.ts
@@ -72,6 +72,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
   readonly #webhook: LocalMockWebhookConfig | undefined;
   #cleanedUp = false;
   #cleanupPromise: Promise<void> | null = null;
+  readonly #inFlightSends = new Set<Promise<SendResult>>();
   #server: StartedWebhookServer | null = null;
   #serverStarting: Promise<StartedWebhookServer> | null = null;
 
@@ -124,7 +125,13 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
     if (this.#cleanedUp) {
       throw this.#cleanedUpError();
     }
-    return await super.send(context);
+    const sending = super.send(context);
+    this.#inFlightSends.add(sending);
+    try {
+      return await sending;
+    } finally {
+      this.#inFlightSends.delete(sending);
+    }
   }
 
   override async waitForInbound(context: WaitContext): Promise<InboundEnvelope | null> {
@@ -161,6 +168,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
   override async cleanup(): Promise<void> {
     this.#cleanedUp = true;
     this.#cleanupPromise ??= (async () => {
+      await Promise.allSettled(this.#inFlightSends);
       await this.#closeWebhookServer();
       await super.cleanup();
     })();

--- a/src/providers/builtin/whatsapp.ts
+++ b/src/providers/builtin/whatsapp.ts
@@ -73,6 +73,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
   #cleanedUp = false;
   #cleanupPromise: Promise<void> | null = null;
   readonly #inFlightSends = new Set<Promise<SendResult>>();
+  readonly #inFlightWebhookRequests = new Set<Promise<Response>>();
   #server: StartedWebhookServer | null = null;
   #serverStarting: Promise<StartedWebhookServer> | null = null;
 
@@ -159,6 +160,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
       matches: (entry) =>
         entry.provider === this.id &&
         isAddressInChannel(entry.threadId, target.threadId ?? target.channelId ?? target.id),
+      signal: context.signal,
       since: context.since,
     })) {
       yield event;
@@ -168,11 +170,26 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
   override async cleanup(): Promise<void> {
     this.#cleanedUp = true;
     this.#cleanupPromise ??= (async () => {
-      await Promise.allSettled(this.#inFlightSends);
-      await this.#closeWebhookServer();
+      const closingServer = this.#closeWebhookServer();
+      void closingServer.catch(() => undefined);
+      await Promise.allSettled([...this.#inFlightSends, ...this.#inFlightWebhookRequests]);
+      await closingServer;
       await super.cleanup();
     })();
     await this.#cleanupPromise;
+  }
+
+  #handleWebhookRequest(request: Request): Promise<Response> {
+    if (this.#cleanedUp) {
+      return Promise.resolve(this.#cleanedUpResponse());
+    }
+    const handling = this.#handleWebhook(request);
+    this.#inFlightWebhookRequests.add(handling);
+    void handling.then(
+      () => this.#inFlightWebhookRequests.delete(handling),
+      () => this.#inFlightWebhookRequests.delete(handling),
+    );
+    return handling;
   }
 
   async #handleWebhook(request: Request): Promise<Response> {
@@ -235,7 +252,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
       let server: StartedWebhookServer;
       try {
         server = await startWebhookServer({
-          handle: (request) => this.#handleWebhook(request),
+          handle: (request) => this.#handleWebhookRequest(request),
           host,
           path: webhookPath,
           port,
@@ -286,6 +303,10 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
 
   #cleanedUpError(): CrablineError {
     return new CrablineError(`Provider "${this.id}" has been cleaned up.`, { kind: "config" });
+  }
+
+  #cleanedUpResponse(): Response {
+    return new Response(`Provider "${this.id}" has been cleaned up.`, { status: 503 });
   }
 }
 

--- a/src/providers/builtin/whatsapp.ts
+++ b/src/providers/builtin/whatsapp.ts
@@ -68,8 +68,9 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
   readonly #publicUrl: string | undefined;
   readonly #recorderPath: string;
   readonly #webhook: LocalMockWebhookConfig | undefined;
+  #cleanedUp = false;
+  #cleanupPromise: Promise<void> | null = null;
   #server: StartedWebhookServer | null = null;
-  #serverClosing: Promise<void> | null = null;
   #serverStarting: Promise<StartedWebhookServer> | null = null;
 
   constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
@@ -149,20 +150,12 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
   }
 
   override async cleanup(): Promise<void> {
-    if (this.#serverClosing) {
-      await this.#serverClosing;
-    } else {
-      const closing = this.#closeWebhookServer();
-      this.#serverClosing = closing;
-      try {
-        await closing;
-      } finally {
-        if (this.#serverClosing === closing) {
-          this.#serverClosing = null;
-        }
-      }
-    }
-    await super.cleanup();
+    this.#cleanedUp = true;
+    this.#cleanupPromise ??= (async () => {
+      await this.#closeWebhookServer();
+      await super.cleanup();
+    })();
+    await this.#cleanupPromise;
   }
 
   async #handleWebhook(request: Request): Promise<Response> {
@@ -208,8 +201,8 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
   }
 
   async #ensureWebhookServer(): Promise<StartedWebhookServer> {
-    if (this.#serverClosing) {
-      await this.#serverClosing;
+    if (this.#cleanedUp) {
+      throw this.#cleanedUpError();
     }
     if (this.#server) {
       return this.#server;
@@ -221,9 +214,10 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
     const host = this.#webhook?.host ?? DEFAULT_WHATSAPP_WEBHOOK.host;
     const port = this.#webhook?.port ?? DEFAULT_WHATSAPP_WEBHOOK.port;
     const webhookPath = this.#webhook?.path ?? DEFAULT_WHATSAPP_WEBHOOK.path;
-    const starting = (async () => {
+    const starting = (async (): Promise<StartedWebhookServer> => {
+      let server: StartedWebhookServer;
       try {
-        return await startWebhookServer({
+        server = await startWebhookServer({
           handle: (request) => this.#handleWebhook(request),
           host,
           path: webhookPath,
@@ -235,13 +229,17 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
           { cause: error, kind: "connectivity" },
         );
       }
+
+      this.#server = server;
+      if (this.#cleanedUp) {
+        throw this.#cleanedUpError();
+      }
+      return server;
     })();
     this.#serverStarting = starting;
 
     try {
-      const server = await starting;
-      this.#server = server;
-      return server;
+      return await starting;
     } finally {
       if (this.#serverStarting === starting) {
         this.#serverStarting = null;
@@ -250,14 +248,15 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
   }
 
   async #closeWebhookServer(): Promise<void> {
-    let server = this.#server;
-    if (!server && this.#serverStarting) {
+    const starting = this.#serverStarting;
+    if (starting) {
       try {
-        server = await this.#serverStarting;
+        await starting;
       } catch {
-        return;
+        // A failed startup has no listener; a cleanup race publishes one below.
       }
     }
+    const server = this.#server;
     if (!server) {
       return;
     }
@@ -266,6 +265,10 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
       this.#server = null;
     }
     await server.close();
+  }
+
+  #cleanedUpError(): CrablineError {
+    return new CrablineError(`Provider "${this.id}" has been cleaned up.`, { kind: "config" });
   }
 }
 

--- a/src/providers/builtin/whatsapp.ts
+++ b/src/providers/builtin/whatsapp.ts
@@ -16,17 +16,16 @@ import type {
   WaitContext,
   WatchContext,
 } from "../types.js";
+import { getBuiltinTargetCodec, WHATSAPP_WA_ID_RULE } from "../target-normalizers.js";
 import { startWebhookServer, type StartedWebhookServer } from "../webhook-server.js";
 import {
   authorFromBotFlag,
-  createNativeTargetCodec,
   genericMockPayloadWithNativeThread,
   isRecord,
   normalizeAuthor,
   optionalRecord,
   optionalString,
   requireNativeInboundId,
-  type NativeIdRule,
 } from "./native-local-mock.js";
 
 type NormalizedWhatsAppWebhookMessage = {
@@ -44,12 +43,6 @@ type NormalizedWhatsAppWebhookMessage = {
   raw?: unknown;
   text?: string;
   threadId?: string;
-};
-
-const WHATSAPP_WA_ID_RULE: NativeIdRule = {
-  example: "15551234567",
-  name: "WhatsApp wa_id",
-  pattern: /^\d{7,15}$/u,
 };
 
 const DEFAULT_WHATSAPP_WEBHOOK = {
@@ -81,10 +74,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
 
   constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
     super({
-      codec: createNativeTargetCodec({
-        channel: WHATSAPP_WA_ID_RULE,
-        channelLabel: "WhatsApp wa_id",
-      }),
+      codec: getBuiltinTargetCodec("whatsapp"),
       config,
       id,
       options: {

--- a/src/providers/builtin/whatsapp.ts
+++ b/src/providers/builtin/whatsapp.ts
@@ -71,10 +71,12 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
   readonly #recorderPath: string;
   readonly #webhook: LocalMockWebhookConfig | undefined;
   #cleanedUp = false;
+  #cleanupBegun = false;
   #cleanupPromise: Promise<void> | null = null;
   readonly #inFlightSends = new Set<Promise<SendResult>>();
   readonly #inFlightWebhookRequests = new Set<Promise<Response>>();
   #server: StartedWebhookServer | null = null;
+  #serverClosing: Promise<void> | null = null;
   #serverStarting: Promise<StartedWebhookServer> | null = null;
 
   constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
@@ -167,20 +169,28 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
     }
   }
 
+  beginCleanup(): void {
+    if (this.#cleanupBegun) {
+      return;
+    }
+    this.#cleanupBegun = true;
+    this.#serverClosing = this.#closeWebhookServer();
+    void this.#serverClosing.catch(() => undefined);
+  }
+
   override async cleanup(): Promise<void> {
+    this.beginCleanup();
     this.#cleanedUp = true;
     this.#cleanupPromise ??= (async () => {
-      const closingServer = this.#closeWebhookServer();
-      void closingServer.catch(() => undefined);
       await Promise.allSettled([...this.#inFlightSends, ...this.#inFlightWebhookRequests]);
-      await closingServer;
+      await this.#serverClosing;
       await super.cleanup();
     })();
     await this.#cleanupPromise;
   }
 
   #handleWebhookRequest(request: Request): Promise<Response> {
-    if (this.#cleanedUp) {
+    if (this.#cleanupBegun) {
       return Promise.resolve(this.#cleanedUpResponse());
     }
     const handling = this.#handleWebhook(request);
@@ -235,7 +245,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
   }
 
   async #ensureWebhookServer(): Promise<StartedWebhookServer> {
-    if (this.#cleanedUp) {
+    if (this.#cleanupBegun) {
       throw this.#cleanedUpError();
     }
     if (this.#server) {
@@ -265,7 +275,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
       }
 
       this.#server = server;
-      if (this.#cleanedUp) {
+      if (this.#cleanupBegun) {
         throw this.#cleanedUpError();
       }
       return server;

--- a/src/providers/builtin/whatsapp.ts
+++ b/src/providers/builtin/whatsapp.ts
@@ -13,6 +13,8 @@ import type {
   ProbeResult,
   ProviderAdapter,
   ProviderContext,
+  SendContext,
+  SendResult,
   WaitContext,
   WatchContext,
 } from "../types.js";
@@ -116,6 +118,13 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
       details.push(`dm reachable ${target.id}`);
     }
     return { details, healthy: true };
+  }
+
+  override async send(context: SendContext): Promise<SendResult> {
+    if (this.#cleanedUp) {
+      throw this.#cleanedUpError();
+    }
+    return await super.send(context);
   }
 
   override async waitForInbound(context: WaitContext): Promise<InboundEnvelope | null> {

--- a/src/providers/builtin/zalo.ts
+++ b/src/providers/builtin/zalo.ts
@@ -3,22 +3,15 @@ import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
 import { LocalMockProviderAdapter } from "../local-mock.js";
 import type { ProviderAdapter } from "../types.js";
+import { getBuiltinTargetCodec, ZALO_ID_RULE } from "../target-normalizers.js";
 import {
   authorFromBotFlag,
-  createNativeTargetCodec,
   genericMockPayloadWithNativeThread,
   isRecord,
   optionalRecord,
   optionalString,
   requireNativeInboundId,
-  type NativeIdRule,
 } from "./native-local-mock.js";
-
-const ZALO_ID_RULE: NativeIdRule = {
-  example: "123456789012345678",
-  name: "Zalo user or OA id",
-  pattern: /^\d{6,20}$/u,
-};
 
 export function resolveZaloAdapterConfig(
   config: ProviderConfig,
@@ -33,10 +26,7 @@ export function resolveZaloAdapterConfig(
 export class ZaloProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
     super({
-      codec: createNativeTargetCodec({
-        channel: ZALO_ID_RULE,
-        channelLabel: "Zalo user_id or oa_id",
-      }),
+      codec: getBuiltinTargetCodec("zalo"),
       config,
       id,
       options: {

--- a/src/providers/local-mock.ts
+++ b/src/providers/local-mock.ts
@@ -238,6 +238,7 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
       matches: (entry) =>
         entry.provider === this.id &&
         isAddressInChannel(entry.threadId, target.threadId ?? target.channelId),
+      signal: context.signal,
       since: context.since,
     })) {
       yield event;

--- a/src/providers/local-mock.ts
+++ b/src/providers/local-mock.ts
@@ -21,6 +21,8 @@ import type {
 } from "./types.js";
 import { startWebhookServer, type StartedWebhookServer } from "./webhook-server.js";
 
+export { createGenericLocalMockTargetCodec } from "./target-normalizers.js";
+
 export type LocalMockWebhookConfig = {
   host?: string;
   path?: string;
@@ -42,37 +44,6 @@ export type LocalMockTargetCodec = {
   normalize(target: ProviderContext["fixture"]["target"]): NormalizedTarget;
   resolveThreadId(target: ProviderContext["fixture"]["target"]): string;
 };
-
-export function createGenericLocalMockTargetCodec(
-  platform: ProviderPlatform,
-): LocalMockTargetCodec {
-  const prefix = `${platform}:`;
-  const encode = (value: string) => (value.startsWith(prefix) ? value : `${prefix}${value}`);
-  return {
-    normalize(target): NormalizedTarget {
-      const normalized: NormalizedTarget = {
-        id: target.id,
-        metadata: target.metadata,
-      };
-      if (target.channelId) {
-        normalized.channelId = encode(target.channelId);
-      } else if (!target.threadId) {
-        normalized.channelId = encode(target.id);
-      }
-      if (target.threadId) {
-        normalized.channelId ??= encode(target.id);
-        normalized.threadId = target.threadId.startsWith(prefix)
-          ? target.threadId
-          : `${normalized.channelId}:${target.threadId}`;
-      }
-      return normalized;
-    },
-    resolveThreadId(target) {
-      const normalized = this.normalize(target);
-      return normalized.threadId ?? normalized.channelId ?? encode(normalized.id);
-    },
-  };
-}
 
 type MockWebhookPayload = {
   author?: "assistant" | "system" | "user";
@@ -135,7 +106,7 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
   readonly id;
   readonly platform;
   readonly status = "ready" as const;
-  readonly supports = ["probe", "send", "roundtrip", "agent"] as const;
+  readonly supports: ProviderAdapter["supports"];
 
   readonly #codec: LocalMockTargetCodec;
   readonly #config: ProviderConfig;
@@ -155,6 +126,7 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
   }) {
     this.id = params.id;
     this.platform = params.options.platform;
+    this.supports = [...params.config.capabilities];
     this.#codec = params.codec;
     this.#config = params.config;
     this.#options = params.options;

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -6,8 +6,19 @@ export type RecordedInboundEnvelope = InboundEnvelope & {
   recordedAt: string;
 };
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    const done = () => {
+      clearTimeout(timeout);
+      signal?.removeEventListener("abort", done);
+      resolve();
+    };
+    const timeout = setTimeout(done, ms);
+    signal?.addEventListener("abort", done, { once: true });
+  });
 }
 
 function toRecordKey(event: InboundEnvelope): string {
@@ -264,14 +275,21 @@ export async function* watchRecordedInbound(params: {
   filePath: string;
   matches: (event: RecordedInboundEnvelope) => boolean;
   pollMs?: number;
+  signal?: AbortSignal | undefined;
   since?: string | undefined;
 }): AsyncIterable<RecordedInboundEnvelope> {
   const state = createIncrementalReadState();
   const seen = new Set<string>();
 
-  while (true) {
+  while (!params.signal?.aborted) {
     const events = await readRecordedInboundAppend(params.filePath, state);
+    if (params.signal?.aborted) {
+      return;
+    }
     for (const event of events) {
+      if (params.signal?.aborted) {
+        return;
+      }
       const key = toRecordKey(event);
       if (seen.has(key)) {
         continue;
@@ -293,6 +311,6 @@ export async function* watchRecordedInbound(params: {
       }
     }
 
-    await sleep(params.pollMs ?? 250);
+    await sleep(params.pollMs ?? 250, params.signal);
   }
 }

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -22,6 +22,10 @@ export type Registry = {
 
 type LazyAdapterId = BuiltinProviderAdapterId;
 type ProviderFactory = () => Promise<ProviderAdapter>;
+type ActiveWatch = {
+  abort(): void;
+  close(): Promise<void>;
+};
 type LazyProviderFactory = (params: {
   config: ProviderConfig;
   providerId: string;
@@ -109,6 +113,8 @@ class LazyProviderAdapter implements ProviderAdapter {
   readonly #adapterName: string;
   readonly #factory: ProviderFactory;
   readonly #normalizeTarget: ProviderAdapter["normalizeTarget"];
+  readonly #activeWatches = new Set<ActiveWatch>();
+  readonly #inFlightOperations = new Set<Promise<unknown>>();
   #cleanedUp = false;
   #cleanupPromise: Promise<void> | null = null;
   #providerPromise: Promise<ProviderAdapter> | null = null;
@@ -136,25 +142,111 @@ class LazyProviderAdapter implements ProviderAdapter {
     return this.#normalizeTarget(target);
   }
 
-  async probe(context: ProviderContext): Promise<ProbeResult> {
-    return await (await this.#provider()).probe(context);
+  probe(context: ProviderContext): Promise<ProbeResult> {
+    return this.#runOperation(async () => await (await this.#provider()).probe(context));
   }
 
-  async send(context: SendContext): Promise<SendResult> {
-    return await (await this.#provider()).send(context);
+  send(context: SendContext): Promise<SendResult> {
+    return this.#runOperation(async () => await (await this.#provider()).send(context));
   }
 
-  async waitForInbound(context: WaitContext): Promise<InboundEnvelope | null> {
-    return await (await this.#provider()).waitForInbound(context);
+  waitForInbound(context: WaitContext): Promise<InboundEnvelope | null> {
+    return this.#runOperation(async () => await (await this.#provider()).waitForInbound(context));
   }
 
   watch(context: WatchContext): AsyncIterable<InboundEnvelope> {
-    return this.#watch(context);
+    if (this.#cleanedUp) {
+      const error = this.#cleanedUpError();
+      return {
+        [Symbol.asyncIterator](): AsyncIterator<InboundEnvelope> {
+          return {
+            next: () => Promise.reject(error),
+          };
+        },
+      };
+    }
+    const controller = new AbortController();
+    const abortFromContext = () => controller.abort(context.signal?.reason);
+    if (context.signal?.aborted) {
+      abortFromContext();
+    } else {
+      context.signal?.addEventListener("abort", abortFromContext, { once: true });
+    }
+    const source = this.#watch(context, controller.signal)[Symbol.asyncIterator]();
+    let activeWatch: ActiveWatch;
+    let closed = false;
+    let closePromise: Promise<IteratorResult<InboundEnvelope>> | null = null;
+    const finish = () => {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      context.signal?.removeEventListener("abort", abortFromContext);
+      this.#activeWatches.delete(activeWatch);
+    };
+    const close = () => {
+      closePromise ??= (async () => {
+        controller.abort();
+        try {
+          return source.return
+            ? await source.return()
+            : { done: true as const, value: undefined as never };
+        } finally {
+          finish();
+        }
+      })();
+      return closePromise;
+    };
+    const iterator: AsyncIterableIterator<InboundEnvelope> = {
+      async next() {
+        try {
+          const result = await source.next();
+          if (result.done) {
+            finish();
+          }
+          return result;
+        } catch (error) {
+          finish();
+          throw error;
+        }
+      },
+      return: close,
+      async throw(error?: unknown) {
+        controller.abort();
+        try {
+          if (source.throw) {
+            return await source.throw(error);
+          }
+          throw error;
+        } finally {
+          finish();
+        }
+      },
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+    };
+    activeWatch = {
+      abort: () => controller.abort(),
+      close: async () => {
+        await close();
+      },
+    };
+    this.#activeWatches.add(activeWatch);
+    return iterator;
   }
 
   async cleanup(): Promise<void> {
     this.#cleanedUp = true;
-    this.#cleanupPromise ??= this.#cleanupProvider();
+    for (const watch of this.#activeWatches) {
+      watch.abort();
+    }
+    this.#cleanupPromise ??= (async () => {
+      const closingWatches = [...this.#activeWatches].map(async (watch) => await watch.close());
+      await Promise.allSettled(this.#inFlightOperations);
+      await Promise.allSettled(closingWatches);
+      await this.#cleanupProvider();
+    })();
     await this.#cleanupPromise;
   }
 
@@ -167,22 +259,17 @@ class LazyProviderAdapter implements ProviderAdapter {
         { cause: error, kind: "config" },
       );
     });
-    const provider = await this.#providerPromise;
-    if (this.#cleanedUp) {
-      await this.#cleanupPromise;
-      throw this.#cleanedUpError();
-    }
-    return provider;
+    return await this.#providerPromise;
   }
 
-  async *#watch(context: WatchContext): AsyncIterable<InboundEnvelope> {
+  async *#watch(context: WatchContext, signal: AbortSignal): AsyncIterable<InboundEnvelope> {
     const provider = await this.#provider();
     if (!provider.watch) {
       throw new CrablineError(`Provider "${this.id}" does not implement watch.`, {
         kind: "config",
       });
     }
-    yield* provider.watch(context);
+    yield* provider.watch({ ...context, signal });
   }
 
   #assertActive(): void {
@@ -197,6 +284,19 @@ class LazyProviderAdapter implements ProviderAdapter {
       return;
     }
     await (await providerPromise).cleanup?.();
+  }
+
+  #runOperation<T>(run: () => Promise<T>): Promise<T> {
+    if (this.#cleanedUp) {
+      return Promise.reject(this.#cleanedUpError());
+    }
+    const operation = run();
+    this.#inFlightOperations.add(operation);
+    void operation.then(
+      () => this.#inFlightOperations.delete(operation),
+      () => this.#inFlightOperations.delete(operation),
+    );
+    return operation;
   }
 
   #cleanedUpError(): CrablineError {

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -1,15 +1,9 @@
 import { CrablineError } from "../core/errors.js";
-import type {
-  BuiltinAdapterId,
-  FixtureMode,
-  ManifestDefinition,
-  ProviderConfig,
-} from "../config/schema.js";
+import type { BuiltinAdapterId, ManifestDefinition, ProviderConfig } from "../config/schema.js";
 import { ScriptProviderAdapter } from "./builtin/script.js";
 import { OPENCLAW_SUPPORT_CATALOG } from "./catalog.js";
 import type {
   InboundEnvelope,
-  NormalizedTarget,
   ProbeResult,
   ProviderAdapter,
   ProviderContext,
@@ -19,20 +13,14 @@ import type {
   WaitContext,
   WatchContext,
 } from "./types.js";
+import { getBuiltinTargetCodec, type BuiltinProviderAdapterId } from "./target-normalizers.js";
 
 export type Registry = {
   catalog: typeof OPENCLAW_SUPPORT_CATALOG;
   resolve(providerId: string, fixtureId: string): ProviderAdapter;
 };
 
-const COMMON_PROVIDER_SUPPORT = [
-  "probe",
-  "send",
-  "roundtrip",
-  "agent",
-] as const satisfies readonly FixtureMode[];
-
-type LazyAdapterId = Exclude<BuiltinAdapterId, "script">;
+type LazyAdapterId = BuiltinProviderAdapterId;
 type ProviderFactory = () => Promise<ProviderAdapter>;
 type LazyProviderFactory = (params: {
   config: ProviderConfig;
@@ -95,17 +83,6 @@ function isLazyAdapter(adapter: BuiltinAdapterId): adapter is LazyAdapterId {
   return adapter in LAZY_PROVIDER_FACTORIES;
 }
 
-function normalizeTarget(target: ProviderContext["fixture"]["target"]): NormalizedTarget {
-  const normalized: NormalizedTarget = { id: target.id, metadata: target.metadata };
-  if (target.channelId) {
-    normalized.channelId = target.channelId;
-  }
-  if (target.threadId) {
-    normalized.threadId = target.threadId;
-  }
-  return normalized;
-}
-
 function createLazyProvider(params: {
   adapter: LazyAdapterId;
   config: ProviderConfig;
@@ -116,9 +93,10 @@ function createLazyProvider(params: {
     adapterName: params.adapter,
     factory: () => LAZY_PROVIDER_FACTORIES[params.adapter](params),
     id: params.providerId,
+    normalizeTarget: getBuiltinTargetCodec(params.adapter).normalize,
     platform: params.config.platform,
     status: "ready",
-    supports: COMMON_PROVIDER_SUPPORT,
+    supports: params.config.capabilities,
   });
 }
 
@@ -130,26 +108,29 @@ class LazyProviderAdapter implements ProviderAdapter {
 
   readonly #adapterName: string;
   readonly #factory: ProviderFactory;
+  readonly #normalizeTarget: ProviderAdapter["normalizeTarget"];
   #providerPromise: Promise<ProviderAdapter> | null = null;
 
   constructor(params: {
     adapterName: string;
     factory: ProviderFactory;
     id: string;
+    normalizeTarget: ProviderAdapter["normalizeTarget"];
     platform: ProviderAdapter["platform"];
     status: ProviderSupportStatus;
     supports: ProviderAdapter["supports"];
   }) {
     this.#adapterName = params.adapterName;
     this.#factory = params.factory;
+    this.#normalizeTarget = params.normalizeTarget;
     this.id = params.id;
     this.platform = params.platform;
     this.status = params.status;
     this.supports = params.supports;
   }
 
-  normalizeTarget(target: ProviderContext["fixture"]["target"]): NormalizedTarget {
-    return normalizeTarget(target);
+  normalizeTarget(target: ProviderContext["fixture"]["target"]) {
+    return this.#normalizeTarget(target);
   }
 
   async probe(context: ProviderContext): Promise<ProbeResult> {

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -109,6 +109,8 @@ class LazyProviderAdapter implements ProviderAdapter {
   readonly #adapterName: string;
   readonly #factory: ProviderFactory;
   readonly #normalizeTarget: ProviderAdapter["normalizeTarget"];
+  #cleanedUp = false;
+  #cleanupPromise: Promise<void> | null = null;
   #providerPromise: Promise<ProviderAdapter> | null = null;
 
   constructor(params: {
@@ -130,6 +132,7 @@ class LazyProviderAdapter implements ProviderAdapter {
   }
 
   normalizeTarget(target: ProviderContext["fixture"]["target"]) {
+    this.#assertActive();
     return this.#normalizeTarget(target);
   }
 
@@ -150,13 +153,13 @@ class LazyProviderAdapter implements ProviderAdapter {
   }
 
   async cleanup(): Promise<void> {
-    if (!this.#providerPromise) {
-      return;
-    }
-    await (await this.#providerPromise).cleanup?.();
+    this.#cleanedUp = true;
+    this.#cleanupPromise ??= this.#cleanupProvider();
+    await this.#cleanupPromise;
   }
 
   async #provider(): Promise<ProviderAdapter> {
+    this.#assertActive();
     this.#providerPromise ??= this.#factory().catch((error: unknown) => {
       this.#providerPromise = null;
       throw new CrablineError(
@@ -164,7 +167,12 @@ class LazyProviderAdapter implements ProviderAdapter {
         { cause: error, kind: "config" },
       );
     });
-    return await this.#providerPromise;
+    const provider = await this.#providerPromise;
+    if (this.#cleanedUp) {
+      await this.#cleanupPromise;
+      throw this.#cleanedUpError();
+    }
+    return provider;
   }
 
   async *#watch(context: WatchContext): AsyncIterable<InboundEnvelope> {
@@ -175,6 +183,24 @@ class LazyProviderAdapter implements ProviderAdapter {
       });
     }
     yield* provider.watch(context);
+  }
+
+  #assertActive(): void {
+    if (this.#cleanedUp) {
+      throw this.#cleanedUpError();
+    }
+  }
+
+  async #cleanupProvider(): Promise<void> {
+    const providerPromise = this.#providerPromise;
+    if (!providerPromise) {
+      return;
+    }
+    await (await providerPromise).cleanup?.();
+  }
+
+  #cleanedUpError(): CrablineError {
+    return new CrablineError(`Provider "${this.id}" has been cleaned up.`, { kind: "config" });
   }
 }
 

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -26,6 +26,10 @@ type ActiveWatch = {
   abort(): void;
   close(): Promise<void>;
 };
+type AdmittedOperation = {
+  completion: Promise<unknown>;
+  dispatched: Promise<void>;
+};
 type LazyProviderFactory = (params: {
   config: ProviderConfig;
   providerId: string;
@@ -114,9 +118,10 @@ class LazyProviderAdapter implements ProviderAdapter {
   readonly #factory: ProviderFactory;
   readonly #normalizeTarget: ProviderAdapter["normalizeTarget"];
   readonly #activeWatches = new Set<ActiveWatch>();
-  readonly #inFlightOperations = new Set<Promise<unknown>>();
+  readonly #inFlightOperations = new Set<AdmittedOperation>();
   #cleanedUp = false;
   #cleanupPromise: Promise<void> | null = null;
+  #providerInstance: ProviderAdapter | null = null;
   #providerPromise: Promise<ProviderAdapter> | null = null;
 
   constructor(params: {
@@ -143,15 +148,15 @@ class LazyProviderAdapter implements ProviderAdapter {
   }
 
   probe(context: ProviderContext): Promise<ProbeResult> {
-    return this.#runOperation(async () => await (await this.#provider()).probe(context));
+    return this.#runOperation((provider) => provider.probe(context));
   }
 
   send(context: SendContext): Promise<SendResult> {
-    return this.#runOperation(async () => await (await this.#provider()).send(context));
+    return this.#runOperation((provider) => provider.send(context));
   }
 
   waitForInbound(context: WaitContext): Promise<InboundEnvelope | null> {
-    return this.#runOperation(async () => await (await this.#provider()).waitForInbound(context));
+    return this.#runOperation((provider) => provider.waitForInbound(context));
   }
 
   watch(context: WatchContext): AsyncIterable<InboundEnvelope> {
@@ -242,23 +247,36 @@ class LazyProviderAdapter implements ProviderAdapter {
       watch.abort();
     }
     this.#cleanupPromise ??= (async () => {
+      const operations = [...this.#inFlightOperations];
       const closingWatches = [...this.#activeWatches].map(async (watch) => await watch.close());
-      await Promise.allSettled(this.#inFlightOperations);
+      const providerCleanupBegun = this.#beginProviderCleanup();
+      void providerCleanupBegun.catch(() => undefined);
+      const providerCleanup = this.#cleanupProvider(
+        operations.map((operation) => operation.dispatched),
+        providerCleanupBegun,
+      );
+      void providerCleanup.catch(() => undefined);
+      await Promise.allSettled(operations.map((operation) => operation.completion));
       await Promise.allSettled(closingWatches);
-      await this.#cleanupProvider();
+      await providerCleanup;
     })();
     await this.#cleanupPromise;
   }
 
   async #provider(): Promise<ProviderAdapter> {
     this.#assertActive();
-    this.#providerPromise ??= this.#factory().catch((error: unknown) => {
-      this.#providerPromise = null;
-      throw new CrablineError(
-        `Provider adapter "${this.#adapterName}" could not load. Install its optional peer dependencies before using this adapter.`,
-        { cause: error, kind: "config" },
-      );
-    });
+    this.#providerPromise ??= this.#factory()
+      .then((provider) => {
+        this.#providerInstance = provider;
+        return provider;
+      })
+      .catch((error: unknown) => {
+        this.#providerPromise = null;
+        throw new CrablineError(
+          `Provider adapter "${this.#adapterName}" could not load. Install its optional peer dependencies before using this adapter.`,
+          { cause: error, kind: "config" },
+        );
+      });
     return await this.#providerPromise;
   }
 
@@ -278,25 +296,63 @@ class LazyProviderAdapter implements ProviderAdapter {
     }
   }
 
-  async #cleanupProvider(): Promise<void> {
+  #beginProviderCleanup(): Promise<ProviderAdapter | null> {
+    if (this.#providerInstance) {
+      try {
+        this.#providerInstance.beginCleanup?.();
+        return Promise.resolve(this.#providerInstance);
+      } catch (error) {
+        return Promise.reject(error);
+      }
+    }
     const providerPromise = this.#providerPromise;
     if (!providerPromise) {
-      return;
+      return Promise.resolve(null);
     }
-    await (await providerPromise).cleanup?.();
+    return providerPromise.then((provider) => {
+      provider.beginCleanup?.();
+      return provider;
+    });
   }
 
-  #runOperation<T>(run: () => Promise<T>): Promise<T> {
+  async #cleanupProvider(
+    dispatched: readonly Promise<void>[],
+    providerCleanupBegun: Promise<ProviderAdapter | null>,
+  ): Promise<void> {
+    await Promise.allSettled(dispatched);
+    const provider = await providerCleanupBegun;
+    if (!provider) {
+      return;
+    }
+    await provider.cleanup?.();
+  }
+
+  #runOperation<T>(run: (provider: ProviderAdapter) => Promise<T>): Promise<T> {
     if (this.#cleanedUp) {
       return Promise.reject(this.#cleanedUpError());
     }
-    const operation = run();
+    let markDispatched: (() => void) | undefined;
+    const dispatched = new Promise<void>((resolve) => {
+      markDispatched = resolve;
+    });
+    const completion = (async () => {
+      try {
+        const provider = await this.#provider();
+        const result = run(provider);
+        markDispatched?.();
+        return await result;
+      } catch (error) {
+        markDispatched?.();
+        throw error;
+      }
+    })();
+    const operation = { completion, dispatched };
     this.#inFlightOperations.add(operation);
-    void operation.then(
+    void completion.then(
       () => this.#inFlightOperations.delete(operation),
       () => this.#inFlightOperations.delete(operation),
     );
-    return operation;
+    return completion;
   }
 
   #cleanedUpError(): CrablineError {

--- a/src/providers/target-normalizers.ts
+++ b/src/providers/target-normalizers.ts
@@ -1,0 +1,330 @@
+import type { BuiltinAdapterId, FixtureDefinition, ProviderPlatform } from "../config/schema.js";
+import { CrablineError } from "../core/errors.js";
+import type { LocalMockTargetCodec } from "./local-mock.js";
+import type { NativeIdRule } from "./native-ids.js";
+import { SLACK_CHANNEL_ID_RULE, SLACK_TS_RULE } from "./slack-ids.js";
+import type { NormalizedTarget } from "./types.js";
+
+export type BuiltinProviderAdapterId = Exclude<BuiltinAdapterId, "script">;
+
+export const DISCORD_SNOWFLAKE_RULE: NativeIdRule = {
+  example: "123456789012345678",
+  name: "Discord snowflake id",
+  pattern: /^\d{17,20}$/u,
+};
+
+export const FEISHU_CHAT_ID_RULE: NativeIdRule = {
+  example: "oc_abc123",
+  name: "Feishu chat_id",
+  pattern: /^oc_[A-Za-z0-9_-]+$/u,
+};
+
+export const FEISHU_MESSAGE_ID_RULE: NativeIdRule = {
+  example: "om_abc123",
+  name: "Feishu message_id",
+  pattern: /^om_[A-Za-z0-9_-]+$/u,
+};
+
+export const GOOGLE_CHAT_SPACE_RULE: NativeIdRule = {
+  example: "spaces/AAAABbbbCCC",
+  name: "Google Chat space name",
+  pattern: /^spaces\/[A-Za-z0-9_-]+$/u,
+};
+
+export const GOOGLE_CHAT_THREAD_RULE: NativeIdRule = {
+  example: "spaces/AAAABbbbCCC/threads/BBBBccccDDD",
+  name: "Google Chat thread name",
+  pattern: /^spaces\/[A-Za-z0-9_-]+\/threads\/[A-Za-z0-9_-]+$/u,
+};
+
+export const IMESSAGE_THREAD_RULE: NativeIdRule = {
+  example: "+15551234567, user@example.com, or iMessage;-;chat-guid",
+  name: "iMessage recipient or chat GUID",
+  pattern:
+    /^(?:\+[1-9]\d{6,14}|[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}|(?:iMessage|SMS);[+-];.+)$/u,
+};
+
+export const MATRIX_ROOM_ID_RULE: NativeIdRule = {
+  example: "!abcdef:matrix.org",
+  name: "Matrix room id",
+  pattern: /^![^:\s]+:[^\s]+$/u,
+};
+
+export const MATRIX_EVENT_ID_RULE: NativeIdRule = {
+  example: "$eventid:matrix.org",
+  name: "Matrix event id",
+  pattern: /^\$[^\s]+(?::[^\s]+)?$/u,
+};
+
+export const MATTERMOST_ID_RULE: NativeIdRule = {
+  example: "abcdefghijklmnopqrstuvwx12",
+  name: "Mattermost id",
+  pattern: /^[a-z0-9]{26}$/u,
+};
+
+export const MSTEAMS_CONVERSATION_ID_RULE: NativeIdRule = {
+  example: "a:opaque-conversation-id",
+  name: "Microsoft Teams conversation id",
+  pattern: /^.+$/su,
+};
+
+export const TELEGRAM_CHAT_ID_RULE: NativeIdRule = {
+  example: "-1001234567890 or @channelusername",
+  name: "Telegram chat id",
+  pattern: /^(?:-?\d+|@[A-Za-z][A-Za-z0-9_]{4,31})$/u,
+};
+
+export const TELEGRAM_MESSAGE_THREAD_ID_RULE: NativeIdRule = {
+  example: "42",
+  name: "Telegram message_thread_id",
+  pattern: /^\d+$/u,
+};
+
+export const WHATSAPP_WA_ID_RULE: NativeIdRule = {
+  example: "15551234567",
+  name: "WhatsApp wa_id",
+  pattern: /^\d{7,15}$/u,
+};
+
+export const ZALO_ID_RULE: NativeIdRule = {
+  example: "123456789012345678",
+  name: "Zalo user or OA id",
+  pattern: /^\d{6,20}$/u,
+};
+
+function requireNativeId(value: string, rule: NativeIdRule, label: string): string {
+  if (!rule.pattern.test(value)) {
+    throw new CrablineError(`${label} must be a native ${rule.name} such as ${rule.example}.`, {
+      kind: "config",
+    });
+  }
+  return value;
+}
+
+function createNativeTargetCodec(options: {
+  channel: NativeIdRule;
+  channelLabel?: string | undefined;
+  thread?: NativeIdRule | undefined;
+  threadLabel?: string | undefined;
+}): LocalMockTargetCodec {
+  const channelLabel = options.channelLabel ?? "channelId";
+  const threadLabel = options.threadLabel ?? "threadId";
+  const threadRule = options.thread ?? options.channel;
+
+  return {
+    normalize(target): NormalizedTarget {
+      const channelId = requireNativeId(
+        target.channelId ?? target.id,
+        options.channel,
+        channelLabel,
+      );
+      const normalized: NormalizedTarget = {
+        channelId,
+        id: target.id,
+        metadata: target.metadata,
+      };
+      if (target.threadId) {
+        normalized.threadId = requireNativeId(target.threadId, threadRule, threadLabel);
+      }
+      return normalized;
+    },
+    resolveThreadId(target) {
+      const normalized = this.normalize(target);
+      return normalized.threadId ?? normalized.channelId ?? normalized.id;
+    },
+  };
+}
+
+export function createGenericLocalMockTargetCodec(
+  platform: ProviderPlatform,
+): LocalMockTargetCodec {
+  const prefix = `${platform}:`;
+  const encode = (value: string) => (value.startsWith(prefix) ? value : `${prefix}${value}`);
+  return {
+    normalize(target): NormalizedTarget {
+      const normalized: NormalizedTarget = {
+        id: target.id,
+        metadata: target.metadata,
+      };
+      if (target.channelId) {
+        normalized.channelId = encode(target.channelId);
+      } else if (!target.threadId) {
+        normalized.channelId = encode(target.id);
+      }
+      if (target.threadId) {
+        normalized.channelId ??= encode(target.id);
+        normalized.threadId = target.threadId.startsWith(prefix)
+          ? target.threadId
+          : `${normalized.channelId}:${target.threadId}`;
+      }
+      return normalized;
+    },
+    resolveThreadId(target) {
+      const normalized = this.normalize(target);
+      return normalized.threadId ?? normalized.channelId ?? encode(normalized.id);
+    },
+  };
+}
+
+function requireSlackChannelId(value: string, label: string): string {
+  if (!SLACK_CHANNEL_ID_RULE.pattern.test(value)) {
+    throw new CrablineError(
+      `Slack ${label} must be a native Slack conversation id such as C1234567890, G1234567890, or D1234567890.`,
+      { kind: "config" },
+    );
+  }
+  return value;
+}
+
+function requireSlackThreadTs(value: string, label: string): string {
+  if (!SLACK_TS_RULE.pattern.test(value)) {
+    throw new CrablineError(`Slack ${label} must be a Slack timestamp such as 1700000000.000100.`, {
+      kind: "config",
+    });
+  }
+  return value;
+}
+
+const SLACK_TARGET_CODEC: LocalMockTargetCodec = {
+  normalize(target): NormalizedTarget {
+    const channelId = requireSlackChannelId(target.channelId ?? target.id, "channelId");
+    const normalized: NormalizedTarget = {
+      channelId,
+      id: target.id,
+      metadata: target.metadata,
+    };
+    if (target.threadId) {
+      normalized.threadId = requireSlackThreadTs(target.threadId, "threadId");
+    }
+    return normalized;
+  },
+  resolveThreadId(target) {
+    const normalized = this.normalize(target);
+    return normalized.threadId ?? normalized.channelId ?? normalized.id;
+  },
+};
+
+const TELEGRAM_BASE_CODEC = createNativeTargetCodec({
+  channel: TELEGRAM_CHAT_ID_RULE,
+  channelLabel: "Telegram chat_id",
+  thread: TELEGRAM_MESSAGE_THREAD_ID_RULE,
+  threadLabel: "Telegram message_thread_id",
+});
+
+export function parseCanonicalTelegramTopic(
+  value: string,
+): { chatId: string; topicId: string } | undefined {
+  const separator = value.lastIndexOf(":");
+  if (separator <= 0) {
+    return undefined;
+  }
+  const chatId = value.slice(0, separator);
+  const topicId = value.slice(separator + 1);
+  if (
+    !TELEGRAM_CHAT_ID_RULE.pattern.test(chatId) ||
+    !TELEGRAM_MESSAGE_THREAD_ID_RULE.pattern.test(topicId)
+  ) {
+    return undefined;
+  }
+  return { chatId, topicId };
+}
+
+const TELEGRAM_TARGET_CODEC: LocalMockTargetCodec = {
+  normalize(target) {
+    const canonicalTopic = target.threadId
+      ? parseCanonicalTelegramTopic(target.threadId)
+      : undefined;
+    const targetChatId = target.channelId ?? target.id;
+    if (
+      canonicalTopic &&
+      requireNativeId(targetChatId, TELEGRAM_CHAT_ID_RULE, "Telegram chat_id") !==
+        canonicalTopic.chatId
+    ) {
+      throw new CrablineError("Telegram canonical topic chat_id must match the target chat_id.", {
+        kind: "config",
+      });
+    }
+    const normalized = TELEGRAM_BASE_CODEC.normalize({
+      ...target,
+      ...(canonicalTopic ? { channelId: canonicalTopic.chatId } : {}),
+      threadId: undefined,
+    });
+    if (!target.threadId) {
+      return normalized;
+    }
+    const topicId = requireNativeId(
+      canonicalTopic?.topicId ?? target.threadId,
+      TELEGRAM_MESSAGE_THREAD_ID_RULE,
+      "Telegram message_thread_id",
+    );
+    return {
+      ...normalized,
+      threadId: `${normalized.channelId}:${topicId}`,
+    };
+  },
+  resolveThreadId(target) {
+    const normalized = this.normalize(target);
+    return normalized.threadId ?? normalized.channelId ?? normalized.id;
+  },
+};
+
+const BUILTIN_TARGET_CODECS = {
+  discord: createNativeTargetCodec({
+    channel: DISCORD_SNOWFLAKE_RULE,
+    channelLabel: "Discord channel_id",
+    thread: DISCORD_SNOWFLAKE_RULE,
+    threadLabel: "Discord thread id",
+  }),
+  feishu: createNativeTargetCodec({
+    channel: FEISHU_CHAT_ID_RULE,
+    channelLabel: "Feishu chat_id",
+    thread: FEISHU_MESSAGE_ID_RULE,
+    threadLabel: "Feishu message_id",
+  }),
+  googlechat: createNativeTargetCodec({
+    channel: GOOGLE_CHAT_SPACE_RULE,
+    channelLabel: "Google Chat space.name",
+    thread: GOOGLE_CHAT_THREAD_RULE,
+    threadLabel: "Google Chat thread.name",
+  }),
+  imessage: createNativeTargetCodec({
+    channel: IMESSAGE_THREAD_RULE,
+    channelLabel: "iMessage recipient or chat GUID",
+  }),
+  loopback: createGenericLocalMockTargetCodec("loopback"),
+  matrix: createNativeTargetCodec({
+    channel: MATRIX_ROOM_ID_RULE,
+    channelLabel: "Matrix room_id",
+    thread: MATRIX_EVENT_ID_RULE,
+    threadLabel: "Matrix event_id",
+  }),
+  mattermost: createNativeTargetCodec({
+    channel: MATTERMOST_ID_RULE,
+    channelLabel: "Mattermost channel_id",
+  }),
+  msteams: createNativeTargetCodec({
+    channel: MSTEAMS_CONVERSATION_ID_RULE,
+    channelLabel: "Microsoft Teams conversation.id",
+  }),
+  slack: SLACK_TARGET_CODEC,
+  telegram: TELEGRAM_TARGET_CODEC,
+  whatsapp: createNativeTargetCodec({
+    channel: WHATSAPP_WA_ID_RULE,
+    channelLabel: "WhatsApp wa_id",
+  }),
+  zalo: createNativeTargetCodec({
+    channel: ZALO_ID_RULE,
+    channelLabel: "Zalo user_id or oa_id",
+  }),
+} satisfies Record<BuiltinProviderAdapterId, LocalMockTargetCodec>;
+
+export function getBuiltinTargetCodec(adapter: BuiltinProviderAdapterId): LocalMockTargetCodec {
+  return BUILTIN_TARGET_CODECS[adapter];
+}
+
+export function normalizeBuiltinTarget(
+  adapter: BuiltinProviderAdapterId,
+  target: FixtureDefinition["target"],
+): NormalizedTarget {
+  return getBuiltinTargetCodec(adapter).normalize(target);
+}

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -65,6 +65,7 @@ export type WaitContext = ProviderContext & {
 };
 
 export type WatchContext = ProviderContext & {
+  signal?: AbortSignal | undefined;
   since?: string;
 };
 

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -79,6 +79,8 @@ export interface ProviderAdapter {
   send(context: SendContext): Promise<SendResult>;
   waitForInbound(context: WaitContext): Promise<InboundEnvelope | null>;
   watch?(context: WatchContext): AsyncIterable<InboundEnvelope>;
+  /** Stops external admission synchronously before cleanup drains accepted work. */
+  beginCleanup?(): void;
   cleanup?(): Promise<void>;
 }
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -71,6 +71,30 @@ describe("manifest schema", () => {
     ).toThrow(/fixture missing-provider references unknown provider missing/u);
   });
 
+  it("rejects fixture modes outside provider capabilities", () => {
+    expect(() =>
+      ManifestSchema.parse({
+        configVersion: 1,
+        fixtures: [
+          {
+            id: "unsupported-roundtrip",
+            mode: "roundtrip",
+            provider: "local",
+            target: { id: "echo-bot" },
+          },
+        ],
+        providers: {
+          local: {
+            adapter: "loopback",
+            capabilities: ["probe", "send"],
+          },
+        },
+      }),
+    ).toThrow(
+      /fixture unsupported-roundtrip uses mode roundtrip, but provider local declares capabilities probe, send/u,
+    );
+  });
+
   it("parses a valid loopback fixture", () => {
     const manifest = ManifestSchema.parse({
       configVersion: 1,
@@ -225,6 +249,62 @@ describe("manifest schema", () => {
     });
 
     expect(manifest.providers.slack?.script?.commands.waitForInbound).toBe("wait");
+  });
+
+  it("rejects adapter config blocks for a different built-in adapter", () => {
+    expect(() =>
+      ManifestSchema.parse({
+        configVersion: 1,
+        fixtures: [],
+        providers: {
+          slack: {
+            adapter: "slack",
+            telegram: {},
+          },
+        },
+      }),
+    ).toThrow(/telegram configuration requires adapter=telegram, got adapter=slack/u);
+  });
+
+  it("keeps script adapter configuration behind script commands", () => {
+    expect(() =>
+      ManifestSchema.parse({
+        configVersion: 1,
+        fixtures: [],
+        providers: {
+          slack: {
+            adapter: "script",
+            capabilities: ["probe"],
+            platform: "slack",
+            script: {
+              commands: {
+                probe: "probe",
+              },
+            },
+            slack: {},
+          },
+        },
+      }),
+    ).toThrow(
+      /script adapter cannot use slack configuration; configure provider behavior through script\.commands/u,
+    );
+
+    expect(() =>
+      ManifestSchema.parse({
+        configVersion: 1,
+        fixtures: [],
+        providers: {
+          slack: {
+            adapter: "slack",
+            script: {
+              commands: {
+                probe: "probe",
+              },
+            },
+          },
+        },
+      }),
+    ).toThrow(/script configuration requires adapter=script, got adapter=slack/u);
   });
 
   it("parses a built-in slack provider with webhook defaults", () => {

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -463,6 +463,40 @@ describe("recorder", () => {
     expect(next.value?.id).toBe("evt-3");
   });
 
+  it("stops before yielding buffered events after abort", async () => {
+    const filePath = await createRecorderPath();
+    await appendRecordedInbound(filePath, {
+      author: "user",
+      id: "evt-buffered-1",
+      provider: "slack",
+      sentAt: new Date().toISOString(),
+      text: "first",
+      threadId: "slack:C999",
+    });
+    await appendRecordedInbound(filePath, {
+      author: "user",
+      id: "evt-buffered-2",
+      provider: "slack",
+      sentAt: new Date().toISOString(),
+      text: "second",
+      threadId: "slack:C999",
+    });
+    const controller = new AbortController();
+    const iterator = watchRecordedInbound({
+      filePath,
+      matches: () => true,
+      signal: controller.signal,
+    })[Symbol.asyncIterator]();
+
+    await expect(iterator.next()).resolves.toMatchObject({
+      done: false,
+      value: { id: "evt-buffered-1" },
+    });
+    controller.abort();
+
+    await expect(iterator.next()).resolves.toEqual({ done: true, value: undefined });
+  });
+
   it("reads only appended records while watching a large recorder", async () => {
     const filePath = await createRecorderPath();
     const history = Array.from(

--- a/test/registry-lifecycle.test.ts
+++ b/test/registry-lifecycle.test.ts
@@ -1,0 +1,260 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ManifestDefinition, ProviderConfig } from "../src/config/schema.js";
+import { createRegistry } from "../src/providers/registry.js";
+import type { ProviderContext, SendContext } from "../src/providers/types.js";
+import { createTempDir, disposeTempDir } from "./test-helpers.js";
+
+type AppendRecordedInbound = typeof import("../src/providers/recorder.js").appendRecordedInbound;
+type WatchRecordedInbound = typeof import("../src/providers/recorder.js").watchRecordedInbound;
+
+const recorderMocks = vi.hoisted(() => ({
+  actualAppendRecordedInbound: undefined as AppendRecordedInbound | undefined,
+  actualWatchRecordedInbound: undefined as WatchRecordedInbound | undefined,
+  appendRecordedInbound: vi.fn<AppendRecordedInbound>(),
+  watchRecordedInbound: vi.fn<WatchRecordedInbound>(),
+}));
+
+vi.mock("../src/providers/recorder.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/providers/recorder.js")>();
+  recorderMocks.actualAppendRecordedInbound = actual.appendRecordedInbound;
+  recorderMocks.actualWatchRecordedInbound = actual.watchRecordedInbound;
+  recorderMocks.appendRecordedInbound.mockImplementation(actual.appendRecordedInbound);
+  recorderMocks.watchRecordedInbound.mockImplementation(actual.watchRecordedInbound);
+  return {
+    ...actual,
+    appendRecordedInbound: recorderMocks.appendRecordedInbound,
+    watchRecordedInbound: recorderMocks.watchRecordedInbound,
+  };
+});
+
+beforeEach(() => {
+  recorderMocks.appendRecordedInbound.mockReset();
+  recorderMocks.appendRecordedInbound.mockImplementation(
+    recorderMocks.actualAppendRecordedInbound!,
+  );
+  recorderMocks.watchRecordedInbound.mockReset();
+  recorderMocks.watchRecordedInbound.mockImplementation(recorderMocks.actualWatchRecordedInbound!);
+});
+
+function createTelegramManifest(recorderPath: string): {
+  config: ProviderConfig;
+  context: ProviderContext;
+  manifest: ManifestDefinition;
+} {
+  const config: ProviderConfig = {
+    adapter: "telegram",
+    capabilities: ["probe", "send", "roundtrip", "agent"],
+    env: [],
+    platform: "telegram",
+    status: "active",
+    telegram: {
+      mode: "auto",
+      recorder: { path: recorderPath },
+      webhook: {
+        host: "127.0.0.1",
+        path: "/telegram/webhook",
+        port: 0,
+      },
+    },
+  };
+  const fixture = {
+    env: [],
+    id: "telegram-roundtrip",
+    inboundMatch: {
+      author: "assistant" as const,
+      nonce: "contains" as const,
+      strategy: "contains" as const,
+    },
+    mode: "roundtrip" as const,
+    provider: "telegram",
+    retries: 0,
+    tags: [],
+    target: { id: "123456789", metadata: {} },
+    timeoutMs: 500,
+  };
+  const manifest: ManifestDefinition = {
+    configVersion: 1,
+    fixtures: [fixture],
+    providers: { telegram: config },
+    userName: "crabline",
+  };
+  return {
+    config,
+    context: {
+      config,
+      fixture,
+      manifestPath: "/tmp/crabline.yaml",
+      providerId: "telegram",
+      userName: "crabline",
+    },
+    manifest,
+  };
+}
+
+describe("lazy provider lifecycle", () => {
+  it("drains an operation admitted before provider materialization", async () => {
+    const directory = await createTempDir();
+    const recorderPath = path.join(directory, "telegram.jsonl");
+    let cleanup: Promise<void> | undefined;
+    let sending: Promise<unknown> | undefined;
+    try {
+      const { context, manifest } = createTelegramManifest(recorderPath);
+      const provider = createRegistry(manifest, "/tmp/crabline.yaml").resolve(
+        "telegram",
+        context.fixture.id,
+      );
+      sending = provider.send({
+        ...context,
+        mode: "roundtrip",
+        nonce: "lazy-materialization-race",
+        text: "admitted before cleanup",
+      });
+
+      cleanup = provider.cleanup?.();
+
+      await expect(sending).resolves.toMatchObject({ accepted: true });
+      await cleanup;
+      expect((await readFile(recorderPath, "utf8")).trim().split("\n")).toHaveLength(2);
+    } finally {
+      await sending?.catch(() => undefined);
+      await cleanup?.catch(() => undefined);
+      await disposeTempDir(directory);
+    }
+  });
+
+  it("waits for an admitted non-WhatsApp send before cleanup resolves", async () => {
+    const directory = await createTempDir();
+    const recorderPath = path.join(directory, "telegram.jsonl");
+    let cleanup: Promise<void> | undefined;
+    let releaseReply: (() => void) | undefined;
+    let sending: Promise<unknown> | undefined;
+    const replyBlocked = new Promise<void>((resolve) => {
+      releaseReply = resolve;
+    });
+    let appendCount = 0;
+    recorderMocks.appendRecordedInbound.mockImplementation(async (...args) => {
+      appendCount += 1;
+      if (appendCount === 2) {
+        await replyBlocked;
+      }
+      return await recorderMocks.actualAppendRecordedInbound!(...args);
+    });
+
+    try {
+      const { context, manifest } = createTelegramManifest(recorderPath);
+      const provider = createRegistry(manifest, "/tmp/crabline.yaml").resolve(
+        "telegram",
+        context.fixture.id,
+      );
+      const sendContext: SendContext = {
+        ...context,
+        mode: "roundtrip",
+        nonce: "lazy-cleanup-race",
+        text: "finish before cleanup",
+      };
+
+      sending = provider.send(sendContext);
+      await vi.waitFor(() => expect(recorderMocks.appendRecordedInbound).toHaveBeenCalledTimes(2));
+
+      let cleanupResolved = false;
+      cleanup = provider.cleanup?.().then(() => {
+        cleanupResolved = true;
+      });
+      await Promise.resolve();
+      expect(cleanupResolved).toBe(false);
+
+      releaseReply?.();
+      await cleanup;
+      await sending;
+      const contentsAfterCleanup = await readFile(recorderPath, "utf8");
+      expect(contentsAfterCleanup.trim().split("\n")).toHaveLength(2);
+      await Promise.resolve();
+      expect(await readFile(recorderPath, "utf8")).toBe(contentsAfterCleanup);
+    } finally {
+      releaseReply?.();
+      await sending?.catch(() => undefined);
+      await cleanup?.catch(() => undefined);
+      await disposeTempDir(directory);
+    }
+  });
+
+  it("cancels and drains an admitted watch before cleanup resolves", async () => {
+    const directory = await createTempDir();
+    const recorderPath = path.join(directory, "telegram.jsonl");
+    let markWatchStarted: (() => void) | undefined;
+    const watchStarted = new Promise<void>((resolve) => {
+      markWatchStarted = resolve;
+    });
+    let watchStopped = false;
+    recorderMocks.watchRecordedInbound.mockImplementationOnce(async function* (params) {
+      markWatchStarted?.();
+      if (!params.signal?.aborted) {
+        await new Promise<void>((resolve) => {
+          params.signal?.addEventListener("abort", () => resolve(), { once: true });
+        });
+      }
+      watchStopped = true;
+      yield* [];
+    });
+
+    try {
+      const { context, manifest } = createTelegramManifest(recorderPath);
+      const provider = createRegistry(manifest, "/tmp/crabline.yaml").resolve(
+        "telegram",
+        context.fixture.id,
+      );
+      const iterator = provider.watch!(context)[Symbol.asyncIterator]();
+      const pending = iterator.next();
+      await watchStarted;
+
+      await provider.cleanup?.();
+
+      expect(watchStopped).toBe(true);
+      await expect(pending).resolves.toEqual({ done: true, value: undefined });
+    } finally {
+      await disposeTempDir(directory);
+    }
+  });
+
+  it("aborts a pending watch before forwarding iterator throws", async () => {
+    const directory = await createTempDir();
+    const recorderPath = path.join(directory, "telegram.jsonl");
+    let markWatchStarted: (() => void) | undefined;
+    const watchStarted = new Promise<void>((resolve) => {
+      markWatchStarted = resolve;
+    });
+    let watchStopped = false;
+    recorderMocks.watchRecordedInbound.mockImplementationOnce(async function* (params) {
+      markWatchStarted?.();
+      if (!params.signal?.aborted) {
+        await new Promise<void>((resolve) => {
+          params.signal?.addEventListener("abort", () => resolve(), { once: true });
+        });
+      }
+      watchStopped = true;
+      yield* [];
+    });
+
+    try {
+      const { context, manifest } = createTelegramManifest(recorderPath);
+      const provider = createRegistry(manifest, "/tmp/crabline.yaml").resolve(
+        "telegram",
+        context.fixture.id,
+      );
+      const iterator = provider.watch!(context)[Symbol.asyncIterator]();
+      const pending = iterator.next();
+      await watchStarted;
+      const thrownError = new Error("stop watching");
+
+      const thrown = iterator.throw!(thrownError);
+
+      await expect(pending).resolves.toEqual({ done: true, value: undefined });
+      await expect(thrown).rejects.toBe(thrownError);
+      expect(watchStopped).toBe(true);
+    } finally {
+      await disposeTempDir(directory);
+    }
+  });
+});

--- a/test/registry-lifecycle.test.ts
+++ b/test/registry-lifecycle.test.ts
@@ -7,25 +7,46 @@ import type { ProviderContext, SendContext } from "../src/providers/types.js";
 import { createTempDir, disposeTempDir } from "./test-helpers.js";
 
 type AppendRecordedInbound = typeof import("../src/providers/recorder.js").appendRecordedInbound;
+type StartWebhookServer = typeof import("../src/providers/webhook-server.js").startWebhookServer;
+type WaitForRecordedInbound = typeof import("../src/providers/recorder.js").waitForRecordedInbound;
 type WatchRecordedInbound = typeof import("../src/providers/recorder.js").watchRecordedInbound;
+type WebhookHandler = Parameters<StartWebhookServer>[0]["handle"];
 
 const recorderMocks = vi.hoisted(() => ({
   actualAppendRecordedInbound: undefined as AppendRecordedInbound | undefined,
+  actualWaitForRecordedInbound: undefined as WaitForRecordedInbound | undefined,
   actualWatchRecordedInbound: undefined as WatchRecordedInbound | undefined,
   appendRecordedInbound: vi.fn<AppendRecordedInbound>(),
+  waitForRecordedInbound: vi.fn<WaitForRecordedInbound>(),
   watchRecordedInbound: vi.fn<WatchRecordedInbound>(),
+}));
+const webhookMocks = vi.hoisted(() => ({
+  actualStartWebhookServer: undefined as StartWebhookServer | undefined,
+  startWebhookServer: vi.fn<StartWebhookServer>(),
 }));
 
 vi.mock("../src/providers/recorder.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../src/providers/recorder.js")>();
   recorderMocks.actualAppendRecordedInbound = actual.appendRecordedInbound;
+  recorderMocks.actualWaitForRecordedInbound = actual.waitForRecordedInbound;
   recorderMocks.actualWatchRecordedInbound = actual.watchRecordedInbound;
   recorderMocks.appendRecordedInbound.mockImplementation(actual.appendRecordedInbound);
+  recorderMocks.waitForRecordedInbound.mockImplementation(actual.waitForRecordedInbound);
   recorderMocks.watchRecordedInbound.mockImplementation(actual.watchRecordedInbound);
   return {
     ...actual,
     appendRecordedInbound: recorderMocks.appendRecordedInbound,
+    waitForRecordedInbound: recorderMocks.waitForRecordedInbound,
     watchRecordedInbound: recorderMocks.watchRecordedInbound,
+  };
+});
+vi.mock("../src/providers/webhook-server.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/providers/webhook-server.js")>();
+  webhookMocks.actualStartWebhookServer = actual.startWebhookServer;
+  webhookMocks.startWebhookServer.mockImplementation(actual.startWebhookServer);
+  return {
+    ...actual,
+    startWebhookServer: webhookMocks.startWebhookServer,
   };
 });
 
@@ -34,8 +55,14 @@ beforeEach(() => {
   recorderMocks.appendRecordedInbound.mockImplementation(
     recorderMocks.actualAppendRecordedInbound!,
   );
+  recorderMocks.waitForRecordedInbound.mockReset();
+  recorderMocks.waitForRecordedInbound.mockImplementation(
+    recorderMocks.actualWaitForRecordedInbound!,
+  );
   recorderMocks.watchRecordedInbound.mockReset();
   recorderMocks.watchRecordedInbound.mockImplementation(recorderMocks.actualWatchRecordedInbound!);
+  webhookMocks.startWebhookServer.mockReset();
+  webhookMocks.startWebhookServer.mockImplementation(webhookMocks.actualStartWebhookServer!);
 });
 
 function createTelegramManifest(recorderPath: string): {
@@ -94,6 +121,125 @@ function createTelegramManifest(recorderPath: string): {
 }
 
 describe("lazy provider lifecycle", () => {
+  it("starts concrete WhatsApp cleanup before draining admitted registry work", async () => {
+    const directory = await createTempDir();
+    const recorderPath = path.join(directory, "whatsapp.jsonl");
+    let cleanup: Promise<void> | undefined;
+    let handle: WebhookHandler | undefined;
+    let markWaitStarted: (() => void) | undefined;
+    let waiting: Promise<unknown> | undefined;
+    const waitStarted = new Promise<void>((resolve) => {
+      markWaitStarted = resolve;
+    });
+    const close = vi.fn(async () => undefined);
+    recorderMocks.waitForRecordedInbound.mockImplementationOnce(async (params) => {
+      markWaitStarted?.();
+      return await recorderMocks.actualWaitForRecordedInbound!(params);
+    });
+    webhookMocks.startWebhookServer.mockImplementationOnce(async (params) => {
+      handle = params.handle;
+      return {
+        close,
+        endpointUrl: "http://127.0.0.1:43210/whatsapp/webhook",
+      };
+    });
+
+    try {
+      const config: ProviderConfig = {
+        adapter: "whatsapp",
+        capabilities: ["probe", "send", "roundtrip", "agent"],
+        env: [],
+        platform: "whatsapp",
+        status: "active",
+        whatsapp: {
+          recorder: { path: recorderPath },
+          webhook: {
+            host: "127.0.0.1",
+            path: "/whatsapp/webhook",
+            port: 0,
+          },
+        },
+      };
+      const fixture = {
+        env: [],
+        id: "whatsapp-roundtrip",
+        inboundMatch: {
+          author: "assistant" as const,
+          nonce: "contains" as const,
+          strategy: "contains" as const,
+        },
+        mode: "roundtrip" as const,
+        provider: "whatsapp",
+        retries: 0,
+        tags: [],
+        target: { id: "15551234567", metadata: {} },
+        timeoutMs: 500,
+      };
+      const manifest: ManifestDefinition = {
+        configVersion: 1,
+        fixtures: [fixture],
+        providers: { whatsapp: config },
+        userName: "crabline",
+      };
+      const context: ProviderContext = {
+        config,
+        fixture,
+        manifestPath: "/tmp/crabline.yaml",
+        providerId: "whatsapp",
+        userName: "crabline",
+      };
+      const provider = createRegistry(manifest, context.manifestPath).resolve(
+        "whatsapp",
+        fixture.id,
+      );
+      await provider.probe(context);
+      let waitResolved = false;
+      waiting = provider
+        .waitForInbound({
+          ...context,
+          nonce: "registry-cleanup-race",
+          since: new Date().toISOString(),
+          timeoutMs: 200,
+        })
+        .then((result) => {
+          waitResolved = true;
+          return result;
+        });
+      await waitStarted;
+
+      let cleanupResolved = false;
+      cleanup = provider.cleanup?.().then(() => {
+        cleanupResolved = true;
+      });
+
+      expect(close).toHaveBeenCalledTimes(1);
+      expect(waitResolved).toBe(false);
+      expect(cleanupResolved).toBe(false);
+      await expect(
+        handle!(
+          new Request("http://127.0.0.1:43210/whatsapp/webhook", {
+            body: JSON.stringify({
+              id: "wa-rejected-after-registry-cleanup",
+              text: "must not be recorded",
+              threadId: "15551234567",
+            }),
+            headers: { "content-type": "application/json" },
+            method: "POST",
+          }),
+        ),
+      ).resolves.toMatchObject({ status: 503 });
+      expect(recorderMocks.appendRecordedInbound).not.toHaveBeenCalled();
+
+      await expect(waiting).resolves.toBeNull();
+      await cleanup;
+      await expect(readFile(recorderPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await waiting?.catch(() => undefined);
+      await cleanup?.catch(() => undefined);
+      await disposeTempDir(directory);
+    }
+  });
+
   it("drains an operation admitted before provider materialization", async () => {
     const directory = await createTempDir();
     const recorderPath = path.join(directory, "telegram.jsonl");

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
+import type { ManifestDefinition, ProviderConfig } from "../src/config/schema.js";
+import { TelegramProviderAdapter } from "../src/providers/builtin/telegram.js";
 import { createRegistry } from "../src/providers/registry.js";
-import type { ManifestDefinition } from "../src/config/schema.js";
 
 const manifest: ManifestDefinition = {
   configVersion: 1,
@@ -35,6 +36,97 @@ describe("registry", () => {
     const provider = registry.resolve("local", "fixture");
     expect(provider.id).toBe("local");
     expect(provider.status).toBe("ready");
+  });
+
+  it("uses configured capabilities and concrete target normalization before loading adapters", () => {
+    const config: ProviderConfig = {
+      adapter: "telegram",
+      capabilities: ["probe"],
+      env: [],
+      platform: "telegram",
+      status: "active",
+      telegram: {
+        mode: "auto",
+        recorder: {},
+        webhook: {
+          host: "127.0.0.1",
+          path: "/telegram/webhook",
+          port: 0,
+        },
+      },
+    };
+    const fixture = {
+      ...manifest.fixtures[0]!,
+      id: "telegram-topic",
+      mode: "probe" as const,
+      provider: "telegram",
+      target: {
+        id: "-1001234567890",
+        metadata: {},
+        threadId: "-1001234567890:42",
+      },
+    };
+    const telegramManifest: ManifestDefinition = {
+      ...manifest,
+      fixtures: [fixture],
+      providers: { telegram: config },
+    };
+
+    const lazyProvider = createRegistry(telegramManifest, "/tmp/crabline.yaml").resolve(
+      "telegram",
+      fixture.id,
+    );
+    const concreteProvider = new TelegramProviderAdapter("telegram", config, "crabline");
+
+    expect(lazyProvider.supports).toEqual(["probe"]);
+    expect(concreteProvider.supports).toEqual(["probe"]);
+    expect(lazyProvider.normalizeTarget(fixture.target)).toEqual(
+      concreteProvider.normalizeTarget(fixture.target),
+    );
+    expect(lazyProvider.normalizeTarget(fixture.target)).toMatchObject({
+      channelId: "-1001234567890",
+      threadId: "-1001234567890:42",
+    });
+  });
+
+  it("applies provider-specific validation through lazy adapters", () => {
+    const whatsappManifest: ManifestDefinition = {
+      ...manifest,
+      fixtures: [
+        {
+          ...manifest.fixtures[0]!,
+          id: "whatsapp-fixture",
+          provider: "whatsapp",
+          target: { id: "not-a-wa-id", metadata: {} },
+        },
+      ],
+      providers: {
+        whatsapp: {
+          adapter: "whatsapp",
+          capabilities: ["probe", "send", "roundtrip", "agent"],
+          env: [],
+          platform: "whatsapp",
+          status: "active",
+          whatsapp: {
+            recorder: {},
+            webhook: {
+              host: "127.0.0.1",
+              path: "/whatsapp/webhook",
+              port: 0,
+            },
+          },
+        },
+      },
+    };
+
+    const provider = createRegistry(whatsappManifest, "/tmp/crabline.yaml").resolve(
+      "whatsapp",
+      "whatsapp-fixture",
+    );
+
+    expect(() => provider.normalizeTarget(whatsappManifest.fixtures[0]!.target)).toThrow(
+      /WhatsApp wa_id/u,
+    );
   });
 
   it("throws for unknown providers", () => {

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -1,7 +1,11 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import type { ManifestDefinition, ProviderConfig } from "../src/config/schema.js";
 import { TelegramProviderAdapter } from "../src/providers/builtin/telegram.js";
 import { createRegistry } from "../src/providers/registry.js";
+import type { ProviderContext, SendContext, WaitContext } from "../src/providers/types.js";
+import { createTempDir, disposeTempDir } from "./test-helpers.js";
 
 const manifest: ManifestDefinition = {
   configVersion: 1,
@@ -127,6 +131,76 @@ describe("registry", () => {
     expect(() => provider.normalizeTarget(whatsappManifest.fixtures[0]!.target)).toThrow(
       /WhatsApp wa_id/u,
     );
+  });
+
+  it("keeps cleanup terminal before lazy provider materialization", async () => {
+    const directory = await createTempDir();
+    const recorderPath = path.join(directory, "whatsapp.jsonl");
+    try {
+      const config: ProviderConfig = {
+        adapter: "whatsapp",
+        capabilities: ["probe", "send", "roundtrip", "agent"],
+        env: [],
+        platform: "whatsapp",
+        status: "active",
+        whatsapp: {
+          recorder: { path: recorderPath },
+          webhook: {
+            host: "127.0.0.1",
+            path: "/whatsapp/webhook",
+            port: 0,
+          },
+        },
+      };
+      const fixture = {
+        ...manifest.fixtures[0]!,
+        id: "whatsapp-cleanup",
+        mode: "send" as const,
+        provider: "whatsapp",
+        target: { id: "15551234567", metadata: {} },
+      };
+      const lazyManifest: ManifestDefinition = {
+        ...manifest,
+        fixtures: [fixture],
+        providers: { whatsapp: config },
+      };
+      const provider = createRegistry(lazyManifest, "/tmp/crabline.yaml").resolve(
+        "whatsapp",
+        fixture.id,
+      );
+      const context: ProviderContext = {
+        config,
+        fixture,
+        manifestPath: "/tmp/crabline.yaml",
+        providerId: "whatsapp",
+        userName: "crabline",
+      };
+      const sendContext: SendContext = {
+        ...context,
+        mode: "send",
+        nonce: "lazy-cleanup",
+        text: "must not run",
+      };
+      const waitContext: WaitContext = {
+        ...context,
+        nonce: "lazy-cleanup",
+        since: new Date().toISOString(),
+        timeoutMs: 100,
+      };
+
+      await provider.cleanup?.();
+
+      await expect(provider.send(sendContext)).rejects.toThrow(/has been cleaned up/u);
+      await expect(provider.probe(context)).rejects.toThrow(/has been cleaned up/u);
+      await expect(provider.waitForInbound(waitContext)).rejects.toThrow(/has been cleaned up/u);
+      await expect(provider.watch?.(context)[Symbol.asyncIterator]().next()).rejects.toThrow(
+        /has been cleaned up/u,
+      );
+      expect(() => provider.normalizeTarget(fixture.target)).toThrow(/has been cleaned up/u);
+      await expect(readFile(recorderPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await disposeTempDir(directory);
+    }
   });
 
   it("throws for unknown providers", () => {

--- a/test/whatsapp-provider-lifecycle.test.ts
+++ b/test/whatsapp-provider-lifecycle.test.ts
@@ -85,5 +85,37 @@ describe("WhatsApp provider lifecycle", () => {
 
     await Promise.all([provider.cleanup(), provider.cleanup()]);
     expect(close).toHaveBeenCalledTimes(1);
+    await expect(provider.probe(context)).rejects.toThrow(/has been cleaned up/u);
+    expect(webhookMocks.startWebhookServer).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes an in-flight listener when cleanup wins the startup race", async () => {
+    let resolveStart:
+      | ((server: { close(): Promise<void>; endpointUrl: string }) => void)
+      | undefined;
+    const close = vi.fn(async () => undefined);
+    webhookMocks.startWebhookServer.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveStart = resolve;
+      }),
+    );
+    const config = createConfig();
+    const provider = new WhatsAppProviderAdapter("whatsapp", config, "crabline");
+    const context = createContext(config);
+
+    const probe = provider.probe(context);
+    await vi.waitFor(() => expect(webhookMocks.startWebhookServer).toHaveBeenCalledTimes(1));
+
+    const cleanup = provider.cleanup();
+    await expect(provider.probe(context)).rejects.toThrow(/has been cleaned up/u);
+    resolveStart?.({
+      close,
+      endpointUrl: "http://127.0.0.1:43210/whatsapp/webhook",
+    });
+
+    await expect(probe).rejects.toThrow(/has been cleaned up/u);
+    await cleanup;
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(webhookMocks.startWebhookServer).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/whatsapp-provider-lifecycle.test.ts
+++ b/test/whatsapp-provider-lifecycle.test.ts
@@ -1,7 +1,10 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ProviderConfig } from "../src/config/schema.js";
 import { WhatsAppProviderAdapter } from "../src/providers/builtin/whatsapp.js";
-import type { ProviderContext } from "../src/providers/types.js";
+import type { ProviderContext, SendContext } from "../src/providers/types.js";
+import { createTempDir, disposeTempDir } from "./test-helpers.js";
 
 const webhookMocks = vi.hoisted(() => ({
   startWebhookServer: vi.fn(),
@@ -15,7 +18,7 @@ beforeEach(() => {
   webhookMocks.startWebhookServer.mockReset();
 });
 
-function createConfig(): ProviderConfig {
+function createConfig(recorderPath?: string): ProviderConfig {
   return {
     adapter: "whatsapp",
     capabilities: ["probe", "send", "roundtrip", "agent"],
@@ -23,7 +26,7 @@ function createConfig(): ProviderConfig {
     platform: "whatsapp",
     status: "active",
     whatsapp: {
-      recorder: {},
+      recorder: recorderPath ? { path: recorderPath } : {},
       webhook: {
         host: "127.0.0.1",
         path: "/whatsapp/webhook",
@@ -117,5 +120,29 @@ describe("WhatsApp provider lifecycle", () => {
     await cleanup;
     expect(close).toHaveBeenCalledTimes(1);
     expect(webhookMocks.startWebhookServer).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects sends after cleanup without mutating the recorder", async () => {
+    const directory = await createTempDir();
+    const recorderPath = path.join(directory, "whatsapp.jsonl");
+    try {
+      const config = createConfig(recorderPath);
+      const provider = new WhatsAppProviderAdapter("whatsapp", config, "crabline");
+      const context = createContext(config);
+      const sendContext: SendContext = {
+        ...context,
+        mode: "send",
+        nonce: "whatsapp-cleanup-send",
+        text: "must not be recorded",
+      };
+
+      await provider.cleanup();
+
+      await expect(provider.send(sendContext)).rejects.toThrow(/has been cleaned up/u);
+      await expect(readFile(recorderPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+      expect(webhookMocks.startWebhookServer).not.toHaveBeenCalled();
+    } finally {
+      await disposeTempDir(directory);
+    }
   });
 });

--- a/test/whatsapp-provider-lifecycle.test.ts
+++ b/test/whatsapp-provider-lifecycle.test.ts
@@ -7,6 +7,9 @@ import type { ProviderContext, SendContext } from "../src/providers/types.js";
 import { createTempDir, disposeTempDir } from "./test-helpers.js";
 
 type AppendRecordedInbound = typeof import("../src/providers/recorder.js").appendRecordedInbound;
+type WebhookHandler = Parameters<
+  typeof import("../src/providers/webhook-server.js").startWebhookServer
+>[0]["handle"];
 
 const webhookMocks = vi.hoisted(() => ({
   startWebhookServer: vi.fn(),
@@ -213,6 +216,107 @@ describe("WhatsApp provider lifecycle", () => {
     } finally {
       releaseReply?.();
       await sending?.catch(() => undefined);
+      await cleanup?.catch(() => undefined);
+      await disposeTempDir(directory);
+    }
+  });
+
+  it("closes ingress before draining admitted webhook work", async () => {
+    const directory = await createTempDir();
+    const recorderPath = path.join(directory, "whatsapp.jsonl");
+    let cleanup: Promise<void> | undefined;
+    let handle: WebhookHandler | undefined;
+    let releaseAppend: (() => void) | undefined;
+    let request: Promise<Response> | undefined;
+    const appendBlocked = new Promise<void>((resolve) => {
+      releaseAppend = resolve;
+    });
+    const close = vi.fn(async () => undefined);
+    webhookMocks.startWebhookServer.mockImplementationOnce(async (params) => {
+      handle = params.handle;
+      return {
+        close,
+        endpointUrl: "http://127.0.0.1:43210/whatsapp/webhook",
+      };
+    });
+    recorderMocks.appendRecordedInbound.mockImplementationOnce(async (...args) => {
+      await appendBlocked;
+      return await recorderMocks.actualAppendRecordedInbound!(...args);
+    });
+
+    try {
+      const config = createConfig(recorderPath);
+      const provider = new WhatsAppProviderAdapter("whatsapp", config, "crabline");
+      const context = createContext(config);
+      await provider.probe(context);
+
+      request = handle!(
+        new Request("http://127.0.0.1:43210/whatsapp/webhook", {
+          body: JSON.stringify({
+            entry: [
+              {
+                changes: [
+                  {
+                    value: {
+                      messages: [
+                        {
+                          from: "15551234567",
+                          id: "wa-cleanup-ingress-1",
+                          text: { body: "finish before cleanup" },
+                          type: "text",
+                        },
+                        {
+                          from: "15551234567",
+                          id: "wa-cleanup-ingress-2",
+                          text: { body: "finish the admitted batch" },
+                          type: "text",
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            ],
+          }),
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        }),
+      );
+      await vi.waitFor(() => expect(recorderMocks.appendRecordedInbound).toHaveBeenCalledTimes(1));
+
+      let cleanupResolved = false;
+      cleanup = provider.cleanup().then(() => {
+        cleanupResolved = true;
+      });
+      expect(close).toHaveBeenCalledTimes(1);
+      await Promise.resolve();
+      expect(cleanupResolved).toBe(false);
+
+      await expect(
+        handle!(
+          new Request("http://127.0.0.1:43210/whatsapp/webhook", {
+            body: JSON.stringify({
+              id: "wa-rejected-ingress",
+              text: "must not be recorded",
+              threadId: "15551234567",
+            }),
+            headers: { "content-type": "application/json" },
+            method: "POST",
+          }),
+        ),
+      ).resolves.toMatchObject({ status: 503 });
+      expect(recorderMocks.appendRecordedInbound).toHaveBeenCalledTimes(1);
+
+      releaseAppend?.();
+      await expect(request).resolves.toMatchObject({ status: 200 });
+      await cleanup;
+      const contentsAfterCleanup = await readFile(recorderPath, "utf8");
+      expect(contentsAfterCleanup.trim().split("\n")).toHaveLength(2);
+      await Promise.resolve();
+      expect(await readFile(recorderPath, "utf8")).toBe(contentsAfterCleanup);
+    } finally {
+      releaseAppend?.();
+      await request?.catch(() => undefined);
       await cleanup?.catch(() => undefined);
       await disposeTempDir(directory);
     }

--- a/test/whatsapp-provider-lifecycle.test.ts
+++ b/test/whatsapp-provider-lifecycle.test.ts
@@ -6,16 +6,35 @@ import { WhatsAppProviderAdapter } from "../src/providers/builtin/whatsapp.js";
 import type { ProviderContext, SendContext } from "../src/providers/types.js";
 import { createTempDir, disposeTempDir } from "./test-helpers.js";
 
+type AppendRecordedInbound = typeof import("../src/providers/recorder.js").appendRecordedInbound;
+
 const webhookMocks = vi.hoisted(() => ({
   startWebhookServer: vi.fn(),
+}));
+const recorderMocks = vi.hoisted(() => ({
+  actualAppendRecordedInbound: undefined as AppendRecordedInbound | undefined,
+  appendRecordedInbound: vi.fn<AppendRecordedInbound>(),
 }));
 
 vi.mock("../src/providers/webhook-server.js", () => ({
   startWebhookServer: webhookMocks.startWebhookServer,
 }));
+vi.mock("../src/providers/recorder.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/providers/recorder.js")>();
+  recorderMocks.actualAppendRecordedInbound = actual.appendRecordedInbound;
+  recorderMocks.appendRecordedInbound.mockImplementation(actual.appendRecordedInbound);
+  return {
+    ...actual,
+    appendRecordedInbound: recorderMocks.appendRecordedInbound,
+  };
+});
 
 beforeEach(() => {
   webhookMocks.startWebhookServer.mockReset();
+  recorderMocks.appendRecordedInbound.mockReset();
+  recorderMocks.appendRecordedInbound.mockImplementation(
+    recorderMocks.actualAppendRecordedInbound!,
+  );
 });
 
 function createConfig(recorderPath?: string): ProviderConfig {
@@ -142,6 +161,59 @@ describe("WhatsApp provider lifecycle", () => {
       await expect(readFile(recorderPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
       expect(webhookMocks.startWebhookServer).not.toHaveBeenCalled();
     } finally {
+      await disposeTempDir(directory);
+    }
+  });
+
+  it("waits for an admitted send before cleanup resolves", async () => {
+    const directory = await createTempDir();
+    const recorderPath = path.join(directory, "whatsapp.jsonl");
+    let cleanup: Promise<void> | undefined;
+    let releaseReply: (() => void) | undefined;
+    let sending: Promise<unknown> | undefined;
+    const replyBlocked = new Promise<void>((resolve) => {
+      releaseReply = resolve;
+    });
+    let appendCount = 0;
+    recorderMocks.appendRecordedInbound.mockImplementation(async (...args) => {
+      appendCount += 1;
+      if (appendCount === 2) {
+        await replyBlocked;
+      }
+      return await recorderMocks.actualAppendRecordedInbound!(...args);
+    });
+
+    try {
+      const config = createConfig(recorderPath);
+      const provider = new WhatsAppProviderAdapter("whatsapp", config, "crabline");
+      const context = createContext(config);
+      sending = provider.send({
+        ...context,
+        mode: "roundtrip",
+        nonce: "whatsapp-cleanup-race",
+        text: "finish before cleanup",
+      });
+      await vi.waitFor(() => expect(recorderMocks.appendRecordedInbound).toHaveBeenCalledTimes(2));
+
+      let cleanupResolved = false;
+      cleanup = provider.cleanup().then(() => {
+        cleanupResolved = true;
+      });
+      await Promise.resolve();
+      expect(cleanupResolved).toBe(false);
+      expect((await readFile(recorderPath, "utf8")).trim().split("\n")).toHaveLength(1);
+
+      releaseReply?.();
+      await cleanup;
+      await sending;
+      const contentsAfterCleanup = await readFile(recorderPath, "utf8");
+      expect(contentsAfterCleanup.trim().split("\n")).toHaveLength(2);
+      await Promise.resolve();
+      expect(await readFile(recorderPath, "utf8")).toBe(contentsAfterCleanup);
+    } finally {
+      releaseReply?.();
+      await sending?.catch(() => undefined);
+      await cleanup?.catch(() => undefined);
       await disposeTempDir(directory);
     }
   });


### PR DESCRIPTION
## Summary
- enforce provider capability and adapter configuration ownership
- make lazy adapter cleanup terminal while draining admitted operations and iterators
- close WhatsApp ingress before draining accepted work through the production registry

## Verification
- autoreview: gpt-5.6-sol high, clean (0.94)
- Crabbox: `run_9dbd8dc200c8`
- `pnpm verify`: 44 files, 327 tests passed

## Release note
- updated `CHANGELOG.md` and `docs/channel-setup.md`