### PR TITLE
fix(servers): preserve native delivery state and bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Preserve Zalo polling updates across disconnects and webhook changes, reject future Matrix sync tokens, normalize JSON media types, and bound Signal SSE clients and buffers.
 - Authenticate configured Discord interactions, answer native PING requests, exclude outbound mock records from inbound matching, filter WhatsApp webhooks by phone number, and validate loopback pagination limits.
 - Bound WhatsApp binary-node complexity and signal bundles, align encoder and decoder limits, preserve coherent X25519 fallback behavior, validate queue startup before listening, keep reconnect delivery FIFO, and accept bounded legacy group JIDs.
 - Preserve primary watch and adapter-start failures, retain shutdown handlers through cleanup, validate smoke-lock tokens, enforce Zalo probe envelopes, and reject ambiguous config names and formats.

--- a/src/servers/http.ts
+++ b/src/servers/http.ts
@@ -123,8 +123,8 @@ export async function parseUnknownRequestBody(
   }
   const contentType = request.headers["content-type"] ?? "";
   const includesJson = Array.isArray(contentType)
-    ? contentType.some((entry) => entry.includes("json"))
-    : contentType.includes("json");
+    ? contentType.some((entry) => entry.toLowerCase().includes("json"))
+    : contentType.toLowerCase().includes("json");
   if (includesJson) {
     try {
       return JSON.parse(body.toString("utf8")) as unknown;

--- a/src/servers/matrix.ts
+++ b/src/servers/matrix.ts
@@ -239,7 +239,7 @@ function parseSyncToken(value: string | null): number | null | undefined {
 
 async function handleSync(url: URL, state: MatrixServerState): Promise<Response> {
   const since = parseSyncToken(url.searchParams.get("since"));
-  if (since === null) {
+  if (since === null || (since !== undefined && since > state.nextSequence - 1)) {
     return matrixError("M_UNKNOWN_POS", "Unknown position", 400);
   }
   const timeout = Math.min(readInteger(url.searchParams.get("timeout")) ?? 0, 1_000);

--- a/src/servers/signal.ts
+++ b/src/servers/signal.ts
@@ -24,7 +24,9 @@ type SignalServerState = {
   account: string;
   adminToken: string;
   clients: Set<ServerResponse>;
+  drainingClients: WeakSet<ServerResponse>;
   maxPendingInboundEvents: number;
+  maxSseClients: number;
   nextTimestamp: number;
   onEvent: ServerEventObserver | undefined;
   pendingEvents: string[];
@@ -32,6 +34,9 @@ type SignalServerState = {
 };
 
 const SIGNAL_CLI_SSE_KEEPALIVE_MS = 15_000;
+const DEFAULT_MAX_SIGNAL_SSE_CLIENTS = 32;
+const MAX_SIGNAL_SSE_BUFFER_BYTES = 2 * 1024 * 1024;
+type SignalSseWriteResult = "accepted" | "backpressured" | "rejected";
 
 export type SignalServerManifest = {
   account: string;
@@ -62,6 +67,7 @@ export type StartSignalServerParams = {
   port?: number | undefined;
   recorderPath?: string | undefined;
   maxPendingInboundEvents?: number | undefined;
+  maxSseClients?: number | undefined;
 };
 
 async function appendEvent(state: SignalServerState, event: ServerRequestEvent): Promise<void> {
@@ -83,19 +89,91 @@ function rpcError(code: number, message: string, id: unknown = null, status = 40
   );
 }
 
+function evictSignalClient(state: SignalServerState, client: ServerResponse): void {
+  state.clients.delete(client);
+  state.drainingClients.delete(client);
+  client.destroy();
+}
+
+function scheduleSignalDrain(state: SignalServerState, client: ServerResponse): void {
+  if (state.drainingClients.has(client) || client.destroyed || client.writableEnded) {
+    return;
+  }
+  state.drainingClients.add(client);
+  client.once("drain", () => {
+    state.drainingClients.delete(client);
+    flushPendingSignalEvents(state, client);
+  });
+}
+
+function writeSignalSse(
+  state: SignalServerState,
+  client: ServerResponse,
+  event: string,
+): SignalSseWriteResult {
+  if (client.destroyed) {
+    state.clients.delete(client);
+    return "rejected";
+  }
+  if (client.writableEnded) {
+    evictSignalClient(state, client);
+    return "rejected";
+  }
+  const eventBytes = Buffer.byteLength(event);
+  if (eventBytes > MAX_SIGNAL_SSE_BUFFER_BYTES) {
+    return "rejected";
+  }
+  if (client.writableNeedDrain) {
+    evictSignalClient(state, client);
+    return "rejected";
+  }
+  if (client.writableLength + eventBytes > MAX_SIGNAL_SSE_BUFFER_BYTES) {
+    evictSignalClient(state, client);
+    return "rejected";
+  }
+  if (!client.write(event)) {
+    scheduleSignalDrain(state, client);
+    return "backpressured";
+  }
+  return "accepted";
+}
+
+function queueSignalEvent(state: SignalServerState, event: string): boolean {
+  if (
+    Buffer.byteLength(event) > MAX_SIGNAL_SSE_BUFFER_BYTES ||
+    state.pendingEvents.length >= state.maxPendingInboundEvents
+  ) {
+    return false;
+  }
+  state.pendingEvents.push(event);
+  return true;
+}
+
+function flushPendingSignalEvents(state: SignalServerState, client: ServerResponse): void {
+  while (state.pendingEvents.length > 0) {
+    const result = writeSignalSse(state, client, state.pendingEvents[0]!);
+    if (result === "accepted") {
+      state.pendingEvents.shift();
+      continue;
+    }
+    if (result === "backpressured") {
+      state.pendingEvents.shift();
+    }
+    break;
+  }
+}
+
 function emitSignalEvent(state: SignalServerState, payload: unknown): boolean {
   const event = `event:receive\ndata:${JSON.stringify(payload)}\n\n`;
   if (state.clients.size === 0) {
-    if (state.pendingEvents.length >= state.maxPendingInboundEvents) {
-      return false;
-    }
-    state.pendingEvents.push(event);
-    return true;
+    return queueSignalEvent(state, event);
   }
+  let delivered = false;
   for (const client of state.clients) {
-    client.write(event);
+    const result = writeSignalSse(state, client, event);
+    delivered = result === "accepted" || result === "backpressured" || delivered;
   }
-  return true;
+  return delivered || queueSignalEvent(state, event);
 }
 
 async function handleAdminInbound(params: {
@@ -162,6 +240,13 @@ async function handleRequest(params: {
 }): Promise<void> {
   const url = new URL(params.request.url ?? "/", "http://localhost");
   if (url.pathname === "/api/v1/events" && params.request.method === "GET") {
+    if (params.state.clients.size >= params.state.maxSseClients) {
+      await writeResponse(
+        params.response,
+        jsonResponse({ error: "Too many event stream clients", ok: false }, 503),
+      );
+      return;
+    }
     await appendEvent(params.state, {
       at: new Date().toISOString(),
       method: "GET",
@@ -175,11 +260,12 @@ async function handleRequest(params: {
       "content-type": "text/event-stream",
     });
     params.response.flushHeaders();
+    params.response.once("close", () => {
+      params.state.clients.delete(params.response);
+      params.state.drainingClients.delete(params.response);
+    });
     params.state.clients.add(params.response);
-    for (const event of params.state.pendingEvents.splice(0)) {
-      params.response.write(event);
-    }
-    params.response.once("close", () => params.state.clients.delete(params.response));
+    flushPendingSignalEvents(params.state, params.response);
     return;
   }
 
@@ -245,7 +331,12 @@ export async function startSignalServer(
     account: params.account ?? "+15550000000",
     adminToken: params.adminToken ?? randomBytes(24).toString("base64url"),
     clients: new Set(),
+    drainingClients: new WeakSet(),
     maxPendingInboundEvents: resolveMaxPendingInboundEvents(params.maxPendingInboundEvents),
+    maxSseClients:
+      Number.isSafeInteger(params.maxSseClients) && (params.maxSseClients ?? 0) > 0
+        ? params.maxSseClients!
+        : DEFAULT_MAX_SIGNAL_SSE_CLIENTS,
     nextTimestamp: Date.now(),
     onEvent: params.onEvent,
     pendingEvents: [],
@@ -280,7 +371,7 @@ export async function startSignalServer(
   });
   const keepalive = setInterval(() => {
     for (const client of state.clients) {
-      client.write(":\n");
+      writeSignalSse(state, client, ":\n");
     }
   }, SIGNAL_CLI_SSE_KEEPALIVE_MS);
   keepalive.unref();

--- a/src/servers/zalo.ts
+++ b/src/servers/zalo.ts
@@ -43,8 +43,11 @@ type ZaloUpdate = {
 };
 
 type PendingUpdateRequest = {
+  active: boolean;
+  onDisconnect(): void;
+  request: IncomingMessage;
   resolve(response: Response): void;
-  timeout: NodeJS.Timeout;
+  timeout: NodeJS.Timeout | undefined;
 };
 
 type WebhookAddress = {
@@ -311,7 +314,32 @@ function nextUpdate(state: ZaloServerState): Response | undefined {
   return update ? zaloOk(update) : undefined;
 }
 
-function waitForUpdate(state: ZaloServerState, timeoutSeconds: number): Promise<Response> {
+function settlePendingUpdate(
+  state: ZaloServerState,
+  pending: PendingUpdateRequest,
+  response: Response,
+): boolean {
+  if (!pending.active) {
+    return false;
+  }
+  pending.active = false;
+  const index = state.pendingRequests.indexOf(pending);
+  if (index >= 0) {
+    state.pendingRequests.splice(index, 1);
+  }
+  if (pending.timeout) {
+    clearTimeout(pending.timeout);
+  }
+  pending.request.socket.off("close", pending.onDisconnect);
+  pending.resolve(response);
+  return true;
+}
+
+function waitForUpdate(
+  request: IncomingMessage,
+  state: ZaloServerState,
+  timeoutSeconds: number,
+): Promise<Response> {
   const queued = nextUpdate(state);
   if (queued) {
     return Promise.resolve(queued);
@@ -321,30 +349,37 @@ function waitForUpdate(state: ZaloServerState, timeoutSeconds: number): Promise<
   }
   return new Promise((resolve) => {
     const pending: PendingUpdateRequest = {
+      active: true,
+      onDisconnect: () => {
+        settlePendingUpdate(state, pending, zaloError("Client closed request", 499));
+      },
+      request,
       resolve,
-      timeout: setTimeout(() => {
-        const index = state.pendingRequests.indexOf(pending);
-        if (index >= 0) {
-          state.pendingRequests.splice(index, 1);
-        }
-        resolve(zaloError("Request timeout", 408));
-      }, timeoutSeconds * 1000),
+      timeout: undefined,
     };
     state.pendingRequests.push(pending);
+    request.socket.once("close", pending.onDisconnect);
+    pending.timeout = setTimeout(() => {
+      settlePendingUpdate(state, pending, zaloError("Request timeout", 408));
+    }, timeoutSeconds * 1000);
+    pending.timeout.unref();
+    if (request.socket.destroyed) {
+      pending.onDisconnect();
+    }
   });
 }
 
 function deliverPollingUpdate(state: ZaloServerState, update: ZaloUpdate): boolean {
-  const pending = state.pendingRequests.shift();
-  if (!pending) {
-    if (state.updates.length >= state.maxPendingInboundEvents) {
-      return false;
+  while (state.pendingRequests.length > 0) {
+    const pending = state.pendingRequests[0]!;
+    if (settlePendingUpdate(state, pending, zaloOk(update))) {
+      return true;
     }
-    state.updates.push(update);
-    return true;
   }
-  clearTimeout(pending.timeout);
-  pending.resolve(zaloOk(update));
+  if (state.updates.length >= state.maxPendingInboundEvents) {
+    return false;
+  }
+  state.updates.push(update);
   return true;
 }
 
@@ -483,7 +518,7 @@ async function handleZaloMethod(
     }
     const parsedTimeout = Number(readTrimmedString(body.timeout) ?? "30");
     const timeout = Number.isFinite(parsedTimeout) ? Math.max(0, Math.min(parsedTimeout, 50)) : 30;
-    return await waitForUpdate(state, timeout);
+    return await waitForUpdate(request, state, timeout);
   }
   if (method === "sendMessage" || method === "sendPhoto") {
     const chatId = requireParam(body, "chat_id");
@@ -526,7 +561,6 @@ async function handleZaloMethod(
     if (target instanceof Response) {
       return target;
     }
-    state.updates.length = 0;
     const webhook = { secretToken, updatedAt: Date.now(), url: parsedUrl.href };
     state.webhook = webhook;
     return zaloOk({ updated_at: webhook.updatedAt, url: webhook.url });
@@ -615,8 +649,7 @@ export async function startZaloServer(
   return {
     async close() {
       for (const pending of state.pendingRequests.splice(0)) {
-        clearTimeout(pending.timeout);
-        pending.resolve(zaloError("Server shutting down", 503));
+        settlePendingUpdate(state, pending, zaloError("Server shutting down", 503));
       }
       await httpServer.close();
     },

--- a/test/http-server.test.ts
+++ b/test/http-server.test.ts
@@ -3,6 +3,7 @@ import { PassThrough } from "node:stream";
 import { describe, expect, it } from "vitest";
 import {
   drainRequestBody,
+  parseUnknownRequestBody,
   readBody,
   readInteger,
   RequestBodyTooLargeError,
@@ -50,6 +51,13 @@ describe("server HTTP body reader", () => {
     expect(readInteger(String(Number.MIN_SAFE_INTEGER))).toBe(Number.MIN_SAFE_INTEGER);
     expect(readInteger(String(Number.MAX_SAFE_INTEGER + 1))).toBeUndefined();
     expect(readInteger("-9007199254740992")).toBeUndefined();
+  });
+
+  it("recognizes JSON media types case-insensitively", async () => {
+    const request = createRequest({ "content-type": "Application/JSON; Charset=UTF-8" });
+    const parsed = parseUnknownRequestBody(request);
+    request.end('{"ok":true}');
+    await expect(parsed).resolves.toEqual({ ok: true });
   });
 
   it("does not expose unexpected exception details", async () => {

--- a/test/matrix-server.test.ts
+++ b/test/matrix-server.test.ts
@@ -220,7 +220,7 @@ describe("Matrix local provider server", () => {
     });
     servers.push(server);
 
-    for (const since of ["", "0", "s-1", "snot-a-sequence", `s${"9".repeat(32)}`]) {
+    for (const since of ["", "0", "s-1", "s1", "snot-a-sequence", `s${"9".repeat(32)}`]) {
       const response = await fetch(
         `${server.manifest.endpoints.syncUrl}?since=${encodeURIComponent(since)}`,
         {

--- a/test/signal-server.test.ts
+++ b/test/signal-server.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
-import { Agent } from "node:http";
+import { Agent, ServerResponse } from "node:http";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { startSignalServer, type StartedSignalServer } from "../src/index.js";
 import { createTempDir, disposeTempDir, requestHttp } from "./test-helpers.js";
 
@@ -180,6 +180,82 @@ describe("signal local provider server", () => {
       error: "Pending inbound queue is full (1 events)",
       ok: false,
     });
+  });
+
+  it("resumes queued event delivery after SSE backpressure drains", async () => {
+    const server = await startSignalServer({ adminToken: "admin" });
+    servers.push(server);
+    const sendInbound = (text: string) =>
+      fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({ sourceNumber: "+15557654321", text }),
+        headers: {
+          "content-type": "application/json",
+          "x-crabline-admin-token": "admin",
+        },
+        method: "POST",
+      });
+    expect((await sendInbound("first queued")).status).toBe(200);
+    expect((await sendInbound("second queued")).status).toBe(200);
+
+    const originalWrite = ServerResponse.prototype.write;
+    let backpressuredResponse: ServerResponse | undefined;
+    const write = vi.spyOn(ServerResponse.prototype, "write").mockImplementation(function (
+      this: ServerResponse,
+      ...args: Parameters<typeof originalWrite>
+    ) {
+      const accepted = Reflect.apply(originalWrite, this, args) as boolean;
+      if (
+        backpressuredResponse === undefined &&
+        typeof args[0] === "string" &&
+        args[0].startsWith("event:receive")
+      ) {
+        backpressuredResponse = this;
+        return false;
+      }
+      return accepted;
+    });
+    const controller = new AbortController();
+    try {
+      const events = await fetch(server.manifest.endpoints.eventsUrl, {
+        signal: controller.signal,
+      });
+      await vi.waitFor(() => expect(backpressuredResponse).toBeDefined());
+      backpressuredResponse!.emit("drain");
+
+      const reader = events.body!.getReader();
+      const decoder = new TextDecoder();
+      let received = "";
+      while (!received.includes("second queued")) {
+        const chunk = await reader.read();
+        if (chunk.done) {
+          break;
+        }
+        received += decoder.decode(chunk.value, { stream: true });
+      }
+      expect(received).toContain("first queued");
+      expect(received).toContain("second queued");
+    } finally {
+      controller.abort();
+      write.mockRestore();
+    }
+  });
+
+  it("bounds concurrent event stream clients", async () => {
+    const server = await startSignalServer({ maxSseClients: 1 });
+    servers.push(server);
+    const controller = new AbortController();
+    const first = await fetch(server.manifest.endpoints.eventsUrl, {
+      signal: controller.signal,
+    });
+    expect(first.status).toBe(200);
+
+    const overloaded = await fetch(server.manifest.endpoints.eventsUrl);
+    expect(overloaded.status).toBe(503);
+    await expect(overloaded.json()).resolves.toEqual({
+      error: "Too many event stream clients",
+      ok: false,
+    });
+    controller.abort();
   });
 
   it("drains unauthenticated admin request bodies", async () => {

--- a/test/zalo-server.test.ts
+++ b/test/zalo-server.test.ts
@@ -212,6 +212,95 @@ describe("Zalo local provider server", () => {
     }
   });
 
+  it("keeps queued updates when webhook delivery is enabled", async () => {
+    const webhook = createServer((_request, response) => {
+      response.statusCode = 200;
+      response.end("ok");
+    });
+    await new Promise<void>((resolve) => webhook.listen(0, "127.0.0.1", resolve));
+    const address = webhook.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Unable to resolve webhook test server address.");
+    }
+    const server = await startZaloServer({ botToken: "sample" });
+    servers.push(server);
+    try {
+      const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({ chatId: "chat-1", senderId: "user-1", text: "queued" }),
+        headers: adminHeaders(server),
+        method: "POST",
+      });
+      expect(inbound.status).toBe(200);
+
+      const configured = await fetch(`${server.manifest.baseUrl}/botsample/setWebhook`, {
+        body: JSON.stringify({
+          secret_token: "secret-token",
+          url: `http://127.0.0.1:${address.port}/zalo`,
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      expect(configured.status).toBe(200);
+      expect(
+        (
+          await fetch(`${server.manifest.baseUrl}/botsample/deleteWebhook`, {
+            method: "POST",
+          })
+        ).status,
+      ).toBe(200);
+
+      const updates = await fetch(`${server.manifest.baseUrl}/botsample/getUpdates?timeout=0`, {
+        method: "POST",
+      });
+      await expect(updates.json()).resolves.toMatchObject({
+        ok: true,
+        result: { message: { text: "queued" } },
+      });
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        webhook.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+
+  it("does not deliver updates to disconnected long polls", async () => {
+    let observePoll: (() => void) | undefined;
+    const pollObserved = new Promise<void>((resolve) => {
+      observePoll = resolve;
+    });
+    const server = await startZaloServer({
+      botToken: "sample",
+      onEvent: async (event) => {
+        if (event.path === "/bot<redacted>/getUpdates") {
+          observePoll?.();
+        }
+      },
+    });
+    servers.push(server);
+    const controller = new AbortController();
+    const pending = fetch(`${server.manifest.baseUrl}/botsample/getUpdates?timeout=30`, {
+      signal: controller.signal,
+    });
+    await pollObserved;
+    controller.abort();
+    await expect(pending).rejects.toThrow(/aborted/u);
+
+    const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({ chatId: "chat-1", senderId: "user-1", text: "after disconnect" }),
+      headers: adminHeaders(server),
+      method: "POST",
+    });
+    expect(inbound.status).toBe(200);
+
+    const updates = await fetch(`${server.manifest.baseUrl}/botsample/getUpdates?timeout=0`, {
+      method: "POST",
+    });
+    await expect(updates.json()).resolves.toMatchObject({
+      ok: true,
+      result: { message: { text: "after disconnect" } },
+    });
+  });
+
   it("enforces an absolute webhook delivery deadline while responses trickle", async () => {
     const webhook = createServer((_request, response) => {
       response.writeHead(200, { "content-type": "text/plain" });


### PR DESCRIPTION
## Summary
- preserve Zalo updates across disconnected polls and webhook changes
- reject future Matrix sync positions and normalize JSON media types
- bound Signal SSE clients and buffers with explicit slow-client eviction
- resume accepted backpressured queue delivery on `drain`

## Verification
- `pnpm lint`
- `pnpm exec vitest run test/http-server.test.ts test/matrix-server.test.ts test/signal-server.test.ts test/zalo-server.test.ts` (29 tests)
- autoreview: gpt-5.6-sol/high, clean on rebased head
- Crabbox `pnpm verify`: `run_b27b87f9734b` (50 files, 505 tests)

## Audit
Remediates confirmed findings from exact-main clawpatch run `20260712T153646-34dc24`.
