### PR TITLE
fix(lifecycle): preserve failures and validate startup inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Preserve primary watch and adapter-start failures, retain shutdown handlers through cleanup, validate smoke-lock tokens, enforce Zalo probe envelopes, and reject ambiguous config names and formats.
 - Preserve provider-native WhatsApp message acknowledgements, legacy group JIDs, bounded inbound admission, WebSocket error isolation, and strict handshake varints.
 - Authenticate built-in Telegram, Slack, and Zalo webhooks, bound recorder wait state, accept Slack user send targets, preserve canonical Telegram topics, and complete WhatsApp cleanup after close failures.
 - Harden HTTP stream failure handling, bound Mattermost WebSocket delivery, move Slack rate-limit controls out of provider payloads, drain Slack callback bodies, and validate release dispatch and existing release state.

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -35,6 +35,7 @@ export type ReadyFileIdentity = {
 
 type ProgramDependencies = {
   acquireReadyFileLease?: (filePath: string) => Promise<() => Promise<void>>;
+  createRegistry?: typeof createRegistry;
   publishReadyFile?: (filePath: string, contents: string) => Promise<ReadyFileIdentity>;
   removeReadyFile?: (
     filePath: string,
@@ -143,6 +144,7 @@ export function createProgram(
 ): Command {
   const program = new Command();
   const acquireReadyLease = dependencies.acquireReadyFileLease ?? acquireReadyFileLease;
+  const registryFactory = dependencies.createRegistry ?? createRegistry;
   const publish = dependencies.publishReadyFile ?? publishReadyFileUnlocked;
   const removeReady = dependencies.removeReadyFile ?? removeReadyFileIfOwned;
   const startServer = dependencies.startServer ?? startCrablineServer;
@@ -161,7 +163,7 @@ export function createProgram(
     .action(async () => {
       const options = program.opts() as GlobalOptions;
       const { manifest, path } = await loadManifest(options.config);
-      const registry = createRegistry(manifest, path);
+      const registry = registryFactory(manifest, path);
       const payload = {
         configured: Object.entries(manifest.providers).map(([id, config]) => ({
           adapter: config.adapter,
@@ -203,7 +205,7 @@ export function createProgram(
       if (!fixture) {
         throw new CrablineError(`Unknown fixture: ${fixtureId}`, { kind: "config" });
       }
-      const registry = createRegistry(manifest, path);
+      const registry = registryFactory(manifest, path);
       const result = await runFixtureCommand({
         fixtureId: fixture.id,
         manifest,
@@ -222,7 +224,7 @@ export function createProgram(
       .action(async (fixtureId) => {
         const options = program.opts() as GlobalOptions;
         const { manifest, path } = await loadManifest(options.config);
-        const registry = createRegistry(manifest, path);
+        const registry = registryFactory(manifest, path);
         const result = await runFixtureCommand({
           fixtureId,
           manifest,
@@ -241,7 +243,7 @@ export function createProgram(
     .action(async (fixtureIds) => {
       const options = program.opts() as GlobalOptions;
       const { manifest, path } = await loadManifest(options.config);
-      const registry = createRegistry(manifest, path);
+      const registry = registryFactory(manifest, path);
       const result = await runSuite({
         fixtureIds,
         manifest,
@@ -264,13 +266,15 @@ export function createProgram(
           throw new CrablineError(`Unknown fixture: ${fixtureId}`, { kind: "config" });
         }
 
-        const provider = createRegistry(manifest, path).resolve(fixture.provider, fixture.id);
+        const provider = registryFactory(manifest, path).resolve(fixture.provider, fixture.id);
         if (!provider.watch) {
           throw new CrablineError(`Provider "${fixture.provider}" does not implement watch.`, {
             kind: "config",
           });
         }
 
+        let watchError: unknown;
+        let watchFailed = false;
         try {
           for await (const message of provider.watch({
             config: manifest.providers[fixture.provider]!,
@@ -285,8 +289,20 @@ export function createProgram(
                 : `${message.sentAt} ${message.author} ${message.text}`,
             );
           }
-        } finally {
+        } catch (error) {
+          watchFailed = true;
+          watchError = error;
+        }
+        try {
           await provider.cleanup?.();
+        } catch (cleanupError) {
+          throw combineLifecycleErrors(
+            watchFailed ? [watchError, cleanupError] : [cleanupError],
+            "Crabline watch lifecycle failed.",
+          );
+        }
+        if (watchFailed) {
+          throw watchError;
         }
       });
     });
@@ -418,7 +434,6 @@ export function createProgram(
       }
       finishStartup();
       finishPublication();
-      shutdown.dispose();
       const cleanupErrors: unknown[] = [];
       const readyToRemove = publishedReady;
       for (const cleanup of [
@@ -443,6 +458,7 @@ export function createProgram(
           }
         }
       }
+      shutdown.dispose();
       if (actionFailed || cleanupErrors.length > 0) {
         throw combineLifecycleErrors(
           actionFailed ? [actionError, ...cleanupErrors] : cleanupErrors,
@@ -470,7 +486,7 @@ export function createProgram(
 type ShutdownSignal = "SIGINT" | "SIGTERM";
 
 type SignalTarget = {
-  once(event: ShutdownSignal, listener: () => void): unknown;
+  on(event: ShutdownSignal, listener: () => void): unknown;
   removeListener(event: ShutdownSignal, listener: () => void): unknown;
 };
 
@@ -693,7 +709,7 @@ function installShutdownHandler(
   requested(): boolean;
   wait(): Promise<void>;
 } {
-  let shuttingDown = false;
+  let shutdownPromise: Promise<void> | undefined;
   let resolveWait: (() => void) | undefined;
   let rejectWait: ((error: unknown) => void) | undefined;
   const wait = new Promise<void>((resolve, reject) => {
@@ -706,18 +722,26 @@ function installShutdownHandler(
     signalTarget.removeListener("SIGTERM", shutdown);
   };
   const shutdown = () => {
-    if (shuttingDown) {
+    if (shutdownPromise) {
       return;
     }
-    shuttingDown = true;
-    removeListeners();
-    void Promise.resolve().then(close).then(resolveWait, rejectWait);
+    shutdownPromise = Promise.resolve().then(close);
+    void shutdownPromise.then(
+      () => {
+        removeListeners();
+        resolveWait?.();
+      },
+      (error: unknown) => {
+        removeListeners();
+        rejectWait?.(error);
+      },
+    );
   };
-  signalTarget.once("SIGINT", shutdown);
-  signalTarget.once("SIGTERM", shutdown);
+  signalTarget.on("SIGINT", shutdown);
+  signalTarget.on("SIGTERM", shutdown);
   return {
     dispose: removeListeners,
-    requested: () => shuttingDown,
+    requested: () => shutdownPromise !== undefined,
     wait: () => wait,
   };
 }

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -79,13 +79,12 @@ export async function loadManifest(
     throw configLoadError(resolvedPath, error, ensureErrorMessage(error));
   }
 
+  const isJson = path.extname(resolvedPath).toLowerCase() === ".json";
   let parsed: unknown;
   try {
-    parsed = resolvedPath.endsWith(".json") ? JSON.parse(raw) : YAML.parse(raw, { merge: true });
+    parsed = isJson ? JSON.parse(raw) : YAML.parse(raw, { merge: true });
   } catch (error) {
-    const detail = resolvedPath.endsWith(".json")
-      ? formatJsonParseError(error)
-      : formatYamlParseError(error);
+    const detail = isJson ? formatJsonParseError(error) : formatYamlParseError(error);
     throw configLoadError(resolvedPath, new Error(detail), detail);
   }
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -639,7 +639,7 @@ const StrictManifestSchema = z
   .strictObject({
     configVersion: z.literal(1).default(1),
     fixtures: z.array(FixtureSchema).default([]),
-    providers: z.record(z.string(), ProviderConfigSchema).default({}),
+    providers: z.record(z.string().min(1), ProviderConfigSchema).default({}),
     userName: z.string().min(1).default("crabline"),
   })
   .superRefine((manifest, ctx) => {

--- a/src/openclaw.ts
+++ b/src/openclaw.ts
@@ -4,6 +4,7 @@ import {
   startCrablineServer,
   type CrablineServerChannel,
   type CrablineServerManifest,
+  type StartCrablineServerParams,
   type StartedCrablineServer,
 } from "./servers/index.js";
 import { SLACK_OPENCLAW_CRABLINE_PROVIDER_BRIDGE } from "./openclaw/bridges/slack.js";
@@ -160,29 +161,50 @@ export function createOpenClawCrablineOutboundFromRecorderEvent(params: {
 
 export async function startOpenClawCrablineAdapter(
   params: StartOpenClawCrablineAdapterParams,
+  dependencies: {
+    createProviderAdapter?: typeof createOpenClawCrablineProviderAdapter;
+    startServer?: (params: StartCrablineServerParams) => Promise<StartedCrablineServer>;
+  } = {},
 ): Promise<StartedOpenClawCrablineAdapter> {
-  const server: StartedCrablineServer = await startCrablineServer({
+  const server: StartedCrablineServer = await (dependencies.startServer ?? startCrablineServer)({
     channel: params.channel,
     onEvent: params.onEvent,
     recorderPath: params.recorderPath,
   });
-  const providerAdapter = createOpenClawCrablineProviderAdapter(server.manifest);
-  const binding = providerAdapter.createBinding();
-  return {
-    ...binding,
-    close: server.close,
-    createGatewayConfig: (openclawConfig = params.openclawConfig ?? {}) =>
-      binding.createGatewayConfig(openclawConfig),
-    createAgentDelivery: ({ target }) => providerAdapter.createAgentDelivery(parseQaTarget(target)),
-    createInbound: ({ input }) => providerAdapter.createInbound(input),
-    createOutboundFromRecorderEvent: ({ event, targetByProviderTarget }) =>
-      providerAdapter.createOutboundFromRecorderEvent({
-        event,
-        targetByProviderTarget,
-      }),
-    manifest: server.manifest,
-    probe: () => providerAdapter.probe(),
-  };
+  try {
+    const providerAdapter = (
+      dependencies.createProviderAdapter ?? createOpenClawCrablineProviderAdapter
+    )(server.manifest);
+    const binding = providerAdapter.createBinding();
+    return {
+      ...binding,
+      close: server.close,
+      createGatewayConfig: (openclawConfig = params.openclawConfig ?? {}) =>
+        binding.createGatewayConfig(openclawConfig),
+      createAgentDelivery: ({ target }) =>
+        providerAdapter.createAgentDelivery(parseQaTarget(target)),
+      createInbound: ({ input }) => providerAdapter.createInbound(input),
+      createOutboundFromRecorderEvent: ({ event, targetByProviderTarget }) =>
+        providerAdapter.createOutboundFromRecorderEvent({
+          event,
+          targetByProviderTarget,
+        }),
+      manifest: server.manifest,
+      probe: () => providerAdapter.probe(),
+    };
+  } catch (error) {
+    try {
+      await server.close();
+    } catch (closeError) {
+      const aggregateError = new AggregateError(
+        [error, closeError],
+        "OpenClaw Crabline adapter startup failed.",
+      );
+      aggregateError.cause = error;
+      throw aggregateError;
+    }
+    throw error;
+  }
 }
 
 type SmokeRunDependencies = {

--- a/src/openclaw/bridges/zalo.ts
+++ b/src/openclaw/bridges/zalo.ts
@@ -28,7 +28,16 @@ export const ZALO_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablineProv
         if (!response.ok) {
           throw new Error(`Crabline Zalo getMe probe failed with HTTP ${response.status}.`);
         }
-        return await response.json();
+        const result = await response.json();
+        const bot = isRecord(result) && isRecord(result.result) ? result.result : undefined;
+        if (!isRecord(result) || result.ok !== true || !readNonBlankString(bot?.id)) {
+          const detail =
+            (isRecord(result) ? readNonBlankString(result.description) : undefined) ??
+            (isRecord(result) ? readNonBlankString(result.error) : undefined) ??
+            "invalid response";
+          throw new Error(`Crabline Zalo getMe probe failed: ${detail}.`);
+        }
+        return result;
       },
       createBinding() {
         return {

--- a/src/openclaw/smoke-lock.ts
+++ b/src/openclaw/smoke-lock.ts
@@ -252,6 +252,8 @@ function isPositiveSafeInteger(value: unknown): value is number {
   return Number.isSafeInteger(value) && Number(value) > 0;
 }
 
+const LOCK_TOKEN_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u;
+
 function parseLockOwner(contents: string): SmokeLockOwner {
   let owner: Partial<RenewableSmokeLockOwner>;
   try {
@@ -266,7 +268,7 @@ function parseLockOwner(contents: string): SmokeLockOwner {
     !isCrablineServerChannel(owner.channel) ||
     !isPositiveSafeInteger(owner.pid) ||
     typeof owner.token !== "string" ||
-    owner.token.length === 0
+    !LOCK_TOKEN_PATTERN.test(owner.token)
   ) {
     throw new Error("OpenClaw Crabline smoke lock owner metadata is malformed.");
   }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -758,6 +758,132 @@ describe("cli", () => {
     expect(close).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps signal handlers installed until server cleanup completes", async () => {
+    let finishClose: (() => void) | undefined;
+    const close = vi.fn(
+      async () =>
+        await new Promise<void>((resolve) => {
+          finishClose = resolve;
+        }),
+    );
+    const baseline = process.listenerCount("SIGTERM");
+    const program = createProgram(() => undefined, {
+      startServer: async () => ({
+        close,
+        manifest: {
+          adminToken: "fake",
+          baseUrl: "http://127.0.0.1:12345",
+          botToken: "sample",
+          endpoints: {
+            adminInboundUrl: "http://127.0.0.1:12345/crabline/telegram/inbound",
+            apiRoot: "http://127.0.0.1:12345",
+          },
+          env: { TELEGRAM_BOT_TOKEN: "sample" },
+          provider: "telegram",
+          recorderPath: "telegram.jsonl",
+          version: 1,
+        },
+      }),
+    });
+    const running = program.parseAsync(["node", "crabline", "--json", "serve", "telegram"]);
+    await vi.waitFor(() => expect(process.listenerCount("SIGTERM")).toBeGreaterThan(baseline));
+
+    process.emit("SIGTERM", "SIGTERM");
+    await vi.waitFor(() => expect(close).toHaveBeenCalledTimes(1));
+    expect(process.listenerCount("SIGTERM")).toBeGreaterThan(baseline);
+
+    finishClose?.();
+    await running;
+    expect(process.listenerCount("SIGTERM")).toBe(baseline);
+  });
+
+  it("preserves watch and cleanup failures", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const configPath = path.join(directory, "crabline.yaml");
+    await writeText(
+      configPath,
+      [
+        "configVersion: 1",
+        "providers:",
+        "  local:",
+        "    adapter: loopback",
+        "fixtures:",
+        "  - id: watched",
+        "    provider: local",
+        "    mode: agent",
+        "    target:",
+        "      id: echo-bot",
+      ].join("\n"),
+    );
+    const watchError = new Error("watch exploded");
+    const cleanupError = new Error("cleanup exploded");
+    const provider = {
+      async cleanup() {
+        throw cleanupError;
+      },
+      async *watch() {
+        yield await Promise.reject(watchError);
+      },
+    };
+    const program = createProgram(() => undefined, {
+      createRegistry: () =>
+        ({
+          resolve: () => provider,
+        }) as never,
+    });
+
+    const failure = await program
+      .parseAsync(["node", "crabline", "--config", configPath, "watch", "watched"])
+      .catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(AggregateError);
+    expect((failure as AggregateError).errors).toEqual([watchError, cleanupError]);
+    expect((failure as AggregateError).cause).toBe(watchError);
+  });
+
+  it("preserves an undefined watch failure", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const configPath = path.join(directory, "crabline.yaml");
+    await writeText(
+      configPath,
+      [
+        "configVersion: 1",
+        "providers:",
+        "  local:",
+        "    adapter: loopback",
+        "fixtures:",
+        "  - id: watched",
+        "    provider: local",
+        "    mode: agent",
+        "    target:",
+        "      id: echo-bot",
+      ].join("\n"),
+    );
+    const provider = {
+      cleanup: vi.fn(async () => undefined),
+      async *watch() {
+        yield await Promise.reject(undefined);
+      },
+    };
+    const program = createProgram(() => undefined, {
+      createRegistry: () =>
+        ({
+          resolve: () => provider,
+        }) as never,
+    });
+
+    let caught: { rejected: boolean; value: unknown } = { rejected: false, value: "not-thrown" };
+    try {
+      await program.parseAsync(["node", "crabline", "--config", configPath, "watch", "watched"]);
+    } catch (error) {
+      caught = { rejected: true, value: error };
+    }
+    expect(caught).toEqual({ rejected: true, value: undefined });
+    expect(provider.cleanup).toHaveBeenCalledTimes(1);
+  });
+
   it("preserves shutdown and ready-file cleanup failures", async () => {
     const directory = await createTempDir();
     directories.push(directory);

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -138,6 +138,16 @@ describe("manifest schema", () => {
     ).toThrow(/fixture missing-provider references unknown provider missing/u);
   });
 
+  it("rejects empty provider identifiers", () => {
+    expect(() =>
+      ManifestSchema.parse({
+        configVersion: 1,
+        fixtures: [],
+        providers: { "": { adapter: "loopback" } },
+      }),
+    ).toThrow(/Too small/u);
+  });
+
   it("rejects fixture modes outside provider capabilities", () => {
     expect(() =>
       ManifestSchema.parse({

--- a/test/load.test.ts
+++ b/test/load.test.ts
@@ -55,6 +55,15 @@ describe("config load", () => {
     expect(loaded.path).toBe(configPath);
   });
 
+  it("parses explicit JSON paths case-insensitively", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const configPath = path.join(directory, "crabline.JSON");
+    await writeText(configPath, "configVersion: 1\nproviders: {}\nfixtures: []\n");
+
+    await expect(loadManifest(configPath)).rejects.toThrow(/JSON parse error/u);
+  });
+
   it("loads the shipped OpenClaw bridge fixture with YAML anchors", async () => {
     const configPath = path.resolve("fixtures/examples/openclaw-bridge.yaml");
 

--- a/test/openclaw-smoke-lock.test.ts
+++ b/test/openclaw-smoke-lock.test.ts
@@ -53,6 +53,40 @@ describe("OpenClaw smoke lock cleanup", () => {
     });
   });
 
+  it("rejects lock tokens that can escape token-specific filenames", async () => {
+    const outputDir = await createTempDir();
+    const lockDirectory = path.join(
+      path.resolve(outputDir),
+      `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`,
+    );
+    try {
+      await fs.mkdir(lockDirectory);
+      await fs.writeFile(
+        path.join(lockDirectory, "owner.json"),
+        `${JSON.stringify({
+          channel: "telegram",
+          pid: 4_242,
+          token: ["..", "..", "..", "..", "sentinel"].join("/"),
+        })}\n`,
+      );
+
+      await expect(
+        acquireOpenClawCrablineSmokeRunLock(
+          { channel: "telegram", outputDir },
+          {
+            isProcessAlive: () => true,
+            now: () => 1_000,
+            pid: 5_252,
+            processStartedAtMs: 200,
+            startHeartbeat: disableHeartbeat,
+          },
+        ),
+      ).rejects.toThrow("OpenClaw Crabline smoke lock owner metadata is malformed.");
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
   it("secures an empty Windows lock directory before writing sensitive contents", async () => {
     const outputDir = await createTempDir();
     const destinationPath = path.join(outputDir, "current.json");

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -315,6 +315,41 @@ describe("OpenClaw local provider bridge", () => {
     }
   });
 
+  it("rejects Zalo application errors returned with HTTP 200", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ description: "Unauthorized", error_code: 401, ok: false }), {
+        headers: { "content-type": "application/json" },
+        status: 200,
+      }),
+    );
+    try {
+      await expect(probeOpenClawCrablineProvider(zaloManifest)).rejects.toThrow(
+        "Crabline Zalo getMe probe failed: Unauthorized.",
+      );
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  it.each([{ ok: true }, { ok: true, result: null }, { ok: true, result: {} }])(
+    "rejects malformed Zalo success payloads: %j",
+    async (payload) => {
+      const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(payload), {
+          headers: { "content-type": "application/json" },
+          status: 200,
+        }),
+      );
+      try {
+        await expect(probeOpenClawCrablineProvider(zaloManifest)).rejects.toThrow(
+          "Crabline Zalo getMe probe failed: invalid response.",
+        );
+      } finally {
+        fetchMock.mockRestore();
+      }
+    },
+  );
+
   it.each([
     { label: "Mattermost users.me", manifest: mattermostManifest },
     { label: "Matrix whoami", manifest: matrixManifest },
@@ -686,6 +721,24 @@ describe("OpenClaw local provider bridge", () => {
     } finally {
       await adapter.close();
     }
+  });
+
+  it("closes a started server when adapter construction fails", async () => {
+    const startupError = new Error("adapter construction failed");
+    const close = vi.fn(async () => undefined);
+
+    await expect(
+      startOpenClawCrablineAdapter(
+        { channel: "telegram" },
+        {
+          createProviderAdapter() {
+            throw startupError;
+          },
+          startServer: async () => ({ close, manifest }),
+        },
+      ),
+    ).rejects.toBe(startupError);
+    expect(close).toHaveBeenCalledTimes(1);
   });
 
   it("maps QA targets, inbound messages, and recorder events", () => {


### PR DESCRIPTION
## Summary
- preserve watch failures alongside cleanup errors and retain shutdown handlers through cleanup
- close provider servers when OpenClaw adapter construction fails
- validate config formats, provider ids, smoke-lock tokens, and Zalo probe envelopes

## Verification
- `pnpm lint`
- `pnpm exec vitest run test/cli.test.ts test/config.test.ts test/load.test.ts test/openclaw-smoke-lock.test.ts test/openclaw.test.ts` (157 tests)
- autoreview: gpt-5.6-sol/high, clean
- Crabbox `pnpm verify`: `run_bb0742bad440` (50 files, 483 tests)

## Audit
Remediates confirmed findings from exact-main clawpatch run `20260712T153646-34dc24`.
