### PR TITLE
fix(providers): enforce webhook and cursor bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Preserve provider-native WhatsApp message acknowledgements, legacy group JIDs, bounded inbound admission, WebSocket error isolation, and strict handshake varints.
+- Authenticate built-in Telegram, Slack, and Zalo webhooks, bound recorder wait state, accept Slack user send targets, preserve canonical Telegram topics, and complete WhatsApp cleanup after close failures.
 - Hold serve ready-file ownership across startup and shutdown, preserve live manifests on failed replacement, and retain compound cleanup failures.
 - Reject invalid matchers and provider/fixture mismatches before side effects, drain aborted provider work before cleanup, preserve frozen primary smoke failures, and recover stale smoke locks after PID reuse.
 - Preserve Slack thread scope and validate Telegram command entities.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ explicit `env` declarations, script command availability, and config shape; it
 does not require live Slack, Discord, Telegram, WhatsApp, Matrix, iMessage, or
 other platform secrets for local mocks.
 
+When configured, Slack `signingSecret`, Telegram `secretToken`, and Zalo
+`webhookSecret` enforce the provider-native webhook authentication headers.
+
 ## Built-In Mock Channels
 
 All built-in mock providers support:

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -75,6 +75,16 @@ Provider credential fields such as `botToken`, `accessToken`, `baseURL`, or
 `serverUrl` are optional mock metadata. They are not required for local mock
 execution.
 
+Optional webhook credentials enforce each provider's native authentication
+header before JSON parsing or recorder writes:
+
+- Slack `signingSecret` or `SLACK_SIGNING_SECRET` verifies
+  `X-Slack-Request-Timestamp` and `X-Slack-Signature`.
+- Telegram `secretToken` or `TELEGRAM_WEBHOOK_SECRET_TOKEN` verifies
+  `X-Telegram-Bot-Api-Secret-Token`.
+- Zalo `webhookSecret` or `ZALO_WEBHOOK_SECRET` verifies
+  `X-Bot-Api-Secret-Token`.
+
 The built-in `whatsapp` adapter implements Meta's GET verification challenge
 and requires `X-Hub-Signature-256` on POST requests. Set `whatsapp.appSecret`
 and `whatsapp.verifyToken` (or `WHATSAPP_APP_SECRET` and

--- a/fixtures/examples/crabline.example.yaml
+++ b/fixtures/examples/crabline.example.yaml
@@ -10,6 +10,7 @@ providers:
   telegram:
     adapter: telegram
     telegram:
+      # secretToken: replace-with-telegram-webhook-secret
       recorder:
         path: ./.crabline/recorders/telegram.jsonl
       webhook:
@@ -30,6 +31,7 @@ providers:
   slack:
     adapter: slack
     slack:
+      # signingSecret: replace-with-slack-signing-secret
       recorder:
         path: ./.crabline/recorders/slack.jsonl
       webhook:
@@ -90,6 +92,7 @@ providers:
   zalo:
     adapter: zalo
     zalo:
+      # webhookSecret: replace-with-zalo-webhook-secret
       recorder:
         path: ./.crabline/recorders/zalo.jsonl
       webhook:

--- a/fixtures/examples/crabline.example.yaml
+++ b/fixtures/examples/crabline.example.yaml
@@ -10,7 +10,7 @@ providers:
   telegram:
     adapter: telegram
     telegram:
-      # secretToken: replace-with-telegram-webhook-secret
+      # secretToken: test-token-placeholder
       recorder:
         path: ./.crabline/recorders/telegram.jsonl
       webhook:
@@ -31,7 +31,7 @@ providers:
   slack:
     adapter: slack
     slack:
-      # signingSecret: replace-with-slack-signing-secret
+      # signingSecret: test-token-placeholder
       recorder:
         path: ./.crabline/recorders/slack.jsonl
       webhook:
@@ -92,7 +92,7 @@ providers:
   zalo:
     adapter: zalo
     zalo:
-      # webhookSecret: replace-with-zalo-webhook-secret
+      # webhookSecret: test-token-placeholder
       recorder:
         path: ./.crabline/recorders/zalo.jsonl
       webhook:

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -117,6 +117,7 @@ const SlackWebhookSchema = z.strictObject({
 
 const SlackConfigSchema = z.strictObject({
   recorder: SlackRecorderSchema.default({}),
+  signingSecret: z.string().min(1).optional(),
   webhook: SlackWebhookSchema.default({
     host: "127.0.0.1",
     path: "/slack/events",

--- a/src/providers/builtin/native-local-mock.ts
+++ b/src/providers/builtin/native-local-mock.ts
@@ -1,3 +1,4 @@
+import { createHash, timingSafeEqual } from "node:crypto";
 import { CrablineError } from "../../core/errors.js";
 import type { NativeIdRule } from "../native-ids.js";
 import type { InboundEnvelope } from "../types.js";
@@ -6,6 +7,13 @@ export type { NativeIdRule } from "../native-ids.js";
 
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+export function createSecretVerifier(expected: string): (candidate: string | null) => boolean {
+  const expectedDigest = createHash("sha256").update(expected).digest();
+  return (candidate) =>
+    candidate !== null &&
+    timingSafeEqual(createHash("sha256").update(candidate).digest(), expectedDigest);
 }
 
 export function optionalRecord(

--- a/src/providers/builtin/slack.ts
+++ b/src/providers/builtin/slack.ts
@@ -1,3 +1,4 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
 import path from "node:path";
 import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
@@ -11,6 +12,50 @@ import {
   optionalString,
   requireNativeInboundId,
 } from "./native-local-mock.js";
+
+const SLACK_SIGNATURE_TOLERANCE_SECONDS = 5 * 60;
+
+type SlackEnvironment = Partial<Pick<NodeJS.ProcessEnv, "SLACK_SIGNING_SECRET">>;
+
+export function resolveSlackAdapterConfig(
+  config: ProviderConfig,
+  env: SlackEnvironment = process.env,
+) {
+  return {
+    signingSecret: config.slack?.signingSecret ?? env.SLACK_SIGNING_SECRET,
+  };
+}
+
+function authenticateSlackWebhook(
+  request: Request,
+  rawBody: string,
+  signingSecret: string,
+): Response | undefined {
+  const timestamp = request.headers.get("x-slack-request-timestamp");
+  const signature = request.headers.get("x-slack-signature");
+  const timestampSeconds = timestamp ? Number(timestamp) : Number.NaN;
+  if (
+    !timestamp ||
+    !signature ||
+    !Number.isSafeInteger(timestampSeconds) ||
+    Math.abs(Date.now() / 1000 - timestampSeconds) > SLACK_SIGNATURE_TOLERANCE_SECONDS
+  ) {
+    return new Response("unauthorized", { status: 401 });
+  }
+
+  const expected = `v0=${createHmac("sha256", signingSecret)
+    .update(`v0:${timestamp}:${rawBody}`)
+    .digest("hex")}`;
+  const actualBuffer = Buffer.from(signature);
+  const expectedBuffer = Buffer.from(expected);
+  if (
+    actualBuffer.length !== expectedBuffer.length ||
+    !timingSafeEqual(actualBuffer, expectedBuffer)
+  ) {
+    return new Response("unauthorized", { status: 401 });
+  }
+  return undefined;
+}
 
 function slackAuthorFromEvent(event: Record<string, unknown>): InboundEnvelope["author"] {
   if (typeof event.bot_id === "string" || event.subtype === "bot_message") {
@@ -124,11 +169,19 @@ function matchesSlackThread(
 
 export class SlackProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
+    const resolvedConfig = resolveSlackAdapterConfig(config);
     super({
       codec: getBuiltinTargetCodec("slack"),
       config,
       id,
       options: {
+        ...(resolvedConfig.signingSecret
+          ? {
+              authenticateWebhookRequest(request: Request, rawBody: string) {
+                return authenticateSlackWebhook(request, rawBody, resolvedConfig.signingSecret!);
+              },
+            }
+          : {}),
         defaultWebhook: { host: "127.0.0.1", path: "/slack/events", port: 8787 },
         endpointLabel: "events endpoint",
         matchesThread: matchesSlackThread,

--- a/src/providers/builtin/telegram.ts
+++ b/src/providers/builtin/telegram.ts
@@ -11,6 +11,7 @@ import {
 import type { ProviderAdapter } from "../types.js";
 import {
   authorFromBotFlag,
+  createSecretVerifier,
   genericMockPayloadWithNativeThread,
   isRecord,
   optionalRecord,
@@ -151,16 +152,18 @@ export function normalizeTelegramWebhookPayload(payload: unknown) {
 export class TelegramProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string) {
     const resolvedConfig = resolveTelegramAdapterConfig(config);
+    const authenticateWebhook = resolvedConfig.secretToken
+      ? createSecretVerifier(resolvedConfig.secretToken)
+      : undefined;
     super({
       codec: getBuiltinTargetCodec("telegram"),
       config,
       id,
       options: {
-        ...(resolvedConfig.secretToken
+        ...(authenticateWebhook
           ? {
               authenticateWebhookRequest(request: Request) {
-                return request.headers.get("x-telegram-bot-api-secret-token") ===
-                  resolvedConfig.secretToken
+                return authenticateWebhook(request.headers.get("x-telegram-bot-api-secret-token"))
                   ? undefined
                   : new Response("unauthorized", { status: 401 });
               },

--- a/src/providers/builtin/telegram.ts
+++ b/src/providers/builtin/telegram.ts
@@ -86,6 +86,7 @@ function normalizeGenericTelegramPayload(payload: Record<string, unknown>) {
     ? {
         ...normalizedRecord,
         raw,
+        threadId: `${canonicalTopic.chatId}:${canonicalTopic.topicId}`,
         message: {
           ...(isRecord(normalizedRecord.message) ? normalizedRecord.message : {}),
           threadId: `${canonicalTopic.chatId}:${canonicalTopic.topicId}`,
@@ -149,11 +150,22 @@ export function normalizeTelegramWebhookPayload(payload: unknown) {
 
 export class TelegramProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string) {
+    const resolvedConfig = resolveTelegramAdapterConfig(config);
     super({
       codec: getBuiltinTargetCodec("telegram"),
       config,
       id,
       options: {
+        ...(resolvedConfig.secretToken
+          ? {
+              authenticateWebhookRequest(request: Request) {
+                return request.headers.get("x-telegram-bot-api-secret-token") ===
+                  resolvedConfig.secretToken
+                  ? undefined
+                  : new Response("unauthorized", { status: 401 });
+              },
+            }
+          : {}),
         defaultWebhook: {
           host: "127.0.0.1",
           path: "/telegram/webhook",

--- a/src/providers/builtin/whatsapp.ts
+++ b/src/providers/builtin/whatsapp.ts
@@ -197,8 +197,23 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
     this.#cleanedUp = true;
     this.#cleanupPromise ??= (async () => {
       await Promise.allSettled([...this.#inFlightSends, ...this.#inFlightWebhookRequests]);
-      await this.#serverClosing;
-      await super.cleanup();
+      const errors: unknown[] = [];
+      try {
+        await this.#serverClosing;
+      } catch (error) {
+        errors.push(error);
+      }
+      try {
+        await super.cleanup();
+      } catch (error) {
+        errors.push(error);
+      }
+      if (errors.length === 1) {
+        throw errors[0];
+      }
+      if (errors.length > 1) {
+        throw new AggregateError(errors, "WhatsApp cleanup failed");
+      }
     })();
     await this.#cleanupPromise;
   }

--- a/src/providers/builtin/zalo.ts
+++ b/src/providers/builtin/zalo.ts
@@ -25,11 +25,22 @@ export function resolveZaloAdapterConfig(
 
 export class ZaloProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
+    const resolvedConfig = resolveZaloAdapterConfig(config);
     super({
       codec: getBuiltinTargetCodec("zalo"),
       config,
       id,
       options: {
+        ...(resolvedConfig.webhookSecret
+          ? {
+              authenticateWebhookRequest(request: Request) {
+                return request.headers.get("x-bot-api-secret-token") ===
+                  resolvedConfig.webhookSecret
+                  ? undefined
+                  : new Response("unauthorized", { status: 401 });
+              },
+            }
+          : {}),
         defaultWebhook: { host: "127.0.0.1", path: "/zalo/webhook", port: 8794 },
         endpointLabel: "webhook endpoint",
         normalizeWebhookPayload: normalizeZaloWebhookPayload,

--- a/src/providers/builtin/zalo.ts
+++ b/src/providers/builtin/zalo.ts
@@ -6,6 +6,7 @@ import type { ProviderAdapter } from "../types.js";
 import { getBuiltinTargetCodec, ZALO_ID_RULE } from "../target-normalizers.js";
 import {
   authorFromBotFlag,
+  createSecretVerifier,
   genericMockPayloadWithNativeThread,
   isRecord,
   optionalRecord,
@@ -26,16 +27,18 @@ export function resolveZaloAdapterConfig(
 export class ZaloProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
     const resolvedConfig = resolveZaloAdapterConfig(config);
+    const authenticateWebhook = resolvedConfig.webhookSecret
+      ? createSecretVerifier(resolvedConfig.webhookSecret)
+      : undefined;
     super({
       codec: getBuiltinTargetCodec("zalo"),
       config,
       id,
       options: {
-        ...(resolvedConfig.webhookSecret
+        ...(authenticateWebhook
           ? {
               authenticateWebhookRequest(request: Request) {
-                return request.headers.get("x-bot-api-secret-token") ===
-                  resolvedConfig.webhookSecret
+                return authenticateWebhook(request.headers.get("x-bot-api-secret-token"))
                   ? undefined
                   : new Response("unauthorized", { status: 401 });
               },

--- a/src/providers/local-mock.ts
+++ b/src/providers/local-mock.ts
@@ -31,6 +31,10 @@ export type LocalMockWebhookConfig = {
 };
 
 export type LocalMockAdapterOptions = {
+  authenticateWebhookRequest?: (
+    request: Request,
+    rawBody: string,
+  ) => Promise<Response | undefined> | Response | undefined;
   defaultWebhook: Required<Pick<LocalMockWebhookConfig, "host" | "path" | "port">>;
   endpointLabel: string;
   matchesThread?: (
@@ -44,6 +48,8 @@ export type LocalMockAdapterOptions = {
   recorderPath?: string | undefined;
   webhook?: LocalMockWebhookConfig | undefined;
 };
+
+const MAX_WAIT_CURSORS = 64;
 
 export type LocalMockTargetCodec = {
   normalize(target: ProviderContext["fixture"]["target"]): NormalizedTarget;
@@ -211,8 +217,18 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
     const expectedAuthor = context.fixture.inboundMatch.author;
     const channelId = context.threadId ?? target.threadId ?? target.channelId;
     const cursorKey = JSON.stringify([context.nonce, context.since, channelId]);
-    const cursor = this.#waitCursors.get(cursorKey) ?? createRecordedInboundCursor();
+    const existingCursor = this.#waitCursors.get(cursorKey);
+    if (existingCursor) {
+      this.#waitCursors.delete(cursorKey);
+    }
+    const cursor = existingCursor ?? createRecordedInboundCursor();
     this.#waitCursors.set(cursorKey, cursor);
+    while (this.#waitCursors.size > MAX_WAIT_CURSORS) {
+      const oldestKey = this.#waitCursors.keys().next().value;
+      if (oldestKey !== undefined) {
+        this.#waitCursors.delete(oldestKey);
+      }
+    }
 
     try {
       const event = await waitForRecordedInbound({
@@ -283,7 +299,15 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
     }
     let payload: MockWebhookPayload;
     try {
-      const rawPayload = await request.json();
+      const rawBody = await request.text();
+      const authenticationFailure = await this.#options.authenticateWebhookRequest?.(
+        request,
+        rawBody,
+      );
+      if (authenticationFailure) {
+        return authenticationFailure;
+      }
+      const rawPayload = JSON.parse(rawBody) as unknown;
       payload = normalizeWebhookPayload(
         this.#options.normalizeWebhookPayload
           ? this.#options.normalizeWebhookPayload(rawPayload)

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -21,11 +21,6 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
   });
 }
 
-function toRecordKey(event: InboundEnvelope): string {
-  return JSON.stringify([event.provider, event.threadId, event.id]);
-}
-
-const MAX_SEEN_KEYS = 4096;
 const pendingAppends = new Map<string, Promise<void>>();
 
 type IncrementalReadState = {
@@ -43,7 +38,6 @@ type IncrementalReadState = {
 export type RecordedInboundCursor = {
   buffered: RecordedInboundEnvelope[];
   readState: IncrementalReadState;
-  seen: Set<string>;
 };
 
 const CONTINUITY_BYTES = 4096;
@@ -61,19 +55,7 @@ export function createRecordedInboundCursor(): RecordedInboundCursor {
   return {
     buffered: [],
     readState: createIncrementalReadState(),
-    seen: new Set(),
   };
-}
-
-function rememberSeenKey(seen: Set<string>, key: string): void {
-  seen.add(key);
-  if (seen.size <= MAX_SEEN_KEYS) {
-    return;
-  }
-  const oldest = seen.values().next().value;
-  if (oldest !== undefined) {
-    seen.delete(oldest);
-  }
 }
 
 function resetIncrementalReadState(state: IncrementalReadState): void {
@@ -257,12 +239,6 @@ export async function waitForRecordedInbound(params: {
         ? cursor.buffered.splice(0)
         : await readRecordedInboundAppend(params.filePath, cursor.readState);
     for (const [index, event] of events.entries()) {
-      const key = toRecordKey(event);
-      if (cursor.seen.has(key)) {
-        continue;
-      }
-      rememberSeenKey(cursor.seen, key);
-
       if (params.since && new Date(event.sentAt).getTime() < new Date(params.since).getTime()) {
         continue;
       }
@@ -291,7 +267,6 @@ export async function* watchRecordedInbound(params: {
   since?: string | undefined;
 }): AsyncIterable<RecordedInboundEnvelope> {
   const state = createIncrementalReadState();
-  const seen = new Set<string>();
 
   while (!params.signal?.aborted) {
     const events = await readRecordedInboundAppend(params.filePath, state);
@@ -302,12 +277,6 @@ export async function* watchRecordedInbound(params: {
       if (params.signal?.aborted) {
         return;
       }
-      const key = toRecordKey(event);
-      if (seen.has(key)) {
-        continue;
-      }
-      rememberSeenKey(seen, key);
-
       if (params.since && new Date(event.sentAt).getTime() < new Date(params.since).getTime()) {
         continue;
       }

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -25,7 +25,7 @@ function toRecordKey(event: InboundEnvelope): string {
   return JSON.stringify([event.provider, event.threadId, event.id]);
 }
 
-const MAX_WATCH_SEEN_KEYS = 4096;
+const MAX_SEEN_KEYS = 4096;
 const pendingAppends = new Map<string, Promise<void>>();
 
 type IncrementalReadState = {
@@ -63,6 +63,17 @@ export function createRecordedInboundCursor(): RecordedInboundCursor {
     readState: createIncrementalReadState(),
     seen: new Set(),
   };
+}
+
+function rememberSeenKey(seen: Set<string>, key: string): void {
+  seen.add(key);
+  if (seen.size <= MAX_SEEN_KEYS) {
+    return;
+  }
+  const oldest = seen.values().next().value;
+  if (oldest !== undefined) {
+    seen.delete(oldest);
+  }
 }
 
 function resetIncrementalReadState(state: IncrementalReadState): void {
@@ -250,7 +261,7 @@ export async function waitForRecordedInbound(params: {
       if (cursor.seen.has(key)) {
         continue;
       }
-      cursor.seen.add(key);
+      rememberSeenKey(cursor.seen, key);
 
       if (params.since && new Date(event.sentAt).getTime() < new Date(params.since).getTime()) {
         continue;
@@ -295,13 +306,7 @@ export async function* watchRecordedInbound(params: {
       if (seen.has(key)) {
         continue;
       }
-      seen.add(key);
-      if (seen.size > MAX_WATCH_SEEN_KEYS) {
-        const oldest = seen.values().next().value;
-        if (oldest !== undefined) {
-          seen.delete(oldest);
-        }
-      }
+      rememberSeenKey(seen, key);
 
       if (params.since && new Date(event.sentAt).getTime() < new Date(params.since).getTime()) {
         continue;

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -22,6 +22,7 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
 }
 
 const pendingAppends = new Map<string, Promise<void>>();
+const MAX_RECENT_RECORD_KEYS = 4096;
 
 type IncrementalReadState = {
   continuity: Buffer;
@@ -38,6 +39,7 @@ type IncrementalReadState = {
 export type RecordedInboundCursor = {
   buffered: RecordedInboundEnvelope[];
   readState: IncrementalReadState;
+  seen: Set<string>;
 };
 
 const CONTINUITY_BYTES = 4096;
@@ -55,7 +57,20 @@ export function createRecordedInboundCursor(): RecordedInboundCursor {
   return {
     buffered: [],
     readState: createIncrementalReadState(),
+    seen: new Set(),
   };
+}
+
+function rememberRecentRecord(seen: Set<string>, event: InboundEnvelope): boolean {
+  const key = JSON.stringify([event.provider, event.threadId, event.id]);
+  if (seen.has(key)) {
+    return false;
+  }
+  seen.add(key);
+  if (seen.size > MAX_RECENT_RECORD_KEYS) {
+    seen.delete(seen.values().next().value!);
+  }
+  return true;
 }
 
 function resetIncrementalReadState(state: IncrementalReadState): void {
@@ -239,6 +254,10 @@ export async function waitForRecordedInbound(params: {
         ? cursor.buffered.splice(0)
         : await readRecordedInboundAppend(params.filePath, cursor.readState);
     for (const [index, event] of events.entries()) {
+      // Incremental read state owns progress; this bounded window only filters appended retries.
+      if (!rememberRecentRecord(cursor.seen, event)) {
+        continue;
+      }
       if (params.since && new Date(event.sentAt).getTime() < new Date(params.since).getTime()) {
         continue;
       }
@@ -267,6 +286,7 @@ export async function* watchRecordedInbound(params: {
   since?: string | undefined;
 }): AsyncIterable<RecordedInboundEnvelope> {
   const state = createIncrementalReadState();
+  const seen = new Set<string>();
 
   while (!params.signal?.aborted) {
     const events = await readRecordedInboundAppend(params.filePath, state);
@@ -276,6 +296,9 @@ export async function* watchRecordedInbound(params: {
     for (const event of events) {
       if (params.signal?.aborted) {
         return;
+      }
+      if (!rememberRecentRecord(seen, event)) {
+        continue;
       }
       if (params.since && new Date(event.sentAt).getTime() < new Date(params.since).getTime()) {
         continue;

--- a/src/providers/target-normalizers.ts
+++ b/src/providers/target-normalizers.ts
@@ -2,7 +2,7 @@ import type { BuiltinAdapterId, FixtureDefinition, ProviderPlatform } from "../c
 import { CrablineError } from "../core/errors.js";
 import type { LocalMockTargetCodec } from "./local-mock.js";
 import type { NativeIdRule } from "./native-ids.js";
-import { slackTargetKey, SLACK_CHANNEL_ID_RULE, SLACK_TS_RULE } from "./slack-ids.js";
+import { slackTargetKey, SLACK_SEND_TARGET_ID_RULE, SLACK_TS_RULE } from "./slack-ids.js";
 import type { NormalizedTarget } from "./types.js";
 
 export type BuiltinProviderAdapterId = Exclude<BuiltinAdapterId, "script">;
@@ -166,10 +166,10 @@ export function createGenericLocalMockTargetCodec(
   };
 }
 
-function requireSlackChannelId(value: string, label: string): string {
-  if (!SLACK_CHANNEL_ID_RULE.pattern.test(value)) {
+function requireSlackSendTargetId(value: string, label: string): string {
+  if (!SLACK_SEND_TARGET_ID_RULE.pattern.test(value)) {
     throw new CrablineError(
-      `Slack ${label} must be a native Slack conversation id such as C1234567890, G1234567890, or D1234567890.`,
+      `Slack ${label} must be a native Slack conversation or user id such as C1234567890, G1234567890, D1234567890, U1234567890, or W1234567890.`,
       { kind: "config" },
     );
   }
@@ -187,7 +187,7 @@ function requireSlackThreadTs(value: string, label: string): string {
 
 const SLACK_TARGET_CODEC: LocalMockTargetCodec = {
   normalize(target): NormalizedTarget {
-    const channelId = requireSlackChannelId(target.channelId ?? target.id, "channelId");
+    const channelId = requireSlackSendTargetId(target.channelId ?? target.id, "channelId");
     const normalized: NormalizedTarget = {
       channelId,
       id: target.id,

--- a/test/local-mock-provider.test.ts
+++ b/test/local-mock-provider.test.ts
@@ -332,4 +332,53 @@ describe("local mock provider", () => {
       ok: true,
     });
   });
+
+  it("bounds successful wait cursors while retaining recent progress", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const recorderPath = path.join(directory, "bounded-waits.jsonl");
+    const config = createConfig();
+    const provider = new LocalMockProviderAdapter({
+      codec: createGenericLocalMockTargetCodec("slack"),
+      config,
+      id: "provider-a",
+      options: {
+        defaultWebhook: { host: "127.0.0.1", path: "/slack/events", port: 0 },
+        endpointLabel: "events endpoint",
+        platform: "slack",
+        recorderPath,
+      },
+    });
+    providers.push(provider);
+    const contexts = Array.from({ length: 65 }, (_, index) => {
+      const context = createContext(config);
+      context.fixture.target = { id: `channel-${index}`, metadata: {} };
+      return {
+        ...context,
+        nonce: `nonce-${index}`,
+        since: new Date(0).toISOString(),
+        threadId: `channel-${index}`,
+        timeoutMs: 20,
+      };
+    });
+
+    for (const [index, context] of contexts.entries()) {
+      await appendRecordedInbound(recorderPath, {
+        author: "assistant",
+        id: `event-${index}`,
+        provider: "provider-a",
+        sentAt: new Date().toISOString(),
+        text: `event ${index}`,
+        threadId: context.threadId,
+      });
+      await expect(provider.waitForInbound(context)).resolves.toMatchObject({
+        id: `event-${index}`,
+      });
+    }
+
+    await expect(provider.waitForInbound(contexts[0]!)).resolves.toMatchObject({
+      id: "event-0",
+    });
+    await expect(provider.waitForInbound(contexts.at(-1)!)).resolves.toBeNull();
+  });
 });

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -195,6 +195,14 @@ describe("recorder", () => {
     ).resolves.toMatchObject({ id: `bounded-${eventCount - 1}` });
     expect(cursor.seen.size).toBe(4096);
     expect(cursor.seen.has(JSON.stringify(["slack", "slack:C123", "bounded-0"]))).toBe(false);
+    await expect(
+      waitForRecordedInbound({
+        cursor,
+        filePath,
+        matches: (event) => event.id === `bounded-${eventCount - 1}`,
+        timeoutMs: 30,
+      }),
+    ).resolves.toBeNull();
   });
 
   it("does not collapse distinct records whose fields contain delimiters", async () => {

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -162,6 +162,29 @@ describe("recorder", () => {
     ).resolves.toEqual(second);
   });
 
+  it("deduplicates recent appended retries without rescanning consumed records", async () => {
+    const filePath = await createRecorderPath();
+    const cursor = createRecordedInboundCursor();
+    const duplicate = {
+      author: "assistant" as const,
+      id: "duplicate",
+      provider: "slack",
+      sentAt: new Date().toISOString(),
+      text: "duplicate",
+      threadId: "slack:C123",
+    };
+    const first = await appendRecordedInbound(filePath, duplicate);
+    await appendRecordedInbound(filePath, duplicate);
+    const next = await appendRecordedInbound(filePath, { ...duplicate, id: "next", text: "next" });
+
+    await expect(
+      waitForRecordedInbound({ cursor, filePath, matches: () => true, timeoutMs: 30 }),
+    ).resolves.toEqual(first);
+    await expect(
+      waitForRecordedInbound({ cursor, filePath, matches: () => true, timeoutMs: 30 }),
+    ).resolves.toEqual(next);
+  });
+
   it("retains incremental wait progress across large recorder histories", async () => {
     const filePath = await createRecorderPath();
     const cursor = createRecordedInboundCursor();

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -162,6 +162,41 @@ describe("recorder", () => {
     ).resolves.toEqual(second);
   });
 
+  it("bounds remembered wait cursor records", async () => {
+    const filePath = await createRecorderPath();
+    const cursor = createRecordedInboundCursor();
+    const now = new Date().toISOString();
+    const eventCount = 4100;
+    await writeFile(
+      filePath,
+      Array.from(
+        { length: eventCount },
+        (_, index) =>
+          `${JSON.stringify({
+            author: "assistant",
+            id: `bounded-${index}`,
+            provider: "slack",
+            recordedAt: now,
+            sentAt: now,
+            text: "bounded",
+            threadId: "slack:C123",
+          })}\n`,
+      ).join(""),
+      "utf8",
+    );
+
+    await expect(
+      waitForRecordedInbound({
+        cursor,
+        filePath,
+        matches: (event) => event.id === `bounded-${eventCount - 1}`,
+        timeoutMs: 30,
+      }),
+    ).resolves.toMatchObject({ id: `bounded-${eventCount - 1}` });
+    expect(cursor.seen.size).toBe(4096);
+    expect(cursor.seen.has(JSON.stringify(["slack", "slack:C123", "bounded-0"]))).toBe(false);
+  });
+
   it("does not collapse distinct records whose fields contain delimiters", async () => {
     const filePath = await createRecorderPath();
     await appendRecordedInbound(filePath, {

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -162,7 +162,7 @@ describe("recorder", () => {
     ).resolves.toEqual(second);
   });
 
-  it("bounds remembered wait cursor records", async () => {
+  it("retains incremental wait progress across large recorder histories", async () => {
     const filePath = await createRecorderPath();
     const cursor = createRecordedInboundCursor();
     const now = new Date().toISOString();
@@ -193,8 +193,6 @@ describe("recorder", () => {
         timeoutMs: 30,
       }),
     ).resolves.toMatchObject({ id: `bounded-${eventCount - 1}` });
-    expect(cursor.seen.size).toBe(4096);
-    expect(cursor.seen.has(JSON.stringify(["slack", "slack:C123", "bounded-0"]))).toBe(false);
     await expect(
       waitForRecordedInbound({
         cursor,

--- a/test/slack-provider.test.ts
+++ b/test/slack-provider.test.ts
@@ -222,7 +222,7 @@ describe("slack provider", () => {
   });
 
   it("verifies Slack request signatures before parsing", async () => {
-    const signingSecret = "slack-signing-secret";
+    const signingSecret = "test-token-placeholder";
     const config = await createSlackConfig(0, signingSecret);
     const provider = new SlackProviderAdapter("slack", config, "crabline");
     providers.push(provider);

--- a/test/slack-provider.test.ts
+++ b/test/slack-provider.test.ts
@@ -1,3 +1,4 @@
+import { createHmac } from "node:crypto";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import type { ProviderConfig } from "../src/config/schema.js";
@@ -14,7 +15,7 @@ afterEach(async () => {
   await Promise.all(directories.splice(0).map(disposeTempDir));
 });
 
-async function createSlackConfig(port: number): Promise<ProviderConfig> {
+async function createSlackConfig(port: number, signingSecret?: string): Promise<ProviderConfig> {
   const directory = await createTempDir();
   directories.push(directory);
 
@@ -25,6 +26,7 @@ async function createSlackConfig(port: number): Promise<ProviderConfig> {
     platform: "slack",
     slack: {
       recorder: { path: path.join(directory, "slack.jsonl") },
+      ...(signingSecret ? { signingSecret } : {}),
       webhook: {
         host: "127.0.0.1",
         path: "/slack/events",
@@ -78,6 +80,12 @@ describe("slack provider", () => {
     expect(provider.normalizeTarget({ id: "C1234567890", metadata: {} })).toMatchObject({
       channelId: "C1234567890",
     });
+    expect(provider.normalizeTarget({ id: "U1234567890", metadata: {} })).toMatchObject({
+      channelId: "U1234567890",
+    });
+    expect(provider.normalizeTarget({ id: "W1234567890", metadata: {} })).toMatchObject({
+      channelId: "W1234567890",
+    });
     expect(
       provider.normalizeTarget({
         channelId: "C1234567890",
@@ -114,10 +122,10 @@ describe("slack provider", () => {
     providers.push(provider);
 
     expect(() => provider.normalizeTarget({ id: "target-1", metadata: {} })).toThrow(
-      /native Slack conversation id/u,
+      /native Slack conversation or user id/u,
     );
     expect(() => provider.normalizeTarget({ id: "slack:C1234567890", metadata: {} })).toThrow(
-      /native Slack conversation id/u,
+      /native Slack conversation or user id/u,
     );
     expect(() =>
       provider.normalizeTarget({
@@ -211,6 +219,49 @@ describe("slack provider", () => {
       text: "ACK nonce-2",
       threadId: threadKey,
     });
+  });
+
+  it("verifies Slack request signatures before parsing", async () => {
+    const signingSecret = "slack-signing-secret";
+    const config = await createSlackConfig(0, signingSecret);
+    const provider = new SlackProviderAdapter("slack", config, "crabline");
+    providers.push(provider);
+    const endpoint = endpointFromDetails((await provider.probe(createContext(config))).details);
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const body = JSON.stringify({
+      event: {
+        channel: "C1234567890",
+        text: "authenticated",
+        ts: "1700000001.000200",
+        type: "message",
+      },
+      type: "event_callback",
+    });
+    const signature = `v0=${createHmac("sha256", signingSecret)
+      .update(`v0:${timestamp}:${body}`)
+      .digest("hex")}`;
+
+    const rejected = await fetch(endpoint, {
+      body,
+      headers: {
+        "content-type": "application/json",
+        "x-slack-request-timestamp": timestamp,
+        "x-slack-signature": "v0=invalid",
+      },
+      method: "POST",
+    });
+    expect(rejected.status).toBe(401);
+
+    const accepted = await fetch(endpoint, {
+      body,
+      headers: {
+        "content-type": "application/json",
+        "x-slack-request-timestamp": timestamp,
+        "x-slack-signature": signature,
+      },
+      method: "POST",
+    });
+    expect(accepted.status).toBe(200);
   });
 
   it("matches channel-aware and legacy generic thread webhooks", async () => {

--- a/test/telegram-provider.test.ts
+++ b/test/telegram-provider.test.ts
@@ -17,7 +17,7 @@ afterEach(async () => {
   await Promise.all(directories.splice(0).map(disposeTempDir));
 });
 
-async function createTelegramConfig(port: number): Promise<ProviderConfig> {
+async function createTelegramConfig(port: number, secretToken?: string): Promise<ProviderConfig> {
   const directory = await createTempDir();
   directories.push(directory);
 
@@ -30,6 +30,7 @@ async function createTelegramConfig(port: number): Promise<ProviderConfig> {
     telegram: {
       mode: "webhook",
       recorder: { path: path.join(directory, "telegram.jsonl") },
+      ...(secretToken ? { secretToken } : {}),
       webhook: {
         host: "127.0.0.1",
         path: "/telegram/webhook",
@@ -189,6 +190,7 @@ describe("telegram provider", () => {
     };
     expect(normalizeTelegramWebhookPayload(nested)).toMatchObject({
       raw: nested,
+      threadId: "-100123:42",
       message: {
         id: "generic-2",
         text: "nested topic reply",
@@ -287,6 +289,36 @@ describe("telegram provider", () => {
       id: "1",
       text: "ACK nonce-2",
     });
+  });
+
+  it("authenticates webhook requests before parsing", async () => {
+    const config = await createTelegramConfig(0, "telegram-webhook-secret");
+    const provider = new TelegramProviderAdapter("telegram", config, "crabline");
+    providers.push(provider);
+
+    const probe = await provider.probe(createContext(config));
+    const endpoint = probe.details.find((detail) => detail.startsWith("webhook endpoint "));
+    expect(endpoint).toBeDefined();
+    const url = endpoint!.replace("webhook endpoint ", "");
+
+    const rejected = await fetch(url, {
+      body: "{malformed",
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    expect(rejected.status).toBe(401);
+
+    const accepted = await fetch(url, {
+      body: JSON.stringify({
+        message: { chat: { id: 123456789 }, message_id: 3, text: "authenticated" },
+      }),
+      headers: {
+        "content-type": "application/json",
+        "x-telegram-bot-api-secret-token": "telegram-webhook-secret",
+      },
+      method: "POST",
+    });
+    expect(accepted.status).toBe(200);
   });
 
   it("returns channel-like webhook errors for malformed inbound events", async () => {

--- a/test/telegram-provider.test.ts
+++ b/test/telegram-provider.test.ts
@@ -292,7 +292,7 @@ describe("telegram provider", () => {
   });
 
   it("authenticates webhook requests before parsing", async () => {
-    const config = await createTelegramConfig(0, "telegram-webhook-secret");
+    const config = await createTelegramConfig(0, "test-token-placeholder");
     const provider = new TelegramProviderAdapter("telegram", config, "crabline");
     providers.push(provider);
 
@@ -314,7 +314,7 @@ describe("telegram provider", () => {
       }),
       headers: {
         "content-type": "application/json",
-        "x-telegram-bot-api-secret-token": "telegram-webhook-secret",
+        "x-telegram-bot-api-secret-token": "test-token-placeholder",
       },
       method: "POST",
     });

--- a/test/whatsapp-provider-lifecycle.test.ts
+++ b/test/whatsapp-provider-lifecycle.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ProviderConfig } from "../src/config/schema.js";
 import { WhatsAppProviderAdapter } from "../src/providers/builtin/whatsapp.js";
+import { LocalMockProviderAdapter } from "../src/providers/local-mock.js";
 import type { ProviderContext, SendContext } from "../src/providers/types.js";
 import { createTempDir, disposeTempDir } from "./test-helpers.js";
 
@@ -127,6 +128,26 @@ describe("WhatsApp provider lifecycle", () => {
     expect(close).toHaveBeenCalledTimes(1);
     await expect(provider.probe(context)).rejects.toThrow(/has been cleaned up/u);
     expect(webhookMocks.startWebhookServer).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs superclass cleanup when listener close fails", async () => {
+    const closeError = new Error("close failed");
+    webhookMocks.startWebhookServer.mockResolvedValueOnce({
+      async close() {
+        throw closeError;
+      },
+      endpointUrl: "http://127.0.0.1:43210/whatsapp/webhook",
+    });
+    const superCleanup = vi.spyOn(LocalMockProviderAdapter.prototype, "cleanup");
+    const config = createConfig();
+    const provider = new WhatsAppProviderAdapter("whatsapp", config, "crabline");
+    try {
+      await provider.probe(createContext(config));
+      await expect(provider.cleanup()).rejects.toBe(closeError);
+      expect(superCleanup).toHaveBeenCalledTimes(1);
+    } finally {
+      superCleanup.mockRestore();
+    }
   });
 
   it("closes an in-flight listener when cleanup wins the startup race", async () => {

--- a/test/zalo-provider.test.ts
+++ b/test/zalo-provider.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { normalizeZaloWebhookPayload, ZaloProviderAdapter } from "../src/providers/builtin/zalo.js";
-import { runLocalMockProviderContract } from "./local-mock-provider-helpers.js";
+import {
+  createLocalMockConfig,
+  createProviderContext,
+  runLocalMockProviderContract,
+} from "./local-mock-provider-helpers.js";
 
 describe("Zalo webhook normalizer", () => {
   it("normalizes text messages with the provider message id", () => {
@@ -46,6 +50,43 @@ describe("Zalo webhook normalizer", () => {
       raw: payload,
       threadId: "123456789012",
     });
+  });
+
+  it("requires the configured webhook secret before parsing", async () => {
+    const config = await createLocalMockConfig("zalo", "/zalo/webhook");
+    config.zalo!.webhookSecret = "zalo-webhook-secret";
+    const provider = new ZaloProviderAdapter("zalo", config, "crabline");
+    try {
+      const probe = await provider.probe(
+        createProviderContext("zalo", config, { id: "123456789012", metadata: {} }),
+      );
+      const endpoint = probe.details
+        .find((detail) => detail.includes("http://"))
+        ?.replace(/^.*?(https?:\/\/\S+)$/u, "$1");
+      expect(endpoint).toBeDefined();
+
+      const rejected = await fetch(endpoint!, {
+        body: "{malformed",
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      expect(rejected.status).toBe(401);
+
+      const accepted = await fetch(endpoint!, {
+        body: JSON.stringify({
+          message: { msg_id: "zalo-auth-1", text: "authenticated" },
+          sender: { id: "123456789012" },
+        }),
+        headers: {
+          "content-type": "application/json",
+          "x-bot-api-secret-token": "zalo-webhook-secret",
+        },
+        method: "POST",
+      });
+      expect(accepted.status).toBe(200);
+    } finally {
+      await provider.cleanup();
+    }
   });
 });
 

--- a/test/zalo-provider.test.ts
+++ b/test/zalo-provider.test.ts
@@ -54,7 +54,7 @@ describe("Zalo webhook normalizer", () => {
 
   it("requires the configured webhook secret before parsing", async () => {
     const config = await createLocalMockConfig("zalo", "/zalo/webhook");
-    config.zalo!.webhookSecret = "zalo-webhook-secret";
+    config.zalo!.webhookSecret = "test-token-placeholder";
     const provider = new ZaloProviderAdapter("zalo", config, "crabline");
     try {
       const probe = await provider.probe(
@@ -79,7 +79,7 @@ describe("Zalo webhook normalizer", () => {
         }),
         headers: {
           "content-type": "application/json",
-          "x-bot-api-secret-token": "zalo-webhook-secret",
+          "x-bot-api-secret-token": "test-token-placeholder",
         },
         method: "POST",
       });


### PR DESCRIPTION
## Summary
- authenticate Telegram, Slack, and Zalo local-mock webhooks before parsing or recording payloads
- bound recorder wait state and adapter cursor retention while deduplicating appended retries
- preserve canonical Telegram topics, accept Slack user send targets, and finish WhatsApp superclass cleanup after listener failures
- document optional provider-native webhook credentials and add a changelog entry

## Verification
- `pnpm lint`
- focused recorder/provider tests
- Crabbox `run_cacfe04d8923`: `pnpm verify` (50 files, 453 tests)
- autoreview: gpt-5.6-sol/high, clean (0.88 confidence)