### PR TITLE
fix(servers): enforce protocol safety contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Randomize externally bound provider credentials, preserve Slack MPIM and Matrix sync errors, bound server shutdown, and enforce safe Zalo webhooks.
 - Pin privileged release workflow actions to immutable revisions.
 - Redact inherited secret-named environment values from script diagnostics.
 - Verify production tarballs through their installed npm command shims.

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -331,6 +331,11 @@ receives the native Zalo `{ ok, result }` event envelope with
 otherwise injected messages are returned by `getUpdates`. Provider errors use
 Zalo's `{ ok, error_code, description }` shape.
 
+`setWebhook` requires HTTPS, matching Zalo's public API. A loopback-bound
+Crabline server also accepts a loopback HTTP URL for independent local client
+tests. Non-loopback binds reject webhook destinations that resolve to private,
+loopback, or link-local addresses.
+
 The authenticated admin ingress is only a test control plane. Post a message
 such as:
 

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -104,7 +104,9 @@ The complete multi-channel script fixture is available in
 ## Local Provider Servers
 
 Server-backed channels currently include Mattermost, Matrix, Signal, Slack,
-Telegram, and WhatsApp.
+Telegram, WhatsApp, and Zalo. Loopback binds retain stable local credentials for
+fixture compatibility. Non-loopback binds generate fresh provider-shaped
+credentials unless the corresponding token or secret option is supplied.
 
 ### Mattermost
 

--- a/src/servers/http.ts
+++ b/src/servers/http.ts
@@ -154,6 +154,20 @@ export function formatUrlHost(host: string): string {
   return host.includes(":") ? `[${host}]` : host;
 }
 
+export function isLoopbackHost(host: string): boolean {
+  const normalized = host
+    .trim()
+    .replace(/^\[(.*)\]$/u, "$1")
+    .toLowerCase();
+  return (
+    normalized === "localhost" ||
+    normalized.endsWith(".localhost") ||
+    normalized === "::1" ||
+    normalized.startsWith("::ffff:127.") ||
+    /^127(?:\.\d{1,3}){3}$/u.test(normalized)
+  );
+}
+
 export async function writeResponse(
   response: ServerResponse,
   fetchResponse: Response,

--- a/src/servers/http.ts
+++ b/src/servers/http.ts
@@ -13,6 +13,7 @@ export type ServerRequestEvent = {
 
 export const ADMIN_TOKEN_HEADER = "x-crabline-admin-token";
 export const DEFAULT_MAX_REQUEST_BODY_BYTES = 1024 * 1024;
+export const DEFAULT_SERVER_SHUTDOWN_GRACE_MS = 250;
 
 export class InvalidJsonBodyError extends Error {
   constructor(cause: unknown) {
@@ -179,12 +180,20 @@ export async function writeResponse(
   response.end(Buffer.from(await fetchResponse.arrayBuffer()));
 }
 
-export function closeServer(server: Server): Promise<void> {
+export function closeServer(
+  server: Server,
+  graceMs = DEFAULT_SERVER_SHUTDOWN_GRACE_MS,
+): Promise<void> {
   return new Promise((resolve, reject) => {
     const closeIdleInterval = setInterval(() => server.closeIdleConnections(), 25);
     closeIdleInterval.unref();
+    const forceCloseTimer = setTimeout(() => {
+      server.closeAllConnections();
+    }, graceMs);
+    forceCloseTimer.unref();
     server.close((error) => {
       clearInterval(closeIdleInterval);
+      clearTimeout(forceCloseTimer);
       if (error) {
         reject(error);
         return;

--- a/src/servers/matrix.ts
+++ b/src/servers/matrix.ts
@@ -225,16 +225,23 @@ function syncRoom(room: MatrixRoom, since: number | undefined) {
   };
 }
 
-function parseSyncToken(value: string | null): number | undefined {
-  if (!value) {
+function parseSyncToken(value: string | null): number | null | undefined {
+  if (value === null) {
     return undefined;
   }
   const match = /^s(\d+)$/u.exec(value);
-  return match ? Number(match[1]) : undefined;
+  if (!match) {
+    return null;
+  }
+  const sequence = Number(match[1]);
+  return Number.isSafeInteger(sequence) ? sequence : null;
 }
 
 async function handleSync(url: URL, state: MatrixServerState): Promise<Response> {
   const since = parseSyncToken(url.searchParams.get("since"));
+  if (since === null) {
+    return matrixError("M_UNKNOWN_POS", "Unknown position", 400);
+  }
   const timeout = Math.min(readInteger(url.searchParams.get("timeout")) ?? 0, 1_000);
   const hasNewEvents = [...state.rooms.values()].some((room) =>
     room.timeline.some((entry) => since === undefined || entry.sequence > since),

--- a/src/servers/mattermost.ts
+++ b/src/servers/mattermost.ts
@@ -8,6 +8,7 @@ import {
   hasAdminToken,
   InvalidJsonBodyError,
   isJsonObject,
+  isLoopbackHost,
   jsonResponse,
   parseUnknownRequestBody,
   queryRecord,
@@ -484,11 +485,14 @@ function attachWebSocketServer(params: {
 export async function startMattermostServer(
   params: StartMattermostServerParams = {},
 ): Promise<StartedMattermostServer> {
+  const host = params.host ?? "127.0.0.1";
   const botUserId = params.botUserId ?? mattermostId("crabline-mattermost-bot");
   const botUsername = params.botUsername ?? "crabline_bot";
   const state: MattermostServerState = {
     adminToken: params.adminToken ?? randomBytes(24).toString("base64url"),
-    botToken: params.botToken ?? "crabline-mattermost-token",
+    botToken:
+      params.botToken ??
+      (isLoopbackHost(host) ? "crabline-mattermost-token" : randomBytes(13).toString("hex")),
     botUserId,
     botUsername,
     channels: new Map(),
@@ -511,7 +515,7 @@ export async function startMattermostServer(
       }
       return undefined;
     },
-    host: params.host ?? "127.0.0.1",
+    host,
     port: params.port ?? 0,
     serverName: "Mattermost",
   });

--- a/src/servers/mattermost.ts
+++ b/src/servers/mattermost.ts
@@ -18,6 +18,7 @@ import {
   type ServerRequestEvent,
 } from "./http.js";
 import { recordServerEvent, type ServerEventObserver } from "./recorder.js";
+import { closeWebSocketServer } from "./websocket.js";
 
 type MattermostPost = {
   channel_id: string;
@@ -473,12 +474,7 @@ function attachWebSocketServer(params: {
   });
   return async () => {
     params.server.off("upgrade", onUpgrade);
-    for (const client of websocketServer.clients) {
-      client.close();
-    }
-    await new Promise<void>((resolve, reject) =>
-      websocketServer.close((error) => (error ? reject(error) : resolve())),
-    );
+    await closeWebSocketServer(websocketServer);
   };
 }
 

--- a/src/servers/mattermost.ts
+++ b/src/servers/mattermost.ts
@@ -515,10 +515,13 @@ export async function startMattermostServer(
     port: params.port ?? 0,
     serverName: "Mattermost",
   });
-  const closeWebSocketServer = attachWebSocketServer({ server: httpServer.server, state });
+  const closeMattermostWebSocketServer = attachWebSocketServer({
+    server: httpServer.server,
+    state,
+  });
   return {
     async close() {
-      await closeWebSocketServer();
+      await closeMattermostWebSocketServer();
       await httpServer.close();
     },
     manifest: {

--- a/src/servers/slack.ts
+++ b/src/servers/slack.ts
@@ -1,5 +1,5 @@
 import type { IncomingMessage } from "node:http";
-import { createHmac, randomBytes } from "node:crypto";
+import { createHmac, randomBytes, randomInt } from "node:crypto";
 import path from "node:path";
 import {
   adminAuthError,
@@ -223,6 +223,10 @@ function hasThreadParent(
 function nextSlackTs(state: SlackServerState): string {
   const index = state.nextTsIndex++;
   return `${1_700_000_000 + Math.floor(index / 1_000_000)}.${String(index % 1_000_000).padStart(6, "0")}`;
+}
+
+function randomDecimalDigits(length: number): string {
+  return Array.from({ length }, () => randomInt(10)).join("");
 }
 
 function nextDmChannelId(state: SlackServerState): string {
@@ -704,7 +708,7 @@ export async function startSlackServer(
     messagesByChannel: new Map(),
   };
   if (externallyBound && !params.botToken) {
-    const generatedBotValue = `xoxb-${randomBytes(6).toString("hex")}-${randomBytes(12).toString("base64url")}`;
+    const generatedBotValue = `xoxb-${randomDecimalDigits(12)}-${randomDecimalDigits(12)}-${randomBytes(18).toString("base64url")}`;
     state.botToken = generatedBotValue;
   }
   if (externallyBound && !params.signingSecret) {

--- a/src/servers/slack.ts
+++ b/src/servers/slack.ts
@@ -6,6 +6,7 @@ import {
   hasAdminToken,
   InvalidJsonBodyError,
   isJsonObject,
+  isLoopbackHost,
   jsonResponse,
   parseUnknownRequestBody,
   queryRecord,
@@ -631,21 +632,28 @@ async function handleRequest(params: { request: IncomingMessage; state: SlackSer
 export async function startSlackServer(
   params: StartSlackServerParams = {},
 ): Promise<StartedSlackServer> {
+  const host = params.host ?? "127.0.0.1";
+  const externallyBound = !isLoopbackHost(host);
   const state: SlackServerState = {
     adminToken: params.adminToken ?? randomBytes(24).toString("base64url"),
     botId: params.botId ?? "BCRABLINE",
-    botToken: params.botToken ?? "xoxb-crabline-slack-token",
+    botToken:
+      params.botToken ??
+      (externallyBound
+        ? `xoxb-${randomBytes(6).toString("hex")}-${randomBytes(12).toString("base64url")}`
+        : "xoxb-crabline-slack-token"),
     botUserId: params.botUserId ?? "UCRABBOT",
     eventsRequestUrl: params.eventsRequestUrl,
     nextDmIndex: 1,
     nextTsIndex: 100,
     onEvent: params.onEvent,
     recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "slack.jsonl"),
-    signingSecret: params.signingSecret ?? "crabline-slack-signing-secret",
+    signingSecret:
+      params.signingSecret ??
+      (externallyBound ? randomBytes(16).toString("hex") : "crabline-slack-signing-secret"),
     userDmChannels: new Map(),
     messagesByChannel: new Map(),
   };
-  const host = params.host ?? "127.0.0.1";
   const httpServer = await startHttpJsonServer({
     handle: (request) => handleRequest({ request, state }),
     handleError: (error) => {

--- a/src/servers/slack.ts
+++ b/src/servers/slack.ts
@@ -474,9 +474,9 @@ async function handleSlackApi(params: {
         return slackOk({
           channel: {
             id: channel.id,
-            is_group: true,
+            is_group: false,
             is_mpim: true,
-            members: channel.users,
+            members: [params.state.botUserId, ...channel.users],
           },
         });
       }
@@ -501,9 +501,9 @@ async function handleSlackApi(params: {
         channel: {
           id: channel,
           is_channel: channel.startsWith("C"),
-          is_group: channel.startsWith("G"),
+          is_group: mpim ? false : channel.startsWith("G"),
           is_im: channel.startsWith("D"),
-          ...(mpim ? { is_mpim: true, members: mpim.users } : {}),
+          ...(mpim ? { is_mpim: true, members: [params.state.botUserId, ...mpim.users] } : {}),
           name: "crabline",
         },
       });

--- a/src/servers/slack.ts
+++ b/src/servers/slack.ts
@@ -690,11 +690,7 @@ export async function startSlackServer(
   const state: SlackServerState = {
     adminToken: params.adminToken ?? randomBytes(24).toString("base64url"),
     botId: params.botId ?? "BCRABLINE",
-    botToken:
-      params.botToken ??
-      (externallyBound
-        ? `xoxb-${randomBytes(6).toString("hex")}-${randomBytes(12).toString("base64url")}`
-        : "xoxb-crabline-slack-token"),
+    botToken: params.botToken ?? "xoxb-crabline-slack-token",
     botUserId: params.botUserId ?? "UCRABBOT",
     eventsRequestUrl: params.eventsRequestUrl,
     nextDmIndex: 1,
@@ -702,13 +698,19 @@ export async function startSlackServer(
     nextTsIndex: 100,
     onEvent: params.onEvent,
     recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "slack.jsonl"),
-    signingSecret:
-      params.signingSecret ??
-      (externallyBound ? randomBytes(16).toString("hex") : "crabline-slack-signing-secret"),
+    signingSecret: params.signingSecret ?? "crabline-slack-signing-secret",
     userDmChannels: new Map(),
     userMpimChannels: new Map(),
     messagesByChannel: new Map(),
   };
+  if (externallyBound && !params.botToken) {
+    const generatedBotValue = `xoxb-${randomBytes(6).toString("hex")}-${randomBytes(12).toString("base64url")}`;
+    state.botToken = generatedBotValue;
+  }
+  if (externallyBound && !params.signingSecret) {
+    const generatedSigningValue = randomBytes(16).toString("hex");
+    state.signingSecret = generatedSigningValue;
+  }
   const httpServer = await startHttpJsonServer({
     handle: (request) => handleRequest({ request, state }),
     handleError: (error) => {

--- a/src/servers/slack.ts
+++ b/src/servers/slack.ts
@@ -47,11 +47,13 @@ type SlackServerState = {
   botUserId: string;
   eventsRequestUrl: string | undefined;
   nextDmIndex: number;
+  nextMpimIndex: number;
   nextTsIndex: number;
   onEvent: ServerEventObserver | undefined;
   recorderPath: string;
   signingSecret: string;
   userDmChannels: Map<string, string>;
+  userMpimChannels: Map<string, { id: string; users: string[] }>;
   messagesByChannel: Map<string, SlackMessage[]>;
 };
 
@@ -228,6 +230,11 @@ function nextDmChannelId(state: SlackServerState): string {
   return `D${String(index).padStart(9, "0")}`;
 }
 
+function nextMpimChannelId(state: SlackServerState): string {
+  const index = state.nextMpimIndex++;
+  return `G${String(index).padStart(9, "0")}`;
+}
+
 function dmChannelForUser(state: SlackServerState, userId: string): string {
   const existing = state.userDmChannels.get(userId);
   if (existing) {
@@ -236,6 +243,38 @@ function dmChannelForUser(state: SlackServerState, userId: string): string {
   const channelId = nextDmChannelId(state);
   state.userDmChannels.set(userId, channelId);
   return channelId;
+}
+
+function mpimChannelForUsers(
+  state: SlackServerState,
+  users: string[],
+): { id: string; users: string[] } {
+  const key = [...users].sort().join(",");
+  const existing = state.userMpimChannels.get(key);
+  if (existing) {
+    return existing;
+  }
+  const channel = { id: nextMpimChannelId(state), users: [...users] };
+  state.userMpimChannels.set(key, channel);
+  return channel;
+}
+
+function requireSlackUsers(value: unknown): string[] | Response {
+  const rawUsers = readTrimmedString(value);
+  if (!rawUsers) {
+    return slackError("users_list_not_supplied");
+  }
+  const users = rawUsers.split(",").map((user) => user.trim());
+  if (users.length > 8) {
+    return slackError("too_many_users");
+  }
+  if (users.some((user) => !SLACK_USER_ID_RULE.pattern.test(user))) {
+    return slackError("user_not_found");
+  }
+  if (new Set(users).size !== users.length) {
+    return slackError("invalid_user_combination");
+  }
+  return users;
 }
 
 function appendMessage(state: SlackServerState, message: SlackMessage): SlackMessage {
@@ -422,12 +461,22 @@ async function handleSlackApi(params: {
       return slackOk({ channel, message, ts: message.ts });
     }
     case "conversations.open": {
-      const users = readTrimmedString(params.body.users);
-      const firstUser = users?.split(",")[0]?.trim();
-      const user = requireSlackUserId(firstUser);
-      if (user instanceof Response) {
-        return user;
+      const users = requireSlackUsers(params.body.users);
+      if (users instanceof Response) {
+        return users;
       }
+      if (users.length > 1) {
+        const channel = mpimChannelForUsers(params.state, users);
+        return slackOk({
+          channel: {
+            id: channel.id,
+            is_group: true,
+            is_mpim: true,
+            members: channel.users,
+          },
+        });
+      }
+      const user = users[0]!;
       return slackOk({
         channel: {
           id: dmChannelForUser(params.state, user),
@@ -441,12 +490,16 @@ async function handleSlackApi(params: {
       if (channel instanceof Response) {
         return channel;
       }
+      const mpim = [...params.state.userMpimChannels.values()].find(
+        (candidate) => candidate.id === channel,
+      );
       return slackOk({
         channel: {
           id: channel,
           is_channel: channel.startsWith("C"),
           is_group: channel.startsWith("G"),
           is_im: channel.startsWith("D"),
+          ...(mpim ? { is_mpim: true, members: mpim.users } : {}),
           name: "crabline",
         },
       });
@@ -645,6 +698,7 @@ export async function startSlackServer(
     botUserId: params.botUserId ?? "UCRABBOT",
     eventsRequestUrl: params.eventsRequestUrl,
     nextDmIndex: 1,
+    nextMpimIndex: 1,
     nextTsIndex: 100,
     onEvent: params.onEvent,
     recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "slack.jsonl"),
@@ -652,6 +706,7 @@ export async function startSlackServer(
       params.signingSecret ??
       (externallyBound ? randomBytes(16).toString("hex") : "crabline-slack-signing-secret"),
     userDmChannels: new Map(),
+    userMpimChannels: new Map(),
     messagesByChannel: new Map(),
   };
   const httpServer = await startHttpJsonServer({

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -10,6 +10,7 @@ import {
   hasAdminToken,
   InvalidJsonBodyError,
   isJsonObject,
+  isLoopbackHost,
   jsonResponse,
   queryRecord,
   readBody,
@@ -649,11 +650,17 @@ async function handleRequest(params: { request: IncomingMessage; state: Telegram
 export async function startTelegramServer(
   params: StartTelegramServerParams = {},
 ): Promise<StartedTelegramServer> {
+  const host = params.host ?? "127.0.0.1";
+  const botId = params.botId ?? 424242;
   const state: TelegramServerState = {
     activeUpdatePoll: undefined,
     adminToken: params.adminToken ?? randomBytes(24).toString("hex"),
-    botId: params.botId ?? 424242,
-    botToken: params.botToken ?? "424242:crabline-telegram-token",
+    botId,
+    botToken:
+      params.botToken ??
+      (isLoopbackHost(host)
+        ? "424242:crabline-telegram-token"
+        : `${botId}:${randomBytes(26).toString("base64url")}`),
     botUsername: params.botUsername ?? "crabline_bot",
     nextMessageId: 1,
     nextUpdateId: 1,
@@ -662,7 +669,6 @@ export async function startTelegramServer(
     closing: false,
     updates: [],
   };
-  const host = params.host ?? "127.0.0.1";
   const port = params.port ?? 0;
   const server = createServer(async (request, response) => {
     try {

--- a/src/servers/websocket.ts
+++ b/src/servers/websocket.ts
@@ -1,0 +1,33 @@
+import { WebSocket, type WebSocketServer } from "ws";
+import { DEFAULT_SERVER_SHUTDOWN_GRACE_MS } from "./http.js";
+
+export async function closeWebSocketServer(
+  server: WebSocketServer,
+  graceMs = DEFAULT_SERVER_SHUTDOWN_GRACE_MS,
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const forceCloseTimer = setTimeout(() => {
+      for (const client of server.clients) {
+        client.terminate();
+      }
+    }, graceMs);
+    forceCloseTimer.unref();
+
+    server.close((error) => {
+      clearTimeout(forceCloseTimer);
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+
+    for (const client of server.clients) {
+      if (client.readyState === WebSocket.OPEN) {
+        client.close(1001, "Server shutting down");
+      } else if (client.readyState !== WebSocket.CLOSED) {
+        client.terminate();
+      }
+    }
+  });
+}

--- a/src/servers/whatsapp-baileys-websocket.ts
+++ b/src/servers/whatsapp-baileys-websocket.ts
@@ -24,6 +24,7 @@ import { decodeHandshakeMessage, encodeHandshakeMessage } from "./whatsapp-wire/
 import { KEY_BUNDLE_TYPE, xmppPreKey, xmppSignedPreKey } from "./whatsapp-wire/signal.js";
 import { WebSocket, WebSocketServer, type RawData } from "ws";
 import type { ServerRequestEvent } from "./http.js";
+import { closeWebSocketServer } from "./websocket.js";
 
 // Keep the local server independent from Baileys at runtime. Tests use Baileys
 // as a black-box client to verify this narrow WhatsApp Web wire subset.
@@ -598,19 +599,8 @@ export function attachWhatsAppBaileysWebSocketServer(
   return {
     async close() {
       params.httpServer.off("upgrade", handleUpgrade);
-      for (const client of wss.clients) {
-        client.close();
-      }
       pendingMessages.length = 0;
-      await new Promise<void>((resolve, reject) => {
-        wss.close((error) => {
-          if (error) {
-            reject(error);
-            return;
-          }
-          resolve();
-        });
-      });
+      await closeWebSocketServer(wss);
     },
     deliverInboundMessage(message) {
       let delivered = false;

--- a/src/servers/whatsapp.ts
+++ b/src/servers/whatsapp.ts
@@ -6,6 +6,7 @@ import {
   hasAdminToken,
   InvalidJsonBodyError,
   isJsonObject,
+  isLoopbackHost,
   jsonResponse,
   parseUnknownRequestBody,
   queryRecord,
@@ -470,6 +471,7 @@ async function handleRequest(params: { request: IncomingMessage; state: WhatsApp
 export async function startWhatsAppServer(
   params: StartWhatsAppServerParams = {},
 ): Promise<StartedWhatsAppServer> {
+  const host = params.host ?? "127.0.0.1";
   const graphVersion = params.graphVersion ?? DEFAULT_GRAPH_VERSION;
   if (!WHATSAPP_GRAPH_VERSION_RE.test(graphVersion)) {
     throw new Error(`Invalid WhatsApp Graph API version: ${graphVersion}.`);
@@ -479,7 +481,11 @@ export async function startWhatsAppServer(
     throw new Error("WhatsApp phoneNumberId must contain only digits.");
   }
   const state: WhatsAppServerState = {
-    accessToken: params.accessToken ?? "crabline-whatsapp-access-token",
+    accessToken:
+      params.accessToken ??
+      (isLoopbackHost(host)
+        ? "crabline-whatsapp-access-token"
+        : `EAA${randomBytes(24).toString("base64url")}`),
     adminToken: params.adminToken ?? randomBytes(24).toString("hex"),
     deliverInboundMessage: () => "queued",
     displayPhoneNumber: params.displayPhoneNumber ?? "15550000000",
@@ -490,7 +496,6 @@ export async function startWhatsAppServer(
     recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "whatsapp.jsonl"),
     selfJid: params.selfJid ?? "15550000000@s.whatsapp.net",
   };
-  const host = params.host ?? "127.0.0.1";
   const httpServer = await startHttpJsonServer({
     handle: (request) => handleRequest({ request, state }),
     handleError: (error) => {

--- a/src/servers/zalo.ts
+++ b/src/servers/zalo.ts
@@ -7,6 +7,7 @@ import {
   hasAdminToken,
   InvalidJsonBodyError,
   isJsonObject,
+  isLoopbackHost,
   jsonResponse,
   parseUnknownRequestBody,
   queryRecord,
@@ -361,7 +362,9 @@ export async function startZaloServer(
     adminToken: params.adminToken ?? randomBytes(24).toString("hex"),
     botId: params.botId ?? "1459232241454765289",
     botName: params.botName ?? "bot.crabline",
-    botToken: params.botToken ?? "crabline-zalo-bot-token",
+    botToken:
+      params.botToken ??
+      (isLoopbackHost(host) ? "crabline-zalo-bot-token" : randomBytes(32).toString("base64url")),
     nextMessage: 1,
     onEvent: params.onEvent,
     pendingRequests: [],

--- a/src/servers/zalo.ts
+++ b/src/servers/zalo.ts
@@ -1,5 +1,8 @@
 import { randomBytes } from "node:crypto";
-import type { IncomingMessage } from "node:http";
+import { lookup } from "node:dns/promises";
+import { request as requestHttp, type IncomingMessage } from "node:http";
+import { request as requestHttps } from "node:https";
+import { BlockList, isIP } from "node:net";
 import path from "node:path";
 import {
   adminAuthError,
@@ -22,6 +25,7 @@ type ZaloChatType = "GROUP" | "PRIVATE";
 
 const DEFAULT_WEBHOOK_DELIVERY_TIMEOUT_MS = 5_000;
 const MAX_WEBHOOK_DELIVERY_TIMEOUT_MS = 30_000;
+const BLOCKED_WEBHOOK_ADDRESSES = createBlockedWebhookAddresses();
 
 type ZaloMessage = {
   chat: { chat_type: ZaloChatType; id: string };
@@ -42,8 +46,18 @@ type PendingUpdateRequest = {
   timeout: NodeJS.Timeout;
 };
 
+type WebhookAddress = {
+  address: string;
+  family: 4 | 6;
+};
+
+type ValidatedWebhookTarget = {
+  addresses: WebhookAddress[] | undefined;
+};
+
 type ZaloServerState = {
   adminToken: string;
+  allowLoopbackHttpWebhook: boolean;
   botId: string;
   botName: string;
   botToken: string;
@@ -51,6 +65,7 @@ type ZaloServerState = {
   onEvent: ServerEventObserver | undefined;
   pendingRequests: PendingUpdateRequest[];
   recorderPath: string;
+  restrictWebhookTargets: boolean;
   updates: ZaloUpdate[];
   webhook: { secretToken: string; updatedAt: number; url: string } | undefined;
   webhookDeliveryTimeoutMs: number;
@@ -139,6 +154,134 @@ function webhookDeliveryTimeoutMs(value: number | undefined): number {
   return Math.max(1, Math.min(Math.floor(value), MAX_WEBHOOK_DELIVERY_TIMEOUT_MS));
 }
 
+function createBlockedWebhookAddresses(): BlockList {
+  const blockList = new BlockList();
+  for (const [address, prefix] of [
+    ["0.0.0.0", 8],
+    ["10.0.0.0", 8],
+    ["100.64.0.0", 10],
+    ["127.0.0.0", 8],
+    ["169.254.0.0", 16],
+    ["172.16.0.0", 12],
+    ["192.168.0.0", 16],
+    ["224.0.0.0", 4],
+    ["240.0.0.0", 4],
+  ] as const) {
+    blockList.addSubnet(address, prefix, "ipv4");
+  }
+  for (const [address, prefix] of [
+    ["::", 128],
+    ["::1", 128],
+    ["fc00::", 7],
+    ["fe80::", 10],
+    ["ff00::", 8],
+  ] as const) {
+    blockList.addSubnet(address, prefix, "ipv6");
+  }
+  return blockList;
+}
+
+function normalizeHostname(hostname: string): string {
+  return hostname.replace(/^\[(.*)\]$/u, "$1").replace(/%25/gu, "%");
+}
+
+function isBlockedWebhookAddress(address: string): boolean {
+  const normalized = normalizeHostname(address);
+  const mappedIpv4 = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/iu.exec(normalized)?.[1];
+  if (mappedIpv4) {
+    return BLOCKED_WEBHOOK_ADDRESSES.check(mappedIpv4, "ipv4");
+  }
+  const family = isIP(normalized);
+  return family === 4
+    ? BLOCKED_WEBHOOK_ADDRESSES.check(normalized, "ipv4")
+    : family === 6
+      ? BLOCKED_WEBHOOK_ADDRESSES.check(normalized, "ipv6")
+      : false;
+}
+
+async function resolveWebhookAddresses(hostname: string): Promise<WebhookAddress[]> {
+  const normalized = normalizeHostname(hostname);
+  const family = isIP(normalized);
+  if (family === 4 || family === 6) {
+    return [{ address: normalized, family }];
+  }
+  return (await lookup(normalized, { all: true, verbatim: true })).flatMap((entry) =>
+    entry.family === 4 || entry.family === 6
+      ? [{ address: entry.address, family: entry.family }]
+      : [],
+  );
+}
+
+async function validateWebhookUrl(
+  url: URL,
+  state: Pick<ZaloServerState, "allowLoopbackHttpWebhook" | "restrictWebhookTargets">,
+): Promise<Response | ValidatedWebhookTarget> {
+  if (
+    url.protocol === "http:" &&
+    (!state.allowLoopbackHttpWebhook || !isLoopbackHost(url.hostname))
+  ) {
+    return zaloError("url must use HTTPS", 400);
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    return zaloError("url must use HTTPS", 400);
+  }
+  if (!state.restrictWebhookTargets) {
+    return { addresses: undefined };
+  }
+
+  let addresses: WebhookAddress[];
+  try {
+    addresses = await resolveWebhookAddresses(url.hostname);
+  } catch {
+    return zaloError("url host could not be resolved", 400);
+  }
+  if (addresses.length === 0 || addresses.some((entry) => isBlockedWebhookAddress(entry.address))) {
+    return zaloError("url must not target a private or link-local address", 400);
+  }
+  return { addresses };
+}
+
+async function postWebhook(
+  url: URL,
+  body: string,
+  secretToken: string,
+  timeoutMs: number,
+  address: WebhookAddress | undefined,
+): Promise<number> {
+  return await new Promise<number>((resolve, reject) => {
+    const send = url.protocol === "https:" ? requestHttps : requestHttp;
+    const request = send(
+      url,
+      {
+        ...(address ? { family: address.family } : {}),
+        headers: {
+          "content-length": String(Buffer.byteLength(body)),
+          "content-type": "application/json",
+          "x-bot-api-secret-token": secretToken,
+        },
+        ...(address
+          ? {
+              lookup: (_hostname, _options, callback) =>
+                callback(null, address.address, address.family),
+            }
+          : {}),
+        method: "POST",
+      },
+      (response) => {
+        response.resume();
+        response.once("end", () => resolve(response.statusCode ?? 0));
+      },
+    );
+    request.setTimeout(timeoutMs, () => {
+      request.destroy(
+        new DOMException(`Webhook delivery timed out after ${timeoutMs}ms`, "TimeoutError"),
+      );
+    });
+    request.once("error", reject);
+    request.end(body);
+  });
+}
+
 function nextUpdate(state: ZaloServerState): Response | undefined {
   const update = state.updates.shift();
   return update ? zaloOk(update) : undefined;
@@ -178,26 +321,29 @@ function deliverPollingUpdate(state: ZaloServerState, update: ZaloUpdate): void 
 }
 
 async function deliverWebhookUpdate(
+  state: ZaloServerState,
   webhook: NonNullable<ZaloServerState["webhook"]>,
   update: ZaloUpdate,
-  timeoutMs: number,
 ): Promise<Response | undefined> {
+  const url = new URL(webhook.url);
+  const target = await validateWebhookUrl(url, state);
+  if (target instanceof Response) {
+    return target;
+  }
   try {
-    const response = await fetch(webhook.url, {
-      body: JSON.stringify({ ok: true, result: update }),
-      headers: {
-        "content-type": "application/json",
-        "x-bot-api-secret-token": webhook.secretToken,
-      },
-      method: "POST",
-      signal: AbortSignal.timeout(timeoutMs),
-    });
-    if (!response.ok) {
-      return zaloError(`Webhook delivery failed with HTTP ${response.status}`, 502);
+    const status = await postWebhook(
+      url,
+      JSON.stringify({ ok: true, result: update }),
+      webhook.secretToken,
+      state.webhookDeliveryTimeoutMs,
+      target.addresses?.[0],
+    );
+    if (status < 200 || status >= 300) {
+      return zaloError(`Webhook delivery failed with HTTP ${status}`, 502);
     }
   } catch (error) {
     if (error instanceof DOMException && error.name === "TimeoutError") {
-      return zaloError(`Webhook delivery timed out after ${timeoutMs}ms`, 502);
+      return zaloError(`Webhook delivery timed out after ${state.webhookDeliveryTimeoutMs}ms`, 502);
     }
     return zaloError(
       `Webhook delivery failed: ${error instanceof Error ? error.message : String(error)}`,
@@ -250,7 +396,7 @@ async function handleAdminInbound(
     type: "admin",
   });
   if (state.webhook?.url) {
-    const error = await deliverWebhookUpdate(state.webhook, update, state.webhookDeliveryTimeoutMs);
+    const error = await deliverWebhookUpdate(state, state.webhook, update);
     if (error) {
       return error;
     }
@@ -331,10 +477,11 @@ async function handleZaloMethod(
     try {
       parsedUrl = new URL(webhookUrl);
     } catch {
-      return zaloError("url must be a valid HTTP or HTTPS URL", 400);
+      return zaloError("url must be a valid HTTPS URL", 400);
     }
-    if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
-      return zaloError("url must be a valid HTTP or HTTPS URL", 400);
+    const target = await validateWebhookUrl(parsedUrl, state);
+    if (target instanceof Response) {
+      return target;
     }
     state.updates.length = 0;
     const webhook = { secretToken, updatedAt: Date.now(), url: parsedUrl.href };
@@ -360,6 +507,7 @@ export async function startZaloServer(
   const host = params.host ?? "127.0.0.1";
   const state: ZaloServerState = {
     adminToken: params.adminToken ?? randomBytes(24).toString("hex"),
+    allowLoopbackHttpWebhook: isLoopbackHost(host),
     botId: params.botId ?? "1459232241454765289",
     botName: params.botName ?? "bot.crabline",
     botToken:
@@ -369,6 +517,7 @@ export async function startZaloServer(
     onEvent: params.onEvent,
     pendingRequests: [],
     recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "zalo.jsonl"),
+    restrictWebhookTargets: !isLoopbackHost(host),
     updates: [],
     webhook: undefined,
     webhookDeliveryTimeoutMs: webhookDeliveryTimeoutMs(params.webhookDeliveryTimeoutMs),

--- a/test/matrix-server.test.ts
+++ b/test/matrix-server.test.ts
@@ -211,6 +211,39 @@ describe("Matrix local provider server", () => {
     });
   });
 
+  it("returns M_UNKNOWN_POS for malformed sync tokens instead of initial sync", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const server = await startMatrixServer({
+      accessToken: "matrix-token",
+      recorderPath: path.join(directory, "matrix-sync-token.jsonl"),
+    });
+    servers.push(server);
+
+    for (const since of ["", "0", "s-1", "snot-a-sequence", `s${"9".repeat(32)}`]) {
+      const response = await fetch(
+        `${server.manifest.endpoints.syncUrl}?since=${encodeURIComponent(since)}`,
+        {
+          headers: auth("matrix-token"),
+        },
+      );
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({
+        errcode: "M_UNKNOWN_POS",
+        error: "Unknown position",
+      });
+    }
+
+    const initial = await fetch(server.manifest.endpoints.syncUrl, {
+      headers: auth("matrix-token"),
+    });
+    expect(initial.status).toBe(200);
+    await expect(initial.json()).resolves.toMatchObject({
+      next_batch: expect.stringMatching(/^s\d+$/u),
+      rooms: { join: expect.any(Object) },
+    });
+  });
+
   it("returns provider-native internal errors without exception details", async () => {
     const directory = await createTempDir();
     directories.push(directory);

--- a/test/matrix-server.test.ts
+++ b/test/matrix-server.test.ts
@@ -215,7 +215,7 @@ describe("Matrix local provider server", () => {
     const directory = await createTempDir();
     directories.push(directory);
     const server = await startMatrixServer({
-      accessToken: "matrix-token",
+      accessToken: "test-auth-token",
       recorderPath: path.join(directory, "matrix-sync-token.jsonl"),
     });
     servers.push(server);
@@ -224,7 +224,7 @@ describe("Matrix local provider server", () => {
       const response = await fetch(
         `${server.manifest.endpoints.syncUrl}?since=${encodeURIComponent(since)}`,
         {
-          headers: auth("matrix-token"),
+          headers: auth("test-auth-token"),
         },
       );
       expect(response.status).toBe(400);
@@ -235,7 +235,7 @@ describe("Matrix local provider server", () => {
     }
 
     const initial = await fetch(server.manifest.endpoints.syncUrl, {
-      headers: auth("matrix-token"),
+      headers: auth("test-auth-token"),
     });
     expect(initial.status).toBe(200);
     await expect(initial.json()).resolves.toMatchObject({

--- a/test/server-credentials.test.ts
+++ b/test/server-credentials.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  startMattermostServer,
+  startSlackServer,
+  startTelegramServer,
+  startWhatsAppServer,
+  startZaloServer,
+  type StartedCrablineServer,
+} from "../src/index.js";
+
+const servers: StartedCrablineServer[] = [];
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => server.close()));
+});
+
+describe("externally bound provider server credentials", () => {
+  it("generates fresh provider-shaped defaults and mirrors them into env manifests", async () => {
+    const first = await startServers();
+    const second = await startServers();
+
+    expect(first.mattermost.manifest.botToken).toMatch(/^[a-f0-9]{26}$/u);
+    expect(first.mattermost.manifest.env.MATTERMOST_BOT_TOKEN).toBe(
+      first.mattermost.manifest.botToken,
+    );
+    expect(second.mattermost.manifest.botToken).not.toBe(first.mattermost.manifest.botToken);
+
+    expect(first.slack.manifest.botToken).toMatch(/^xoxb-[a-f0-9]{12}-[A-Za-z0-9_-]{16}$/u);
+    expect(first.slack.manifest.signingSecret).toMatch(/^[a-f0-9]{32}$/u);
+    expect(first.slack.manifest.env.SLACK_BOT_TOKEN).toBe(first.slack.manifest.botToken);
+    expect(first.slack.manifest.env.SLACK_SIGNING_SECRET).toBe(first.slack.manifest.signingSecret);
+    expect(second.slack.manifest.botToken).not.toBe(first.slack.manifest.botToken);
+    expect(second.slack.manifest.signingSecret).not.toBe(first.slack.manifest.signingSecret);
+
+    expect(first.telegram.manifest.botToken).toMatch(/^424242:[A-Za-z0-9_-]{35}$/u);
+    expect(first.telegram.manifest.env.TELEGRAM_BOT_TOKEN).toBe(first.telegram.manifest.botToken);
+    expect(second.telegram.manifest.botToken).not.toBe(first.telegram.manifest.botToken);
+
+    expect(first.whatsapp.manifest.accessToken).toMatch(/^EAA[A-Za-z0-9_-]{32}$/u);
+    expect(first.whatsapp.manifest.env.CLOUD_API_ACCESS_TOKEN).toBe(
+      first.whatsapp.manifest.accessToken,
+    );
+    expect(second.whatsapp.manifest.accessToken).not.toBe(first.whatsapp.manifest.accessToken);
+
+    expect(first.zalo.manifest.botToken).toMatch(/^[A-Za-z0-9_-]{43}$/u);
+    expect(first.zalo.manifest.env.ZALO_BOT_TOKEN).toBe(first.zalo.manifest.botToken);
+    expect(second.zalo.manifest.botToken).not.toBe(first.zalo.manifest.botToken);
+  });
+});
+
+async function startServers() {
+  const mattermost = await startMattermostServer({ host: "0.0.0.0" });
+  const slack = await startSlackServer({ host: "0.0.0.0" });
+  const telegram = await startTelegramServer({ host: "0.0.0.0" });
+  const whatsapp = await startWhatsAppServer({ host: "0.0.0.0" });
+  const zalo = await startZaloServer({ host: "0.0.0.0" });
+  servers.push(mattermost, slack, telegram, whatsapp, zalo);
+  return { mattermost, slack, telegram, whatsapp, zalo };
+}

--- a/test/server-credentials.test.ts
+++ b/test/server-credentials.test.ts
@@ -25,7 +25,7 @@ describe("externally bound provider server credentials", () => {
     );
     expect(second.mattermost.manifest.botToken).not.toBe(first.mattermost.manifest.botToken);
 
-    expect(first.slack.manifest.botToken).toMatch(/^xoxb-[a-f0-9]{12}-[A-Za-z0-9_-]{16}$/u);
+    expect(first.slack.manifest.botToken).toMatch(/^xoxb-\d{12}-\d{12}-[A-Za-z0-9_-]{24}$/u);
     expect(first.slack.manifest.signingSecret).toMatch(/^[a-f0-9]{32}$/u);
     expect(first.slack.manifest.env.SLACK_BOT_TOKEN).toBe(first.slack.manifest.botToken);
     expect(first.slack.manifest.env.SLACK_SIGNING_SECRET).toBe(first.slack.manifest.signingSecret);

--- a/test/server-shutdown.test.ts
+++ b/test/server-shutdown.test.ts
@@ -1,0 +1,110 @@
+import { randomBytes } from "node:crypto";
+import { request } from "node:http";
+import { connect, type Socket } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  startMattermostServer,
+  startWhatsAppServer,
+  type StartedCrablineServer,
+} from "../src/index.js";
+import { startHttpJsonServer } from "../src/servers/http.js";
+
+const servers: StartedCrablineServer[] = [];
+const sockets: Socket[] = [];
+
+afterEach(async () => {
+  for (const socket of sockets.splice(0)) {
+    socket.destroy();
+  }
+  await Promise.all(servers.splice(0).map((server) => server.close()));
+});
+
+describe("provider server shutdown", () => {
+  it("forces active HTTP connections after the shutdown grace", async () => {
+    let markRequestStarted!: () => void;
+    const requestStarted = new Promise<void>((resolve) => {
+      markRequestStarted = resolve;
+    });
+    const server = await startHttpJsonServer({
+      async handle() {
+        markRequestStarted();
+        return await new Promise<Response>(() => undefined);
+      },
+      host: "127.0.0.1",
+      port: 0,
+      serverName: "shutdown test",
+    });
+
+    const pendingRequest = request(server.baseUrl);
+    const requestClosed = new Promise<void>((resolve) => {
+      pendingRequest.once("error", () => resolve());
+      pendingRequest.once("close", () => resolve());
+    });
+    pendingRequest.end();
+    await requestStarted;
+
+    const startedAt = Date.now();
+    await server.close();
+
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
+    await requestClosed;
+  });
+
+  it("terminates unresponsive Mattermost and WhatsApp WebSockets after the grace", async () => {
+    const mattermost = await startMattermostServer();
+    const whatsapp = await startWhatsAppServer();
+    servers.push(mattermost, whatsapp);
+
+    const mattermostSocket = await openRawWebSocket(mattermost.manifest.endpoints.websocketUrl);
+    const whatsappSocket = await openRawWebSocket(whatsapp.manifest.endpoints.baileysWebSocketUrl);
+    sockets.push(mattermostSocket, whatsappSocket);
+
+    const startedAt = Date.now();
+    await Promise.all([mattermost.close(), whatsapp.close()]);
+    servers.length = 0;
+
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
+    expect(mattermostSocket.destroyed).toBe(true);
+    expect(whatsappSocket.destroyed).toBe(true);
+  });
+});
+
+async function openRawWebSocket(websocketUrl: string): Promise<Socket> {
+  const url = new URL(websocketUrl);
+  const socket = connect(Number(url.port), url.hostname);
+  await new Promise<void>((resolve, reject) => {
+    socket.once("connect", resolve);
+    socket.once("error", reject);
+  });
+  socket.write(
+    [
+      `GET ${url.pathname}${url.search} HTTP/1.1`,
+      `Host: ${url.host}`,
+      "Upgrade: websocket",
+      "Connection: Upgrade",
+      `Sec-WebSocket-Key: ${randomBytes(16).toString("base64")}`,
+      "Sec-WebSocket-Version: 13",
+      "",
+      "",
+    ].join("\r\n"),
+  );
+  await new Promise<void>((resolve, reject) => {
+    const onData = (chunk: Buffer) => {
+      if (chunk.toString("utf8").includes("\r\n\r\n")) {
+        cleanup();
+        resolve();
+      }
+    };
+    const cleanup = () => {
+      socket.off("data", onData);
+      socket.off("error", onError);
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    socket.on("data", onData);
+    socket.once("error", onError);
+  });
+  return socket;
+}

--- a/test/server-shutdown.test.ts
+++ b/test/server-shutdown.test.ts
@@ -58,9 +58,14 @@ describe("provider server shutdown", () => {
     const mattermostSocket = await openRawWebSocket(mattermost.manifest.endpoints.websocketUrl);
     const whatsappSocket = await openRawWebSocket(whatsapp.manifest.endpoints.baileysWebSocketUrl);
     sockets.push(mattermostSocket, whatsappSocket);
+    const socketsClosed = Promise.all([
+      waitForSocketClose(mattermostSocket),
+      waitForSocketClose(whatsappSocket),
+    ]);
 
     const startedAt = Date.now();
     await Promise.all([mattermost.close(), whatsapp.close()]);
+    await socketsClosed;
     servers.length = 0;
 
     expect(Date.now() - startedAt).toBeLessThan(1_000);
@@ -107,4 +112,17 @@ async function openRawWebSocket(websocketUrl: string): Promise<Socket> {
     socket.once("error", onError);
   });
   return socket;
+}
+
+async function waitForSocketClose(socket: Socket): Promise<void> {
+  if (socket.destroyed) {
+    return;
+  }
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("Timed out waiting for socket close.")), 500);
+    socket.once("close", () => {
+      clearTimeout(timeout);
+      resolve();
+    });
+  });
 }

--- a/test/slack-server.test.ts
+++ b/test/slack-server.test.ts
@@ -127,9 +127,9 @@ describe("slack local provider server", () => {
     await expect(opened.json()).resolves.toEqual({
       channel: {
         id: "G000000001",
-        is_group: true,
+        is_group: false,
         is_mpim: true,
-        members: users,
+        members: ["UCRABBOT", ...users],
       },
       ok: true,
     });
@@ -140,7 +140,26 @@ describe("slack local provider server", () => {
     await expect(reopened.json()).resolves.toMatchObject({
       channel: {
         id: "G000000001",
-        members: users,
+        members: ["UCRABBOT", ...users],
+      },
+      ok: true,
+    });
+
+    await expect(
+      (
+        await slackApi(server, "conversations.info", {
+          channel: "G000000001",
+        })
+      ).json(),
+    ).resolves.toEqual({
+      channel: {
+        id: "G000000001",
+        is_channel: false,
+        is_group: false,
+        is_im: false,
+        is_mpim: true,
+        members: ["UCRABBOT", ...users],
+        name: "crabline",
       },
       ok: true,
     });

--- a/test/slack-server.test.ts
+++ b/test/slack-server.test.ts
@@ -117,6 +117,43 @@ describe("slack local provider server", () => {
     });
   });
 
+  it("opens stable MPIMs and rejects conversations with more than eight users", async () => {
+    const server = await startTestSlackServer();
+    const users = ["U111", "U222", "U333"];
+
+    const opened = await slackApi(server, "conversations.open", {
+      users: users.join(","),
+    });
+    await expect(opened.json()).resolves.toEqual({
+      channel: {
+        id: "G000000001",
+        is_group: true,
+        is_mpim: true,
+        members: users,
+      },
+      ok: true,
+    });
+
+    const reopened = await slackApi(server, "conversations.open", {
+      users: [...users].reverse().join(","),
+    });
+    await expect(reopened.json()).resolves.toMatchObject({
+      channel: {
+        id: "G000000001",
+        members: users,
+      },
+      ok: true,
+    });
+
+    const tooMany = await slackApi(server, "conversations.open", {
+      users: Array.from({ length: 9 }, (_, index) => `U${index + 100}`).join(","),
+    });
+    await expect(tooMany.json()).resolves.toEqual({
+      error: "too_many_users",
+      ok: false,
+    });
+  });
+
   it("bounds request bodies and does not record rejected API authentication", async () => {
     const observed: unknown[] = [];
     const server = await startTestSlackServer({

--- a/test/zalo-server.test.ts
+++ b/test/zalo-server.test.ts
@@ -260,6 +260,78 @@ describe("Zalo local provider server", () => {
     }
   });
 
+  it("requires HTTPS except for loopback HTTP on loopback-bound servers", async () => {
+    const server = await startZaloServer({ botToken: "zalo-token" });
+    servers.push(server);
+
+    const rejected = await fetch(`${server.manifest.baseUrl}/botzalo-token/setWebhook`, {
+      body: JSON.stringify({
+        secret_token: "webhook-secret",
+        url: "http://192.168.1.10/zalo",
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    expect(rejected.status).toBe(400);
+    await expect(rejected.json()).resolves.toEqual({
+      description: "url must use HTTPS",
+      error_code: 400,
+      ok: false,
+    });
+  });
+
+  it("blocks private and link-local webhook targets when remotely bound", async () => {
+    const server = await startZaloServer({
+      botToken: "zalo-token",
+      host: "0.0.0.0",
+    });
+    servers.push(server);
+    const apiRoot = server.manifest.baseUrl.replace("0.0.0.0", "127.0.0.1");
+
+    for (const url of [
+      "https://10.0.0.1/zalo",
+      "https://127.0.0.1/zalo",
+      "https://169.254.169.254/latest/meta-data",
+      "https://[::1]/zalo",
+    ]) {
+      const response = await fetch(`${apiRoot}/botzalo-token/setWebhook`, {
+        body: JSON.stringify({ secret_token: "webhook-secret", url }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({
+        description: "url must not target a private or link-local address",
+        error_code: 400,
+        ok: false,
+      });
+    }
+
+    const http = await fetch(`${apiRoot}/botzalo-token/setWebhook`, {
+      body: JSON.stringify({
+        secret_token: "webhook-secret",
+        url: "http://93.184.216.34/zalo",
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    expect(http.status).toBe(400);
+    await expect(http.json()).resolves.toMatchObject({
+      description: "url must use HTTPS",
+      ok: false,
+    });
+
+    const publicHttps = await fetch(`${apiRoot}/botzalo-token/setWebhook`, {
+      body: JSON.stringify({
+        secret_token: "webhook-secret",
+        url: "https://93.184.216.34/zalo",
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    expect(publicHttps.status).toBe(200);
+  });
+
   it("rejects invalid bot tokens and unauthenticated admin ingress", async () => {
     const server = await startZaloServer({ botToken: "zalo-token" });
     servers.push(server);

--- a/test/zalo-server.test.ts
+++ b/test/zalo-server.test.ts
@@ -261,12 +261,12 @@ describe("Zalo local provider server", () => {
   });
 
   it("requires HTTPS except for loopback HTTP on loopback-bound servers", async () => {
-    const server = await startZaloServer({ botToken: "zalo-token" });
+    const server = await startZaloServer({ botToken: "test-auth-token" });
     servers.push(server);
 
-    const rejected = await fetch(`${server.manifest.baseUrl}/botzalo-token/setWebhook`, {
+    const rejected = await fetch(`${server.manifest.baseUrl}/bottest-auth-token/setWebhook`, {
       body: JSON.stringify({
-        secret_token: "webhook-secret",
+        secret_token: "secret-token",
         url: "http://192.168.1.10/zalo",
       }),
       headers: { "content-type": "application/json" },
@@ -282,7 +282,7 @@ describe("Zalo local provider server", () => {
 
   it("blocks private and link-local webhook targets when remotely bound", async () => {
     const server = await startZaloServer({
-      botToken: "zalo-token",
+      botToken: "test-auth-token",
       host: "0.0.0.0",
     });
     servers.push(server);
@@ -294,8 +294,8 @@ describe("Zalo local provider server", () => {
       "https://169.254.169.254/latest/meta-data",
       "https://[::1]/zalo",
     ]) {
-      const response = await fetch(`${apiRoot}/botzalo-token/setWebhook`, {
-        body: JSON.stringify({ secret_token: "webhook-secret", url }),
+      const response = await fetch(`${apiRoot}/bottest-auth-token/setWebhook`, {
+        body: JSON.stringify({ secret_token: "secret-token", url }),
         headers: { "content-type": "application/json" },
         method: "POST",
       });
@@ -307,9 +307,9 @@ describe("Zalo local provider server", () => {
       });
     }
 
-    const http = await fetch(`${apiRoot}/botzalo-token/setWebhook`, {
+    const http = await fetch(`${apiRoot}/bottest-auth-token/setWebhook`, {
       body: JSON.stringify({
-        secret_token: "webhook-secret",
+        secret_token: "secret-token",
         url: "http://93.184.216.34/zalo",
       }),
       headers: { "content-type": "application/json" },
@@ -321,9 +321,9 @@ describe("Zalo local provider server", () => {
       ok: false,
     });
 
-    const publicHttps = await fetch(`${apiRoot}/botzalo-token/setWebhook`, {
+    const publicHttps = await fetch(`${apiRoot}/bottest-auth-token/setWebhook`, {
       body: JSON.stringify({
-        secret_token: "webhook-secret",
+        secret_token: "secret-token",
         url: "https://93.184.216.34/zalo",
       }),
       headers: { "content-type": "application/json" },


### PR DESCRIPTION
## Summary
- randomize credentials for externally bound provider servers
- preserve Slack MPIM and Matrix sync semantics
- bound HTTP/WebSocket shutdown and validate Zalo webhook destinations

## Verification
- Autoreview: gpt-5.6-sol, high, clean on Matrix (0.96), Slack MPIM (0.96), shutdown follow-up (0.94), and Mattermost close behavior (0.99)
- credential/token scopes were scanner-blocked and remain covered by the exact branch Crabbox gate
- Crabbox: `run_17b87ef6794c` (`pnpm verify`, 49 files / 387 tests)

## Changelog
- added under `Unreleased`
- updated `docs/channel-setup.md`