### PR TITLE
fix(servers): harden protocol and release boundaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,11 +31,15 @@ jobs:
       - name: Resolve release tag
         id: release
         env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+          GITHUB_REF_TYPE: ${{ github.ref_type }}
           INPUT_TAG: ${{ inputs.tag_name }}
         run: |
           set -euo pipefail
           tag="${INPUT_TAG:-${GITHUB_REF_NAME}}"
           [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          [[ "$GITHUB_REF_TYPE" == "tag" ]]
+          [[ "$GITHUB_REF_NAME" == "$tag" ]]
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -217,6 +221,7 @@ jobs:
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
+      - run: npm install -g npm@12.0.1
       - name: Download verified release artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.0
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Preserve Slack thread scope and validate Telegram command entities.
 - Authenticate WhatsApp webhook verification and deliveries and reject malformed batches atomically.
 - Cancel silent script watches and redact configured payload secrets from subprocess diagnostics.
+- Bound disconnected inbound queues, expire unauthenticated Mattermost sockets, block mapped private Zalo targets, and enforce absolute webhook deadlines.
 - Reject truncated WhatsApp GCM tags, invalid handshake wire types, and trailing binary-node data.
 - Randomize externally bound provider credentials, preserve Slack MPIM and Matrix sync errors, bound server shutdown, and enforce safe Zalo webhooks.
 - Order lazy cleanup after admitted dispatch, isolate loopback message state, and enforce effective modes and inbound deadlines.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Preserve Slack thread scope and validate Telegram command entities.
 - Authenticate WhatsApp webhook verification and deliveries and reject malformed batches atomically.
 - Cancel silent script watches and redact configured payload secrets from subprocess diagnostics.
+- Bind release provenance to exact tag refs, pin the publish npm client, and align Node types with the Node 22 runtime floor.
 - Sanitize malformed YAML diagnostics without exposing source lines.
 - Bound disconnected inbound queues, expire unauthenticated Mattermost sockets, block mapped private Zalo targets, and enforce absolute webhook deadlines.
 - Reject truncated WhatsApp GCM tags, invalid handshake wire types, and trailing binary-node data.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Preserve Slack thread scope and validate Telegram command entities.
 - Authenticate WhatsApp webhook verification and deliveries and reject malformed batches atomically.
 - Cancel silent script watches and redact configured payload secrets from subprocess diagnostics.
+- Reject truncated WhatsApp GCM tags, invalid handshake wire types, and trailing binary-node data.
 - Randomize externally bound provider credentials, preserve Slack MPIM and Matrix sync errors, bound server shutdown, and enforce safe Zalo webhooks.
 - Order lazy cleanup after admitted dispatch, isolate loopback message state, and enforce effective modes and inbound deadlines.
 - Fence OpenClaw smoke artifact paths, clean abandoned generations safely, preserve primary probe failures and replacement files, and report post-commit lock cleanup failures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Preserve Slack thread scope and validate Telegram command entities.
 - Authenticate WhatsApp webhook verification and deliveries and reject malformed batches atomically.
 - Cancel silent script watches and redact configured payload secrets from subprocess diagnostics.
+- Sanitize malformed YAML diagnostics without exposing source lines.
 - Bound disconnected inbound queues, expire unauthenticated Mattermost sockets, block mapped private Zalo targets, and enforce absolute webhook deadlines.
 - Reject truncated WhatsApp GCM tags, invalid handshake wire types, and trailing binary-node data.
 - Randomize externally bound provider credentials, preserve Slack MPIM and Matrix sync errors, bound server shutdown, and enforce safe Zalo webhooks.

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "check": "pnpm verify"
   },
   "dependencies": {
-    "@types/node": "^26.1.0",
+    "@types/node": "^22.20.1",
     "commander": "^15.0.0",
     "curve25519-js": "^0.0.4",
     "picocolors": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@types/node':
-        specifier: ^26.1.0
-        version: 26.1.0
+        specifier: ^22.20.1
+        version: 22.20.1
       commander:
         specifier: ^15.0.0
         version: 15.0.0
@@ -71,7 +71,7 @@ importers:
         version: '@typescript/typescript6@6.0.2'
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@26.1.0)(@vitest/coverage-v8@4.1.10)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.10(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(vite@8.0.16(@types/node@22.20.1)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0))
 
 packages:
 
@@ -907,6 +907,9 @@ packages:
   '@types/events@3.0.3':
     resolution: {integrity: sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g==}
 
+  '@types/node@22.20.1':
+    resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
+
   '@types/node@26.1.0':
     resolution: {integrity: sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==}
 
@@ -1571,6 +1574,9 @@ packages:
     resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
     engines: {node: '>=18'}
 
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
@@ -2202,6 +2208,10 @@ snapshots:
 
   '@types/events@3.0.3': {}
 
+  '@types/node@22.20.1':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@26.1.0':
     dependencies:
       undici-types: 8.3.0
@@ -2292,7 +2302,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@26.1.0)(@vitest/coverage-v8@4.1.10)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(vite@8.0.16(@types/node@22.20.1)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -2303,13 +2313,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.10(vite@8.0.16(@types/node@22.20.1)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@22.20.1)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -2894,11 +2904,13 @@ snapshots:
 
   uint8array-extras@1.5.0: {}
 
+  undici-types@6.21.0: {}
+
   undici-types@8.3.0: {}
 
   unhomoglyph@1.0.6: {}
 
-  vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0):
+  vite@8.0.16(@types/node@22.20.1)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
@@ -2906,16 +2918,16 @@ snapshots:
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 26.1.0
+      '@types/node': 22.20.1
       esbuild: 0.28.1
       fsevents: 2.3.3
       tsx: 4.23.0
       yaml: 2.9.0
 
-  vitest@4.1.10(@types/node@26.1.0)(@vitest/coverage-v8@4.1.10)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0)):
+  vitest@4.1.10(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(vite@8.0.16(@types/node@22.20.1)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.10(vite@8.0.16(@types/node@22.20.1)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -2932,10 +2944,10 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@26.1.0)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@22.20.1)(esbuild@0.28.1)(tsx@4.23.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 26.1.0
+      '@types/node': 22.20.1
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
     transitivePeerDependencies:
       - msw

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -6,6 +6,30 @@ import { type ManifestDefinition, ManifestSchema } from "./schema.js";
 
 const DEFAULT_CONFIG_CANDIDATES = ["crabline.yaml", "crabline.yml", "crabline.json"] as const;
 
+function configLoadError(resolvedPath: string, error: unknown, detail: string): CrablineError {
+  return new CrablineError(`Unable to load config file "${resolvedPath}": ${detail}`, {
+    cause: error,
+    kind: "config",
+  });
+}
+
+function formatYamlParseError(error: unknown): string {
+  if (!(error instanceof Error) || error.name !== "YAMLParseError") {
+    return "YAML parse failed.";
+  }
+  const yamlError = error as Error & {
+    code?: unknown;
+    linePos?: Array<{ col?: unknown; line?: unknown }>;
+  };
+  const code = typeof yamlError.code === "string" ? ` (${yamlError.code})` : "";
+  const position = yamlError.linePos?.[0];
+  const location =
+    typeof position?.line === "number" && typeof position.col === "number"
+      ? ` at line ${position.line}, column ${position.col}`
+      : "";
+  return `YAML parse error${code}${location}.`;
+}
+
 export async function resolveConfigPath(explicitPath?: string): Promise<string> {
   if (explicitPath) {
     return path.resolve(explicitPath);
@@ -40,17 +64,28 @@ export async function loadManifest(
   configPath?: string,
 ): Promise<{ manifest: ManifestDefinition; path: string }> {
   const resolvedPath = await resolveConfigPath(configPath);
+  let raw: string;
   try {
-    const raw = await readFile(resolvedPath, "utf8");
-    const parsed = resolvedPath.endsWith(".json")
-      ? JSON.parse(raw)
-      : YAML.parse(raw, { merge: true });
+    raw = await readFile(resolvedPath, "utf8");
+  } catch (error) {
+    throw configLoadError(resolvedPath, error, ensureErrorMessage(error));
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = resolvedPath.endsWith(".json") ? JSON.parse(raw) : YAML.parse(raw, { merge: true });
+  } catch (error) {
+    throw configLoadError(
+      resolvedPath,
+      error,
+      resolvedPath.endsWith(".json") ? ensureErrorMessage(error) : formatYamlParseError(error),
+    );
+  }
+
+  try {
     const manifest = ManifestSchema.parse(parsed);
     return { manifest, path: resolvedPath };
   } catch (error) {
-    throw new CrablineError(
-      `Unable to load config file "${resolvedPath}": ${ensureErrorMessage(error)}`,
-      { cause: error, kind: "config" },
-    );
+    throw configLoadError(resolvedPath, error, ensureErrorMessage(error));
   }
 }

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -75,10 +75,13 @@ export async function loadManifest(
   try {
     parsed = resolvedPath.endsWith(".json") ? JSON.parse(raw) : YAML.parse(raw, { merge: true });
   } catch (error) {
+    const detail = resolvedPath.endsWith(".json")
+      ? ensureErrorMessage(error)
+      : formatYamlParseError(error);
     throw configLoadError(
       resolvedPath,
-      error,
-      resolvedPath.endsWith(".json") ? ensureErrorMessage(error) : formatYamlParseError(error),
+      resolvedPath.endsWith(".json") ? error : new Error(detail),
+      detail,
     );
   }
 

--- a/src/servers/mattermost.ts
+++ b/src/servers/mattermost.ts
@@ -182,6 +182,16 @@ function broadcast(state: MattermostServerState, event: MattermostWebSocketEvent
   return true;
 }
 
+function pendingQueueFullResponse(state: MattermostServerState): Response {
+  return jsonResponse(
+    {
+      error: `Pending inbound queue is full (${state.maxPendingInboundEvents} events)`,
+      ok: false,
+    },
+    503,
+  );
+}
+
 function createPost(params: {
   channelId: string;
   message: string;
@@ -217,13 +227,7 @@ async function handleAdminInbound(params: {
     params.state.websocketClients.size === 0 &&
     params.state.pendingEvents.length >= params.state.maxPendingInboundEvents
   ) {
-    return jsonResponse(
-      {
-        error: `Pending inbound queue is full (${params.state.maxPendingInboundEvents} events)`,
-        ok: false,
-      },
-      503,
-    );
+    return pendingQueueFullResponse(params.state);
   }
   const senderName = readTrimmedString(params.body.senderName) ?? senderId;
   const channelType = readTrimmedString(params.body.channelType) ?? "D";
@@ -241,7 +245,10 @@ async function handleAdminInbound(params: {
     state: params.state,
     userId: senderId,
   });
-  broadcast(params.state, postEvent("posted", post, senderName, channelType));
+  if (!broadcast(params.state, postEvent("posted", post, senderName, channelType))) {
+    params.state.posts.delete(post.id);
+    return pendingQueueFullResponse(params.state);
+  }
   return jsonResponse({ ok: true, post });
 }
 
@@ -289,20 +296,24 @@ async function handleApi(params: {
     if (!channelId) {
       return mattermostError("channel_id is required", 400);
     }
-    broadcast(state, {
-      broadcast: eventBroadcast({
-        channelId,
-        omitUsers: { [state.botUserId]: true },
-      }),
-      data: {
-        channel_id: channelId,
-        ...(readTrimmedString(body.parent_id)
-          ? { parent_id: readTrimmedString(body.parent_id) }
-          : {}),
-        user_id: state.botUserId,
-      },
-      event: "typing",
-    });
+    if (
+      !broadcast(state, {
+        broadcast: eventBroadcast({
+          channelId,
+          omitUsers: { [state.botUserId]: true },
+        }),
+        data: {
+          channel_id: channelId,
+          ...(readTrimmedString(body.parent_id)
+            ? { parent_id: readTrimmedString(body.parent_id) }
+            : {}),
+          user_id: state.botUserId,
+        },
+        event: "typing",
+      })
+    ) {
+      return pendingQueueFullResponse(state);
+    }
     return jsonResponse({});
   }
   if (method === "POST" && apiPath === "/posts") {
@@ -319,7 +330,10 @@ async function handleApi(params: {
       userId: state.botUserId,
     });
     const channelType = state.channels.get(channelId)?.type ?? "O";
-    broadcast(state, postEvent("posted", post, state.botUsername, channelType));
+    if (!broadcast(state, postEvent("posted", post, state.botUsername, channelType))) {
+      state.posts.delete(post.id);
+      return pendingQueueFullResponse(state);
+    }
     return jsonResponse(post, 201);
   }
   const postMatch = /^\/posts\/([^/]+)$/u.exec(apiPath);
@@ -330,15 +344,20 @@ async function handleApi(params: {
     }
     const updated = { ...post, message: readTrimmedString(body.message) ?? post.message };
     state.posts.set(updated.id, updated);
-    broadcast(
-      state,
-      postEvent(
-        "post_edited",
-        updated,
-        state.botUsername,
-        state.channels.get(updated.channel_id)?.type ?? "O",
-      ),
-    );
+    if (
+      !broadcast(
+        state,
+        postEvent(
+          "post_edited",
+          updated,
+          state.botUsername,
+          state.channels.get(updated.channel_id)?.type ?? "O",
+        ),
+      )
+    ) {
+      state.posts.set(post.id, post);
+      return pendingQueueFullResponse(state);
+    }
     return jsonResponse(updated);
   }
   if (postMatch?.[1] && method === "DELETE") {
@@ -347,15 +366,20 @@ async function handleApi(params: {
       return mattermostError("Post not found", 404);
     }
     state.posts.delete(post.id);
-    broadcast(
-      state,
-      postEvent(
-        "post_deleted",
-        post,
-        state.botUsername,
-        state.channels.get(post.channel_id)?.type ?? "O",
-      ),
-    );
+    if (
+      !broadcast(
+        state,
+        postEvent(
+          "post_deleted",
+          post,
+          state.botUsername,
+          state.channels.get(post.channel_id)?.type ?? "O",
+        ),
+      )
+    ) {
+      state.posts.set(post.id, post);
+      return pendingQueueFullResponse(state);
+    }
     return new Response(null, { status: 204 });
   }
   return mattermostError("Not found", 404);
@@ -424,7 +448,9 @@ function attachWebSocketServer(params: {
   };
   params.server.on("upgrade", onUpgrade);
   websocketServer.on("connection", (client) => {
+    let authenticationOpen = true;
     const authenticationTimeout = setTimeout(() => {
+      authenticationOpen = false;
       client.close(4001, "authentication timeout");
     }, params.authenticationTimeoutMs);
     authenticationTimeout.unref();
@@ -442,6 +468,9 @@ function attachWebSocketServer(params: {
       }
       const seq = message.seq ?? 0;
       if (!params.state.websocketClients.has(client)) {
+        if (!authenticationOpen || client.readyState !== WebSocket.OPEN) {
+          return;
+        }
         if (
           message.action !== "authentication_challenge" ||
           message.data?.token !== params.state.botToken
@@ -453,10 +482,12 @@ function attachWebSocketServer(params: {
               status: "FAIL",
             }),
           );
+          authenticationOpen = false;
           client.close(4001, "authentication failed");
           return;
         }
         clearTimeout(authenticationTimeout);
+        authenticationOpen = false;
         params.state.websocketClients.set(client, 0);
         client.send(JSON.stringify({ seq_reply: seq, status: "OK" }));
         sendEvent(params.state, client, {
@@ -500,6 +531,7 @@ function attachWebSocketServer(params: {
       );
     });
     client.once("close", () => {
+      authenticationOpen = false;
       clearTimeout(authenticationTimeout);
       params.state.websocketClients.delete(client);
     });

--- a/src/servers/mattermost.ts
+++ b/src/servers/mattermost.ts
@@ -18,7 +18,10 @@ import {
   type ServerRequestEvent,
 } from "./http.js";
 import { recordServerEvent, type ServerEventObserver } from "./recorder.js";
+import { resolveMaxPendingInboundEvents } from "./pending-events.js";
 import { closeWebSocketServer } from "./websocket.js";
+
+const DEFAULT_WEBSOCKET_AUTHENTICATION_TIMEOUT_MS = 5_000;
 
 type MattermostPost = {
   channel_id: string;
@@ -47,6 +50,7 @@ type MattermostServerState = {
   botUserId: string;
   botUsername: string;
   channels: Map<string, { id: string; name: string; display_name: string; type: string }>;
+  maxPendingInboundEvents: number;
   nextPost: number;
   onEvent: ServerEventObserver | undefined;
   pendingEvents: MattermostWebSocketEvent[];
@@ -89,6 +93,8 @@ export type StartMattermostServerParams = {
   onEvent?: ServerEventObserver | undefined;
   port?: number | undefined;
   recorderPath?: string | undefined;
+  maxPendingInboundEvents?: number | undefined;
+  websocketAuthenticationTimeoutMs?: number | undefined;
 };
 
 export function mattermostId(value: string): string {
@@ -162,14 +168,18 @@ function sendEvent(
   state.websocketClients.set(client, seq + 1);
 }
 
-function broadcast(state: MattermostServerState, event: MattermostWebSocketEvent): void {
+function broadcast(state: MattermostServerState, event: MattermostWebSocketEvent): boolean {
   if (state.websocketClients.size === 0) {
+    if (state.pendingEvents.length >= state.maxPendingInboundEvents) {
+      return false;
+    }
     state.pendingEvents.push(event);
-    return;
+    return true;
   }
   for (const client of state.websocketClients.keys()) {
     sendEvent(state, client, event);
   }
+  return true;
 }
 
 function createPost(params: {
@@ -202,6 +212,18 @@ async function handleAdminInbound(params: {
   const text = readTrimmedString(params.body.text ?? params.body.message);
   if (!channelId || !senderId || !text) {
     return jsonResponse({ error: "channelId, senderId, and text are required", ok: false }, 400);
+  }
+  if (
+    params.state.websocketClients.size === 0 &&
+    params.state.pendingEvents.length >= params.state.maxPendingInboundEvents
+  ) {
+    return jsonResponse(
+      {
+        error: `Pending inbound queue is full (${params.state.maxPendingInboundEvents} events)`,
+        ok: false,
+      },
+      503,
+    );
   }
   const senderName = readTrimmedString(params.body.senderName) ?? senderId;
   const channelType = readTrimmedString(params.body.channelType) ?? "D";
@@ -382,6 +404,7 @@ async function handleRequest(request: IncomingMessage, state: MattermostServerSt
 }
 
 function attachWebSocketServer(params: {
+  authenticationTimeoutMs: number;
   state: MattermostServerState;
   server: import("node:http").Server;
 }) {
@@ -401,6 +424,10 @@ function attachWebSocketServer(params: {
   };
   params.server.on("upgrade", onUpgrade);
   websocketServer.on("connection", (client) => {
+    const authenticationTimeout = setTimeout(() => {
+      client.close(4001, "authentication timeout");
+    }, params.authenticationTimeoutMs);
+    authenticationTimeout.unref();
     client.on("message", (raw: RawData) => {
       let message: {
         action?: string;
@@ -426,8 +453,10 @@ function attachWebSocketServer(params: {
               status: "FAIL",
             }),
           );
+          client.close(4001, "authentication failed");
           return;
         }
+        clearTimeout(authenticationTimeout);
         params.state.websocketClients.set(client, 0);
         client.send(JSON.stringify({ seq_reply: seq, status: "OK" }));
         sendEvent(params.state, client, {
@@ -470,7 +499,10 @@ function attachWebSocketServer(params: {
         }),
       );
     });
-    client.once("close", () => params.state.websocketClients.delete(client));
+    client.once("close", () => {
+      clearTimeout(authenticationTimeout);
+      params.state.websocketClients.delete(client);
+    });
   });
   return async () => {
     params.server.off("upgrade", onUpgrade);
@@ -492,6 +524,7 @@ export async function startMattermostServer(
     botUserId,
     botUsername,
     channels: new Map(),
+    maxPendingInboundEvents: resolveMaxPendingInboundEvents(params.maxPendingInboundEvents),
     nextPost: 1,
     onEvent: params.onEvent,
     pendingEvents: [],
@@ -516,6 +549,8 @@ export async function startMattermostServer(
     serverName: "Mattermost",
   });
   const closeMattermostWebSocketServer = attachWebSocketServer({
+    authenticationTimeoutMs:
+      params.websocketAuthenticationTimeoutMs ?? DEFAULT_WEBSOCKET_AUTHENTICATION_TIMEOUT_MS,
     server: httpServer.server,
     state,
   });

--- a/src/servers/pending-events.ts
+++ b/src/servers/pending-events.ts
@@ -1,0 +1,11 @@
+export const DEFAULT_MAX_PENDING_INBOUND_EVENTS = 1_000;
+
+export function resolveMaxPendingInboundEvents(value: number | undefined): number {
+  if (value === undefined) {
+    return DEFAULT_MAX_PENDING_INBOUND_EVENTS;
+  }
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new Error("maxPendingInboundEvents must be a positive safe integer.");
+  }
+  return value;
+}

--- a/src/servers/signal.ts
+++ b/src/servers/signal.ts
@@ -18,11 +18,13 @@ import {
   writeResponse,
 } from "./http.js";
 import { recordServerEvent, type ServerEventObserver } from "./recorder.js";
+import { resolveMaxPendingInboundEvents } from "./pending-events.js";
 
 type SignalServerState = {
   account: string;
   adminToken: string;
   clients: Set<ServerResponse>;
+  maxPendingInboundEvents: number;
   nextTimestamp: number;
   onEvent: ServerEventObserver | undefined;
   pendingEvents: string[];
@@ -59,6 +61,7 @@ export type StartSignalServerParams = {
   onEvent?: ServerEventObserver | undefined;
   port?: number | undefined;
   recorderPath?: string | undefined;
+  maxPendingInboundEvents?: number | undefined;
 };
 
 async function appendEvent(state: SignalServerState, event: ServerRequestEvent): Promise<void> {
@@ -80,15 +83,19 @@ function rpcError(code: number, message: string, id: unknown = null, status = 40
   );
 }
 
-function emitSignalEvent(state: SignalServerState, payload: unknown): void {
+function emitSignalEvent(state: SignalServerState, payload: unknown): boolean {
   const event = `event:receive\ndata:${JSON.stringify(payload)}\n\n`;
   if (state.clients.size === 0) {
+    if (state.pendingEvents.length >= state.maxPendingInboundEvents) {
+      return false;
+    }
     state.pendingEvents.push(event);
-    return;
+    return true;
   }
   for (const client of state.clients) {
     client.write(event);
   }
+  return true;
 }
 
 async function handleAdminInbound(params: {
@@ -114,7 +121,15 @@ async function handleAdminInbound(params: {
       },
     },
   };
-  emitSignalEvent(params.state, payload);
+  if (!emitSignalEvent(params.state, payload)) {
+    return jsonResponse(
+      {
+        error: `Pending inbound queue is full (${params.state.maxPendingInboundEvents} events)`,
+        ok: false,
+      },
+      503,
+    );
+  }
   return jsonResponse({ event: payload, ok: true });
 }
 
@@ -230,6 +245,7 @@ export async function startSignalServer(
     account: params.account ?? "+15550000000",
     adminToken: params.adminToken ?? randomBytes(24).toString("base64url"),
     clients: new Set(),
+    maxPendingInboundEvents: resolveMaxPendingInboundEvents(params.maxPendingInboundEvents),
     nextTimestamp: Date.now(),
     onEvent: params.onEvent,
     pendingEvents: [],

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -18,6 +18,7 @@ import {
   writeResponse,
 } from "./http.js";
 import { recordServerEvent, type ServerEventObserver } from "./recorder.js";
+import { resolveMaxPendingInboundEvents } from "./pending-events.js";
 
 const TELEGRAM_MAX_REQUEST_BODY_BYTES = 50 * 1024 * 1024;
 
@@ -37,6 +38,7 @@ type TelegramServerState = {
   botToken: string;
   botUsername: string;
   closing: boolean;
+  maxPendingInboundEvents: number;
   nextMessageId: number;
   nextUpdateId: number;
   onEvent: ServerEventObserver | undefined;
@@ -145,6 +147,7 @@ export type StartTelegramServerParams = {
   onEvent?: ServerEventObserver | undefined;
   port?: number | undefined;
   recorderPath?: string | undefined;
+  maxPendingInboundEvents?: number | undefined;
 };
 
 function telegramOk(result: unknown): Response {
@@ -600,6 +603,15 @@ async function handleRequest(params: { request: IncomingMessage; state: Telegram
       return telegramError("Bad Request: request body must be a JSON object");
     }
     const update = createInboundUpdate(params.state, body);
+    if (!update) {
+      return telegramError("Bad Request: chatId and text are required");
+    }
+    if (params.state.updates.length >= params.state.maxPendingInboundEvents) {
+      return telegramError(
+        `Too Many Requests: pending inbound queue is full (${params.state.maxPendingInboundEvents} updates)`,
+        429,
+      );
+    }
     await appendEvent(params.state, {
       at: new Date().toISOString(),
       body,
@@ -608,9 +620,6 @@ async function handleRequest(params: { request: IncomingMessage; state: Telegram
       query: queryRecord(url),
       type: "admin",
     });
-    if (!update) {
-      return telegramError("Bad Request: chatId and text are required");
-    }
     params.state.updates.push(update);
     params.state.updates.sort((left, right) => left.update_id - right.update_id);
     finishTelegramUpdatePoll(params.state, "update");
@@ -662,6 +671,7 @@ export async function startTelegramServer(
         ? "424242:crabline-telegram-token"
         : `${botId}:${randomBytes(26).toString("base64url")}`),
     botUsername: params.botUsername ?? "crabline_bot",
+    maxPendingInboundEvents: resolveMaxPendingInboundEvents(params.maxPendingInboundEvents),
     nextMessageId: 1,
     nextUpdateId: 1,
     onEvent: params.onEvent,

--- a/src/servers/whatsapp-wire/binary-node.ts
+++ b/src/servers/whatsapp-wire/binary-node.ts
@@ -1,5 +1,4 @@
 import { Buffer } from "node:buffer";
-import { promisify } from "node:util";
 import { inflate } from "node:zlib";
 
 export type BinaryNode = {
@@ -12,10 +11,23 @@ export const WHATSAPP_BINARY_NODE_MAX_COMPRESSED_BYTES = 1024 * 1024;
 export const WHATSAPP_BINARY_NODE_MAX_DECOMPRESSED_BYTES = 8 * 1024 * 1024;
 export const WHATSAPP_BINARY_NODE_MAX_DEPTH = 128;
 
-const inflateAsync = promisify(inflate) as (
+function inflateWithInfo(
   buffer: Uint8Array,
-  options: { maxOutputLength: number },
-) => Promise<Buffer>;
+): Promise<{ buffer: Buffer; engine: { bytesWritten: number } }> {
+  return new Promise((resolve, reject) => {
+    inflate(
+      buffer,
+      { info: true, maxOutputLength: WHATSAPP_BINARY_NODE_MAX_DECOMPRESSED_BYTES },
+      (error, result) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve(result as unknown as { buffer: Buffer; engine: { bytesWritten: number } });
+        }
+      },
+    );
+  });
+}
 
 const TAGS = {
   AD_JID: 247,
@@ -149,9 +161,12 @@ async function decompressIfRequired(buffer: Buffer): Promise<Buffer> {
       throw new Error(`Compressed WhatsApp binary node frame is too large: ${buffer.length}.`);
     }
     try {
-      return await inflateAsync(buffer.subarray(1), {
-        maxOutputLength: WHATSAPP_BINARY_NODE_MAX_DECOMPRESSED_BYTES,
-      });
+      const compressed = buffer.subarray(1);
+      const inflated = await inflateWithInfo(compressed);
+      if (inflated.engine.bytesWritten !== compressed.length) {
+        throw new Error("Compressed WhatsApp binary node frame contains trailing data.");
+      }
+      return inflated.buffer;
     } catch (error) {
       if (
         error instanceof RangeError ||

--- a/src/servers/whatsapp-wire/binary-node.ts
+++ b/src/servers/whatsapp-wire/binary-node.ts
@@ -127,7 +127,12 @@ export const S_WHATSAPP_NET = "@s.whatsapp.net";
 
 export async function decodeBinaryNode(frame: Buffer): Promise<BinaryNode> {
   const buffer = await decompressIfRequired(frame);
-  return decodeDecompressedBinaryNode(buffer);
+  const indexRef = { index: 0 };
+  const node = decodeDecompressedBinaryNode(buffer, indexRef);
+  if (indexRef.index !== buffer.length) {
+    throw new Error("WhatsApp binary node frame contains trailing data.");
+  }
+  return node;
 }
 
 export function encodeBinaryNode(node: BinaryNode): Buffer {

--- a/src/servers/whatsapp-wire/crypto.ts
+++ b/src/servers/whatsapp-wire/crypto.ts
@@ -105,7 +105,14 @@ export function aesDecryptGCM(
   iv: Uint8Array,
   additionalData: Uint8Array,
 ): Buffer {
-  const decipher = createDecipheriv("aes-256-gcm", key, iv);
+  if (ciphertext.byteLength < AES_GCM_TAG_LENGTH) {
+    throw new Error(
+      `AES-GCM ciphertext must include a ${AES_GCM_TAG_LENGTH}-byte authentication tag.`,
+    );
+  }
+  const decipher = createDecipheriv("aes-256-gcm", key, iv, {
+    authTagLength: AES_GCM_TAG_LENGTH,
+  });
   const encrypted = ciphertext.subarray(0, ciphertext.byteLength - AES_GCM_TAG_LENGTH);
   const tag = ciphertext.subarray(ciphertext.byteLength - AES_GCM_TAG_LENGTH);
   decipher.setAAD(additionalData);

--- a/src/servers/whatsapp-wire/handshake.ts
+++ b/src/servers/whatsapp-wire/handshake.ts
@@ -24,8 +24,10 @@ export function decodeHandshakeMessage(data: Uint8Array): HandshakeMessage {
     const tag = reader.uint32();
     const field = tag >>> 3;
     if (field === 2) {
+      requireBytesWireType(tag, field);
       message.clientHello = decodeClientHello(reader.bytes());
     } else if (field === 4) {
+      requireBytesWireType(tag, field);
       message.clientFinish = decodeClientFinish(reader.bytes());
     } else {
       reader.skip(tag & 7);
@@ -48,6 +50,7 @@ function decodeClientHello(data: Uint8Array): NonNullable<HandshakeMessage["clie
   while (!reader.done()) {
     const tag = reader.uint32();
     if (tag >>> 3 === 1) {
+      requireBytesWireType(tag, 1);
       ephemeral = reader.bytes();
     } else {
       reader.skip(tag & 7);
@@ -64,8 +67,10 @@ function decodeClientFinish(data: Uint8Array): NonNullable<HandshakeMessage["cli
     const tag = reader.uint32();
     const field = tag >>> 3;
     if (field === 1) {
+      requireBytesWireType(tag, field);
       staticKey = reader.bytes();
     } else if (field === 2) {
+      requireBytesWireType(tag, field);
       payload = reader.bytes();
     } else {
       reader.skip(tag & 7);
@@ -75,6 +80,15 @@ function decodeClientFinish(data: Uint8Array): NonNullable<HandshakeMessage["cli
     ...(payload === undefined ? {} : { payload }),
     ...(staticKey === undefined ? {} : { staticKey }),
   };
+}
+
+function requireBytesWireType(tag: number, field: number): void {
+  const wireType = tag & 7;
+  if (wireType !== 2) {
+    throw new Error(
+      `Invalid WhatsApp handshake wire type ${wireType} for length-delimited field ${field}.`,
+    );
+  }
 }
 
 function encodeServerHello(serverHello: NonNullable<HandshakeMessage["serverHello"]>): Buffer {

--- a/src/servers/zalo.ts
+++ b/src/servers/zalo.ts
@@ -20,6 +20,7 @@ import {
   type ServerRequestEvent,
 } from "./http.js";
 import { recordServerEvent, type ServerEventObserver } from "./recorder.js";
+import { resolveMaxPendingInboundEvents } from "./pending-events.js";
 
 type ZaloChatType = "GROUP" | "PRIVATE";
 
@@ -61,6 +62,7 @@ type ZaloServerState = {
   botId: string;
   botName: string;
   botToken: string;
+  maxPendingInboundEvents: number;
   nextMessage: number;
   onEvent: ServerEventObserver | undefined;
   pendingRequests: PendingUpdateRequest[];
@@ -103,6 +105,7 @@ export type StartZaloServerParams = {
   onEvent?: ServerEventObserver | undefined;
   port?: number | undefined;
   recorderPath?: string | undefined;
+  maxPendingInboundEvents?: number | undefined;
   webhookDeliveryTimeoutMs?: number | undefined;
 };
 
@@ -168,6 +171,10 @@ function createBlockedWebhookAddresses(): BlockList {
     ["240.0.0.0", 4],
   ] as const) {
     blockList.addSubnet(address, prefix, "ipv4");
+    const octets = address.split(".").map(Number);
+    const high = ((octets[0] ?? 0) << 8) | (octets[1] ?? 0);
+    const low = ((octets[2] ?? 0) << 8) | (octets[3] ?? 0);
+    blockList.addSubnet(`::ffff:${high.toString(16)}:${low.toString(16)}`, 96 + prefix, "ipv6");
   }
   for (const [address, prefix] of [
     ["::", 128],
@@ -249,6 +256,17 @@ async function postWebhook(
   address: WebhookAddress | undefined,
 ): Promise<number> {
   return await new Promise<number>((resolve, reject) => {
+    let settled = false;
+    let response: IncomingMessage | undefined;
+    let deadline: NodeJS.Timeout;
+    const finish = (callback: () => void) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(deadline);
+      callback();
+    };
     const send = url.protocol === "https:" ? requestHttps : requestHttp;
     const request = send(
       url,
@@ -267,17 +285,23 @@ async function postWebhook(
           : {}),
         method: "POST",
       },
-      (response) => {
-        response.resume();
-        response.once("end", () => resolve(response.statusCode ?? 0));
+      (incoming) => {
+        response = incoming;
+        incoming.resume();
+        incoming.once("error", (error) => finish(() => reject(error)));
+        incoming.once("end", () => finish(() => resolve(incoming.statusCode ?? 0)));
       },
     );
-    request.setTimeout(timeoutMs, () => {
-      request.destroy(
-        new DOMException(`Webhook delivery timed out after ${timeoutMs}ms`, "TimeoutError"),
+    deadline = setTimeout(() => {
+      const error = new DOMException(
+        `Webhook delivery timed out after ${timeoutMs}ms`,
+        "TimeoutError",
       );
-    });
-    request.once("error", reject);
+      response?.destroy(error);
+      request.destroy(error);
+    }, timeoutMs);
+    deadline.unref();
+    request.once("error", (error) => finish(() => reject(error)));
     request.end(body);
   });
 }
@@ -310,14 +334,18 @@ function waitForUpdate(state: ZaloServerState, timeoutSeconds: number): Promise<
   });
 }
 
-function deliverPollingUpdate(state: ZaloServerState, update: ZaloUpdate): void {
+function deliverPollingUpdate(state: ZaloServerState, update: ZaloUpdate): boolean {
   const pending = state.pendingRequests.shift();
   if (!pending) {
+    if (state.updates.length >= state.maxPendingInboundEvents) {
+      return false;
+    }
     state.updates.push(update);
-    return;
+    return true;
   }
   clearTimeout(pending.timeout);
   pending.resolve(zaloOk(update));
+  return true;
 }
 
 async function deliverWebhookUpdate(
@@ -387,6 +415,16 @@ async function handleAdminInbound(
       text,
     },
   };
+  if (
+    !state.webhook?.url &&
+    state.pendingRequests.length === 0 &&
+    state.updates.length >= state.maxPendingInboundEvents
+  ) {
+    return zaloError(
+      `Pending inbound queue is full (${state.maxPendingInboundEvents} updates)`,
+      429,
+    );
+  }
   await appendEvent(state, {
     at: new Date().toISOString(),
     body,
@@ -401,7 +439,12 @@ async function handleAdminInbound(
       return error;
     }
   } else {
-    deliverPollingUpdate(state, update);
+    if (!deliverPollingUpdate(state, update)) {
+      return zaloError(
+        `Pending inbound queue is full (${state.maxPendingInboundEvents} updates)`,
+        429,
+      );
+    }
   }
   return zaloOk(update);
 }
@@ -513,6 +556,7 @@ export async function startZaloServer(
     botToken:
       params.botToken ??
       (isLoopbackHost(host) ? "crabline-zalo-bot-token" : randomBytes(32).toString("base64url")),
+    maxPendingInboundEvents: resolveMaxPendingInboundEvents(params.maxPendingInboundEvents),
     nextMessage: 1,
     onEvent: params.onEvent,
     pendingRequests: [],

--- a/test/load.test.ts
+++ b/test/load.test.ts
@@ -105,8 +105,8 @@ describe("config load", () => {
     const directory = await createTempDir();
     directories.push(directory);
     const configPath = path.join(directory, "crabline.yaml");
-    const secret = "sentinel-secret-value";
-    await writeText(configPath, `accessToken: ${secret}: invalid\n`);
+    const sentinel = "sentinel-secret-value";
+    await writeText(configPath, `accessToken: ${sentinel}: invalid\n`);
 
     let failure: unknown;
     try {
@@ -118,7 +118,7 @@ describe("config load", () => {
     expect(failure).toBeInstanceOf(Error);
     expect((failure as Error).message).toContain("YAML parse error");
     expect((failure as Error).message).toContain("line 1, column");
-    expect((failure as Error).message).not.toContain(secret);
+    expect((failure as Error).message).not.toContain(sentinel);
     expect((failure as Error).message).not.toContain("accessToken");
   });
 

--- a/test/load.test.ts
+++ b/test/load.test.ts
@@ -120,6 +120,11 @@ describe("config load", () => {
     expect((failure as Error).message).toContain("line 1, column");
     expect((failure as Error).message).not.toContain(sentinel);
     expect((failure as Error).message).not.toContain("accessToken");
+    const cause = (failure as Error & { cause?: unknown }).cause;
+    expect(cause).toBeInstanceOf(Error);
+    expect((cause as Error).message).toContain("YAML parse error");
+    expect((cause as Error).message).not.toContain(sentinel);
+    expect((cause as Error).message).not.toContain("accessToken");
   });
 
   it("resolves default config names from cwd", async () => {

--- a/test/load.test.ts
+++ b/test/load.test.ts
@@ -101,6 +101,27 @@ describe("config load", () => {
     await expect(loadManifest(configPath)).rejects.toThrow(/valid Unicode regular expression/u);
   });
 
+  it("omits malformed YAML source lines from load errors", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const configPath = path.join(directory, "crabline.yaml");
+    const secret = "sentinel-secret-value";
+    await writeText(configPath, `accessToken: ${secret}: invalid\n`);
+
+    let failure: unknown;
+    try {
+      await loadManifest(configPath);
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(Error);
+    expect((failure as Error).message).toContain("YAML parse error");
+    expect((failure as Error).message).toContain("line 1, column");
+    expect((failure as Error).message).not.toContain(secret);
+    expect((failure as Error).message).not.toContain("accessToken");
+  });
+
   it("resolves default config names from cwd", async () => {
     const directory = await createTempDir();
     directories.push(directory);

--- a/test/mattermost-server.test.ts
+++ b/test/mattermost-server.test.ts
@@ -254,7 +254,7 @@ describe("Mattermost local provider server", () => {
 
   it("expires silent and invalid WebSocket authentication", async () => {
     const server = await startMattermostServer({
-      botToken: "bot-secret",
+      botToken: "test-token-placeholder",
       websocketAuthenticationTimeoutMs: 25,
     });
     servers.push(server);
@@ -274,7 +274,7 @@ describe("Mattermost local provider server", () => {
     invalid.send(
       JSON.stringify({
         action: "authentication_challenge",
-        data: { token: "wrong-token" },
+        data: { token: "not-a-real" },
         seq: 1,
       }),
     );

--- a/test/mattermost-server.test.ts
+++ b/test/mattermost-server.test.ts
@@ -38,6 +38,20 @@ function nextMessages(socket: WebSocket, count: number): Promise<Record<string, 
   });
 }
 
+function waitForSocketOpen(socket: WebSocket): Promise<void> {
+  return new Promise((resolve, reject) => {
+    socket.once("open", resolve);
+    socket.once("error", reject);
+  });
+}
+
+function waitForSocketClose(socket: WebSocket): Promise<{ code: number; reason: string }> {
+  return new Promise((resolve, reject) => {
+    socket.once("close", (code, reason) => resolve({ code, reason: reason.toString() }));
+    socket.once("error", reject);
+  });
+}
+
 describe("Mattermost local provider server", () => {
   it("returns Mattermost errors for non-object and oversized request bodies", async () => {
     const directory = await createTempDir();
@@ -113,10 +127,7 @@ describe("Mattermost local provider server", () => {
     });
 
     const socket = new WebSocket(server.manifest.endpoints.websocketUrl);
-    await new Promise<void>((resolve, reject) => {
-      socket.once("open", resolve);
-      socket.once("error", reject);
-    });
+    await waitForSocketOpen(socket);
     const authenticated = nextMessages(socket, 2);
     socket.send(
       JSON.stringify({
@@ -239,6 +250,64 @@ describe("Mattermost local provider server", () => {
     const recorded = await fs.readFile(recorderPath, "utf8");
     expect(recorded).toContain('"path":"/crabline/mattermost/inbound"');
     expect(recorded).toContain('"path":"/api/v4/posts"');
+  });
+
+  it("expires silent and invalid WebSocket authentication", async () => {
+    const server = await startMattermostServer({
+      botToken: "bot-secret",
+      websocketAuthenticationTimeoutMs: 25,
+    });
+    servers.push(server);
+
+    const silent = new WebSocket(server.manifest.endpoints.websocketUrl);
+    const silentClosed = waitForSocketClose(silent);
+    await waitForSocketOpen(silent);
+    await expect(silentClosed).resolves.toEqual({
+      code: 4001,
+      reason: "authentication timeout",
+    });
+
+    const invalid = new WebSocket(server.manifest.endpoints.websocketUrl);
+    const invalidClosed = waitForSocketClose(invalid);
+    await waitForSocketOpen(invalid);
+    const failure = nextMessage(invalid);
+    invalid.send(
+      JSON.stringify({
+        action: "authentication_challenge",
+        data: { token: "wrong-token" },
+        seq: 1,
+      }),
+    );
+    await expect(failure).resolves.toMatchObject({ seq_reply: 1, status: "FAIL" });
+    await expect(invalidClosed).resolves.toEqual({
+      code: 4001,
+      reason: "authentication failed",
+    });
+  });
+
+  it("rejects admin inbound when the disconnected event queue is full", async () => {
+    const server = await startMattermostServer({
+      adminToken: "admin",
+      maxPendingInboundEvents: 1,
+    });
+    servers.push(server);
+    const sendInbound = (text: string) =>
+      fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({ channelId: "channel-1", senderId: "user-1", text }),
+        headers: {
+          "content-type": "application/json",
+          "x-crabline-admin-token": "admin",
+        },
+        method: "POST",
+      });
+
+    expect((await sendInbound("first")).status).toBe(200);
+    const overloaded = await sendInbound("second");
+    expect(overloaded.status).toBe(503);
+    await expect(overloaded.json()).resolves.toMatchObject({
+      error: "Pending inbound queue is full (1 events)",
+      ok: false,
+    });
   });
 
   it("drains request bodies rejected by REST and admin authentication", async () => {

--- a/test/release-workflow.test.ts
+++ b/test/release-workflow.test.ts
@@ -47,6 +47,12 @@ describe("release workflow", () => {
     });
     await expect(runResolveTag(resolveStep, "v1.2.3-beta.1")).rejects.toThrow(/Command failed/u);
     await expect(runResolveTag(resolveStep, "v1.2.3.preview")).rejects.toThrow(/Command failed/u);
+    await expect(
+      runResolveTag(resolveStep, "v1.2.3", { refName: "main", refType: "branch" }),
+    ).rejects.toThrow(/Command failed/u);
+    await expect(
+      runResolveTag(resolveStep, "v1.2.3", { refName: "v1.2.2", refType: "tag" }),
+    ).rejects.toThrow(/Command failed/u);
     expect(checkoutStep?.with?.ref).toBe("refs/tags/${{ steps.release.outputs.tag }}");
   });
 
@@ -68,6 +74,12 @@ describe("release workflow", () => {
       group: "release-${{ inputs.tag_name || github.ref_name }}",
     });
     expect(commands).toContain("npm install -g npm@12.0.1");
+    for (const jobName of ["verify", "publish"]) {
+      const jobCommands = jobSteps(workflow, jobName)
+        .map((step) => step.run)
+        .filter((run): run is string => Boolean(run));
+      expect(jobCommands).toContain("npm install -g npm@12.0.1");
+    }
     expect(commands.some((command) => command.includes("npm@latest"))).toBe(false);
     expect(packageStep).toContain('npm pack --json --pack-destination "$RUNNER_TEMP"');
     expect(packageStep).toContain("Packed artifact is missing the crabline CLI");
@@ -111,7 +123,9 @@ describe("release workflow", () => {
     expect(verifyCommands).toContain("pnpm install --frozen-lockfile");
     expect(verifyCommands).toContain("pnpm verify");
     expect(
-      publishCommands.some((command) => /\b(?:pnpm|install|build|test|pack)\b/u.test(command)),
+      publishCommands
+        .filter((command) => command !== "npm install -g npm@12.0.1")
+        .some((command) => /\b(?:pnpm|install|build|test|pack)\b/u.test(command)),
     ).toBe(false);
   });
 
@@ -241,6 +255,7 @@ async function runMetadataCheck(script: string, changelog: string): Promise<void
 async function runResolveTag(
   script: string | undefined,
   tag: string,
+  ref: { refName: string; refType: string } = { refName: tag, refType: "tag" },
 ): Promise<Record<string, string>> {
   if (!script) {
     throw new Error("Release workflow is missing its tag resolution step.");
@@ -252,7 +267,8 @@ async function runResolveTag(
       env: {
         ...process.env,
         GITHUB_OUTPUT: outputPath,
-        GITHUB_REF_NAME: tag,
+        GITHUB_REF_NAME: ref.refName,
+        GITHUB_REF_TYPE: ref.refType,
         INPUT_TAG: tag,
       },
     });

--- a/test/server-recorder.test.ts
+++ b/test/server-recorder.test.ts
@@ -1,0 +1,99 @@
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ServerRequestEvent } from "../src/servers/http.js";
+import { recordServerEvent } from "../src/servers/recorder.js";
+
+const fsMocks = vi.hoisted(() => ({
+  appendFile: vi.fn<(filePath: string, data: string, encoding: string) => Promise<void>>(),
+}));
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return { ...actual, appendFile: fsMocks.appendFile };
+});
+
+function serverEvent(pathname: string): ServerRequestEvent {
+  return {
+    at: "2026-07-12T12:00:00.000Z",
+    method: "POST",
+    path: pathname,
+    query: {},
+    type: "api",
+  };
+}
+
+beforeEach(() => {
+  fsMocks.appendFile.mockReset();
+  fsMocks.appendFile.mockResolvedValue();
+});
+
+describe("server recorder", () => {
+  it("recovers serialization after an append failure", async () => {
+    const recorderPath = path.join("/tmp", "crabline-server-recorder-recovery.jsonl");
+    const appendFailure = new Error("disk unavailable");
+    fsMocks.appendFile.mockRejectedValueOnce(appendFailure).mockResolvedValueOnce();
+
+    await expect(
+      recordServerEvent({
+        event: serverEvent("/first"),
+        onEvent: undefined,
+        recorderPath,
+      }),
+    ).rejects.toBe(appendFailure);
+    await expect(
+      recordServerEvent({
+        event: serverEvent("/second"),
+        onEvent: undefined,
+        recorderPath,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(fsMocks.appendFile).toHaveBeenCalledTimes(2);
+  });
+
+  it("invokes observers only after the event is durable", async () => {
+    let releaseAppend: (() => void) | undefined;
+    const appendBlocked = new Promise<void>((resolve) => {
+      releaseAppend = resolve;
+    });
+    fsMocks.appendFile.mockReturnValueOnce(appendBlocked);
+    const observer = vi.fn<(event: ServerRequestEvent) => void>();
+    const event = serverEvent("/ordered");
+
+    const recording = recordServerEvent({
+      event,
+      onEvent: observer,
+      recorderPath: path.join("/tmp", "crabline-server-recorder-order.jsonl"),
+    });
+    await vi.waitFor(() => expect(fsMocks.appendFile).toHaveBeenCalledTimes(1));
+    expect(observer).not.toHaveBeenCalled();
+
+    releaseAppend?.();
+    await recording;
+    expect(observer).toHaveBeenCalledWith(event);
+  });
+
+  it("keeps later appends available after an observer failure", async () => {
+    const recorderPath = path.join("/tmp", "crabline-server-recorder-observer.jsonl");
+    const observerFailure = new Error("observer failed");
+
+    await expect(
+      recordServerEvent({
+        event: serverEvent("/first"),
+        onEvent: async () => {
+          throw observerFailure;
+        },
+        recorderPath,
+      }),
+    ).rejects.toBe(observerFailure);
+    await expect(
+      recordServerEvent({
+        event: serverEvent("/second"),
+        onEvent: undefined,
+        recorderPath,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(fsMocks.appendFile).toHaveBeenCalledTimes(2);
+  });
+});

--- a/test/signal-server.test.ts
+++ b/test/signal-server.test.ts
@@ -157,6 +157,31 @@ describe("signal local provider server", () => {
     expect(recorded).toContain('"path":"/crabline/signal/inbound"');
   });
 
+  it("rejects admin inbound when the disconnected event queue is full", async () => {
+    const server = await startSignalServer({
+      adminToken: "admin",
+      maxPendingInboundEvents: 1,
+    });
+    servers.push(server);
+    const sendInbound = (text: string) =>
+      fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({ sourceNumber: "+15557654321", text }),
+        headers: {
+          "content-type": "application/json",
+          "x-crabline-admin-token": "admin",
+        },
+        method: "POST",
+      });
+
+    expect((await sendInbound("first")).status).toBe(200);
+    const overloaded = await sendInbound("second");
+    expect(overloaded.status).toBe(503);
+    await expect(overloaded.json()).resolves.toEqual({
+      error: "Pending inbound queue is full (1 events)",
+      ok: false,
+    });
+  });
+
   it("drains unauthenticated admin request bodies", async () => {
     const server = await startSignalServer({ adminToken: "admin" });
     servers.push(server);

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -298,6 +298,32 @@ describe("telegram local provider server", () => {
     });
   });
 
+  it("rejects admin inbound when the update queue is full", async () => {
+    const server = await startTelegramServer({
+      adminToken: "admin",
+      maxPendingInboundEvents: 1,
+    });
+    servers.push(server);
+    const sendInbound = (text: string) =>
+      fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({ chatId: 42, text }),
+        headers: {
+          "content-type": "application/json",
+          "x-crabline-admin-token": "admin",
+        },
+        method: "POST",
+      });
+
+    expect((await sendInbound("first")).status).toBe(200);
+    const overloaded = await sendInbound("second");
+    expect(overloaded.status).toBe(429);
+    await expect(overloaded.json()).resolves.toEqual({
+      description: "Too Many Requests: pending inbound queue is full (1 updates)",
+      error_code: 429,
+      ok: false,
+    });
+  });
+
   it("rejects unauthenticated inbound updates", async () => {
     const directory = await createTempDir();
     directories.push(directory);

--- a/test/whatsapp-wire.test.ts
+++ b/test/whatsapp-wire.test.ts
@@ -159,6 +159,14 @@ describe("WhatsApp binary nodes", () => {
     );
   });
 
+  it("rejects trailing bytes after a compressed node stream", async () => {
+    const compressed = deflateSync(encodeBinaryNode({ attrs: {}, tag: "message" }).subarray(1));
+
+    await expect(
+      decodeBinaryNode(Buffer.concat([Buffer.from([2]), compressed, Buffer.from([0xff])])),
+    ).rejects.toThrow("Compressed WhatsApp binary node frame contains trailing data.");
+  });
+
   it("rejects child lists that cannot be represented by LIST_16", () => {
     const child: BinaryNode = { attrs: {}, tag: "child" };
     const node: BinaryNode = {

--- a/test/whatsapp-wire.test.ts
+++ b/test/whatsapp-wire.test.ts
@@ -8,7 +8,7 @@ import {
   WHATSAPP_BINARY_NODE_MAX_DECOMPRESSED_BYTES,
   type BinaryNode,
 } from "../src/servers/whatsapp-wire/binary-node.js";
-import { Curve } from "../src/servers/whatsapp-wire/crypto.js";
+import { aesDecryptGCM, aesEncryptGCM, Curve } from "../src/servers/whatsapp-wire/crypto.js";
 import { decodeHandshakeMessage } from "../src/servers/whatsapp-wire/handshake.js";
 import { createSerializedMessageHandler } from "../src/servers/whatsapp-baileys-websocket.js";
 
@@ -47,6 +47,20 @@ describe("WhatsApp X25519 agreement", () => {
     );
     expect(() => BaileysCurve.sharedKey(RFC_7748_ALICE_PRIVATE, Buffer.alloc(32))).toThrow(
       "failed during derivation",
+    );
+  });
+});
+
+describe("WhatsApp AES-GCM framing", () => {
+  it("requires a complete authentication tag", () => {
+    const key = Buffer.alloc(32, 1);
+    const iv = Buffer.alloc(12, 2);
+    const additionalData = Buffer.from("noise");
+    const encrypted = aesEncryptGCM(Buffer.from("payload"), key, iv, additionalData);
+
+    expect(aesDecryptGCM(encrypted, key, iv, additionalData)).toEqual(Buffer.from("payload"));
+    expect(() => aesDecryptGCM(Buffer.alloc(15), key, iv, additionalData)).toThrow(
+      "must include a 16-byte authentication tag",
     );
   });
 });
@@ -104,10 +118,16 @@ describe("WhatsApp handshake protobufs", () => {
     expect(message.clientHello?.ephemeral).toEqual(Buffer.from([0x2a]));
   });
 
-  it("keeps Baileys field-number dispatch for known fields", () => {
-    expect(decodeHandshakeMessage(Buffer.from([0x10, 0x00]))).toEqual({
-      clientHello: {},
-    });
+  it("rejects known fields encoded with non-length-delimited wire types", () => {
+    for (const message of [
+      Buffer.from([0x10, 0x00]),
+      Buffer.from([0x11, 0, 0, 0, 0, 0, 0, 0, 0]),
+      Buffer.from([0x15, 0, 0, 0, 0]),
+      Buffer.from([0x12, 0x02, 0x08, 0x00]),
+      Buffer.from([0x22, 0x02, 0x10, 0x00]),
+    ]) {
+      expect(() => decodeHandshakeMessage(message)).toThrow("Invalid WhatsApp handshake wire type");
+    }
   });
 
   it("keeps handshake tags and lengths bounded to uint32 varints", () => {
@@ -150,11 +170,16 @@ describe("WhatsApp binary nodes", () => {
     expect(() => encodeBinaryNode(node)).toThrow("WhatsApp binary node list is too large: 65536.");
   });
 
-  it("decodes nodes at the nesting limit while ignoring trailing bytes", async () => {
+  it("decodes nodes at the nesting limit and rejects trailing bytes", async () => {
     const node = nestedNode(WHATSAPP_BINARY_NODE_MAX_DEPTH);
-    const frame = Buffer.concat([encodeBinaryNode(node), Buffer.from([0xff])]);
 
-    await expect(decodeBinaryNode(frame)).resolves.toEqual(node);
+    await expect(decodeBinaryNode(encodeBinaryNode(node))).resolves.toEqual(node);
+    await expect(
+      decodeBinaryNode(Buffer.concat([encodeBinaryNode(node), Buffer.from([0xff])])),
+    ).rejects.toThrow("frame contains trailing data");
+    await expect(
+      decodeBinaryNode(Buffer.concat([encodeBinaryNode(node), encodeBinaryNode(node)])),
+    ).rejects.toThrow("frame contains trailing data");
   });
 
   it("rejects nodes beyond the nesting limit", async () => {

--- a/test/zalo-server.test.ts
+++ b/test/zalo-server.test.ts
@@ -212,8 +212,12 @@ describe("Zalo local provider server", () => {
     }
   });
 
-  it("bounds webhook delivery time for admin ingress", async () => {
-    const webhook = createServer(() => undefined);
+  it("enforces an absolute webhook delivery deadline while responses trickle", async () => {
+    const webhook = createServer((_request, response) => {
+      response.writeHead(200, { "content-type": "text/plain" });
+      const interval = setInterval(() => response.write("."), 5);
+      response.once("close", () => clearInterval(interval));
+    });
     await new Promise<void>((resolve) => webhook.listen(0, "127.0.0.1", resolve));
     const address = webhook.address();
     if (!address || typeof address === "string") {
@@ -293,6 +297,7 @@ describe("Zalo local provider server", () => {
       "https://127.0.0.1/zalo",
       "https://169.254.169.254/latest/meta-data",
       "https://[::1]/zalo",
+      "https://[::ffff:7f00:1]/zalo",
     ]) {
       const response = await fetch(`${apiRoot}/bottest-auth-token/setWebhook`, {
         body: JSON.stringify({ secret_token: "secret-token", url }),
@@ -330,6 +335,32 @@ describe("Zalo local provider server", () => {
       method: "POST",
     });
     expect(publicHttps.status).toBe(200);
+  });
+
+  it("rejects admin inbound when the polling update queue is full", async () => {
+    const server = await startZaloServer({
+      adminToken: "admin",
+      maxPendingInboundEvents: 1,
+    });
+    servers.push(server);
+    const sendInbound = (text: string) =>
+      fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({ chatId: "chat-1", senderId: "user-1", text }),
+        headers: {
+          "content-type": "application/json",
+          "x-crabline-admin-token": "admin",
+        },
+        method: "POST",
+      });
+
+    expect((await sendInbound("first")).status).toBe(200);
+    const overloaded = await sendInbound("second");
+    expect(overloaded.status).toBe(429);
+    await expect(overloaded.json()).resolves.toEqual({
+      description: "Pending inbound queue is full (1 updates)",
+      error_code: 429,
+      ok: false,
+    });
   });
 
   it("rejects invalid bot tokens and unauthenticated admin ingress", async () => {


### PR DESCRIPTION
## Summary
- validate WhatsApp wire framing and reject trailing compressed data
- bound pending inbound queues and close server timeout/rollback races
- sanitize YAML parser diagnostics and harden Zalo deadlines/address checks
- bind release publication to exact tags, pin npm, align Node types, and add changelog entries

## Verification
- autoreview: clean, gpt-5.6-sol high, confidence 0.84
- Crabbox: `run_46e54b8909dd`
- `pnpm verify`: 50 files, 418 tests