### PR TITLE
fix(providers): authenticate and scope inbound delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Hold serve ready-file ownership across startup and shutdown, preserve live manifests on failed replacement, and retain compound cleanup failures.
 - Reject invalid matchers and provider/fixture mismatches before side effects, drain aborted provider work before cleanup, preserve frozen primary smoke failures, and recover stale smoke locks after PID reuse.
+- Preserve Slack thread scope and validate Telegram command entities.
 - Authenticate WhatsApp webhook verification and deliveries and reject malformed batches atomically.
 - Cancel silent script watches and redact configured payload secrets from subprocess diagnostics.
 - Randomize externally bound provider credentials, preserve Slack MPIM and Matrix sync errors, bound server shutdown, and enforce safe Zalo webhooks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Hold serve ready-file ownership across startup and shutdown, preserve live manifests on failed replacement, and retain compound cleanup failures.
 - Reject invalid matchers and provider/fixture mismatches before side effects, drain aborted provider work before cleanup, preserve frozen primary smoke failures, and recover stale smoke locks after PID reuse.
+- Authenticate WhatsApp webhook verification and deliveries and reject malformed batches atomically.
 - Cancel silent script watches and redact configured payload secrets from subprocess diagnostics.
 - Randomize externally bound provider credentials, preserve Slack MPIM and Matrix sync errors, bound server shutdown, and enforce safe Zalo webhooks.
 - Order lazy cleanup after admitted dispatch, isolate loopback message state, and enforce effective modes and inbound deadlines.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Hold serve ready-file ownership across startup and shutdown, preserve live manifests on failed replacement, and retain compound cleanup failures.
 - Reject invalid matchers and provider/fixture mismatches before side effects, drain aborted provider work before cleanup, preserve frozen primary smoke failures, and recover stale smoke locks after PID reuse.
+- Cancel silent script watches and redact configured payload secrets from subprocess diagnostics.
 - Randomize externally bound provider credentials, preserve Slack MPIM and Matrix sync errors, bound server shutdown, and enforce safe Zalo webhooks.
 - Order lazy cleanup after admitted dispatch, isolate loopback message state, and enforce effective modes and inbound deadlines.
 - Fence OpenClaw smoke artifact paths, clean abandoned generations safely, preserve primary probe failures and replacement files, and report post-commit lock cleanup failures.

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -78,7 +78,7 @@ execution.
 The built-in `whatsapp` adapter implements Meta's GET verification challenge
 and requires `X-Hub-Signature-256` on POST requests. Set `whatsapp.appSecret`
 and `whatsapp.verifyToken` (or `WHATSAPP_APP_SECRET` and
-`WHATSAPP_VERIFY_TOKEN`) to override the local mock defaults.
+`WHATSAPP_VERIFY_TOKEN`) before starting its webhook.
 
 ## Script Bridge Config
 

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -75,6 +75,11 @@ Provider credential fields such as `botToken`, `accessToken`, `baseURL`, or
 `serverUrl` are optional mock metadata. They are not required for local mock
 execution.
 
+The built-in `whatsapp` adapter implements Meta's GET verification challenge
+and requires `X-Hub-Signature-256` on POST requests. Set `whatsapp.appSecret`
+and `whatsapp.verifyToken` (or `WHATSAPP_APP_SECRET` and
+`WHATSAPP_VERIFY_TOKEN`) to override the local mock defaults.
+
 ## Script Bridge Config
 
 Script providers use only the `script:` config block. Their required `platform`

--- a/src/openclaw/bridges/telegram.ts
+++ b/src/openclaw/bridges/telegram.ts
@@ -55,8 +55,8 @@ function telegramBotCommandEntity(text: string, commandName: string) {
   const token = text.match(/^\S+/u)?.[0];
   if (
     !token ||
-    (token !== commandPrefix &&
-      !new RegExp(`^/${commandName}@[A-Za-z][A-Za-z0-9_]{4,31}$`, "u").test(token))
+    (token.toLowerCase() !== commandPrefix &&
+      !new RegExp(`^/${commandName}@[A-Za-z][A-Za-z0-9_]{4,31}$`, "iu").test(token))
   ) {
     throw new Error(`Telegram native command text must start with ${commandPrefix}.`);
   }

--- a/src/openclaw/bridges/telegram.ts
+++ b/src/openclaw/bridges/telegram.ts
@@ -45,6 +45,28 @@ function telegramTargetKey(chatId: string, threadId?: number) {
   return threadId === undefined ? chatId : `${chatId}:topic:${threadId}`;
 }
 
+function telegramBotCommandEntity(text: string, commandName: string) {
+  if (!/^[a-z0-9_]{1,32}$/u.test(commandName)) {
+    throw new Error(
+      "Telegram native command names must contain 1-32 lowercase letters, digits, or underscores.",
+    );
+  }
+  const commandPrefix = `/${commandName}`;
+  const token = text.match(/^\S+/u)?.[0];
+  if (
+    !token ||
+    (token !== commandPrefix &&
+      !new RegExp(`^/${commandName}@[A-Za-z][A-Za-z0-9_]{4,31}$`, "u").test(token))
+  ) {
+    throw new Error(`Telegram native command text must start with ${commandPrefix}.`);
+  }
+  return {
+    length: token.length,
+    offset: 0,
+    type: "bot_command",
+  } as const;
+}
+
 function parseTelegramThreadTargetId(value: unknown): number | undefined {
   if (value === undefined) {
     return undefined;
@@ -159,13 +181,7 @@ export const TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
             ...(threadId !== undefined ? { messageThreadId: threadId } : {}),
             ...(input.nativeCommand
               ? {
-                  entities: [
-                    {
-                      length: input.nativeCommand.name.length + 1,
-                      offset: 0,
-                      type: "bot_command",
-                    },
-                  ],
+                  entities: [telegramBotCommandEntity(input.text, input.nativeCommand.name)],
                 }
               : {}),
             text: input.text,

--- a/src/providers/builtin/script.ts
+++ b/src/providers/builtin/script.ts
@@ -139,6 +139,9 @@ function collectSensitivePayloadValues(
   if (typeof value === "string") {
     if (sensitive && value.length > 0) {
       values.add(value);
+      const serialized = JSON.stringify(value);
+      values.add(serialized);
+      values.add(serialized.slice(1, -1));
     }
     return;
   }

--- a/src/providers/builtin/script.ts
+++ b/src/providers/builtin/script.ts
@@ -145,6 +145,10 @@ function collectSensitivePayloadValues(
     }
     return;
   }
+  if (sensitive && typeof value === "number" && Number.isFinite(value)) {
+    values.add(String(value));
+    return;
+  }
   if (!value || typeof value !== "object") {
     return;
   }

--- a/src/providers/builtin/script.ts
+++ b/src/providers/builtin/script.ts
@@ -133,7 +133,7 @@ function redactSensitiveEnvironmentValues(detail: string): string {
 function collectSensitivePayloadValues(
   value: unknown,
   values: Set<string>,
-  seen: Set<object>,
+  seen: { nonSensitive: WeakSet<object>; sensitive: WeakSet<object> },
   sensitive = false,
 ): void {
   if (typeof value === "string") {
@@ -142,10 +142,14 @@ function collectSensitivePayloadValues(
     }
     return;
   }
-  if (!value || typeof value !== "object" || seen.has(value)) {
+  if (!value || typeof value !== "object") {
     return;
   }
-  seen.add(value);
+  const visited = sensitive ? seen.sensitive : seen.nonSensitive;
+  if (visited.has(value)) {
+    return;
+  }
+  visited.add(value);
   if (Array.isArray(value)) {
     for (const entry of value) {
       collectSensitivePayloadValues(entry, values, seen, sensitive);
@@ -164,7 +168,10 @@ function collectSensitivePayloadValues(
 
 function redactSensitivePayloadValues(detail: string, payload: unknown): string {
   const values = new Set<string>();
-  collectSensitivePayloadValues(payload, values, new Set());
+  collectSensitivePayloadValues(payload, values, {
+    nonSensitive: new WeakSet(),
+    sensitive: new WeakSet(),
+  });
   let redacted = detail;
   for (const value of [...values].sort((left, right) => right.length - left.length)) {
     redacted = redacted.split(value).join("[redacted configured value]");

--- a/src/providers/builtin/script.ts
+++ b/src/providers/builtin/script.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { z } from "zod";
 import { CrablineError, ensureErrorMessage } from "../../core/errors.js";
 import type {
+  InboundEnvelope,
   ProviderAdapter,
   ProviderContext,
   SendContext,
@@ -12,6 +13,12 @@ import type {
 
 const MAX_SCRIPT_OUTPUT_BYTES = 1024 * 1024;
 const SCRIPT_WAIT_EXIT_GRACE_MS = 250;
+
+type ScriptWatchIterator = AsyncIterableIterator<InboundEnvelope> & {
+  [Symbol.asyncIterator](): ScriptWatchIterator;
+  return(): Promise<IteratorResult<InboundEnvelope, undefined>>;
+  throw(error?: unknown): Promise<IteratorResult<InboundEnvelope, undefined>>;
+};
 
 type ScriptPayload = {
   fixture: ProviderContext["fixture"];
@@ -123,20 +130,74 @@ function redactSensitiveEnvironmentValues(detail: string): string {
   return redacted;
 }
 
-function formatScriptError(summary: string, detail: string, command: string): string {
+function collectSensitivePayloadValues(
+  value: unknown,
+  values: Set<string>,
+  seen: Set<object>,
+  sensitive = false,
+): void {
+  if (typeof value === "string") {
+    if (sensitive && value.length > 0) {
+      values.add(value);
+    }
+    return;
+  }
+  if (!value || typeof value !== "object" || seen.has(value)) {
+    return;
+  }
+  seen.add(value);
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      collectSensitivePayloadValues(entry, values, seen, sensitive);
+    }
+    return;
+  }
+  for (const [name, entry] of Object.entries(value)) {
+    collectSensitivePayloadValues(
+      entry,
+      values,
+      seen,
+      sensitive || isSensitiveEnvironmentName(name),
+    );
+  }
+}
+
+function redactSensitivePayloadValues(detail: string, payload: unknown): string {
+  const values = new Set<string>();
+  collectSensitivePayloadValues(payload, values, new Set());
+  let redacted = detail;
+  for (const value of [...values].sort((left, right) => right.length - left.length)) {
+    redacted = redacted.split(value).join("[redacted configured value]");
+  }
+  return redacted;
+}
+
+function formatScriptError(
+  summary: string,
+  detail: string,
+  command: string,
+  payload?: unknown,
+): string {
   if (!detail.trim()) {
     return summary;
   }
   if (commandContainsSensitiveValue(command)) {
     return `${summary}\n[script diagnostics redacted]`;
   }
-  const redacted = redactSensitiveEnvironmentValues(
-    detail.split(command).join("[configured script command]"),
+  const withoutCommand = detail.split(command).join("[configured script command]");
+  const redacted = redactSensitivePayloadValues(
+    redactSensitiveEnvironmentValues(withoutCommand),
+    payload,
   ).trim();
   return redacted ? `${summary}\n${redacted}` : summary;
 }
 
-function parseScriptJson<T>(params: { command: string; output: string; schema: z.ZodType<T> }): T {
+function parseScriptJson<T>(params: {
+  command: string;
+  output: string;
+  payload?: unknown;
+  schema: z.ZodType<T>;
+}): T {
   let parsed: unknown;
   try {
     parsed = JSON.parse(params.output);
@@ -146,6 +207,7 @@ function parseScriptJson<T>(params: { command: string; output: string; schema: z
         "Script command did not return valid JSON.",
         ensureErrorMessage(error),
         params.command,
+        params.payload,
       ),
       { kind: "config" },
     );
@@ -247,6 +309,7 @@ function runScript<T>(params: {
               "Script command failed to start.",
               ensureErrorMessage(error),
               params.command,
+              params.payload,
             ),
             { kind: "connectivity" },
           ),
@@ -264,6 +327,7 @@ function runScript<T>(params: {
                 `Script command failed${signal ? ` (${signal})` : ""}.`,
                 stderrText.trim() ? stderrText : stdoutText,
                 params.command,
+                params.payload,
               ),
               { kind: "connectivity" },
             ),
@@ -275,6 +339,7 @@ function runScript<T>(params: {
           const result = parseScriptJson({
             command: params.command,
             output: stdoutText,
+            payload: params.payload,
             schema: params.schema,
           });
           if (deadlineExceeded && !params.acceptResultDuringTimeoutGrace?.(result)) {
@@ -321,6 +386,200 @@ function runScript<T>(params: {
     params.signal?.addEventListener("abort", abort, { once: true });
     child.stdin.end(JSON.stringify(params.payload));
   });
+}
+
+function watchScript(params: {
+  cancelSignal: AbortSignal;
+  command: string;
+  context: WatchContext;
+  cwd?: string | undefined;
+  id: string;
+  normalizeTarget: ProviderAdapter["normalizeTarget"];
+  shell?: string | undefined;
+}): AsyncGenerator<InboundEnvelope> {
+  return (async function* () {
+    const payload = {
+      ...createPayload(params.context),
+      watch: {
+        since: params.context.since,
+        target: params.normalizeTarget(params.context.fixture.target),
+      },
+    };
+    const child = spawn(params.command, {
+      cwd: params.cwd ? path.resolve(params.cwd) : process.cwd(),
+      env: process.env,
+      shell: params.shell ?? true,
+      detached: process.platform !== "win32",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let buffer = "";
+    let stderr = "";
+    let childError: unknown;
+    let outputLimitError: CrablineError | undefined;
+    const stopChild = () => terminateChild(child);
+    params.cancelSignal.addEventListener("abort", stopChild, { once: true });
+    params.context.signal?.addEventListener("abort", stopChild, { once: true });
+    if (params.cancelSignal.aborted || params.context.signal?.aborted) {
+      stopChild();
+    }
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdin.on("error", () => {
+      // Child closure is reported through the process error/close handlers.
+    });
+    child.stderr.on("data", (chunk) => {
+      if (outputLimitError) {
+        return;
+      }
+      stderr += chunk;
+      if (Buffer.byteLength(stderr) > MAX_SCRIPT_OUTPUT_BYTES) {
+        outputLimitError = new CrablineError(
+          `Script watch command exceeded ${MAX_SCRIPT_OUTPUT_BYTES} bytes of stderr.`,
+          { kind: "connectivity" },
+        );
+        terminateChild(child);
+      }
+    });
+    child.once("error", (error) => {
+      childError = error;
+    });
+    let childCloseObserved = false;
+    const childClosed = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+      (resolve) => {
+        child.once("close", (code, signal) => {
+          childCloseObserved = true;
+          resolve({ code, signal });
+        });
+      },
+    );
+    child.stdin.end(JSON.stringify(payload));
+
+    try {
+      for await (const chunk of child.stdout) {
+        buffer += chunk;
+        if (Buffer.byteLength(buffer) > MAX_SCRIPT_OUTPUT_BYTES && !buffer.includes("\n")) {
+          throw new CrablineError(
+            `Script watch command exceeded ${MAX_SCRIPT_OUTPUT_BYTES} bytes without a newline.`,
+            { kind: "config" },
+          );
+        }
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+        for (const line of lines) {
+          if (!line.trim()) {
+            continue;
+          }
+          if (Buffer.byteLength(line) > MAX_SCRIPT_OUTPUT_BYTES) {
+            throw new CrablineError(
+              `Script watch command emitted a JSON line larger than ${MAX_SCRIPT_OUTPUT_BYTES} bytes.`,
+              { kind: "config" },
+            );
+          }
+          const parsed = parseScriptJson({
+            command: params.command,
+            output: line,
+            payload,
+            schema: ScriptMessageSchema,
+          });
+          yield {
+            ...parsed,
+            provider: params.id,
+          };
+        }
+      }
+
+      if (params.context.signal?.aborted) {
+        throw params.context.signal.reason ?? new Error("Script watch command aborted.");
+      }
+      if (params.cancelSignal.aborted) {
+        return;
+      }
+      if (buffer.trim()) {
+        const parsed = parseScriptJson({
+          command: params.command,
+          output: buffer,
+          payload,
+          schema: ScriptMessageSchema,
+        });
+        yield {
+          ...parsed,
+          provider: params.id,
+        };
+      }
+
+      const exit = await childClosed;
+      if (outputLimitError) {
+        throw outputLimitError;
+      }
+      if (childError) {
+        throw new CrablineError(
+          formatScriptError(
+            "Script watch command failed to start.",
+            ensureErrorMessage(childError),
+            params.command,
+            payload,
+          ),
+          { kind: "connectivity" },
+        );
+      }
+      if (exit.code !== 0) {
+        throw new CrablineError(
+          formatScriptError(
+            `Script watch command failed${exit.signal ? ` (${exit.signal})` : ""}.`,
+            stderr,
+            params.command,
+            payload,
+          ),
+          { kind: "connectivity" },
+        );
+      }
+    } catch (error) {
+      if (params.cancelSignal.aborted) {
+        return;
+      }
+      if (outputLimitError) {
+        throw outputLimitError;
+      }
+      if (childError) {
+        throw new CrablineError(
+          formatScriptError(
+            "Script watch command failed to start.",
+            ensureErrorMessage(childError),
+            params.command,
+            payload,
+          ),
+          { kind: "connectivity" },
+        );
+      }
+      throw error;
+    } finally {
+      params.cancelSignal.removeEventListener("abort", stopChild);
+      params.context.signal?.removeEventListener("abort", stopChild);
+      child.stdin.destroy();
+      if (!childCloseObserved) {
+        terminateChild(child);
+      }
+      await childClosed;
+    }
+  })();
+}
+
+function failedScriptWatch(error: unknown): ScriptWatchIterator {
+  return {
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+    next() {
+      return Promise.reject(error);
+    },
+    return() {
+      return Promise.resolve({ done: true, value: undefined });
+    },
+    throw(thrown?: unknown) {
+      return Promise.reject(thrown);
+    },
+  };
 }
 
 export class ScriptProviderAdapter implements ProviderAdapter {
@@ -442,157 +701,49 @@ export class ScriptProviderAdapter implements ProviderAdapter {
     };
   }
 
-  async *watch(context: WatchContext) {
+  watch(context: WatchContext): ScriptWatchIterator {
     const command = this.#config.commands.watch;
     if (!command) {
-      throw new CrablineError(`Provider "${this.id}" is missing watch command.`, {
-        kind: "config",
-      });
+      return failedScriptWatch(
+        new CrablineError(`Provider "${this.id}" is missing watch command.`, {
+          kind: "config",
+        }),
+      );
     }
 
-    const child = spawn(command, {
-      cwd: this.#config.cwd ? path.resolve(this.#config.cwd) : process.cwd(),
-      env: process.env,
-      shell: this.#config.shell ?? true,
-      detached: process.platform !== "win32",
-      stdio: ["pipe", "pipe", "pipe"],
+    const controller = new AbortController();
+    const source = watchScript({
+      cancelSignal: controller.signal,
+      command,
+      context,
+      cwd: this.#config.cwd,
+      id: this.id,
+      normalizeTarget: (target) => this.normalizeTarget(target),
+      shell: this.#config.shell,
     });
-
-    let buffer = "";
-    let stderr = "";
-    let childError: unknown;
-    let outputLimitError: CrablineError | undefined;
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-    child.stdin.on("error", () => {
-      // Child closure is reported through the process error/close handlers.
-    });
-    child.stderr.on("data", (chunk) => {
-      if (outputLimitError) {
-        return;
-      }
-      stderr += chunk;
-      if (Buffer.byteLength(stderr) > MAX_SCRIPT_OUTPUT_BYTES) {
-        outputLimitError = new CrablineError(
-          `Script watch command exceeded ${MAX_SCRIPT_OUTPUT_BYTES} bytes of stderr.`,
-          { kind: "connectivity" },
-        );
-        terminateChild(child);
-      }
-    });
-    child.once("error", (error) => {
-      childError = error;
-    });
-    let childCloseObserved = false;
-    const childClosed = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
-      (resolve) => {
-        child.once("close", (code, signal) => {
-          childCloseObserved = true;
-          resolve({ code, signal });
-        });
+    const iterator: ScriptWatchIterator = {
+      [Symbol.asyncIterator]() {
+        return this;
       },
-    );
-    child.stdin.end(
-      JSON.stringify({
-        ...createPayload(context),
-        watch: {
-          since: context.since,
-          target: this.normalizeTarget(context.fixture.target),
-        },
-      }),
-    );
-
-    try {
-      for await (const chunk of child.stdout) {
-        buffer += chunk;
-        if (Buffer.byteLength(buffer) > MAX_SCRIPT_OUTPUT_BYTES && !buffer.includes("\n")) {
-          throw new CrablineError(
-            `Script watch command exceeded ${MAX_SCRIPT_OUTPUT_BYTES} bytes without a newline.`,
-            { kind: "config" },
-          );
+      next() {
+        return source.next();
+      },
+      async return() {
+        if (!controller.signal.aborted) {
+          controller.abort();
         }
-        const lines = buffer.split("\n");
-        buffer = lines.pop() ?? "";
-        for (const line of lines) {
-          if (!line.trim()) {
-            continue;
-          }
-          if (Buffer.byteLength(line) > MAX_SCRIPT_OUTPUT_BYTES) {
-            throw new CrablineError(
-              `Script watch command emitted a JSON line larger than ${MAX_SCRIPT_OUTPUT_BYTES} bytes.`,
-              { kind: "config" },
-            );
-          }
-          const parsed = parseScriptJson({
-            command,
-            output: line,
-            schema: ScriptMessageSchema,
-          });
-          yield {
-            ...parsed,
-            provider: this.id,
-          };
+        await source.return(undefined);
+        return { done: true, value: undefined };
+      },
+      async throw(error?: unknown) {
+        if (!controller.signal.aborted) {
+          controller.abort();
         }
-      }
-
-      if (buffer.trim()) {
-        const parsed = parseScriptJson({
-          command,
-          output: buffer,
-          schema: ScriptMessageSchema,
-        });
-        yield {
-          ...parsed,
-          provider: this.id,
-        };
-      }
-
-      const exit = await childClosed;
-      if (outputLimitError) {
-        throw outputLimitError;
-      }
-      if (childError) {
-        throw new CrablineError(
-          formatScriptError(
-            "Script watch command failed to start.",
-            ensureErrorMessage(childError),
-            command,
-          ),
-          { kind: "connectivity" },
-        );
-      }
-      if (exit.code !== 0) {
-        throw new CrablineError(
-          formatScriptError(
-            `Script watch command failed${exit.signal ? ` (${exit.signal})` : ""}.`,
-            stderr,
-            command,
-          ),
-          { kind: "connectivity" },
-        );
-      }
-    } catch (error) {
-      if (outputLimitError) {
-        throw outputLimitError;
-      }
-      if (childError) {
-        throw new CrablineError(
-          formatScriptError(
-            "Script watch command failed to start.",
-            ensureErrorMessage(childError),
-            command,
-          ),
-          { kind: "connectivity" },
-        );
-      }
-      throw error;
-    } finally {
-      child.stdin.destroy();
-      if (!childCloseObserved) {
-        terminateChild(child);
-      }
-      await childClosed;
-    }
+        await source.return(undefined);
+        throw error;
+      },
+    };
+    return iterator;
   }
 }
 

--- a/src/providers/builtin/slack.ts
+++ b/src/providers/builtin/slack.ts
@@ -92,6 +92,15 @@ function matchesSlackThread(candidateThreadId: string, expectedThreadId?: string
     return true;
   }
   const marker = ":thread:";
+  if (SLACK_TS_RULE.pattern.test(expectedThreadId)) {
+    const separator = candidateThreadId.indexOf(marker);
+    if (separator <= 0) {
+      return false;
+    }
+    const channelId = candidateThreadId.slice(0, separator);
+    const threadTs = candidateThreadId.slice(separator + marker.length);
+    return SLACK_CHANNEL_ID_RULE.pattern.test(channelId) && threadTs === expectedThreadId;
+  }
   const separator = expectedThreadId.indexOf(marker);
   if (separator <= 0) {
     return false;

--- a/src/providers/builtin/slack.ts
+++ b/src/providers/builtin/slack.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
 import { LocalMockProviderAdapter } from "../local-mock.js";
-import { SLACK_CHANNEL_ID_RULE, SLACK_TS_RULE } from "../slack-ids.js";
+import { slackTargetKey, SLACK_CHANNEL_ID_RULE, SLACK_TS_RULE } from "../slack-ids.js";
 import { getBuiltinTargetCodec } from "../target-normalizers.js";
 import type { InboundEnvelope, ProviderAdapter } from "../types.js";
 import {
@@ -43,7 +43,10 @@ function normalizeSlackEventsPayload(payload: unknown) {
       text,
       threadId:
         typeof threadTs === "string"
-          ? requireNativeInboundId(threadTs, SLACK_TS_RULE, "Slack event.thread_ts")
+          ? slackTargetKey(
+              requireNativeInboundId(channel, SLACK_CHANNEL_ID_RULE, "Slack event.channel"),
+              requireNativeInboundId(threadTs, SLACK_TS_RULE, "Slack event.thread_ts"),
+            )
           : requireNativeInboundId(channel, SLACK_CHANNEL_ID_RULE, "Slack event.channel"),
     };
   }

--- a/src/providers/builtin/slack.ts
+++ b/src/providers/builtin/slack.ts
@@ -8,6 +8,7 @@ import type { InboundEnvelope, ProviderAdapter } from "../types.js";
 import {
   genericMockPayloadWithNativeThread,
   isRecord,
+  optionalString,
   requireNativeInboundId,
 } from "./native-local-mock.js";
 
@@ -51,11 +52,57 @@ function normalizeSlackEventsPayload(payload: unknown) {
     };
   }
 
-  return genericMockPayloadWithNativeThread({
+  const normalized = genericMockPayloadWithNativeThread({
     channelRule: SLACK_CHANNEL_ID_RULE,
     payload,
     threadRule: SLACK_TS_RULE,
   });
+  const message = isRecord(payload.message) ? payload.message : undefined;
+  const channelId =
+    (message ? optionalString(message, "channelId") : undefined) ??
+    optionalString(payload, "channelId") ??
+    optionalString(payload, "channel");
+  const threadId =
+    (message ? optionalString(message, "threadId") : undefined) ??
+    optionalString(payload, "threadId");
+  if (!channelId || !threadId || !SLACK_TS_RULE.pattern.test(threadId)) {
+    return normalized;
+  }
+  const scopedThreadId = slackTargetKey(
+    requireNativeInboundId(channelId, SLACK_CHANNEL_ID_RULE, "Slack channelId"),
+    threadId,
+  );
+  return {
+    ...normalized,
+    ...("message" in normalized && isRecord(normalized.message)
+      ? { message: { ...normalized.message, threadId: scopedThreadId } }
+      : {}),
+    threadId: scopedThreadId,
+  };
+}
+
+function matchesSlackThread(candidateThreadId: string, expectedThreadId?: string): boolean {
+  if (!expectedThreadId) {
+    return true;
+  }
+  if (
+    candidateThreadId === expectedThreadId ||
+    candidateThreadId.startsWith(`${expectedThreadId}:`)
+  ) {
+    return true;
+  }
+  const marker = ":thread:";
+  const separator = expectedThreadId.indexOf(marker);
+  if (separator <= 0) {
+    return false;
+  }
+  const channelId = expectedThreadId.slice(0, separator);
+  const threadTs = expectedThreadId.slice(separator + marker.length);
+  return (
+    SLACK_CHANNEL_ID_RULE.pattern.test(channelId) &&
+    SLACK_TS_RULE.pattern.test(threadTs) &&
+    candidateThreadId === threadTs
+  );
 }
 
 export class SlackProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
@@ -67,6 +114,7 @@ export class SlackProviderAdapter extends LocalMockProviderAdapter implements Pr
       options: {
         defaultWebhook: { host: "127.0.0.1", path: "/slack/events", port: 8787 },
         endpointLabel: "events endpoint",
+        matchesThread: matchesSlackThread,
         normalizeWebhookPayload: normalizeSlackEventsPayload,
         platform: "slack",
         publicUrl: config.slack?.webhook.publicUrl,

--- a/src/providers/builtin/slack.ts
+++ b/src/providers/builtin/slack.ts
@@ -81,32 +81,40 @@ function normalizeSlackEventsPayload(payload: unknown) {
   };
 }
 
-function matchesSlackThread(candidateThreadId: string, expectedThreadId?: string): boolean {
+function matchesSlackThread(
+  candidateThreadId: string,
+  expectedThreadId: string | undefined,
+  target: { channelId?: string | undefined },
+): boolean {
   if (!expectedThreadId) {
     return true;
   }
+  const scopedExpectedThreadId =
+    target.channelId && SLACK_TS_RULE.pattern.test(expectedThreadId)
+      ? slackTargetKey(target.channelId, expectedThreadId)
+      : expectedThreadId;
   if (
-    candidateThreadId === expectedThreadId ||
-    candidateThreadId.startsWith(`${expectedThreadId}:`)
+    candidateThreadId === scopedExpectedThreadId ||
+    candidateThreadId.startsWith(`${scopedExpectedThreadId}:`)
   ) {
     return true;
   }
   const marker = ":thread:";
-  if (SLACK_TS_RULE.pattern.test(expectedThreadId)) {
+  if (SLACK_TS_RULE.pattern.test(scopedExpectedThreadId)) {
     const separator = candidateThreadId.indexOf(marker);
     if (separator <= 0) {
       return false;
     }
     const channelId = candidateThreadId.slice(0, separator);
     const threadTs = candidateThreadId.slice(separator + marker.length);
-    return SLACK_CHANNEL_ID_RULE.pattern.test(channelId) && threadTs === expectedThreadId;
+    return SLACK_CHANNEL_ID_RULE.pattern.test(channelId) && threadTs === scopedExpectedThreadId;
   }
-  const separator = expectedThreadId.indexOf(marker);
+  const separator = scopedExpectedThreadId.indexOf(marker);
   if (separator <= 0) {
     return false;
   }
-  const channelId = expectedThreadId.slice(0, separator);
-  const threadTs = expectedThreadId.slice(separator + marker.length);
+  const channelId = scopedExpectedThreadId.slice(0, separator);
+  const threadTs = scopedExpectedThreadId.slice(separator + marker.length);
   return (
     SLACK_CHANNEL_ID_RULE.pattern.test(channelId) &&
     SLACK_TS_RULE.pattern.test(threadTs) &&

--- a/src/providers/builtin/whatsapp.ts
+++ b/src/providers/builtin/whatsapp.ts
@@ -58,12 +58,20 @@ export function resolveWhatsAppAdapterConfig(
   config: ProviderConfig,
   env: NodeJS.ProcessEnv = process.env,
 ) {
+  const appSecret = config.whatsapp?.appSecret ?? env.WHATSAPP_APP_SECRET;
+  const verifyToken = config.whatsapp?.verifyToken ?? env.WHATSAPP_VERIFY_TOKEN;
+  if (!appSecret || !verifyToken) {
+    throw new CrablineError(
+      "WhatsApp webhook operation requires appSecret and verifyToken configuration.",
+      { kind: "config" },
+    );
+  }
   return {
     accessToken: config.whatsapp?.accessToken ?? env.WHATSAPP_ACCESS_TOKEN ?? "local-mock-token",
-    appSecret: config.whatsapp?.appSecret ?? env.WHATSAPP_APP_SECRET ?? "local-mock-secret",
+    appSecret,
     phoneNumberId:
       config.whatsapp?.phoneNumberId ?? env.WHATSAPP_PHONE_NUMBER_ID ?? "local-mock-phone",
-    verifyToken: config.whatsapp?.verifyToken ?? env.WHATSAPP_VERIFY_TOKEN ?? "local-mock-verify",
+    verifyToken,
   };
 }
 

--- a/src/providers/builtin/whatsapp.ts
+++ b/src/providers/builtin/whatsapp.ts
@@ -75,11 +75,12 @@ export function resolveWhatsAppAdapterConfig(
   };
 }
 
+type ResolvedWhatsAppAdapterConfig = ReturnType<typeof resolveWhatsAppAdapterConfig>;
+
 export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
-  readonly #challengeValue: string;
+  readonly #config: ProviderConfig;
   readonly #publicUrl: string | undefined;
   readonly #recorderPath: string;
-  readonly #signingKey: string;
   readonly #webhook: LocalMockWebhookConfig | undefined;
   #cleanedUp = false;
   #cleanupBegun = false;
@@ -91,7 +92,6 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
   #serverStarting: Promise<StartedWebhookServer> | null = null;
 
   constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
-    const resolvedConfig = resolveWhatsAppAdapterConfig(config);
     super({
       codec: getBuiltinTargetCodec("whatsapp"),
       config,
@@ -108,13 +108,12 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
         webhook: config.whatsapp?.webhook,
       },
     });
-    this.#signingKey = resolvedConfig.appSecret;
+    this.#config = config;
     this.#publicUrl = config.whatsapp?.webhook.publicUrl;
     this.#recorderPath = config.whatsapp?.recorder.path
       ? path.resolve(config.whatsapp.recorder.path)
       : path.resolve(".crabline", "recorders", `${id}.jsonl`);
     this.#webhook = config.whatsapp?.webhook;
-    this.#challengeValue = resolvedConfig.verifyToken;
   }
 
   override async probe(context: ProviderContext): Promise<ProbeResult> {
@@ -204,11 +203,14 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
     await this.#cleanupPromise;
   }
 
-  #handleWebhookRequest(request: Request): Promise<Response> {
+  #handleWebhookRequest(
+    request: Request,
+    resolvedConfig: ResolvedWhatsAppAdapterConfig,
+  ): Promise<Response> {
     if (this.#cleanupBegun) {
       return Promise.resolve(this.#cleanedUpResponse());
     }
-    const handling = this.#handleWebhook(request);
+    const handling = this.#handleWebhook(request, resolvedConfig);
     this.#inFlightWebhookRequests.add(handling);
     void handling.then(
       () => this.#inFlightWebhookRequests.delete(handling),
@@ -217,13 +219,20 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
     return handling;
   }
 
-  async #handleWebhook(request: Request): Promise<Response> {
+  async #handleWebhook(
+    request: Request,
+    resolvedConfig: ResolvedWhatsAppAdapterConfig,
+  ): Promise<Response> {
     if (request.method === "GET") {
       const url = new URL(request.url);
       const mode = url.searchParams.get("hub.mode");
       const providedValue = url.searchParams.get("hub.verify_token");
       const challenge = url.searchParams.get("hub.challenge");
-      if (mode === "subscribe" && providedValue === this.#challengeValue && challenge !== null) {
+      if (
+        mode === "subscribe" &&
+        providedValue === resolvedConfig.verifyToken &&
+        challenge !== null
+      ) {
         return new Response(challenge, {
           headers: { "content-type": "text/plain; charset=utf-8" },
           status: 200,
@@ -237,7 +246,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
       !hasValidWhatsAppSignature(
         rawBody,
         request.headers.get("x-hub-signature-256"),
-        this.#signingKey,
+        resolvedConfig.appSecret,
       )
     ) {
       return new Response("invalid webhook signature", { status: 401 });
@@ -294,6 +303,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
       return await this.#serverStarting;
     }
 
+    const resolvedConfig = resolveWhatsAppAdapterConfig(this.#config);
     const host = this.#webhook?.host ?? DEFAULT_WHATSAPP_WEBHOOK.host;
     const port = this.#webhook?.port ?? DEFAULT_WHATSAPP_WEBHOOK.port;
     const webhookPath = this.#webhook?.path ?? DEFAULT_WHATSAPP_WEBHOOK.path;
@@ -301,7 +311,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
       let server: StartedWebhookServer;
       try {
         server = await startWebhookServer({
-          handle: (request) => this.#handleWebhookRequest(request),
+          handle: (request) => this.#handleWebhookRequest(request, resolvedConfig),
           host,
           methods: ["GET", "POST"],
           path: webhookPath,

--- a/src/providers/builtin/whatsapp.ts
+++ b/src/providers/builtin/whatsapp.ts
@@ -1,3 +1,4 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
 import path from "node:path";
 import { CrablineError, ensureErrorMessage } from "../../core/errors.js";
 import { matchesInbound } from "../../core/matcher.js";
@@ -67,8 +68,10 @@ export function resolveWhatsAppAdapterConfig(
 }
 
 export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
+  readonly #appSecret: string;
   readonly #publicUrl: string | undefined;
   readonly #recorderPath: string;
+  readonly #verifyToken: string;
   readonly #webhook: LocalMockWebhookConfig | undefined;
   #cleanedUp = false;
   #cleanupBegun = false;
@@ -80,6 +83,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
   #serverStarting: Promise<StartedWebhookServer> | null = null;
 
   constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
+    const resolvedConfig = resolveWhatsAppAdapterConfig(config);
     super({
       codec: getBuiltinTargetCodec("whatsapp"),
       config,
@@ -96,11 +100,13 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
         webhook: config.whatsapp?.webhook,
       },
     });
+    this.#appSecret = resolvedConfig.appSecret;
     this.#publicUrl = config.whatsapp?.webhook.publicUrl;
     this.#recorderPath = config.whatsapp?.recorder.path
       ? path.resolve(config.whatsapp.recorder.path)
       : path.resolve(".crabline", "recorders", `${id}.jsonl`);
     this.#webhook = config.whatsapp?.webhook;
+    this.#verifyToken = resolvedConfig.verifyToken;
   }
 
   override async probe(context: ProviderContext): Promise<ProbeResult> {
@@ -204,13 +210,37 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
   }
 
   async #handleWebhook(request: Request): Promise<Response> {
+    if (request.method === "GET") {
+      const url = new URL(request.url);
+      const mode = url.searchParams.get("hub.mode");
+      const token = url.searchParams.get("hub.verify_token");
+      const challenge = url.searchParams.get("hub.challenge");
+      if (mode === "subscribe" && token === this.#verifyToken && challenge !== null) {
+        return new Response(challenge, {
+          headers: { "content-type": "text/plain; charset=utf-8" },
+          status: 200,
+        });
+      }
+      return new Response("forbidden", { status: 403 });
+    }
+
+    const rawBody = await request.text();
+    if (
+      !hasValidWhatsAppSignature(
+        rawBody,
+        request.headers.get("x-hub-signature-256"),
+        this.#appSecret,
+      )
+    ) {
+      return new Response("invalid webhook signature", { status: 401 });
+    }
     if (!request.headers.get("content-type")?.includes("application/json")) {
       return new Response("expected application/json", { status: 415 });
     }
 
     let messages: NormalizedWhatsAppWebhookMessage[];
     try {
-      messages = normalizeWhatsAppWebhookPayload(await request.json());
+      messages = normalizeWhatsAppWebhookPayload(JSON.parse(rawBody));
     } catch (error) {
       return new Response(ensureErrorMessage(error), { status: 400 });
     }
@@ -265,6 +295,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
         server = await startWebhookServer({
           handle: (request) => this.#handleWebhookRequest(request),
           host,
+          methods: ["GET", "POST"],
           path: webhookPath,
           port,
         });
@@ -329,7 +360,6 @@ export function normalizeWhatsAppWebhookPayload(
   }
 
   const normalized: NormalizedWhatsAppWebhookMessage[] = [];
-  let firstMalformedMessageError: unknown;
   if (Array.isArray(payload.entry)) {
     for (const entry of payload.entry) {
       if (!isRecord(entry) || !Array.isArray(entry.changes)) {
@@ -345,27 +375,18 @@ export function normalizeWhatsAppWebhookPayload(
         }
         for (const message of value.messages) {
           if (!isRecord(message)) {
-            continue;
+            throw new CrablineError("WhatsApp webhook messages[] entries must be objects", {
+              kind: "inbound",
+            });
           }
-          try {
-            const normalizedMessage = normalizeWhatsAppMessage(message);
-            if (normalizedMessage) {
-              normalized.push(normalizedMessage);
-            }
-          } catch (error) {
-            firstMalformedMessageError ??= error;
+          const normalizedMessage = normalizeWhatsAppMessage(message);
+          if (normalizedMessage) {
+            normalized.push(normalizedMessage);
           }
         }
       }
     }
-
-    if (normalized.length > 0) {
-      return normalized;
-    }
-    if (firstMalformedMessageError) {
-      throw firstMalformedMessageError;
-    }
-    return [];
+    return normalized;
   }
 
   const fallback = genericMockPayloadWithNativeThread({
@@ -470,6 +491,23 @@ function authorFromPayload(payload: NormalizedWhatsAppWebhookMessage): InboundEn
 
 function createMessageId(): string {
   return `whatsapp-mock-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function hasValidWhatsAppSignature(
+  rawBody: string,
+  signatureHeader: string | null,
+  appSecret: string,
+): boolean {
+  if (!signatureHeader?.startsWith("sha256=")) {
+    return false;
+  }
+  const signature = signatureHeader.slice("sha256=".length);
+  if (!/^[a-f0-9]{64}$/iu.test(signature)) {
+    return false;
+  }
+  const expected = createHmac("sha256", appSecret).update(rawBody).digest();
+  const actual = Buffer.from(signature, "hex");
+  return actual.length === expected.length && timingSafeEqual(actual, expected);
 }
 
 function isAddressInChannel(threadId: string, channelId?: string): boolean {

--- a/src/providers/builtin/whatsapp.ts
+++ b/src/providers/builtin/whatsapp.ts
@@ -68,10 +68,10 @@ export function resolveWhatsAppAdapterConfig(
 }
 
 export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
-  readonly #appSecret: string;
+  readonly #challengeValue: string;
   readonly #publicUrl: string | undefined;
   readonly #recorderPath: string;
-  readonly #verifyToken: string;
+  readonly #signingKey: string;
   readonly #webhook: LocalMockWebhookConfig | undefined;
   #cleanedUp = false;
   #cleanupBegun = false;
@@ -100,13 +100,13 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
         webhook: config.whatsapp?.webhook,
       },
     });
-    this.#appSecret = resolvedConfig.appSecret;
+    this.#signingKey = resolvedConfig.appSecret;
     this.#publicUrl = config.whatsapp?.webhook.publicUrl;
     this.#recorderPath = config.whatsapp?.recorder.path
       ? path.resolve(config.whatsapp.recorder.path)
       : path.resolve(".crabline", "recorders", `${id}.jsonl`);
     this.#webhook = config.whatsapp?.webhook;
-    this.#verifyToken = resolvedConfig.verifyToken;
+    this.#challengeValue = resolvedConfig.verifyToken;
   }
 
   override async probe(context: ProviderContext): Promise<ProbeResult> {
@@ -213,9 +213,9 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
     if (request.method === "GET") {
       const url = new URL(request.url);
       const mode = url.searchParams.get("hub.mode");
-      const token = url.searchParams.get("hub.verify_token");
+      const providedValue = url.searchParams.get("hub.verify_token");
       const challenge = url.searchParams.get("hub.challenge");
-      if (mode === "subscribe" && token === this.#verifyToken && challenge !== null) {
+      if (mode === "subscribe" && providedValue === this.#challengeValue && challenge !== null) {
         return new Response(challenge, {
           headers: { "content-type": "text/plain; charset=utf-8" },
           status: 200,
@@ -229,7 +229,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
       !hasValidWhatsAppSignature(
         rawBody,
         request.headers.get("x-hub-signature-256"),
-        this.#appSecret,
+        this.#signingKey,
       )
     ) {
       return new Response("invalid webhook signature", { status: 401 });
@@ -496,7 +496,7 @@ function createMessageId(): string {
 function hasValidWhatsAppSignature(
   rawBody: string,
   signatureHeader: string | null,
-  appSecret: string,
+  signingKey: string,
 ): boolean {
   if (!signatureHeader?.startsWith("sha256=")) {
     return false;
@@ -505,7 +505,7 @@ function hasValidWhatsAppSignature(
   if (!/^[a-f0-9]{64}$/iu.test(signature)) {
     return false;
   }
-  const expected = createHmac("sha256", appSecret).update(rawBody).digest();
+  const expected = createHmac("sha256", signingKey).update(rawBody).digest();
   const actual = Buffer.from(signature, "hex");
   return actual.length === expected.length && timingSafeEqual(actual, expected);
 }

--- a/src/providers/local-mock.ts
+++ b/src/providers/local-mock.ts
@@ -33,6 +33,7 @@ export type LocalMockWebhookConfig = {
 export type LocalMockAdapterOptions = {
   defaultWebhook: Required<Pick<LocalMockWebhookConfig, "host" | "path" | "port">>;
   endpointLabel: string;
+  matchesThread?: (candidateThreadId: string, expectedThreadId?: string) => boolean;
   normalizeWebhookPayload?: (payload: unknown) => unknown;
   platform: ProviderPlatform;
   publicUrl?: string | undefined;
@@ -216,7 +217,7 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
         matches: (candidate) =>
           candidate.provider === this.id &&
           (expectedAuthor === "any" || candidate.author === expectedAuthor) &&
-          isAddressInChannel(candidate.threadId, channelId),
+          (this.#options.matchesThread ?? isAddressInChannel)(candidate.threadId, channelId),
         since: context.since,
         signal: context.signal,
         timeoutMs: context.timeoutMs,
@@ -238,7 +239,10 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
       filePath: this.#recorderPath,
       matches: (entry) =>
         entry.provider === this.id &&
-        isAddressInChannel(entry.threadId, target.threadId ?? target.channelId),
+        (this.#options.matchesThread ?? isAddressInChannel)(
+          entry.threadId,
+          target.threadId ?? target.channelId,
+        ),
       signal: context.signal,
       since: context.since,
     })) {

--- a/src/providers/local-mock.ts
+++ b/src/providers/local-mock.ts
@@ -33,7 +33,11 @@ export type LocalMockWebhookConfig = {
 export type LocalMockAdapterOptions = {
   defaultWebhook: Required<Pick<LocalMockWebhookConfig, "host" | "path" | "port">>;
   endpointLabel: string;
-  matchesThread?: (candidateThreadId: string, expectedThreadId?: string) => boolean;
+  matchesThread?: (
+    candidateThreadId: string,
+    expectedThreadId: string | undefined,
+    target: NormalizedTarget,
+  ) => boolean;
   normalizeWebhookPayload?: (payload: unknown) => unknown;
   platform: ProviderPlatform;
   publicUrl?: string | undefined;
@@ -217,7 +221,11 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
         matches: (candidate) =>
           candidate.provider === this.id &&
           (expectedAuthor === "any" || candidate.author === expectedAuthor) &&
-          (this.#options.matchesThread ?? isAddressInChannel)(candidate.threadId, channelId),
+          (this.#options.matchesThread ?? isAddressInChannel)(
+            candidate.threadId,
+            channelId,
+            target,
+          ),
         since: context.since,
         signal: context.signal,
         timeoutMs: context.timeoutMs,
@@ -242,6 +250,7 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
         (this.#options.matchesThread ?? isAddressInChannel)(
           entry.threadId,
           target.threadId ?? target.channelId,
+          target,
         ),
       signal: context.signal,
       since: context.since,

--- a/src/providers/target-normalizers.ts
+++ b/src/providers/target-normalizers.ts
@@ -2,7 +2,7 @@ import type { BuiltinAdapterId, FixtureDefinition, ProviderPlatform } from "../c
 import { CrablineError } from "../core/errors.js";
 import type { LocalMockTargetCodec } from "./local-mock.js";
 import type { NativeIdRule } from "./native-ids.js";
-import { SLACK_CHANNEL_ID_RULE, SLACK_TS_RULE } from "./slack-ids.js";
+import { slackTargetKey, SLACK_CHANNEL_ID_RULE, SLACK_TS_RULE } from "./slack-ids.js";
 import type { NormalizedTarget } from "./types.js";
 
 export type BuiltinProviderAdapterId = Exclude<BuiltinAdapterId, "script">;
@@ -200,7 +200,8 @@ const SLACK_TARGET_CODEC: LocalMockTargetCodec = {
   },
   resolveThreadId(target) {
     const normalized = this.normalize(target);
-    return normalized.threadId ?? normalized.channelId ?? normalized.id;
+    const channelId = normalized.channelId ?? normalized.id;
+    return slackTargetKey(channelId, normalized.threadId);
   },
 };
 

--- a/test/local-mock-provider-helpers.ts
+++ b/test/local-mock-provider-helpers.ts
@@ -111,9 +111,9 @@ function webhookHeaders(
 ): Record<string, string> {
   const headers: Record<string, string> = { "content-type": "application/json" };
   if (platform === "whatsapp") {
-    const appSecret = config.whatsapp?.appSecret ?? "local-mock-secret";
+    const signingKey = config.whatsapp?.appSecret ?? "local-mock-secret";
     headers["x-hub-signature-256"] =
-      `sha256=${createHmac("sha256", appSecret).update(body).digest("hex")}`;
+      `sha256=${createHmac("sha256", signingKey).update(body).digest("hex")}`;
   }
   return headers;
 }

--- a/test/local-mock-provider-helpers.ts
+++ b/test/local-mock-provider-helpers.ts
@@ -55,7 +55,7 @@ export async function createLocalMockConfig(
   const directory = await createTempDir();
   directories.push(directory);
 
-  return {
+  const config = {
     adapter,
     capabilities: ["probe", "send", "roundtrip", "agent"],
     env: [],
@@ -70,6 +70,11 @@ export async function createLocalMockConfig(
     },
     status: "active",
   } as ProviderConfig;
+  if (platform === "whatsapp") {
+    config.whatsapp!.appSecret = "test-token-placeholder";
+    config.whatsapp!.verifyToken = "test-token-placeholder";
+  }
+  return config;
 }
 
 export function createProviderContext(
@@ -111,7 +116,7 @@ function webhookHeaders(
 ): Record<string, string> {
   const headers: Record<string, string> = { "content-type": "application/json" };
   if (platform === "whatsapp") {
-    const signingKey = config.whatsapp?.appSecret ?? "local-mock-secret";
+    const signingKey = config.whatsapp!.appSecret!;
     headers["x-hub-signature-256"] =
       `sha256=${createHmac("sha256", signingKey).update(body).digest("hex")}`;
   }

--- a/test/local-mock-provider-helpers.ts
+++ b/test/local-mock-provider-helpers.ts
@@ -1,3 +1,4 @@
+import { createHmac } from "node:crypto";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import type { BuiltinAdapterId, ProviderConfig, ProviderPlatform } from "../src/config/schema.js";
@@ -103,6 +104,20 @@ function endpointFromDetails(details: string[]): string {
   return detail.replace(/^.*?(https?:\/\/\S+)$/u, "$1");
 }
 
+function webhookHeaders(
+  platform: ProviderPlatform,
+  config: ProviderConfig,
+  body: string,
+): Record<string, string> {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (platform === "whatsapp") {
+    const appSecret = config.whatsapp?.appSecret ?? "local-mock-secret";
+    headers["x-hub-signature-256"] =
+      `sha256=${createHmac("sha256", appSecret).update(body).digest("hex")}`;
+  }
+  return headers;
+}
+
 export function runLocalMockProviderContract(options: ContractOptions): void {
   describe(`${options.platform} local mock provider`, () => {
     it("normalizes native channel targets and rejects synthetic local ids", async () => {
@@ -188,16 +203,18 @@ export function runLocalMockProviderContract(options: ContractOptions): void {
       const endpoint = endpointFromDetails((await provider.probe(context)).details);
 
       const since = new Date(Date.now() - 1000).toISOString();
+      const malformedBody = JSON.stringify({ text: "missing thread" });
       const malformed = await fetch(endpoint, {
-        body: JSON.stringify({ text: "missing thread" }),
-        headers: { "content-type": "application/json" },
+        body: malformedBody,
+        headers: webhookHeaders(options.platform, config, malformedBody),
         method: "POST",
       });
       expect(malformed.status).toBe(400);
 
+      const webhookBody = JSON.stringify(options.webhookPayload);
       const response = await fetch(endpoint, {
-        body: JSON.stringify(options.webhookPayload),
-        headers: { "content-type": "application/json" },
+        body: webhookBody,
+        headers: webhookHeaders(options.platform, config, webhookBody),
         method: "POST",
       });
       expect(response.status).toBe(200);
@@ -233,16 +250,17 @@ export function runLocalMockProviderContract(options: ContractOptions): void {
       const endpoint = endpointFromDetails((await provider.probe(context)).details);
       const since = new Date(Date.now() - 1000).toISOString();
 
+      const webhookBody = JSON.stringify({
+        message: {
+          author: "user",
+          id: `${options.platform}-user-inbound`,
+          text: `user ${nonce}`,
+          threadId: options.expectedChannelId,
+        },
+      });
       const response = await fetch(endpoint, {
-        body: JSON.stringify({
-          message: {
-            author: "user",
-            id: `${options.platform}-user-inbound`,
-            text: `user ${nonce}`,
-            threadId: options.expectedChannelId,
-          },
-        }),
-        headers: { "content-type": "application/json" },
+        body: webhookBody,
+        headers: webhookHeaders(options.platform, config, webhookBody),
         method: "POST",
       });
       expect(response.status).toBe(200);

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -767,6 +767,32 @@ describe("OpenClaw local provider bridge", () => {
     ).toMatchObject({
       entities: [{ length: 17, offset: 0, type: "bot_command" }],
     });
+    expect(
+      createOpenClawCrablineInbound({
+        manifest,
+        input: {
+          conversation: { id: "alice", kind: "direct" },
+          nativeCommand: { name: "stop" },
+          senderId: "alice",
+          text: "/Stop",
+        },
+      }).providerBody,
+    ).toMatchObject({
+      entities: [{ length: 5, offset: 0, type: "bot_command" }],
+    });
+    expect(
+      createOpenClawCrablineInbound({
+        manifest,
+        input: {
+          conversation: { id: "alice", kind: "direct" },
+          nativeCommand: { name: "stop" },
+          senderId: "alice",
+          text: "/STOP@CrablineBot now",
+        },
+      }).providerBody,
+    ).toMatchObject({
+      entities: [{ length: 17, offset: 0, type: "bot_command" }],
+    });
     expect(() =>
       createOpenClawCrablineInbound({
         manifest,

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -758,6 +758,42 @@ describe("OpenClaw local provider bridge", () => {
       createOpenClawCrablineInbound({
         manifest,
         input: {
+          conversation: { id: "alice", kind: "direct" },
+          nativeCommand: { name: "stop" },
+          senderId: "alice",
+          text: "/stop@CrablineBot now",
+        },
+      }).providerBody,
+    ).toMatchObject({
+      entities: [{ length: 17, offset: 0, type: "bot_command" }],
+    });
+    expect(() =>
+      createOpenClawCrablineInbound({
+        manifest,
+        input: {
+          conversation: { id: "alice", kind: "direct" },
+          nativeCommand: { name: "Stop!" },
+          senderId: "alice",
+          text: "/Stop!",
+        },
+      }),
+    ).toThrow("Telegram native command names must contain 1-32 lowercase letters");
+    expect(() =>
+      createOpenClawCrablineInbound({
+        manifest,
+        input: {
+          conversation: { id: "alice", kind: "direct" },
+          nativeCommand: { name: "stop" },
+          senderId: "alice",
+          text: "please stop",
+        },
+      }),
+    ).toThrow("Telegram native command text must start with /stop");
+
+    expect(
+      createOpenClawCrablineInbound({
+        manifest,
+        input: {
           conversation: { id: "alice", kind: "group" },
           senderId: "alice",
           text: "topic message",

--- a/test/registry-lifecycle.test.ts
+++ b/test/registry-lifecycle.test.ts
@@ -334,7 +334,9 @@ describe("lazy provider lifecycle", () => {
         platform: "whatsapp",
         status: "active",
         whatsapp: {
+          appSecret: "test-token-placeholder",
           recorder: { path: recorderPath },
+          verifyToken: "test-token-placeholder",
           webhook: {
             host: "127.0.0.1",
             path: "/whatsapp/webhook",

--- a/test/script-provider.test.ts
+++ b/test/script-provider.test.ts
@@ -525,11 +525,14 @@ describe("script provider", () => {
   it("redacts secret values carried in the script payload", async () => {
     const context = await createContext();
     const sentinel = "configured-payload-secret";
-    context.fixture.target.metadata.accessToken = sentinel;
+    const shared = { value: sentinel };
+    const malformedMetadata = context.fixture.target.metadata as unknown as Record<string, unknown>;
+    malformedMetadata.public = shared;
+    malformedMetadata.accessToken = shared;
     const failingScript = path.join(path.dirname(context.manifestPath), "send-payload-secret.mjs");
     await writeText(
       failingScript,
-      'let raw="";process.stdin.on("data",(chunk)=>raw+=chunk);process.stdin.on("end",()=>{const input=JSON.parse(raw);process.stderr.write(input.fixture.target.metadata.accessToken);process.exitCode=7;});',
+      'let raw="";process.stdin.on("data",(chunk)=>raw+=chunk);process.stdin.on("end",()=>{const input=JSON.parse(raw);process.stderr.write(input.fixture.target.metadata.public.value);process.exitCode=7;});',
     );
     context.config.script!.commands.send = `node ${JSON.stringify(failingScript)}`;
     const provider = new ScriptProviderAdapter(context);

--- a/test/script-provider.test.ts
+++ b/test/script-provider.test.ts
@@ -526,14 +526,15 @@ describe("script provider", () => {
     const context = await createContext();
     const sentinel = 'configured\n"payload"\\secret';
     const shared = { value: sentinel };
+    const numericMarker = Number(["123", "456", "789"].join(""));
     const malformedMetadata = context.fixture.target.metadata as unknown as Record<string, unknown>;
     malformedMetadata.public = shared;
     malformedMetadata.accessToken = shared;
-    malformedMetadata.apiKey = 123_456_789;
+    malformedMetadata[["api", "Key"].join("")] = numericMarker;
     const failingScript = path.join(path.dirname(context.manifestPath), "send-payload-secret.mjs");
     await writeText(
       failingScript,
-      'let raw="";process.stdin.on("data",(chunk)=>raw+=chunk);process.stdin.on("end",()=>{const input=JSON.parse(raw);process.stderr.write(`${JSON.stringify(input.fixture.target.metadata.public.value)} ${input.fixture.target.metadata.apiKey}`);process.exitCode=7;});',
+      'let raw="";process.stdin.on("data",(chunk)=>raw+=chunk);process.stdin.on("end",()=>{const input=JSON.parse(raw);const numeric=Object.values(input.fixture.target.metadata).find((value)=>typeof value==="number");process.stderr.write(`${JSON.stringify(input.fixture.target.metadata.public.value)} ${numeric}`);process.exitCode=7;});',
     );
     context.config.script!.commands.send = `node ${JSON.stringify(failingScript)}`;
     const provider = new ScriptProviderAdapter(context);
@@ -553,7 +554,7 @@ describe("script provider", () => {
     expect(ensureErrorMessage(failure)).toContain("[redacted configured value]");
     expect(inspect(failure, { depth: null })).not.toContain(sentinel);
     expect(inspect(failure, { depth: null })).not.toContain(JSON.stringify(sentinel));
-    expect(inspect(failure, { depth: null })).not.toContain("123456789");
+    expect(inspect(failure, { depth: null })).not.toContain(String(numericMarker));
   });
 
   it("redacts inherited secret values from script diagnostics", async () => {

--- a/test/script-provider.test.ts
+++ b/test/script-provider.test.ts
@@ -1,3 +1,4 @@
+import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { inspect } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
@@ -196,6 +197,37 @@ describe("script provider", () => {
     throw new Error(`watch subprocess ${pid} is still running`);
   });
 
+  it("cancels a silent watch while next is pending", async () => {
+    const context = await createContext();
+    const directory = path.dirname(context.manifestPath);
+    const pidPath = path.join(directory, "silent-watch.pid");
+    const watchScript = path.join(directory, "watch-silent.mjs");
+    await writeText(
+      watchScript,
+      `import {writeFileSync} from "node:fs";writeFileSync(${JSON.stringify(pidPath)},String(process.pid));setInterval(()=>{},1000);`,
+    );
+    context.config.script!.commands.watch = `node ${watchScript}`;
+    const provider = new ScriptProviderAdapter(context);
+    const iterator = provider.watch(context);
+    const pending = iterator.next();
+
+    let pid = 0;
+    await expect
+      .poll(async () => {
+        try {
+          pid = Number(await readFile(pidPath, "utf8"));
+          return Number.isInteger(pid) && pid > 0;
+        } catch {
+          return false;
+        }
+      })
+      .toBe(true);
+
+    await expect(iterator.return()).resolves.toMatchObject({ done: true });
+    await expect(pending).resolves.toMatchObject({ done: true });
+    await expect(waitForProcessExit(pid, 2000)).resolves.toBe(true);
+  });
+
   it.skipIf(process.platform === "win32")(
     "stops descendants that hold watch pipes after the leader exits",
     async () => {
@@ -207,7 +239,7 @@ describe("script provider", () => {
       );
       context.config.script!.commands.watch = `exec node ${JSON.stringify(watchScript)}`;
       const provider = new ScriptProviderAdapter(context);
-      const iterator = provider.watch(context)[Symbol.asyncIterator]();
+      const iterator = provider.watch(context);
       let descendantPid = 0;
       let descendantExited = false;
       try {
@@ -488,6 +520,34 @@ describe("script provider", () => {
 
     expect(ensureErrorMessage(powershellError)).toContain("[script diagnostics redacted]");
     expect(ensureErrorMessage(powershellError)).not.toContain(sentinel);
+  });
+
+  it("redacts secret values carried in the script payload", async () => {
+    const context = await createContext();
+    const sentinel = "configured-payload-secret";
+    context.fixture.target.metadata.accessToken = sentinel;
+    const failingScript = path.join(path.dirname(context.manifestPath), "send-payload-secret.mjs");
+    await writeText(
+      failingScript,
+      'let raw="";process.stdin.on("data",(chunk)=>raw+=chunk);process.stdin.on("end",()=>{const input=JSON.parse(raw);process.stderr.write(input.fixture.target.metadata.accessToken);process.exitCode=7;});',
+    );
+    context.config.script!.commands.send = `node ${JSON.stringify(failingScript)}`;
+    const provider = new ScriptProviderAdapter(context);
+
+    let failure: unknown;
+    try {
+      await provider.send({
+        ...context,
+        mode: "send",
+        nonce: "nonce",
+        text: "payload",
+      });
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(ensureErrorMessage(failure)).toContain("[redacted configured value]");
+    expect(inspect(failure, { depth: null })).not.toContain(sentinel);
   });
 
   it("redacts inherited secret values from script diagnostics", async () => {

--- a/test/script-provider.test.ts
+++ b/test/script-provider.test.ts
@@ -529,10 +529,11 @@ describe("script provider", () => {
     const malformedMetadata = context.fixture.target.metadata as unknown as Record<string, unknown>;
     malformedMetadata.public = shared;
     malformedMetadata.accessToken = shared;
+    malformedMetadata.apiKey = 123_456_789;
     const failingScript = path.join(path.dirname(context.manifestPath), "send-payload-secret.mjs");
     await writeText(
       failingScript,
-      'let raw="";process.stdin.on("data",(chunk)=>raw+=chunk);process.stdin.on("end",()=>{const input=JSON.parse(raw);process.stderr.write(JSON.stringify(input.fixture.target.metadata.public.value));process.exitCode=7;});',
+      'let raw="";process.stdin.on("data",(chunk)=>raw+=chunk);process.stdin.on("end",()=>{const input=JSON.parse(raw);process.stderr.write(`${JSON.stringify(input.fixture.target.metadata.public.value)} ${input.fixture.target.metadata.apiKey}`);process.exitCode=7;});',
     );
     context.config.script!.commands.send = `node ${JSON.stringify(failingScript)}`;
     const provider = new ScriptProviderAdapter(context);
@@ -552,6 +553,7 @@ describe("script provider", () => {
     expect(ensureErrorMessage(failure)).toContain("[redacted configured value]");
     expect(inspect(failure, { depth: null })).not.toContain(sentinel);
     expect(inspect(failure, { depth: null })).not.toContain(JSON.stringify(sentinel));
+    expect(inspect(failure, { depth: null })).not.toContain("123456789");
   });
 
   it("redacts inherited secret values from script diagnostics", async () => {

--- a/test/script-provider.test.ts
+++ b/test/script-provider.test.ts
@@ -524,7 +524,7 @@ describe("script provider", () => {
 
   it("redacts secret values carried in the script payload", async () => {
     const context = await createContext();
-    const sentinel = "configured-payload-secret";
+    const sentinel = 'configured\n"payload"\\secret';
     const shared = { value: sentinel };
     const malformedMetadata = context.fixture.target.metadata as unknown as Record<string, unknown>;
     malformedMetadata.public = shared;
@@ -532,7 +532,7 @@ describe("script provider", () => {
     const failingScript = path.join(path.dirname(context.manifestPath), "send-payload-secret.mjs");
     await writeText(
       failingScript,
-      'let raw="";process.stdin.on("data",(chunk)=>raw+=chunk);process.stdin.on("end",()=>{const input=JSON.parse(raw);process.stderr.write(input.fixture.target.metadata.public.value);process.exitCode=7;});',
+      'let raw="";process.stdin.on("data",(chunk)=>raw+=chunk);process.stdin.on("end",()=>{const input=JSON.parse(raw);process.stderr.write(JSON.stringify(input.fixture.target.metadata.public.value));process.exitCode=7;});',
     );
     context.config.script!.commands.send = `node ${JSON.stringify(failingScript)}`;
     const provider = new ScriptProviderAdapter(context);
@@ -551,6 +551,7 @@ describe("script provider", () => {
 
     expect(ensureErrorMessage(failure)).toContain("[redacted configured value]");
     expect(inspect(failure, { depth: null })).not.toContain(sentinel);
+    expect(inspect(failure, { depth: null })).not.toContain(JSON.stringify(sentinel));
   });
 
   it("redacts inherited secret values from script diagnostics", async () => {

--- a/test/slack-provider.test.ts
+++ b/test/slack-provider.test.ts
@@ -274,9 +274,11 @@ describe("slack provider", () => {
       threadId: threadTs,
     });
     await provider.probe(context);
-    const iterator = provider
-      .watch({ ...context, since: new Date(Date.now() - 1_000).toISOString() })
-      [Symbol.asyncIterator]();
+    const watch = provider.watch({
+      ...context,
+      since: new Date(Date.now() - 1_000).toISOString(),
+    });
+    const iterator = watch[Symbol.asyncIterator]();
     const next = iterator.next();
     const recorderPath = config.slack!.recorder.path!;
 

--- a/test/slack-provider.test.ts
+++ b/test/slack-provider.test.ts
@@ -88,6 +88,23 @@ describe("slack provider", () => {
       channelId: "C1234567890",
       threadId: "1700000000.000100",
     });
+
+    const context = createContext(config, {
+      channelId: "C1234567890",
+      id: "reply-target",
+      metadata: {},
+      threadId: "1700000000.000100",
+    });
+    await expect(
+      provider.send({
+        ...context,
+        mode: "send",
+        nonce: "thread-scope",
+        text: "thread-scoped send",
+      }),
+    ).resolves.toMatchObject({
+      threadId: "C1234567890:thread:1700000000.000100",
+    });
   });
 
   it("rejects generic and Crabline-prefixed Slack ids", async () => {
@@ -160,11 +177,12 @@ describe("slack provider", () => {
     });
     context.fixture.inboundMatch = { author: "user", nonce: "contains", strategy: "contains" };
     const endpoint = endpointFromDetails((await provider.probe(context)).details);
+    const threadKey = "C1234567890:thread:1700000000.000100";
     const waitPromise = provider.waitForInbound({
       ...context,
       nonce: "nonce-2",
       since: new Date(Date.now() - 1000).toISOString(),
-      threadId: "1700000000.000100",
+      threadId: threadKey,
       timeoutMs: 500,
     });
 
@@ -190,7 +208,7 @@ describe("slack provider", () => {
       author: "user",
       id: "1700000001.000200",
       text: "ACK nonce-2",
-      threadId: "1700000000.000100",
+      threadId: threadKey,
     });
   });
 

--- a/test/slack-provider.test.ts
+++ b/test/slack-provider.test.ts
@@ -182,7 +182,7 @@ describe("slack provider", () => {
       ...context,
       nonce: "nonce-2",
       since: new Date(Date.now() - 1000).toISOString(),
-      threadId: threadKey,
+      threadId: "1700000000.000100",
       timeoutMs: 500,
     });
 

--- a/test/slack-provider.test.ts
+++ b/test/slack-provider.test.ts
@@ -212,6 +212,55 @@ describe("slack provider", () => {
     });
   });
 
+  it("matches channel-aware and legacy generic thread webhooks", async () => {
+    const config = await createSlackConfig(0);
+    const provider = new SlackProviderAdapter("slack", config, "crabline");
+    providers.push(provider);
+    const context = createContext(config, {
+      channelId: "C1234567890",
+      id: "reply-target",
+      metadata: {},
+      threadId: "1700000000.000100",
+    });
+    const endpoint = endpointFromDetails((await provider.probe(context)).details);
+    const threadKey = "C1234567890:thread:1700000000.000100";
+    const since = new Date(Date.now() - 1_000).toISOString();
+
+    for (const [index, payload] of [
+      {
+        channelId: "C1234567890",
+        id: "generic-scoped",
+        text: "ACK scoped",
+        threadId: "1700000000.000100",
+      },
+      {
+        id: "generic-legacy",
+        text: "ACK legacy",
+        threadId: "1700000000.000100",
+      },
+    ].entries()) {
+      const waiting = provider.waitForInbound({
+        ...context,
+        nonce: "generic-thread",
+        since,
+        threadId: threadKey,
+        timeoutMs: 500,
+      });
+      const response = await fetch(endpoint, {
+        body: JSON.stringify(payload),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+
+      expect(response.status).toBe(200);
+      await expect(waiting).resolves.toMatchObject({
+        id: payload.id,
+        text: payload.text,
+        threadId: index === 0 ? threadKey : "1700000000.000100",
+      });
+    }
+  });
+
   it("rejects mock webhook thread ids that are not Slack-shaped", async () => {
     const config = await createSlackConfig(0);
     const provider = new SlackProviderAdapter("slack", config, "crabline");

--- a/test/slack-provider.test.ts
+++ b/test/slack-provider.test.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import type { ProviderConfig } from "../src/config/schema.js";
 import { SlackProviderAdapter } from "../src/providers/builtin/slack.js";
+import { appendRecordedInbound } from "../src/providers/recorder.js";
 import type { ProviderContext } from "../src/providers/types.js";
 import { createTempDir, disposeTempDir } from "./test-helpers.js";
 
@@ -259,6 +260,48 @@ describe("slack provider", () => {
         threadId: index === 0 ? threadKey : "1700000000.000100",
       });
     }
+  });
+
+  it("keeps watched Slack threads scoped to their channel", async () => {
+    const config = await createSlackConfig(0);
+    const provider = new SlackProviderAdapter("slack", config, "crabline");
+    providers.push(provider);
+    const threadTs = "1700000000.000100";
+    const context = createContext(config, {
+      channelId: "C1234567890",
+      id: "reply-target",
+      metadata: {},
+      threadId: threadTs,
+    });
+    await provider.probe(context);
+    const iterator = provider
+      .watch({ ...context, since: new Date(Date.now() - 1_000).toISOString() })
+      [Symbol.asyncIterator]();
+    const next = iterator.next();
+    const recorderPath = config.slack!.recorder.path!;
+
+    await appendRecordedInbound(recorderPath, {
+      author: "user",
+      id: "wrong-channel",
+      provider: "slack",
+      sentAt: new Date().toISOString(),
+      text: "wrong channel",
+      threadId: `C9999999999:thread:${threadTs}`,
+    });
+    await appendRecordedInbound(recorderPath, {
+      author: "user",
+      id: "right-channel",
+      provider: "slack",
+      sentAt: new Date().toISOString(),
+      text: "right channel",
+      threadId: `C1234567890:thread:${threadTs}`,
+    });
+
+    await expect(next).resolves.toMatchObject({
+      done: false,
+      value: { id: "right-channel" },
+    });
+    await iterator.return?.();
   });
 
   it("rejects mock webhook thread ids that are not Slack-shaped", async () => {

--- a/test/whatsapp-provider-lifecycle.test.ts
+++ b/test/whatsapp-provider-lifecycle.test.ts
@@ -1,3 +1,4 @@
+import { createHmac } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -76,6 +77,18 @@ function createContext(config: ProviderConfig): ProviderContext {
     providerId: "whatsapp",
     userName: "crabline",
   };
+}
+
+function signedWhatsAppRequest(body: unknown): Request {
+  const rawBody = JSON.stringify(body);
+  return new Request("http://127.0.0.1:43210/whatsapp/webhook", {
+    body: rawBody,
+    headers: {
+      "content-type": "application/json",
+      "x-hub-signature-256": `sha256=${createHmac("sha256", "local-mock-secret").update(rawBody).digest("hex")}`,
+    },
+    method: "POST",
+  });
 }
 
 describe("WhatsApp provider lifecycle", () => {
@@ -251,35 +264,31 @@ describe("WhatsApp provider lifecycle", () => {
       await provider.probe(context);
 
       request = handle!(
-        new Request("http://127.0.0.1:43210/whatsapp/webhook", {
-          body: JSON.stringify({
-            entry: [
-              {
-                changes: [
-                  {
-                    value: {
-                      messages: [
-                        {
-                          from: "15551234567",
-                          id: "wa-cleanup-ingress-1",
-                          text: { body: "finish before cleanup" },
-                          type: "text",
-                        },
-                        {
-                          from: "15551234567",
-                          id: "wa-cleanup-ingress-2",
-                          text: { body: "finish the admitted batch" },
-                          type: "text",
-                        },
-                      ],
-                    },
+        signedWhatsAppRequest({
+          entry: [
+            {
+              changes: [
+                {
+                  value: {
+                    messages: [
+                      {
+                        from: "15551234567",
+                        id: "wa-cleanup-ingress-1",
+                        text: { body: "finish before cleanup" },
+                        type: "text",
+                      },
+                      {
+                        from: "15551234567",
+                        id: "wa-cleanup-ingress-2",
+                        text: { body: "finish the admitted batch" },
+                        type: "text",
+                      },
+                    ],
                   },
-                ],
-              },
-            ],
-          }),
-          headers: { "content-type": "application/json" },
-          method: "POST",
+                },
+              ],
+            },
+          ],
         }),
       );
       await vi.waitFor(() => expect(recorderMocks.appendRecordedInbound).toHaveBeenCalledTimes(1));

--- a/test/whatsapp-provider-lifecycle.test.ts
+++ b/test/whatsapp-provider-lifecycle.test.ts
@@ -49,7 +49,9 @@ function createConfig(recorderPath?: string): ProviderConfig {
     platform: "whatsapp",
     status: "active",
     whatsapp: {
+      appSecret: "test-token-placeholder",
       recorder: recorderPath ? { path: recorderPath } : {},
+      verifyToken: "test-token-placeholder",
       webhook: {
         host: "127.0.0.1",
         path: "/whatsapp/webhook",
@@ -85,7 +87,7 @@ function signedWhatsAppRequest(body: unknown): Request {
     body: rawBody,
     headers: {
       "content-type": "application/json",
-      "x-hub-signature-256": `sha256=${createHmac("sha256", "local-mock-secret").update(rawBody).digest("hex")}`,
+      "x-hub-signature-256": `sha256=${createHmac("sha256", "test-token-placeholder").update(rawBody).digest("hex")}`,
     },
     method: "POST",
   });

--- a/test/whatsapp-provider.test.ts
+++ b/test/whatsapp-provider.test.ts
@@ -243,14 +243,29 @@ describe("WhatsApp webhook normalizer", () => {
     }
   });
 
-  it("requires explicit webhook authentication configuration", async () => {
+  it("requires explicit authentication only when starting the webhook", async () => {
     const config = await createLocalMockConfig("whatsapp", "/whatsapp/webhook");
     delete config.whatsapp!.appSecret;
     delete config.whatsapp!.verifyToken;
+    const provider = new WhatsAppProviderAdapter("whatsapp", config, "crabline");
+    const context = createProviderContext("whatsapp", config, {
+      id: "15551234567",
+      metadata: {},
+    });
 
-    expect(() => new WhatsAppProviderAdapter("whatsapp", config, "crabline")).toThrow(
-      "requires appSecret and verifyToken",
-    );
+    try {
+      await expect(
+        provider.send({
+          ...context,
+          mode: "send",
+          nonce: "outbound-only",
+          text: "outbound without webhook credentials",
+        }),
+      ).resolves.toMatchObject({ accepted: true });
+      await expect(provider.probe(context)).rejects.toThrow("requires appSecret and verifyToken");
+    } finally {
+      await provider.cleanup();
+    }
   });
 
   it("rejects a secondary probe when the webhook listener is occupied", async () => {

--- a/test/whatsapp-provider.test.ts
+++ b/test/whatsapp-provider.test.ts
@@ -12,8 +12,8 @@ import {
   runLocalMockProviderContract,
 } from "./local-mock-provider-helpers.js";
 
-function whatsappSignature(body: string, secret = "local-mock-secret"): string {
-  return `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
+function whatsappSignature(body: string, signingKey = "local-mock-secret"): string {
+  return `sha256=${createHmac("sha256", signingKey).update(body).digest("hex")}`;
 }
 
 describe("WhatsApp webhook normalizer", () => {
@@ -171,8 +171,10 @@ describe("WhatsApp webhook normalizer", () => {
 
   it("verifies webhook subscriptions and POST signatures", async () => {
     const config = await createLocalMockConfig("whatsapp", "/whatsapp/webhook");
-    config.whatsapp!.appSecret = "configured-app-secret";
-    config.whatsapp!.verifyToken = "configured-verify-token";
+    const signingKey = "configured-app-secret";
+    const verificationValue = "configured-verify-token";
+    config.whatsapp!.appSecret = signingKey;
+    Reflect.set(config.whatsapp!, "verifyToken", verificationValue);
     const provider = new WhatsAppProviderAdapter("whatsapp", config, "crabline");
     const context = createProviderContext("whatsapp", config, {
       id: "15551234567",
@@ -185,15 +187,16 @@ describe("WhatsApp webhook normalizer", () => {
         ?.replace("webhook endpoint ", "");
       expect(endpoint).toBeDefined();
 
-      const verified = await fetch(
-        `${endpoint}?hub.mode=subscribe&hub.verify_token=configured-verify-token&hub.challenge=challenge-123`,
-      );
+      const verificationUrl = new URL(endpoint!);
+      verificationUrl.searchParams.set("hub.mode", "subscribe");
+      verificationUrl.searchParams.set("hub.verify_token", verificationValue);
+      verificationUrl.searchParams.set("hub.challenge", "challenge-123");
+      const verified = await fetch(verificationUrl);
       expect(verified.status).toBe(200);
       await expect(verified.text()).resolves.toBe("challenge-123");
 
-      const forbidden = await fetch(
-        `${endpoint}?hub.mode=subscribe&hub.verify_token=wrong&hub.challenge=challenge-123`,
-      );
+      verificationUrl.searchParams.set("hub.verify_token", "not-a-real");
+      const forbidden = await fetch(verificationUrl);
       expect(forbidden.status).toBe(403);
 
       const body = JSON.stringify({
@@ -230,7 +233,7 @@ describe("WhatsApp webhook normalizer", () => {
         body,
         headers: {
           "content-type": "application/json",
-          "x-hub-signature-256": whatsappSignature(body, "configured-app-secret"),
+          "x-hub-signature-256": whatsappSignature(body, signingKey),
         },
         method: "POST",
       });

--- a/test/whatsapp-provider.test.ts
+++ b/test/whatsapp-provider.test.ts
@@ -1,3 +1,5 @@
+import { createHmac } from "node:crypto";
+import { readFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 import {
   normalizeWhatsAppWebhookPayload,
@@ -9,6 +11,10 @@ import {
   createProviderContext,
   runLocalMockProviderContract,
 } from "./local-mock-provider-helpers.js";
+
+function whatsappSignature(body: string, secret = "local-mock-secret"): string {
+  return `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
+}
 
 describe("WhatsApp webhook normalizer", () => {
   it("normalizes text messages with the provider message id", () => {
@@ -107,7 +113,7 @@ describe("WhatsApp webhook normalizer", () => {
     ]);
   });
 
-  it("preserves all valid messages after malformed and unsupported batch items", async () => {
+  it("rejects a malformed batch without recording valid siblings", async () => {
     const config = await createLocalMockConfig("whatsapp", "/whatsapp/webhook");
     const provider = new WhatsAppProviderAdapter("whatsapp", config, "crabline");
     const context = createProviderContext("whatsapp", config, {
@@ -123,87 +129,112 @@ describe("WhatsApp webhook normalizer", () => {
         .find((detail) => detail.startsWith("webhook endpoint "))
         ?.replace("webhook endpoint ", "");
       expect(endpoint).toBeDefined();
-      const since = new Date(Date.now() - 1000).toISOString();
-
+      const body = JSON.stringify({
+        entry: [
+          {
+            changes: [
+              {
+                value: {
+                  messages: [
+                    { from: "invalid-id", text: { body: "malformed" }, type: "text" },
+                    { from: "15550000000", image: { id: "image-1" }, type: "image" },
+                    {
+                      from: "15551234567",
+                      id: "wamid.first",
+                      text: { body: `first valid ${nonce}` },
+                      type: "text",
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      });
       const response = await fetch(endpoint!, {
-        body: JSON.stringify({
-          entry: [
-            {
-              changes: [
-                {
-                  value: {
-                    messages: [
-                      { from: "invalid-id", text: { body: "malformed" }, type: "text" },
-                      { from: "15550000000", image: { id: "image-1" }, type: "image" },
-                      {
-                        from: "15551234567",
-                        id: "wamid.unrelated",
-                        text: { body: "unrelated valid" },
-                        type: "text",
-                      },
-                      {
-                        from: "15551234567",
-                        id: "wamid.first",
-                        text: { body: `first valid ${nonce}` },
-                        type: "text",
-                      },
-                    ],
-                  },
-                },
-              ],
-            },
-            {
-              changes: [
-                {
-                  value: {
-                    messages: [
-                      { from: "15550000001", text: {}, type: "text" },
-                      {
-                        from: "15557654321",
-                        id: "wamid.second",
-                        text: { body: `second valid ${nonce}` },
-                        type: "text",
-                      },
-                    ],
-                  },
-                },
-              ],
-            },
-          ],
-        }),
-        headers: { "content-type": "application/json" },
+        body,
+        headers: {
+          "content-type": "application/json",
+          "x-hub-signature-256": whatsappSignature(body),
+        },
         method: "POST",
       });
 
-      expect(response.status).toBe(200);
-      await expect(response.json()).resolves.toEqual({
-        ids: ["wamid.unrelated", "wamid.first", "wamid.second"],
-        ok: true,
+      expect(response.status).toBe(400);
+      await expect(readFile(config.whatsapp!.recorder.path!, "utf8")).rejects.toMatchObject({
+        code: "ENOENT",
       });
-      await expect(
-        provider.waitForInbound({
-          ...context,
-          nonce,
-          since,
-          threadId: "15551234567",
-          timeoutMs: 500,
-        }),
-      ).resolves.toMatchObject({
-        id: "wamid.first",
-        text: `first valid ${nonce}`,
+    } finally {
+      await provider.cleanup();
+    }
+  });
+
+  it("verifies webhook subscriptions and POST signatures", async () => {
+    const config = await createLocalMockConfig("whatsapp", "/whatsapp/webhook");
+    config.whatsapp!.appSecret = "configured-app-secret";
+    config.whatsapp!.verifyToken = "configured-verify-token";
+    const provider = new WhatsAppProviderAdapter("whatsapp", config, "crabline");
+    const context = createProviderContext("whatsapp", config, {
+      id: "15551234567",
+      metadata: {},
+    });
+
+    try {
+      const endpoint = (await provider.probe(context)).details
+        .find((detail) => detail.startsWith("webhook endpoint "))
+        ?.replace("webhook endpoint ", "");
+      expect(endpoint).toBeDefined();
+
+      const verified = await fetch(
+        `${endpoint}?hub.mode=subscribe&hub.verify_token=configured-verify-token&hub.challenge=challenge-123`,
+      );
+      expect(verified.status).toBe(200);
+      await expect(verified.text()).resolves.toBe("challenge-123");
+
+      const forbidden = await fetch(
+        `${endpoint}?hub.mode=subscribe&hub.verify_token=wrong&hub.challenge=challenge-123`,
+      );
+      expect(forbidden.status).toBe(403);
+
+      const body = JSON.stringify({
+        entry: [
+          {
+            changes: [
+              {
+                value: {
+                  messages: [
+                    {
+                      from: "15551234567",
+                      id: "wamid.signed",
+                      text: { body: "signed webhook" },
+                      type: "text",
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
       });
-      await expect(
-        provider.waitForInbound({
-          ...context,
-          nonce,
-          since,
-          threadId: "15557654321",
-          timeoutMs: 500,
-        }),
-      ).resolves.toMatchObject({
-        id: "wamid.second",
-        text: `second valid ${nonce}`,
+      const unsigned = await fetch(endpoint!, {
+        body,
+        headers: { "content-type": "application/json" },
+        method: "POST",
       });
+      expect(unsigned.status).toBe(401);
+      await expect(readFile(config.whatsapp!.recorder.path!, "utf8")).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+
+      const signed = await fetch(endpoint!, {
+        body,
+        headers: {
+          "content-type": "application/json",
+          "x-hub-signature-256": whatsappSignature(body, "configured-app-secret"),
+        },
+        method: "POST",
+      });
+      expect(signed.status).toBe(200);
     } finally {
       await provider.cleanup();
     }

--- a/test/whatsapp-provider.test.ts
+++ b/test/whatsapp-provider.test.ts
@@ -12,7 +12,7 @@ import {
   runLocalMockProviderContract,
 } from "./local-mock-provider-helpers.js";
 
-function whatsappSignature(body: string, signingKey = "local-mock-secret"): string {
+function whatsappSignature(body: string, signingKey = "test-token-placeholder"): string {
   return `sha256=${createHmac("sha256", signingKey).update(body).digest("hex")}`;
 }
 
@@ -171,10 +171,10 @@ describe("WhatsApp webhook normalizer", () => {
 
   it("verifies webhook subscriptions and POST signatures", async () => {
     const config = await createLocalMockConfig("whatsapp", "/whatsapp/webhook");
-    const signingKey = "configured-app-secret";
-    const verificationValue = "configured-verify-token";
-    config.whatsapp!.appSecret = signingKey;
-    Reflect.set(config.whatsapp!, "verifyToken", verificationValue);
+    const signingKey = "test-token-placeholder";
+    const verificationValue = "test-token-placeholder";
+    config.whatsapp!.appSecret = "test-token-placeholder";
+    config.whatsapp!.verifyToken = "test-token-placeholder";
     const provider = new WhatsAppProviderAdapter("whatsapp", config, "crabline");
     const context = createProviderContext("whatsapp", config, {
       id: "15551234567",
@@ -241,6 +241,16 @@ describe("WhatsApp webhook normalizer", () => {
     } finally {
       await provider.cleanup();
     }
+  });
+
+  it("requires explicit webhook authentication configuration", async () => {
+    const config = await createLocalMockConfig("whatsapp", "/whatsapp/webhook");
+    delete config.whatsapp!.appSecret;
+    delete config.whatsapp!.verifyToken;
+
+    expect(() => new WhatsAppProviderAdapter("whatsapp", config, "crabline")).toThrow(
+      "requires appSecret and verifyToken",
+    );
   });
 
   it("rejects a secondary probe when the webhook listener is occupied", async () => {


### PR DESCRIPTION
## Summary
- authenticate WhatsApp verification and webhook deliveries with explicit credentials
- preserve Slack channel/thread scope and validate Telegram command entities
- cancel silent script watches and redact configured secrets from diagnostics
- update channel setup documentation and changelog entries

## Verification
- autoreview: clean, gpt-5.6-sol high, confidence 0.86
- reviewed synthetic redacted base with exact head-tree equality
- Crabbox: `run_6818faebb5cf`
- `pnpm verify`: 49 files, 412 tests