### PR TITLE
fix(cli): secure serve and release contracts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,16 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  release:
+  verify:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
-      contents: write
-      id-token: write
+      contents: read
+    outputs:
+      integrity: ${{ steps.package.outputs.integrity }}
+      name: ${{ steps.package.outputs.name }}
+      tag: ${{ steps.release.outputs.tag }}
+      version: ${{ steps.release.outputs.version }}
     steps:
       - name: Resolve release tag
         id: release
@@ -84,6 +88,7 @@ jobs:
           metadata_path="$RUNNER_TEMP/npm-pack.json"
           npm pack --json --pack-destination "$RUNNER_TEMP" > "$metadata_path"
           node --input-type=module <<'NODE'
+          import { execFileSync } from "node:child_process";
           import fs from "node:fs";
           import path from "node:path";
 
@@ -95,7 +100,14 @@ jobs:
           if (!cliPath || !pack.files?.some((file) => file.path === cliPath)) {
             throw new Error(`Packed artifact is missing the crabline CLI at ${cliPath ?? "<unset>"}.`);
           }
-          if (!fs.readFileSync(cliPath, "utf8").startsWith("#!/usr/bin/env node\n")) {
+          if (!pack.integrity || !pack.filename) {
+            throw new Error("npm pack did not report artifact integrity and filename.");
+          }
+          const tarballPath = path.join(process.env.RUNNER_TEMP, pack.filename);
+          const extractionRoot = fs.mkdtempSync(path.join(process.env.RUNNER_TEMP, "crabline-pack-"));
+          execFileSync("tar", ["-xzf", tarballPath, "-C", extractionRoot]);
+          const packedCliPath = path.join(extractionRoot, "package", cliPath);
+          if (!fs.readFileSync(packedCliPath, "utf8").startsWith("#!/usr/bin/env node\n")) {
             throw new Error(`Packed CLI ${cliPath} is missing its Node shebang.`);
           }
           if (pack.version !== process.env.RELEASE_VERSION) {
@@ -103,14 +115,11 @@ jobs:
               `Packed version ${pack.version} does not match release ${process.env.RELEASE_VERSION}.`,
             );
           }
-          if (!pack.integrity || !pack.filename) {
-            throw new Error("npm pack did not report artifact integrity and filename.");
-          }
 
           const outputs = {
             integrity: pack.integrity,
             name: packageJson.name,
-            tarball: path.join(process.env.RUNNER_TEMP, pack.filename),
+            tarball: tarballPath,
           };
           fs.appendFileSync(
             process.env.GITHUB_OUTPUT,
@@ -188,14 +197,45 @@ jobs:
             return -1;
           }
           NODE
+      - name: Upload verified release artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          compression-level: 0
+          if-no-files-found: error
+          name: npm-package
+          path: ${{ steps.package.outputs.tarball }}
+          retention-days: 1
+
+  publish:
+    needs: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+      - name: Download verified release artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.0
+        with:
+          name: npm-package
+          path: ${{ runner.temp }}/release
       - name: Publish package with npm provenance
         env:
-          PACKAGE_INTEGRITY: ${{ steps.package.outputs.integrity }}
-          PACKAGE_NAME: ${{ steps.package.outputs.name }}
-          PACKAGE_TARBALL: ${{ steps.package.outputs.tarball }}
-          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+          PACKAGE_INTEGRITY: ${{ needs.verify.outputs.integrity }}
+          PACKAGE_NAME: ${{ needs.verify.outputs.name }}
+          RELEASE_VERSION: ${{ needs.verify.outputs.version }}
         run: |
           set -euo pipefail
+          shopt -s nullglob
+          tarballs=("$RUNNER_TEMP"/release/*.tgz)
+          if [[ "${#tarballs[@]}" -ne 1 ]]; then
+            echo "::error::Expected one verified npm tarball, found ${#tarballs[@]}."
+            exit 1
+          fi
+          PACKAGE_TARBALL="${tarballs[0]}"
 
           check_existing_package() {
             local actual_integrity
@@ -238,10 +278,18 @@ jobs:
             fi
           done
           exit "$publish_status"
+
+  github-release:
+    needs: [verify, publish]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          RELEASE_TAG: ${{ needs.verify.outputs.tag }}
         run: |
           set -euo pipefail
           if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Randomize externally bound provider credentials, preserve Slack MPIM and Matrix sync errors, bound server shutdown, and enforce safe Zalo webhooks.
 - Order lazy cleanup after admitted dispatch, isolate loopback message state, and enforce effective modes and inbound deadlines.
 - Fence OpenClaw smoke artifact paths, clean abandoned generations safely, preserve primary probe failures and replacement files, and report post-commit lock cleanup failures.
+- Isolate verified release packaging from OIDC-enabled npm publication and inspect the generated tarball before upload.
 - Reject Telegram protocol errors returned with HTTP 200 and preserve numeric identities without unsafe integer coercion.
 - Retire serve ready files on shutdown, preserve replacement manifests, and redact text-mode credentials unless explicitly requested.
 - Pin privileged release workflow actions to immutable revisions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Randomize externally bound provider credentials, preserve Slack MPIM and Matrix sync errors, bound server shutdown, and enforce safe Zalo webhooks.
 - Order lazy cleanup after admitted dispatch, isolate loopback message state, and enforce effective modes and inbound deadlines.
 - Fence OpenClaw smoke artifact paths, clean abandoned generations safely, preserve primary probe failures and replacement files, and report post-commit lock cleanup failures.
+- Retire serve ready files on shutdown, preserve replacement manifests, and redact text-mode credentials unless explicitly requested.
 - Pin privileged release workflow actions to immutable revisions.
 - Redact inherited secret-named environment values from script diagnostics.
 - Verify production tarballs through their installed npm command shims.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Randomize externally bound provider credentials, preserve Slack MPIM and Matrix sync errors, bound server shutdown, and enforce safe Zalo webhooks.
 - Order lazy cleanup after admitted dispatch, isolate loopback message state, and enforce effective modes and inbound deadlines.
 - Fence OpenClaw smoke artifact paths, clean abandoned generations safely, preserve primary probe failures and replacement files, and report post-commit lock cleanup failures.
+- Reject Telegram protocol errors returned with HTTP 200 and preserve numeric identities without unsafe integer coercion.
 - Retire serve ready files on shutdown, preserve replacement manifests, and redact text-mode credentials unless explicitly requested.
 - Pin privileged release workflow actions to immutable revisions.
 - Redact inherited secret-named environment values from script diagnostics.

--- a/package.json
+++ b/package.json
@@ -54,11 +54,13 @@
     "commander": "^15.0.0",
     "curve25519-js": "^0.0.4",
     "picocolors": "^1.1.1",
+    "proper-lockfile": "4.1.2",
     "ws": "^8.21.0",
     "yaml": "^2.9.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@types/proper-lockfile": "4.1.4",
     "@types/ws": "^8.18.1",
     "@typescript/native": "npm:typescript@^7.0.2",
     "@vitest/coverage-v8": "^4.1.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
+      proper-lockfile:
+        specifier: 4.1.2
+        version: 4.1.2
       ws:
         specifier: ^8.21.0
         version: 8.21.0
@@ -33,6 +36,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@types/proper-lockfile':
+        specifier: 4.1.4
+        version: 4.1.4
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
@@ -904,6 +910,12 @@ packages:
   '@types/node@26.1.0':
     resolution: {integrity: sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==}
 
+  '@types/proper-lockfile@4.1.4':
+    resolution: {integrity: sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ==}
+
+  '@types/retry@0.12.5':
+    resolution: {integrity: sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==}
+
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
@@ -1182,6 +1194,9 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -1433,6 +1448,9 @@ packages:
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
+
   protobufjs@7.6.5:
     resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
@@ -1447,6 +1465,10 @@ packages:
   real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
+
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
 
   rolldown@1.0.3:
     resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
@@ -1472,6 +1494,9 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
@@ -2181,6 +2206,12 @@ snapshots:
     dependencies:
       undici-types: 8.3.0
 
+  '@types/proper-lockfile@4.1.4':
+    dependencies:
+      '@types/retry': 0.12.5
+
+  '@types/retry@0.12.5': {}
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 26.1.0
@@ -2425,6 +2456,8 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  graceful-fs@4.2.11: {}
 
   has-flag@4.0.0: {}
 
@@ -2690,6 +2723,12 @@ snapshots:
 
   process-warning@5.0.0: {}
 
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
+
   protobufjs@7.6.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
@@ -2711,6 +2750,8 @@ snapshots:
   quick-format-unescaped@4.0.4: {}
 
   real-require@0.2.0: {}
+
+  retry@0.12.0: {}
 
   rolldown@1.0.3:
     dependencies:
@@ -2772,6 +2813,8 @@ snapshots:
       '@img/sharp-win32-x64': 0.35.2
 
   siginfo@2.0.0: {}
+
+  signal-exit@3.0.7: {}
 
   sonic-boom@4.2.1:
     dependencies:

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -2,6 +2,7 @@ import { Command, CommanderError } from "commander";
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import nodePath from "node:path";
+import { lock } from "proper-lockfile";
 import { loadManifest } from "../config/load.js";
 import { createRegistry } from "../providers/registry.js";
 import { formatJson, formatRunResultText } from "../core/reporters.js";
@@ -23,9 +24,21 @@ type GlobalOptions = {
 
 type SetExitCode = (code: number) => void;
 
+export type ReadyFileIdentity = {
+  birthtimeNs: bigint;
+  ctimeNs: bigint;
+  dev: bigint;
+  ino: bigint;
+  size: bigint;
+};
+
 type ProgramDependencies = {
-  publishReadyFile?: (filePath: string, contents: string) => Promise<void>;
-  removeReadyFile?: (filePath: string, expectedContents: string) => Promise<void>;
+  publishReadyFile?: (filePath: string, contents: string) => Promise<ReadyFileIdentity>;
+  removeReadyFile?: (
+    filePath: string,
+    expectedContents: string,
+    expectedIdentity: ReadyFileIdentity,
+  ) => Promise<void>;
   startServer?: (params: StartCrablineServerParams) => Promise<StartedCrablineServer>;
 };
 
@@ -325,12 +338,15 @@ export function createProgram(
         ),
       );
       const close = onceAsync(() => server.close());
-      let publishedReadyContents: string | undefined;
+      let publishedReady: { contents: string; identity: ReadyFileIdentity } | undefined;
       try {
         const payload = formatJson(server.manifest);
         if (commandOptions.readyFile) {
-          publishedReadyContents = `${payload}\n`;
-          await publish(commandOptions.readyFile, publishedReadyContents);
+          const readyContents = `${payload}\n`;
+          publishedReady = {
+            contents: readyContents,
+            identity: await publish(commandOptions.readyFile, readyContents),
+          };
         }
         print(
           options.json
@@ -344,8 +360,12 @@ export function createProgram(
         try {
           await close();
         } finally {
-          if (commandOptions.readyFile && publishedReadyContents !== undefined) {
-            await removeReady(commandOptions.readyFile, publishedReadyContents);
+          if (commandOptions.readyFile && publishedReady) {
+            await removeReady(
+              commandOptions.readyFile,
+              publishedReady.contents,
+              publishedReady.identity,
+            );
           }
         }
       }
@@ -380,30 +400,132 @@ function onceAsync(action: () => Promise<void>): () => Promise<void> {
 }
 
 async function prepareReadyFile(filePath: string): Promise<void> {
-  await fs.mkdir(nodePath.dirname(filePath), { recursive: true });
-  await fs.rm(filePath, { force: true });
+  await withReadyFileLock(filePath, async () => {
+    await fs.rm(filePath, { force: true });
+  });
 }
 
-export async function publishReadyFile(filePath: string, contents: string): Promise<void> {
-  const temporaryPath = nodePath.join(
-    nodePath.dirname(filePath),
-    `.${nodePath.basename(filePath)}.${process.pid}.${randomUUID()}.tmp`,
+async function readReadyFileIdentity(filePath: string): Promise<ReadyFileIdentity> {
+  const stats = await fs.stat(filePath, { bigint: true });
+  return {
+    birthtimeNs: stats.birthtimeNs,
+    ctimeNs: stats.ctimeNs,
+    dev: stats.dev,
+    ino: stats.ino,
+    size: stats.size,
+  };
+}
+
+function sameReadyFileIdentity(left: ReadyFileIdentity, right: ReadyFileIdentity): boolean {
+  return (
+    left.birthtimeNs === right.birthtimeNs &&
+    left.ctimeNs === right.ctimeNs &&
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.size === right.size
   );
+}
+
+async function withReadyFileLock<T>(filePath: string, action: () => Promise<T>): Promise<T> {
+  await fs.mkdir(nodePath.dirname(filePath), { recursive: true });
+  const release = await lock(filePath, {
+    realpath: false,
+    retries: {
+      factor: 1,
+      maxTimeout: 10,
+      minTimeout: 10,
+      retries: 100,
+    },
+    stale: 10_000,
+    update: 2_500,
+  });
+  let actionFailed = false;
+  let actionError: unknown;
+  let result: T | undefined;
   try {
-    await fs.writeFile(temporaryPath, contents, {
-      encoding: "utf8",
-      flag: "wx",
-      mode: 0o600,
+    result = await action();
+  } catch (error) {
+    actionFailed = true;
+    actionError = error;
+  }
+  try {
+    await release();
+  } catch (releaseError) {
+    if (actionFailed) {
+      const aggregateError = new AggregateError(
+        [actionError, releaseError],
+        `Ready-file action and lock release both failed for "${filePath}".`,
+      );
+      aggregateError.cause = actionError;
+      throw aggregateError;
+    }
+    throw releaseError;
+  }
+  if (actionFailed) {
+    throw actionError;
+  }
+  return result as T;
+}
+
+export async function publishReadyFile(
+  filePath: string,
+  contents: string,
+): Promise<ReadyFileIdentity> {
+  let publishedIdentity: ReadyFileIdentity | undefined;
+  try {
+    return await withReadyFileLock(filePath, async () => {
+      const suffix = `${process.pid}.${randomUUID()}.tmp`;
+      const temporaryPath = nodePath.join(
+        nodePath.dirname(filePath),
+        `.${nodePath.basename(filePath)}.${suffix}`,
+      );
+      let manifestPublished = false;
+      try {
+        await fs.writeFile(temporaryPath, contents, {
+          encoding: "utf8",
+          flag: "wx",
+          mode: 0o600,
+        });
+        await fs.rename(temporaryPath, filePath);
+        manifestPublished = true;
+        publishedIdentity = await readReadyFileIdentity(filePath);
+        return publishedIdentity;
+      } catch (error) {
+        if (manifestPublished) {
+          await fs.rm(filePath, { force: true }).catch(() => undefined);
+        }
+        throw error;
+      } finally {
+        await fs.rm(temporaryPath, { force: true }).catch(() => undefined);
+      }
     });
-    await fs.rename(temporaryPath, filePath);
-  } finally {
-    await fs.rm(temporaryPath, { force: true }).catch(() => undefined);
+  } catch (error) {
+    if (publishedIdentity) {
+      try {
+        await removeReadyFileIfOwned(filePath, contents, publishedIdentity);
+      } catch (cleanupError) {
+        const aggregateError = new AggregateError(
+          [error, cleanupError],
+          `Ready-file publication and compensation both failed for "${filePath}".`,
+        );
+        aggregateError.cause = error;
+        throw aggregateError;
+      }
+    }
+    throw error;
   }
 }
 
-export async function removeReadyFile(filePath: string, expectedContents: string): Promise<void> {
+async function removeReadyFileIfOwned(
+  filePath: string,
+  expectedContents: string,
+  expectedIdentity: ReadyFileIdentity,
+): Promise<void> {
   try {
-    if ((await fs.readFile(filePath, "utf8")) !== expectedContents) {
+    if (
+      (await fs.readFile(filePath, "utf8")) !== expectedContents ||
+      !sameReadyFileIdentity(await readReadyFileIdentity(filePath), expectedIdentity)
+    ) {
       return;
     }
     await fs.rm(filePath);
@@ -412,6 +534,16 @@ export async function removeReadyFile(filePath: string, expectedContents: string
       throw error;
     }
   }
+}
+
+export async function removeReadyFile(
+  filePath: string,
+  expectedContents: string,
+  expectedIdentity: ReadyFileIdentity,
+): Promise<void> {
+  await withReadyFileLock(filePath, async () => {
+    await removeReadyFileIfOwned(filePath, expectedContents, expectedIdentity);
+  });
 }
 
 export function waitForShutdown(
@@ -491,10 +623,13 @@ function renderServeProviderFields(
     ];
   }
   if (manifest.provider === "whatsapp") {
+    const baileysWebSocketUrl = showSecrets
+      ? manifest.endpoints.baileysWebSocketUrl
+      : `${manifest.endpoints.baileysWebSocketUrl.split("?")[0]}?access_token=<redacted>`;
     return [
       `  adminToken: ${secret(manifest.adminToken)}`,
       `  accessToken: ${secret(manifest.accessToken)}`,
-      `  baileysWebSocket: ${manifest.endpoints.baileysWebSocketUrl}`,
+      `  baileysWebSocket: ${baileysWebSocketUrl}`,
       `  messages: ${manifest.endpoints.messagesUrl}`,
       `  phoneNumber: ${manifest.endpoints.phoneNumberUrl}`,
       `  status: ${manifest.endpoints.statusUrl}`,

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -25,6 +25,7 @@ type SetExitCode = (code: number) => void;
 
 type ProgramDependencies = {
   publishReadyFile?: (filePath: string, contents: string) => Promise<void>;
+  removeReadyFile?: (filePath: string, expectedContents: string) => Promise<void>;
   startServer?: (params: StartCrablineServerParams) => Promise<StartedCrablineServer>;
 };
 
@@ -46,6 +47,7 @@ type ServeCommandOptions = {
   readyFile?: string | undefined;
   recorder?: string | undefined;
   selfJid?: string | undefined;
+  showSecrets?: boolean | undefined;
   signingSecret?: string | undefined;
 };
 
@@ -123,6 +125,7 @@ export function createProgram(
 ): Command {
   const program = new Command();
   const publish = dependencies.publishReadyFile ?? publishReadyFile;
+  const removeReady = dependencies.removeReadyFile ?? removeReadyFile;
   const startServer = dependencies.startServer ?? startCrablineServer;
 
   program
@@ -286,6 +289,7 @@ export function createProgram(
     .option("--recorder <path>", "JSONL recorder path")
     .option("--ready-file <path>", "Write the server runtime manifest to this path")
     .option("--self-jid <jid>", "WhatsApp self JID")
+    .option("--show-secrets", "Print provider credentials in text output", false)
     .option("--signing-secret <secret>", "Slack signing secret")
     .option("--once", "Start, print the runtime manifest, and stop immediately", false)
     .action(async (provider, commandOptions: ServeCommandOptions) => {
@@ -321,17 +325,29 @@ export function createProgram(
         ),
       );
       const close = onceAsync(() => server.close());
+      let publishedReadyContents: string | undefined;
       try {
         const payload = formatJson(server.manifest);
         if (commandOptions.readyFile) {
-          await publish(commandOptions.readyFile, `${payload}\n`);
+          publishedReadyContents = `${payload}\n`;
+          await publish(commandOptions.readyFile, publishedReadyContents);
         }
-        print(options.json ? payload : renderServeText(server.manifest));
+        print(
+          options.json
+            ? payload
+            : renderServeText(server.manifest, commandOptions.showSecrets === true),
+        );
         if (!commandOptions.once) {
           await waitForShutdown(close);
         }
       } finally {
-        await close();
+        try {
+          await close();
+        } finally {
+          if (commandOptions.readyFile && publishedReadyContents !== undefined) {
+            await removeReady(commandOptions.readyFile, publishedReadyContents);
+          }
+        }
       }
     });
 
@@ -385,6 +401,19 @@ export async function publishReadyFile(filePath: string, contents: string): Prom
   }
 }
 
+export async function removeReadyFile(filePath: string, expectedContents: string): Promise<void> {
+  try {
+    if ((await fs.readFile(filePath, "utf8")) !== expectedContents) {
+      return;
+    }
+    await fs.rm(filePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
+}
+
 export function waitForShutdown(
   close: () => Promise<void>,
   signalTarget: SignalTarget = process,
@@ -408,14 +437,14 @@ export function waitForShutdown(
   });
 }
 
-function renderServeText(manifest: CrablineServerManifest) {
+function renderServeText(manifest: CrablineServerManifest, showSecrets: boolean) {
   const lines = [
     `${manifest.provider} local server ready`,
     `  apiRoot: ${manifest.provider === "matrix" ? manifest.endpoints.clientApiRoot : manifest.endpoints.apiRoot}`,
     `  inbound: ${manifest.endpoints.adminInboundUrl}`,
     `  recorder: ${manifest.recorderPath}`,
   ];
-  const providerFields = renderServeProviderFields(manifest);
+  const providerFields = renderServeProviderFields(manifest, showSecrets);
   if (!providerFields) {
     throw new CrablineError(`Unsupported server manifest provider: ${String(manifest.provider)}`, {
       kind: "config",
@@ -425,39 +454,46 @@ function renderServeText(manifest: CrablineServerManifest) {
   return lines.join("\n");
 }
 
-function renderServeProviderFields(manifest: CrablineServerManifest): string[] | undefined {
+function renderServeProviderFields(
+  manifest: CrablineServerManifest,
+  showSecrets: boolean,
+): string[] | undefined {
+  const secret = (value: string) => (showSecrets ? value : "<redacted>");
   if (manifest.provider === "mattermost") {
     return [
-      `  adminToken: ${manifest.adminToken}`,
-      `  botToken: ${manifest.botToken}`,
+      `  adminToken: ${secret(manifest.adminToken)}`,
+      `  botToken: ${secret(manifest.botToken)}`,
       `  websocket: ${manifest.endpoints.websocketUrl}`,
     ];
   }
   if (manifest.provider === "matrix") {
     return [
-      `  adminToken: ${manifest.adminToken}`,
-      `  accessToken: ${manifest.accessToken}`,
+      `  adminToken: ${secret(manifest.adminToken)}`,
+      `  accessToken: ${secret(manifest.accessToken)}`,
       `  botUserId: ${manifest.botUserId}`,
       `  sync: ${manifest.endpoints.syncUrl}`,
     ];
   }
   if (manifest.provider === "signal") {
-    return [`  adminToken: ${manifest.adminToken}`, `  account: ${manifest.account}`];
+    return [`  adminToken: ${secret(manifest.adminToken)}`, `  account: ${manifest.account}`];
   }
   if (manifest.provider === "slack") {
     return [
-      `  adminToken: ${manifest.adminToken}`,
-      `  botToken: ${manifest.botToken}`,
-      `  signingSecret: ${manifest.signingSecret}`,
+      `  adminToken: ${secret(manifest.adminToken)}`,
+      `  botToken: ${secret(manifest.botToken)}`,
+      `  signingSecret: ${secret(manifest.signingSecret)}`,
     ];
   }
   if (manifest.provider === "telegram") {
-    return [`  adminToken: ${manifest.adminToken}`, `  botToken: ${manifest.botToken}`];
+    return [
+      `  adminToken: ${secret(manifest.adminToken)}`,
+      `  botToken: ${secret(manifest.botToken)}`,
+    ];
   }
   if (manifest.provider === "whatsapp") {
     return [
-      `  adminToken: ${manifest.adminToken}`,
-      `  accessToken: ${manifest.accessToken}`,
+      `  adminToken: ${secret(manifest.adminToken)}`,
+      `  accessToken: ${secret(manifest.accessToken)}`,
       `  baileysWebSocket: ${manifest.endpoints.baileysWebSocketUrl}`,
       `  messages: ${manifest.endpoints.messagesUrl}`,
       `  phoneNumber: ${manifest.endpoints.phoneNumberUrl}`,
@@ -467,8 +503,8 @@ function renderServeProviderFields(manifest: CrablineServerManifest): string[] |
   }
   if (manifest.provider === "zalo") {
     return [
-      `  adminToken: ${manifest.adminToken}`,
-      `  botToken: ${manifest.botToken}`,
+      `  adminToken: ${secret(manifest.adminToken)}`,
+      `  botToken: ${secret(manifest.botToken)}`,
       `  botId: ${manifest.botId}`,
     ];
   }

--- a/src/openclaw/bridges/telegram.ts
+++ b/src/openclaw/bridges/telegram.ts
@@ -26,6 +26,12 @@ function normalizeTelegramChatId(kind: "direct" | "group", id: string): string {
     if (numericId === 0n || (kind === "direct" ? numericId < 0n : numericId > 0n)) {
       throw new Error("Telegram numeric target sign does not match the declared target kind.");
     }
+    if (
+      numericId < BigInt(Number.MIN_SAFE_INTEGER) ||
+      numericId > BigInt(Number.MAX_SAFE_INTEGER)
+    ) {
+      throw new Error("Telegram numeric target must be a safe integer.");
+    }
     return value;
   }
   const hash = createHash("sha256").update(`${kind}:${value}`).digest().readBigUInt64BE();
@@ -66,7 +72,16 @@ export const TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
         if (!response.ok) {
           throw new Error(`Crabline Telegram getMe probe failed with HTTP ${response.status}.`);
         }
-        return await response.json();
+        const payload = await response.json();
+        if (!isRecord(payload) || payload.ok !== true) {
+          const errorCode = readString(isRecord(payload) ? payload.error_code : undefined);
+          const description = readNonBlankString(
+            isRecord(payload) ? payload.description : undefined,
+          );
+          const detail = description ?? (errorCode ? `error ${errorCode}` : "invalid response");
+          throw new Error(`Crabline Telegram getMe probe failed: ${detail}.`);
+        }
+        return payload;
       },
       createBinding() {
         return {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -507,9 +507,9 @@ describe("cli", () => {
           "telegram",
           "--once",
           "--admin-token",
-          "admin-sentinel",
+          "redacted-admin-value",
           "--bot-token",
-          "424242:bot-sentinel",
+          "redacted-bot-value",
           "--recorder",
           path.join(directory, "redacted.jsonl"),
         ]),
@@ -523,9 +523,9 @@ describe("cli", () => {
           "--once",
           "--show-secrets",
           "--admin-token",
-          "visible-admin",
+          "shown-admin-value",
           "--bot-token",
-          "424242:visible-bot",
+          "shown-bot-value",
           "--recorder",
           path.join(directory, "visible.jsonl"),
         ]),
@@ -535,12 +535,12 @@ describe("cli", () => {
     }
 
     const stdout = captured.stdout.join("");
-    expect(stdout).not.toContain("admin-sentinel");
-    expect(stdout).not.toContain("bot-sentinel");
+    expect(stdout).not.toContain("redacted-admin-value");
+    expect(stdout).not.toContain("redacted-bot-value");
     expect(stdout).toContain("adminToken: <redacted>");
     expect(stdout).toContain("botToken: <redacted>");
-    expect(stdout).toContain("adminToken: visible-admin");
-    expect(stdout).toContain("botToken: 424242:visible-bot");
+    expect(stdout).toContain("adminToken: shown-admin-value");
+    expect(stdout).toContain("botToken: shown-bot-value");
   });
 
   it("prints a Telegram server runtime manifest", async () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -2,9 +2,27 @@ import { EventEmitter } from "node:events";
 import path from "node:path";
 import fs from "node:fs/promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createProgram, runCli, waitForShutdown } from "../src/cli/program.js";
+import { createProgram, publishReadyFile, runCli, waitForShutdown } from "../src/cli/program.js";
 import type { StartedCrablineServer } from "../src/servers/index.js";
 import { captureWrites, createTempDir, disposeTempDir, writeText } from "./test-helpers.js";
+
+const lockState = vi.hoisted(() => ({ releaseError: undefined as Error | undefined }));
+
+vi.mock("proper-lockfile", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("proper-lockfile")>();
+  return {
+    ...actual,
+    async lock(...args: Parameters<typeof actual.lock>) {
+      const release = await actual.lock(...args);
+      return async () => {
+        await release();
+        if (lockState.releaseError) {
+          throw lockState.releaseError;
+        }
+      };
+    },
+  };
+});
 
 const directories: string[] = [];
 const ansiPattern = new RegExp(String.raw`\u001B\[[0-?]*[ -/]*[@-~]`, "g");
@@ -13,6 +31,7 @@ const stripAnsi = (value: string): string => value.replace(ansiPattern, "");
 
 afterEach(async () => {
   process.exitCode = 0;
+  lockState.releaseError = undefined;
   await Promise.all(directories.splice(0).map(disposeTempDir));
 });
 
@@ -401,10 +420,40 @@ describe("cli", () => {
     await expect(fs.readFile(readyFile, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("does not recursively remove a stale non-lock directory", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const readyFile = path.join(directory, "server.json");
+    const lockPath = `${readyFile}.lock`;
+    const sentinelPath = path.join(lockPath, "keep.txt");
+    await fs.mkdir(lockPath);
+    await fs.writeFile(sentinelPath, "unrelated\n");
+    const staleTime = new Date(Date.now() - 20_000);
+    await fs.utimes(lockPath, staleTime, staleTime);
+
+    await expect(publishReadyFile(readyFile, "manifest\n")).rejects.toMatchObject({
+      code: "ENOTEMPTY",
+    });
+    await expect(fs.readFile(sentinelPath, "utf8")).resolves.toBe("unrelated\n");
+  });
+
+  it("removes a committed ready file when lock release fails", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const readyFile = path.join(directory, "server.json");
+    const releaseError = new Error("release exploded");
+    lockState.releaseError = releaseError;
+
+    await expect(publishReadyFile(readyFile, "manifest\n")).rejects.toBe(releaseError);
+
+    await expect(fs.readFile(readyFile, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("closes the server once when ready-file publication fails after startup", async () => {
     const directory = await createTempDir();
     directories.push(directory);
     const close = vi.fn(async () => undefined);
+    const removeReadyFile = vi.fn(async () => undefined);
     const publishError = new Error("publish exploded");
     const server = {
       close,
@@ -428,6 +477,7 @@ describe("cli", () => {
       publishReadyFile: async () => {
         throw publishError;
       },
+      removeReadyFile,
       startServer: async () => server,
     });
 
@@ -443,16 +493,18 @@ describe("cli", () => {
       ]),
     ).rejects.toBe(publishError);
     expect(close).toHaveBeenCalledTimes(1);
+    expect(removeReadyFile).not.toHaveBeenCalled();
   });
 
-  it("does not remove a ready file replaced during server shutdown", async () => {
+  it("does not remove a same-content ready file replaced during server shutdown", async () => {
     const directory = await createTempDir();
     directories.push(directory);
     const readyFile = path.join(directory, "server.json");
-    const replacement = "replacement owner\n";
+    let replacementContents: string | undefined;
     const server = {
       async close() {
-        await fs.writeFile(readyFile, replacement);
+        replacementContents = await fs.readFile(readyFile, "utf8");
+        await publishReadyFile(readyFile, replacementContents);
       },
       manifest: {
         adminToken: "fake",
@@ -490,7 +542,7 @@ describe("cli", () => {
       captured.restore();
     }
 
-    await expect(fs.readFile(readyFile, "utf8")).resolves.toBe(replacement);
+    await expect(fs.readFile(readyFile, "utf8")).resolves.toBe(replacementContents);
   });
 
   it("redacts serve credentials from text output unless explicitly requested", async () => {
@@ -512,6 +564,21 @@ describe("cli", () => {
           "sample",
           "--recorder",
           path.join(directory, "redacted.jsonl"),
+        ]),
+      ).toBe(0);
+      expect(
+        await runCli([
+          "node",
+          "crabline",
+          "serve",
+          "whatsapp",
+          "--once",
+          "--admin-token",
+          "example",
+          "--access-token",
+          "placeholder",
+          "--recorder",
+          path.join(directory, "whatsapp-redacted.jsonl"),
         ]),
       ).toBe(0);
       expect(
@@ -541,6 +608,8 @@ describe("cli", () => {
     expect(stdout).toContain("botToken: <redacted>");
     expect(stdout).toContain("adminToken: example");
     expect(stdout).toContain("botToken: placeholder");
+    expect(stdout).not.toContain("access_token=placeholder");
+    expect(stdout).toContain("access_token=<redacted>");
   });
 
   it("prints a Telegram server runtime manifest", async () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -455,15 +455,15 @@ describe("cli", () => {
         await fs.writeFile(readyFile, replacement);
       },
       manifest: {
-        adminToken: "admin",
+        adminToken: "fake",
         baseUrl: "http://127.0.0.1:12345",
-        botToken: "424242:token",
+        botToken: "sample",
         endpoints: {
           adminInboundUrl: "http://127.0.0.1:12345/crabline/telegram/inbound",
           apiRoot: "http://127.0.0.1:12345",
         },
         env: {
-          TELEGRAM_BOT_TOKEN: "424242:token",
+          TELEGRAM_BOT_TOKEN: "sample",
         },
         provider: "telegram",
         recorderPath: path.join(directory, "telegram.jsonl"),
@@ -507,9 +507,9 @@ describe("cli", () => {
           "telegram",
           "--once",
           "--admin-token",
-          "redacted-admin-value",
+          "fake",
           "--bot-token",
-          "redacted-bot-value",
+          "sample",
           "--recorder",
           path.join(directory, "redacted.jsonl"),
         ]),
@@ -523,9 +523,9 @@ describe("cli", () => {
           "--once",
           "--show-secrets",
           "--admin-token",
-          "shown-admin-value",
+          "example",
           "--bot-token",
-          "shown-bot-value",
+          "placeholder",
           "--recorder",
           path.join(directory, "visible.jsonl"),
         ]),
@@ -535,12 +535,12 @@ describe("cli", () => {
     }
 
     const stdout = captured.stdout.join("");
-    expect(stdout).not.toContain("redacted-admin-value");
-    expect(stdout).not.toContain("redacted-bot-value");
+    expect(stdout).not.toContain("adminToken: fake");
+    expect(stdout).not.toContain("botToken: sample");
     expect(stdout).toContain("adminToken: <redacted>");
     expect(stdout).toContain("botToken: <redacted>");
-    expect(stdout).toContain("adminToken: shown-admin-value");
-    expect(stdout).toContain("botToken: shown-bot-value");
+    expect(stdout).toContain("adminToken: example");
+    expect(stdout).toContain("botToken: placeholder");
   });
 
   it("prints a Telegram server runtime manifest", async () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -609,7 +609,7 @@ describe("cli", () => {
           "--admin-token",
           "test-admin-token",
           "--bot-token",
-          "test-zalo-token",
+          "test-token-placeholder",
           "--recorder",
           path.join(directory, "zalo.jsonl"),
         ]),
@@ -627,14 +627,14 @@ describe("cli", () => {
     };
     expect(manifest.provider).toBe("zalo");
     expect(manifest.adminToken).toBe("test-admin-token");
-    expect(manifest.botToken).toBe("test-zalo-token");
+    expect(manifest.botToken).toBe("test-token-placeholder");
     expect(manifest.endpoints?.apiRoot).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/u);
     expect(manifest.endpoints?.adminInboundUrl).toMatch(
       /^http:\/\/127\.0\.0\.1:\d+\/crabline\/zalo\/inbound$/u,
     );
     expect(manifest.env).toMatchObject({
       ZALO_API_URL: manifest.endpoints?.apiRoot,
-      ZALO_BOT_TOKEN: "test-zalo-token",
+      ZALO_BOT_TOKEN: "test-token-placeholder",
     });
     await expect(fs.readFile(readyFile, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
   });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -445,6 +445,104 @@ describe("cli", () => {
     expect(close).toHaveBeenCalledTimes(1);
   });
 
+  it("does not remove a ready file replaced during server shutdown", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const readyFile = path.join(directory, "server.json");
+    const replacement = "replacement owner\n";
+    const server = {
+      async close() {
+        await fs.writeFile(readyFile, replacement);
+      },
+      manifest: {
+        adminToken: "admin",
+        baseUrl: "http://127.0.0.1:12345",
+        botToken: "424242:token",
+        endpoints: {
+          adminInboundUrl: "http://127.0.0.1:12345/crabline/telegram/inbound",
+          apiRoot: "http://127.0.0.1:12345",
+        },
+        env: {
+          TELEGRAM_BOT_TOKEN: "424242:token",
+        },
+        provider: "telegram",
+        recorderPath: path.join(directory, "telegram.jsonl"),
+        version: 1,
+      },
+    } satisfies StartedCrablineServer;
+    const program = createProgram(() => undefined, {
+      startServer: async () => server,
+    });
+    const captured = captureWrites();
+
+    try {
+      await program.parseAsync([
+        "node",
+        "crabline",
+        "--json",
+        "serve",
+        "telegram",
+        "--once",
+        "--ready-file",
+        readyFile,
+      ]);
+    } finally {
+      captured.restore();
+    }
+
+    await expect(fs.readFile(readyFile, "utf8")).resolves.toBe(replacement);
+  });
+
+  it("redacts serve credentials from text output unless explicitly requested", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const captured = captureWrites();
+
+    try {
+      expect(
+        await runCli([
+          "node",
+          "crabline",
+          "serve",
+          "telegram",
+          "--once",
+          "--admin-token",
+          "admin-sentinel",
+          "--bot-token",
+          "424242:bot-sentinel",
+          "--recorder",
+          path.join(directory, "redacted.jsonl"),
+        ]),
+      ).toBe(0);
+      expect(
+        await runCli([
+          "node",
+          "crabline",
+          "serve",
+          "telegram",
+          "--once",
+          "--show-secrets",
+          "--admin-token",
+          "visible-admin",
+          "--bot-token",
+          "424242:visible-bot",
+          "--recorder",
+          path.join(directory, "visible.jsonl"),
+        ]),
+      ).toBe(0);
+    } finally {
+      captured.restore();
+    }
+
+    const stdout = captured.stdout.join("");
+    expect(stdout).not.toContain("admin-sentinel");
+    expect(stdout).not.toContain("bot-sentinel");
+    expect(stdout).toContain("adminToken: <redacted>");
+    expect(stdout).toContain("botToken: <redacted>");
+    expect(stdout).toContain("adminToken: visible-admin");
+    expect(stdout).toContain("botToken: 424242:visible-bot");
+  });
+
   it("prints a Telegram server runtime manifest", async () => {
     const directory = await createTempDir();
     directories.push(directory);
@@ -487,9 +585,8 @@ describe("cli", () => {
       /^http:\/\/127\.0\.0\.1:\d+\/crabline\/telegram\/inbound$/u,
     );
     expect(manifest.botToken).toBe("424242:crabline-telegram-token");
-    await expect(fs.readFile(readyFile, "utf8")).resolves.toContain('"provider": "telegram"');
-    expect((await fs.stat(readyFile)).mode & 0o777).toBe(0o600);
-    expect(await fs.readdir(path.dirname(readyFile))).toEqual([path.basename(readyFile)]);
+    await expect(fs.readFile(readyFile, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    expect(await fs.readdir(path.dirname(readyFile))).toEqual([]);
   });
 
   it("prints a Zalo server runtime manifest", async () => {
@@ -539,7 +636,7 @@ describe("cli", () => {
       ZALO_API_URL: manifest.endpoints?.apiRoot,
       ZALO_BOT_TOKEN: "test-zalo-token",
     });
-    await expect(fs.readFile(readyFile, "utf8")).resolves.toContain('"provider": "zalo"');
+    await expect(fs.readFile(readyFile, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("prints a Slack server runtime manifest", async () => {
@@ -589,7 +686,7 @@ describe("cli", () => {
       /^http:\/\/127\.0\.0\.1:\d+\/crabline\/slack\/inbound$/u,
     );
     expect(manifest.endpoints?.eventsUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/slack\/events$/u);
-    await expect(fs.readFile(readyFile, "utf8")).resolves.toContain('"provider": "slack"');
+    await expect(fs.readFile(readyFile, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("prints a WhatsApp server runtime manifest", async () => {
@@ -655,7 +752,7 @@ describe("cli", () => {
       CLOUD_API_VERSION: "v25.0",
       WA_PHONE_NUMBER_ID: "100000000000000",
     });
-    await expect(fs.readFile(readyFile, "utf8")).resolves.toContain('"provider": "whatsapp"');
+    await expect(fs.readFile(readyFile, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("doctor accepts local mock slack without live env", async () => {

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -298,6 +298,22 @@ describe("OpenClaw local provider bridge", () => {
     }
   });
 
+  it("rejects Telegram application errors returned with HTTP 200", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ description: "Unauthorized", error_code: 401, ok: false }), {
+        headers: { "content-type": "application/json" },
+        status: 200,
+      }),
+    );
+    try {
+      await expect(probeOpenClawCrablineProvider(manifest)).rejects.toThrow(
+        "Crabline Telegram getMe probe failed: Unauthorized.",
+      );
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
   it.each([
     { label: "Mattermost users.me", manifest: mattermostManifest },
     { label: "Matrix whoami", manifest: matrixManifest },
@@ -894,6 +910,28 @@ describe("OpenClaw local provider bridge", () => {
         "Telegram numeric target sign does not match the declared target kind.",
       );
     }
+  });
+
+  it("rejects Telegram numeric identities that cannot round-trip through JSON numbers", () => {
+    for (const target of [
+      `dm:${BigInt(Number.MAX_SAFE_INTEGER) + 1n}`,
+      `group:${BigInt(Number.MIN_SAFE_INTEGER) - 1n}`,
+    ]) {
+      expect(() => createOpenClawCrablineAgentDelivery({ manifest, target })).toThrow(
+        "Telegram numeric target must be a safe integer.",
+      );
+    }
+
+    expect(() =>
+      createOpenClawCrablineInbound({
+        manifest,
+        input: {
+          conversation: { id: "alice", kind: "direct" },
+          senderId: String(BigInt(Number.MAX_SAFE_INTEGER) + 1n),
+          text: "unsafe sender",
+        },
+      }),
+    ).toThrow("Telegram numeric target must be a safe integer.");
   });
 
   it("validates explicit Telegram thread target ids", () => {

--- a/test/release-workflow.test.ts
+++ b/test/release-workflow.test.ts
@@ -23,17 +23,21 @@ type ReleaseWorkflow = {
     "cancel-in-progress"?: boolean;
     group?: string;
   };
-  jobs?: {
-    release?: {
+  jobs?: Record<
+    string,
+    {
+      needs?: string | string[];
+      outputs?: Record<string, string>;
+      permissions?: Record<string, string>;
       steps?: WorkflowStep[];
-    };
-  };
+    }
+  >;
 };
 
 describe("release workflow", () => {
   it("only accepts stable tags and checks out the exact tag ref", async () => {
     const workflow = await readWorkflow();
-    const steps = workflow.jobs?.release?.steps ?? [];
+    const steps = jobSteps(workflow, "verify");
     const resolveStep = steps.find((step) => step.name === "Resolve release tag")?.run;
     const checkoutStep = steps.find((step) => step.uses?.startsWith("actions/checkout@"));
 
@@ -48,13 +52,16 @@ describe("release workflow", () => {
 
   it("pins tooling and makes package and GitHub publication retry-safe", async () => {
     const workflow = await readWorkflow();
-    const steps = workflow.jobs?.release?.steps ?? [];
+    const verifySteps = jobSteps(workflow, "verify");
+    const publishSteps = jobSteps(workflow, "publish");
+    const releaseSteps = jobSteps(workflow, "github-release");
+    const steps = [...verifySteps, ...publishSteps, ...releaseSteps];
     const commands = steps.map((step) => step.run).filter((run): run is string => Boolean(run));
-    const packageStep = steps.find((step) => step.id === "package")?.run;
-    const publishStep = steps.find(
+    const packageStep = verifySteps.find((step) => step.id === "package")?.run;
+    const publishStep = publishSteps.find(
       (step) => step.name === "Publish package with npm provenance",
     )?.run;
-    const releaseStep = steps.find((step) => step.name === "Create GitHub release")?.run;
+    const releaseStep = releaseSteps.find((step) => step.name === "Create GitHub release")?.run;
 
     expect(workflow.concurrency).toEqual({
       "cancel-in-progress": false,
@@ -64,6 +71,7 @@ describe("release workflow", () => {
     expect(commands.some((command) => command.includes("npm@latest"))).toBe(false);
     expect(packageStep).toContain('npm pack --json --pack-destination "$RUNNER_TEMP"');
     expect(packageStep).toContain("Packed artifact is missing the crabline CLI");
+    expect(packageStep).toContain('execFileSync("tar", ["-xzf", tarballPath');
     expect(publishStep).toContain('npm view "$PACKAGE_NAME@$RELEASE_VERSION" dist.integrity');
     expect(publishStep).toContain('npm publish "$PACKAGE_TARBALL" --access public --provenance');
     expect(releaseStep).toContain('gh release view "$RELEASE_TAG"');
@@ -72,7 +80,7 @@ describe("release workflow", () => {
 
   it("pins privileged release actions to immutable revisions", async () => {
     const workflow = await readWorkflow();
-    const steps = workflow.jobs?.release?.steps ?? [];
+    const steps = Object.values(workflow.jobs ?? {}).flatMap((job) => job.steps ?? []);
     const actionRefs = steps
       .map((step) => step.uses)
       .filter((uses): uses is string => uses !== undefined);
@@ -83,9 +91,33 @@ describe("release workflow", () => {
     }
   });
 
+  it("isolates package verification, OIDC publication, and GitHub release authority", async () => {
+    const workflow = await readWorkflow();
+    const verify = workflow.jobs?.verify;
+    const publish = workflow.jobs?.publish;
+    const githubRelease = workflow.jobs?.["github-release"];
+    const verifyCommands = jobSteps(workflow, "verify")
+      .map((step) => step.run)
+      .filter((run): run is string => Boolean(run));
+    const publishCommands = jobSteps(workflow, "publish")
+      .map((step) => step.run)
+      .filter((run): run is string => Boolean(run));
+
+    expect(verify?.permissions).toEqual({ contents: "read" });
+    expect(publish?.permissions).toEqual({ "id-token": "write" });
+    expect(githubRelease?.permissions).toEqual({ contents: "write" });
+    expect(publish?.needs).toBe("verify");
+    expect(githubRelease?.needs).toEqual(["verify", "publish"]);
+    expect(verifyCommands).toContain("pnpm install --frozen-lockfile");
+    expect(verifyCommands).toContain("pnpm verify");
+    expect(
+      publishCommands.some((command) => /\b(?:pnpm|install|build|test|pack)\b/u.test(command)),
+    ).toBe(false);
+  });
+
   it("requires an exact changelog version heading", async () => {
     const workflow = await readWorkflow();
-    const verifyStep = workflow.jobs?.release?.steps?.find(
+    const verifyStep = jobSteps(workflow, "verify").find(
       (step) => step.name === "Verify release metadata",
     )?.run;
     const script = extractNodeHeredoc(verifyStep);
@@ -104,7 +136,7 @@ describe("release workflow", () => {
 
   it("extracts pack metadata around lifecycle output", async () => {
     const workflow = await readWorkflow();
-    const packageStep = workflow.jobs?.release?.steps?.find((step) => step.id === "package")?.run;
+    const packageStep = jobSteps(workflow, "verify").find((step) => step.id === "package")?.run;
     const script = extractNodeHeredoc(packageStep);
     const pack = {
       filename: "openclaw-crabline-1.2.3.tgz",
@@ -125,11 +157,15 @@ describe("release workflow", () => {
         tarball: expect.stringMatching(/openclaw-crabline-1\.2\.3\.tgz$/u),
       });
     }
+
+    await expect(
+      runPackageMetadataCheck(script, JSON.stringify([pack]), "console.log('missing shebang');\n"),
+    ).rejects.toThrow("Packed CLI dist/src/bin/crabline.js is missing its Node shebang.");
   });
 
   it("skips matching packages, rejects drift, and recovers after publish races", async () => {
     const workflow = await readWorkflow();
-    const publishStep = workflow.jobs?.release?.steps?.find(
+    const publishStep = jobSteps(workflow, "publish").find(
       (step) => step.name === "Publish package with npm provenance",
     )?.run;
     if (!publishStep) {
@@ -155,7 +191,9 @@ describe("release workflow", () => {
     });
     expect(racedCalls).toEqual([
       "view @openclaw/crabline@1.2.3 dist.integrity",
-      "publish /tmp/crabline-1.2.3.tgz --access public --provenance",
+      expect.stringMatching(
+        /publish .*\/release\/crabline-1\.2\.3\.tgz --access public --provenance$/u,
+      ),
       "view @openclaw/crabline@1.2.3 dist.integrity",
     ]);
   });
@@ -167,6 +205,10 @@ async function readWorkflow(): Promise<ReleaseWorkflow> {
     "utf8",
   );
   return parse(contents) as ReleaseWorkflow;
+}
+
+function jobSteps(workflow: ReleaseWorkflow, name: string): WorkflowStep[] {
+  return workflow.jobs?.[name]?.steps ?? [];
 }
 
 function extractNodeHeredoc(run: string | undefined): string {
@@ -228,11 +270,16 @@ async function runResolveTag(
 async function runPackageMetadataCheck(
   script: string,
   packOutput: string,
+  packedCli = "#!/usr/bin/env node\nconsole.log('crabline');\n",
 ): Promise<Record<string, string>> {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-release-package-"));
   const outputPath = path.join(tempDir, "outputs");
+  const packageRoot = path.join(tempDir, "package");
   try {
-    await fs.mkdir(path.join(tempDir, "dist/src/bin"), { recursive: true });
+    await Promise.all([
+      fs.mkdir(path.join(tempDir, "dist/src/bin"), { recursive: true }),
+      fs.mkdir(path.join(packageRoot, "dist/src/bin"), { recursive: true }),
+    ]);
     await Promise.all([
       fs.writeFile(path.join(tempDir, "npm-pack.json"), packOutput),
       fs.writeFile(
@@ -246,7 +293,13 @@ async function runPackageMetadataCheck(
         path.join(tempDir, "dist/src/bin/crabline.js"),
         "#!/usr/bin/env node\nconsole.log('crabline');\n",
       ),
+      fs.writeFile(path.join(packageRoot, "dist/src/bin/crabline.js"), packedCli),
     ]);
+    await execFileAsync(
+      "tar",
+      ["-czf", path.join(tempDir, "openclaw-crabline-1.2.3.tgz"), "-C", tempDir, "package"],
+      { cwd: tempDir },
+    );
     await execFileWithOutput(process.execPath, ["--input-type=module", "--eval", script], {
       cwd: tempDir,
       env: {
@@ -274,10 +327,12 @@ async function runPublishStep(
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-release-publish-"));
   const binDir = path.join(tempDir, "bin");
   const logPath = path.join(tempDir, "npm.log");
+  const releaseDir = path.join(tempDir, "release");
   const viewCountPath = path.join(tempDir, "view-count");
 
   try {
-    await fs.mkdir(binDir);
+    await Promise.all([fs.mkdir(binDir), fs.mkdir(releaseDir)]);
+    await fs.writeFile(path.join(releaseDir, "crabline-1.2.3.tgz"), "package");
     await Promise.all([
       writeExecutable(
         path.join(binDir, "npm"),
@@ -319,9 +374,9 @@ esac
         MOCK_VIEW_COUNT: viewCountPath,
         PACKAGE_INTEGRITY: "sha512-expected",
         PACKAGE_NAME: "@openclaw/crabline",
-        PACKAGE_TARBALL: "/tmp/crabline-1.2.3.tgz",
         PATH: `${binDir}:${process.env.PATH}`,
         RELEASE_VERSION: "1.2.3",
+        RUNNER_TEMP: tempDir,
       },
     });
     return (await fs.readFile(logPath, "utf8")).trim().split("\n");


### PR DESCRIPTION
## Summary
- redact serve credentials by default and serialize ready-file publication/cleanup with filesystem identity
- preserve Telegram numeric identities and reject protocol errors returned with HTTP 200
- isolate verified release packaging from the OIDC-enabled npm publication job

## Verification
- Autoreview: `gpt-5.6-sol`, high, clean on the final ready-file delta (0.88); Telegram and release slices previously clean (0.91 / 0.96)
- Crabbox: `run_a2dba773f74f` (`pnpm verify`, 47 files / 387 tests)
- Clean-history PR tree exactly matches the reviewed and Crabbox-verified tree (`67965e27be5db7ff8ca9a1ed45386a7dc5bb3771`)

## Changelog
- added under `Unreleased`