### PR TITLE
fix(runtime): enforce provider lifecycle deadlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Randomize externally bound provider credentials, preserve Slack MPIM and Matrix sync errors, bound server shutdown, and enforce safe Zalo webhooks.
+- Order lazy cleanup after admitted dispatch, isolate loopback message state, and enforce effective modes and inbound deadlines.
 - Pin privileged release workflow actions to immutable revisions.
 - Redact inherited secret-named environment values from script diagnostics.
 - Verify production tarballs through their installed npm command shims.

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -22,8 +22,27 @@ export type SuiteRunResult = {
   totalPassed: number;
 };
 
+const INBOUND_DEADLINE_REACHED = Symbol("inbound deadline reached");
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function raceInboundDeadline<T>(
+  operation: Promise<T>,
+  timeoutMs: number,
+): Promise<T | typeof INBOUND_DEADLINE_REACHED> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<typeof INBOUND_DEADLINE_REACHED>((resolve) => {
+    timer = setTimeout(() => resolve(INBOUND_DEADLINE_REACHED), timeoutMs);
+  });
+  try {
+    return await Promise.race([operation, deadline]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
 }
 
 export async function runFixtureCommand(params: {
@@ -33,13 +52,15 @@ export async function runFixtureCommand(params: {
   modeOverride?: "agent" | "probe" | "roundtrip" | "send";
   registry: Registry;
 }): Promise<CommandRunResult> {
-  const fixture = params.manifest.fixtures.find((entry) => entry.id === params.fixtureId);
-  if (!fixture) {
+  const configuredFixture = params.manifest.fixtures.find((entry) => entry.id === params.fixtureId);
+  if (!configuredFixture) {
     throw new CrablineError(`Unknown fixture: ${params.fixtureId}`, { kind: "config" });
   }
 
+  const mode = params.modeOverride ?? configuredFixture.mode;
+  const fixture =
+    mode === configuredFixture.mode ? configuredFixture : { ...configuredFixture, mode };
   const provider = params.registry.resolve(fixture.provider, fixture.id);
-  const mode = params.modeOverride ?? fixture.mode;
   const diagnostics: string[] = [];
 
   if (!provider.supports.includes(mode)) {
@@ -137,13 +158,19 @@ export async function runFixtureCommand(params: {
         try {
           while (Date.now() < inboundDeadline) {
             const timeoutMs = inboundDeadline - Date.now();
-            const candidate = await provider.waitForInbound({
-              ...contextBase,
-              nonce,
-              since,
-              threadId: accepted.threadId,
+            const candidate = await raceInboundDeadline(
+              provider.waitForInbound({
+                ...contextBase,
+                nonce,
+                since,
+                threadId: accepted.threadId,
+                timeoutMs,
+              }),
               timeoutMs,
-            });
+            );
+            if (candidate === INBOUND_DEADLINE_REACHED) {
+              break;
+            }
             if (!candidate) {
               break;
             }

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -158,10 +158,12 @@ export async function runFixtureCommand(params: {
         try {
           while (Date.now() < inboundDeadline) {
             const timeoutMs = inboundDeadline - Date.now();
+            const controller = new AbortController();
             const candidate = await raceInboundDeadline(
               provider.waitForInbound({
                 ...contextBase,
                 nonce,
+                signal: controller.signal,
                 since,
                 threadId: accepted.threadId,
                 timeoutMs,
@@ -169,6 +171,7 @@ export async function runFixtureCommand(params: {
               timeoutMs,
             );
             if (candidate === INBOUND_DEADLINE_REACHED) {
+              controller.abort(new Error("Inbound wait deadline reached."));
               break;
             }
             if (!candidate) {

--- a/src/providers/builtin/loopback.ts
+++ b/src/providers/builtin/loopback.ts
@@ -20,6 +20,23 @@ function createMessageId(): string {
   return `loopback-mock-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
+function cloneRawMessage(raw: LoopbackRawMessage): LoopbackRawMessage {
+  return { ...raw };
+}
+
+function cloneMessage(message: LoopbackMessage): LoopbackMessage {
+  return {
+    ...message,
+    author: { ...message.author },
+    metadata: {
+      dateSent: new Date(message.metadata.dateSent),
+      edited: message.metadata.edited,
+      ...(message.metadata.editedAt ? { editedAt: new Date(message.metadata.editedAt) } : {}),
+    },
+    raw: cloneRawMessage(message.raw),
+  };
+}
+
 function toPostableText(message: PostableMessage): string {
   if (typeof message === "string") {
     return message;
@@ -109,7 +126,7 @@ export class LoopbackChatAdapter {
     existing.metadata.edited = true;
     existing.metadata.editedAt = new Date();
     existing.raw.text = text;
-    return Promise.resolve({ id: existing.id, raw: existing.raw, threadId });
+    return Promise.resolve({ id: existing.id, raw: cloneRawMessage(existing.raw), threadId });
   }
 
   encodeThreadId(platformData: ThreadAddress): string {
@@ -129,7 +146,7 @@ export class LoopbackChatAdapter {
     const limit = options?.limit ?? messages.length;
     if (!options?.cursor) {
       const result: { messages: LoopbackMessage[]; nextCursor?: string } = {
-        messages: messages.slice(-limit),
+        messages: messages.slice(-limit).map(cloneMessage),
       };
       if (messages.length - limit > 0) {
         result.nextCursor = String(messages.length - limit);
@@ -139,7 +156,7 @@ export class LoopbackChatAdapter {
 
     const offset = Number(options.cursor);
     const result: { messages: LoopbackMessage[]; nextCursor?: string } = {
-      messages: messages.slice(Math.max(0, offset - limit), offset),
+      messages: messages.slice(Math.max(0, offset - limit), offset).map(cloneMessage),
     };
     if (offset - limit > 0) {
       result.nextCursor = String(offset - limit);
@@ -178,7 +195,7 @@ export class LoopbackChatAdapter {
         dateSent: new Date(raw.timestamp),
         edited: false,
       },
-      raw,
+      raw: cloneRawMessage(raw),
       text: raw.text,
       threadId: raw.threadId,
     };
@@ -198,7 +215,7 @@ export class LoopbackChatAdapter {
     } satisfies LoopbackRawMessage;
     const parsed = this.parseMessage(raw);
     this.#append(threadId, parsed);
-    return Promise.resolve({ id: raw.id, raw, threadId });
+    return Promise.resolve({ id: raw.id, raw: cloneRawMessage(raw), threadId });
   }
 
   removeReaction(): Promise<void> {
@@ -223,19 +240,19 @@ export class LoopbackChatAdapter {
     } satisfies LoopbackRawMessage;
     const parsed = this.parseMessage(raw);
     this.#append(threadId, parsed);
-    return parsed;
+    return cloneMessage(parsed);
   }
 
   listSince(threadId: string, since: string): LoopbackMessage[] {
     const sinceTime = new Date(since).getTime();
-    return (this.#messages.get(threadId) ?? []).filter(
-      (entry) => entry.metadata.dateSent.getTime() >= sinceTime,
-    );
+    return (this.#messages.get(threadId) ?? [])
+      .filter((entry) => entry.metadata.dateSent.getTime() >= sinceTime)
+      .map(cloneMessage);
   }
 
   #append(threadId: string, message: LoopbackMessage): void {
     const bucket = this.#messages.get(threadId) ?? [];
-    bucket.push(message);
+    bucket.push(cloneMessage(message));
     this.#messages.set(threadId, bucket);
   }
 }

--- a/src/providers/builtin/script.ts
+++ b/src/providers/builtin/script.ts
@@ -168,6 +168,7 @@ function runScript<T>(params: {
   payload: unknown;
   schema: z.ZodType<T>;
   shell?: string | undefined;
+  signal?: AbortSignal | undefined;
   timeoutGraceMs?: number | undefined;
   timeoutMs: number;
 }): Promise<T> {
@@ -186,6 +187,12 @@ function runScript<T>(params: {
     let outputBytes = 0;
     let settled = false;
     let timeoutGrace: NodeJS.Timeout | undefined;
+    const abort = () => {
+      finish(() => {
+        terminateChild(child);
+        reject(params.signal?.reason ?? new Error("Script command aborted."));
+      });
+    };
 
     const finish = (callback: () => void) => {
       if (settled) {
@@ -194,6 +201,7 @@ function runScript<T>(params: {
       settled = true;
       clearTimeout(timeout);
       clearTimeout(timeoutGrace);
+      params.signal?.removeEventListener("abort", abort);
       callback();
     };
 
@@ -306,6 +314,11 @@ function runScript<T>(params: {
     }, params.timeoutMs);
     timeout.unref();
 
+    if (params.signal?.aborted) {
+      abort();
+      return;
+    }
+    params.signal?.addEventListener("abort", abort, { once: true });
     child.stdin.end(JSON.stringify(params.payload));
   });
 }
@@ -414,6 +427,7 @@ export class ScriptProviderAdapter implements ProviderAdapter {
       },
       schema: ScriptInboundResultSchema,
       shell: this.#config.shell,
+      signal: context.signal,
       timeoutGraceMs: SCRIPT_WAIT_EXIT_GRACE_MS,
       timeoutMs: context.timeoutMs,
     });

--- a/src/providers/builtin/whatsapp.ts
+++ b/src/providers/builtin/whatsapp.ts
@@ -150,6 +150,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
         ) &&
         matchesInbound(event, context.fixture.inboundMatch, context.nonce),
       since: context.since,
+      signal: context.signal,
       timeoutMs: context.timeoutMs,
     });
   }

--- a/src/providers/local-mock.ts
+++ b/src/providers/local-mock.ts
@@ -218,6 +218,7 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
           (expectedAuthor === "any" || candidate.author === expectedAuthor) &&
           isAddressInChannel(candidate.threadId, channelId),
         since: context.since,
+        signal: context.signal,
         timeoutMs: context.timeoutMs,
       });
       if (!event) {

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -233,13 +233,14 @@ export async function waitForRecordedInbound(params: {
   filePath: string;
   matches: (event: RecordedInboundEnvelope) => boolean;
   pollMs?: number;
+  signal?: AbortSignal | undefined;
   since?: string | undefined;
   timeoutMs: number;
 }): Promise<RecordedInboundEnvelope | null> {
   const deadline = Date.now() + params.timeoutMs;
   const cursor = params.cursor ?? createRecordedInboundCursor();
 
-  while (Date.now() <= deadline) {
+  while (!params.signal?.aborted && Date.now() <= deadline) {
     const events =
       cursor.buffered.length > 0
         ? cursor.buffered.splice(0)
@@ -265,7 +266,7 @@ export async function waitForRecordedInbound(params: {
     if (remainingMs <= 0) {
       return null;
     }
-    await sleep(Math.min(params.pollMs ?? 200, remainingMs));
+    await sleep(Math.min(params.pollMs ?? 200, remainingMs), params.signal);
   }
 
   return null;

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -160,7 +160,7 @@ class LazyProviderAdapter implements ProviderAdapter {
   }
 
   waitForInbound(context: WaitContext): Promise<InboundEnvelope | null> {
-    return this.#runOperation((provider) => provider.waitForInbound(context));
+    return this.#runOperation((provider) => provider.waitForInbound(context), context.signal);
   }
 
   watch(context: WatchContext): AsyncIterable<InboundEnvelope> {
@@ -330,7 +330,10 @@ class LazyProviderAdapter implements ProviderAdapter {
     await provider.cleanup?.();
   }
 
-  #runOperation<T>(run: (provider: ProviderAdapter) => Promise<T>): Promise<T> {
+  #runOperation<T>(
+    run: (provider: ProviderAdapter) => Promise<T>,
+    signal?: AbortSignal,
+  ): Promise<T> {
     if (this.#cleanedUp) {
       return Promise.reject(this.#cleanedUpError());
     }
@@ -348,7 +351,32 @@ class LazyProviderAdapter implements ProviderAdapter {
         const result = run(provider);
         dispatch.reached = true;
         markDispatched?.();
-        return await result;
+        if (!signal) {
+          return await result;
+        }
+        return await new Promise<T>((resolve, reject) => {
+          const finish = () => signal.removeEventListener("abort", abort);
+          const abort = () => {
+            finish();
+            reject(signal.reason ?? new Error("Provider operation aborted."));
+          };
+          if (signal.aborted) {
+            abort();
+            void result.catch(() => undefined);
+            return;
+          }
+          signal.addEventListener("abort", abort, { once: true });
+          void result.then(
+            (value) => {
+              finish();
+              resolve(value);
+            },
+            (error: unknown) => {
+              finish();
+              reject(error);
+            },
+          );
+        });
       } catch (error) {
         dispatch.reached = true;
         markDispatched?.();

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -26,9 +26,13 @@ type ActiveWatch = {
   abort(): void;
   close(): Promise<void>;
 };
+type DispatchBarrier = {
+  promise: Promise<void>;
+  reached: boolean;
+};
 type AdmittedOperation = {
   completion: Promise<unknown>;
-  dispatched: Promise<void>;
+  dispatch: DispatchBarrier;
 };
 type LazyProviderFactory = (params: {
   config: ProviderConfig;
@@ -249,11 +253,8 @@ class LazyProviderAdapter implements ProviderAdapter {
     this.#cleanupPromise ??= (async () => {
       const operations = [...this.#inFlightOperations];
       const closingWatches = [...this.#activeWatches].map(async (watch) => await watch.close());
-      const providerCleanupBegun = this.#beginProviderCleanup();
-      void providerCleanupBegun.catch(() => undefined);
       const providerCleanup = this.#cleanupProvider(
-        operations.map((operation) => operation.dispatched),
-        providerCleanupBegun,
+        operations.map((operation) => operation.dispatch),
       );
       void providerCleanup.catch(() => undefined);
       await Promise.allSettled(operations.map((operation) => operation.completion));
@@ -315,12 +316,14 @@ class LazyProviderAdapter implements ProviderAdapter {
     });
   }
 
-  async #cleanupProvider(
-    dispatched: readonly Promise<void>[],
-    providerCleanupBegun: Promise<ProviderAdapter | null>,
-  ): Promise<void> {
-    await Promise.allSettled(dispatched);
-    const provider = await providerCleanupBegun;
+  async #cleanupProvider(dispatches: readonly DispatchBarrier[]): Promise<void> {
+    const pendingDispatches = dispatches
+      .filter((dispatch) => !dispatch.reached)
+      .map((dispatch) => dispatch.promise);
+    if (pendingDispatches.length > 0) {
+      await Promise.allSettled(pendingDispatches);
+    }
+    const provider = await this.#beginProviderCleanup();
     if (!provider) {
       return;
     }
@@ -335,18 +338,24 @@ class LazyProviderAdapter implements ProviderAdapter {
     const dispatched = new Promise<void>((resolve) => {
       markDispatched = resolve;
     });
+    const dispatch: DispatchBarrier = {
+      promise: dispatched,
+      reached: false,
+    };
     const completion = (async () => {
       try {
         const provider = await this.#provider();
         const result = run(provider);
+        dispatch.reached = true;
         markDispatched?.();
         return await result;
       } catch (error) {
+        dispatch.reached = true;
         markDispatched?.();
         throw error;
       }
     })();
-    const operation = { completion, dispatched };
+    const operation = { completion, dispatch };
     this.#inFlightOperations.add(operation);
     void completion.then(
       () => this.#inFlightOperations.delete(operation),

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -59,6 +59,7 @@ export type SendContext = ProviderContext & {
 
 export type WaitContext = ProviderContext & {
   nonce: string;
+  signal?: AbortSignal | undefined;
   since: string;
   threadId?: string | undefined;
   timeoutMs: number;

--- a/test/loopback-adapter.test.ts
+++ b/test/loopback-adapter.test.ts
@@ -65,6 +65,62 @@ describe("loopback chat adapter", () => {
     expect(previous.nextCursor).toBeUndefined();
   });
 
+  it("isolates stored messages from mutable inputs and returns", async () => {
+    adapter = new LoopbackChatAdapter("crabline");
+    const threadId = adapter.encodeThreadId({ id: "user-1" });
+
+    const ingested = adapter.ingestUserMessage(threadId, "original");
+    ingested.author.userName = "mutated";
+    ingested.metadata.dateSent.setTime(0);
+    ingested.raw.text = "mutated";
+    ingested.text = "mutated";
+
+    const firstFetch = await adapter.fetchMessages(threadId);
+    expect(firstFetch.messages[0]).toMatchObject({
+      author: { userName: "loopback" },
+      raw: { text: "original" },
+      text: "original",
+    });
+    expect(firstFetch.messages[0]?.metadata.dateSent.getTime()).not.toBe(0);
+
+    firstFetch.messages[0]!.metadata.dateSent.setTime(0);
+    firstFetch.messages[0]!.raw.text = "changed after fetch";
+    firstFetch.messages[0]!.text = "changed after fetch";
+    expect((await adapter.fetchMessages(threadId)).messages[0]).toMatchObject({
+      raw: { text: "original" },
+      text: "original",
+    });
+
+    const posted = await adapter.postMessage(threadId, "posted");
+    posted.raw.text = "changed after post";
+    await adapter.editMessage(threadId, posted.id, "edited");
+    const edited = await adapter.editMessage(threadId, posted.id, "edited again");
+    edited.raw.text = "changed after edit";
+
+    const listed = adapter.listSince(threadId, new Date(0).toISOString());
+    listed[1]!.metadata.editedAt!.setTime(0);
+    listed[1]!.raw.text = "changed after list";
+
+    const finalFetch = await adapter.fetchMessages(threadId);
+    expect(finalFetch.messages[1]).toMatchObject({
+      metadata: { edited: true },
+      raw: { text: "edited again" },
+      text: "edited again",
+    });
+    expect(finalFetch.messages[1]?.metadata.editedAt?.getTime()).not.toBe(0);
+
+    const raw = {
+      author: "user" as const,
+      id: "raw",
+      text: "parsed",
+      threadId,
+      timestamp: new Date().toISOString(),
+    };
+    const parsed = adapter.parseMessage(raw);
+    raw.text = "changed after parse";
+    expect(parsed.raw.text).toBe("parsed");
+  });
+
   it("supports direct adapter operations", async () => {
     adapter = new LoopbackChatAdapter("crabline");
 

--- a/test/registry-lifecycle.test.ts
+++ b/test/registry-lifecycle.test.ts
@@ -390,6 +390,44 @@ describe("lazy provider lifecycle", () => {
     }
   });
 
+  it("does not let an aborted lazy inbound wait block cleanup", async () => {
+    const directory = await createTempDir();
+    const recorderPath = path.join(directory, "telegram.jsonl");
+    let markWaitStarted: (() => void) | undefined;
+    const waitStarted = new Promise<void>((resolve) => {
+      markWaitStarted = resolve;
+    });
+    recorderMocks.waitForRecordedInbound.mockImplementationOnce(async () => {
+      markWaitStarted?.();
+      return await new Promise<never>(() => undefined);
+    });
+
+    try {
+      const { context, manifest } = createTelegramManifest(recorderPath);
+      const provider = createRegistry(manifest, context.manifestPath).resolve(
+        "telegram",
+        context.fixture.id,
+      );
+      const controller = new AbortController();
+      const waiting = provider.waitForInbound({
+        ...context,
+        nonce: "aborted-lazy-wait",
+        signal: controller.signal,
+        since: new Date().toISOString(),
+        timeoutMs: 100,
+      });
+      await waitStarted;
+      const abortReason = new Error("inbound deadline reached");
+
+      controller.abort(abortReason);
+
+      await expect(waiting).rejects.toBe(abortReason);
+      await expect(provider.cleanup?.()).resolves.toBeUndefined();
+    } finally {
+      await disposeTempDir(directory);
+    }
+  });
+
   it("cancels and drains an admitted watch before cleanup resolves", async () => {
     const directory = await createTempDir();
     const recorderPath = path.join(directory, "telegram.jsonl");

--- a/test/registry-lifecycle.test.ts
+++ b/test/registry-lifecycle.test.ts
@@ -24,6 +24,11 @@ const webhookMocks = vi.hoisted(() => ({
   actualStartWebhookServer: undefined as StartWebhookServer | undefined,
   startWebhookServer: vi.fn<StartWebhookServer>(),
 }));
+const telegramLifecycle = vi.hoisted(() => ({
+  importBarrier: undefined as Promise<void> | undefined,
+  onBeginCleanup: undefined as (() => void) | undefined,
+  onProbe: undefined as (() => void) | undefined,
+}));
 
 vi.mock("../src/providers/recorder.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../src/providers/recorder.js")>();
@@ -49,6 +54,26 @@ vi.mock("../src/providers/webhook-server.js", async (importOriginal) => {
     startWebhookServer: webhookMocks.startWebhookServer,
   };
 });
+vi.mock("../src/providers/builtin/telegram.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/providers/builtin/telegram.js")>();
+  await telegramLifecycle.importBarrier;
+  return {
+    ...actual,
+    TelegramProviderAdapter: class extends actual.TelegramProviderAdapter {
+      override async probe(context: ProviderContext) {
+        if (telegramLifecycle.onProbe) {
+          telegramLifecycle.onProbe();
+          return { details: [], healthy: true };
+        }
+        return await super.probe(context);
+      }
+
+      beginCleanup(): void {
+        telegramLifecycle.onBeginCleanup?.();
+      }
+    },
+  };
+});
 
 beforeEach(() => {
   recorderMocks.appendRecordedInbound.mockReset();
@@ -63,6 +88,9 @@ beforeEach(() => {
   recorderMocks.watchRecordedInbound.mockImplementation(recorderMocks.actualWatchRecordedInbound!);
   webhookMocks.startWebhookServer.mockReset();
   webhookMocks.startWebhookServer.mockImplementation(webhookMocks.actualStartWebhookServer!);
+  telegramLifecycle.importBarrier = undefined;
+  telegramLifecycle.onBeginCleanup = undefined;
+  telegramLifecycle.onProbe = undefined;
 });
 
 function createTelegramManifest(recorderPath: string): {
@@ -236,6 +264,42 @@ describe("lazy provider lifecycle", () => {
     } finally {
       await waiting?.catch(() => undefined);
       await cleanup?.catch(() => undefined);
+      await disposeTempDir(directory);
+    }
+  });
+
+  it("dispatches admitted work before beginning concrete cleanup", async () => {
+    const directory = await createTempDir();
+    const recorderPath = path.join(directory, "telegram.jsonl");
+    let releaseImport: (() => void) | undefined;
+    const events: string[] = [];
+    telegramLifecycle.importBarrier = new Promise<void>((resolve) => {
+      releaseImport = resolve;
+    });
+    telegramLifecycle.onProbe = () => events.push("probe");
+    telegramLifecycle.onBeginCleanup = () => events.push("beginCleanup");
+
+    try {
+      const { context, manifest } = createTelegramManifest(recorderPath);
+      const provider = createRegistry(manifest, context.manifestPath).resolve(
+        "telegram",
+        context.fixture.id,
+      );
+      const probing = provider.probe(context);
+      const cleanup = provider.cleanup?.();
+
+      await Promise.resolve();
+      expect(events).toEqual([]);
+
+      releaseImport?.();
+      await expect(probing).resolves.toEqual({ details: [], healthy: true });
+      await cleanup;
+      expect(events).toEqual(["probe", "beginCleanup"]);
+    } finally {
+      releaseImport?.();
+      telegramLifecycle.importBarrier = undefined;
+      telegramLifecycle.onBeginCleanup = undefined;
+      telegramLifecycle.onProbe = undefined;
       await disposeTempDir(directory);
     }
   });

--- a/test/run.behavior.test.ts
+++ b/test/run.behavior.test.ts
@@ -114,6 +114,64 @@ describe("run behavior", () => {
     expect(missingEnv.failureKind).toBe("config");
   });
 
+  it("uses one effective fixture for mode overrides in provider contexts", async () => {
+    const contextFixtures: ManifestDefinition["fixtures"] = [];
+    let outboundText = "";
+    const provider: ProviderAdapter = {
+      id: "mock",
+      platform: "loopback",
+      status: "ready",
+      supports: ["probe", "send", "roundtrip", "agent"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      probe: async (context) => {
+        contextFixtures.push(context.fixture);
+        return { details: [], healthy: true };
+      },
+      send: async (context) => {
+        contextFixtures.push(context.fixture);
+        outboundText = context.text;
+        return { accepted: true, messageId: "sent", threadId: "thread" };
+      },
+      waitForInbound: async (context) => {
+        contextFixtures.push(context.fixture);
+        return {
+          author: "assistant",
+          id: "inbound",
+          provider: "mock",
+          sentAt: new Date().toISOString(),
+          text: `ACK ${context.nonce}`,
+          threadId: "thread",
+        };
+      },
+    };
+    const capableManifest = withAllCapabilities(manifest);
+
+    const agent = await runFixtureCommand({
+      fixtureId: "fixture",
+      manifest: capableManifest,
+      manifestPath: "/tmp/crabline.yaml",
+      modeOverride: "agent",
+      registry: buildRegistry(provider),
+    });
+    const probe = await runFixtureCommand({
+      fixtureId: "fixture",
+      manifest: capableManifest,
+      manifestPath: "/tmp/crabline.yaml",
+      modeOverride: "probe",
+      registry: buildRegistry(provider),
+    });
+
+    expect(agent.ok).toBe(true);
+    expect(probe.ok).toBe(true);
+    expect(contextFixtures[0]).toBe(contextFixtures[1]);
+    expect(contextFixtures[0]?.mode).toBe("agent");
+    expect(contextFixtures[2]?.mode).toBe("probe");
+    expect(capableManifest.fixtures[0]?.mode).toBe("roundtrip");
+    expect(outboundText).toContain("crabline agent fixture");
+  });
+
   it("classifies probe and send failures", async () => {
     const provider: ProviderAdapter = {
       id: "mock",
@@ -308,6 +366,40 @@ describe("run behavior", () => {
     expect(sendCalls).toBe(1);
     expect(waitCalls).toBeGreaterThan(1);
     expect(waitCalls).toBeLessThan(10);
+  });
+
+  it("bounds a hung inbound provider by the core deadline", async () => {
+    let rejectWait: ((error: Error) => void) | undefined;
+    const provider: ProviderAdapter = {
+      id: "mock",
+      platform: "loopback",
+      status: "ready",
+      supports: ["probe", "send", "roundtrip", "agent"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      probe: async () => ({ details: [], healthy: true }),
+      send: async () => ({ accepted: true, messageId: "sent", threadId: "thread" }),
+      waitForInbound: async () =>
+        await new Promise<never>((_resolve, reject) => {
+          rejectWait = reject;
+        }),
+    };
+    const boundedManifest = withAllCapabilities({
+      ...manifest,
+      fixtures: [{ ...manifest.fixtures[0]!, timeoutMs: 20 }],
+    });
+
+    const result = await runFixtureCommand({
+      fixtureId: "fixture",
+      manifest: boundedManifest,
+      manifestPath: "/tmp/crabline.yaml",
+      registry: buildRegistry(provider),
+    });
+
+    expect(result.failureKind).toBe("timeout");
+    rejectWait?.(new Error("late provider failure"));
+    await Promise.resolve();
   });
 
   it("fails an otherwise successful fixture when cleanup fails", async () => {


### PR DESCRIPTION
## Summary
- order provider cleanup after admitted dispatch completes
- isolate loopback message state and apply effective mode overrides
- abort timed-out inbound waits across lazy and script-backed providers

## Verification
- Autoreview: gpt-5.6-sol, high, clean (0.92)
- Crabbox: `run_c43cbfbd0232` (`pnpm verify`, 47 files / 385 tests)

## Changelog
- added under `Unreleased`