### PR TITLE
fix(whatsapp): bound wire state and preserve delivery order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Bound WhatsApp binary-node complexity and signal bundles, align encoder and decoder limits, preserve coherent X25519 fallback behavior, validate queue startup before listening, keep reconnect delivery FIFO, and accept bounded legacy group JIDs.
 - Preserve primary watch and adapter-start failures, retain shutdown handlers through cleanup, validate smoke-lock tokens, enforce Zalo probe envelopes, and reject ambiguous config names and formats.
 - Preserve provider-native WhatsApp message acknowledgements, legacy group JIDs, bounded inbound admission, WebSocket error isolation, and strict handshake varints.
 - Authenticate built-in Telegram, Slack, and Zalo webhooks, bound recorder wait state, accept Slack user send targets, preserve canonical Telegram topics, and complete WhatsApp cleanup after close failures.

--- a/src/openclaw/bridges/whatsapp.ts
+++ b/src/openclaw/bridges/whatsapp.ts
@@ -9,7 +9,7 @@ import {
 } from "../shared.js";
 
 const WHATSAPP_JID_RE =
-  /^(?:\d{7,15}(?::\d+)?@s\.whatsapp\.net|\d{7,15}@c\.us|\d{5,}@g\.us|\d{7,15}@lid)$/iu;
+  /^(?:\d{7,15}(?::\d+)?@s\.whatsapp\.net|\d{7,15}@c\.us|\d{5,20}(?:-\d{5,20})?@g\.us|\d{7,15}@lid)$/iu;
 
 function requireWhatsAppJid(value: string, label: string): string {
   const trimmed = value.trim();

--- a/src/servers/whatsapp-baileys-websocket.ts
+++ b/src/servers/whatsapp-baileys-websocket.ts
@@ -31,6 +31,8 @@ import { closeWebSocketServer } from "./websocket.js";
 const EMPTY_BUFFER = Buffer.alloc(0);
 const IV_LENGTH = 12;
 const MAX_PENDING_INBOUND_MESSAGES = 1_000;
+export const MAX_WHATSAPP_SIGNAL_BUNDLES = 1_024;
+const SIGNAL_BUNDLE_JID_RE = /^\d{7,15}(?::\d+)?@(?:s\.whatsapp\.net|lid)$/iu;
 type NodeBuffer = Buffer<ArrayBufferLike>;
 const WHATSAPP_NOISE_CERT_CHAIN = Buffer.from(
   "CncKMwjjAhADGiCRKg7Kg1iu4CSulwLBaxX51Tefw6VXGgZqcr5OEbXIRiDQ04bOBijQjZ/TBhJA34Bj82jAHhLpCWBNVBlGnFDieamd8+138S57uMt9ke9mrn5r4+VepwBPKEgHjob6bR70rlCmWDkxZv+CfVjIAxJ2CjIIAxAAGiAcUamsMDmUxsjQuS6hh4pTNHZZnMWZ++o1mX2aqQzOYiCAka6+Bij/3rfcBhJAJw8pRkhTn+1IcOJQVN1OlZg6uikYnCumyO7acFVVX3U3QPXsGSq2TCbCbWrebSC593Su43EgprIDlfU8ZgWFBw==",
@@ -72,13 +74,68 @@ export type WhatsAppBaileysInboundMessage = {
   pushName?: string | undefined;
 };
 
-type MockSignalBundle = {
+export function resolveMaxPendingWhatsAppInboundMessages(value: number | undefined): number {
+  const resolved = value ?? MAX_PENDING_INBOUND_MESSAGES;
+  if (!Number.isSafeInteger(resolved) || resolved < 1) {
+    throw new Error("WhatsApp maxPendingInboundMessages must be a positive safe integer.");
+  }
+  return resolved;
+}
+
+export type MockSignalBundle = {
   identityKey: KeyPair;
   preKey: KeyPair;
   preKeyId: number;
   registrationId: number;
   signedPreKey: SignedKeyPair;
 };
+
+export class WhatsAppSignalBundleStore {
+  readonly #bundles = new Map<string, MockSignalBundle>();
+
+  constructor(private readonly maxBundles = MAX_WHATSAPP_SIGNAL_BUNDLES) {
+    if (!Number.isSafeInteger(maxBundles) || maxBundles < 1) {
+      throw new Error("WhatsApp maxSignalBundles must be a positive safe integer.");
+    }
+  }
+
+  get size(): number {
+    return this.#bundles.size;
+  }
+
+  resolveMany(jids: string[]): MockSignalBundle[] {
+    const uniqueNewJids = new Set<string>();
+    for (const jid of jids) {
+      if (!SIGNAL_BUNDLE_JID_RE.test(jid)) {
+        throw new Error(`Invalid WhatsApp signal bundle JID: ${jid}.`);
+      }
+      if (!this.#bundles.has(jid)) {
+        uniqueNewJids.add(jid);
+      }
+    }
+    if (this.#bundles.size + uniqueNewJids.size > this.maxBundles) {
+      throw new Error(`WhatsApp signal bundle limit exceeded (${this.maxBundles}).`);
+    }
+    return jids.map((jid) => this.#resolve(jid));
+  }
+
+  #resolve(jid: string): MockSignalBundle {
+    const existing = this.#bundles.get(jid);
+    if (existing) {
+      return existing;
+    }
+    const identityKey = Curve.generateKeyPair();
+    const bundle = {
+      identityKey,
+      preKey: Curve.generateKeyPair(),
+      preKeyId: 1,
+      registrationId: 1,
+      signedPreKey: signedKeyPair(identityKey, 1),
+    };
+    this.#bundles.set(jid, bundle);
+    return bundle;
+  }
+}
 
 export function createSerializedMessageHandler<T>(
   processMessage: (message: T) => Promise<void>,
@@ -295,7 +352,7 @@ class WhatsAppBaileysWebSocketSession {
       path: string;
       onOpen(session: WhatsAppBaileysWebSocketSession): void;
       selfJid: string;
-      signalBundles: Map<string, MockSignalBundle>;
+      signalBundles: WhatsAppSignalBundleStore;
     },
   ) {
     this.#handleSerializedMessage = createSerializedMessageHandler(
@@ -389,7 +446,24 @@ class WhatsAppBaileysWebSocketSession {
       return { attrs, content: [{ attrs: {}, tag: "digest" }], tag: "iq" };
     }
     if (node.attrs.xmlns === "encrypt" && child?.tag === "key") {
-      return { attrs, content: [this.#createKeyList(child)], tag: "iq" };
+      try {
+        return { attrs, content: [this.#createKeyList(child)], tag: "iq" };
+      } catch (error) {
+        return {
+          attrs: { ...attrs, type: "error" },
+          content: [
+            {
+              attrs: {
+                code: "400",
+                text: error instanceof Error ? error.message : String(error),
+                type: "modify",
+              },
+              tag: "error",
+            },
+          ],
+          tag: "iq",
+        };
+      }
     }
     if (node.attrs.xmlns === "usync" && child?.tag === "usync") {
       return { attrs, content: [this.#createUSyncResult(child)], tag: "iq" };
@@ -473,15 +547,16 @@ class WhatsAppBaileysWebSocketSession {
 
   #createKeyList(keyNode: BinaryNode): BinaryNode {
     const users = children(keyNode).filter((child) => child.tag === "user");
+    const jids = users.map((userNode) => requireAttr(userNode, "jid"));
+    const bundles = this.params.signalBundles.resolveMany(jids);
     return {
       attrs: {},
-      content: users.map((userNode) => this.#createKeyUser(requireAttr(userNode, "jid"))),
+      content: jids.map((jid, index) => this.#createKeyUser(jid, bundles[index]!)),
       tag: "list",
     };
   }
 
-  #createKeyUser(jid: string): BinaryNode {
-    const bundle = resolveSignalBundle(this.params.signalBundles, jid);
+  #createKeyUser(jid: string, bundle: MockSignalBundle): BinaryNode {
     return {
       attrs: { jid },
       content: [
@@ -557,14 +632,12 @@ class WhatsAppBaileysWebSocketSession {
 export function attachWhatsAppBaileysWebSocketServer(
   params: WhatsAppBaileysWebSocketServerParams,
 ): WhatsAppBaileysWebSocketServer {
-  const signalBundles = new Map<string, MockSignalBundle>();
+  const signalBundles = new WhatsAppSignalBundleStore();
   const sessions = new Set<WhatsAppBaileysWebSocketSession>();
   const pendingMessages: WhatsAppBaileysInboundMessage[] = [];
-  const maxPendingInboundMessages =
-    params.maxPendingInboundMessages ?? MAX_PENDING_INBOUND_MESSAGES;
-  if (!Number.isSafeInteger(maxPendingInboundMessages) || maxPendingInboundMessages < 1) {
-    throw new Error("WhatsApp maxPendingInboundMessages must be a positive safe integer.");
-  }
+  const maxPendingInboundMessages = resolveMaxPendingWhatsAppInboundMessages(
+    params.maxPendingInboundMessages,
+  );
   let pendingReservations = 0;
   const wss = new WebSocketServer({ noServer: true });
   const flushPendingMessages = (session: WhatsAppBaileysWebSocketSession) => {
@@ -596,7 +669,7 @@ export function attachWhatsAppBaileysWebSocketServer(
     const session = new WhatsAppBaileysWebSocketSession(socket, {
       appendEvent: params.appendEvent,
       onOpen: (openSession) => {
-        setImmediate(() => flushPendingMessages(openSession));
+        flushPendingMessages(openSession);
       },
       path: params.path,
       selfJid: params.selfJid,
@@ -642,6 +715,17 @@ export function attachWhatsAppBaileysWebSocketServer(
           }
           settled = true;
           try {
+            if (pendingMessages.length > 0) {
+              releaseReservation();
+              if (pendingMessages.length >= maxPendingInboundMessages) {
+                throw new Error("WhatsApp inbound delivery reservation exceeded queue capacity.");
+              }
+              pendingMessages.push(message);
+              for (const session of sessions) {
+                flushPendingMessages(session);
+              }
+              return pendingMessages.includes(message) ? "queued" : "delivered";
+            }
             let delivered = false;
             for (const session of sessions) {
               if (session.deliverInboundMessage(message)) {
@@ -650,6 +734,10 @@ export function attachWhatsAppBaileysWebSocketServer(
             }
             if (delivered) {
               return "delivered";
+            }
+            releaseReservation();
+            if (pendingMessages.length >= maxPendingInboundMessages) {
+              throw new Error("WhatsApp inbound delivery reservation exceeded queue capacity.");
             }
             pendingMessages.push(message);
             return "queued";
@@ -740,26 +828,6 @@ function requireAttr(node: BinaryNode, name: string): string {
 function lidForJid(jid: string): string {
   const user = jid.split("@", 1)[0]?.split(":", 1)[0] ?? "15550000000";
   return `${user}@lid`;
-}
-
-function resolveSignalBundle(
-  signalBundles: Map<string, MockSignalBundle>,
-  jid: string,
-): MockSignalBundle {
-  const existing = signalBundles.get(jid);
-  if (existing) {
-    return existing;
-  }
-  const identityKey = Curve.generateKeyPair();
-  const bundle = {
-    identityKey,
-    preKey: Curve.generateKeyPair(),
-    preKeyId: 1,
-    registrationId: 1,
-    signedPreKey: signedKeyPair(identityKey, 1),
-  };
-  signalBundles.set(jid, bundle);
-  return bundle;
 }
 
 function sanitizeNodeForJson(value: unknown): unknown {

--- a/src/servers/whatsapp-wire/binary-node.ts
+++ b/src/servers/whatsapp-wire/binary-node.ts
@@ -10,6 +10,13 @@ export type BinaryNode = {
 export const WHATSAPP_BINARY_NODE_MAX_COMPRESSED_BYTES = 1024 * 1024;
 export const WHATSAPP_BINARY_NODE_MAX_DECOMPRESSED_BYTES = 8 * 1024 * 1024;
 export const WHATSAPP_BINARY_NODE_MAX_DEPTH = 128;
+export const WHATSAPP_BINARY_NODE_MAX_NODES = 32_768;
+export const WHATSAPP_BINARY_NODE_MAX_LIST_ITEMS = 131_072;
+
+type DecodeBudget = {
+  listItems: number;
+  nodes: number;
+};
 
 function inflateWithInfo(
   buffer: Uint8Array,
@@ -140,7 +147,10 @@ export const S_WHATSAPP_NET = "@s.whatsapp.net";
 export async function decodeBinaryNode(frame: Buffer): Promise<BinaryNode> {
   const buffer = await decompressIfRequired(frame);
   const indexRef = { index: 0 };
-  const node = decodeDecompressedBinaryNode(buffer, indexRef);
+  const node = decodeDecompressedBinaryNode(buffer, indexRef, 1, {
+    listItems: 0,
+    nodes: 0,
+  });
   if (indexRef.index !== buffer.length) {
     throw new Error("WhatsApp binary node frame contains trailing data.");
   }
@@ -148,7 +158,7 @@ export async function decodeBinaryNode(frame: Buffer): Promise<BinaryNode> {
 }
 
 export function encodeBinaryNode(node: BinaryNode): Buffer {
-  return Buffer.from(encodeBinaryNodeInner(node, [0]));
+  return Buffer.from(encodeBinaryNodeInner(node, [0], 1));
 }
 
 async function decompressIfRequired(buffer: Buffer): Promise<Buffer> {
@@ -189,11 +199,16 @@ async function decompressIfRequired(buffer: Buffer): Promise<Buffer> {
 
 function decodeDecompressedBinaryNode(
   buffer: Buffer,
-  indexRef = { index: 0 },
-  depth = 1,
+  indexRef: { index: number },
+  depth: number,
+  budget: DecodeBudget,
 ): BinaryNode {
   if (depth > WHATSAPP_BINARY_NODE_MAX_DEPTH) {
     throw new Error(`WhatsApp binary node nesting exceeds ${WHATSAPP_BINARY_NODE_MAX_DEPTH}.`);
+  }
+  budget.nodes += 1;
+  if (budget.nodes > WHATSAPP_BINARY_NODE_MAX_NODES) {
+    throw new Error(`WhatsApp binary node count exceeds ${WHATSAPP_BINARY_NODE_MAX_NODES}.`);
   }
   const checkEOS = (length: number) => {
     if (!Number.isSafeInteger(length) || length < 0 || length > buffer.length - indexRef.index) {
@@ -273,16 +288,23 @@ function decodeDecompressedBinaryNode(
     return startByte >> 7 !== 0 ? value.slice(0, -1) : value;
   };
   const readListSize = (tag: number) => {
+    let size: number;
     if (tag === TAGS.LIST_EMPTY) {
-      return 0;
+      size = 0;
+    } else if (tag === TAGS.LIST_8) {
+      size = readByte();
+    } else if (tag === TAGS.LIST_16) {
+      size = readInt(2);
+    } else {
+      throw new Error(`Invalid WhatsApp list tag: ${tag}.`);
     }
-    if (tag === TAGS.LIST_8) {
-      return readByte();
+    budget.listItems += size;
+    if (budget.listItems > WHATSAPP_BINARY_NODE_MAX_LIST_ITEMS) {
+      throw new Error(
+        `WhatsApp binary node list items exceed ${WHATSAPP_BINARY_NODE_MAX_LIST_ITEMS}.`,
+      );
     }
-    if (tag === TAGS.LIST_16) {
-      return readInt(2);
-    }
-    throw new Error(`Invalid WhatsApp list tag: ${tag}.`);
+    return size;
   };
   const isListTag = (tag: number) =>
     tag === TAGS.LIST_EMPTY || tag === TAGS.LIST_8 || tag === TAGS.LIST_16;
@@ -335,7 +357,7 @@ function decodeDecompressedBinaryNode(
     const items: BinaryNode[] = [];
     const size = readListSize(tag);
     for (let index = 0; index < size; index += 1) {
-      items.push(decodeDecompressedBinaryNode(buffer, indexRef, depth + 1));
+      items.push(decodeDecompressedBinaryNode(buffer, indexRef, depth + 1, budget));
     }
     return items;
   };
@@ -415,7 +437,10 @@ function decodeDecompressedBinaryNode(
   return content === undefined ? { attrs, tag } : { attrs, content, tag };
 }
 
-function encodeBinaryNodeInner(node: BinaryNode, buffer: number[]): number[] {
+function encodeBinaryNodeInner(node: BinaryNode, buffer: number[], depth: number): number[] {
+  if (depth > WHATSAPP_BINARY_NODE_MAX_DEPTH) {
+    throw new Error(`WhatsApp binary node nesting exceeds ${WHATSAPP_BINARY_NODE_MAX_DEPTH}.`);
+  }
   if (!node.tag) {
     throw new Error("Invalid WhatsApp binary node: tag is required.");
   }
@@ -437,7 +462,7 @@ function encodeBinaryNodeInner(node: BinaryNode, buffer: number[]): number[] {
   } else if (Array.isArray(node.content)) {
     writeListStart(buffer, node.content.length);
     for (const child of node.content) {
-      encodeBinaryNodeInner(child, buffer);
+      encodeBinaryNodeInner(child, buffer, depth + 1);
     }
   } else if (node.content !== undefined) {
     throw new Error(`Invalid WhatsApp binary node content for <${node.tag}>.`);

--- a/src/servers/whatsapp-wire/crypto.ts
+++ b/src/servers/whatsapp-wire/crypto.ts
@@ -8,13 +8,14 @@ import {
   diffieHellman,
   generateKeyPairSync,
   hkdfSync,
+  randomBytes,
 } from "node:crypto";
 import { createRequire } from "node:module";
 
 const require = createRequire(import.meta.url);
 
 type Curve25519Module = {
-  generateKeyPair(seed?: Uint8Array): { private: Uint8Array; public: Uint8Array };
+  generateKeyPair(seed: Uint8Array): { private: Uint8Array; public: Uint8Array };
   sharedKey(privateKey: Uint8Array, publicKey: Uint8Array): Uint8Array;
   sign(privateKey: Uint8Array, message: Uint8Array): Uint8Array;
 };
@@ -42,34 +43,30 @@ export type SignedKeyPair = {
   signature: Buffer;
 };
 
-export const Curve = {
-  generateKeyPair(): KeyPair {
-    try {
-      const { privateKey, publicKey } = generateKeyPairSync("x25519", {
-        privateKeyEncoding: { format: "der", type: "pkcs8" },
-        publicKeyEncoding: { format: "der", type: "spki" },
-      });
-      return {
-        private: privateKey.subarray(
-          PRIVATE_KEY_DER_PREFIX.length,
-          PRIVATE_KEY_DER_PREFIX.length + 32,
-        ),
-        public: publicKey.subarray(PUBLIC_KEY_DER_PREFIX.length, PUBLIC_KEY_DER_PREFIX.length + 32),
-      };
-    } catch {
-      const keyPair = curve25519.generateKeyPair();
-      return {
-        private: Buffer.from(keyPair.private),
-        public: Buffer.from(keyPair.public),
-      };
-    }
-  },
+type NativeCurveBackend = {
+  generateKeyPair(): KeyPair;
+  sharedKey(privateKey: Uint8Array, publicKey: Uint8Array): Buffer;
+};
 
-  sharedKey(privateKey: Uint8Array, publicKey: Uint8Array): Buffer {
-    const rawPublicKey = scrubSignalPublicKey(publicKey);
-    if (typeof diffieHellman !== "function") {
-      return Buffer.from(curve25519.sharedKey(Buffer.from(privateKey), rawPublicKey));
-    }
+type CurveApi = NativeCurveBackend & {
+  sign(privateKey: Uint8Array, message: Uint8Array): Buffer;
+};
+
+const nativeCurveBackend: NativeCurveBackend = {
+  generateKeyPair() {
+    const { privateKey, publicKey } = generateKeyPairSync("x25519", {
+      privateKeyEncoding: { format: "der", type: "pkcs8" },
+      publicKeyEncoding: { format: "der", type: "spki" },
+    });
+    return {
+      private: privateKey.subarray(
+        PRIVATE_KEY_DER_PREFIX.length,
+        PRIVATE_KEY_DER_PREFIX.length + 32,
+      ),
+      public: publicKey.subarray(PUBLIC_KEY_DER_PREFIX.length, PUBLIC_KEY_DER_PREFIX.length + 32),
+    };
+  },
+  sharedKey(privateKey, publicKey) {
     const nodePrivateKey = createPrivateKey({
       format: "der",
       key: Buffer.concat([PRIVATE_KEY_DER_PREFIX, Buffer.from(privateKey)]),
@@ -77,16 +74,68 @@ export const Curve = {
     });
     const nodePublicKey = createPublicKey({
       format: "der",
-      key: Buffer.concat([PUBLIC_KEY_DER_PREFIX, rawPublicKey]),
+      key: Buffer.concat([PUBLIC_KEY_DER_PREFIX, Buffer.from(publicKey)]),
       type: "spki",
     });
     return diffieHellman({ privateKey: nodePrivateKey, publicKey: nodePublicKey });
   },
-
-  sign(privateKey: Uint8Array, message: Uint8Array): Buffer {
-    return Buffer.from(curve25519.sign(Buffer.from(privateKey), Buffer.from(message)));
-  },
 };
+
+function isUnsupportedNativeCurveError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  return (
+    code === "ERR_OSSL_EVP_UNSUPPORTED" ||
+    code === "ERR_CRYPTO_UNSUPPORTED_OPERATION" ||
+    code === "ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE"
+  );
+}
+
+export function createCurve(nativeBackend: NativeCurveBackend = nativeCurveBackend): CurveApi {
+  let nativeAvailable = true;
+  return {
+    generateKeyPair(): KeyPair {
+      if (nativeAvailable) {
+        try {
+          return nativeBackend.generateKeyPair();
+        } catch {
+          nativeAvailable = false;
+        }
+      }
+      const keyPair = curve25519.generateKeyPair(randomBytes(32));
+      return {
+        private: Buffer.from(keyPair.private),
+        public: Buffer.from(keyPair.public),
+      };
+    },
+
+    sharedKey(privateKey: Uint8Array, publicKey: Uint8Array): Buffer {
+      if (privateKey.byteLength !== 32) {
+        throw new Error(`Invalid Signal private key length: ${privateKey.byteLength}.`);
+      }
+      const rawPublicKey = scrubSignalPublicKey(publicKey);
+      if (rawPublicKey.every((byte) => byte === 0)) {
+        throw new Error("X25519 failed during derivation for an invalid peer key.");
+      }
+      if (nativeAvailable) {
+        try {
+          return nativeBackend.sharedKey(privateKey, rawPublicKey);
+        } catch (error) {
+          if (!isUnsupportedNativeCurveError(error)) {
+            throw error;
+          }
+          nativeAvailable = false;
+        }
+      }
+      return Buffer.from(curve25519.sharedKey(Buffer.from(privateKey), rawPublicKey));
+    },
+
+    sign(privateKey: Uint8Array, message: Uint8Array): Buffer {
+      return Buffer.from(curve25519.sign(Buffer.from(privateKey), Buffer.from(message)));
+    },
+  };
+}
+
+export const Curve = createCurve();
 
 export function aesEncryptGCM(
   plaintext: Uint8Array,
@@ -121,13 +170,22 @@ export function aesDecryptGCM(
 }
 
 export function encodeBigEndian(value: number, length = 4): Buffer {
-  let remaining = value;
-  const bytes = new Array<number>(length).fill(0);
-  for (let index = length - 1; index >= 0; index -= 1) {
-    bytes[index] = remaining & 0xff;
-    remaining >>>= 8;
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error("Big-endian values must be non-negative safe integers.");
   }
-  return Buffer.from(bytes);
+  if (!Number.isSafeInteger(length) || length < 1 || length > 1024) {
+    throw new Error("Big-endian lengths must be safe integers between 1 and 1024.");
+  }
+  let remaining = BigInt(value);
+  if (remaining >= 1n << BigInt(length * 8)) {
+    throw new Error(`Big-endian value ${value} does not fit in ${length} bytes.`);
+  }
+  const bytes = Buffer.alloc(length);
+  for (let index = length - 1; index >= 0; index -= 1) {
+    bytes[index] = Number(remaining & 0xffn);
+    remaining >>= 8n;
+  }
+  return bytes;
 }
 
 export function hkdf(

--- a/src/servers/whatsapp.ts
+++ b/src/servers/whatsapp.ts
@@ -18,6 +18,7 @@ import {
 import { recordServerEvent, type ServerEventObserver } from "./recorder.js";
 import {
   attachWhatsAppBaileysWebSocketServer,
+  resolveMaxPendingWhatsAppInboundMessages,
   type PreparedWhatsAppBaileysInboundDelivery,
   type WhatsAppBaileysInboundMessage,
 } from "./whatsapp-baileys-websocket.js";
@@ -501,6 +502,9 @@ export async function startWhatsAppServer(
   if (!/^\d+$/u.test(phoneNumberId)) {
     throw new Error("WhatsApp phoneNumberId must contain only digits.");
   }
+  const maxPendingInboundMessages = resolveMaxPendingWhatsAppInboundMessages(
+    params.maxPendingInboundMessages,
+  );
   const state: WhatsAppServerState = {
     accessToken:
       params.accessToken ??
@@ -552,7 +556,7 @@ export async function startWhatsAppServer(
     accessToken: state.accessToken,
     appendEvent: (event) => appendEvent(state, event),
     httpServer: httpServer.server,
-    maxPendingInboundMessages: params.maxPendingInboundMessages,
+    maxPendingInboundMessages,
     path: "/ws/chat",
     selfJid: state.selfJid,
   });

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -1111,6 +1111,15 @@ describe("OpenClaw local provider bridge", () => {
       replyChannel: "whatsapp",
       replyTo: "15551234567@s.whatsapp.net",
     });
+    expect(
+      createOpenClawCrablineAgentDelivery({
+        manifest: whatsappManifest,
+        target: "group:15551234567-1234567890@g.us",
+      }),
+    ).toMatchObject({
+      to: "15551234567-1234567890@g.us",
+      replyTo: "15551234567-1234567890@g.us",
+    });
     expect(() =>
       createOpenClawCrablineAgentDelivery({
         manifest: whatsappManifest,
@@ -1157,6 +1166,33 @@ describe("OpenClaw local provider bridge", () => {
         kind: "group",
       },
     });
+    expect(
+      createOpenClawCrablineInbound({
+        manifest: whatsappManifest,
+        input: {
+          conversation: { id: "15551234567-1234567890@g.us", kind: "group" },
+          senderId: "15551234567@s.whatsapp.net",
+          text: "legacy group",
+        },
+      }),
+    ).toMatchObject({
+      providerBody: { chatJid: "15551234567-1234567890@g.us" },
+      providerTargetKey: "15551234567-1234567890@g.us",
+      stateConversation: { id: "15551234567-1234567890@g.us", kind: "group" },
+    });
+    for (const id of [
+      "1234-1234567890@g.us",
+      "1234567890-1234@g.us",
+      "1234567890--1234567890@g.us",
+      "1234567890-1234567890-extra@g.us",
+    ]) {
+      expect(() =>
+        createOpenClawCrablineAgentDelivery({
+          manifest: whatsappManifest,
+          target: `group:${id}`,
+        }),
+      ).toThrow("WhatsApp target must be a native WhatsApp JID.");
+    }
 
     expect(
       createOpenClawCrablineOutboundFromRecorderEvent({

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import { createServer as createNetServer } from "node:net";
 import path from "node:path";
 import {
   initAuthCreds,
@@ -151,6 +152,23 @@ async function expectWebSocketUpgradeRejected(url: string): Promise<void> {
   });
 }
 
+async function resolveFreePort(): Promise<number> {
+  const server = createNetServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    server.close();
+    throw new Error("Unable to resolve free port.");
+  }
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve())),
+  );
+  return address.port;
+}
+
 afterEach(async () => {
   vi.restoreAllMocks();
   await Promise.all(servers.splice(0).map((server) => server.close()));
@@ -158,6 +176,17 @@ afterEach(async () => {
 });
 
 describe("whatsapp local provider server", () => {
+  it("validates inbound queue limits before binding the HTTP port", async () => {
+    const port = await resolveFreePort();
+    await expect(startWhatsAppServer({ maxPendingInboundMessages: 0, port })).rejects.toThrow(
+      "must be a positive safe integer",
+    );
+
+    const server = await startWhatsAppServer({ port });
+    servers.push(server);
+    expect(new URL(server.manifest.baseUrl).port).toBe(String(port));
+  });
+
   it("serves Cloud API sends and injected inbound webhook payloads", async () => {
     const directory = await createTempDir();
     directories.push(directory);
@@ -580,6 +609,23 @@ describe("whatsapp local provider server", () => {
           ),
         "Baileys connection open",
       );
+      const liveInbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({
+          chatJid: "120363001234567890@g.us",
+          pushName: "Fake Sender",
+          senderJid: "15551234567@s.whatsapp.net",
+          text: "hello after reconnect",
+        }),
+        headers: {
+          "content-type": "application/json",
+          [ADMIN_TOKEN_HEADER]: server.manifest.adminToken,
+        },
+        method: "POST",
+      });
+      await expect(liveInbound.json()).resolves.toMatchObject({
+        delivery: "delivered",
+        ok: true,
+      });
       await socket.sendMessage("15551234567@s.whatsapp.net", {
         text: "hello through real baileys",
       });
@@ -600,23 +646,25 @@ describe("whatsapp local provider server", () => {
         () =>
           messageUpserts
             .flatMap((event) => event.messages)
-            .some(
+            .filter(
               (message) =>
                 message.key?.remoteJid === "120363001234567890@g.us" &&
-                message.key.participant === "15551234567@s.whatsapp.net" &&
-                message.message?.conversation === "hello from queued admin inbound",
-            ),
-        "queued Baileys inbound messages.upsert",
+                message.key.participant === "15551234567@s.whatsapp.net",
+            ).length >= 2,
+        "queued and live Baileys inbound messages.upsert",
       );
-      const queuedMessages = messageUpserts
+      const inboundMessages = messageUpserts
         .flatMap((event) => event.messages)
         .filter(
           (message) =>
             message.key?.remoteJid === "120363001234567890@g.us" &&
-            message.message?.conversation === "hello from queued admin inbound",
+            message.key.participant === "15551234567@s.whatsapp.net",
         );
-      expect(queuedMessages).toHaveLength(1);
-      expect(queuedMessages[0]).toMatchObject({
+      expect(inboundMessages.map((message) => message.message?.conversation)).toEqual([
+        "hello from queued admin inbound",
+        "hello after reconnect",
+      ]);
+      expect(inboundMessages[0]).toMatchObject({
         key: {
           fromMe: false,
           participant: "15551234567@s.whatsapp.net",

--- a/test/whatsapp-wire.test.ts
+++ b/test/whatsapp-wire.test.ts
@@ -6,11 +6,21 @@ import {
   encodeBinaryNode,
   WHATSAPP_BINARY_NODE_MAX_DEPTH,
   WHATSAPP_BINARY_NODE_MAX_DECOMPRESSED_BYTES,
+  WHATSAPP_BINARY_NODE_MAX_NODES,
   type BinaryNode,
 } from "../src/servers/whatsapp-wire/binary-node.js";
-import { aesDecryptGCM, aesEncryptGCM, Curve } from "../src/servers/whatsapp-wire/crypto.js";
+import {
+  aesDecryptGCM,
+  aesEncryptGCM,
+  createCurve,
+  Curve,
+  encodeBigEndian,
+} from "../src/servers/whatsapp-wire/crypto.js";
 import { decodeHandshakeMessage } from "../src/servers/whatsapp-wire/handshake.js";
-import { createSerializedMessageHandler } from "../src/servers/whatsapp-baileys-websocket.js";
+import {
+  createSerializedMessageHandler,
+  WhatsAppSignalBundleStore,
+} from "../src/servers/whatsapp-baileys-websocket.js";
 
 const RFC_7748_ALICE_PRIVATE = Buffer.from(
   "77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a",
@@ -48,6 +58,43 @@ describe("WhatsApp X25519 agreement", () => {
     expect(() => BaileysCurve.sharedKey(RFC_7748_ALICE_PRIVATE, Buffer.alloc(32))).toThrow(
       "failed during derivation",
     );
+  });
+
+  it("uses the JS backend coherently after native key generation fails", () => {
+    let nativeSharedKeyCalls = 0;
+    const curve = createCurve({
+      generateKeyPair() {
+        throw new Error("native X25519 unavailable");
+      },
+      sharedKey() {
+        nativeSharedKeyCalls += 1;
+        throw new Error("native shared key should not run");
+      },
+    });
+    const alice = curve.generateKeyPair();
+    const bob = curve.generateKeyPair();
+
+    expect(curve.sharedKey(alice.private, bob.public)).toEqual(
+      curve.sharedKey(bob.private, alice.public),
+    );
+    expect(nativeSharedKeyCalls).toBe(0);
+  });
+});
+
+describe("WhatsApp integer encoding", () => {
+  it("encodes values wider than 32 bits", () => {
+    expect(encodeBigEndian(2 ** 32, 5).toString("hex")).toBe("0100000000");
+    expect(encodeBigEndian(Number.MAX_SAFE_INTEGER, 7).toString("hex")).toBe("1fffffffffffff");
+  });
+
+  it.each([
+    [-1, 4],
+    [1.5, 4],
+    [Number.POSITIVE_INFINITY, 4],
+    [256, 1],
+    [1, 0],
+  ])("rejects invalid value or length: %s, %s", (value, length) => {
+    expect(() => encodeBigEndian(value, length)).toThrow(/Big-endian/u);
   });
 });
 
@@ -194,9 +241,37 @@ describe("WhatsApp binary nodes", () => {
   it("rejects nodes beyond the nesting limit", async () => {
     const node = nestedNode(WHATSAPP_BINARY_NODE_MAX_DEPTH + 1);
 
-    await expect(decodeBinaryNode(encodeBinaryNode(node))).rejects.toThrow(
+    expect(() => encodeBinaryNode(node)).toThrow(
       `WhatsApp binary node nesting exceeds ${WHATSAPP_BINARY_NODE_MAX_DEPTH}.`,
     );
+  });
+
+  it("rejects aggregate node counts beyond the structural budget", async () => {
+    const child: BinaryNode = { attrs: {}, tag: "x" };
+    const node: BinaryNode = {
+      attrs: {},
+      content: Array<BinaryNode>(WHATSAPP_BINARY_NODE_MAX_NODES).fill(child),
+      tag: "root",
+    };
+
+    await expect(decodeBinaryNode(encodeBinaryNode(node))).rejects.toThrow(
+      `WhatsApp binary node count exceeds ${WHATSAPP_BINARY_NODE_MAX_NODES}.`,
+    );
+  });
+});
+
+describe("WhatsApp signal bundle store", () => {
+  it("validates JIDs and bounds retained key material", () => {
+    const store = new WhatsAppSignalBundleStore(1);
+    const first = store.resolveMany(["15551234567@s.whatsapp.net"]);
+    expect(first).toHaveLength(1);
+    expect(store.resolveMany(["15551234567@s.whatsapp.net"])[0]).toBe(first[0]);
+    expect(store.size).toBe(1);
+    expect(() => store.resolveMany(["not-a-jid"])).toThrow(/Invalid WhatsApp signal bundle JID/u);
+    expect(() => store.resolveMany(["15557654321@s.whatsapp.net"])).toThrow(
+      /signal bundle limit exceeded/u,
+    );
+    expect(store.size).toBe(1);
   });
 });
 


### PR DESCRIPTION
## Summary
- bound binary-node structure and signal bundle allocation
- align encoder depth and integer encoding with decoder contracts
- make X25519 fallback coherent and validate queue limits before listening
- preserve reconnect FIFO delivery and bounded legacy group JIDs

## Verification
- `pnpm lint`
- `pnpm exec vitest run test/whatsapp-wire.test.ts test/whatsapp-server.test.ts test/openclaw.test.ts` (76 tests)
- autoreview: gpt-5.6-sol/high, clean on rebased head
- Crabbox `pnpm verify`: `run_9b2b4091caf8` (50 files, 493 tests)

## Audit
Remediates confirmed findings from exact-main clawpatch run `20260712T153646-34dc24`.
