### PR TITLE
fix(openclaw): harden artifact publication safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Randomize externally bound provider credentials, preserve Slack MPIM and Matrix sync errors, bound server shutdown, and enforce safe Zalo webhooks.
 - Order lazy cleanup after admitted dispatch, isolate loopback message state, and enforce effective modes and inbound deadlines.
+- Fence OpenClaw smoke artifact paths, clean abandoned generations safely, preserve primary probe failures and replacement files, and report post-commit lock cleanup failures.
 - Pin privileged release workflow actions to immutable revisions.
 - Redact inherited secret-named environment values from script diagnostics.
 - Verify production tarballs through their installed npm command shims.

--- a/src/openclaw.ts
+++ b/src/openclaw.ts
@@ -240,16 +240,20 @@ export async function runOpenClawCrablineChannelDriverSmoke(
       }
       if (probeFailure instanceof Error) {
         const existingCause = probeFailure.cause;
-        Object.defineProperty(probeFailure, "cause", {
-          configurable: true,
-          value:
-            existingCause === undefined
-              ? cleanupError
-              : new AggregateError(
-                  [existingCause, cleanupError],
-                  "OpenClaw Crabline provider probe cleanup also failed.",
-                ),
-        });
+        try {
+          Object.defineProperty(probeFailure, "cause", {
+            configurable: true,
+            value:
+              existingCause === undefined
+                ? cleanupError
+                : new AggregateError(
+                    [existingCause, cleanupError],
+                    "OpenClaw Crabline provider probe cleanup also failed.",
+                  ),
+          });
+        } catch {
+          // Some provider errors are frozen; preserving the primary failure is authoritative.
+        }
         throw probeFailure;
       }
       const combinedError = new Error("OpenClaw Crabline provider probe and cleanup both failed.", {

--- a/src/openclaw.ts
+++ b/src/openclaw.ts
@@ -224,10 +224,44 @@ export async function runOpenClawCrablineChannelDriverSmoke(
       recorderPath,
     });
     let probe: unknown;
+    let probeFailed = false;
+    let probeFailure: unknown;
     try {
       probe = await adapter.probe();
-    } finally {
+    } catch (error) {
+      probeFailed = true;
+      probeFailure = error;
+    }
+    try {
       await adapter.close();
+    } catch (cleanupError) {
+      if (!probeFailed) {
+        throw cleanupError;
+      }
+      if (probeFailure instanceof Error) {
+        const existingCause = probeFailure.cause;
+        Object.defineProperty(probeFailure, "cause", {
+          configurable: true,
+          value:
+            existingCause === undefined
+              ? cleanupError
+              : new AggregateError(
+                  [existingCause, cleanupError],
+                  "OpenClaw Crabline provider probe cleanup also failed.",
+                ),
+        });
+        throw probeFailure;
+      }
+      const combinedError = new Error("OpenClaw Crabline provider probe and cleanup both failed.", {
+        cause: cleanupError,
+      });
+      Object.defineProperty(combinedError, "errors", {
+        value: [probeFailure, cleanupError],
+      });
+      throw combinedError;
+    }
+    if (probeFailed) {
+      throw probeFailure;
     }
 
     const capabilityReport = {
@@ -266,6 +300,7 @@ export async function runOpenClawCrablineChannelDriverSmoke(
         manifestPath: generation.manifestPath,
         smoke: generation.smoke,
         smokeArtifactPath: generation.smokeArtifactPath,
+        ...(generation.warnings ? { warnings: generation.warnings } : {}),
       },
     };
   } catch (error) {
@@ -299,6 +334,14 @@ export async function runOpenClawCrablineChannelDriverSmoke(
       });
       throw combinedError;
     }
+    const detail = cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
+    outcome.result = {
+      ...outcome.result,
+      warnings: [
+        ...(outcome.result.warnings ?? []),
+        `OpenClaw Crabline smoke committed but lock cleanup failed: ${detail}`,
+      ],
+    };
   }
 
   if (!outcome.committed) {

--- a/src/openclaw/artifact-generation.ts
+++ b/src/openclaw/artifact-generation.ts
@@ -27,6 +27,7 @@ export type OpenClawCrablineArtifactPointer = {
 export type PublishedOpenClawCrablineArtifactGeneration = OpenClawCrablineArtifactPointer & {
   pointerPath: string;
   smoke: Record<string, unknown>;
+  warnings?: string[];
 };
 
 type PublishGenerationDependencies = {
@@ -37,6 +38,15 @@ type PublishGenerationDependencies = {
   secureWindowsDirectory?: (directoryPath: string) => Promise<void>;
   secureWindowsFile?: (filePath: string) => Promise<void>;
 };
+
+function assertCanonicalSelectionPaths(selection: OpenClawCrablineChannelDriverSelection): void {
+  if (
+    selection.capabilityMatrixPath !== OPENCLAW_CRABLINE_CHANNEL_CAPABILITY_MATRIX_PATH ||
+    selection.smokeArtifactPath !== OPENCLAW_CRABLINE_CHANNEL_SMOKE_PATH
+  ) {
+    throw new Error("OpenClaw Crabline artifact selection paths are malformed.");
+  }
+}
 
 function isMissingPathError(error: unknown): boolean {
   return (error as NodeJS.ErrnoException).code === "ENOENT";
@@ -135,6 +145,37 @@ async function assertCurrentGenerationExists(
   }
 }
 
+async function pruneArtifactStore(params: {
+  lock: OpenClawCrablineSmokeRunLock;
+  pointer: OpenClawCrablineArtifactPointer | null;
+  store: Awaited<ReturnType<typeof securePrivateDirectory>>;
+}): Promise<void> {
+  const retainedGenerations = new Set(
+    params.pointer
+      ? [params.pointer.generation, params.pointer.previousGeneration].filter(
+          (generation): generation is string => generation !== undefined,
+        )
+      : [],
+  );
+  for (const entry of await fs.readdir(params.store.directoryPath, { withFileTypes: true })) {
+    const isAbandonedStaging = entry.isDirectory() && entry.name.startsWith(".staging-");
+    const isObsoleteGeneration =
+      entry.isDirectory() &&
+      GENERATION_NAME_PATTERN.test(entry.name) &&
+      !retainedGenerations.has(entry.name);
+    if (!isAbandonedStaging && !isObsoleteGeneration) {
+      continue;
+    }
+    await params.lock.assertOwned();
+    await params.store.assertIdentityAt();
+    await fs.rm(path.join(params.store.directoryPath, entry.name), {
+      force: true,
+      recursive: true,
+    });
+    await params.store.assertIdentityAt();
+  }
+}
+
 export async function publishOpenClawCrablineArtifactGeneration(
   params: {
     capabilityReport: unknown;
@@ -146,6 +187,7 @@ export async function publishOpenClawCrablineArtifactGeneration(
   },
   dependencies: PublishGenerationDependencies = {},
 ): Promise<PublishedOpenClawCrablineArtifactGeneration> {
+  assertCanonicalSelectionPaths(params.selection);
   const outputDir = path.resolve(params.outputDir);
   await fs.mkdir(outputDir, { recursive: true });
   const storePath = path.join(outputDir, OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY);
@@ -161,6 +203,11 @@ export async function publishOpenClawCrablineArtifactGeneration(
   if (currentPointer) {
     await assertCurrentGenerationExists(outputDir, currentPointer);
   }
+  await pruneArtifactStore({
+    lock: params.lock,
+    pointer: currentPointer,
+    store,
+  });
 
   const generationId = dependencies.createGenerationId?.() ?? randomUUID();
   const generation = `generation-${generationId}`;
@@ -226,36 +273,62 @@ export async function publishOpenClawCrablineArtifactGeneration(
     },
   ] as const;
 
-  await params.lock.assertOwned();
-  for (const artifact of artifactContents) {
-    await staging.assertIdentityAt();
-    await publishPrivateFile(
-      path.join(stagingPath, artifact.fileName),
-      artifact.contents,
-      fileOptions,
-    );
-    await staging.assertIdentityAt();
+  let installed = false;
+  let committed = false;
+  try {
+    await params.lock.assertOwned();
+    for (const artifact of artifactContents) {
+      await staging.assertIdentityAt();
+      await publishPrivateFile(
+        path.join(stagingPath, artifact.fileName),
+        artifact.contents,
+        fileOptions,
+      );
+      await staging.assertIdentityAt();
+    }
+    await params.lock.assertOwned();
+    await fs.rename(stagingPath, generationPath);
+    installed = true;
+    await staging.assertIdentityAt(generationPath);
+    await store.assertIdentityAt();
+
+    await dependencies.beforePointerSwitch?.(pointer);
+    await params.lock.commitFileAtomically({
+      contents: `${JSON.stringify(pointer, null, 2)}\n`,
+      destinationPath: path.join(outputDir, OPENCLAW_CRABLINE_ARTIFACT_POINTER_PATH),
+      stageDirectory: store.directoryPath,
+      stageFile: async (filePath, contents) => {
+        await store.assertIdentityAt();
+        await publishPrivateFile(filePath, contents, fileOptions);
+        await store.assertIdentityAt();
+      },
+    });
+    committed = true;
+    let warnings: string[] | undefined;
+    try {
+      await pruneArtifactStore({
+        lock: params.lock,
+        pointer: await readOpenClawCrablineArtifactPointer(outputDir),
+        store,
+      });
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      warnings = [`OpenClaw Crabline artifact retention cleanup failed: ${detail}`];
+    }
+
+    return {
+      ...pointer,
+      pointerPath: OPENCLAW_CRABLINE_ARTIFACT_POINTER_PATH,
+      smoke,
+      ...(warnings ? { warnings } : {}),
+    };
+  } finally {
+    if (!committed) {
+      const unpublishedPath = installed ? generationPath : stagingPath;
+      await staging
+        .assertIdentityAt(unpublishedPath)
+        .then(() => fs.rm(unpublishedPath, { force: true, recursive: true }))
+        .catch(() => undefined);
+    }
   }
-  await params.lock.assertOwned();
-  await fs.rename(stagingPath, generationPath);
-  await staging.assertIdentityAt(generationPath);
-  await store.assertIdentityAt();
-
-  await dependencies.beforePointerSwitch?.(pointer);
-  await params.lock.commitFileAtomically({
-    contents: `${JSON.stringify(pointer, null, 2)}\n`,
-    destinationPath: path.join(outputDir, OPENCLAW_CRABLINE_ARTIFACT_POINTER_PATH),
-    stageDirectory: store.directoryPath,
-    stageFile: async (filePath, contents) => {
-      await store.assertIdentityAt();
-      await publishPrivateFile(filePath, contents, fileOptions);
-      await store.assertIdentityAt();
-    },
-  });
-
-  return {
-    ...pointer,
-    pointerPath: OPENCLAW_CRABLINE_ARTIFACT_POINTER_PATH,
-    smoke,
-  };
 }

--- a/src/openclaw/artifact-generation.ts
+++ b/src/openclaw/artifact-generation.ts
@@ -306,9 +306,13 @@ export async function publishOpenClawCrablineArtifactGeneration(
     committed = true;
     let warnings: string[] | undefined;
     try {
+      const committedPointer = await readOpenClawCrablineArtifactPointer(outputDir);
+      if (!committedPointer) {
+        throw new Error("OpenClaw Crabline artifact pointer is missing after publication.");
+      }
       await pruneArtifactStore({
         lock: params.lock,
-        pointer: await readOpenClawCrablineArtifactPointer(outputDir),
+        pointer: committedPointer,
         store,
       });
     } catch (error) {
@@ -325,10 +329,21 @@ export async function publishOpenClawCrablineArtifactGeneration(
   } finally {
     if (!committed) {
       const unpublishedPath = installed ? generationPath : stagingPath;
-      await staging
-        .assertIdentityAt(unpublishedPath)
-        .then(() => fs.rm(unpublishedPath, { force: true, recursive: true }))
-        .catch(() => undefined);
+      let referencedByPointer = false;
+      if (installed) {
+        try {
+          referencedByPointer =
+            (await readOpenClawCrablineArtifactPointer(outputDir))?.generation === generation;
+        } catch {
+          referencedByPointer = true;
+        }
+      }
+      if (!referencedByPointer) {
+        await staging
+          .assertIdentityAt(unpublishedPath)
+          .then(() => fs.rm(unpublishedPath, { force: true, recursive: true }))
+          .catch(() => undefined);
+      }
     }
   }
 }

--- a/src/openclaw/artifact-generation.ts
+++ b/src/openclaw/artifact-generation.ts
@@ -332,8 +332,10 @@ export async function publishOpenClawCrablineArtifactGeneration(
       let referencedByPointer = false;
       if (installed) {
         try {
+          const livePointer = await readOpenClawCrablineArtifactPointer(outputDir);
           referencedByPointer =
-            (await readOpenClawCrablineArtifactPointer(outputDir))?.generation === generation;
+            livePointer?.generation === generation ||
+            livePointer?.previousGeneration === generation;
         } catch {
           referencedByPointer = true;
         }

--- a/src/openclaw/private-file.ts
+++ b/src/openclaw/private-file.ts
@@ -331,6 +331,7 @@ export async function publishPrivateFileAtomically(
   filePath: string,
   contents: string,
   options: {
+    afterRename?: (filePath: string) => Promise<void>;
     platform?: NodeJS.Platform;
     secureWindowsFile?: (temporaryPath: string) => Promise<void>;
   } = {},
@@ -355,12 +356,8 @@ export async function publishPrivateFileAtomically(
     await handle.sync();
     await assertPathIdentity(temporaryPath, identity);
     await fs.rename(temporaryPath, filePath);
-    try {
-      await assertPathIdentity(filePath, identity);
-    } catch (error) {
-      await fs.rm(filePath, { force: true }).catch(() => undefined);
-      throw error;
-    }
+    await options.afterRename?.(filePath);
+    await assertPathIdentity(filePath, identity);
   } finally {
     try {
       await handle?.close();

--- a/src/openclaw/shared.ts
+++ b/src/openclaw/shared.ts
@@ -37,6 +37,7 @@ export type OpenClawCrablineChannelDriverSmokeResult = {
   manifestPath: string;
   smoke: unknown;
   smokeArtifactPath: string;
+  warnings?: string[];
 };
 
 export type OpenClawCrablineConversation = {

--- a/src/openclaw/smoke-lock.ts
+++ b/src/openclaw/smoke-lock.ts
@@ -74,6 +74,7 @@ type SmokeLockRuntime = {
   isProcessAlive: IsProcessAlive;
   leaseMs: number;
   now: () => number;
+  sleep: Sleep;
 };
 
 const LOCK_OWNER_FILE = "owner.json";
@@ -391,6 +392,36 @@ function isLockOwnerActive(record: SmokeLockRecord, runtime: SmokeLockRuntime): 
   return ageMs >= -runtime.leaseMs && ageMs <= runtime.leaseMs;
 }
 
+function needsLiveOwnerConfirmation(record: SmokeLockRecord, runtime: SmokeLockRuntime): boolean {
+  return (
+    isRenewableOwner(record.owner) &&
+    runtime.isProcessAlive(record.owner.pid) &&
+    !(
+      record.owner.pid === runtime.currentPid &&
+      record.owner.processStartedAtMs !== runtime.currentProcessStartedAtMs
+    ) &&
+    !isLockOwnerActive(record, runtime)
+  );
+}
+
+async function observedOwnerChangedDuringConfirmation(
+  lockDirectory: string,
+  observed: SmokeLockRecord,
+  runtime: SmokeLockRuntime,
+): Promise<boolean> {
+  if (!needsLiveOwnerConfirmation(observed, runtime)) {
+    return false;
+  }
+  await runtime.sleep(Math.max(1, Math.ceil(runtime.leaseMs / 3)));
+  const revalidated = await readLockRecord(lockDirectory);
+  return (
+    revalidated.kind === "record" &&
+    (revalidated.record.owner.token !== observed.owner.token ||
+      revalidated.record.renewedAtMs !== observed.renewedAtMs ||
+      isLockOwnerActive(revalidated.record, runtime))
+  );
+}
+
 function activeRunError(params: {
   cause?: unknown;
   channel?: CrablineServerChannel;
@@ -619,6 +650,16 @@ async function resolveLockClaim(params: {
       requestedChannel: params.requestedChannel,
     });
   }
+  if (
+    await observedOwnerChangedDuringConfirmation(
+      params.claim.directoryPath,
+      observed.record,
+      params.runtime,
+    )
+  ) {
+    await resolveLockClaim(params);
+    return;
+  }
 
   const revalidated = await readLockRecord(params.claim.directoryPath);
   if (revalidated.kind === "missing") {
@@ -678,6 +719,17 @@ async function resolveLockContention(params: {
       outputDir: params.outputDir,
       requestedChannel: params.requestedChannel,
     });
+  }
+  if (
+    observed.kind === "record" &&
+    (await observedOwnerChangedDuringConfirmation(
+      params.lockDirectory,
+      observed.record,
+      params.runtime,
+    ))
+  ) {
+    await resolveLockContention(params);
+    return;
   }
 
   await params.beforeRecoveryClaim();
@@ -775,6 +827,7 @@ export async function acquireOpenClawCrablineSmokeRunLock(
     beforeRecoveryClaim?: BeforeRecoveryClaim;
     beforeReleaseClaim?: BeforeReleaseClaim;
     removeDirectory?: RemoveLockDirectory;
+    sleep?: Sleep;
     startHeartbeat?: StartHeartbeat;
   } = {},
 ): Promise<OpenClawCrablineSmokeRunLock> {
@@ -787,6 +840,7 @@ export async function acquireOpenClawCrablineSmokeRunLock(
     isProcessAlive: dependencies.isProcessAlive ?? isProcessAlive,
     leaseMs: dependencies.leaseMs ?? LOCK_LEASE_MS,
     now: dependencies.now ?? Date.now,
+    sleep: dependencies.sleep ?? sleep,
   };
   const createdAtMs = runtime.now();
   if (

--- a/src/openclaw/smoke-lock.ts
+++ b/src/openclaw/smoke-lock.ts
@@ -412,7 +412,7 @@ async function observedOwnerChangedDuringConfirmation(
   if (!needsLiveOwnerConfirmation(observed, runtime)) {
     return false;
   }
-  await runtime.sleep(Math.max(1, Math.ceil(runtime.leaseMs / 3)));
+  await runtime.sleep(runtime.leaseMs);
   const revalidated = await readLockRecord(lockDirectory);
   return (
     revalidated.kind === "record" &&

--- a/test/openclaw-artifact-generation.test.ts
+++ b/test/openclaw-artifact-generation.test.ts
@@ -150,6 +150,66 @@ describe("OpenClaw artifact generation publication", () => {
     }
   });
 
+  it("preserves a generation retained as a successor pointer rollback", async () => {
+    const outputDir = await createTempDir();
+    const lock = createLock();
+    const commitFailure = new Error("successor replaced the pointer");
+    const successorGeneration = "generation-22222222-2222-4222-8222-222222222222";
+    lock.commitFileAtomically.mockImplementation(
+      async ({ contents, destinationPath, stageFile }) => {
+        await stageFile(destinationPath, contents);
+        const pointer = JSON.parse(contents) as Record<string, unknown>;
+        const generation = String(pointer.generation);
+        await fs.writeFile(
+          destinationPath,
+          `${JSON.stringify(
+            {
+              ...pointer,
+              capabilityMatrixPath: String(pointer.capabilityMatrixPath).replace(
+                generation,
+                successorGeneration,
+              ),
+              generation: successorGeneration,
+              manifestPath: String(pointer.manifestPath).replace(generation, successorGeneration),
+              previousGeneration: generation,
+              smokeArtifactPath: String(pointer.smokeArtifactPath).replace(
+                generation,
+                successorGeneration,
+              ),
+            },
+            null,
+            2,
+          )}\n`,
+        );
+        throw commitFailure;
+      },
+    );
+    try {
+      await expect(
+        publishOpenClawCrablineArtifactGeneration(publishParams(outputDir, lock), {
+          createGenerationId: () => "11111111-1111-4111-8111-111111111111",
+        }),
+      ).rejects.toBe(commitFailure);
+
+      const pointer = await readOpenClawCrablineArtifactPointer(outputDir);
+      expect(pointer).toMatchObject({
+        generation: successorGeneration,
+        previousGeneration: "generation-11111111-1111-4111-8111-111111111111",
+      });
+      await expect(
+        fs.stat(
+          path.join(
+            outputDir,
+            OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY,
+            pointer!.previousGeneration!,
+          ),
+        ),
+      ).resolves.toBeDefined();
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
   it("retains the committed generation when the pointer disappears before pruning", async () => {
     const outputDir = await createTempDir();
     const lock = createLock();

--- a/test/openclaw-artifact-generation.test.ts
+++ b/test/openclaw-artifact-generation.test.ts
@@ -125,6 +125,55 @@ describe("OpenClaw artifact generation publication", () => {
     }
   });
 
+  it("preserves a generation when pointer publication fails after the rename", async () => {
+    const outputDir = await createTempDir();
+    const lock = createLock();
+    const commitFailure = new Error("post-rename verification failed");
+    lock.commitFileAtomically.mockImplementation(
+      async ({ contents, destinationPath, stageFile }) => {
+        await stageFile(destinationPath, contents);
+        throw commitFailure;
+      },
+    );
+    try {
+      await expect(
+        publishOpenClawCrablineArtifactGeneration(publishParams(outputDir, lock), {
+          createGenerationId: () => "11111111-1111-4111-8111-111111111111",
+        }),
+      ).rejects.toBe(commitFailure);
+
+      const pointer = await readOpenClawCrablineArtifactPointer(outputDir);
+      expect(pointer?.generation).toBe("generation-11111111-1111-4111-8111-111111111111");
+      await expect(fs.stat(path.join(outputDir, pointer!.manifestPath))).resolves.toBeDefined();
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
+  it("retains the committed generation when the pointer disappears before pruning", async () => {
+    const outputDir = await createTempDir();
+    const lock = createLock();
+    lock.commitFileAtomically.mockImplementation(
+      async ({ contents, destinationPath, stageFile }) => {
+        await stageFile(destinationPath, contents);
+        await fs.rm(destinationPath);
+      },
+    );
+    try {
+      const result = await publishOpenClawCrablineArtifactGeneration(
+        publishParams(outputDir, lock),
+        { createGenerationId: () => "11111111-1111-4111-8111-111111111111" },
+      );
+
+      expect(result.warnings).toEqual([
+        "OpenClaw Crabline artifact retention cleanup failed: OpenClaw Crabline artifact pointer is missing after publication.",
+      ]);
+      await expect(fs.stat(path.join(outputDir, result.manifestPath))).resolves.toBeDefined();
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
   it("fences an expired owner without touching a successor's uncommitted generation", async () => {
     const outputDir = await createTempDir();
     const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });

--- a/test/openclaw-artifact-generation.test.ts
+++ b/test/openclaw-artifact-generation.test.ts
@@ -60,6 +60,27 @@ function publishParams(outputDir: string, lock = createLock()) {
 }
 
 describe("OpenClaw artifact generation publication", () => {
+  it("rejects caller-controlled artifact paths before creating the store", async () => {
+    const outputDir = await createTempDir();
+    const params = publishParams(outputDir);
+    try {
+      await expect(
+        publishOpenClawCrablineArtifactGeneration({
+          ...params,
+          selection: {
+            ...params.selection,
+            capabilityMatrixPath: "../escaped.json",
+          } as unknown as typeof params.selection,
+        }),
+      ).rejects.toThrow("OpenClaw Crabline artifact selection paths are malformed.");
+      await expect(
+        fs.access(path.join(outputDir, OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY)),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
   it("publishes one complete owner-only generation behind an atomic pointer", async () => {
     const outputDir = await createTempDir();
     const lock = createLock();
@@ -379,7 +400,7 @@ describe("OpenClaw artifact generation publication", () => {
     }
   });
 
-  it("preserves owner-only crash leftovers while publishing a new generation", async () => {
+  it("removes failed staging and retains only the current and previous generations", async () => {
     const outputDir = await createTempDir();
     const storePath = path.join(outputDir, OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY);
     const abandonedGeneration = "generation-22222222-2222-4222-8222-222222222222";
@@ -407,13 +428,24 @@ describe("OpenClaw artifact generation publication", () => {
         createGenerationId: () => "44444444-4444-4444-8444-444444444444",
       });
 
-      await expect(fs.stat(path.join(storePath, abandonedGeneration))).resolves.toBeDefined();
+      await expect(fs.stat(path.join(storePath, abandonedGeneration))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
       await expect(
         fs.stat(path.join(storePath, ".staging-33333333-3333-4333-8333-333333333333")),
-      ).resolves.toBeDefined();
+      ).rejects.toMatchObject({ code: "ENOENT" });
       expect((await readOpenClawCrablineArtifactPointer(outputDir))?.generation).toBe(
         third.generation,
       );
+
+      const fourth = await publishOpenClawCrablineArtifactGeneration(publishParams(outputDir), {
+        createGenerationId: () => "55555555-5555-4555-8555-555555555555",
+      });
+      await expect(fs.stat(path.join(storePath, first.generation))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      await expect(fs.stat(path.join(storePath, third.generation))).resolves.toBeDefined();
+      await expect(fs.stat(path.join(storePath, fourth.generation))).resolves.toBeDefined();
     } finally {
       await disposeTempDir(outputDir);
     }

--- a/test/openclaw-private-file.test.ts
+++ b/test/openclaw-private-file.test.ts
@@ -215,6 +215,28 @@ describe("OpenClaw private file publication", () => {
     }
   });
 
+  it("preserves a replacement installed after the atomic rename", async () => {
+    const directory = await createTempDir();
+    try {
+      const filePath = path.join(directory, "manifest.json");
+      const displacedPath = `${filePath}.published`;
+
+      await expect(
+        publishPrivateFileAtomically(filePath, "private\n", {
+          afterRename: async (publishedPath) => {
+            await fs.rename(publishedPath, displacedPath);
+            await fs.writeFile(publishedPath, "replacement\n");
+          },
+        }),
+      ).rejects.toThrow("Private file path identity changed during publication.");
+
+      await expect(fs.readFile(filePath, "utf8")).resolves.toBe("replacement\n");
+      await expect(fs.readFile(displacedPath, "utf8")).resolves.toBe("private\n");
+    } finally {
+      await disposeTempDir(directory);
+    }
+  });
+
   it("uses Windows PowerShell to set and verify the current SID ACL", async () => {
     const calls: Parameters<WindowsAclRunner>[] = [];
     const run: WindowsAclRunner = async (...args) => {

--- a/test/openclaw-smoke-lock.test.ts
+++ b/test/openclaw-smoke-lock.test.ts
@@ -777,6 +777,45 @@ describe("OpenClaw smoke lock cleanup", () => {
     }
   });
 
+  it("does not reclaim a live owner after a forward clock jump when its heartbeat advances", async () => {
+    const outputDir = await createTempDir();
+    const params = { channel: "telegram" as const, outputDir };
+    let now = 1_000;
+    let renew: (() => Promise<void>) | undefined;
+    try {
+      const firstLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+        isProcessAlive: () => true,
+        leaseMs: 1_000,
+        now: () => now,
+        pid: 4_242,
+        processStartedAtMs: 100,
+        startHeartbeat: (heartbeat) => {
+          renew = heartbeat;
+          return disableHeartbeat(heartbeat, 333);
+        },
+      });
+
+      now = 100_000;
+      await expect(
+        acquireOpenClawCrablineSmokeRunLock(params, {
+          isProcessAlive: () => true,
+          leaseMs: 1_000,
+          now: () => now,
+          pid: 5_252,
+          processStartedAtMs: 200,
+          sleep: async () => {
+            await renew!();
+          },
+          startHeartbeat: disableHeartbeat,
+        }),
+      ).rejects.toThrow("OpenClaw Crabline smoke is already running");
+
+      await firstLock.release();
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
   it("retries strict owner parsing failures during release", async () => {
     const outputDir = await createTempDir();
     const params = { channel: "telegram" as const, outputDir };

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -1860,6 +1860,36 @@ describe("OpenClaw local provider bridge", () => {
     }
   });
 
+  it("preserves a frozen provider probe failure when adapter cleanup also fails", async () => {
+    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-openclaw-frozen-error-"));
+    const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
+    const primaryFailure = Object.freeze(new Error("frozen probe failure"));
+    try {
+      await expect(
+        runSmokeWithDependencies(
+          { outputDir, selection },
+          {
+            startAdapter: async (params) => {
+              const adapter = await startOpenClawCrablineAdapter(params);
+              return {
+                ...adapter,
+                close: async () => {
+                  await adapter.close();
+                  throw new Error("adapter close failed");
+                },
+                probe: async () => {
+                  throw primaryFailure;
+                },
+              };
+            },
+          },
+        ),
+      ).rejects.toBe(primaryFailure);
+    } finally {
+      await fs.rm(outputDir, { recursive: true, force: true });
+    }
+  });
+
   it.each(["setup", "probe", "cleanup"] as const)(
     "preserves the complete prior artifact generation on %s failure",
     async (failureStage) => {

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -1789,6 +1789,9 @@ describe("OpenClaw local provider bridge", () => {
         manifestPath: result.manifestPath,
         result: { ok: true, provider: "telegram" },
       });
+      expect(result.warnings).toEqual([
+        "OpenClaw Crabline smoke committed but lock cleanup failed: lock release retries exhausted",
+      ]);
     } finally {
       await fs.rm(outputDir, { recursive: true, force: true });
     }
@@ -1811,6 +1814,38 @@ describe("OpenClaw local provider bridge", () => {
               const adapter = await startOpenClawCrablineAdapter(params);
               return {
                 ...adapter,
+                probe: async () => {
+                  throw primaryFailure;
+                },
+              };
+            },
+          },
+        ),
+      ).rejects.toBe(primaryFailure);
+      expect(primaryFailure.cause).toBe(cleanupFailure);
+    } finally {
+      await fs.rm(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves the primary provider probe failure when adapter cleanup also fails", async () => {
+    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-openclaw-probe-errors-"));
+    const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
+    const primaryFailure = new Error("probe failed");
+    const cleanupFailure = new Error("adapter close failed");
+    try {
+      await expect(
+        runSmokeWithDependencies(
+          { outputDir, selection },
+          {
+            startAdapter: async (params) => {
+              const adapter = await startOpenClawCrablineAdapter(params);
+              return {
+                ...adapter,
+                close: async () => {
+                  await adapter.close();
+                  throw cleanupFailure;
+                },
                 probe: async () => {
                   throw primaryFailure;
                 },


### PR DESCRIPTION
## Summary
- fence caller-controlled artifact paths and preserve replacement files
- recover stale smoke locks without deleting live or rollback generations
- preserve primary probe failures and surface cleanup failures

## Verification
- Autoreview: gpt-5.6-sol, high, clean (0.94)
- Crabbox: `run_956879f6c6a7` (`pnpm verify`, 47 files / 388 tests)

## Changelog
- added under `Unreleased`