### PR TITLE
fix(servers): bound delivery and release state

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,12 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
           ref: refs/tags/${{ steps.release.outputs.tag }}
+      - name: Verify checked out release tag
+        env:
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          [[ "$(git rev-parse "refs/tags/${RELEASE_TAG}^{commit}")" == "$(git rev-parse HEAD)" ]]
       - name: Verify release metadata
         env:
           RELEASE_VERSION: ${{ steps.release.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Resolve release tag
         id: release
         env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_REF_NAME: ${{ github.ref_name }}
           GITHUB_REF_TYPE: ${{ github.ref_type }}
           INPUT_TAG: ${{ inputs.tag_name }}
@@ -38,8 +39,10 @@ jobs:
           set -euo pipefail
           tag="${INPUT_TAG:-${GITHUB_REF_NAME}}"
           [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
-          [[ "$GITHUB_REF_TYPE" == "tag" ]]
-          [[ "$GITHUB_REF_NAME" == "$tag" ]]
+          if [[ "$GITHUB_EVENT_NAME" != "workflow_dispatch" ]]; then
+            [[ "$GITHUB_REF_TYPE" == "tag" ]]
+            [[ "$GITHUB_REF_NAME" == "$tag" ]]
+          fi
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -297,7 +300,14 @@ jobs:
           RELEASE_TAG: ${{ needs.verify.outputs.tag }}
         run: |
           set -euo pipefail
-          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+          if release_state="$(gh release view "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json isDraft,isPrerelease \
+            --jq '[.isDraft, .isPrerelease] | @tsv' 2>/dev/null)"; then
+            if [[ "$release_state" != $'false\tfalse' ]]; then
+              echo "::error::GitHub release $RELEASE_TAG exists but is draft or prerelease."
+              exit 1
+            fi
             echo "GitHub release $RELEASE_TAG already exists."
             exit 0
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Preserve provider-native WhatsApp message acknowledgements, legacy group JIDs, bounded inbound admission, WebSocket error isolation, and strict handshake varints.
 - Authenticate built-in Telegram, Slack, and Zalo webhooks, bound recorder wait state, accept Slack user send targets, preserve canonical Telegram topics, and complete WhatsApp cleanup after close failures.
+- Harden HTTP stream failure handling, bound Mattermost WebSocket delivery, move Slack rate-limit controls out of provider payloads, drain Slack callback bodies, and validate release dispatch and existing release state.
 - Hold serve ready-file ownership across startup and shutdown, preserve live manifests on failed replacement, and retain compound cleanup failures.
 - Reject invalid matchers and provider/fixture mismatches before side effects, drain aborted provider work before cleanup, preserve frozen primary smoke failures, and recover stale smoke locks after PID reuse.
 - Preserve Slack thread scope and validate Telegram command entities.

--- a/src/servers/http.ts
+++ b/src/servers/http.ts
@@ -34,17 +34,17 @@ export function jsonResponse(value: unknown, status = 200): Response {
 }
 
 export function drainRequestBody(request: IncomingMessage): void {
+  const ignoreError = () => {};
+  request.on("error", ignoreError);
   if (request.destroyed || request.readableEnded) {
     return;
   }
-  const ignoreError = () => {};
   const cleanup = () => {
     request.off("close", cleanup);
     request.off("end", cleanup);
     request.off("error", ignoreError);
   };
 
-  request.on("error", ignoreError);
   request.once("close", cleanup);
   request.once("end", cleanup);
   request.resume();
@@ -271,7 +271,8 @@ export function readInteger(value: unknown): number | undefined {
   if (!stringValue || !/^-?\d+$/u.test(stringValue)) {
     return undefined;
   }
-  return Number(stringValue);
+  const parsed = Number(stringValue);
+  return Number.isSafeInteger(parsed) ? parsed : undefined;
 }
 
 function readBearerToken(authorization: string | undefined): string | undefined {

--- a/src/servers/mattermost.ts
+++ b/src/servers/mattermost.ts
@@ -22,6 +22,17 @@ import { resolveMaxPendingInboundEvents } from "./pending-events.js";
 import { closeWebSocketServer } from "./websocket.js";
 
 const DEFAULT_WEBSOCKET_AUTHENTICATION_TIMEOUT_MS = 5_000;
+const DEFAULT_MAX_WEBSOCKET_BUFFERED_BYTES = 1024 * 1024;
+
+function resolveMaxWebSocketBufferedBytes(value: number | undefined): number {
+  if (value === undefined) {
+    return DEFAULT_MAX_WEBSOCKET_BUFFERED_BYTES;
+  }
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new Error("maxWebSocketBufferedBytes must be a positive safe integer.");
+  }
+  return value;
+}
 
 type MattermostPost = {
   channel_id: string;
@@ -51,6 +62,7 @@ type MattermostServerState = {
   botUsername: string;
   channels: Map<string, { id: string; name: string; display_name: string; type: string }>;
   maxPendingInboundEvents: number;
+  maxWebSocketBufferedBytes: number;
   nextPost: number;
   onEvent: ServerEventObserver | undefined;
   pendingEvents: MattermostWebSocketEvent[];
@@ -94,6 +106,7 @@ export type StartMattermostServerParams = {
   port?: number | undefined;
   recorderPath?: string | undefined;
   maxPendingInboundEvents?: number | undefined;
+  maxWebSocketBufferedBytes?: number | undefined;
   websocketAuthenticationTimeoutMs?: number | undefined;
 };
 
@@ -159,26 +172,44 @@ function sendEvent(
   state: MattermostServerState,
   client: WebSocket,
   event: MattermostWebSocketEvent,
-) {
+): boolean {
   const seq = state.websocketClients.get(client);
   if (seq === undefined || client.readyState !== WebSocket.OPEN) {
-    return;
+    state.websocketClients.delete(client);
+    return false;
   }
-  client.send(JSON.stringify({ ...event, seq }));
+  const payload = JSON.stringify({ ...event, seq });
+  if (
+    client.bufferedAmount + Buffer.byteLength(payload, "utf8") >
+    state.maxWebSocketBufferedBytes
+  ) {
+    state.websocketClients.delete(client);
+    client.close(1013, "client too slow");
+    return false;
+  }
+  try {
+    client.send(payload);
+  } catch {
+    state.websocketClients.delete(client);
+    client.terminate();
+    return false;
+  }
   state.websocketClients.set(client, seq + 1);
+  return true;
 }
 
 function broadcast(state: MattermostServerState, event: MattermostWebSocketEvent): boolean {
-  if (state.websocketClients.size === 0) {
-    if (state.pendingEvents.length >= state.maxPendingInboundEvents) {
-      return false;
-    }
-    state.pendingEvents.push(event);
+  let delivered = false;
+  for (const client of state.websocketClients.keys()) {
+    delivered = sendEvent(state, client, event) || delivered;
+  }
+  if (delivered) {
     return true;
   }
-  for (const client of state.websocketClients.keys()) {
-    sendEvent(state, client, event);
+  if (state.pendingEvents.length >= state.maxPendingInboundEvents) {
+    return false;
   }
+  state.pendingEvents.push(event);
   return true;
 }
 
@@ -498,8 +529,12 @@ function attachWebSocketServer(params: {
           },
           event: "hello",
         });
-        for (const event of params.state.pendingEvents.splice(0)) {
-          sendEvent(params.state, client, event);
+        const pending = params.state.pendingEvents.splice(0);
+        for (const [index, event] of pending.entries()) {
+          if (!sendEvent(params.state, client, event)) {
+            params.state.pendingEvents.unshift(...pending.slice(index));
+            break;
+          }
         }
         return;
       }
@@ -557,6 +592,7 @@ export async function startMattermostServer(
     botUsername,
     channels: new Map(),
     maxPendingInboundEvents: resolveMaxPendingInboundEvents(params.maxPendingInboundEvents),
+    maxWebSocketBufferedBytes: resolveMaxWebSocketBufferedBytes(params.maxWebSocketBufferedBytes),
     nextPost: 1,
     onEvent: params.onEvent,
     pendingEvents: [],

--- a/src/servers/mattermost.ts
+++ b/src/servers/mattermost.ts
@@ -199,6 +199,16 @@ function sendEvent(
 }
 
 function broadcast(state: MattermostServerState, event: MattermostWebSocketEvent): boolean {
+  if (
+    Buffer.byteLength(JSON.stringify({ ...event, seq: 0 }), "utf8") >
+    state.maxWebSocketBufferedBytes
+  ) {
+    for (const client of state.websocketClients.keys()) {
+      state.websocketClients.delete(client);
+      client.close(1013, "client too slow");
+    }
+    return false;
+  }
   let delivered = false;
   for (const client of state.websocketClients.keys()) {
     delivered = sendEvent(state, client, event) || delivered;

--- a/src/servers/slack.ts
+++ b/src/servers/slack.ts
@@ -45,6 +45,12 @@ type SlackServerState = {
   botId: string;
   botToken: string;
   botUserId: string;
+  chatPostMessageRateLimit:
+    | {
+        remaining: number;
+        retryAfterSeconds: number;
+      }
+    | undefined;
   eventsRequestUrl: string | undefined;
   nextDmIndex: number;
   nextMpimIndex: number;
@@ -87,6 +93,12 @@ export type StartSlackServerParams = {
   botId?: string | undefined;
   botToken?: string | undefined;
   botUserId?: string | undefined;
+  chatPostMessageRateLimit?:
+    | {
+        remaining: number;
+        retryAfterSeconds: number;
+      }
+    | undefined;
   eventsRequestUrl?: string | undefined;
   host?: string | undefined;
   onEvent?: ServerEventObserver | undefined;
@@ -111,6 +123,21 @@ function slackRateLimited(retryAfterSeconds = 1): Response {
     },
     status: 429,
   });
+}
+
+function resolveChatPostMessageRateLimit(
+  value: StartSlackServerParams["chatPostMessageRateLimit"],
+): SlackServerState["chatPostMessageRateLimit"] {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Number.isSafeInteger(value.remaining) || value.remaining < 0) {
+    throw new Error("chatPostMessageRateLimit.remaining must be a non-negative safe integer.");
+  }
+  if (!Number.isSafeInteger(value.retryAfterSeconds) || value.retryAfterSeconds < 1) {
+    throw new Error("chatPostMessageRateLimit.retryAfterSeconds must be a positive safe integer.");
+  }
+  return { ...value };
 }
 
 function requireSlackToken(
@@ -385,6 +412,7 @@ async function deliverSlackEvent(
       method: "POST",
       signal: AbortSignal.timeout(3_000),
     });
+    await response.body?.cancel();
     if (!response.ok) {
       return slackError("event_delivery_failed", 502);
     }
@@ -419,8 +447,12 @@ async function handleSlackApi(params: {
         user_id: params.state.botUserId,
       });
     case "chat.postMessage": {
-      if (readBoolean(params.body.simulate_rate_limit) === true) {
-        return slackRateLimited(readInteger(params.body.retry_after) ?? 1);
+      const rateLimit = params.state.chatPostMessageRateLimit;
+      if (rateLimit && rateLimit.remaining <= 0) {
+        return slackRateLimited(rateLimit.retryAfterSeconds);
+      }
+      if (rateLimit) {
+        rateLimit.remaining -= 1;
       }
       const channel = requireSlackSendTargetId(params.body.channel);
       if (channel instanceof Response) {
@@ -696,6 +728,7 @@ export async function startSlackServer(
     botId: params.botId ?? "BCRABLINE",
     botToken: params.botToken ?? "xoxb-crabline-slack-token",
     botUserId: params.botUserId ?? "UCRABBOT",
+    chatPostMessageRateLimit: resolveChatPostMessageRateLimit(params.chatPostMessageRateLimit),
     eventsRequestUrl: params.eventsRequestUrl,
     nextDmIndex: 1,
     nextMpimIndex: 1,

--- a/test/http-server.test.ts
+++ b/test/http-server.test.ts
@@ -1,7 +1,13 @@
 import type { IncomingMessage } from "node:http";
 import { PassThrough } from "node:stream";
 import { describe, expect, it } from "vitest";
-import { readBody, RequestBodyTooLargeError, startHttpJsonServer } from "../src/servers/http.js";
+import {
+  drainRequestBody,
+  readBody,
+  readInteger,
+  RequestBodyTooLargeError,
+  startHttpJsonServer,
+} from "../src/servers/http.js";
 
 type TestRequest = IncomingMessage & PassThrough;
 
@@ -32,6 +38,18 @@ describe("server HTTP body reader", () => {
     const declared = createRequest({ "content-length": "5" });
     await expect(readBody(declared, 4)).rejects.toBeInstanceOf(RequestBodyTooLargeError);
     expectLateErrorHandled(declared);
+
+    const destroyed = createRequest();
+    destroyed.destroy();
+    drainRequestBody(destroyed);
+    expect(() => destroyed.emit("error", new Error("post-destroy error"))).not.toThrow();
+  });
+
+  it("accepts only safe integer values", () => {
+    expect(readInteger(Number.MAX_SAFE_INTEGER)).toBe(Number.MAX_SAFE_INTEGER);
+    expect(readInteger(String(Number.MIN_SAFE_INTEGER))).toBe(Number.MIN_SAFE_INTEGER);
+    expect(readInteger(String(Number.MAX_SAFE_INTEGER + 1))).toBeUndefined();
+    expect(readInteger("-9007199254740992")).toBeUndefined();
   });
 
   it("does not expose unexpected exception details", async () => {

--- a/test/mattermost-server.test.ts
+++ b/test/mattermost-server.test.ts
@@ -310,6 +310,47 @@ describe("Mattermost local provider server", () => {
     });
   });
 
+  it("disconnects slow WebSocket clients and queues undelivered events", async () => {
+    const server = await startMattermostServer({
+      adminToken: "admin",
+      botToken: "test-token-placeholder",
+      maxPendingInboundEvents: 1,
+      maxWebSocketBufferedBytes: 512,
+    });
+    servers.push(server);
+    const socket = new WebSocket(server.manifest.endpoints.websocketUrl);
+    await waitForSocketOpen(socket);
+    const authenticated = nextMessages(socket, 2);
+    socket.send(
+      JSON.stringify({
+        action: "authentication_challenge",
+        data: { token: "test-token-placeholder" },
+        seq: 1,
+      }),
+    );
+    await authenticated;
+    const closed = waitForSocketClose(socket);
+    const sendInbound = (text: string) =>
+      fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({ channelId: "channel-1", senderId: "user-1", text }),
+        headers: {
+          "content-type": "application/json",
+          "x-crabline-admin-token": "admin",
+        },
+        method: "POST",
+      });
+
+    expect((await sendInbound("x".repeat(2_000))).status).toBe(200);
+    await expect(closed).resolves.toEqual({ code: 1013, reason: "client too slow" });
+    expect((await sendInbound("queue is full")).status).toBe(503);
+  });
+
+  it("validates the WebSocket delivery buffer limit", async () => {
+    await expect(startMattermostServer({ maxWebSocketBufferedBytes: 0 })).rejects.toThrow(
+      "maxWebSocketBufferedBytes must be a positive safe integer.",
+    );
+  });
+
   it("drains request bodies rejected by REST and admin authentication", async () => {
     const server = await startMattermostServer({
       adminToken: "admin",

--- a/test/mattermost-server.test.ts
+++ b/test/mattermost-server.test.ts
@@ -340,8 +340,9 @@ describe("Mattermost local provider server", () => {
         method: "POST",
       });
 
-    expect((await sendInbound("x".repeat(2_000))).status).toBe(200);
+    expect((await sendInbound("x".repeat(2_000))).status).toBe(503);
     await expect(closed).resolves.toEqual({ code: 1013, reason: "client too slow" });
+    expect((await sendInbound("queued after oversized event")).status).toBe(200);
     expect((await sendInbound("queue is full")).status).toBe(503);
   });
 

--- a/test/release-workflow.test.ts
+++ b/test/release-workflow.test.ts
@@ -45,6 +45,16 @@ describe("release workflow", () => {
       tag: "v1.2.3",
       version: "1.2.3",
     });
+    await expect(
+      runResolveTag(resolveStep, "v1.2.3", {
+        eventName: "workflow_dispatch",
+        refName: "main",
+        refType: "branch",
+      }),
+    ).resolves.toEqual({
+      tag: "v1.2.3",
+      version: "1.2.3",
+    });
     await expect(runResolveTag(resolveStep, "v1.2.3-beta.1")).rejects.toThrow(/Command failed/u);
     await expect(runResolveTag(resolveStep, "v1.2.3.preview")).rejects.toThrow(/Command failed/u);
     await expect(
@@ -87,7 +97,32 @@ describe("release workflow", () => {
     expect(publishStep).toContain('npm view "$PACKAGE_NAME@$RELEASE_VERSION" dist.integrity');
     expect(publishStep).toContain('npm publish "$PACKAGE_TARBALL" --access public --provenance');
     expect(releaseStep).toContain('gh release view "$RELEASE_TAG"');
+    expect(releaseStep).toContain("--json isDraft,isPrerelease");
     expect(releaseStep).toContain("--verify-tag");
+  });
+
+  it("accepts only published stable GitHub releases as existing", async () => {
+    const workflow = await readWorkflow();
+    const releaseStep = jobSteps(workflow, "github-release").find(
+      (step) => step.name === "Create GitHub release",
+    )?.run;
+    if (!releaseStep) {
+      throw new Error("Release workflow is missing its GitHub release step.");
+    }
+
+    const stableCalls = await runGithubReleaseStep(releaseStep, "stable");
+    expect(stableCalls).toHaveLength(1);
+    expect(stableCalls[0]).toContain("release view v1.2.3");
+
+    for (const state of ["draft", "prerelease"]) {
+      await expect(runGithubReleaseStep(releaseStep, state)).rejects.toThrow(
+        "exists but is draft or prerelease",
+      );
+    }
+
+    const missingCalls = await runGithubReleaseStep(releaseStep, "missing");
+    expect(missingCalls).toHaveLength(2);
+    expect(missingCalls[1]).toContain("release create v1.2.3");
   });
 
   it("pins privileged release actions to immutable revisions", async () => {
@@ -255,7 +290,10 @@ async function runMetadataCheck(script: string, changelog: string): Promise<void
 async function runResolveTag(
   script: string | undefined,
   tag: string,
-  ref: { refName: string; refType: string } = { refName: tag, refType: "tag" },
+  ref: { eventName?: string; refName: string; refType: string } = {
+    refName: tag,
+    refType: "tag",
+  },
 ): Promise<Record<string, string>> {
   if (!script) {
     throw new Error("Release workflow is missing its tag resolution step.");
@@ -266,6 +304,7 @@ async function runResolveTag(
     await execFileWithOutput("bash", ["-c", script], {
       env: {
         ...process.env,
+        GITHUB_EVENT_NAME: ref.eventName ?? "push",
         GITHUB_OUTPUT: outputPath,
         GITHUB_REF_NAME: ref.refName,
         GITHUB_REF_TYPE: ref.refType,
@@ -278,6 +317,45 @@ async function runResolveTag(
         .split("\n")
         .map((line) => line.split("=", 2)),
     );
+  } finally {
+    await fs.rm(tempDir, { force: true, recursive: true });
+  }
+}
+
+async function runGithubReleaseStep(script: string, state: string): Promise<string[]> {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-github-release-"));
+  const binDir = path.join(tempDir, "bin");
+  const logPath = path.join(tempDir, "gh.log");
+  try {
+    await fs.mkdir(binDir);
+    await writeExecutable(
+      path.join(binDir, "gh"),
+      `#!/usr/bin/env bash
+set -euo pipefail
+echo "$*" >> "$MOCK_LOG"
+if [[ "$1 $2" == "release view" ]]; then
+  case "$MOCK_RELEASE_STATE" in
+    stable) printf 'false\\tfalse\\n' ;;
+    draft) printf 'true\\tfalse\\n' ;;
+    prerelease) printf 'false\\ttrue\\n' ;;
+    missing) exit 1 ;;
+    *) exit 2 ;;
+  esac
+fi
+`,
+    );
+    await execFileWithOutput("bash", ["-c", script], {
+      cwd: tempDir,
+      env: {
+        ...process.env,
+        GITHUB_REPOSITORY: "openclaw/crabline",
+        MOCK_LOG: logPath,
+        MOCK_RELEASE_STATE: state,
+        PATH: `${binDir}:${process.env.PATH}`,
+        RELEASE_TAG: "v1.2.3",
+      },
+    });
+    return (await fs.readFile(logPath, "utf8")).trim().split("\n");
   } finally {
     await fs.rm(tempDir, { force: true, recursive: true });
   }

--- a/test/release-workflow.test.ts
+++ b/test/release-workflow.test.ts
@@ -40,6 +40,9 @@ describe("release workflow", () => {
     const steps = jobSteps(workflow, "verify");
     const resolveStep = steps.find((step) => step.name === "Resolve release tag")?.run;
     const checkoutStep = steps.find((step) => step.uses?.startsWith("actions/checkout@"));
+    const verifyCheckoutStep = steps.find(
+      (step) => step.name === "Verify checked out release tag",
+    )?.run;
 
     await expect(runResolveTag(resolveStep, "v1.2.3")).resolves.toEqual({
       tag: "v1.2.3",
@@ -64,6 +67,7 @@ describe("release workflow", () => {
       runResolveTag(resolveStep, "v1.2.3", { refName: "v1.2.2", refType: "tag" }),
     ).rejects.toThrow(/Command failed/u);
     expect(checkoutStep?.with?.ref).toBe("refs/tags/${{ steps.release.outputs.tag }}");
+    expect(verifyCheckoutStep).toContain("refs/tags/${RELEASE_TAG}^{commit}");
   });
 
   it("pins tooling and makes package and GitHub publication retry-safe", async () => {

--- a/test/slack-server.test.ts
+++ b/test/slack-server.test.ts
@@ -8,6 +8,7 @@ import {
   type StartedSlackServer,
   type StartSlackServerParams,
 } from "../src/index.js";
+import { ADMIN_TOKEN_HEADER } from "../src/servers/http.js";
 import { createTempDir, disposeTempDir, requestHttp } from "./test-helpers.js";
 
 const servers: StartedSlackServer[] = [];
@@ -507,6 +508,48 @@ describe("slack local provider server", () => {
     }
   });
 
+  it("cancels unread Events API response bodies", async () => {
+    let resolveClosed: () => void = () => undefined;
+    const responseClosed = new Promise<void>((resolve) => {
+      resolveClosed = resolve;
+    });
+    const eventsReceiver = createServer((_request, response) => {
+      response.once("close", resolveClosed);
+      response.writeHead(200, { "content-type": "text/plain" });
+      response.write("ignored response body");
+    });
+    await new Promise<void>((resolve) => eventsReceiver.listen(0, "127.0.0.1", resolve));
+    const address = eventsReceiver.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Unable to resolve Slack Events API receiver address.");
+    }
+    const server = await startTestSlackServer({
+      eventsRequestUrl: `http://127.0.0.1:${address.port}/slack/events`,
+      signingSecret: "test-token-placeholder",
+    });
+
+    try {
+      const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({
+          channel: "C1234567890",
+          text: "response body disposal",
+          user: "U1234567890",
+        }),
+        headers: {
+          "content-type": "application/json",
+          [ADMIN_TOKEN_HEADER]: server.manifest.adminToken,
+        },
+        method: "POST",
+      });
+      expect(inbound.status).toBe(200);
+      await responseClosed;
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        eventsReceiver.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+
   it("redacts body/query tokens and skips rejected admin inbound recording", async () => {
     const server = await startTestSlackServer();
 
@@ -557,7 +600,9 @@ describe("slack local provider server", () => {
   });
 
   it("returns Slack-shaped posting errors", async () => {
-    const server = await startTestSlackServer();
+    const server = await startTestSlackServer({
+      chatPostMessageRateLimit: { remaining: 2, retryAfterSeconds: 2 },
+    });
 
     await expect(
       (
@@ -572,10 +617,16 @@ describe("slack local provider server", () => {
       ok: false,
     });
 
+    await expect(
+      (
+        await slackApi(server, "chat.postMessage", {
+          channel: "C1234567890",
+          text: "first request",
+        })
+      ).json(),
+    ).resolves.toMatchObject({ ok: true });
     const rateLimited = await slackApi(server, "chat.postMessage", {
       channel: "C1234567890",
-      retry_after: 2,
-      simulate_rate_limit: true,
       text: "slow down",
     });
     expect(rateLimited.status).toBe(429);
@@ -584,6 +635,31 @@ describe("slack local provider server", () => {
       error: "ratelimited",
       ok: false,
     });
+  });
+
+  it("validates out-of-band rate-limit controls", async () => {
+    await expect(
+      startSlackServer({
+        chatPostMessageRateLimit: { remaining: -1, retryAfterSeconds: 1 },
+      }),
+    ).rejects.toThrow("remaining must be a non-negative safe integer");
+    await expect(
+      startSlackServer({
+        chatPostMessageRateLimit: { remaining: 0, retryAfterSeconds: 0 },
+      }),
+    ).rejects.toThrow("retryAfterSeconds must be a positive safe integer");
+  });
+
+  it("does not expose rate-limit controls through chat.postMessage fields", async () => {
+    const server = await startTestSlackServer();
+    const response = await slackApi(server, "chat.postMessage", {
+      channel: "C1234567890",
+      retry_after: 30,
+      simulate_rate_limit: true,
+      text: "ordinary provider payload",
+    });
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ ok: true });
   });
 
   it("handles Slack Events API URL verification", async () => {


### PR DESCRIPTION
## Summary
- keep aborted HTTP request streams error-handled and reject unsafe integer values
- bound Mattermost WebSocket delivery and reject oversized events without poisoning the queue
- cancel Slack Events API response bodies and move rate-limit controls out of provider request fields
- pin manual releases to the requested exact tag and reject draft/prerelease releases as completed
- add a changelog entry

## Verification
- `pnpm lint`
- focused server and release tests
- Crabbox `run_46ae9b272484`: `pnpm verify` (50 files, 460 tests)
- autoreview: gpt-5.6-sol/high, clean (0.90 confidence)