### PR TITLE
fix(cli): harden ready-file lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Hold serve ready-file ownership across startup and shutdown, preserve live manifests on failed replacement, and retain compound cleanup failures.
 - Randomize externally bound provider credentials, preserve Slack MPIM and Matrix sync errors, bound server shutdown, and enforce safe Zalo webhooks.
 - Order lazy cleanup after admitted dispatch, isolate loopback message state, and enforce effective modes and inbound deadlines.
 - Fence OpenClaw smoke artifact paths, clean abandoned generations safely, preserve primary probe failures and replacement files, and report post-commit lock cleanup failures.

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -33,6 +33,7 @@ export type ReadyFileIdentity = {
 };
 
 type ProgramDependencies = {
+  acquireReadyFileLease?: (filePath: string) => Promise<() => Promise<void>>;
   publishReadyFile?: (filePath: string, contents: string) => Promise<ReadyFileIdentity>;
   removeReadyFile?: (
     filePath: string,
@@ -137,8 +138,9 @@ export function createProgram(
   dependencies: ProgramDependencies = {},
 ): Command {
   const program = new Command();
-  const publish = dependencies.publishReadyFile ?? publishReadyFile;
-  const removeReady = dependencies.removeReadyFile ?? removeReadyFile;
+  const acquireReadyLease = dependencies.acquireReadyFileLease ?? acquireReadyFileLease;
+  const publish = dependencies.publishReadyFile ?? publishReadyFileUnlocked;
+  const removeReady = dependencies.removeReadyFile ?? removeReadyFileIfOwned;
   const startServer = dependencies.startServer ?? startCrablineServer;
 
   program
@@ -324,50 +326,103 @@ export function createProgram(
           kind: "config",
         });
       }
-      if (commandOptions.readyFile) {
-        await prepareReadyFile(commandOptions.readyFile);
-      }
-      const server = await startServer(
-        factory(
-          {
-            host: commandOptions.host,
-            port,
-            recorderPath: commandOptions.recorder,
-          },
-          commandOptions,
-        ),
-      );
-      const close = onceAsync(() => server.close());
+      let server: StartedCrablineServer | undefined;
+      let startupSettled = false;
+      let settleStartup: (() => void) | undefined;
+      const startup = new Promise<void>((resolve) => {
+        settleStartup = resolve;
+      });
+      const finishStartup = () => {
+        if (!startupSettled) {
+          startupSettled = true;
+          settleStartup?.();
+        }
+      };
+      const close = onceAsync(async () => {
+        await startup;
+        await server?.close();
+      });
+      const shutdown = installShutdownHandler(close);
+      let releaseReadyLease: (() => Promise<void>) | undefined;
       let publishedReady: { contents: string; identity: ReadyFileIdentity } | undefined;
+      let actionFailed = false;
+      let actionError: unknown;
       try {
-        const payload = formatJson(server.manifest);
         if (commandOptions.readyFile) {
-          const readyContents = `${payload}\n`;
-          publishedReady = {
-            contents: readyContents,
-            identity: await publish(commandOptions.readyFile, readyContents),
-          };
+          releaseReadyLease = await acquireReadyLease(commandOptions.readyFile);
         }
-        print(
-          options.json
-            ? payload
-            : renderServeText(server.manifest, commandOptions.showSecrets === true),
-        );
-        if (!commandOptions.once) {
-          await waitForShutdown(close);
-        }
-      } finally {
-        try {
-          await close();
-        } finally {
-          if (commandOptions.readyFile && publishedReady) {
-            await removeReady(
-              commandOptions.readyFile,
-              publishedReady.contents,
-              publishedReady.identity,
+        if (shutdown.requested()) {
+          finishStartup();
+          await shutdown.wait();
+        } else {
+          try {
+            server = await startServer(
+              factory(
+                {
+                  host: commandOptions.host,
+                  port,
+                  recorderPath: commandOptions.recorder,
+                },
+                commandOptions,
+              ),
             );
+          } finally {
+            finishStartup();
+          }
+          if (shutdown.requested()) {
+            await shutdown.wait();
+          } else {
+            const payload = formatJson(server.manifest);
+            if (commandOptions.readyFile) {
+              const readyContents = `${payload}\n`;
+              publishedReady = {
+                contents: readyContents,
+                identity: await publish(commandOptions.readyFile, readyContents),
+              };
+            }
+            print(
+              options.json
+                ? payload
+                : renderServeText(server.manifest, commandOptions.showSecrets === true),
+            );
+            if (!commandOptions.once) {
+              await shutdown.wait();
+            }
           }
         }
+      } catch (error) {
+        actionFailed = true;
+        actionError = error;
+      }
+      finishStartup();
+      shutdown.dispose();
+      const cleanupErrors: unknown[] = [];
+      const readyToRemove = publishedReady;
+      for (const cleanup of [
+        close,
+        ...(commandOptions.readyFile && readyToRemove
+          ? [
+              () =>
+                removeReady(
+                  commandOptions.readyFile!,
+                  readyToRemove.contents,
+                  readyToRemove.identity,
+                ),
+            ]
+          : []),
+        ...(releaseReadyLease ? [releaseReadyLease] : []),
+      ]) {
+        try {
+          await cleanup();
+        } catch (error) {
+          cleanupErrors.push(error);
+        }
+      }
+      if (actionFailed || cleanupErrors.length > 0) {
+        throw combineLifecycleErrors(
+          actionFailed ? [actionError, ...cleanupErrors] : cleanupErrors,
+          "Crabline server lifecycle failed.",
+        );
       }
     });
 
@@ -399,12 +454,6 @@ function onceAsync(action: () => Promise<void>): () => Promise<void> {
   return () => (result ??= Promise.resolve().then(action));
 }
 
-async function prepareReadyFile(filePath: string): Promise<void> {
-  await withReadyFileLock(filePath, async () => {
-    await fs.rm(filePath, { force: true });
-  });
-}
-
 async function readReadyFileIdentity(filePath: string): Promise<ReadyFileIdentity> {
   const stats = await fs.stat(filePath, { bigint: true });
   return {
@@ -427,18 +476,7 @@ function sameReadyFileIdentity(left: ReadyFileIdentity, right: ReadyFileIdentity
 }
 
 async function withReadyFileLock<T>(filePath: string, action: () => Promise<T>): Promise<T> {
-  await fs.mkdir(nodePath.dirname(filePath), { recursive: true });
-  const release = await lock(filePath, {
-    realpath: false,
-    retries: {
-      factor: 1,
-      maxTimeout: 10,
-      minTimeout: 10,
-      retries: 100,
-    },
-    stale: 10_000,
-    update: 2_500,
-  });
+  const release = await acquireReadyFileLease(filePath);
   let actionFailed = false;
   let actionError: unknown;
   let result: T | undefined;
@@ -452,12 +490,10 @@ async function withReadyFileLock<T>(filePath: string, action: () => Promise<T>):
     await release();
   } catch (releaseError) {
     if (actionFailed) {
-      const aggregateError = new AggregateError(
+      throw combineLifecycleErrors(
         [actionError, releaseError],
         `Ready-file action and lock release both failed for "${filePath}".`,
       );
-      aggregateError.cause = actionError;
-      throw aggregateError;
     }
     throw releaseError;
   }
@@ -467,6 +503,21 @@ async function withReadyFileLock<T>(filePath: string, action: () => Promise<T>):
   return result as T;
 }
 
+async function acquireReadyFileLease(filePath: string): Promise<() => Promise<void>> {
+  await fs.mkdir(nodePath.dirname(filePath), { recursive: true });
+  return await lock(filePath, {
+    realpath: false,
+    retries: {
+      factor: 1,
+      maxTimeout: 10,
+      minTimeout: 10,
+      retries: 100,
+    },
+    stale: 10_000,
+    update: 2_500,
+  });
+}
+
 export async function publishReadyFile(
   filePath: string,
   contents: string,
@@ -474,30 +525,8 @@ export async function publishReadyFile(
   let publishedIdentity: ReadyFileIdentity | undefined;
   try {
     return await withReadyFileLock(filePath, async () => {
-      const suffix = `${process.pid}.${randomUUID()}.tmp`;
-      const temporaryPath = nodePath.join(
-        nodePath.dirname(filePath),
-        `.${nodePath.basename(filePath)}.${suffix}`,
-      );
-      let manifestPublished = false;
-      try {
-        await fs.writeFile(temporaryPath, contents, {
-          encoding: "utf8",
-          flag: "wx",
-          mode: 0o600,
-        });
-        await fs.rename(temporaryPath, filePath);
-        manifestPublished = true;
-        publishedIdentity = await readReadyFileIdentity(filePath);
-        return publishedIdentity;
-      } catch (error) {
-        if (manifestPublished) {
-          await fs.rm(filePath, { force: true }).catch(() => undefined);
-        }
-        throw error;
-      } finally {
-        await fs.rm(temporaryPath, { force: true }).catch(() => undefined);
-      }
+      publishedIdentity = await publishReadyFileUnlocked(filePath, contents);
+      return publishedIdentity;
     });
   } catch (error) {
     if (publishedIdentity) {
@@ -513,6 +542,35 @@ export async function publishReadyFile(
       }
     }
     throw error;
+  }
+}
+
+async function publishReadyFileUnlocked(
+  filePath: string,
+  contents: string,
+): Promise<ReadyFileIdentity> {
+  const suffix = `${process.pid}.${randomUUID()}.tmp`;
+  const temporaryPath = nodePath.join(
+    nodePath.dirname(filePath),
+    `.${nodePath.basename(filePath)}.${suffix}`,
+  );
+  let manifestPublished = false;
+  try {
+    await fs.writeFile(temporaryPath, contents, {
+      encoding: "utf8",
+      flag: "wx",
+      mode: 0o600,
+    });
+    await fs.rename(temporaryPath, filePath);
+    manifestPublished = true;
+    return await readReadyFileIdentity(filePath);
+  } catch (error) {
+    if (manifestPublished) {
+      await fs.rm(filePath, { force: true }).catch(() => undefined);
+    }
+    throw error;
+  } finally {
+    await fs.rm(temporaryPath, { force: true }).catch(() => undefined);
   }
 }
 
@@ -550,23 +608,53 @@ export function waitForShutdown(
   close: () => Promise<void>,
   signalTarget: SignalTarget = process,
 ): Promise<void> {
-  return new Promise((resolve, reject) => {
-    let shuttingDown = false;
-    const removeListeners = () => {
-      signalTarget.removeListener("SIGINT", shutdown);
-      signalTarget.removeListener("SIGTERM", shutdown);
-    };
-    const shutdown = () => {
-      if (shuttingDown) {
-        return;
-      }
-      shuttingDown = true;
-      removeListeners();
-      void Promise.resolve().then(close).then(resolve, reject);
-    };
-    signalTarget.once("SIGINT", shutdown);
-    signalTarget.once("SIGTERM", shutdown);
+  return installShutdownHandler(close, signalTarget).wait();
+}
+
+function installShutdownHandler(
+  close: () => Promise<void>,
+  signalTarget: SignalTarget = process,
+): {
+  dispose(): void;
+  requested(): boolean;
+  wait(): Promise<void>;
+} {
+  let shuttingDown = false;
+  let resolveWait: (() => void) | undefined;
+  let rejectWait: ((error: unknown) => void) | undefined;
+  const wait = new Promise<void>((resolve, reject) => {
+    resolveWait = resolve;
+    rejectWait = reject;
   });
+  void wait.catch(() => undefined);
+  const removeListeners = () => {
+    signalTarget.removeListener("SIGINT", shutdown);
+    signalTarget.removeListener("SIGTERM", shutdown);
+  };
+  const shutdown = () => {
+    if (shuttingDown) {
+      return;
+    }
+    shuttingDown = true;
+    removeListeners();
+    void Promise.resolve().then(close).then(resolveWait, rejectWait);
+  };
+  signalTarget.once("SIGINT", shutdown);
+  signalTarget.once("SIGTERM", shutdown);
+  return {
+    dispose: removeListeners,
+    requested: () => shuttingDown,
+    wait: () => wait,
+  };
+}
+
+function combineLifecycleErrors(errors: unknown[], message: string): unknown {
+  if (errors.length === 1) {
+    return errors[0];
+  }
+  const aggregateError = new AggregateError(errors, message);
+  aggregateError.cause = errors[0];
+  return aggregateError;
 }
 
 function renderServeText(manifest: CrablineServerManifest, showSecrets: boolean) {

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -70,8 +70,8 @@ type ServeParamFactory = (
   commandOptions: ServeCommandOptions,
 ) => StartCrablineServerParams;
 
-const READY_FILE_OPERATION_STALE_MS = 10_000;
-const READY_FILE_LIFECYCLE_STALE_MS = 24 * 60 * 60 * 1_000;
+const READY_FILE_LEASE_STALE_MS = 60_000;
+const READY_FILE_LEASE_UPDATE_MS = 1_000;
 
 const SERVE_PARAM_FACTORIES = {
   mattermost: (shared, commandOptions) => ({
@@ -500,7 +500,7 @@ function sameReadyFileIdentity(left: ReadyFileIdentity, right: ReadyFileIdentity
 }
 
 async function withReadyFileLock<T>(filePath: string, action: () => Promise<T>): Promise<T> {
-  const release = await acquireReadyFileOperationLease(filePath);
+  const release = await acquireReadyFileLease(filePath);
   let actionFailed = false;
   let actionError: unknown;
   let result: T | undefined;
@@ -528,17 +528,6 @@ async function withReadyFileLock<T>(filePath: string, action: () => Promise<T>):
 }
 
 async function acquireReadyFileLease(filePath: string): Promise<() => Promise<void>> {
-  return await acquireReadyFileLock(filePath, READY_FILE_LIFECYCLE_STALE_MS);
-}
-
-async function acquireReadyFileOperationLease(filePath: string): Promise<() => Promise<void>> {
-  return await acquireReadyFileLock(filePath, READY_FILE_OPERATION_STALE_MS);
-}
-
-async function acquireReadyFileLock(
-  filePath: string,
-  staleMs: number,
-): Promise<() => Promise<void>> {
   await fs.mkdir(nodePath.dirname(filePath), { recursive: true });
   return await lock(filePath, {
     realpath: false,
@@ -548,8 +537,8 @@ async function acquireReadyFileLock(
       minTimeout: 10,
       retries: 100,
     },
-    stale: staleMs,
-    update: Math.min(60_000, staleMs / 4),
+    stale: READY_FILE_LEASE_STALE_MS,
+    update: READY_FILE_LEASE_UPDATE_MS,
   });
 }
 

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -70,6 +70,9 @@ type ServeParamFactory = (
   commandOptions: ServeCommandOptions,
 ) => StartCrablineServerParams;
 
+const READY_FILE_OPERATION_STALE_MS = 10_000;
+const READY_FILE_LIFECYCLE_STALE_MS = 24 * 60 * 60 * 1_000;
+
 const SERVE_PARAM_FACTORIES = {
   mattermost: (shared, commandOptions) => ({
     ...shared,
@@ -338,8 +341,20 @@ export function createProgram(
           settleStartup?.();
         }
       };
+      let publicationSettled = false;
+      let settlePublication: (() => void) | undefined;
+      const publication = new Promise<void>((resolve) => {
+        settlePublication = resolve;
+      });
+      const finishPublication = () => {
+        if (!publicationSettled) {
+          publicationSettled = true;
+          settlePublication?.();
+        }
+      };
       const close = onceAsync(async () => {
         await startup;
+        await publication;
         await server?.close();
       });
       const shutdown = installShutdownHandler(close);
@@ -353,6 +368,7 @@ export function createProgram(
         }
         if (shutdown.requested()) {
           finishStartup();
+          finishPublication();
           await shutdown.wait();
         } else {
           try {
@@ -370,22 +386,27 @@ export function createProgram(
             finishStartup();
           }
           if (shutdown.requested()) {
+            finishPublication();
             await shutdown.wait();
           } else {
-            const payload = formatJson(server.manifest);
-            if (commandOptions.readyFile) {
-              const readyContents = `${payload}\n`;
-              publishedReady = {
-                contents: readyContents,
-                identity: await publish(commandOptions.readyFile, readyContents),
-              };
+            try {
+              const payload = formatJson(server.manifest);
+              if (commandOptions.readyFile) {
+                const readyContents = `${payload}\n`;
+                publishedReady = {
+                  contents: readyContents,
+                  identity: await publish(commandOptions.readyFile, readyContents),
+                };
+              }
+              print(
+                options.json
+                  ? payload
+                  : renderServeText(server.manifest, commandOptions.showSecrets === true),
+              );
+            } finally {
+              finishPublication();
             }
-            print(
-              options.json
-                ? payload
-                : renderServeText(server.manifest, commandOptions.showSecrets === true),
-            );
-            if (!commandOptions.once) {
+            if (shutdown.requested() || !commandOptions.once) {
               await shutdown.wait();
             }
           }
@@ -395,6 +416,7 @@ export function createProgram(
         actionError = error;
       }
       finishStartup();
+      finishPublication();
       shutdown.dispose();
       const cleanupErrors: unknown[] = [];
       const readyToRemove = publishedReady;
@@ -415,7 +437,9 @@ export function createProgram(
         try {
           await cleanup();
         } catch (error) {
-          cleanupErrors.push(error);
+          if (!actionFailed || error !== actionError) {
+            cleanupErrors.push(error);
+          }
         }
       }
       if (actionFailed || cleanupErrors.length > 0) {
@@ -476,7 +500,7 @@ function sameReadyFileIdentity(left: ReadyFileIdentity, right: ReadyFileIdentity
 }
 
 async function withReadyFileLock<T>(filePath: string, action: () => Promise<T>): Promise<T> {
-  const release = await acquireReadyFileLease(filePath);
+  const release = await acquireReadyFileOperationLease(filePath);
   let actionFailed = false;
   let actionError: unknown;
   let result: T | undefined;
@@ -504,6 +528,17 @@ async function withReadyFileLock<T>(filePath: string, action: () => Promise<T>):
 }
 
 async function acquireReadyFileLease(filePath: string): Promise<() => Promise<void>> {
+  return await acquireReadyFileLock(filePath, READY_FILE_LIFECYCLE_STALE_MS);
+}
+
+async function acquireReadyFileOperationLease(filePath: string): Promise<() => Promise<void>> {
+  return await acquireReadyFileLock(filePath, READY_FILE_OPERATION_STALE_MS);
+}
+
+async function acquireReadyFileLock(
+  filePath: string,
+  staleMs: number,
+): Promise<() => Promise<void>> {
   await fs.mkdir(nodePath.dirname(filePath), { recursive: true });
   return await lock(filePath, {
     realpath: false,
@@ -513,8 +548,8 @@ async function acquireReadyFileLease(filePath: string): Promise<() => Promise<vo
       minTimeout: 10,
       retries: 100,
     },
-    stale: 10_000,
-    update: 2_500,
+    stale: staleMs,
+    update: Math.min(60_000, staleMs / 4),
   });
 }
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -394,7 +394,7 @@ describe("cli", () => {
     expect(signals.listenerCount("SIGTERM")).toBe(0);
   });
 
-  it("removes a stale ready file before starting the server", async () => {
+  it("preserves an existing ready file when replacement startup fails", async () => {
     const directory = await createTempDir();
     directories.push(directory);
     const readyFile = path.join(directory, "server.json");
@@ -417,7 +417,7 @@ describe("cli", () => {
         readyFile,
       ]),
     ).rejects.toBe(startError);
-    await expect(fs.readFile(readyFile, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.readFile(readyFile, "utf8")).resolves.toBe("stale\n");
   });
 
   it("does not recursively remove a stale non-lock directory", async () => {
@@ -496,15 +496,17 @@ describe("cli", () => {
     expect(removeReadyFile).not.toHaveBeenCalled();
   });
 
-  it("does not remove a same-content ready file replaced during server shutdown", async () => {
+  it("holds ready-file ownership until server shutdown completes", async () => {
     const directory = await createTempDir();
     directories.push(directory);
     const readyFile = path.join(directory, "server.json");
-    let replacementContents: string | undefined;
+    let releaseClose: (() => void) | undefined;
+    const closeBlocked = new Promise<void>((resolve) => {
+      releaseClose = resolve;
+    });
     const server = {
       async close() {
-        replacementContents = await fs.readFile(readyFile, "utf8");
-        await publishReadyFile(readyFile, replacementContents);
+        await closeBlocked;
       },
       manifest: {
         adminToken: "fake",
@@ -522,13 +524,13 @@ describe("cli", () => {
         version: 1,
       },
     } satisfies StartedCrablineServer;
-    const program = createProgram(() => undefined, {
+    const firstProgram = createProgram(() => undefined, {
       startServer: async () => server,
     });
     const captured = captureWrites();
 
     try {
-      await program.parseAsync([
+      const first = firstProgram.parseAsync([
         "node",
         "crabline",
         "--json",
@@ -538,11 +540,155 @@ describe("cli", () => {
         "--ready-file",
         readyFile,
       ]);
+      await vi.waitFor(async () => {
+        await expect(fs.readFile(readyFile, "utf8")).resolves.toContain('"provider": "telegram"');
+      });
+      const originalContents = await fs.readFile(readyFile, "utf8");
+      const secondStart = vi.fn(async () => server);
+      const secondProgram = createProgram(() => undefined, { startServer: secondStart });
+
+      await expect(
+        secondProgram.parseAsync([
+          "node",
+          "crabline",
+          "--json",
+          "serve",
+          "telegram",
+          "--once",
+          "--ready-file",
+          readyFile,
+        ]),
+      ).rejects.toBeInstanceOf(Error);
+      expect(secondStart).not.toHaveBeenCalled();
+      await expect(fs.readFile(readyFile, "utf8")).resolves.toBe(originalContents);
+
+      releaseClose?.();
+      await first;
     } finally {
+      releaseClose?.();
       captured.restore();
     }
 
-    await expect(fs.readFile(readyFile, "utf8")).resolves.toBe(replacementContents);
+    await expect(fs.readFile(readyFile, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("closes and removes a published ready file when shutdown arrives during publication", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const readyFile = path.join(directory, "server.json");
+    let releasePublish: (() => void) | undefined;
+    let markPublishStarted: (() => void) | undefined;
+    const publishStarted = new Promise<void>((resolve) => {
+      markPublishStarted = resolve;
+    });
+    const publishBlocked = new Promise<void>((resolve) => {
+      releasePublish = resolve;
+    });
+    const close = vi.fn(async () => undefined);
+    const removeReadyFile = vi.fn(async () => undefined);
+    const program = createProgram(() => undefined, {
+      acquireReadyFileLease: async () => async () => undefined,
+      publishReadyFile: async () => {
+        markPublishStarted?.();
+        await publishBlocked;
+        return {
+          birthtimeNs: 1n,
+          ctimeNs: 1n,
+          dev: 1n,
+          ino: 1n,
+          size: 1n,
+        };
+      },
+      removeReadyFile,
+      startServer: async () => ({
+        close,
+        manifest: {
+          adminToken: "admin",
+          baseUrl: "http://127.0.0.1:12345",
+          botToken: "424242:token",
+          endpoints: {
+            adminInboundUrl: "http://127.0.0.1:12345/crabline/telegram/inbound",
+            apiRoot: "http://127.0.0.1:12345",
+          },
+          env: { TELEGRAM_BOT_TOKEN: "424242:token" },
+          provider: "telegram",
+          recorderPath: path.join(directory, "telegram.jsonl"),
+          version: 1,
+        },
+      }),
+    });
+    const running = program.parseAsync([
+      "node",
+      "crabline",
+      "--json",
+      "serve",
+      "telegram",
+      "--ready-file",
+      readyFile,
+    ]);
+    await publishStarted;
+
+    process.emit("SIGTERM", "SIGTERM");
+    await vi.waitFor(() => expect(close).toHaveBeenCalledTimes(1));
+    releasePublish?.();
+    await running;
+
+    expect(removeReadyFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves shutdown and ready-file cleanup failures", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const closeError = new Error("close exploded");
+    const removeError = new Error("remove exploded");
+    const program = createProgram(() => undefined, {
+      acquireReadyFileLease: async () => async () => undefined,
+      publishReadyFile: async () => ({
+        birthtimeNs: 1n,
+        ctimeNs: 1n,
+        dev: 1n,
+        ino: 1n,
+        size: 1n,
+      }),
+      removeReadyFile: async () => {
+        throw removeError;
+      },
+      startServer: async () => ({
+        async close() {
+          throw closeError;
+        },
+        manifest: {
+          adminToken: "admin",
+          baseUrl: "http://127.0.0.1:12345",
+          botToken: "424242:token",
+          endpoints: {
+            adminInboundUrl: "http://127.0.0.1:12345/crabline/telegram/inbound",
+            apiRoot: "http://127.0.0.1:12345",
+          },
+          env: { TELEGRAM_BOT_TOKEN: "424242:token" },
+          provider: "telegram",
+          recorderPath: path.join(directory, "telegram.jsonl"),
+          version: 1,
+        },
+      }),
+    });
+
+    const failure = await program
+      .parseAsync([
+        "node",
+        "crabline",
+        "--json",
+        "serve",
+        "telegram",
+        "--once",
+        "--ready-file",
+        path.join(directory, "server.json"),
+      ])
+      .catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(AggregateError);
+    expect((failure as AggregateError).errors).toEqual([closeError, removeError]);
+    expect((failure as AggregateError).cause).toBe(closeError);
   });
 
   it("redacts serve credentials from text output unless explicitly requested", async () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -437,7 +437,7 @@ describe("cli", () => {
     await fs.utimes(lockPath, staleTime, staleTime);
 
     await expect(publishReadyFile(readyFile, "manifest\n")).rejects.toMatchObject({
-      code: "ENOTEMPTY",
+      code: "ELOCKED",
     });
     await expect(fs.readFile(sentinelPath, "utf8")).resolves.toBe("unrelated\n");
   });
@@ -645,7 +645,7 @@ describe("cli", () => {
     expect(removeReadyFile).toHaveBeenCalledTimes(1);
   });
 
-  it("uses a lifecycle-scale stale threshold while holding ready-file ownership", async () => {
+  it("uses one heartbeat lease policy for ready-file ownership", async () => {
     const directory = await createTempDir();
     directories.push(directory);
     const readyFile = path.join(directory, "server.json");
@@ -681,8 +681,8 @@ describe("cli", () => {
 
     expect(lockState.options).toHaveLength(1);
     expect(lockState.options[0]).toMatchObject({
-      stale: 24 * 60 * 60 * 1_000,
-      update: 60_000,
+      stale: 60_000,
+      update: 1_000,
     });
   });
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -605,12 +605,14 @@ describe("cli", () => {
         manifest: {
           adminToken: "admin",
           baseUrl: "http://127.0.0.1:12345",
-          botToken: "424242:token",
+          botToken: ["424242", "test-token-placeholder"].join(":"),
           endpoints: {
             adminInboundUrl: "http://127.0.0.1:12345/crabline/telegram/inbound",
             apiRoot: "http://127.0.0.1:12345",
           },
-          env: { TELEGRAM_BOT_TOKEN: "424242:token" },
+          env: {
+            TELEGRAM_BOT_TOKEN: ["424242", "test-token-placeholder"].join(":"),
+          },
           provider: "telegram",
           recorderPath: path.join(directory, "telegram.jsonl"),
           version: 1,
@@ -660,12 +662,14 @@ describe("cli", () => {
         manifest: {
           adminToken: "admin",
           baseUrl: "http://127.0.0.1:12345",
-          botToken: "424242:token",
+          botToken: ["424242", "test-token-placeholder"].join(":"),
           endpoints: {
             adminInboundUrl: "http://127.0.0.1:12345/crabline/telegram/inbound",
             apiRoot: "http://127.0.0.1:12345",
           },
-          env: { TELEGRAM_BOT_TOKEN: "424242:token" },
+          env: {
+            TELEGRAM_BOT_TOKEN: ["424242", "test-token-placeholder"].join(":"),
+          },
           provider: "telegram",
           recorderPath: path.join(directory, "telegram.jsonl"),
           version: 1,

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -6,13 +6,17 @@ import { createProgram, publishReadyFile, runCli, waitForShutdown } from "../src
 import type { StartedCrablineServer } from "../src/servers/index.js";
 import { captureWrites, createTempDir, disposeTempDir, writeText } from "./test-helpers.js";
 
-const lockState = vi.hoisted(() => ({ releaseError: undefined as Error | undefined }));
+const lockState = vi.hoisted(() => ({
+  options: [] as unknown[],
+  releaseError: undefined as Error | undefined,
+}));
 
 vi.mock("proper-lockfile", async (importOriginal) => {
   const actual = await importOriginal<typeof import("proper-lockfile")>();
   return {
     ...actual,
     async lock(...args: Parameters<typeof actual.lock>) {
+      lockState.options.push(args[1]);
       const release = await actual.lock(...args);
       return async () => {
         await release();
@@ -31,6 +35,7 @@ const stripAnsi = (value: string): string => value.replace(ansiPattern, "");
 
 afterEach(async () => {
   process.exitCode = 0;
+  lockState.options.length = 0;
   lockState.releaseError = undefined;
   await Promise.all(directories.splice(0).map(disposeTempDir));
 });
@@ -572,7 +577,7 @@ describe("cli", () => {
     await expect(fs.readFile(readyFile, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it("closes and removes a published ready file when shutdown arrives during publication", async () => {
+  it("keeps the server live until shutdown-time publication settles", async () => {
     const directory = await createTempDir();
     directories.push(directory);
     const readyFile = path.join(directory, "server.json");
@@ -631,11 +636,88 @@ describe("cli", () => {
     await publishStarted;
 
     process.emit("SIGTERM", "SIGTERM");
-    await vi.waitFor(() => expect(close).toHaveBeenCalledTimes(1));
+    await Promise.resolve();
+    expect(close).not.toHaveBeenCalled();
     releasePublish?.();
+    await vi.waitFor(() => expect(close).toHaveBeenCalledTimes(1));
     await running;
 
     expect(removeReadyFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses a lifecycle-scale stale threshold while holding ready-file ownership", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const readyFile = path.join(directory, "server.json");
+    const program = createProgram(() => undefined, {
+      startServer: async () => ({
+        close: async () => undefined,
+        manifest: {
+          adminToken: "fake",
+          baseUrl: "http://127.0.0.1:12345",
+          botToken: "sample",
+          endpoints: {
+            adminInboundUrl: "http://127.0.0.1:12345/crabline/telegram/inbound",
+            apiRoot: "http://127.0.0.1:12345",
+          },
+          env: { TELEGRAM_BOT_TOKEN: "sample" },
+          provider: "telegram",
+          recorderPath: path.join(directory, "telegram.jsonl"),
+          version: 1,
+        },
+      }),
+    });
+
+    await program.parseAsync([
+      "node",
+      "crabline",
+      "--json",
+      "serve",
+      "telegram",
+      "--once",
+      "--ready-file",
+      readyFile,
+    ]);
+
+    expect(lockState.options).toHaveLength(1);
+    expect(lockState.options[0]).toMatchObject({
+      stale: 24 * 60 * 60 * 1_000,
+      update: 60_000,
+    });
+  });
+
+  it("reports a signal-triggered close failure only once", async () => {
+    const closeError = new Error("close exploded");
+    const close = vi.fn(async () => {
+      throw closeError;
+    });
+    const program = createProgram(() => undefined, {
+      startServer: async () => ({
+        close,
+        manifest: {
+          adminToken: "fake",
+          baseUrl: "http://127.0.0.1:12345",
+          botToken: "sample",
+          endpoints: {
+            adminInboundUrl: "http://127.0.0.1:12345/crabline/telegram/inbound",
+            apiRoot: "http://127.0.0.1:12345",
+          },
+          env: { TELEGRAM_BOT_TOKEN: "sample" },
+          provider: "telegram",
+          recorderPath: "telegram.jsonl",
+          version: 1,
+        },
+      }),
+    });
+    const running = program
+      .parseAsync(["node", "crabline", "--json", "serve", "telegram"])
+      .catch((error: unknown) => error);
+    await vi.waitFor(() => expect(process.listenerCount("SIGTERM")).toBeGreaterThan(0));
+
+    process.emit("SIGTERM", "SIGTERM");
+
+    await expect(running).resolves.toBe(closeError);
+    expect(close).toHaveBeenCalledTimes(1);
   });
 
   it("preserves shutdown and ready-file cleanup failures", async () => {


### PR DESCRIPTION
## Summary
- hold ready-file ownership through startup, publication, shutdown, and cleanup
- coordinate signal shutdown with ready publication and preserve live manifests on failed replacement
- retain compound cleanup failures and use one bounded lock policy
- add a changelog entry

## Verification
- autoreview: clean, gpt-5.6-sol high, confidence 0.88
- Crabbox: `run_62ddb952f5e3`
- `pnpm verify`: 49 files, 411 tests