### PR TITLE
fix(providers): enforce native webhook and inbound boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Authenticate configured Discord interactions, answer native PING requests, exclude outbound mock records from inbound matching, filter WhatsApp webhooks by phone number, and validate loopback pagination limits.
 - Bound WhatsApp binary-node complexity and signal bundles, align encoder and decoder limits, preserve coherent X25519 fallback behavior, validate queue startup before listening, keep reconnect delivery FIFO, and accept bounded legacy group JIDs.
 - Preserve primary watch and adapter-start failures, retain shutdown handlers through cleanup, validate smoke-lock tokens, enforce Zalo probe envelopes, and reject ambiguous config names and formats.
 - Preserve provider-native WhatsApp message acknowledgements, legacy group JIDs, bounded inbound admission, WebSocket error isolation, and strict handshake varints.

--- a/README.md
+++ b/README.md
@@ -91,8 +91,9 @@ explicit `env` declarations, script command availability, and config shape; it
 does not require live Slack, Discord, Telegram, WhatsApp, Matrix, iMessage, or
 other platform secrets for local mocks.
 
-When configured, Slack `signingSecret`, Telegram `secretToken`, and Zalo
-`webhookSecret` enforce the provider-native webhook authentication headers.
+When configured, Discord `publicKey`, Slack `signingSecret`, Telegram
+`secretToken`, and Zalo `webhookSecret` enforce the provider-native webhook
+authentication headers.
 
 ## Built-In Mock Channels
 

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -78,6 +78,8 @@ execution.
 Optional webhook credentials enforce each provider's native authentication
 header before JSON parsing or recorder writes:
 
+- Discord `publicKey` or `DISCORD_PUBLIC_KEY` verifies
+  `X-Signature-Ed25519` over `X-Signature-Timestamp` plus the raw request body.
 - Slack `signingSecret` or `SLACK_SIGNING_SECRET` verifies
   `X-Slack-Request-Timestamp` and `X-Slack-Signature`.
 - Telegram `secretToken` or `TELEGRAM_WEBHOOK_SECRET_TOKEN` verifies

--- a/src/providers/builtin/discord.ts
+++ b/src/providers/builtin/discord.ts
@@ -1,3 +1,4 @@
+import { createPublicKey, verify, type KeyObject } from "node:crypto";
 import path from "node:path";
 import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
@@ -17,7 +18,7 @@ type DiscordEnvironment = Partial<
   Pick<NodeJS.ProcessEnv, "DISCORD_APPLICATION_ID" | "DISCORD_BOT_TOKEN" | "DISCORD_PUBLIC_KEY">
 >;
 
-export async function resolveDiscordAdapterConfig(
+function resolveDiscordAdapterConfigValue(
   config: ProviderConfig,
   userName: string,
   env: DiscordEnvironment = process.env,
@@ -37,6 +38,41 @@ export async function resolveDiscordAdapterConfig(
       : {}),
     userName,
   };
+}
+
+export async function resolveDiscordAdapterConfig(
+  config: ProviderConfig,
+  userName: string,
+  env: DiscordEnvironment = process.env,
+) {
+  return resolveDiscordAdapterConfigValue(config, userName, env);
+}
+
+function discordPublicKey(value: string): KeyObject {
+  if (!/^[0-9a-f]{64}$/iu.test(value)) {
+    throw new CrablineError("Discord publicKey must be a 32-byte hexadecimal Ed25519 key.", {
+      kind: "config",
+    });
+  }
+  return createPublicKey({
+    format: "der",
+    key: Buffer.concat([Buffer.from("302a300506032b6570032100", "hex"), Buffer.from(value, "hex")]),
+    type: "spki",
+  });
+}
+
+function authenticateDiscordWebhook(publicKey: KeyObject, request: Request, rawBody: string) {
+  const signature = request.headers.get("x-signature-ed25519");
+  const timestamp = request.headers.get("x-signature-timestamp");
+  if (
+    !signature ||
+    !timestamp ||
+    !/^[0-9a-f]{128}$/iu.test(signature) ||
+    !verify(null, Buffer.from(timestamp + rawBody), publicKey, Buffer.from(signature, "hex"))
+  ) {
+    return new Response("invalid request signature", { status: 401 });
+  }
+  return undefined;
 }
 
 function toRecorderPath(providerId: string, config: ProviderConfig): string {
@@ -89,18 +125,32 @@ function normalizeDiscordWebhookPayload(payload: unknown) {
 }
 
 export class DiscordProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
-  constructor(id: string, config: ProviderConfig, _userName: string) {
+  constructor(id: string, config: ProviderConfig, userName: string) {
+    const resolvedConfig = resolveDiscordAdapterConfigValue(config, userName);
+    const publicKey = resolvedConfig.publicKey
+      ? discordPublicKey(resolvedConfig.publicKey)
+      : undefined;
     super({
       codec: getBuiltinTargetCodec("discord"),
       config,
       id,
       options: {
+        ...(publicKey
+          ? {
+              authenticateWebhookRequest: (request: Request, rawBody: string) =>
+                authenticateDiscordWebhook(publicKey, request, rawBody),
+            }
+          : {}),
         defaultWebhook: {
           host: "127.0.0.1",
           path: "/discord/interactions",
           port: 8788,
         },
         endpointLabel: "interactions endpoint",
+        handleWebhookPayload: (payload) =>
+          isRecord(payload) && payload.type === 1
+            ? Response.json({ type: 1 }, { status: 200 })
+            : undefined,
         normalizeWebhookPayload: normalizeDiscordWebhookPayload,
         platform: "discord",
         publicUrl: config.discord?.webhook.publicUrl,

--- a/src/providers/builtin/loopback.ts
+++ b/src/providers/builtin/loopback.ts
@@ -143,6 +143,14 @@ export class LoopbackChatAdapter {
     options?: { cursor?: string; limit?: number },
   ): Promise<{ messages: LoopbackMessage[]; nextCursor?: string }> {
     const messages = [...(this.#messages.get(threadId) ?? [])];
+    if (
+      options?.limit !== undefined &&
+      (!Number.isSafeInteger(options.limit) || options.limit <= 0)
+    ) {
+      throw new CrablineError("Loopback message limit must be a positive safe integer.", {
+        kind: "config",
+      });
+    }
     const limit = options?.limit ?? messages.length;
     if (!options?.cursor) {
       const result: { messages: LoopbackMessage[]; nextCursor?: string } = {

--- a/src/providers/builtin/whatsapp.ts
+++ b/src/providers/builtin/whatsapp.ts
@@ -266,13 +266,14 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
     ) {
       return new Response("invalid webhook signature", { status: 401 });
     }
-    if (!request.headers.get("content-type")?.includes("application/json")) {
+    const mediaType = request.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase();
+    if (mediaType !== "application/json") {
       return new Response("expected application/json", { status: 415 });
     }
 
     let messages: NormalizedWhatsAppWebhookMessage[];
     try {
-      messages = normalizeWhatsAppWebhookPayload(JSON.parse(rawBody));
+      messages = normalizeWhatsAppWebhookPayload(JSON.parse(rawBody), resolvedConfig.phoneNumberId);
     } catch (error) {
       return new Response(ensureErrorMessage(error), { status: 400 });
     }
@@ -387,6 +388,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
 
 export function normalizeWhatsAppWebhookPayload(
   payload: unknown,
+  expectedPhoneNumberId?: string,
 ): NormalizedWhatsAppWebhookMessage[] {
   if (!isRecord(payload)) {
     throw new CrablineError("WhatsApp webhook payload must be an object", { kind: "inbound" });
@@ -404,6 +406,13 @@ export function normalizeWhatsAppWebhookPayload(
         }
         const value = optionalRecord(change, "value");
         if (!value || !Array.isArray(value.messages)) {
+          continue;
+        }
+        const metadata = optionalRecord(value, "metadata");
+        if (
+          expectedPhoneNumberId !== undefined &&
+          optionalString(metadata ?? {}, "phone_number_id") !== expectedPhoneNumberId
+        ) {
           continue;
         }
         for (const message of value.messages) {

--- a/src/providers/local-mock.ts
+++ b/src/providers/local-mock.ts
@@ -42,6 +42,7 @@ export type LocalMockAdapterOptions = {
     expectedThreadId: string | undefined,
     target: NormalizedTarget,
   ) => boolean;
+  handleWebhookPayload?: (payload: unknown) => Promise<Response | undefined> | Response | undefined;
   normalizeWebhookPayload?: (payload: unknown) => unknown;
   platform: ProviderPlatform;
   publicUrl?: string | undefined;
@@ -111,6 +112,15 @@ function normalizeWebhookPayload(payload: unknown): MockWebhookPayload {
 
 function mockReplyText(params: { platform: ProviderPlatform; text: string }) {
   return `[${params.platform} mock] ${params.text}`;
+}
+
+function isOutboundRecord(event: InboundEnvelope): boolean {
+  return (
+    event.raw !== null &&
+    typeof event.raw === "object" &&
+    "direction" in event.raw &&
+    event.raw.direction === "outbound"
+  );
 }
 
 export class LocalMockProviderAdapter implements ProviderAdapter {
@@ -236,6 +246,7 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
         filePath: this.#recorderPath,
         matches: (candidate) =>
           candidate.provider === this.id &&
+          !isOutboundRecord(candidate) &&
           (expectedAuthor === "any" || candidate.author === expectedAuthor) &&
           (this.#options.matchesThread ?? isAddressInChannel)(
             candidate.threadId,
@@ -263,6 +274,7 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
       filePath: this.#recorderPath,
       matches: (entry) =>
         entry.provider === this.id &&
+        !isOutboundRecord(entry) &&
         (this.#options.matchesThread ?? isAddressInChannel)(
           entry.threadId,
           target.threadId ?? target.channelId,
@@ -294,7 +306,8 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
   }
 
   async #handleWebhook(request: Request): Promise<Response> {
-    if (!request.headers.get("content-type")?.includes("application/json")) {
+    const mediaType = request.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase();
+    if (mediaType !== "application/json") {
       return new Response("expected application/json", { status: 415 });
     }
     let payload: MockWebhookPayload;
@@ -308,6 +321,10 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
         return authenticationFailure;
       }
       const rawPayload = JSON.parse(rawBody) as unknown;
+      const directResponse = await this.#options.handleWebhookPayload?.(rawPayload);
+      if (directResponse) {
+        return directResponse;
+      }
       payload = normalizeWebhookPayload(
         this.#options.normalizeWebhookPayload
           ? this.#options.normalizeWebhookPayload(rawPayload)

--- a/test/discord-provider.test.ts
+++ b/test/discord-provider.test.ts
@@ -1,3 +1,5 @@
+import { generateKeyPairSync, sign } from "node:crypto";
+import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { createServer } from "node:net";
 import { afterEach, describe, expect, it } from "vitest";
@@ -82,6 +84,65 @@ function createContext(config: ProviderConfig): ProviderContext {
 }
 
 describe("discord provider", () => {
+  it("verifies configured signatures and answers PING without recording it", async () => {
+    const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+    const config = await createDiscordConfig(0);
+    config.discord!.publicKey = publicKey
+      .export({ format: "der", type: "spki" })
+      .subarray(-32)
+      .toString("hex");
+    const provider = new DiscordProviderAdapter("discord", config, "crabline");
+    providers.push(provider);
+    const endpoint = (await provider.probe(createContext(config))).details
+      .find((detail) => detail.startsWith("interactions endpoint "))
+      ?.replace("interactions endpoint ", "");
+    expect(endpoint).toBeDefined();
+    const body = JSON.stringify({ type: 1 });
+    const timestamp = "1700000000";
+    const signature = sign(null, Buffer.from(timestamp + body), privateKey).toString("hex");
+
+    const unsigned = await fetch(endpoint!, {
+      body,
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    expect(unsigned.status).toBe(401);
+
+    const wrongMediaType = await fetch(endpoint!, {
+      body,
+      headers: {
+        "content-type": "text/application/jsonish",
+        "x-signature-ed25519": signature,
+        "x-signature-timestamp": timestamp,
+      },
+      method: "POST",
+    });
+    expect(wrongMediaType.status).toBe(415);
+
+    const pong = await fetch(endpoint!, {
+      body,
+      headers: {
+        "content-type": "Application/JSON; Charset=UTF-8",
+        "x-signature-ed25519": signature,
+        "x-signature-timestamp": timestamp,
+      },
+      method: "POST",
+    });
+    expect(pong.status).toBe(200);
+    await expect(pong.json()).resolves.toEqual({ type: 1 });
+    await expect(readFile(config.discord!.recorder.path!, "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("rejects malformed configured public keys", async () => {
+    const config = await createDiscordConfig(0);
+    config.discord!.publicKey = "not-a-public-key";
+    expect(() => new DiscordProviderAdapter("discord", config, "crabline")).toThrow(
+      /32-byte hexadecimal Ed25519 key/u,
+    );
+  });
+
   it("normalizes native channel and thread targets", async () => {
     const config = await createDiscordConfig(0);
     const provider = new DiscordProviderAdapter("discord", config, "crabline");

--- a/test/local-mock-provider.test.ts
+++ b/test/local-mock-provider.test.ts
@@ -333,6 +333,63 @@ describe("local mock provider", () => {
     });
   });
 
+  it("never returns outbound sends through inbound wait or watch", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const recorderPath = path.join(directory, "directions.jsonl");
+    const config = createConfig();
+    config.slack!.recorder.path = recorderPath;
+    const provider = new SlackProviderAdapter("provider-a", config, "crabline");
+    providers.push(provider);
+    const context = createContext(config);
+    context.fixture.mode = "roundtrip";
+    context.fixture.inboundMatch.author = "any";
+    const since = new Date(Date.now() - 1000).toISOString();
+
+    await provider.send({
+      ...context,
+      mode: "roundtrip",
+      nonce: "direction-nonce",
+      text: "hello direction-nonce",
+    });
+
+    await expect(
+      provider.waitForInbound({
+        ...context,
+        nonce: "direction-nonce",
+        since,
+        timeoutMs: 100,
+      }),
+    ).resolves.toMatchObject({
+      author: "assistant",
+      raw: { direction: "mock-reply" },
+    });
+
+    context.fixture.inboundMatch.author = "user";
+    await expect(
+      provider.waitForInbound({
+        ...context,
+        nonce: "direction-nonce",
+        since,
+        timeoutMs: 20,
+      }),
+    ).resolves.toBeNull();
+
+    const watch = provider.watch({
+      ...context,
+      since,
+    });
+    const iterator = watch[Symbol.asyncIterator]();
+    await expect(iterator.next()).resolves.toMatchObject({
+      done: false,
+      value: {
+        author: "assistant",
+        raw: { direction: "mock-reply" },
+      },
+    });
+    await iterator.return?.();
+  });
+
   it("bounds successful wait cursors while retaining recent progress", async () => {
     const directory = await createTempDir();
     directories.push(directory);

--- a/test/loopback-adapter.test.ts
+++ b/test/loopback-adapter.test.ts
@@ -65,6 +65,11 @@ describe("loopback chat adapter", () => {
     expect(previous.nextCursor).toBeUndefined();
   });
 
+  it.each([0, -1, 1.5, Number.POSITIVE_INFINITY])("rejects invalid message limits: %s", (limit) => {
+    adapter = new LoopbackChatAdapter("crabline");
+    expect(() => adapter!.fetchMessages("thread-1", { limit })).toThrow(/positive safe integer/u);
+  });
+
   it("isolates stored messages from mutable inputs and returns", async () => {
     adapter = new LoopbackChatAdapter("crabline");
     const threadId = adapter.encodeThreadId({ id: "user-1" });

--- a/test/whatsapp-provider-lifecycle.test.ts
+++ b/test/whatsapp-provider-lifecycle.test.ts
@@ -293,6 +293,7 @@ describe("WhatsApp provider lifecycle", () => {
               changes: [
                 {
                   value: {
+                    metadata: { phone_number_id: "local-mock-phone" },
                     messages: [
                       {
                         from: "15551234567",

--- a/test/whatsapp-provider.test.ts
+++ b/test/whatsapp-provider.test.ts
@@ -135,6 +135,7 @@ describe("WhatsApp webhook normalizer", () => {
             changes: [
               {
                 value: {
+                  metadata: { phone_number_id: "local-mock-phone" },
                   messages: [
                     { from: "invalid-id", text: { body: "malformed" }, type: "text" },
                     { from: "15550000000", image: { id: "image-1" }, type: "image" },
@@ -174,6 +175,7 @@ describe("WhatsApp webhook normalizer", () => {
     const signingKey = "test-token-placeholder";
     const verificationValue = "test-token-placeholder";
     config.whatsapp!.appSecret = "test-token-placeholder";
+    config.whatsapp!.phoneNumberId = "phone-a";
     config.whatsapp!.verifyToken = "test-token-placeholder";
     const provider = new WhatsAppProviderAdapter("whatsapp", config, "crabline");
     const context = createProviderContext("whatsapp", config, {
@@ -205,6 +207,7 @@ describe("WhatsApp webhook normalizer", () => {
             changes: [
               {
                 value: {
+                  metadata: { phone_number_id: "phone-a" },
                   messages: [
                     {
                       from: "15551234567",
@@ -225,6 +228,23 @@ describe("WhatsApp webhook normalizer", () => {
         method: "POST",
       });
       expect(unsigned.status).toBe(401);
+      await expect(readFile(config.whatsapp!.recorder.path!, "utf8")).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+
+      const wrongNumberBody = body.replace(
+        '"phone_number_id":"phone-a"',
+        '"phone_number_id":"phone-b"',
+      );
+      const wrongNumber = await fetch(endpoint!, {
+        body: wrongNumberBody,
+        headers: {
+          "content-type": "application/json",
+          "x-hub-signature-256": whatsappSignature(wrongNumberBody, signingKey),
+        },
+        method: "POST",
+      });
+      expect(wrongNumber.status).toBe(200);
       await expect(readFile(config.whatsapp!.recorder.path!, "utf8")).rejects.toMatchObject({
         code: "ENOENT",
       });
@@ -421,6 +441,7 @@ runLocalMockProviderContract({
         changes: [
           {
             value: {
+              metadata: { phone_number_id: "local-mock-phone" },
               statuses: [{ id: "wamid.status-only" }],
             },
           },
@@ -430,6 +451,7 @@ runLocalMockProviderContract({
         changes: [
           {
             value: {
+              metadata: { phone_number_id: "local-mock-phone" },
               messages: [
                 {
                   from: "15551234567",


### PR DESCRIPTION
## Summary
- authenticate configured Discord interactions and answer native PING requests
- exclude outbound local-mock records from inbound matching
- filter WhatsApp webhooks by phone number and validate loopback pagination limits
- document Discord public-key authentication

## Verification
- `pnpm lint`
- `pnpm exec vitest run test/whatsapp-provider-lifecycle.test.ts test/whatsapp-provider.test.ts test/discord-provider.test.ts test/local-mock-provider.test.ts test/loopback-adapter.test.ts` (50 tests)
- autoreview: gpt-5.6-sol/high, clean on rebased head
- Crabbox `pnpm verify`: `run_8a0f3b420053` (50 files, 500 tests)

## Audit
Remediates confirmed findings from exact-main clawpatch run `20260712T153646-34dc24`.
