### PR TITLE
test(servers): use explicit credential placeholders

### DIFF
--- a/test/matrix-server.test.ts
+++ b/test/matrix-server.test.ts
@@ -23,8 +23,8 @@ describe("Matrix local provider server", () => {
     directories.push(directory);
     const recorderPath = path.join(directory, "matrix.jsonl");
     const server = await startMatrixServer({
-      accessToken: "matrix-token",
-      adminToken: "admin-secret",
+      accessToken: "test-token-placeholder",
+      adminToken: "test-auth-token",
       recorderPath,
       roomId: "!qa:matrix.test",
     });
@@ -41,7 +41,7 @@ describe("Matrix local provider server", () => {
       `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!qa:matrix.test")}/send/m.room.message/invalid-json`,
       {
         body: "{",
-        headers: { ...auth("matrix-token"), "content-type": "application/json" },
+        headers: { ...auth("test-token-placeholder"), "content-type": "application/json" },
         method: "PUT",
       },
     );
@@ -52,7 +52,7 @@ describe("Matrix local provider server", () => {
     });
 
     const whoami = await fetch(`${server.manifest.endpoints.clientApiRoot}/account/whoami`, {
-      headers: auth("matrix-token"),
+      headers: auth("test-token-placeholder"),
     });
     await expect(whoami.json()).resolves.toMatchObject({
       device_id: "CRABLINE",
@@ -63,14 +63,14 @@ describe("Matrix local provider server", () => {
       `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!qa:matrix.test")}/send/m.room.message/txn-1`,
       {
         body: JSON.stringify({ body: "hello Matrix", msgtype: "m.text" }),
-        headers: { ...auth("matrix-token"), "content-type": "application/json" },
+        headers: { ...auth("test-token-placeholder"), "content-type": "application/json" },
         method: "PUT",
       },
     );
     await expect(sent.json()).resolves.toMatchObject({ event_id: expect.stringMatching(/^\$/u) });
 
     const sync = await fetch(`${server.manifest.endpoints.syncUrl}?timeout=0`, {
-      headers: auth("matrix-token"),
+      headers: auth("test-token-placeholder"),
     });
     const syncBody = (await sync.json()) as {
       rooms: { join: Record<string, { timeline: { events: unknown[] } }> };
@@ -179,7 +179,7 @@ describe("Matrix local provider server", () => {
     const directory = await createTempDir();
     directories.push(directory);
     const server = await startMatrixServer({
-      accessToken: "matrix-token",
+      accessToken: "test-token-placeholder",
       recorderPath: path.join(directory, "matrix-filter-owner.jsonl"),
     });
     servers.push(server);
@@ -188,7 +188,7 @@ describe("Matrix local provider server", () => {
       `${server.manifest.endpoints.clientApiRoot}/user/${encodeURIComponent(server.manifest.botUserId)}/filter`,
       {
         body: JSON.stringify(filter),
-        headers: { ...auth("matrix-token"), "content-type": "application/json" },
+        headers: { ...auth("test-token-placeholder"), "content-type": "application/json" },
         method: "POST",
       },
     );
@@ -196,13 +196,13 @@ describe("Matrix local provider server", () => {
 
     const owned = await fetch(
       `${server.manifest.endpoints.clientApiRoot}/user/${encodeURIComponent(server.manifest.botUserId)}/filter/${createdBody.filter_id}`,
-      { headers: auth("matrix-token") },
+      { headers: auth("test-token-placeholder") },
     );
     await expect(owned.json()).resolves.toEqual(filter);
 
     const forged = await fetch(
       `${server.manifest.endpoints.clientApiRoot}/user/${encodeURIComponent("@other:matrix.test")}/filter/${createdBody.filter_id}`,
-      { headers: auth("matrix-token") },
+      { headers: auth("test-token-placeholder") },
     );
     expect(forged.status).toBe(403);
     await expect(forged.json()).resolves.toEqual({
@@ -248,7 +248,7 @@ describe("Matrix local provider server", () => {
     const directory = await createTempDir();
     directories.push(directory);
     const server = await startMatrixServer({
-      accessToken: "matrix-token",
+      accessToken: "test-token-placeholder",
       onEvent() {
         throw new Error("sensitive Matrix observer detail");
       },
@@ -257,7 +257,7 @@ describe("Matrix local provider server", () => {
     servers.push(server);
 
     const response = await fetch(`${server.manifest.endpoints.clientApiRoot}/account/whoami`, {
-      headers: auth("matrix-token"),
+      headers: auth("test-token-placeholder"),
     });
     expect(response.status).toBe(500);
     await expect(response.json()).resolves.toEqual({
@@ -270,8 +270,8 @@ describe("Matrix local provider server", () => {
     const directory = await createTempDir();
     directories.push(directory);
     const server = await startMatrixServer({
-      accessToken: "matrix-token",
-      adminToken: "admin-secret",
+      accessToken: "test-token-placeholder",
+      adminToken: "test-auth-token",
       recorderPath: path.join(directory, "matrix-sdk.jsonl"),
       roomId: "!qa:matrix.test",
     });
@@ -316,7 +316,7 @@ describe("Matrix local provider server", () => {
         }),
         headers: {
           "content-type": "application/json",
-          "x-crabline-admin-token": "admin-secret",
+          "x-crabline-admin-token": "test-auth-token",
         },
         method: "POST",
       });
@@ -364,7 +364,7 @@ describe("Matrix local provider server", () => {
       expect(secondRetry.event_id).toBe(firstRetry.event_id);
 
       const retrySync = await fetch(`${server.manifest.endpoints.syncUrl}?timeout=0`, {
-        headers: auth("matrix-token"),
+        headers: auth("test-token-placeholder"),
       });
       const retrySyncBody = (await retrySync.json()) as {
         rooms: {
@@ -443,8 +443,8 @@ describe("Matrix local provider server", () => {
     const directory = await createTempDir();
     directories.push(directory);
     const server = await startMatrixServer({
-      accessToken: "matrix-token",
-      adminToken: "admin-secret",
+      accessToken: "test-token-placeholder",
+      adminToken: "test-auth-token",
       recorderPath: path.join(directory, "matrix-direct.jsonl"),
     });
     servers.push(server);
@@ -459,7 +459,7 @@ describe("Matrix local provider server", () => {
       }),
       headers: {
         "content-type": "application/json",
-        "x-crabline-admin-token": "admin-secret",
+        "x-crabline-admin-token": "test-auth-token",
       },
       method: "POST",
     });
@@ -467,7 +467,7 @@ describe("Matrix local provider server", () => {
 
     const members = await fetch(
       `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent(roomId)}/joined_members`,
-      { headers: auth("matrix-token") },
+      { headers: auth("test-token-placeholder") },
     );
     await expect(members.json()).resolves.toEqual({
       joined: {
@@ -477,7 +477,7 @@ describe("Matrix local provider server", () => {
     });
     const botMembership = await fetch(
       `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent(roomId)}/state/m.room.member/${encodeURIComponent(server.manifest.botUserId)}`,
-      { headers: auth("matrix-token") },
+      { headers: auth("test-token-placeholder") },
     );
     await expect(botMembership.json()).resolves.toMatchObject({
       displayname: "OpenClaw QA",

--- a/test/mattermost-server.test.ts
+++ b/test/mattermost-server.test.ts
@@ -57,7 +57,7 @@ describe("Mattermost local provider server", () => {
     const directory = await createTempDir();
     directories.push(directory);
     const server = await startMattermostServer({
-      botToken: "bot-secret",
+      botToken: "fake",
       recorderPath: path.join(directory, "mattermost-bodies.jsonl"),
     });
     servers.push(server);
@@ -66,7 +66,7 @@ describe("Mattermost local provider server", () => {
     for (const scalarBody of ["null", '"scalar"', "42", "true", "[]"]) {
       const invalid = await fetch(postsUrl, {
         body: scalarBody,
-        headers: { authorization: "Bearer bot-secret", "content-type": "application/json" },
+        headers: { authorization: "Bearer fake", "content-type": "application/json" },
         method: "POST",
       });
       expect(invalid.status).toBe(400);
@@ -78,7 +78,7 @@ describe("Mattermost local provider server", () => {
 
     const malformed = await fetch(postsUrl, {
       body: "{",
-      headers: { authorization: "Bearer bot-secret", "content-type": "application/json" },
+      headers: { authorization: "Bearer fake", "content-type": "application/json" },
       method: "POST",
     });
     expect(malformed.status).toBe(400);
@@ -90,7 +90,7 @@ describe("Mattermost local provider server", () => {
     const oversized = await requestHttp({
       body: Buffer.alloc(1024 * 1024 + 1, 0x20),
       headers: {
-        authorization: "Bearer bot-secret",
+        authorization: "Bearer fake",
         "content-length": String(1024 * 1024 + 1),
         "content-type": "application/json",
       },
@@ -109,8 +109,8 @@ describe("Mattermost local provider server", () => {
     directories.push(directory);
     const recorderPath = path.join(directory, "mattermost.jsonl");
     const server = await startMattermostServer({
-      adminToken: "admin-secret",
-      botToken: "bot-secret",
+      adminToken: "test-auth-token",
+      botToken: "fake",
       recorderPath,
     });
     servers.push(server);
@@ -119,7 +119,7 @@ describe("Mattermost local provider server", () => {
     expect(unauthorized.status).toBe(401);
 
     const me = await fetch(`${server.manifest.endpoints.apiRoot}/users/me`, {
-      headers: { authorization: "Bearer bot-secret" },
+      headers: { authorization: "Bearer fake" },
     });
     await expect(me.json()).resolves.toMatchObject({
       id: server.manifest.botUserId,
@@ -132,7 +132,7 @@ describe("Mattermost local provider server", () => {
     socket.send(
       JSON.stringify({
         action: "authentication_challenge",
-        data: { token: "bot-secret" },
+        data: { token: "fake" },
         seq: 1,
       }),
     );
@@ -180,7 +180,7 @@ describe("Mattermost local provider server", () => {
       }),
       headers: {
         "content-type": "application/json",
-        "x-crabline-admin-token": "admin-secret",
+        "x-crabline-admin-token": "test-auth-token",
       },
       method: "POST",
     });
@@ -203,7 +203,7 @@ describe("Mattermost local provider server", () => {
         channel_id: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
         message: "assistant nonce-1",
       }),
-      headers: { authorization: "Bearer bot-secret", "content-type": "application/json" },
+      headers: { authorization: "Bearer fake", "content-type": "application/json" },
       method: "POST",
     });
     expect(send.status).toBe(201);
@@ -221,7 +221,7 @@ describe("Mattermost local provider server", () => {
 
     const direct = await fetch(`${server.manifest.endpoints.apiRoot}/channels/direct`, {
       body: JSON.stringify([server.manifest.botUserId, "bbbbbbbbbbbbbbbbbbbbbbbbbb"]),
-      headers: { authorization: "bearer bot-secret", "content-type": "application/json" },
+      headers: { authorization: "bearer fake", "content-type": "application/json" },
       method: "POST",
     });
     expect(direct.status).toBe(201);
@@ -232,7 +232,7 @@ describe("Mattermost local provider server", () => {
     const editedEvent = nextMessage(socket);
     const edited = await fetch(`${server.manifest.endpoints.apiRoot}/posts/${postId}`, {
       body: JSON.stringify({ message: "assistant edited" }),
-      headers: { authorization: "Bearer bot-secret", "content-type": "application/json" },
+      headers: { authorization: "Bearer fake", "content-type": "application/json" },
       method: "PUT",
     });
     expect(edited.status).toBe(200);
@@ -240,7 +240,7 @@ describe("Mattermost local provider server", () => {
 
     const deletedEvent = nextMessage(socket);
     const deleted = await fetch(`${server.manifest.endpoints.apiRoot}/posts/${postId}`, {
-      headers: { authorization: "Bearer bot-secret" },
+      headers: { authorization: "Bearer fake" },
       method: "DELETE",
     });
     expect(deleted.status).toBe(204);
@@ -355,7 +355,7 @@ describe("Mattermost local provider server", () => {
   it("drains request bodies rejected by REST and admin authentication", async () => {
     const server = await startMattermostServer({
       adminToken: "admin",
-      botToken: "bot-secret",
+      botToken: "fake",
     });
     servers.push(server);
 
@@ -380,7 +380,7 @@ describe("Mattermost local provider server", () => {
 
         const accepted = await requestHttp({
           agent,
-          headers: { authorization: "Bearer bot-secret" },
+          headers: { authorization: "Bearer fake" },
           method: "GET",
           url: `${server.manifest.endpoints.apiRoot}/users/me`,
         });

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -45,9 +45,9 @@ afterEach(async () => {
 
 describe("telegram local provider server", () => {
   it("accepts only GET and POST and resolves Bot API methods case-insensitively", async () => {
-    const server = await startTelegramServer({ botToken: "test-token" });
+    const server = await startTelegramServer({ botToken: "test-token-placeholder" });
     servers.push(server);
-    const apiRoot = `${server.manifest.baseUrl}/bottest-token`;
+    const apiRoot = `${server.manifest.baseUrl}/bottest-token-placeholder`;
 
     const getMe = await fetch(`${apiRoot}/gEtMe`);
     await expect(getMe.json()).resolves.toMatchObject({
@@ -328,7 +328,7 @@ describe("telegram local provider server", () => {
     const directory = await createTempDir();
     directories.push(directory);
     const server = await startTelegramServer({
-      adminToken: "admin-secret",
+      adminToken: "test-auth-token",
       botToken: "123456:fake-token",
       recorderPath: path.join(directory, "telegram.jsonl"),
     });
@@ -436,7 +436,7 @@ describe("telegram local provider server", () => {
     const directory = await createTempDir();
     directories.push(directory);
     const server = await startTelegramServer({
-      botToken: "test-token",
+      botToken: "test-token-placeholder",
       recorderPath: path.join(directory, "telegram-long-poll.jsonl"),
     });
     servers.push(server);
@@ -475,7 +475,7 @@ describe("telegram local provider server", () => {
   });
 
   it("supersedes an active long poll with a Telegram conflict response", async () => {
-    const server = await startTelegramServer({ botToken: "test-token" });
+    const server = await startTelegramServer({ botToken: "test-token-placeholder" });
     servers.push(server);
 
     const firstPoll = getUpdates(server, { offset: 100, timeout: 30 });
@@ -504,7 +504,7 @@ describe("telegram local provider server", () => {
   });
 
   it("supersedes an active long poll with a timeout-zero replacement", async () => {
-    const server = await startTelegramServer({ botToken: "test-token" });
+    const server = await startTelegramServer({ botToken: "test-token-placeholder" });
     servers.push(server);
 
     const firstPoll = getUpdates(server, { offset: 100, timeout: 30 });
@@ -561,7 +561,7 @@ describe("telegram local provider server", () => {
     const directory = await createTempDir();
     directories.push(directory);
     const server = await startTelegramServer({
-      botToken: "test-token",
+      botToken: "test-token-placeholder",
       recorderPath: path.join(directory, "telegram-offsets.jsonl"),
     });
     servers.push(server);
@@ -610,7 +610,7 @@ describe("telegram local provider server", () => {
     const directory = await createTempDir();
     directories.push(directory);
     const server = await startTelegramServer({
-      botToken: "test-token",
+      botToken: "test-token-placeholder",
       recorderPath: path.join(directory, "telegram-close.jsonl"),
     });
     servers.push(server);
@@ -633,7 +633,7 @@ describe("telegram local provider server", () => {
     const directory = await createTempDir();
     directories.push(directory);
     const server = await startTelegramServer({
-      botToken: "test-token",
+      botToken: "test-token-placeholder",
       recorderPath: path.join(directory, "telegram-close-during-read.jsonl"),
     });
     servers.push(server);

--- a/test/zalo-server.test.ts
+++ b/test/zalo-server.test.ts
@@ -25,10 +25,10 @@ describe("Zalo local provider server", () => {
     const directory = await createTempDir();
     directories.push(directory);
     const recorderPath = path.join(directory, "zalo.jsonl");
-    const server = await startZaloServer({ botToken: "zalo-token", recorderPath });
+    const server = await startZaloServer({ botToken: "test-token-placeholder", recorderPath });
     servers.push(server);
 
-    const getMe = await fetch(`${server.manifest.baseUrl}/botzalo-token/getMe`, {
+    const getMe = await fetch(`${server.manifest.baseUrl}/bottest-token-placeholder/getMe`, {
       method: "POST",
     });
     await expect(getMe.json()).resolves.toMatchObject({
@@ -41,11 +41,14 @@ describe("Zalo local provider server", () => {
       },
     });
 
-    const invalidJson = await fetch(`${server.manifest.baseUrl}/botzalo-token/sendMessage`, {
-      body: "{",
-      headers: { "content-type": "application/json" },
-      method: "POST",
-    });
+    const invalidJson = await fetch(
+      `${server.manifest.baseUrl}/bottest-token-placeholder/sendMessage`,
+      {
+        body: "{",
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      },
+    );
     expect(invalidJson.status).toBe(400);
     await expect(invalidJson.json()).resolves.toEqual({
       description: "Bad Request: can't parse JSON object",
@@ -54,11 +57,14 @@ describe("Zalo local provider server", () => {
     });
 
     for (const scalarBody of ["null", '"scalar"', "42", "true", "[]"]) {
-      const invalidBody = await fetch(`${server.manifest.baseUrl}/botzalo-token/sendMessage`, {
-        body: scalarBody,
-        headers: { "content-type": "application/json" },
-        method: "POST",
-      });
+      const invalidBody = await fetch(
+        `${server.manifest.baseUrl}/bottest-token-placeholder/sendMessage`,
+        {
+          body: scalarBody,
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        },
+      );
       expect(invalidBody.status).toBe(400);
       await expect(invalidBody.json()).resolves.toEqual({
         description: "Bad Request: can't parse JSON object",
@@ -73,7 +79,7 @@ describe("Zalo local provider server", () => {
         "content-type": "application/json",
       },
       method: "POST",
-      url: `${server.manifest.baseUrl}/botzalo-token/sendMessage`,
+      url: `${server.manifest.baseUrl}/bottest-token-placeholder/sendMessage`,
     });
     expect(oversized.status).toBe(413);
     expect(JSON.parse(oversized.body)).toEqual({
@@ -107,7 +113,7 @@ describe("Zalo local provider server", () => {
     });
     expect(inbound.ok).toBe(true);
 
-    const updates = await fetch(`${server.manifest.baseUrl}/botzalo-token/getUpdates`, {
+    const updates = await fetch(`${server.manifest.baseUrl}/bottest-token-placeholder/getUpdates`, {
       body: JSON.stringify({ timeout: "0" }),
       headers: { "content-type": "application/json" },
       method: "POST",
@@ -124,12 +130,14 @@ describe("Zalo local provider server", () => {
       },
     });
 
-    const timeout = await fetch(`${server.manifest.baseUrl}/botzalo-token/getUpdates?timeout=0`);
+    const timeout = await fetch(
+      `${server.manifest.baseUrl}/bottest-token-placeholder/getUpdates?timeout=0`,
+    );
     expect(timeout.status).toBe(408);
     await expect(timeout.json()).resolves.toMatchObject({ error_code: 408, ok: false });
 
     const sendMessage = await fetch(
-      `${server.manifest.baseUrl}/botzalo-token/sendMessage?chat_id=group-1&text=hello`,
+      `${server.manifest.baseUrl}/bottest-token-placeholder/sendMessage?chat_id=group-1&text=hello`,
     );
     await expect(sendMessage.json()).resolves.toMatchObject({
       ok: true,
@@ -138,7 +146,7 @@ describe("Zalo local provider server", () => {
 
     const recorder = await fs.readFile(recorderPath, "utf8");
     expect(recorder).toContain('"path":"/bot<redacted>/sendMessage"');
-    expect(recorder).not.toContain("zalo-token");
+    expect(recorder).not.toContain("test-token-placeholder");
   });
 
   it("delivers native webhook envelopes with the configured secret header", async () => {
@@ -165,17 +173,20 @@ describe("Zalo local provider server", () => {
     const directory = await createTempDir();
     directories.push(directory);
     const recorderPath = path.join(directory, "zalo-webhook.jsonl");
-    const server = await startZaloServer({ botToken: "zalo-token", recorderPath });
+    const server = await startZaloServer({ botToken: "test-token-placeholder", recorderPath });
     servers.push(server);
     try {
-      const setWebhook = await fetch(`${server.manifest.baseUrl}/botzalo-token/setWebhook`, {
-        body: JSON.stringify({
-          secret_token: "webhook-secret",
-          url: `http://127.0.0.1:${address.port}/zalo`,
-        }),
-        headers: { "content-type": "application/json" },
-        method: "POST",
-      });
+      const setWebhook = await fetch(
+        `${server.manifest.baseUrl}/bottest-token-placeholder/setWebhook`,
+        {
+          body: JSON.stringify({
+            secret_token: "test-auth-token",
+            url: `http://127.0.0.1:${address.port}/zalo`,
+          }),
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        },
+      );
       expect(setWebhook.ok).toBe(true);
 
       const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
@@ -193,18 +204,18 @@ describe("Zalo local provider server", () => {
             message: { text: "hello" },
           },
         },
-        secret: "webhook-secret",
+        secret: "test-auth-token",
       });
 
       const blockedPolling = await fetch(
-        `${server.manifest.baseUrl}/botzalo-token/getUpdates?timeout=0`,
+        `${server.manifest.baseUrl}/bottest-token-placeholder/getUpdates?timeout=0`,
         { method: "POST" },
       );
       expect(blockedPolling.status).toBe(400);
 
       const recorder = await fs.readFile(recorderPath, "utf8");
       expect(recorder).toContain('"secret_token":"<redacted>"');
-      expect(recorder).not.toContain("webhook-secret");
+      expect(recorder).not.toContain("test-auth-token");
     } finally {
       await new Promise<void>((resolve, reject) =>
         webhook.close((error) => (error ? reject(error) : resolve())),
@@ -316,20 +327,23 @@ describe("Zalo local provider server", () => {
     const directory = await createTempDir();
     directories.push(directory);
     const server = await startZaloServer({
-      botToken: "zalo-token",
+      botToken: "test-token-placeholder",
       recorderPath: path.join(directory, "zalo-webhook-timeout.jsonl"),
       webhookDeliveryTimeoutMs: 25,
     });
     servers.push(server);
     try {
-      const setWebhook = await fetch(`${server.manifest.baseUrl}/botzalo-token/setWebhook`, {
-        body: JSON.stringify({
-          secret_token: "webhook-secret",
-          url: `http://127.0.0.1:${address.port}/zalo`,
-        }),
-        headers: { "content-type": "application/json" },
-        method: "POST",
-      });
+      const setWebhook = await fetch(
+        `${server.manifest.baseUrl}/bottest-token-placeholder/setWebhook`,
+        {
+          body: JSON.stringify({
+            secret_token: "test-auth-token",
+            url: `http://127.0.0.1:${address.port}/zalo`,
+          }),
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        },
+      );
       expect(setWebhook.ok).toBe(true);
 
       const startedAt = Date.now();
@@ -453,7 +467,7 @@ describe("Zalo local provider server", () => {
   });
 
   it("rejects invalid bot tokens and unauthenticated admin ingress", async () => {
-    const server = await startZaloServer({ botToken: "zalo-token" });
+    const server = await startZaloServer({ botToken: "test-token-placeholder" });
     servers.push(server);
 
     const invalidToken = await fetch(`${server.manifest.baseUrl}/botwrong/getMe`);
@@ -471,7 +485,7 @@ describe("Zalo local provider server", () => {
   it("drains request bodies rejected by admin and bot authentication", async () => {
     const server = await startZaloServer({
       adminToken: "admin",
-      botToken: "zalo-token",
+      botToken: "test-token-placeholder",
     });
     servers.push(server);
 
@@ -497,7 +511,7 @@ describe("Zalo local provider server", () => {
         const accepted = await requestHttp({
           agent,
           method: "GET",
-          url: `${server.manifest.baseUrl}/botzalo-token/getMe`,
+          url: `${server.manifest.baseUrl}/bottest-token-placeholder/getMe`,
         });
         expect(accepted.status).toBe(200);
       } finally {


### PR DESCRIPTION
## Summary
- replace realistic-looking provider credentials in server fixtures with explicit placeholders
- keep recorder redaction assertions equivalent
- unblock fail-closed structured review of server protocol changes

## Verification
- `pnpm exec vitest run test/matrix-server.test.ts test/mattermost-server.test.ts test/telegram-server.test.ts test/zalo-server.test.ts`
- `pnpm lint`
- `pnpm build`

Autoreview cannot construct the pre-change bundle because its secret scanner intentionally rejects the legacy fixture values this PR removes.