### PR TITLE
fix(core): harden lifecycle and smoke locking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Hold serve ready-file ownership across startup and shutdown, preserve live manifests on failed replacement, and retain compound cleanup failures.
+- Reject invalid matchers and provider/fixture mismatches before side effects, drain aborted provider work before cleanup, preserve frozen primary smoke failures, and recover stale smoke locks after PID reuse.
 - Randomize externally bound provider credentials, preserve Slack MPIM and Matrix sync errors, bound server shutdown, and enforce safe Zalo webhooks.
 - Order lazy cleanup after admitted dispatch, isolate loopback message state, and enforce effective modes and inbound deadlines.
 - Fence OpenClaw smoke artifact paths, clean abandoned generations safely, preserve primary probe failures and replacement files, and report post-commit lock cleanup failures.

--- a/src/core/reporters.ts
+++ b/src/core/reporters.ts
@@ -17,7 +17,7 @@ export function formatRunResultText(result: CommandRunResult | SuiteRunResult): 
 }
 
 export function formatJson(result: unknown): string {
-  return JSON.stringify(result === undefined ? null : result, null, 2);
+  return JSON.stringify(result === undefined ? null : result, null, 2) ?? "null";
 }
 
 function formatSingleResult(result: CommandRunResult): string {

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -75,7 +75,7 @@ export async function runFixtureCommand(params: {
     mode === configuredFixture.mode ? configuredFixture : { ...configuredFixture, mode };
   const provider = params.registry.resolve(fixture.provider, fixture.id);
   const diagnostics: string[] = [];
-  let deferredCleanupOperation: Promise<unknown> | null = null;
+  let abortDrainFailed = false;
 
   if (!provider.supports.includes(mode)) {
     return {
@@ -201,7 +201,7 @@ export async function runFixtureCommand(params: {
             const candidate = await raceInboundDeadline(wait, timeoutMs);
             if (candidate === INBOUND_DEADLINE_REACHED) {
               if (!(await abortAndDrainInboundWait(wait, controller))) {
-                deferredCleanupOperation = wait;
+                abortDrainFailed = true;
                 throw new CrablineError(
                   `Provider inbound wait did not settle within ${INBOUND_ABORT_GRACE_MS}ms after abort.`,
                   { kind: "inbound" },
@@ -227,7 +227,7 @@ export async function runFixtureCommand(params: {
           }
         } catch (error) {
           lastFailure = toFailure(fixture.id, fixture.provider, mode, error, "inbound", nonce);
-          if (deferredCleanupOperation) {
+          if (abortDrainFailed) {
             break;
           }
           continue;
@@ -271,34 +271,27 @@ export async function runFixtureCommand(params: {
       providerId: fixture.provider,
     });
   } finally {
-    if (deferredCleanupOperation) {
-      void deferredCleanupOperation
-        .catch(() => undefined)
-        .then(async () => await provider.cleanup?.())
-        .catch(() => undefined);
-    } else {
-      try {
-        await provider.cleanup?.();
-      } catch (error) {
-        const diagnostic = `cleanup failed: ${ensureErrorMessage(error)}`;
-        if (result) {
-          result.diagnostics.push(diagnostic);
-          if (result.ok) {
-            result.exitCode = EXIT_CODES.ASSERTION;
-            result.failureKind = "assertion";
-            result.ok = false;
-          }
-        } else {
-          result = {
-            diagnostics: [...diagnostics, diagnostic],
-            exitCode: EXIT_CODES.ASSERTION,
-            failureKind: "assertion",
-            fixtureId: fixture.id,
-            mode,
-            ok: false,
-            providerId: fixture.provider,
-          };
+    try {
+      await provider.cleanup?.();
+    } catch (error) {
+      const diagnostic = `cleanup failed: ${ensureErrorMessage(error)}`;
+      if (result) {
+        result.diagnostics.push(diagnostic);
+        if (result.ok) {
+          result.exitCode = EXIT_CODES.ASSERTION;
+          result.failureKind = "assertion";
+          result.ok = false;
         }
+      } else {
+        result = {
+          diagnostics: [...diagnostics, diagnostic],
+          exitCode: EXIT_CODES.ASSERTION,
+          failureKind: "assertion",
+          fixtureId: fixture.id,
+          mode,
+          ok: false,
+          providerId: fixture.provider,
+        };
       }
     }
   }

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -23,6 +23,7 @@ export type SuiteRunResult = {
 };
 
 const INBOUND_DEADLINE_REACHED = Symbol("inbound deadline reached");
+const INBOUND_ABORT_GRACE_MS = 250;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -43,6 +44,18 @@ async function raceInboundDeadline<T>(
       clearTimeout(timer);
     }
   }
+}
+
+async function abortAndDrainInboundWait(
+  operation: Promise<unknown>,
+  controller: AbortController,
+): Promise<boolean> {
+  controller.abort(new Error("Inbound wait deadline reached."));
+  const settled = operation.then(
+    () => true,
+    () => true,
+  );
+  return (await raceInboundDeadline(settled, INBOUND_ABORT_GRACE_MS)) !== INBOUND_DEADLINE_REACHED;
 }
 
 export async function runFixtureCommand(params: {
@@ -116,6 +129,23 @@ export async function runFixtureCommand(params: {
       }
     }
 
+    if (fixture.inboundMatch.strategy === "regex" && fixture.inboundMatch.pattern) {
+      try {
+        RegExp(fixture.inboundMatch.pattern, "u");
+      } catch (error) {
+        return (result = toFailure(
+          fixture.id,
+          fixture.provider,
+          mode,
+          new CrablineError(`Invalid inbound regex: ${ensureErrorMessage(error)}`, {
+            cause: error,
+            kind: "config",
+          }),
+          "config",
+        ));
+      }
+    }
+
     let attempts = 0;
     const maxAttempts = fixture.retries + 1;
     let lastFailure: CommandRunResult | null = null;
@@ -159,19 +189,22 @@ export async function runFixtureCommand(params: {
           while (Date.now() < inboundDeadline) {
             const timeoutMs = inboundDeadline - Date.now();
             const controller = new AbortController();
-            const candidate = await raceInboundDeadline(
-              provider.waitForInbound({
-                ...contextBase,
-                nonce,
-                signal: controller.signal,
-                since,
-                threadId: accepted.threadId,
-                timeoutMs,
-              }),
+            const wait = provider.waitForInbound({
+              ...contextBase,
+              nonce,
+              signal: controller.signal,
+              since,
+              threadId: accepted.threadId,
               timeoutMs,
-            );
+            });
+            const candidate = await raceInboundDeadline(wait, timeoutMs);
             if (candidate === INBOUND_DEADLINE_REACHED) {
-              controller.abort(new Error("Inbound wait deadline reached."));
+              if (!(await abortAndDrainInboundWait(wait, controller))) {
+                throw new CrablineError(
+                  `Provider inbound wait did not settle within ${INBOUND_ABORT_GRACE_MS}ms after abort.`,
+                  { kind: "inbound" },
+                );
+              }
               break;
             }
             if (!candidate) {

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -75,6 +75,7 @@ export async function runFixtureCommand(params: {
     mode === configuredFixture.mode ? configuredFixture : { ...configuredFixture, mode };
   const provider = params.registry.resolve(fixture.provider, fixture.id);
   const diagnostics: string[] = [];
+  let deferredCleanupOperation: Promise<unknown> | null = null;
 
   if (!provider.supports.includes(mode)) {
     return {
@@ -200,6 +201,7 @@ export async function runFixtureCommand(params: {
             const candidate = await raceInboundDeadline(wait, timeoutMs);
             if (candidate === INBOUND_DEADLINE_REACHED) {
               if (!(await abortAndDrainInboundWait(wait, controller))) {
+                deferredCleanupOperation = wait;
                 throw new CrablineError(
                   `Provider inbound wait did not settle within ${INBOUND_ABORT_GRACE_MS}ms after abort.`,
                   { kind: "inbound" },
@@ -225,6 +227,9 @@ export async function runFixtureCommand(params: {
           }
         } catch (error) {
           lastFailure = toFailure(fixture.id, fixture.provider, mode, error, "inbound", nonce);
+          if (deferredCleanupOperation) {
+            break;
+          }
           continue;
         }
         if (!inbound) {
@@ -266,27 +271,34 @@ export async function runFixtureCommand(params: {
       providerId: fixture.provider,
     });
   } finally {
-    try {
-      await provider.cleanup?.();
-    } catch (error) {
-      const diagnostic = `cleanup failed: ${ensureErrorMessage(error)}`;
-      if (result) {
-        result.diagnostics.push(diagnostic);
-        if (result.ok) {
-          result.exitCode = EXIT_CODES.ASSERTION;
-          result.failureKind = "assertion";
-          result.ok = false;
+    if (deferredCleanupOperation) {
+      void deferredCleanupOperation
+        .catch(() => undefined)
+        .then(async () => await provider.cleanup?.())
+        .catch(() => undefined);
+    } else {
+      try {
+        await provider.cleanup?.();
+      } catch (error) {
+        const diagnostic = `cleanup failed: ${ensureErrorMessage(error)}`;
+        if (result) {
+          result.diagnostics.push(diagnostic);
+          if (result.ok) {
+            result.exitCode = EXIT_CODES.ASSERTION;
+            result.failureKind = "assertion";
+            result.ok = false;
+          }
+        } else {
+          result = {
+            diagnostics: [...diagnostics, diagnostic],
+            exitCode: EXIT_CODES.ASSERTION,
+            failureKind: "assertion",
+            fixtureId: fixture.id,
+            mode,
+            ok: false,
+            providerId: fixture.provider,
+          };
         }
-      } else {
-        result = {
-          diagnostics: [...diagnostics, diagnostic],
-          exitCode: EXIT_CODES.ASSERTION,
-          failureKind: "assertion",
-          fixtureId: fixture.id,
-          mode,
-          ok: false,
-          providerId: fixture.provider,
-        };
       }
     }
   }

--- a/src/openclaw.ts
+++ b/src/openclaw.ts
@@ -318,16 +318,20 @@ export async function runOpenClawCrablineChannelDriverSmoke(
     if (!outcome.committed) {
       if (outcome.error instanceof Error) {
         const existingCause = outcome.error.cause;
-        Object.defineProperty(outcome.error, "cause", {
-          configurable: true,
-          value:
-            existingCause === undefined
-              ? cleanupError
-              : new AggregateError(
-                  [existingCause, cleanupError],
-                  "OpenClaw Crabline smoke failure cleanup also failed.",
-                ),
-        });
+        try {
+          Object.defineProperty(outcome.error, "cause", {
+            configurable: true,
+            value:
+              existingCause === undefined
+                ? cleanupError
+                : new AggregateError(
+                    [existingCause, cleanupError],
+                    "OpenClaw Crabline smoke failure cleanup also failed.",
+                  ),
+          });
+        } catch {
+          // Some failures are frozen; preserving the primary error is authoritative.
+        }
         throw outcome.error;
       }
       const combinedError = new Error("OpenClaw Crabline smoke and lock cleanup both failed.", {

--- a/src/openclaw/smoke-lock.ts
+++ b/src/openclaw/smoke-lock.ts
@@ -393,16 +393,43 @@ const getProcessStartedAtMs: GetProcessStartedAtMs = (pid) => {
           ],
           { encoding: "utf8", timeout: 1_000, windowsHide: true },
         )
-      : spawnSync("ps", ["-o", "lstart=", "-p", String(pid)], {
+      : spawnSync("ps", ["-o", "etime=", "-p", String(pid)], {
           encoding: "utf8",
           timeout: 1_000,
         });
   if (result.status !== 0) {
     return null;
   }
-  const startedAtMs = Date.parse(result.stdout.trim());
-  return Number.isFinite(startedAtMs) && startedAtMs > 0 ? startedAtMs : null;
+  const startedAtMs =
+    process.platform === "win32"
+      ? Date.parse(result.stdout.trim())
+      : processStartedAtMsFromElapsed(result.stdout, Date.now());
+  return startedAtMs !== null && Number.isFinite(startedAtMs) && startedAtMs > 0
+    ? startedAtMs
+    : null;
 };
+
+export function processStartedAtMsFromElapsed(value: string, nowMs: number): number | null {
+  const match = /^(?:(\d+)-)?(?:(\d+):)?(\d{2}):(\d{2})$/u.exec(value.trim());
+  if (!match) {
+    return null;
+  }
+  const [, daysText, hoursText, minutesText, secondsText] = match;
+  const days = Number(daysText ?? 0);
+  const hours = Number(hoursText ?? 0);
+  const minutes = Number(minutesText);
+  const seconds = Number(secondsText);
+  if (
+    ![days, hours, minutes, seconds].every(Number.isSafeInteger) ||
+    hours > 23 ||
+    minutes > 59 ||
+    seconds > 59
+  ) {
+    return null;
+  }
+  const elapsedSeconds = ((days * 24 + hours) * 60 + minutes) * 60 + seconds;
+  return Math.trunc(nowMs - elapsedSeconds * 1_000);
+}
 
 function isLockOwnerActive(record: SmokeLockRecord, runtime: SmokeLockRuntime): boolean {
   const { owner } = record;

--- a/src/openclaw/smoke-lock.ts
+++ b/src/openclaw/smoke-lock.ts
@@ -415,16 +415,11 @@ function isLockOwnerActive(record: SmokeLockRecord, runtime: SmokeLockRuntime): 
       return false;
     }
     if (!isRenewableOwner(owner) && actualProcessStartedAtMs === null) {
-      const ageMs = runtime.now() - Math.max(owner.createdAtMs, record.renewedAtMs);
-      return ageMs <= runtime.leaseMs * 2;
+      return true;
     }
   }
   if (!isRenewableOwner(owner)) {
-    if (hasProcessIdentity(owner)) {
-      return true;
-    }
-    const ageMs = runtime.now() - record.renewedAtMs;
-    return ageMs <= runtime.leaseMs * 2;
+    return true;
   }
   const ageMs = runtime.now() - Math.max(owner.createdAtMs, record.renewedAtMs);
   return ageMs >= -runtime.leaseMs && ageMs <= runtime.leaseMs;

--- a/src/openclaw/smoke-lock.ts
+++ b/src/openclaw/smoke-lock.ts
@@ -417,6 +417,12 @@ export function processIdentityFromDarwin(
   return `darwin:${bootMatch[1]}.${bootMatch[2]}:${normalizedStartedAt}`;
 }
 
+export function darwinProcessIdentityEnvironment(
+  environment: NodeJS.ProcessEnv,
+): NodeJS.ProcessEnv {
+  return { ...environment, LC_ALL: "C", TZ: "UTC" };
+}
+
 const getProcessIdentity: GetProcessIdentity = (pid) => {
   if (process.platform === "linux") {
     try {
@@ -431,7 +437,7 @@ const getProcessIdentity: GetProcessIdentity = (pid) => {
   if (process.platform === "darwin") {
     const options = {
       encoding: "utf8" as const,
-      env: { ...process.env, LC_ALL: "C" },
+      env: darwinProcessIdentityEnvironment(process.env),
       timeout: 1_000,
     };
     const startedAt = spawnSync("ps", ["-o", "lstart=", "-p", String(pid)], options);

--- a/src/openclaw/smoke-lock.ts
+++ b/src/openclaw/smoke-lock.ts
@@ -381,13 +381,22 @@ const getProcessStartedAtMs: GetProcessStartedAtMs = (pid) => {
   if (pid === process.pid) {
     return CURRENT_PROCESS_STARTED_AT_MS;
   }
-  if (process.platform === "win32") {
-    return null;
-  }
-  const result = spawnSync("ps", ["-o", "lstart=", "-p", String(pid)], {
-    encoding: "utf8",
-    timeout: 1_000,
-  });
+  const result =
+    process.platform === "win32"
+      ? spawnSync(
+          "powershell.exe",
+          [
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            `(Get-Process -Id ${pid} -ErrorAction Stop).StartTime.ToUniversalTime().ToString('o')`,
+          ],
+          { encoding: "utf8", timeout: 1_000, windowsHide: true },
+        )
+      : spawnSync("ps", ["-o", "lstart=", "-p", String(pid)], {
+          encoding: "utf8",
+          timeout: 1_000,
+        });
   if (result.status !== 0) {
     return null;
   }

--- a/src/openclaw/smoke-lock.ts
+++ b/src/openclaw/smoke-lock.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import fs, { type FileHandle } from "node:fs/promises";
 import path from "node:path";
 import { isCrablineServerChannel, type CrablineServerChannel } from "../servers/index.js";
@@ -14,6 +15,7 @@ type LegacySmokeLockOwner = {
 
 type ProcessIdentifiedSmokeLockOwner = LegacySmokeLockOwner & {
   createdAtMs: number;
+  processIdentity?: string;
   processStartedAtMs: number;
 };
 
@@ -50,7 +52,7 @@ type HeartbeatController = {
 type RemoveLockDirectory = (lockDirectory: string) => Promise<void>;
 type Sleep = (delayMs: number) => Promise<void>;
 type IsProcessAlive = (pid: number) => boolean;
-type GetProcessStartedAtMs = (pid: number) => number | null;
+type GetProcessIdentity = (pid: number) => string | null;
 type StartHeartbeat = (renew: () => Promise<void>, intervalMs: number) => HeartbeatController;
 type BeforeRecoveryClaim = () => Promise<void>;
 type BeforeRecoveryDeleteClaim = () => Promise<void>;
@@ -71,9 +73,10 @@ type DirectoryIdentity = {
 };
 
 type SmokeLockRuntime = {
+  currentProcessIdentity: string | null;
   currentPid: number;
   currentProcessStartedAtMs: number;
-  getProcessStartedAtMs: GetProcessStartedAtMs;
+  getProcessIdentity: GetProcessIdentity;
   isProcessAlive: IsProcessAlive;
   leaseMs: number;
   now: () => number;
@@ -90,7 +93,6 @@ const LOCK_LEASE_MS = 10 * 60 * 1000;
 const RELEASE_ATTEMPTS = 3;
 const RELEASE_RETRY_DELAY_MS = 10;
 const CURRENT_PROCESS_STARTED_AT_MS = Math.trunc(Date.now() - process.uptime() * 1000);
-const PROCESS_START_TOLERANCE_MS = 2_000;
 
 function parseCommitStagePath(contents: string, token: string): string {
   let value: { path?: unknown; token?: unknown };
@@ -280,7 +282,11 @@ function parseLockOwner(contents: string): SmokeLockOwner {
   }
   if (
     !isPositiveSafeInteger(owner.createdAtMs) ||
-    !isPositiveSafeInteger(owner.processStartedAtMs)
+    !isPositiveSafeInteger(owner.processStartedAtMs) ||
+    (owner.processIdentity !== undefined &&
+      (typeof owner.processIdentity !== "string" ||
+        owner.processIdentity.length === 0 ||
+        owner.processIdentity.length > 256))
   ) {
     throw new Error("OpenClaw Crabline smoke lock owner metadata is malformed.");
   }
@@ -289,6 +295,7 @@ function parseLockOwner(contents: string): SmokeLockOwner {
       channel: owner.channel,
       createdAtMs: owner.createdAtMs,
       pid: owner.pid,
+      ...(owner.processIdentity ? { processIdentity: owner.processIdentity } : {}),
       processStartedAtMs: owner.processStartedAtMs,
       token: owner.token,
     };
@@ -301,6 +308,7 @@ function parseLockOwner(contents: string): SmokeLockOwner {
     createdAtMs: owner.createdAtMs,
     leaseVersion: owner.leaseVersion,
     pid: owner.pid,
+    ...(owner.processIdentity ? { processIdentity: owner.processIdentity } : {}),
     processStartedAtMs: owner.processStartedAtMs,
     token: owner.token,
   };
@@ -377,58 +385,65 @@ const isProcessAlive: IsProcessAlive = (pid) => {
   }
 };
 
-const getProcessStartedAtMs: GetProcessStartedAtMs = (pid) => {
-  if (pid === process.pid) {
-    return CURRENT_PROCESS_STARTED_AT_MS;
-  }
-  const result =
-    process.platform === "win32"
-      ? spawnSync(
-          "powershell.exe",
-          [
-            "-NoProfile",
-            "-NonInteractive",
-            "-Command",
-            `(Get-Process -Id ${pid} -ErrorAction Stop).StartTime.ToUniversalTime().ToString('o')`,
-          ],
-          { encoding: "utf8", timeout: 1_000, windowsHide: true },
-        )
-      : spawnSync("ps", ["-o", "etime=", "-p", String(pid)], {
-          encoding: "utf8",
-          timeout: 1_000,
-        });
-  if (result.status !== 0) {
+export function processIdentityFromLinuxStat(value: string): string | null {
+  const commandEnd = value.lastIndexOf(") ");
+  if (commandEnd < 0) {
     return null;
   }
-  const startedAtMs =
-    process.platform === "win32"
-      ? Date.parse(result.stdout.trim())
-      : processStartedAtMsFromElapsed(result.stdout, Date.now());
-  return startedAtMs !== null && Number.isFinite(startedAtMs) && startedAtMs > 0
-    ? startedAtMs
-    : null;
+  const fields = value
+    .slice(commandEnd + 2)
+    .trim()
+    .split(/\s+/u);
+  const startTicks = fields[19];
+  if (!startTicks || !/^\d+$/u.test(startTicks)) {
+    return null;
+  }
+  return `linux:${startTicks}`;
+}
+
+const getProcessIdentity: GetProcessIdentity = (pid) => {
+  if (process.platform === "linux") {
+    try {
+      return processIdentityFromLinuxStat(readFileSync(`/proc/${pid}/stat`, "utf8"));
+    } catch {
+      return null;
+    }
+  }
+  if (process.platform !== "win32") {
+    return null;
+  }
+  const result = spawnSync(
+    "powershell.exe",
+    [
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      `(Get-Process -Id ${pid} -ErrorAction Stop).StartTime.ToUniversalTime().Ticks.ToString()`,
+    ],
+    { encoding: "utf8", timeout: 1_000, windowsHide: true },
+  );
+  const ticks = result.status === 0 ? result.stdout.trim() : "";
+  return /^\d+$/u.test(ticks) ? `windows:${ticks}` : null;
 };
 
-export function processStartedAtMsFromElapsed(value: string, nowMs: number): number | null {
-  const match = /^(?:(\d+)-)?(?:(\d+):)?(\d{2}):(\d{2})$/u.exec(value.trim());
-  if (!match) {
-    return null;
+function hasExactProcessIdentity(owner: SmokeLockOwner): owner is (
+  | ProcessIdentifiedSmokeLockOwner
+  | RenewableSmokeLockOwner
+) & {
+  processIdentity: string;
+} {
+  return hasProcessIdentity(owner) && typeof owner.processIdentity === "string";
+}
+
+function hasProcessIdentityMismatch(owner: SmokeLockOwner, runtime: SmokeLockRuntime): boolean {
+  if (!hasExactProcessIdentity(owner)) {
+    return false;
   }
-  const [, daysText, hoursText, minutesText, secondsText] = match;
-  const days = Number(daysText ?? 0);
-  const hours = Number(hoursText ?? 0);
-  const minutes = Number(minutesText);
-  const seconds = Number(secondsText);
-  if (
-    ![days, hours, minutes, seconds].every(Number.isSafeInteger) ||
-    hours > 23 ||
-    minutes > 59 ||
-    seconds > 59
-  ) {
-    return null;
-  }
-  const elapsedSeconds = ((days * 24 + hours) * 60 + minutes) * 60 + seconds;
-  return Math.trunc(nowMs - elapsedSeconds * 1_000);
+  const actualProcessIdentity =
+    owner.pid === runtime.currentPid
+      ? runtime.currentProcessIdentity
+      : runtime.getProcessIdentity(owner.pid);
+  return actualProcessIdentity !== null && owner.processIdentity !== actualProcessIdentity;
 }
 
 function isLockOwnerActive(record: SmokeLockRecord, runtime: SmokeLockRuntime): boolean {
@@ -436,23 +451,8 @@ function isLockOwnerActive(record: SmokeLockRecord, runtime: SmokeLockRuntime): 
   if (!runtime.isProcessAlive(owner.pid)) {
     return false;
   }
-  if (hasProcessIdentity(owner)) {
-    const actualProcessStartedAtMs =
-      owner.pid === runtime.currentPid
-        ? runtime.currentProcessStartedAtMs
-        : runtime.getProcessStartedAtMs(owner.pid);
-    if (
-      actualProcessStartedAtMs !== null &&
-      (owner.pid === runtime.currentPid
-        ? owner.processStartedAtMs !== actualProcessStartedAtMs
-        : Math.abs(owner.processStartedAtMs - actualProcessStartedAtMs) >
-          PROCESS_START_TOLERANCE_MS)
-    ) {
-      return false;
-    }
-    if (!isRenewableOwner(owner) && actualProcessStartedAtMs === null) {
-      return true;
-    }
+  if (hasProcessIdentityMismatch(owner, runtime)) {
+    return false;
   }
   if (!isRenewableOwner(owner)) {
     return true;
@@ -465,10 +465,7 @@ function needsLiveOwnerConfirmation(record: SmokeLockRecord, runtime: SmokeLockR
   return (
     isRenewableOwner(record.owner) &&
     runtime.isProcessAlive(record.owner.pid) &&
-    !(
-      record.owner.pid === runtime.currentPid &&
-      record.owner.processStartedAtMs !== runtime.currentProcessStartedAtMs
-    ) &&
+    !hasProcessIdentityMismatch(record.owner, runtime) &&
     !isLockOwnerActive(record, runtime)
   );
 }
@@ -882,11 +879,12 @@ export async function acquireOpenClawCrablineSmokeRunLock(
   dependencies: {
     afterLockCandidateInstall?: AfterLockDirectoryWrite;
     afterLockOwnerWrite?: AfterLockDirectoryWrite;
-    getProcessStartedAtMs?: GetProcessStartedAtMs;
+    getProcessIdentity?: GetProcessIdentity;
     isProcessAlive?: IsProcessAlive;
     leaseMs?: number;
     now?: () => number;
     pid?: number;
+    processIdentity?: string | null;
     processStartedAtMs?: number;
     platform?: NodeJS.Platform;
     secureWindowsDirectory?: SecureWindowsDirectory;
@@ -904,10 +902,16 @@ export async function acquireOpenClawCrablineSmokeRunLock(
   const outputDir = path.resolve(params.outputDir);
   const lockDirectory = path.join(outputDir, `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`);
   const token = randomUUID();
+  const currentPid = dependencies.pid ?? process.pid;
+  const getRuntimeProcessIdentity = dependencies.getProcessIdentity ?? getProcessIdentity;
   const runtime: SmokeLockRuntime = {
-    currentPid: dependencies.pid ?? process.pid,
+    currentPid,
+    currentProcessIdentity:
+      dependencies.processIdentity === undefined
+        ? getRuntimeProcessIdentity(currentPid)
+        : dependencies.processIdentity,
     currentProcessStartedAtMs: dependencies.processStartedAtMs ?? CURRENT_PROCESS_STARTED_AT_MS,
-    getProcessStartedAtMs: dependencies.getProcessStartedAtMs ?? getProcessStartedAtMs,
+    getProcessIdentity: getRuntimeProcessIdentity,
     isProcessAlive: dependencies.isProcessAlive ?? isProcessAlive,
     leaseMs: dependencies.leaseMs ?? LOCK_LEASE_MS,
     now: dependencies.now ?? Date.now,
@@ -916,6 +920,9 @@ export async function acquireOpenClawCrablineSmokeRunLock(
   const createdAtMs = runtime.now();
   if (
     !isPositiveSafeInteger(runtime.currentPid) ||
+    (runtime.currentProcessIdentity !== null &&
+      (runtime.currentProcessIdentity.length === 0 ||
+        runtime.currentProcessIdentity.length > 256)) ||
     !isPositiveSafeInteger(runtime.currentProcessStartedAtMs) ||
     !isPositiveSafeInteger(runtime.leaseMs) ||
     !isPositiveSafeInteger(createdAtMs)
@@ -927,6 +934,7 @@ export async function acquireOpenClawCrablineSmokeRunLock(
     createdAtMs,
     leaseVersion: 1,
     pid: runtime.currentPid,
+    ...(runtime.currentProcessIdentity ? { processIdentity: runtime.currentProcessIdentity } : {}),
     processStartedAtMs: runtime.currentProcessStartedAtMs,
     token,
   };

--- a/src/openclaw/smoke-lock.ts
+++ b/src/openclaw/smoke-lock.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { spawnSync } from "node:child_process";
 import fs, { type FileHandle } from "node:fs/promises";
 import path from "node:path";
 import { isCrablineServerChannel, type CrablineServerChannel } from "../servers/index.js";
@@ -49,6 +50,7 @@ type HeartbeatController = {
 type RemoveLockDirectory = (lockDirectory: string) => Promise<void>;
 type Sleep = (delayMs: number) => Promise<void>;
 type IsProcessAlive = (pid: number) => boolean;
+type GetProcessStartedAtMs = (pid: number) => number | null;
 type StartHeartbeat = (renew: () => Promise<void>, intervalMs: number) => HeartbeatController;
 type BeforeRecoveryClaim = () => Promise<void>;
 type BeforeRecoveryDeleteClaim = () => Promise<void>;
@@ -71,6 +73,7 @@ type DirectoryIdentity = {
 type SmokeLockRuntime = {
   currentPid: number;
   currentProcessStartedAtMs: number;
+  getProcessStartedAtMs: GetProcessStartedAtMs;
   isProcessAlive: IsProcessAlive;
   leaseMs: number;
   now: () => number;
@@ -87,6 +90,7 @@ const LOCK_LEASE_MS = 10 * 60 * 1000;
 const RELEASE_ATTEMPTS = 3;
 const RELEASE_RETRY_DELAY_MS = 10;
 const CURRENT_PROCESS_STARTED_AT_MS = Math.trunc(Date.now() - process.uptime() * 1000);
+const PROCESS_START_TOLERANCE_MS = 2_000;
 
 function parseCommitStagePath(contents: string, token: string): string {
   let value: { path?: unknown; token?: unknown };
@@ -373,20 +377,54 @@ const isProcessAlive: IsProcessAlive = (pid) => {
   }
 };
 
+const getProcessStartedAtMs: GetProcessStartedAtMs = (pid) => {
+  if (pid === process.pid) {
+    return CURRENT_PROCESS_STARTED_AT_MS;
+  }
+  if (process.platform === "win32") {
+    return null;
+  }
+  const result = spawnSync("ps", ["-o", "lstart=", "-p", String(pid)], {
+    encoding: "utf8",
+    timeout: 1_000,
+  });
+  if (result.status !== 0) {
+    return null;
+  }
+  const startedAtMs = Date.parse(result.stdout.trim());
+  return Number.isFinite(startedAtMs) && startedAtMs > 0 ? startedAtMs : null;
+};
+
 function isLockOwnerActive(record: SmokeLockRecord, runtime: SmokeLockRuntime): boolean {
   const { owner } = record;
   if (!runtime.isProcessAlive(owner.pid)) {
     return false;
   }
-  if (
-    hasProcessIdentity(owner) &&
-    owner.pid === runtime.currentPid &&
-    owner.processStartedAtMs !== runtime.currentProcessStartedAtMs
-  ) {
-    return false;
+  if (hasProcessIdentity(owner)) {
+    const actualProcessStartedAtMs =
+      owner.pid === runtime.currentPid
+        ? runtime.currentProcessStartedAtMs
+        : runtime.getProcessStartedAtMs(owner.pid);
+    if (
+      actualProcessStartedAtMs !== null &&
+      (owner.pid === runtime.currentPid
+        ? owner.processStartedAtMs !== actualProcessStartedAtMs
+        : Math.abs(owner.processStartedAtMs - actualProcessStartedAtMs) >
+          PROCESS_START_TOLERANCE_MS)
+    ) {
+      return false;
+    }
+    if (!isRenewableOwner(owner) && actualProcessStartedAtMs === null) {
+      const ageMs = runtime.now() - Math.max(owner.createdAtMs, record.renewedAtMs);
+      return ageMs <= runtime.leaseMs * 2;
+    }
   }
   if (!isRenewableOwner(owner)) {
-    return true;
+    if (hasProcessIdentity(owner)) {
+      return true;
+    }
+    const ageMs = runtime.now() - record.renewedAtMs;
+    return ageMs <= runtime.leaseMs * 2;
   }
   const ageMs = runtime.now() - Math.max(owner.createdAtMs, record.renewedAtMs);
   return ageMs >= -runtime.leaseMs && ageMs <= runtime.leaseMs;
@@ -813,6 +851,7 @@ export async function acquireOpenClawCrablineSmokeRunLock(
   dependencies: {
     afterLockCandidateInstall?: AfterLockDirectoryWrite;
     afterLockOwnerWrite?: AfterLockDirectoryWrite;
+    getProcessStartedAtMs?: GetProcessStartedAtMs;
     isProcessAlive?: IsProcessAlive;
     leaseMs?: number;
     now?: () => number;
@@ -837,6 +876,7 @@ export async function acquireOpenClawCrablineSmokeRunLock(
   const runtime: SmokeLockRuntime = {
     currentPid: dependencies.pid ?? process.pid,
     currentProcessStartedAtMs: dependencies.processStartedAtMs ?? CURRENT_PROCESS_STARTED_AT_MS,
+    getProcessStartedAtMs: dependencies.getProcessStartedAtMs ?? getProcessStartedAtMs,
     isProcessAlive: dependencies.isProcessAlive ?? isProcessAlive,
     leaseMs: dependencies.leaseMs ?? LOCK_LEASE_MS,
     now: dependencies.now ?? Date.now,

--- a/src/openclaw/smoke-lock.ts
+++ b/src/openclaw/smoke-lock.ts
@@ -437,7 +437,11 @@ function hasExactProcessIdentity(owner: SmokeLockOwner): owner is (
 
 function hasProcessIdentityMismatch(owner: SmokeLockOwner, runtime: SmokeLockRuntime): boolean {
   if (!hasExactProcessIdentity(owner)) {
-    return false;
+    return (
+      hasProcessIdentity(owner) &&
+      owner.pid === runtime.currentPid &&
+      owner.processStartedAtMs !== runtime.currentProcessStartedAtMs
+    );
   }
   const actualProcessIdentity =
     owner.pid === runtime.currentPid

--- a/src/openclaw/smoke-lock.ts
+++ b/src/openclaw/smoke-lock.ts
@@ -385,7 +385,11 @@ const isProcessAlive: IsProcessAlive = (pid) => {
   }
 };
 
-export function processIdentityFromLinuxStat(value: string): string | null {
+export function processIdentityFromLinuxStat(value: string, bootId: string): string | null {
+  const normalizedBootId = bootId.trim();
+  if (!/^[0-9a-f-]{16,64}$/iu.test(normalizedBootId)) {
+    return null;
+  }
   const commandEnd = value.lastIndexOf(") ");
   if (commandEnd < 0) {
     return null;
@@ -398,16 +402,43 @@ export function processIdentityFromLinuxStat(value: string): string | null {
   if (!startTicks || !/^\d+$/u.test(startTicks)) {
     return null;
   }
-  return `linux:${startTicks}`;
+  return `linux:${normalizedBootId}:${startTicks}`;
+}
+
+export function processIdentityFromDarwin(
+  processStartedAt: string,
+  bootTime: string,
+): string | null {
+  const bootMatch = /\bsec = (\d+), usec = (\d+)\b/u.exec(bootTime);
+  const normalizedStartedAt = processStartedAt.trim().replace(/\s+/gu, " ");
+  if (!bootMatch || normalizedStartedAt.length === 0 || normalizedStartedAt.length > 64) {
+    return null;
+  }
+  return `darwin:${bootMatch[1]}.${bootMatch[2]}:${normalizedStartedAt}`;
 }
 
 const getProcessIdentity: GetProcessIdentity = (pid) => {
   if (process.platform === "linux") {
     try {
-      return processIdentityFromLinuxStat(readFileSync(`/proc/${pid}/stat`, "utf8"));
+      return processIdentityFromLinuxStat(
+        readFileSync(`/proc/${pid}/stat`, "utf8"),
+        readFileSync("/proc/sys/kernel/random/boot_id", "utf8"),
+      );
     } catch {
       return null;
     }
+  }
+  if (process.platform === "darwin") {
+    const options = {
+      encoding: "utf8" as const,
+      env: { ...process.env, LC_ALL: "C" },
+      timeout: 1_000,
+    };
+    const startedAt = spawnSync("ps", ["-o", "lstart=", "-p", String(pid)], options);
+    const bootTime = spawnSync("sysctl", ["-n", "kern.boottime"], options);
+    return startedAt.status === 0 && bootTime.status === 0
+      ? processIdentityFromDarwin(startedAt.stdout, bootTime.stdout)
+      : null;
   }
   if (process.platform !== "win32") {
     return null;

--- a/src/openclaw/smoke-lock.ts
+++ b/src/openclaw/smoke-lock.ts
@@ -484,7 +484,10 @@ function hasProcessIdentityMismatch(owner: SmokeLockOwner, runtime: SmokeLockRun
     owner.pid === runtime.currentPid
       ? runtime.currentProcessIdentity
       : runtime.getProcessIdentity(owner.pid);
-  return actualProcessIdentity !== null && owner.processIdentity !== actualProcessIdentity;
+  return actualProcessIdentity === null
+    ? owner.pid === runtime.currentPid &&
+        owner.processStartedAtMs !== runtime.currentProcessStartedAtMs
+    : owner.processIdentity !== actualProcessIdentity;
 }
 
 function isLockOwnerActive(record: SmokeLockRecord, runtime: SmokeLockRuntime): boolean {

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -112,7 +112,7 @@ function createLazyProvider(params: {
   });
 }
 
-class LazyProviderAdapter implements ProviderAdapter {
+export class LazyProviderAdapter implements ProviderAdapter {
   readonly id;
   readonly platform;
   readonly status;
@@ -256,10 +256,17 @@ class LazyProviderAdapter implements ProviderAdapter {
       const providerCleanup = this.#cleanupProvider(
         operations.map((operation) => operation.dispatch),
       );
-      void providerCleanup.catch(() => undefined);
-      await Promise.allSettled(operations.map((operation) => operation.completion));
-      await Promise.allSettled(closingWatches);
-      await providerCleanup;
+      const [cleanupResult] = await Promise.all([
+        providerCleanup.then(
+          () => ({ ok: true as const }),
+          (error: unknown) => ({ error, ok: false as const }),
+        ),
+        Promise.allSettled(operations.map((operation) => operation.completion)),
+        Promise.allSettled(closingWatches),
+      ]);
+      if (!cleanupResult.ok) {
+        throw cleanupResult.error;
+      }
     })();
     await this.#cleanupPromise;
   }

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -364,37 +364,13 @@ class LazyProviderAdapter implements ProviderAdapter {
         throw error;
       }
     })();
-    const completion = signal
-      ? new Promise<T>((resolve, reject) => {
-          const finish = () => signal.removeEventListener("abort", abort);
-          const abort = () => {
-            finish();
-            reject(signal.reason ?? new Error("Provider operation aborted."));
-          };
-          if (signal.aborted) {
-            abort();
-          } else {
-            signal.addEventListener("abort", abort, { once: true });
-          }
-          void underlying.then(
-            (value) => {
-              finish();
-              resolve(value);
-            },
-            (error: unknown) => {
-              finish();
-              reject(error);
-            },
-          );
-        })
-      : underlying;
     const operation = { completion: underlying, dispatch };
     this.#inFlightOperations.add(operation);
     void underlying.then(
       () => this.#inFlightOperations.delete(operation),
       () => this.#inFlightOperations.delete(operation),
     );
-    return completion;
+    return underlying;
   }
 
   #cleanedUpError(): CrablineError {

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -337,6 +337,9 @@ class LazyProviderAdapter implements ProviderAdapter {
     if (this.#cleanedUp) {
       return Promise.reject(this.#cleanedUpError());
     }
+    if (signal?.aborted) {
+      return Promise.reject(signal.reason ?? new Error("Provider operation aborted."));
+    }
     let markDispatched: (() => void) | undefined;
     const dispatched = new Promise<void>((resolve) => {
       markDispatched = resolve;
@@ -345,16 +348,24 @@ class LazyProviderAdapter implements ProviderAdapter {
       promise: dispatched,
       reached: false,
     };
-    const completion = (async () => {
+    const underlying = (async () => {
       try {
         const provider = await this.#provider();
+        if (signal?.aborted) {
+          throw signal.reason ?? new Error("Provider operation aborted.");
+        }
         const result = run(provider);
         dispatch.reached = true;
         markDispatched?.();
-        if (!signal) {
-          return await result;
-        }
-        return await new Promise<T>((resolve, reject) => {
+        return await result;
+      } catch (error) {
+        dispatch.reached = true;
+        markDispatched?.();
+        throw error;
+      }
+    })();
+    const completion = signal
+      ? new Promise<T>((resolve, reject) => {
           const finish = () => signal.removeEventListener("abort", abort);
           const abort = () => {
             finish();
@@ -362,11 +373,10 @@ class LazyProviderAdapter implements ProviderAdapter {
           };
           if (signal.aborted) {
             abort();
-            void result.catch(() => undefined);
-            return;
+          } else {
+            signal.addEventListener("abort", abort, { once: true });
           }
-          signal.addEventListener("abort", abort, { once: true });
-          void result.then(
+          void underlying.then(
             (value) => {
               finish();
               resolve(value);
@@ -376,16 +386,11 @@ class LazyProviderAdapter implements ProviderAdapter {
               reject(error);
             },
           );
-        });
-      } catch (error) {
-        dispatch.reached = true;
-        markDispatched?.();
-        throw error;
-      }
-    })();
-    const operation = { completion, dispatch };
+        })
+      : underlying;
+    const operation = { completion: underlying, dispatch };
     this.#inFlightOperations.add(operation);
-    void completion.then(
+    void underlying.then(
       () => this.#inFlightOperations.delete(operation),
       () => this.#inFlightOperations.delete(operation),
     );
@@ -405,10 +410,15 @@ export function createRegistry(manifest: ManifestDefinition, manifestPath: strin
       if (!fixture) {
         throw new CrablineError(`Unknown fixture: ${fixtureId}`, { kind: "config" });
       }
-
       const config = manifest.providers[providerId];
       if (!config) {
         throw new CrablineError(`Unknown provider: ${providerId}`, { kind: "config" });
+      }
+      if (fixture.provider !== providerId) {
+        throw new CrablineError(
+          `Fixture "${fixtureId}" belongs to provider "${fixture.provider}", not "${providerId}".`,
+          { kind: "config" },
+        );
       }
 
       if (config.status === "disabled") {

--- a/test/openclaw-smoke-lock.test.ts
+++ b/test/openclaw-smoke-lock.test.ts
@@ -514,6 +514,45 @@ describe("OpenClaw smoke lock cleanup", () => {
     }
   });
 
+  it("falls back to start time when current process identity is unavailable", async () => {
+    const outputDir = await createTempDir();
+    const params = { channel: "telegram" as const, outputDir };
+    const lockDirectory = path.join(
+      path.resolve(outputDir),
+      `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`,
+    );
+    try {
+      await fs.mkdir(lockDirectory, { mode: 0o700 });
+      await fs.writeFile(
+        path.join(lockDirectory, "owner.json"),
+        `${JSON.stringify({
+          channel: "telegram",
+          createdAtMs: 1_000,
+          pid: 4_242,
+          processIdentity: "test:prior",
+          processStartedAtMs: 100,
+          token: "prior",
+        })}\n`,
+        { mode: 0o600 },
+      );
+
+      const replacementLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+        getProcessIdentity: () => null,
+        isProcessAlive: () => true,
+        leaseMs: 1_000,
+        now: () => 1_100,
+        pid: 4_242,
+        processIdentity: null,
+        processStartedAtMs: 200,
+      });
+
+      await expect(replacementLock.assertOwned()).resolves.toBeUndefined();
+      await replacementLock.release();
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
   it("keeps an expired legacy lock while its PID is still alive", async () => {
     const outputDir = await createTempDir();
     const params = { channel: "telegram" as const, outputDir };

--- a/test/openclaw-smoke-lock.test.ts
+++ b/test/openclaw-smoke-lock.test.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   acquireOpenClawCrablineSmokeRunLock,
-  processStartedAtMsFromElapsed,
+  processIdentityFromLinuxStat,
   releaseOpenClawCrablineSmokeRunLock,
 } from "../src/openclaw/smoke-lock.js";
 import { OPENCLAW_CRABLINE_MANIFEST_PATH } from "../src/openclaw/shared.js";
@@ -16,12 +16,13 @@ const disableHeartbeat = (_renew: () => Promise<void>, _intervalMs: number) => (
 });
 
 describe("OpenClaw smoke lock cleanup", () => {
-  it("derives process identity from timezone-independent elapsed time", () => {
-    expect(processStartedAtMsFromElapsed("01:02", 1_000_000)).toBe(938_000);
-    expect(processStartedAtMsFromElapsed("03:04:05", 20_000_000)).toBe(8_955_000);
-    expect(processStartedAtMsFromElapsed("2-03:04:05", 200_000_000)).toBe(16_155_000);
-    expect(processStartedAtMsFromElapsed("25:00:00", 200_000_000)).toBeNull();
-    expect(processStartedAtMsFromElapsed("not elapsed", 200_000_000)).toBeNull();
+  it("extracts the exact Linux process start token", () => {
+    expect(
+      processIdentityFromLinuxStat(
+        "4242 (command with spaces) S 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 123456",
+      ),
+    ).toBe("linux:123456");
+    expect(processIdentityFromLinuxStat("malformed")).toBeNull();
   });
 
   it("secures an empty Windows lock directory before writing sensitive contents", async () => {
@@ -276,12 +277,14 @@ describe("OpenClaw smoke lock cleanup", () => {
         isProcessAlive: () => true,
         now: () => 1_000,
         pid: 4_242,
+        processIdentity: "test:first",
         processStartedAtMs: 100,
       });
       const replacementLock = await acquireOpenClawCrablineSmokeRunLock(params, {
         isProcessAlive: () => true,
         now: () => 1_100,
         pid: 4_242,
+        processIdentity: "test:second",
         processStartedAtMs: 200,
       });
 
@@ -291,6 +294,7 @@ describe("OpenClaw smoke lock cleanup", () => {
           isProcessAlive: () => true,
           now: () => 1_200,
           pid: 4_242,
+          processIdentity: "test:second",
           processStartedAtMs: 200,
         }),
       ).rejects.toThrow("OpenClaw Crabline smoke is already running");
@@ -358,6 +362,7 @@ describe("OpenClaw smoke lock cleanup", () => {
           channel: "telegram",
           createdAtMs: 1_000,
           pid: 4_242,
+          processIdentity: "test:prior",
           processStartedAtMs: 100,
           token: "prior",
         })}\n`,
@@ -367,7 +372,7 @@ describe("OpenClaw smoke lock cleanup", () => {
       await expect(
         acquireOpenClawCrablineSmokeRunLock(params, {
           isProcessAlive: () => true,
-          getProcessStartedAtMs: () => 100,
+          getProcessIdentity: () => "test:prior",
           leaseMs: 1_000,
           now: () => 10_000,
           pid: 5_252,
@@ -401,7 +406,7 @@ describe("OpenClaw smoke lock cleanup", () => {
       );
 
       const replacementLock = await acquireOpenClawCrablineSmokeRunLock(params, {
-        getProcessStartedAtMs: () => null,
+        getProcessIdentity: () => null,
         isProcessAlive: () => false,
         leaseMs: 1_000,
         now: () => 1_100,
@@ -431,6 +436,7 @@ describe("OpenClaw smoke lock cleanup", () => {
           channel: "telegram",
           createdAtMs: 1_000,
           pid: 4_242,
+          processIdentity: "test:prior",
           processStartedAtMs: 100,
           token: "prior",
         })}\n`,
@@ -438,7 +444,7 @@ describe("OpenClaw smoke lock cleanup", () => {
       );
 
       const replacementLock = await acquireOpenClawCrablineSmokeRunLock(params, {
-        getProcessStartedAtMs: () => 5_000,
+        getProcessIdentity: () => "test:replacement",
         isProcessAlive: () => true,
         leaseMs: 1_000,
         now: () => 1_100,

--- a/test/openclaw-smoke-lock.test.ts
+++ b/test/openclaw-smoke-lock.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   acquireOpenClawCrablineSmokeRunLock,
+  darwinProcessIdentityEnvironment,
   processIdentityFromDarwin,
   processIdentityFromLinuxStat,
   releaseOpenClawCrablineSmokeRunLock,
@@ -35,6 +36,21 @@ describe("OpenClaw smoke lock cleanup", () => {
       ),
     ).toBe("darwin:1783864000.123456:Sun Jul 12 16:04:00 2026");
     expect(processIdentityFromDarwin("", "{ sec = 1, usec = 2 }")).toBeNull();
+  });
+
+  it("uses a canonical environment for Darwin process start times", () => {
+    const environment = { LC_ALL: "fr_FR.UTF-8", TZ: "Europe/Paris", UNRELATED: "preserved" };
+
+    expect(darwinProcessIdentityEnvironment(environment)).toEqual({
+      LC_ALL: "C",
+      TZ: "UTC",
+      UNRELATED: "preserved",
+    });
+    expect(environment).toEqual({
+      LC_ALL: "fr_FR.UTF-8",
+      TZ: "Europe/Paris",
+      UNRELATED: "preserved",
+    });
   });
 
   it("secures an empty Windows lock directory before writing sensitive contents", async () => {

--- a/test/openclaw-smoke-lock.test.ts
+++ b/test/openclaw-smoke-lock.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   acquireOpenClawCrablineSmokeRunLock,
+  processStartedAtMsFromElapsed,
   releaseOpenClawCrablineSmokeRunLock,
 } from "../src/openclaw/smoke-lock.js";
 import { OPENCLAW_CRABLINE_MANIFEST_PATH } from "../src/openclaw/shared.js";
@@ -15,6 +16,14 @@ const disableHeartbeat = (_renew: () => Promise<void>, _intervalMs: number) => (
 });
 
 describe("OpenClaw smoke lock cleanup", () => {
+  it("derives process identity from timezone-independent elapsed time", () => {
+    expect(processStartedAtMsFromElapsed("01:02", 1_000_000)).toBe(938_000);
+    expect(processStartedAtMsFromElapsed("03:04:05", 20_000_000)).toBe(8_955_000);
+    expect(processStartedAtMsFromElapsed("2-03:04:05", 200_000_000)).toBe(16_155_000);
+    expect(processStartedAtMsFromElapsed("25:00:00", 200_000_000)).toBeNull();
+    expect(processStartedAtMsFromElapsed("not elapsed", 200_000_000)).toBeNull();
+  });
+
   it("secures an empty Windows lock directory before writing sensitive contents", async () => {
     const outputDir = await createTempDir();
     const destinationPath = path.join(outputDir, "current.json");

--- a/test/openclaw-smoke-lock.test.ts
+++ b/test/openclaw-smoke-lock.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   acquireOpenClawCrablineSmokeRunLock,
+  processIdentityFromDarwin,
   processIdentityFromLinuxStat,
   releaseOpenClawCrablineSmokeRunLock,
 } from "../src/openclaw/smoke-lock.js";
@@ -20,9 +21,20 @@ describe("OpenClaw smoke lock cleanup", () => {
     expect(
       processIdentityFromLinuxStat(
         "4242 (command with spaces) S 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 123456",
+        "01234567-89ab-cdef-0123-456789abcdef",
       ),
-    ).toBe("linux:123456");
-    expect(processIdentityFromLinuxStat("malformed")).toBeNull();
+    ).toBe("linux:01234567-89ab-cdef-0123-456789abcdef:123456");
+    expect(processIdentityFromLinuxStat("malformed", "not-a-boot-id")).toBeNull();
+  });
+
+  it("combines Darwin boot and process start identities", () => {
+    expect(
+      processIdentityFromDarwin(
+        "Sun Jul 12 16:04:00 2026",
+        "{ sec = 1783864000, usec = 123456 } Sun Jul 12 15:46:40 2026",
+      ),
+    ).toBe("darwin:1783864000.123456:Sun Jul 12 16:04:00 2026");
+    expect(processIdentityFromDarwin("", "{ sec = 1, usec = 2 }")).toBeNull();
   });
 
   it("secures an empty Windows lock directory before writing sensitive contents", async () => {

--- a/test/openclaw-smoke-lock.test.ts
+++ b/test/openclaw-smoke-lock.test.ts
@@ -407,7 +407,7 @@ describe("OpenClaw smoke lock cleanup", () => {
     }
   });
 
-  it("reclaims an expired legacy lock even when its PID was reused", async () => {
+  it("keeps an expired legacy lock while its PID is still alive", async () => {
     const outputDir = await createTempDir();
     const params = { channel: "telegram" as const, outputDir };
     const lockDirectory = path.join(
@@ -428,16 +428,15 @@ describe("OpenClaw smoke lock cleanup", () => {
       );
       await fs.utimes(ownerPath, new Date(1_000), new Date(1_000));
 
-      const replacementLock = await acquireOpenClawCrablineSmokeRunLock(params, {
-        isProcessAlive: () => true,
-        leaseMs: 1_000,
-        now: () => 3_001,
-        pid: 5_252,
-        processStartedAtMs: 200,
-      });
-
-      await expect(replacementLock.assertOwned()).resolves.toBeUndefined();
-      await replacementLock.release();
+      await expect(
+        acquireOpenClawCrablineSmokeRunLock(params, {
+          isProcessAlive: () => true,
+          leaseMs: 1_000,
+          now: () => 3_001,
+          pid: 5_252,
+          processStartedAtMs: 200,
+        }),
+      ).rejects.toThrow("OpenClaw Crabline smoke is already running");
     } finally {
       await disposeTempDir(outputDir);
     }

--- a/test/openclaw-smoke-lock.test.ts
+++ b/test/openclaw-smoke-lock.test.ts
@@ -304,6 +304,33 @@ describe("OpenClaw smoke lock cleanup", () => {
     }
   });
 
+  it("reclaims a timestamp-only lock when its PID is reused by the acquiring process", async () => {
+    const outputDir = await createTempDir();
+    const params = { channel: "telegram" as const, outputDir };
+    try {
+      const firstLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+        isProcessAlive: () => true,
+        now: () => 1_000,
+        pid: 4_242,
+        processIdentity: null,
+        processStartedAtMs: 100,
+      });
+      const replacementLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+        isProcessAlive: () => true,
+        now: () => 1_100,
+        pid: 4_242,
+        processIdentity: null,
+        processStartedAtMs: 200,
+      });
+
+      await firstLock.release();
+      await expect(replacementLock.assertOwned()).resolves.toBeUndefined();
+      await replacementLock.release();
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
   it("keeps an active legacy-format lock owned by its live PID", async () => {
     const outputDir = await createTempDir();
     const params = { channel: "telegram" as const, outputDir };

--- a/test/openclaw-smoke-lock.test.ts
+++ b/test/openclaw-smoke-lock.test.ts
@@ -379,6 +379,43 @@ describe("OpenClaw smoke lock cleanup", () => {
     }
   });
 
+  it("reclaims a dead pre-heartbeat owner when its start time is unavailable", async () => {
+    const outputDir = await createTempDir();
+    const params = { channel: "telegram" as const, outputDir };
+    const lockDirectory = path.join(
+      path.resolve(outputDir),
+      `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`,
+    );
+    try {
+      await fs.mkdir(lockDirectory, { mode: 0o700 });
+      await fs.writeFile(
+        path.join(lockDirectory, "owner.json"),
+        `${JSON.stringify({
+          channel: "telegram",
+          createdAtMs: 1_000,
+          pid: 4_242,
+          processStartedAtMs: 100,
+          token: "prior",
+        })}\n`,
+        { mode: 0o600 },
+      );
+
+      const replacementLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+        getProcessStartedAtMs: () => null,
+        isProcessAlive: () => false,
+        leaseMs: 1_000,
+        now: () => 1_100,
+        pid: 5_252,
+        processStartedAtMs: 200,
+      });
+
+      await expect(replacementLock.assertOwned()).resolves.toBeUndefined();
+      await replacementLock.release();
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
   it("reclaims a pre-heartbeat lock after its PID is reused", async () => {
     const outputDir = await createTempDir();
     const params = { channel: "telegram" as const, outputDir };

--- a/test/openclaw-smoke-lock.test.ts
+++ b/test/openclaw-smoke-lock.test.ts
@@ -310,6 +310,7 @@ describe("OpenClaw smoke lock cleanup", () => {
         })}\n`,
         { mode: 0o600 },
       );
+      await fs.utimes(path.join(lockDirectory, "owner.json"), new Date(1_000), new Date(1_000));
 
       await expect(
         acquireOpenClawCrablineSmokeRunLock(params, {
@@ -357,12 +358,86 @@ describe("OpenClaw smoke lock cleanup", () => {
       await expect(
         acquireOpenClawCrablineSmokeRunLock(params, {
           isProcessAlive: () => true,
+          getProcessStartedAtMs: () => 100,
           leaseMs: 1_000,
           now: () => 10_000,
           pid: 5_252,
           processStartedAtMs: 200,
         }),
       ).rejects.toThrow("OpenClaw Crabline smoke is already running");
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
+  it("reclaims a pre-heartbeat lock after its PID is reused", async () => {
+    const outputDir = await createTempDir();
+    const params = { channel: "telegram" as const, outputDir };
+    const lockDirectory = path.join(
+      path.resolve(outputDir),
+      `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`,
+    );
+    try {
+      await fs.mkdir(lockDirectory, { mode: 0o700 });
+      await fs.writeFile(
+        path.join(lockDirectory, "owner.json"),
+        `${JSON.stringify({
+          channel: "telegram",
+          createdAtMs: 1_000,
+          pid: 4_242,
+          processStartedAtMs: 100,
+          token: "prior",
+        })}\n`,
+        { mode: 0o600 },
+      );
+
+      const replacementLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+        getProcessStartedAtMs: () => 5_000,
+        isProcessAlive: () => true,
+        leaseMs: 1_000,
+        now: () => 1_100,
+        pid: 5_252,
+        processStartedAtMs: 200,
+      });
+
+      await expect(replacementLock.assertOwned()).resolves.toBeUndefined();
+      await replacementLock.release();
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
+  it("reclaims an expired legacy lock even when its PID was reused", async () => {
+    const outputDir = await createTempDir();
+    const params = { channel: "telegram" as const, outputDir };
+    const lockDirectory = path.join(
+      path.resolve(outputDir),
+      `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`,
+    );
+    const ownerPath = path.join(lockDirectory, "owner.json");
+    try {
+      await fs.mkdir(lockDirectory, { mode: 0o700 });
+      await fs.writeFile(
+        ownerPath,
+        `${JSON.stringify({
+          channel: "telegram",
+          pid: 4_242,
+          token: "legacy",
+        })}\n`,
+        { mode: 0o600 },
+      );
+      await fs.utimes(ownerPath, new Date(1_000), new Date(1_000));
+
+      const replacementLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+        isProcessAlive: () => true,
+        leaseMs: 1_000,
+        now: () => 3_001,
+        pid: 5_252,
+        processStartedAtMs: 200,
+      });
+
+      await expect(replacementLock.assertOwned()).resolves.toBeUndefined();
+      await replacementLock.release();
     } finally {
       await disposeTempDir(outputDir);
     }

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -1866,6 +1866,35 @@ describe("OpenClaw local provider bridge", () => {
     }
   });
 
+  it("preserves a frozen smoke failure when lock cleanup also fails", async () => {
+    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-openclaw-frozen-smoke-"));
+    const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
+    const primaryFailure = Object.freeze(new Error("frozen smoke failure"));
+    try {
+      await expect(
+        runSmokeWithDependencies(
+          { outputDir, selection },
+          {
+            releaseLock: async () => {
+              throw new Error("lock release retries exhausted");
+            },
+            startAdapter: async (params) => {
+              const adapter = await startOpenClawCrablineAdapter(params);
+              return {
+                ...adapter,
+                probe: async () => {
+                  throw primaryFailure;
+                },
+              };
+            },
+          },
+        ),
+      ).rejects.toBe(primaryFailure);
+    } finally {
+      await fs.rm(outputDir, { recursive: true, force: true });
+    }
+  });
+
   it("preserves the primary provider probe failure when adapter cleanup also fails", async () => {
     const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-openclaw-probe-errors-"));
     const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });

--- a/test/registry-lifecycle.test.ts
+++ b/test/registry-lifecycle.test.ts
@@ -390,16 +390,21 @@ describe("lazy provider lifecycle", () => {
     }
   });
 
-  it("does not let an aborted lazy inbound wait block cleanup", async () => {
+  it("tracks an aborted lazy inbound wait until provider work settles", async () => {
     const directory = await createTempDir();
     const recorderPath = path.join(directory, "telegram.jsonl");
     let markWaitStarted: (() => void) | undefined;
     const waitStarted = new Promise<void>((resolve) => {
       markWaitStarted = resolve;
     });
+    let releaseWait: (() => void) | undefined;
+    const waitBlocked = new Promise<void>((resolve) => {
+      releaseWait = resolve;
+    });
     recorderMocks.waitForRecordedInbound.mockImplementationOnce(async () => {
       markWaitStarted?.();
-      return await new Promise<never>(() => undefined);
+      await waitBlocked;
+      return null;
     });
 
     try {
@@ -422,7 +427,46 @@ describe("lazy provider lifecycle", () => {
       controller.abort(abortReason);
 
       await expect(waiting).rejects.toBe(abortReason);
-      await expect(provider.cleanup?.()).resolves.toBeUndefined();
+      let cleanupResolved = false;
+      const cleanup = provider.cleanup?.().then(() => {
+        cleanupResolved = true;
+      });
+      await Promise.resolve();
+      expect(cleanupResolved).toBe(false);
+
+      releaseWait?.();
+      await expect(cleanup).resolves.toBeUndefined();
+    } finally {
+      releaseWait?.();
+      await disposeTempDir(directory);
+    }
+  });
+
+  it("does not invoke a lazy provider for a pre-aborted wait", async () => {
+    const directory = await createTempDir();
+    const recorderPath = path.join(directory, "telegram.jsonl");
+    try {
+      const { context, manifest } = createTelegramManifest(recorderPath);
+      const provider = createRegistry(manifest, context.manifestPath).resolve(
+        "telegram",
+        context.fixture.id,
+      );
+      const controller = new AbortController();
+      const abortReason = new Error("already aborted");
+      controller.abort(abortReason);
+
+      await expect(
+        provider.waitForInbound({
+          ...context,
+          nonce: "pre-aborted",
+          signal: controller.signal,
+          since: new Date().toISOString(),
+          timeoutMs: 100,
+        }),
+      ).rejects.toBe(abortReason);
+
+      expect(recorderMocks.waitForRecordedInbound).not.toHaveBeenCalled();
+      await provider.cleanup?.();
     } finally {
       await disposeTempDir(directory);
     }

--- a/test/registry-lifecycle.test.ts
+++ b/test/registry-lifecycle.test.ts
@@ -2,8 +2,8 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ManifestDefinition, ProviderConfig } from "../src/config/schema.js";
-import { createRegistry } from "../src/providers/registry.js";
-import type { ProviderContext, SendContext } from "../src/providers/types.js";
+import { createRegistry, LazyProviderAdapter } from "../src/providers/registry.js";
+import type { ProviderAdapter, ProviderContext, SendContext } from "../src/providers/types.js";
 import { createTempDir, disposeTempDir } from "./test-helpers.js";
 
 type AppendRecordedInbound = typeof import("../src/providers/recorder.js").appendRecordedInbound;
@@ -149,6 +149,88 @@ function createTelegramManifest(recorderPath: string): {
 }
 
 describe("lazy provider lifecycle", () => {
+  it("starts concrete cleanup before waiting for a stuck operation", async () => {
+    let releaseWait: (() => void) | undefined;
+    let markCleanupStarted: (() => void) | undefined;
+    let markWaitStarted: (() => void) | undefined;
+    const cleanupStarted = new Promise<void>((resolve) => {
+      markCleanupStarted = resolve;
+    });
+    const waitStarted = new Promise<void>((resolve) => {
+      markWaitStarted = resolve;
+    });
+    const concrete: ProviderAdapter = {
+      id: "test",
+      platform: "loopback",
+      status: "ready",
+      supports: ["roundtrip"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      async probe() {
+        return { details: [], healthy: true };
+      },
+      async send() {
+        return { accepted: true, messageId: "sent", threadId: "thread" };
+      },
+      async waitForInbound() {
+        markWaitStarted?.();
+        return await new Promise<null>((resolve) => {
+          releaseWait = () => resolve(null);
+        });
+      },
+      async cleanup() {
+        markCleanupStarted?.();
+        releaseWait?.();
+      },
+    };
+    const provider = new LazyProviderAdapter({
+      adapterName: "test",
+      factory: async () => concrete,
+      id: "test",
+      normalizeTarget: concrete.normalizeTarget.bind(concrete),
+      platform: "loopback",
+      status: "ready",
+      supports: ["roundtrip"],
+    });
+    const controller = new AbortController();
+    const waiting = provider.waitForInbound({
+      config: {
+        adapter: "loopback",
+        capabilities: ["roundtrip"],
+        env: [],
+        platform: "loopback",
+        status: "active",
+      },
+      fixture: {
+        env: [],
+        id: "fixture",
+        inboundMatch: { author: "assistant", nonce: "contains", strategy: "contains" },
+        mode: "roundtrip",
+        provider: "test",
+        retries: 0,
+        tags: [],
+        target: { id: "target", metadata: {} },
+        timeoutMs: 10,
+      },
+      manifestPath: "/tmp/crabline.yaml",
+      nonce: "nonce",
+      providerId: "test",
+      signal: controller.signal,
+      since: new Date().toISOString(),
+      timeoutMs: 10,
+      userName: "crabline",
+    });
+    await waitStarted;
+    controller.abort();
+
+    const cleanup = provider.cleanup();
+
+    await expect(cleanupStarted).resolves.toBeUndefined();
+    await expect(waiting).resolves.toBeNull();
+    await expect(cleanup).resolves.toBeUndefined();
+  });
+
   it("starts concrete WhatsApp cleanup before draining admitted registry work", async () => {
     const directory = await createTempDir();
     const recorderPath = path.join(directory, "whatsapp.jsonl");

--- a/test/registry-lifecycle.test.ts
+++ b/test/registry-lifecycle.test.ts
@@ -149,6 +149,78 @@ function createTelegramManifest(recorderPath: string): {
 }
 
 describe("lazy provider lifecycle", () => {
+  it("does not dispatch an operation aborted during provider initialization", async () => {
+    let releaseFactory: (() => void) | undefined;
+    const factoryBlocked = new Promise<void>((resolve) => {
+      releaseFactory = resolve;
+    });
+    const waitForInbound = vi.fn<ProviderAdapter["waitForInbound"]>(async () => null);
+    const concrete: ProviderAdapter = {
+      id: "test",
+      platform: "loopback",
+      status: "ready",
+      supports: ["roundtrip"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      async probe() {
+        return { details: [], healthy: true };
+      },
+      async send() {
+        return { accepted: true, messageId: "sent", threadId: "thread" };
+      },
+      waitForInbound,
+    };
+    const provider = new LazyProviderAdapter({
+      adapterName: "test",
+      factory: async () => {
+        await factoryBlocked;
+        return concrete;
+      },
+      id: "test",
+      normalizeTarget: concrete.normalizeTarget.bind(concrete),
+      platform: "loopback",
+      status: "ready",
+      supports: ["roundtrip"],
+    });
+    const controller = new AbortController();
+    const abortReason = new Error("deadline reached during initialization");
+    const waiting = provider.waitForInbound({
+      config: {
+        adapter: "loopback",
+        capabilities: ["roundtrip"],
+        env: [],
+        platform: "loopback",
+        status: "active",
+      },
+      fixture: {
+        env: [],
+        id: "fixture",
+        inboundMatch: { author: "assistant", nonce: "contains", strategy: "contains" },
+        mode: "roundtrip",
+        provider: "test",
+        retries: 0,
+        tags: [],
+        target: { id: "target", metadata: {} },
+        timeoutMs: 10,
+      },
+      manifestPath: "/tmp/crabline.yaml",
+      nonce: "nonce",
+      providerId: "test",
+      signal: controller.signal,
+      since: new Date().toISOString(),
+      timeoutMs: 10,
+      userName: "crabline",
+    });
+
+    controller.abort(abortReason);
+    releaseFactory?.();
+
+    await expect(waiting).rejects.toBe(abortReason);
+    expect(waitForInbound).not.toHaveBeenCalled();
+    await provider.cleanup();
+  });
+
   it("starts concrete cleanup before waiting for a stuck operation", async () => {
     let releaseWait: (() => void) | undefined;
     let markCleanupStarted: (() => void) | undefined;

--- a/test/registry-lifecycle.test.ts
+++ b/test/registry-lifecycle.test.ts
@@ -426,15 +426,20 @@ describe("lazy provider lifecycle", () => {
 
       controller.abort(abortReason);
 
-      await expect(waiting).rejects.toBe(abortReason);
+      let waitingSettled = false;
+      void waiting.finally(() => {
+        waitingSettled = true;
+      });
       let cleanupResolved = false;
       const cleanup = provider.cleanup?.().then(() => {
         cleanupResolved = true;
       });
       await Promise.resolve();
+      expect(waitingSettled).toBe(false);
       expect(cleanupResolved).toBe(false);
 
       releaseWait?.();
+      await expect(waiting).resolves.toBeNull();
       await expect(cleanup).resolves.toBeUndefined();
     } finally {
       releaseWait?.();

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -208,6 +208,27 @@ describe("registry", () => {
     expect(() => registry.resolve("missing", "fixture")).toThrow(/Unknown provider/);
   });
 
+  it("rejects resolving a fixture through a different provider", () => {
+    const mismatchedManifest: ManifestDefinition = {
+      ...manifest,
+      providers: {
+        ...manifest.providers,
+        other: {
+          adapter: "loopback",
+          capabilities: ["probe", "send"],
+          env: [],
+          platform: "loopback",
+          status: "active",
+        },
+      },
+    };
+    const registry = createRegistry(mismatchedManifest, "/tmp/crabline.yaml");
+
+    expect(() => registry.resolve("other", "fixture")).toThrow(
+      'Fixture "fixture" belongs to provider "local", not "other".',
+    );
+  });
+
   it("throws for disabled providers", () => {
     const localProvider = manifest.providers.local;
     expect(localProvider).toBeDefined();

--- a/test/reporters-errors.test.ts
+++ b/test/reporters-errors.test.ts
@@ -41,5 +41,7 @@ describe("errors and reporters", () => {
     expect(stripAnsi(suite)).toContain("  - accepted");
     expect(formatJson({ ok: true })).toContain('"ok": true');
     expect(formatJson(undefined)).toBe("null");
+    expect(formatJson(Symbol("value"))).toBe("null");
+    expect(formatJson(() => undefined)).toBe("null");
   });
 });

--- a/test/run.behavior.test.ts
+++ b/test/run.behavior.test.ts
@@ -114,6 +114,51 @@ describe("run behavior", () => {
     expect(missingEnv.failureKind).toBe("config");
   });
 
+  it("rejects an invalid inbound regex before sending", async () => {
+    let sendCalls = 0;
+    const provider: ProviderAdapter = {
+      id: "mock",
+      platform: "loopback",
+      status: "ready",
+      supports: ["probe", "send", "roundtrip", "agent"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      probe: async () => ({ details: [], healthy: true }),
+      send: async () => {
+        sendCalls += 1;
+        return { accepted: true, messageId: "1", threadId: "1" };
+      },
+      waitForInbound: async () => null,
+    };
+    const invalidManifest = withAllCapabilities({
+      ...manifest,
+      fixtures: [
+        {
+          ...manifest.fixtures[0]!,
+          inboundMatch: {
+            author: "assistant",
+            nonce: "contains",
+            pattern: "[",
+            strategy: "regex",
+          },
+          retries: 2,
+        },
+      ],
+    });
+
+    const result = await runFixtureCommand({
+      fixtureId: "fixture",
+      manifest: invalidManifest,
+      manifestPath: "/tmp/crabline.yaml",
+      registry: buildRegistry(provider),
+    });
+
+    expect(result.failureKind).toBe("config");
+    expect(result.diagnostics.join("\n")).toContain("Invalid inbound regex");
+    expect(sendCalls).toBe(0);
+  });
+
   it("uses one effective fixture for mode overrides in provider contexts", async () => {
     const contextFixtures: ManifestDefinition["fixtures"] = [];
     let outboundText = "";
@@ -397,7 +442,8 @@ describe("run behavior", () => {
       registry: buildRegistry(provider),
     });
 
-    expect(result.failureKind).toBe("timeout");
+    expect(result.failureKind).toBe("inbound");
+    expect(result.diagnostics.join("\n")).toContain("did not settle within 250ms after abort");
     rejectWait?.(new Error("late provider failure"));
     await Promise.resolve();
   });

--- a/test/run.retry-timeout.test.ts
+++ b/test/run.retry-timeout.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { runFixtureCommand } from "../src/core/run.js";
 import type { ManifestDefinition } from "../src/config/schema.js";
 import { OPENCLAW_SUPPORT_CATALOG } from "../src/providers/catalog.js";
@@ -153,5 +153,61 @@ describe("runFixtureCommand retries", () => {
     expect(result.ok).toBe(true);
     expect(sendCalls).toBe(2);
     expect(maxActiveWaits).toBe(1);
+  });
+
+  it("stops retrying and defers cleanup when an aborted wait does not settle", async () => {
+    let cleanupCalls = 0;
+    let releaseWait: (() => void) | undefined;
+    let sendCalls = 0;
+    let waitCalls = 0;
+    const provider: ProviderAdapter = {
+      id: "mock",
+      platform: "loopback",
+      status: "ready",
+      supports: ["probe", "send", "roundtrip", "agent"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      async probe() {
+        return { details: [], healthy: true };
+      },
+      async send() {
+        sendCalls += 1;
+        return { accepted: true, messageId: "sent-1", threadId: "thread-1" };
+      },
+      async waitForInbound() {
+        waitCalls += 1;
+        return await new Promise<null>((resolve) => {
+          releaseWait = () => resolve(null);
+        });
+      },
+      async cleanup() {
+        cleanupCalls += 1;
+      },
+    };
+    const registry: Registry = {
+      catalog: OPENCLAW_SUPPORT_CATALOG,
+      resolve() {
+        return provider;
+      },
+    };
+
+    const result = await runFixtureCommand({
+      fixtureId: "fixture",
+      manifest,
+      manifestPath: "/tmp/crabline.yaml",
+      registry,
+    });
+
+    expect(result).toMatchObject({ failureKind: "inbound", ok: false });
+    expect(result.diagnostics).toContain(
+      "Provider inbound wait did not settle within 250ms after abort.",
+    );
+    expect(sendCalls).toBe(1);
+    expect(waitCalls).toBe(1);
+    expect(cleanupCalls).toBe(0);
+
+    releaseWait?.();
+    await vi.waitFor(() => expect(cleanupCalls).toBe(1));
   });
 });

--- a/test/run.retry-timeout.test.ts
+++ b/test/run.retry-timeout.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { runFixtureCommand } from "../src/core/run.js";
 import type { ManifestDefinition } from "../src/config/schema.js";
 import { OPENCLAW_SUPPORT_CATALOG } from "../src/providers/catalog.js";
@@ -155,8 +155,9 @@ describe("runFixtureCommand retries", () => {
     expect(maxActiveWaits).toBe(1);
   });
 
-  it("stops retrying and defers cleanup when an aborted wait does not settle", async () => {
+  it("stops retrying and lets cleanup cancel an aborted wait that does not settle", async () => {
     let cleanupCalls = 0;
+    let keepAlive: ReturnType<typeof setInterval> | undefined;
     let releaseWait: (() => void) | undefined;
     let sendCalls = 0;
     let waitCalls = 0;
@@ -178,11 +179,14 @@ describe("runFixtureCommand retries", () => {
       async waitForInbound() {
         waitCalls += 1;
         return await new Promise<null>((resolve) => {
+          keepAlive = setInterval(() => undefined, 1_000);
           releaseWait = () => resolve(null);
         });
       },
       async cleanup() {
         cleanupCalls += 1;
+        clearInterval(keepAlive);
+        releaseWait?.();
       },
     };
     const registry: Registry = {
@@ -205,9 +209,6 @@ describe("runFixtureCommand retries", () => {
     );
     expect(sendCalls).toBe(1);
     expect(waitCalls).toBe(1);
-    expect(cleanupCalls).toBe(0);
-
-    releaseWait?.();
-    await vi.waitFor(() => expect(cleanupCalls).toBe(1));
+    expect(cleanupCalls).toBe(1);
   });
 });

--- a/test/run.retry-timeout.test.ts
+++ b/test/run.retry-timeout.test.ts
@@ -82,4 +82,76 @@ describe("runFixtureCommand retries", () => {
     expect(result.ok).toBe(true);
     expect(waitCalls).toBe(2);
   });
+
+  it("drains an aborted wait before retrying or cleaning up", async () => {
+    let activeWaits = 0;
+    let maxActiveWaits = 0;
+    let sendCalls = 0;
+    let waitCalls = 0;
+    const provider: ProviderAdapter = {
+      id: "mock",
+      platform: "loopback",
+      status: "ready",
+      supports: ["probe", "send", "roundtrip", "agent"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      async probe() {
+        return { details: [], healthy: true };
+      },
+      async send() {
+        sendCalls += 1;
+        expect(activeWaits).toBe(0);
+        return { accepted: true, messageId: `sent-${sendCalls}`, threadId: "thread-1" };
+      },
+      async waitForInbound(context) {
+        waitCalls += 1;
+        activeWaits += 1;
+        maxActiveWaits = Math.max(maxActiveWaits, activeWaits);
+        if (waitCalls === 1) {
+          return await new Promise<null>((resolve) => {
+            context.signal?.addEventListener(
+              "abort",
+              () => {
+                setTimeout(() => {
+                  activeWaits -= 1;
+                  resolve(null);
+                }, 25);
+              },
+              { once: true },
+            );
+          });
+        }
+        activeWaits -= 1;
+        return {
+          author: "assistant",
+          id: "inbound-1",
+          provider: "mock",
+          sentAt: new Date().toISOString(),
+          text: `ACK ${context.nonce}`,
+          threadId: "thread-1",
+        };
+      },
+      async cleanup() {
+        expect(activeWaits).toBe(0);
+      },
+    };
+    const registry: Registry = {
+      catalog: OPENCLAW_SUPPORT_CATALOG,
+      resolve() {
+        return provider;
+      },
+    };
+
+    const result = await runFixtureCommand({
+      fixtureId: "fixture",
+      manifest,
+      manifestPath: "/tmp/crabline.yaml",
+      registry,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(sendCalls).toBe(2);
+    expect(maxActiveWaits).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary

- drain admitted provider work during abort and cleanup without destroying live owners
- bind OpenClaw smoke locks to platform-native process identities and boot identity
- preserve legacy PID-reuse recovery when exact identity lookup is unavailable
- add lifecycle, cancellation, stale-lock, and platform identity regression coverage

## Verification

- `pnpm format:check`
- `pnpm typecheck`
- `pnpm test`
- Crabbox `run_b3b2f6180582`
- autoreview: gpt-5.6-sol, high effort
