### PR TITLE
fix(core): preserve lifecycle and publication contracts

### DIFF
--- a/.agents/skills/autoreview/scripts/test-review-harness.ps1
+++ b/.agents/skills/autoreview/scripts/test-review-harness.ps1
@@ -41,5 +41,5 @@ if ($null -ne $Python) {
     exit $LASTEXITCODE
 }
 
-Write-Error 'Python 3 is required to run test-review-harness.'
+[Console]::Error.WriteLine('Python 3 is required to run test-review-harness.')
 exit 127

--- a/.agents/skills/autoreview/scripts/test-review-harness.py
+++ b/.agents/skills/autoreview/scripts/test-review-harness.py
@@ -132,11 +132,14 @@ def write_fixture_file(repo: Path, content: str) -> None:
 
 
 def run(command: list[str], cwd: Path) -> None:
-    subprocess.run(command, cwd=cwd, check=True)
+    env = os.environ.copy()
+    env["GIT_CONFIG_GLOBAL"] = os.devnull
+    env["GIT_CONFIG_NOSYSTEM"] = "1"
+    subprocess.run(command, cwd=cwd, check=True, env=env)
 
 
 def create_fixture_repo(repo: Path, fixture: str) -> None:
-    run(["git", "init", "--quiet"], repo)
+    run(["git", "-c", "init.templateDir=", "init", "--quiet"], repo)
     run(["git", "config", "user.name", "Review Fixture"], repo)
     run(["git", "config", "user.email", "review-fixture@example.com"], repo)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
+      - name: Validate workflows
+        run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7
+
       - name: Verify
         run: pnpm verify
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -58,15 +58,15 @@ jobs:
     steps:
       - name: Checkout
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.profile == 'all' || inputs.profile == matrix.category }}
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Initialize CodeQL
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.profile == 'all' || inputs.profile == matrix.category }}
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           languages: ${{ matrix.language }}
           config-file: ${{ matrix.config_file }}
       - name: Analyze
         if: ${{ github.event_name != 'workflow_dispatch' || inputs.profile == 'all' || inputs.profile == matrix.category }}
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           category: /codeql/${{ matrix.category }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: release-${{ inputs.tag_name || github.ref_name }}
+  group: release
   cancel-in-progress: false
 
 jobs:
@@ -39,10 +39,8 @@ jobs:
           set -euo pipefail
           tag="${INPUT_TAG:-${GITHUB_REF_NAME}}"
           [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
-          if [[ "$GITHUB_EVENT_NAME" != "workflow_dispatch" ]]; then
-            [[ "$GITHUB_REF_TYPE" == "tag" ]]
-            [[ "$GITHUB_REF_NAME" == "$tag" ]]
-          fi
+          [[ "$GITHUB_REF_TYPE" == "tag" ]]
+          [[ "$GITHUB_REF_NAME" == "$tag" ]]
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -52,10 +50,13 @@ jobs:
           ref: refs/tags/${{ steps.release.outputs.tag }}
       - name: Verify checked out release tag
         env:
+          GITHUB_EVENT_SHA: ${{ github.sha }}
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
         run: |
           set -euo pipefail
-          [[ "$(git rev-parse "refs/tags/${RELEASE_TAG}^{commit}")" == "$(git rev-parse HEAD)" ]]
+          release_commit="$(git rev-parse "refs/tags/${RELEASE_TAG}^{commit}")"
+          [[ "$release_commit" == "$(git rev-parse HEAD)" ]]
+          [[ "$release_commit" == "$GITHUB_EVENT_SHA" ]]
       - name: Verify release metadata
         env:
           RELEASE_VERSION: ${{ steps.release.outputs.version }}
@@ -86,7 +87,7 @@ jobs:
           version: 10.32.1
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 24
+          node-version: 22
           cache: pnpm
           registry-url: https://registry.npmjs.org
       - run: npm install -g npm@12.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Harden release, CI, config, CLI, package, and OpenClaw artifact and process-identity boundaries.
 - Preserve Zalo polling updates across disconnects and webhook changes, reject future Matrix sync tokens, normalize JSON media types, and bound Signal SSE clients and buffers.
 - Authenticate configured Discord interactions, answer native PING requests, exclude outbound mock records from inbound matching, filter WhatsApp webhooks by phone number, and validate loopback pagination limits.
 - Bound WhatsApp binary-node complexity and signal bundles, align encoder and decoder limits, preserve coherent X25519 fallback behavior, validate queue startup before listening, keep reconnect delivery FIFO, and accept bounded legacy group JIDs.

--- a/README.md
+++ b/README.md
@@ -86,10 +86,11 @@ Provider ids are local profile names. Fixtures reference them through
 `provider`. Built-in adapters infer their platform from `adapter`; `platform` is
 required only for `adapter: script`.
 
-Built-in provider credentials are optional metadata only. `doctor` checks
-explicit `env` declarations, script command availability, and config shape; it
-does not require live Slack, Discord, Telegram, WhatsApp, Matrix, iMessage, or
-other platform secrets for local mocks.
+Most built-in provider credentials are optional mock metadata. The WhatsApp
+webhook requires `appSecret` and `verifyToken` because every verification or
+delivery request is authenticated. `doctor` checks explicit `env` declarations,
+script command availability, and config shape without requiring live platform
+credentials.
 
 When configured, Discord `publicKey`, Slack `signingSecret`, Telegram
 `secretToken`, and Zalo `webhookSecret` enforce the provider-native webhook
@@ -120,8 +121,9 @@ The built-in providers are:
 - `whatsapp`
 - `zalo`
 
-The `script` adapter can bridge any other OpenClaw channel by running local
-commands for `probe`, `send`, `waitForInbound`, or `watch`.
+The `script` adapter can bridge any OpenClaw channel represented by the
+configured `platform` enum by running local commands for `probe`, `send`,
+`waitForInbound`, or `watch`.
 
 ## Local Provider Servers
 

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -118,6 +118,28 @@ providers:
 The complete multi-channel script fixture is available in
 `fixtures/examples/openclaw-bridge.yaml`.
 
+Each command receives one JSON document on stdin. Every payload contains the
+parsed `fixture` plus `provider.config`, `provider.id`, and
+`provider.manifestPath`. `send` adds `outbound` with `mode`, `nonce`, normalized
+`target`, and `text`; `waitForInbound` adds `wait` with `nonce`, `since`,
+normalized `target`, and `timeoutMs`; `watch` adds `watch` with optional `since`
+and normalized `target`.
+
+Non-watch commands must write exactly one JSON value to stdout:
+
+- `probe`: `{ "healthy": boolean, "details"?: string[] }`
+- `send`: `{ "accepted": boolean, "messageId": string, "threadId": string }`
+- `waitForInbound`: either `{ "timeout": true }` or
+  `{ "message": { "author": "assistant" | "system" | "user", "id": string,
+"sentAt": string, "text": string, "threadId": string, "raw"?: unknown } }`
+
+`watch` writes one message object per JSONL line using the same message schema.
+Blank lines are ignored. Non-watch stdout plus stderr is limited to 1 MiB.
+Watch stderr, each JSONL line, and any unterminated buffered line are each
+limited to 1 MiB. Commands inherit the process environment, use the configured
+`cwd` and `shell`. Non-watch commands are terminated at their operation timeout;
+watch commands are terminated when cancellation fires.
+
 ## Local Provider Servers
 
 Server-backed channels currently include Mattermost, Matrix, Signal, Slack,

--- a/fixtures/examples/crabline.example.yaml
+++ b/fixtures/examples/crabline.example.yaml
@@ -42,6 +42,8 @@ providers:
   whatsapp:
     adapter: whatsapp
     whatsapp:
+      appSecret: placeholder
+      verifyToken: placeholder
       recorder:
         path: ./.crabline/recorders/whatsapp.jsonl
       webhook:

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -592,9 +592,27 @@ export async function publishReadyFile(
   filePath: string,
   contents: string,
 ): Promise<ReadyFileIdentity> {
-  return await withReadyFileLock(filePath, async () =>
-    publishReadyFileUnlocked(filePath, contents),
-  );
+  let publishedIdentity: ReadyFileIdentity | undefined;
+  try {
+    return await withReadyFileLock(filePath, async () => {
+      publishedIdentity = await publishReadyFileUnlocked(filePath, contents);
+      return publishedIdentity;
+    });
+  } catch (error) {
+    if (publishedIdentity) {
+      try {
+        await removeReadyFileIfOwned(filePath, contents, publishedIdentity);
+      } catch (cleanupError) {
+        const aggregateError = new AggregateError(
+          [error, cleanupError],
+          `Ready-file publication and compensation both failed for "${filePath}".`,
+        );
+        aggregateError.cause = error;
+        throw aggregateError;
+      }
+    }
+    throw error;
+  }
 }
 
 async function publishReadyFileUnlocked(

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -273,16 +273,29 @@ export function createProgram(
           });
         }
 
-        let watchError: unknown;
-        let watchFailed = false;
+        const controller = new AbortController();
+        const watch = provider.watch({
+          config: manifest.providers[fixture.provider]!,
+          fixture,
+          manifestPath: path,
+          providerId: fixture.provider,
+          signal: controller.signal,
+          userName: manifest.userName,
+        });
+        const iterator = watch[Symbol.asyncIterator]();
+        const stopWatch = onceAsync(async () => {
+          controller.abort();
+          await iterator.return?.();
+        });
+        const shutdown = installShutdownHandler(stopWatch);
+        const lifecycleErrors: unknown[] = [];
         try {
-          for await (const message of provider.watch({
-            config: manifest.providers[fixture.provider]!,
-            fixture,
-            manifestPath: path,
-            providerId: fixture.provider,
-            userName: manifest.userName,
-          })) {
+          while (true) {
+            const result = await iterator.next();
+            if (result.done) {
+              break;
+            }
+            const message = result.value;
             print(
               options.json
                 ? formatJson(message)
@@ -290,19 +303,26 @@ export function createProgram(
             );
           }
         } catch (error) {
-          watchFailed = true;
-          watchError = error;
+          lifecycleErrors.push(error);
+        }
+        try {
+          await stopWatch();
+        } catch (error) {
+          if (!lifecycleErrors.includes(error)) {
+            lifecycleErrors.push(error);
+          }
         }
         try {
           await provider.cleanup?.();
-        } catch (cleanupError) {
-          throw combineLifecycleErrors(
-            watchFailed ? [watchError, cleanupError] : [cleanupError],
-            "Crabline watch lifecycle failed.",
-          );
+        } catch (error) {
+          if (!lifecycleErrors.includes(error)) {
+            lifecycleErrors.push(error);
+          }
+        } finally {
+          shutdown.dispose();
         }
-        if (watchFailed) {
-          throw watchError;
+        if (lifecycleErrors.length > 0) {
+          throw combineLifecycleErrors(lifecycleErrors, "Crabline watch lifecycle failed.");
         }
       });
     });
@@ -516,6 +536,15 @@ function sameReadyFileIdentity(left: ReadyFileIdentity, right: ReadyFileIdentity
   );
 }
 
+function sameReadyFileObject(left: ReadyFileIdentity, right: ReadyFileIdentity): boolean {
+  return (
+    left.birthtimeNs === right.birthtimeNs &&
+    left.dev === right.dev &&
+    left.ino === right.ino &&
+    left.size === right.size
+  );
+}
+
 async function withReadyFileLock<T>(filePath: string, action: () => Promise<T>): Promise<T> {
   const release = await acquireReadyFileLease(filePath);
   let actionFailed = false;
@@ -563,27 +592,9 @@ export async function publishReadyFile(
   filePath: string,
   contents: string,
 ): Promise<ReadyFileIdentity> {
-  let publishedIdentity: ReadyFileIdentity | undefined;
-  try {
-    return await withReadyFileLock(filePath, async () => {
-      publishedIdentity = await publishReadyFileUnlocked(filePath, contents);
-      return publishedIdentity;
-    });
-  } catch (error) {
-    if (publishedIdentity) {
-      try {
-        await removeReadyFileIfOwned(filePath, contents, publishedIdentity);
-      } catch (cleanupError) {
-        const aggregateError = new AggregateError(
-          [error, cleanupError],
-          `Ready-file publication and compensation both failed for "${filePath}".`,
-        );
-        aggregateError.cause = error;
-        throw aggregateError;
-      }
-    }
-    throw error;
-  }
+  return await withReadyFileLock(filePath, async () =>
+    publishReadyFileUnlocked(filePath, contents),
+  );
 }
 
 async function publishReadyFileUnlocked(
@@ -641,19 +652,6 @@ async function publishReadyFileUnlocked(
 
 async function backupReadyFile(filePath: string, backupPath: string): Promise<boolean> {
   try {
-    await fs.link(filePath, backupPath);
-    return true;
-  } catch (error) {
-    const code = (error as NodeJS.ErrnoException).code;
-    if (code === "ENOENT") {
-      return false;
-    }
-    if (code === "EEXIST") {
-      throw error;
-    }
-  }
-
-  try {
     await fs.copyFile(filePath, backupPath, fsConstants.COPYFILE_EXCL);
     return true;
   } catch (error) {
@@ -669,6 +667,10 @@ async function removeReadyFileIfOwned(
   expectedContents: string,
   expectedIdentity: ReadyFileIdentity,
 ): Promise<void> {
+  const tombstonePath = nodePath.join(
+    nodePath.dirname(filePath),
+    `.${nodePath.basename(filePath)}.${process.pid}.${randomUUID()}.remove`,
+  );
   try {
     if (
       (await fs.readFile(filePath, "utf8")) !== expectedContents ||
@@ -676,7 +678,23 @@ async function removeReadyFileIfOwned(
     ) {
       return;
     }
-    await fs.rm(filePath);
+    await fs.rename(filePath, tombstonePath);
+    if (
+      (await fs.readFile(tombstonePath, "utf8")) === expectedContents &&
+      sameReadyFileObject(await readReadyFileIdentity(tombstonePath), expectedIdentity)
+    ) {
+      await fs.rm(tombstonePath);
+      return;
+    }
+    try {
+      await fs.link(tombstonePath, filePath);
+      await fs.rm(tombstonePath);
+    } catch (restoreError) {
+      throw new Error(
+        `Ready-file path changed while removing "${filePath}"; the moved file remains at "${tombstonePath}".`,
+        { cause: restoreError },
+      );
+    }
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
       throw error;

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -50,6 +50,18 @@ export const PROVIDER_PLATFORMS = [
 type BuiltinAdapterName = (typeof BUILTIN_ADAPTERS)[number];
 type ProviderPlatformName = (typeof PROVIDER_PLATFORMS)[number];
 
+const HttpUrlSchema = z
+  .string()
+  .url()
+  .refine((value) => {
+    try {
+      const protocol = new URL(value).protocol;
+      return protocol === "http:" || protocol === "https:";
+    } catch {
+      return false;
+    }
+  }, "URL must use http or https");
+
 function inferProviderPlatform(adapter: BuiltinAdapterName): ProviderPlatformName | undefined {
   if (adapter === "script") {
     return undefined;
@@ -74,6 +86,13 @@ const InboundMatchSchema = z
     strategy: z.enum(INBOUND_STRATEGIES).default("contains"),
   })
   .superRefine((value, ctx) => {
+    if (value.strategy === "exact" && value.pattern && value.nonce !== "ignore") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "inboundMatch.strategy=exact requires inboundMatch.nonce=ignore",
+        path: ["nonce"],
+      });
+    }
     if (value.strategy !== "regex" || !value.pattern) {
       return;
     }
@@ -122,7 +141,7 @@ const SlackWebhookSchema = z.strictObject({
   host: z.string().min(1).default("127.0.0.1"),
   path: z.string().min(1).default("/slack/events"),
   port: z.number().int().min(0).max(65_535).default(8787),
-  publicUrl: z.string().url().optional(),
+  publicUrl: HttpUrlSchema.optional(),
 });
 
 const SlackConfigSchema = z.strictObject({
@@ -143,7 +162,7 @@ const DiscordWebhookSchema = z.strictObject({
   host: z.string().min(1).default("127.0.0.1"),
   path: z.string().min(1).default("/discord/interactions"),
   port: z.number().int().min(0).max(65_535).default(8788),
-  publicUrl: z.string().url().optional(),
+  publicUrl: HttpUrlSchema.optional(),
 });
 
 const DiscordConfigSchema = z.strictObject({
@@ -168,12 +187,12 @@ const WhatsAppWebhookSchema = z.strictObject({
   host: z.string().min(1).default("127.0.0.1"),
   path: z.string().min(1).default("/whatsapp/webhook"),
   port: z.number().int().min(0).max(65_535).default(8789),
-  publicUrl: z.string().url().optional(),
+  publicUrl: HttpUrlSchema.optional(),
 });
 
 const WhatsAppConfigSchema = z.strictObject({
   accessToken: z.string().min(1).optional(),
-  apiUrl: z.string().url().optional(),
+  apiUrl: HttpUrlSchema.optional(),
   apiVersion: z.string().min(1).optional(),
   appSecret: z.string().min(1).optional(),
   phoneNumberId: z.string().min(1).optional(),
@@ -200,11 +219,11 @@ const MsTeamsWebhookSchema = z.strictObject({
   host: z.string().min(1).default("127.0.0.1"),
   path: z.string().min(1).default("/msteams/webhook"),
   port: z.number().int().min(0).max(65_535).default(8791),
-  publicUrl: z.string().url().optional(),
+  publicUrl: HttpUrlSchema.optional(),
 });
 
 const MsTeamsConfigSchema = z.strictObject({
-  apiUrl: z.string().url().optional(),
+  apiUrl: HttpUrlSchema.optional(),
   appId: z.string().min(1).optional(),
   appPassword: z.string().min(1).optional(),
   appTenantId: z.string().min(1).optional(),
@@ -236,14 +255,14 @@ const GoogleChatWebhookSchema = z.strictObject({
   host: z.string().min(1).default("127.0.0.1"),
   path: z.string().min(1).default("/googlechat/webhook"),
   port: z.number().int().min(0).max(65_535).default(8792),
-  publicUrl: z.string().url().optional(),
+  publicUrl: HttpUrlSchema.optional(),
 });
 
 const GoogleChatConfigSchema = z.strictObject({
-  apiUrl: z.string().url().optional(),
+  apiUrl: HttpUrlSchema.optional(),
   credentials: GoogleChatCredentialsSchema.optional(),
   disableSignatureVerification: z.boolean().optional(),
-  endpointUrl: z.string().url().optional(),
+  endpointUrl: HttpUrlSchema.optional(),
   googleChatProjectNumber: z.string().min(1).optional(),
   impersonateUser: z.string().min(1).optional(),
   pubsubAudience: z.string().min(1).optional(),
@@ -275,11 +294,11 @@ const TelegramWebhookSchema = z.strictObject({
   host: z.string().min(1).default("127.0.0.1"),
   path: z.string().min(1).default("/telegram/webhook"),
   port: z.number().int().min(0).max(65_535).default(8790),
-  publicUrl: z.string().url().optional(),
+  publicUrl: HttpUrlSchema.optional(),
 });
 
 const TelegramConfigSchema = z.strictObject({
-  apiUrl: z.string().url().optional(),
+  apiUrl: HttpUrlSchema.optional(),
   botToken: z.string().min(1).optional(),
   longPolling: TelegramLongPollingSchema.optional(),
   mode: z.enum(["auto", "polling", "webhook"]).default("auto"),
@@ -303,7 +322,7 @@ const FeishuConfigSchema = z.strictObject({
       host: z.string().min(1).default("127.0.0.1"),
       path: z.string().min(1).default("/feishu/webhook"),
       port: z.number().int().min(0).max(65_535).default(8795),
-      publicUrl: z.string().url().optional(),
+      publicUrl: HttpUrlSchema.optional(),
     })
     .default({
       host: "127.0.0.1",
@@ -320,7 +339,7 @@ const MattermostWebhookSchema = z.strictObject({
   host: z.string().min(1).default("127.0.0.1"),
   path: z.string().min(1).default("/mattermost/webhook"),
   port: z.number().int().min(0).max(65_535).default(8793),
-  publicUrl: z.string().url().optional(),
+  publicUrl: HttpUrlSchema.optional(),
 });
 
 const MattermostWebsocketSchema = z.strictObject({
@@ -330,9 +349,9 @@ const MattermostWebsocketSchema = z.strictObject({
 });
 
 const MattermostConfigSchema = z.strictObject({
-  baseUrl: z.string().url().optional(),
+  baseUrl: HttpUrlSchema.optional(),
   botToken: z.string().min(1).optional(),
-  callbackUrl: z.string().url().optional(),
+  callbackUrl: HttpUrlSchema.optional(),
   recorder: MattermostRecorderSchema.default({}),
   userName: z.string().min(1).optional(),
   webhook: MattermostWebhookSchema.default({
@@ -351,7 +370,7 @@ const ZaloWebhookSchema = z.strictObject({
   host: z.string().min(1).default("127.0.0.1"),
   path: z.string().min(1).default("/zalo/webhook"),
   port: z.number().int().min(0).max(65_535).default(8794),
-  publicUrl: z.string().url().optional(),
+  publicUrl: HttpUrlSchema.optional(),
 });
 
 const ZaloConfigSchema = z.strictObject({
@@ -381,7 +400,7 @@ const MatrixPasswordAuthSchema = z.strictObject({
 
 const MatrixConfigSchema = z.strictObject({
   auth: z.union([MatrixAccessTokenAuthSchema, MatrixPasswordAuthSchema]).optional(),
-  baseURL: z.string().url().optional(),
+  baseURL: HttpUrlSchema.optional(),
   commandPrefix: z.string().min(1).optional(),
   recorder: z.strictObject({ path: z.string().min(1).optional() }).default({}),
   recoveryKey: z.string().min(1).optional(),
@@ -391,7 +410,7 @@ const MatrixConfigSchema = z.strictObject({
       host: z.string().min(1).default("127.0.0.1"),
       path: z.string().min(1).default("/matrix/webhook"),
       port: z.number().int().min(0).max(65_535).default(8797),
-      publicUrl: z.string().url().optional(),
+      publicUrl: HttpUrlSchema.optional(),
     })
     .default({
       host: "127.0.0.1",
@@ -405,13 +424,13 @@ const IMessageConfigSchema = z.strictObject({
   gatewayDurationMs: z.number().int().min(1000).default(180_000),
   local: z.boolean().optional(),
   recorder: z.strictObject({ path: z.string().min(1).optional() }).default({}),
-  serverUrl: z.string().url().optional(),
+  serverUrl: HttpUrlSchema.optional(),
   webhook: z
     .strictObject({
       host: z.string().min(1).default("127.0.0.1"),
       path: z.string().min(1).default("/imessage/webhook"),
       port: z.number().int().min(0).max(65_535).default(8796),
-      publicUrl: z.string().url().optional(),
+      publicUrl: HttpUrlSchema.optional(),
     })
     .default({
       host: "127.0.0.1",

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -276,10 +276,27 @@ export async function runFixtureCommand(params: {
       providerId: fixture.provider,
     });
   } finally {
+    let cleanupError: unknown;
     try {
-      await provider.cleanup?.();
+      const cleanup = provider.cleanup?.();
+      if (cleanup) {
+        if (
+          abortDrainFailed &&
+          (await raceInboundDeadline(cleanup, INBOUND_ABORT_GRACE_MS)) === INBOUND_DEADLINE_REACHED
+        ) {
+          cleanupError = new Error(
+            `Provider cleanup did not settle within ${INBOUND_ABORT_GRACE_MS}ms after an aborted inbound wait.`,
+          );
+        }
+        if (!abortDrainFailed) {
+          await cleanup;
+        }
+      }
     } catch (error) {
-      const diagnostic = `cleanup failed: ${ensureErrorMessage(error)}`;
+      cleanupError = error;
+    }
+    if (cleanupError !== undefined) {
+      const diagnostic = `cleanup failed: ${ensureErrorMessage(cleanupError)}`;
       if (result) {
         result.diagnostics.push(diagnostic);
         if (result.ok) {

--- a/src/openclaw/artifact-generation.ts
+++ b/src/openclaw/artifact-generation.ts
@@ -2,7 +2,12 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { CrablineServerManifest } from "../servers/index.js";
-import { publishPrivateFileAtomically, securePrivateDirectory } from "./private-file.js";
+import {
+  publishPrivateFileAtomically,
+  removeSecuredPrivateDirectory,
+  securePrivateDirectory,
+  syncParentDirectory,
+} from "./private-file.js";
 import {
   OPENCLAW_CRABLINE_ARTIFACT_POINTER_PATH,
   OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY,
@@ -37,6 +42,7 @@ type PublishGenerationDependencies = {
   publishPrivateFile?: typeof publishPrivateFileAtomically;
   secureWindowsDirectory?: (directoryPath: string) => Promise<void>;
   secureWindowsFile?: (filePath: string) => Promise<void>;
+  syncParent?: typeof syncParentDirectory;
 };
 
 function assertCanonicalSelectionPaths(selection: OpenClawCrablineChannelDriverSelection): void {
@@ -149,6 +155,7 @@ async function pruneArtifactStore(params: {
   lock: OpenClawCrablineSmokeRunLock;
   pointer: OpenClawCrablineArtifactPointer | null;
   store: Awaited<ReturnType<typeof securePrivateDirectory>>;
+  directoryOptions?: Parameters<typeof securePrivateDirectory>[1];
 }): Promise<void> {
   const retainedGenerations = new Set(
     params.pointer
@@ -168,10 +175,11 @@ async function pruneArtifactStore(params: {
     }
     await params.lock.assertOwned();
     await params.store.assertIdentityAt();
-    await fs.rm(path.join(params.store.directoryPath, entry.name), {
-      force: true,
-      recursive: true,
-    });
+    const obsolete = await securePrivateDirectory(
+      path.join(params.store.directoryPath, entry.name),
+      params.directoryOptions,
+    );
+    await removeSecuredPrivateDirectory(obsolete);
     await params.store.assertIdentityAt();
   }
 }
@@ -204,6 +212,7 @@ export async function publishOpenClawCrablineArtifactGeneration(
     await assertCurrentGenerationExists(outputDir, currentPointer);
   }
   await pruneArtifactStore({
+    directoryOptions,
     lock: params.lock,
     pointer: currentPointer,
     store,
@@ -223,9 +232,12 @@ export async function publishOpenClawCrablineArtifactGeneration(
     ...(dependencies.secureWindowsFile
       ? { secureWindowsFile: dependencies.secureWindowsFile }
       : {}),
+    ...(dependencies.syncParent ? { syncParent: dependencies.syncParent } : {}),
   };
   let installed = false;
   let committed = false;
+  let primaryError: unknown;
+  let published: PublishedOpenClawCrablineArtifactGeneration | undefined;
   try {
     const pointer: OpenClawCrablineArtifactPointer = {
       capabilityMatrixPath: generationArtifactPath(
@@ -291,6 +303,7 @@ export async function publishOpenClawCrablineArtifactGeneration(
     }
     await params.lock.assertOwned();
     await fs.rename(stagingPath, generationPath);
+    await (dependencies.syncParent ?? syncParentDirectory)(generationPath, dependencies.platform);
     installed = true;
     await staging.assertIdentityAt(generationPath);
     await store.assertIdentityAt();
@@ -314,6 +327,7 @@ export async function publishOpenClawCrablineArtifactGeneration(
         throw new Error("OpenClaw Crabline artifact pointer is missing after publication.");
       }
       await pruneArtifactStore({
+        directoryOptions,
         lock: params.lock,
         pointer: committedPointer,
         store,
@@ -323,32 +337,53 @@ export async function publishOpenClawCrablineArtifactGeneration(
       warnings = [`OpenClaw Crabline artifact retention cleanup failed: ${detail}`];
     }
 
-    return {
+    published = {
       ...pointer,
       pointerPath: OPENCLAW_CRABLINE_ARTIFACT_POINTER_PATH,
       smoke,
       ...(warnings ? { warnings } : {}),
     };
-  } finally {
-    if (!committed) {
-      const unpublishedPath = installed ? generationPath : stagingPath;
-      let referencedByPointer = false;
-      if (installed) {
-        try {
-          const livePointer = await readOpenClawCrablineArtifactPointer(outputDir);
-          referencedByPointer =
-            livePointer?.generation === generation ||
-            livePointer?.previousGeneration === generation;
-        } catch {
-          referencedByPointer = true;
-        }
+  } catch (error) {
+    primaryError = error;
+  }
+
+  if (!committed) {
+    const unpublishedPath = installed ? generationPath : stagingPath;
+    let referencedByPointer = false;
+    if (installed) {
+      try {
+        const livePointer = await readOpenClawCrablineArtifactPointer(outputDir);
+        referencedByPointer =
+          livePointer?.generation === generation || livePointer?.previousGeneration === generation;
+      } catch {
+        referencedByPointer = true;
       }
-      if (!referencedByPointer) {
-        await staging
-          .assertIdentityAt(unpublishedPath)
-          .then(() => fs.rm(unpublishedPath, { force: true, recursive: true }))
-          .catch(() => undefined);
+    }
+    if (!referencedByPointer) {
+      try {
+        await removeSecuredPrivateDirectory(staging, unpublishedPath);
+      } catch (cleanupError) {
+        if (primaryError !== undefined) {
+          const primaryMessage =
+            primaryError instanceof Error ? primaryError.message : String(primaryError);
+          const aggregateError = new AggregateError(
+            [primaryError, cleanupError],
+            `${primaryMessage} OpenClaw Crabline artifact rollback cleanup also failed.`,
+          );
+          aggregateError.cause = primaryError;
+          const primaryCode = (primaryError as NodeJS.ErrnoException).code;
+          if (primaryCode) {
+            Object.assign(aggregateError, { code: primaryCode });
+          }
+          throw aggregateError;
+        }
+        throw cleanupError;
       }
     }
   }
+
+  if (primaryError !== undefined) {
+    throw primaryError;
+  }
+  return published!;
 }

--- a/src/openclaw/private-file.ts
+++ b/src/openclaw/private-file.ts
@@ -148,7 +148,7 @@ const runWindowsAclCommand: WindowsAclRunner = async (command, args, options) =>
   await execFileAsync(command, args, options);
 };
 
-function resolveWindowsPowerShellPath(systemRoot: string | null | undefined): string {
+export function resolveWindowsPowerShellPath(systemRoot: string | null | undefined): string {
   const normalizedRoot = systemRoot?.trim() ? path.win32.normalize(systemRoot.trim()) : undefined;
   if (!normalizedRoot || !/^[A-Za-z]:\\/.test(normalizedRoot)) {
     throw new Error("SystemRoot must be an absolute local Windows path.");
@@ -252,8 +252,8 @@ type DirectoryIdentity = {
   inode: bigint;
 };
 
-async function readDirectoryIdentity(directoryPath: string): Promise<DirectoryIdentity> {
-  const stats = await fs.lstat(directoryPath, { bigint: true });
+async function readDirectoryHandleIdentity(handle: FileHandle): Promise<DirectoryIdentity> {
+  const stats = await handle.stat({ bigint: true });
   if (!stats.isDirectory() || stats.ino <= 0n) {
     throw new Error("The filesystem did not provide a stable private directory identity.");
   }
@@ -285,6 +285,37 @@ export type SecuredPrivateDirectory = {
   directoryPath: string;
 };
 
+export async function syncParentDirectory(
+  filePath: string,
+  platform: NodeJS.Platform = process.platform,
+): Promise<void> {
+  if (platform === "win32") {
+    return;
+  }
+  const handle = await fs.open(path.dirname(filePath), "r");
+  try {
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+export async function removeSecuredPrivateDirectory(
+  secured: SecuredPrivateDirectory,
+  currentPath = secured.directoryPath,
+): Promise<void> {
+  const quarantinePath = path.join(
+    path.dirname(currentPath),
+    `.${path.basename(currentPath)}.${process.pid}.${randomUUID()}.remove`,
+  );
+  await secured.assertIdentityAt(currentPath);
+  await fs.rename(currentPath, quarantinePath);
+  await secured.assertIdentityAt(quarantinePath);
+  await syncParentDirectory(quarantinePath);
+  await fs.rm(quarantinePath, { force: true, recursive: true });
+  await syncParentDirectory(quarantinePath);
+}
+
 export async function securePrivateDirectory(
   directoryPath: string,
   options: {
@@ -302,29 +333,77 @@ export async function securePrivateDirectory(
     }
   }
 
-  const identity = await readDirectoryIdentity(directoryPath);
-  try {
-    if ((options.platform ?? process.platform) === "win32") {
-      await (options.secureWindowsDirectory ?? applyOwnerOnlyWindowsDirectoryAcl)(directoryPath);
-    } else {
-      await fs.chmod(directoryPath, 0o700);
+  const handle = await fs.open(directoryPath, "r");
+  let handleOpen = true;
+  const closeHandle = async () => {
+    if (!handleOpen) {
+      return;
     }
-    await assertDirectoryPathIdentity(directoryPath, identity);
+    handleOpen = false;
+    await handle.close();
+  };
+  let identity: DirectoryIdentity;
+  try {
+    identity = await readDirectoryHandleIdentity(handle);
   } catch (error) {
-    if (created) {
-      await assertDirectoryPathIdentity(directoryPath, identity)
-        .then(() => fs.rm(directoryPath, { force: true, recursive: true }))
-        .catch(() => undefined);
+    try {
+      await closeHandle();
+    } catch (closeError) {
+      const aggregateError = new AggregateError(
+        [error, closeError],
+        "Private directory identity verification failed and its handle could not be closed.",
+      );
+      aggregateError.cause = error;
+      throw aggregateError;
     }
     throw error;
   }
-
-  return {
+  const secured: SecuredPrivateDirectory = {
     async assertIdentityAt(currentPath = directoryPath) {
       await assertDirectoryPathIdentity(currentPath, identity);
     },
     directoryPath,
   };
+  try {
+    await secured.assertIdentityAt();
+    if ((options.platform ?? process.platform) === "win32") {
+      await (options.secureWindowsDirectory ?? applyOwnerOnlyWindowsDirectoryAcl)(directoryPath);
+    } else {
+      await handle.chmod(0o700);
+    }
+    await secured.assertIdentityAt();
+  } catch (error) {
+    let primaryError = error;
+    try {
+      await closeHandle();
+    } catch (closeError) {
+      const aggregateError = new AggregateError(
+        [error, closeError],
+        "Private directory securing failed and its verification handle could not be closed.",
+      );
+      aggregateError.cause = error;
+      primaryError = aggregateError;
+    }
+    if (created) {
+      try {
+        await removeSecuredPrivateDirectory(secured);
+      } catch (cleanupError) {
+        const aggregateError = new AggregateError(
+          [primaryError, cleanupError],
+          `Private directory securing failed and rollback cleanup also failed: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+        aggregateError.cause = primaryError;
+        throw aggregateError;
+      }
+    }
+    throw primaryError;
+  } finally {
+    await closeHandle();
+  }
+
+  return secured;
 }
 
 export async function publishPrivateFileAtomically(
@@ -334,6 +413,7 @@ export async function publishPrivateFileAtomically(
     afterRename?: (filePath: string) => Promise<void>;
     platform?: NodeJS.Platform;
     secureWindowsFile?: (temporaryPath: string) => Promise<void>;
+    syncParent?: (filePath: string, platform?: NodeJS.Platform) => Promise<void>;
   } = {},
 ): Promise<void> {
   const temporaryPath = path.join(
@@ -356,6 +436,7 @@ export async function publishPrivateFileAtomically(
     await handle.sync();
     await assertPathIdentity(temporaryPath, identity);
     await fs.rename(temporaryPath, filePath);
+    await (options.syncParent ?? syncParentDirectory)(filePath, options.platform);
     await options.afterRename?.(filePath);
     await assertPathIdentity(filePath, identity);
   } finally {

--- a/src/openclaw/shared.ts
+++ b/src/openclaw/shared.ts
@@ -63,7 +63,7 @@ export type OpenClawCrablineAgentDelivery = {
 export type OpenClawCrablineInboundInput = {
   conversation: {
     id: string;
-    kind: string;
+    kind: "direct" | "group";
   };
   senderId: string;
   senderName?: string | undefined;
@@ -157,6 +157,9 @@ export function createOpenClawCrablineProviderBridge<
       createInbound(input) {
         if (!readNonBlankString(input.text)) {
           throw new Error("OpenClaw Crabline inbound message text is required.");
+        }
+        if (input.conversation.kind !== "direct" && input.conversation.kind !== "group") {
+          throw new Error("OpenClaw Crabline inbound conversation kind must be direct or group.");
         }
         return adapter.createInbound(input);
       },
@@ -290,7 +293,11 @@ export function parseQaTarget(target: string): ParsedQaTarget {
 }
 
 export function canonicalConversationIdForInbound(input: OpenClawCrablineInboundInput) {
-  return input.conversation.id.trim();
+  const conversationId = readNonBlankString(input.conversation.id);
+  if (!conversationId) {
+    throw new Error("OpenClaw Crabline inbound conversation id is required.");
+  }
+  return conversationId.trim();
 }
 
 function encodeQaThreadComponent(value: string): string {
@@ -300,12 +307,7 @@ function encodeQaThreadComponent(value: string): string {
 export function qaTargetForInbound(input: OpenClawCrablineInboundInput) {
   const conversationId = canonicalConversationIdForInbound(input);
   const threadId = input.threadId?.trim();
-  const prefix =
-    input.conversation.kind === "direct"
-      ? "dm"
-      : input.conversation.kind === "channel"
-        ? "channel"
-        : "group";
+  const prefix = input.conversation.kind === "direct" ? "dm" : "group";
   return threadId
     ? `thread:/v1/${encodeQaThreadComponent(conversationId)}/${encodeQaThreadComponent(threadId)}`
     : `${prefix}:${conversationId}`;

--- a/src/openclaw/smoke-lock.ts
+++ b/src/openclaw/smoke-lock.ts
@@ -4,7 +4,7 @@ import { readFileSync } from "node:fs";
 import fs, { type FileHandle } from "node:fs/promises";
 import path from "node:path";
 import { isCrablineServerChannel, type CrablineServerChannel } from "../servers/index.js";
-import { securePrivateDirectory } from "./private-file.js";
+import { resolveWindowsPowerShellPath, securePrivateDirectory } from "./private-file.js";
 import { OPENCLAW_CRABLINE_MANIFEST_PATH } from "./shared.js";
 
 type LegacySmokeLockOwner = {
@@ -92,6 +92,7 @@ const RELEASE_CLAIM_SUFFIX = ".release";
 const LOCK_LEASE_MS = 10 * 60 * 1000;
 const RELEASE_ATTEMPTS = 3;
 const RELEASE_RETRY_DELAY_MS = 10;
+const MAX_PROCESS_ID = 2_147_483_647;
 const CURRENT_PROCESS_STARTED_AT_MS = Math.trunc(Date.now() - process.uptime() * 1000);
 
 function parseCommitStagePath(contents: string, token: string): string {
@@ -252,6 +253,10 @@ function isPositiveSafeInteger(value: unknown): value is number {
   return Number.isSafeInteger(value) && Number(value) > 0;
 }
 
+function isValidProcessId(value: unknown): value is number {
+  return isPositiveSafeInteger(value) && Number(value) <= MAX_PROCESS_ID;
+}
+
 const LOCK_TOKEN_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u;
 
 function parseLockOwner(contents: string): SmokeLockOwner {
@@ -266,7 +271,7 @@ function parseLockOwner(contents: string): SmokeLockOwner {
   if (
     typeof owner.channel !== "string" ||
     !isCrablineServerChannel(owner.channel) ||
-    !isPositiveSafeInteger(owner.pid) ||
+    !isValidProcessId(owner.pid) ||
     typeof owner.token !== "string" ||
     !LOCK_TOKEN_PATTERN.test(owner.token)
   ) {
@@ -375,15 +380,15 @@ function isRenewableOwner(owner: SmokeLockOwner): owner is RenewableSmokeLockOwn
   return "leaseVersion" in owner && owner.leaseVersion === 1;
 }
 
-const isProcessAlive: IsProcessAlive = (pid) => {
-  if (!Number.isSafeInteger(pid) || pid <= 0) {
+export const isProcessAlive: IsProcessAlive = (pid) => {
+  if (!isValidProcessId(pid)) {
     return false;
   }
   try {
     process.kill(pid, 0);
     return true;
   } catch (error) {
-    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+    return (error as NodeJS.ErrnoException).code === "EPERM";
   }
 };
 
@@ -451,8 +456,14 @@ const getProcessIdentity: GetProcessIdentity = (pid) => {
   if (process.platform !== "win32") {
     return null;
   }
+  let powershellPath: string;
+  try {
+    powershellPath = resolveWindowsPowerShellPath(process.env.SystemRoot);
+  } catch {
+    return null;
+  }
   const result = spawnSync(
-    "powershell.exe",
+    powershellPath,
     [
       "-NoProfile",
       "-NonInteractive",
@@ -475,21 +486,21 @@ function hasExactProcessIdentity(owner: SmokeLockOwner): owner is (
 }
 
 function hasProcessIdentityMismatch(owner: SmokeLockOwner, runtime: SmokeLockRuntime): boolean {
+  if (
+    hasProcessIdentity(owner) &&
+    owner.pid === runtime.currentPid &&
+    owner.processStartedAtMs !== runtime.currentProcessStartedAtMs
+  ) {
+    return true;
+  }
   if (!hasExactProcessIdentity(owner)) {
-    return (
-      hasProcessIdentity(owner) &&
-      owner.pid === runtime.currentPid &&
-      owner.processStartedAtMs !== runtime.currentProcessStartedAtMs
-    );
+    return false;
   }
   const actualProcessIdentity =
     owner.pid === runtime.currentPid
       ? runtime.currentProcessIdentity
       : runtime.getProcessIdentity(owner.pid);
-  return actualProcessIdentity === null
-    ? owner.pid === runtime.currentPid &&
-        owner.processStartedAtMs !== runtime.currentProcessStartedAtMs
-    : owner.processIdentity !== actualProcessIdentity;
+  return actualProcessIdentity !== null && owner.processIdentity !== actualProcessIdentity;
 }
 
 function isLockOwnerActive(record: SmokeLockRecord, runtime: SmokeLockRuntime): boolean {
@@ -965,7 +976,7 @@ export async function acquireOpenClawCrablineSmokeRunLock(
   };
   const createdAtMs = runtime.now();
   if (
-    !isPositiveSafeInteger(runtime.currentPid) ||
+    !isValidProcessId(runtime.currentPid) ||
     (runtime.currentProcessIdentity !== null &&
       (runtime.currentProcessIdentity.length === 0 ||
         runtime.currentProcessIdentity.length > 256)) ||

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -25,9 +25,11 @@ type ProviderFactory = () => Promise<ProviderAdapter>;
 type ActiveWatch = {
   abort(): void;
   close(): Promise<void>;
+  dispatch: DispatchBarrier;
 };
 type DispatchBarrier = {
   promise: Promise<void>;
+  reach(): void;
   reached: boolean;
 };
 type AdmittedOperation = {
@@ -90,6 +92,24 @@ const LAZY_PROVIDER_FACTORIES = {
     return new ZaloProviderAdapter(providerId, config, userName);
   },
 } satisfies Record<LazyAdapterId, LazyProviderFactory>;
+
+function createDispatchBarrier(): DispatchBarrier {
+  let resolveDispatch: (() => void) | undefined;
+  const dispatch: DispatchBarrier = {
+    promise: new Promise<void>((resolve) => {
+      resolveDispatch = resolve;
+    }),
+    reach() {
+      if (dispatch.reached) {
+        return;
+      }
+      dispatch.reached = true;
+      resolveDispatch?.();
+    },
+    reached: false,
+  };
+  return dispatch;
+}
 
 function isLazyAdapter(adapter: BuiltinAdapterId): adapter is LazyAdapterId {
   return adapter in LAZY_PROVIDER_FACTORIES;
@@ -181,7 +201,8 @@ export class LazyProviderAdapter implements ProviderAdapter {
     } else {
       context.signal?.addEventListener("abort", abortFromContext, { once: true });
     }
-    const source = this.#watch(context, controller.signal)[Symbol.asyncIterator]();
+    const dispatch = createDispatchBarrier();
+    const source = this.#watch(context, controller.signal, dispatch)[Symbol.asyncIterator]();
     let activeWatch: ActiveWatch;
     let closed = false;
     let closePromise: Promise<IteratorResult<InboundEnvelope>> | null = null;
@@ -201,6 +222,7 @@ export class LazyProviderAdapter implements ProviderAdapter {
             ? await source.return()
             : { done: true as const, value: undefined as never };
         } finally {
+          dispatch.reach();
           finish();
         }
       })();
@@ -240,6 +262,7 @@ export class LazyProviderAdapter implements ProviderAdapter {
       close: async () => {
         await close();
       },
+      dispatch,
     };
     this.#activeWatches.add(activeWatch);
     return iterator;
@@ -252,11 +275,14 @@ export class LazyProviderAdapter implements ProviderAdapter {
     }
     this.#cleanupPromise ??= (async () => {
       const operations = [...this.#inFlightOperations];
-      const closingWatches = [...this.#activeWatches].map(async (watch) => await watch.close());
+      const watches = [...this.#activeWatches];
+      const closingWatches = watches.map(async (watch) => await watch.close());
       const providerCleanup = this.#cleanupProvider(
-        operations.map((operation) => operation.dispatch),
+        operations
+          .map((operation) => operation.dispatch)
+          .concat(watches.map((watch) => watch.dispatch)),
       );
-      const [cleanupResult] = await Promise.all([
+      const [cleanupResult, , watchResults] = await Promise.all([
         providerCleanup.then(
           () => ({ ok: true as const }),
           (error: unknown) => ({ error, ok: false as const }),
@@ -264,8 +290,17 @@ export class LazyProviderAdapter implements ProviderAdapter {
         Promise.allSettled(operations.map((operation) => operation.completion)),
         Promise.allSettled(closingWatches),
       ]);
+      const teardownErrors = watchResults.flatMap((result) =>
+        result.status === "rejected" ? [result.reason] : [],
+      );
       if (!cleanupResult.ok) {
-        throw cleanupResult.error;
+        teardownErrors.unshift(cleanupResult.error);
+      }
+      if (teardownErrors.length === 1) {
+        throw teardownErrors[0];
+      }
+      if (teardownErrors.length > 1) {
+        throw new AggregateError(teardownErrors, "Provider cleanup failed.");
       }
     })();
     await this.#cleanupPromise;
@@ -288,39 +323,32 @@ export class LazyProviderAdapter implements ProviderAdapter {
     return await this.#providerPromise;
   }
 
-  async *#watch(context: WatchContext, signal: AbortSignal): AsyncIterable<InboundEnvelope> {
-    const provider = await this.#provider();
-    if (!provider.watch) {
-      throw new CrablineError(`Provider "${this.id}" does not implement watch.`, {
-        kind: "config",
-      });
+  async *#watch(
+    context: WatchContext,
+    signal: AbortSignal,
+    dispatch: DispatchBarrier,
+  ): AsyncIterable<InboundEnvelope> {
+    try {
+      const provider = await this.#provider();
+      if (signal.aborted) {
+        return;
+      }
+      if (!provider.watch) {
+        throw new CrablineError(`Provider "${this.id}" does not implement watch.`, {
+          kind: "config",
+        });
+      }
+      dispatch.reach();
+      yield* provider.watch({ ...context, signal });
+    } finally {
+      dispatch.reach();
     }
-    yield* provider.watch({ ...context, signal });
   }
 
   #assertActive(): void {
     if (this.#cleanedUp) {
       throw this.#cleanedUpError();
     }
-  }
-
-  #beginProviderCleanup(): Promise<ProviderAdapter | null> {
-    if (this.#providerInstance) {
-      try {
-        this.#providerInstance.beginCleanup?.();
-        return Promise.resolve(this.#providerInstance);
-      } catch (error) {
-        return Promise.reject(error);
-      }
-    }
-    const providerPromise = this.#providerPromise;
-    if (!providerPromise) {
-      return Promise.resolve(null);
-    }
-    return providerPromise.then((provider) => {
-      provider.beginCleanup?.();
-      return provider;
-    });
   }
 
   async #cleanupProvider(dispatches: readonly DispatchBarrier[]): Promise<void> {
@@ -330,11 +358,34 @@ export class LazyProviderAdapter implements ProviderAdapter {
     if (pendingDispatches.length > 0) {
       await Promise.allSettled(pendingDispatches);
     }
-    const provider = await this.#beginProviderCleanup();
+    let provider = this.#providerInstance;
+    if (!provider) {
+      const providerPromise = this.#providerPromise;
+      if (!providerPromise) {
+        return;
+      }
+      provider = await providerPromise;
+    }
     if (!provider) {
       return;
     }
-    await provider.cleanup?.();
+    const errors: unknown[] = [];
+    try {
+      provider.beginCleanup?.();
+    } catch (error) {
+      errors.push(error);
+    }
+    try {
+      await provider.cleanup?.();
+    } catch (error) {
+      errors.push(error);
+    }
+    if (errors.length === 1) {
+      throw errors[0];
+    }
+    if (errors.length > 1) {
+      throw new AggregateError(errors, "Provider teardown failed.");
+    }
   }
 
   #runOperation<T>(
@@ -347,14 +398,7 @@ export class LazyProviderAdapter implements ProviderAdapter {
     if (signal?.aborted) {
       return Promise.reject(signal.reason ?? new Error("Provider operation aborted."));
     }
-    let markDispatched: (() => void) | undefined;
-    const dispatched = new Promise<void>((resolve) => {
-      markDispatched = resolve;
-    });
-    const dispatch: DispatchBarrier = {
-      promise: dispatched,
-      reached: false,
-    };
+    const dispatch = createDispatchBarrier();
     const underlying = (async () => {
       try {
         const provider = await this.#provider();
@@ -362,12 +406,10 @@ export class LazyProviderAdapter implements ProviderAdapter {
           throw signal.reason ?? new Error("Provider operation aborted.");
         }
         const result = run(provider);
-        dispatch.reached = true;
-        markDispatched?.();
+        dispatch.reach();
         return await result;
       } catch (error) {
-        dispatch.reached = true;
-        markDispatched?.();
+        dispatch.reach();
         throw error;
       }
     })();
@@ -406,6 +448,11 @@ export function createRegistry(manifest: ManifestDefinition, manifestPath: strin
 
       if (config.status === "disabled") {
         throw new CrablineError(`Provider "${providerId}" is disabled.`, { kind: "config" });
+      }
+      if (config.status === "planned") {
+        throw new CrablineError(`Provider "${providerId}" is planned and cannot run.`, {
+          kind: "config",
+        });
       }
 
       const context: ProviderContext = {

--- a/test/ci-workflow.test.ts
+++ b/test/ci-workflow.test.ts
@@ -1,0 +1,39 @@
+import fs from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+
+type WorkflowStep = {
+  run?: string;
+  uses?: string;
+};
+
+type Workflow = {
+  jobs?: Record<string, { steps?: WorkflowStep[] }>;
+};
+
+async function readWorkflow(filePath: string): Promise<Workflow> {
+  return parse(await fs.readFile(filePath, "utf8")) as Workflow;
+}
+
+describe("CI workflow hardening", () => {
+  it("runs actionlint in the primary CI gate", async () => {
+    const workflow = await readWorkflow(".github/workflows/ci.yml");
+    const commands = Object.values(workflow.jobs ?? {}).flatMap(
+      (job) => job.steps?.map((step) => step.run).filter(Boolean) ?? [],
+    );
+
+    expect(commands).toContain("go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7");
+  });
+
+  it("pins CodeQL actions to immutable revisions", async () => {
+    const workflow = await readWorkflow(".github/workflows/codeql.yml");
+    const actionRefs = Object.values(workflow.jobs ?? {}).flatMap(
+      (job) => job.steps?.map((step) => step.uses).filter(Boolean) ?? [],
+    );
+
+    expect(actionRefs).not.toEqual([]);
+    for (const actionRef of actionRefs) {
+      expect(actionRef).toMatch(/^[^@]+@[0-9a-f]{40}$/u);
+    }
+  });
+});

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -480,7 +480,7 @@ describe("cli", () => {
     await expect(fs.readFile(sentinelPath, "utf8")).resolves.toBe("unrelated\n");
   });
 
-  it("preserves a committed ready file when lock release fails", async () => {
+  it("removes a committed ready file when lock release fails", async () => {
     const directory = await createTempDir();
     directories.push(directory);
     const readyFile = path.join(directory, "server.json");
@@ -489,7 +489,7 @@ describe("cli", () => {
 
     await expect(publishReadyFile(readyFile, "manifest\n")).rejects.toBe(releaseError);
 
-    await expect(fs.readFile(readyFile, "utf8")).resolves.toBe("manifest\n");
+    await expect(fs.readFile(readyFile, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("preserves a replacement swapped in during owned ready-file removal", async () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -2,7 +2,13 @@ import { EventEmitter } from "node:events";
 import path from "node:path";
 import fs from "node:fs/promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createProgram, publishReadyFile, runCli, waitForShutdown } from "../src/cli/program.js";
+import {
+  createProgram,
+  publishReadyFile,
+  removeReadyFile,
+  runCli,
+  waitForShutdown,
+} from "../src/cli/program.js";
 import type { StartedCrablineServer } from "../src/servers/index.js";
 import { captureWrites, createTempDir, disposeTempDir, writeText } from "./test-helpers.js";
 
@@ -442,26 +448,20 @@ describe("cli", () => {
     await expect(fs.readFile(readyFile, "utf8")).resolves.toBe("stale\n");
   });
 
-  it.each(["EACCES", "EINVAL", "EMLINK", "EOPNOTSUPP"])(
-    "replaces an existing ready file when hard links fail with %s",
-    async (code) => {
-      const directory = await createTempDir();
-      directories.push(directory);
-      const readyFile = path.join(directory, "server.json");
-      await writeText(readyFile, "stale\n");
-      const linkError = Object.assign(new Error("hard links unavailable"), { code });
-      const linkSpy = vi.spyOn(fs, "link").mockRejectedValueOnce(linkError);
+  it("replaces an existing ready file without hard-linking its backup", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const readyFile = path.join(directory, "server.json");
+    await writeText(readyFile, "stale\n");
+    const linkSpy = vi.spyOn(fs, "link");
 
-      try {
-        await expect(publishReadyFile(readyFile, "replacement\n")).resolves.toBeDefined();
-      } finally {
-        linkSpy.mockRestore();
-      }
+    await expect(publishReadyFile(readyFile, "replacement\n")).resolves.toBeDefined();
 
-      await expect(fs.readFile(readyFile, "utf8")).resolves.toBe("replacement\n");
-      expect(await fs.readdir(directory)).toEqual(["server.json"]);
-    },
-  );
+    expect(linkSpy).not.toHaveBeenCalled();
+    linkSpy.mockRestore();
+    await expect(fs.readFile(readyFile, "utf8")).resolves.toBe("replacement\n");
+    expect(await fs.readdir(directory)).toEqual(["server.json"]);
+  });
 
   it("does not recursively remove a stale non-lock directory", async () => {
     const directory = await createTempDir();
@@ -480,7 +480,7 @@ describe("cli", () => {
     await expect(fs.readFile(sentinelPath, "utf8")).resolves.toBe("unrelated\n");
   });
 
-  it("removes a committed ready file when lock release fails", async () => {
+  it("preserves a committed ready file when lock release fails", async () => {
     const directory = await createTempDir();
     directories.push(directory);
     const readyFile = path.join(directory, "server.json");
@@ -489,14 +489,40 @@ describe("cli", () => {
 
     await expect(publishReadyFile(readyFile, "manifest\n")).rejects.toBe(releaseError);
 
-    await expect(fs.readFile(readyFile, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(fs.readFile(readyFile, "utf8")).resolves.toBe("manifest\n");
+  });
+
+  it("preserves a replacement swapped in during owned ready-file removal", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const readyFile = path.join(directory, "server.json");
+    const displacedFile = path.join(directory, "displaced.json");
+    const contents = "owned\n";
+    const identity = await publishReadyFile(readyFile, contents);
+    const actualRename = fs.rename;
+    const renameSpy = vi.spyOn(fs, "rename").mockImplementation(async (source, destination) => {
+      if (source === readyFile && String(destination).endsWith(".remove")) {
+        await actualRename(readyFile, displacedFile);
+        await fs.writeFile(readyFile, "replacement\n");
+      }
+      await actualRename(source, destination);
+    });
+
+    try {
+      await removeReadyFile(readyFile, contents, identity);
+    } finally {
+      renameSpy.mockRestore();
+    }
+
+    await expect(fs.readFile(readyFile, "utf8")).resolves.toBe("replacement\n");
+    await expect(fs.readFile(displacedFile, "utf8")).resolves.toBe(contents);
   });
 
   it("closes the server once when ready-file publication fails after startup", async () => {
     const directory = await createTempDir();
     directories.push(directory);
     const close = vi.fn(async () => undefined);
-    const removeReadyFile = vi.fn(async () => undefined);
+    const removeReadyFileMock = vi.fn(async () => undefined);
     const publishError = new Error("publish exploded");
     const server = {
       close,
@@ -520,7 +546,7 @@ describe("cli", () => {
       publishReadyFile: async () => {
         throw publishError;
       },
-      removeReadyFile,
+      removeReadyFile: removeReadyFileMock,
       startServer: async () => server,
     });
 
@@ -536,7 +562,7 @@ describe("cli", () => {
       ]),
     ).rejects.toBe(publishError);
     expect(close).toHaveBeenCalledTimes(1);
-    expect(removeReadyFile).not.toHaveBeenCalled();
+    expect(removeReadyFileMock).not.toHaveBeenCalled();
   });
 
   it("holds ready-file ownership until server shutdown completes", async () => {
@@ -628,7 +654,7 @@ describe("cli", () => {
       releasePublish = resolve;
     });
     const close = vi.fn(async () => undefined);
-    const removeReadyFile = vi.fn(async () => undefined);
+    const removeReadyFileMock = vi.fn(async () => undefined);
     const program = createProgram(() => undefined, {
       acquireReadyFileLease: async () => async () => undefined,
       publishReadyFile: async () => {
@@ -642,7 +668,7 @@ describe("cli", () => {
           size: 1n,
         };
       },
-      removeReadyFile,
+      removeReadyFile: removeReadyFileMock,
       startServer: async () => ({
         close,
         manifest: {
@@ -680,7 +706,7 @@ describe("cli", () => {
     await vi.waitFor(() => expect(close).toHaveBeenCalledTimes(1));
     await running;
 
-    expect(removeReadyFile).toHaveBeenCalledTimes(1);
+    expect(removeReadyFileMock).toHaveBeenCalledTimes(1);
   });
 
   it("uses one heartbeat lease policy for ready-file ownership", async () => {
@@ -882,6 +908,62 @@ describe("cli", () => {
     }
     expect(caught).toEqual({ rejected: true, value: undefined });
     expect(provider.cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels and cleans up watch commands on signals", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const configPath = path.join(directory, "crabline.yaml");
+    await writeText(
+      configPath,
+      [
+        "configVersion: 1",
+        "providers:",
+        "  local:",
+        "    adapter: loopback",
+        "fixtures:",
+        "  - id: watched",
+        "    provider: local",
+        "    mode: agent",
+        "    target:",
+        "      id: echo-bot",
+      ].join("\n"),
+    );
+    const cleanup = vi.fn(async () => undefined);
+    let watchSignal: AbortSignal | undefined;
+    const provider = {
+      cleanup,
+      async *watch(context: { signal?: AbortSignal }) {
+        watchSignal = context.signal;
+        await new Promise<void>((resolve) => {
+          context.signal?.addEventListener("abort", () => resolve(), { once: true });
+        });
+        yield* [];
+      },
+    };
+    const program = createProgram(() => undefined, {
+      createRegistry: () =>
+        ({
+          resolve: () => provider,
+        }) as never,
+    });
+    const baseline = process.listenerCount("SIGTERM");
+    const running = program.parseAsync([
+      "node",
+      "crabline",
+      "--config",
+      configPath,
+      "watch",
+      "watched",
+    ]);
+    await vi.waitFor(() => expect(process.listenerCount("SIGTERM")).toBeGreaterThan(baseline));
+
+    process.emit("SIGTERM", "SIGTERM");
+    await running;
+
+    expect(watchSignal?.aborted).toBe(true);
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(process.listenerCount("SIGTERM")).toBe(baseline);
   });
 
   it("preserves shutdown and ready-file cleanup failures", async () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -48,6 +48,49 @@ describe("manifest schema", () => {
     }
   });
 
+  it("rejects exact static patterns that also require a generated nonce", () => {
+    expect(() =>
+      ManifestSchema.parse({
+        configVersion: 1,
+        fixtures: [
+          {
+            id: "impossible-exact-match",
+            inboundMatch: {
+              nonce: "contains",
+              pattern: "static response",
+              strategy: "exact",
+            },
+            mode: "roundtrip",
+            provider: "local",
+            target: { id: "echo-bot" },
+          },
+        ],
+        providers: { local: { adapter: "loopback" } },
+      }),
+    ).toThrow(/strategy=exact requires inboundMatch\.nonce=ignore/u);
+  });
+
+  it("accepts only HTTP(S) provider endpoint URLs", () => {
+    for (const apiUrl of [
+      "data:text/plain,hello",
+      "file:///tmp/provider",
+      "mailto:test@example.com",
+    ]) {
+      expect(() =>
+        ManifestSchema.parse({
+          configVersion: 1,
+          fixtures: [],
+          providers: {
+            whatsapp: {
+              adapter: "whatsapp",
+              whatsapp: { apiUrl },
+            },
+          },
+        }),
+      ).toThrow(/URL must use http or https/u);
+    }
+  });
+
   it("accepts the documented thread target shape", () => {
     expect(() =>
       ManifestSchema.parse({

--- a/test/load.test.ts
+++ b/test/load.test.ts
@@ -83,6 +83,18 @@ describe("config load", () => {
     expect(loaded.manifest).not.toHaveProperty("x-openclaw-bridge");
   });
 
+  it("loads the shipped built-in provider fixture", async () => {
+    const loaded = await loadManifest(path.resolve("fixtures/examples/crabline.example.yaml"));
+
+    expect(loaded.manifest.providers.whatsapp?.whatsapp).toMatchObject({
+      appSecret: "placeholder",
+      verifyToken: "placeholder",
+    });
+    expect(loaded.manifest.fixtures).toContainEqual(
+      expect.objectContaining({ id: "loopback-roundtrip", provider: "local" }),
+    );
+  });
+
   it("rejects invalid inbound regular expressions during config load", async () => {
     const directory = await createTempDir();
     directories.push(directory);

--- a/test/openclaw-artifact-generation.test.ts
+++ b/test/openclaw-artifact-generation.test.ts
@@ -84,10 +84,17 @@ describe("OpenClaw artifact generation publication", () => {
   it("publishes one complete owner-only generation behind an atomic pointer", async () => {
     const outputDir = await createTempDir();
     const lock = createLock();
+    const syncedPaths: string[] = [];
     try {
       const result = await publishOpenClawCrablineArtifactGeneration(
         publishParams(outputDir, lock),
-        { createGenerationId: () => "11111111-1111-4111-8111-111111111111", platform: "linux" },
+        {
+          createGenerationId: () => "11111111-1111-4111-8111-111111111111",
+          platform: "linux",
+          syncParent: async (filePath) => {
+            syncedPaths.push(filePath);
+          },
+        },
       );
 
       expect(result).toMatchObject({
@@ -120,6 +127,13 @@ describe("OpenClaw artifact generation publication", () => {
       ).toBe(0o700);
       expect(lock.assertOwned).toHaveBeenCalledTimes(3);
       expect(lock.commitFileAtomically).toHaveBeenCalledTimes(1);
+      expect(syncedPaths).toContain(
+        path.join(
+          outputDir,
+          OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY,
+          "generation-11111111-1111-4111-8111-111111111111",
+        ),
+      );
     } finally {
       await disposeTempDir(outputDir);
     }
@@ -574,6 +588,33 @@ describe("OpenClaw artifact generation publication", () => {
         ),
       ).rejects.toThrow(/BigInt/u);
       await expect(fs.readdir(storePath)).resolves.toEqual([]);
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
+  it("preserves publication and rollback cleanup failures", async () => {
+    const outputDir = await createTempDir();
+    const storePath = path.join(outputDir, OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY);
+    const generation = "generation-11111111-1111-4111-8111-111111111111";
+    const generationPath = path.join(storePath, generation);
+    const displacedPath = `${generationPath}.displaced`;
+    const publicationError = new Error("pointer switch failed");
+    try {
+      const failure = await publishOpenClawCrablineArtifactGeneration(publishParams(outputDir), {
+        beforePointerSwitch: async () => {
+          await fs.rename(generationPath, displacedPath);
+          await fs.mkdir(generationPath);
+          throw publicationError;
+        },
+        createGenerationId: () => "11111111-1111-4111-8111-111111111111",
+      }).catch((error: unknown) => error);
+
+      expect(failure).toBeInstanceOf(AggregateError);
+      expect((failure as AggregateError).errors[0]).toBe(publicationError);
+      expect((failure as AggregateError).errors[1]).toBeInstanceOf(Error);
+      await expect(fs.stat(generationPath)).resolves.toBeDefined();
+      await expect(fs.stat(displacedPath)).resolves.toBeDefined();
     } finally {
       await disposeTempDir(outputDir);
     }

--- a/test/openclaw-private-file.test.ts
+++ b/test/openclaw-private-file.test.ts
@@ -43,6 +43,28 @@ describe("OpenClaw private file publication", () => {
     }
   });
 
+  it.skipIf(process.platform === "win32")(
+    "rejects a symlinked POSIX directory before changing target permissions",
+    async () => {
+      const directory = await createTempDir();
+      try {
+        const targetPath = path.join(directory, "target");
+        const generationPath = path.join(directory, "generation");
+        await fs.mkdir(targetPath);
+        await fs.chmod(targetPath, 0o777);
+        await fs.symlink(targetPath, generationPath);
+
+        await expect(securePrivateDirectory(generationPath, { platform: "linux" })).rejects.toThrow(
+          "Private directory path identity changed during publication.",
+        );
+
+        expect((await fs.stat(targetPath)).mode & 0o777).toBe(0o777);
+      } finally {
+        await disposeTempDir(directory);
+      }
+    },
+  );
+
   it("secures an empty Windows generation directory before child creation", async () => {
     const directory = await createTempDir();
     try {
@@ -232,6 +254,28 @@ describe("OpenClaw private file publication", () => {
 
       await expect(fs.readFile(filePath, "utf8")).resolves.toBe("replacement\n");
       await expect(fs.readFile(displacedPath, "utf8")).resolves.toBe("private\n");
+    } finally {
+      await disposeTempDir(directory);
+    }
+  });
+
+  it("syncs the parent directory after atomic publication", async () => {
+    const directory = await createTempDir();
+    try {
+      const filePath = path.join(directory, "manifest.json");
+      const events: string[] = [];
+
+      await publishPrivateFileAtomically(filePath, "private\n", {
+        afterRename: async () => {
+          events.push("afterRename");
+        },
+        syncParent: async (publishedPath) => {
+          expect(publishedPath).toBe(filePath);
+          events.push("syncParent");
+        },
+      });
+
+      expect(events).toEqual(["syncParent", "afterRename"]);
     } finally {
       await disposeTempDir(directory);
     }

--- a/test/openclaw-smoke-lock.test.ts
+++ b/test/openclaw-smoke-lock.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   acquireOpenClawCrablineSmokeRunLock,
   darwinProcessIdentityEnvironment,
+  isProcessAlive,
   processIdentityFromDarwin,
   processIdentityFromLinuxStat,
   releaseOpenClawCrablineSmokeRunLock,
@@ -51,6 +52,21 @@ describe("OpenClaw smoke lock cleanup", () => {
       TZ: "Europe/Paris",
       UNRELATED: "preserved",
     });
+  });
+
+  it("rejects oversized PIDs and non-liveness process errors", () => {
+    const kill = vi.spyOn(process, "kill");
+    kill.mockImplementationOnce(() => {
+      throw Object.assign(new Error("invalid pid"), { code: "EINVAL" });
+    });
+    kill.mockImplementationOnce(() => {
+      throw Object.assign(new Error("permission denied"), { code: "EPERM" });
+    });
+
+    expect(isProcessAlive(Number.MAX_SAFE_INTEGER)).toBe(false);
+    expect(isProcessAlive(4_242)).toBe(false);
+    expect(isProcessAlive(4_242)).toBe(true);
+    kill.mockRestore();
   });
 
   it("rejects lock tokens that can escape token-specific filenames", async () => {
@@ -453,7 +469,7 @@ describe("OpenClaw smoke lock cleanup", () => {
           pid: 4_242,
           processIdentity: "test:prior",
           processStartedAtMs: 100,
-          token: "prior",
+          token: "placeholder",
         })}\n`,
         { mode: 0o600 },
       );
@@ -582,6 +598,74 @@ describe("OpenClaw smoke lock cleanup", () => {
 
       await expect(replacementLock.assertOwned()).resolves.toBeUndefined();
       await replacementLock.release();
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
+  it("reclaims a same-second Darwin identity after current PID reuse", async () => {
+    const outputDir = await createTempDir();
+    const params = { channel: "telegram" as const, outputDir };
+    const lockDirectory = path.join(
+      path.resolve(outputDir),
+      `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`,
+    );
+    const darwinIdentity = "darwin:1783864000.123456:Sun Jul 12 16:04:00 2026";
+    try {
+      await fs.mkdir(lockDirectory, { mode: 0o700 });
+      await fs.writeFile(
+        path.join(lockDirectory, "owner.json"),
+        `${JSON.stringify({
+          channel: "telegram",
+          createdAtMs: 1_000,
+          pid: 4_242,
+          processIdentity: darwinIdentity,
+          processStartedAtMs: 100,
+          token: "prior",
+        })}\n`,
+        { mode: 0o600 },
+      );
+
+      const replacementLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+        getProcessIdentity: () => darwinIdentity,
+        isProcessAlive: () => true,
+        leaseMs: 1_000,
+        now: () => 1_100,
+        pid: 4_242,
+        processIdentity: darwinIdentity,
+        processStartedAtMs: 200,
+      });
+
+      await expect(replacementLock.assertOwned()).resolves.toBeUndefined();
+      await replacementLock.release();
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
+  it("rejects lock metadata with a PID outside the supported process range", async () => {
+    const outputDir = await createTempDir();
+    const lockDirectory = path.join(
+      path.resolve(outputDir),
+      `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`,
+    );
+    try {
+      await fs.mkdir(lockDirectory);
+      await fs.writeFile(
+        path.join(lockDirectory, "owner.json"),
+        `${JSON.stringify({
+          channel: "telegram",
+          pid: 2_147_483_648,
+          token: "token-oversized",
+        })}\n`,
+      );
+
+      await expect(
+        acquireOpenClawCrablineSmokeRunLock(
+          { channel: "telegram", outputDir },
+          { isProcessAlive: () => true, now: () => 1_000, pid: 5_252 },
+        ),
+      ).rejects.toThrow("OpenClaw Crabline smoke lock owner metadata is malformed.");
     } finally {
       await disposeTempDir(outputDir);
     }

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -990,6 +990,29 @@ describe("OpenClaw local provider bridge", () => {
     });
   });
 
+  it("rejects blank or unknown inbound conversations before provider translation", () => {
+    expect(() =>
+      createOpenClawCrablineInbound({
+        input: {
+          conversation: { id: "   ", kind: "direct" },
+          senderId: "user-1",
+          text: "hello",
+        },
+        manifest,
+      }),
+    ).toThrow(/required/u);
+    expect(() =>
+      createOpenClawCrablineInbound({
+        input: {
+          conversation: { id: "alice", kind: "channel" } as never,
+          senderId: "user-1",
+          text: "hello",
+        },
+        manifest,
+      }),
+    ).toThrow("OpenClaw Crabline inbound conversation kind must be direct or group.");
+  });
+
   it("rejects blank and malformed reserved QA targets", () => {
     const invalidTargets = [
       "",
@@ -1552,7 +1575,7 @@ describe("OpenClaw local provider bridge", () => {
             text: "hello",
           },
         }),
-      ).toThrow("Mattermost conversation id is required.");
+      ).toThrow("OpenClaw Crabline inbound conversation id is required.");
     }
 
     expect(

--- a/test/package-production.test.ts
+++ b/test/package-production.test.ts
@@ -27,6 +27,7 @@ describe("production package", () => {
       main?: string;
       optionalDependencies?: Record<string, string>;
       peerDependencies?: Record<string, string>;
+      files?: string[];
       types?: string;
       version?: string;
     };
@@ -57,6 +58,11 @@ describe("production package", () => {
     expect(files).toContain(mainPath);
     expect(files).toContain(typesPath);
     expect(files).toContain("assets/crabline-banner.svg");
+    expect(files).toContain("README.md");
+    expect(files).toContain("docs/channel-setup.md");
+    expect(files).toContain("fixtures/examples/crabline.example.yaml");
+    expect(files).toContain("fixtures/examples/openclaw-bridge.yaml");
+    expect(files).toContain("LICENSE");
     expect(files.some((file) => file.startsWith("node_modules/"))).toBe(false);
     expect(files.some((file) => file.startsWith("test/"))).toBe(false);
     expect(files.some((file) => /(^|\/)baileys(\/|$)/u.test(file))).toBe(false);
@@ -91,7 +97,7 @@ describe("production package", () => {
       const tarballPath = path.join(packDirectory, packed.filename);
       await fs.writeFile(
         path.join(consumerDirectory, "package.json"),
-        JSON.stringify({ name: "crabline-production-consumer", private: true }),
+        JSON.stringify({ name: "crabline-production-consumer", private: true, type: "module" }),
       );
       await execFileAsync(
         "npm",
@@ -131,6 +137,33 @@ describe("production package", () => {
         { cwd: consumerDirectory },
       );
       expect(importOutput.trim()).toBe("function");
+
+      await fs.writeFile(
+        path.join(consumerDirectory, "consumer.ts"),
+        [
+          'import { startCrablineServer } from "@openclaw/crabline";',
+          "const start: typeof startCrablineServer = startCrablineServer;",
+          "void start;",
+          "",
+        ].join("\n"),
+      );
+      await execFileAsync(
+        path.join(root, "node_modules", ".bin", process.platform === "win32" ? "tsc6.cmd" : "tsc6"),
+        [
+          "--noEmit",
+          "--module",
+          "NodeNext",
+          "--moduleResolution",
+          "NodeNext",
+          "--target",
+          "ES2022",
+          "--types",
+          "node",
+          "--ignoreConfig",
+          "consumer.ts",
+        ],
+        { cwd: consumerDirectory },
+      );
 
       const cliShim = path.join(
         consumerDirectory,

--- a/test/registry-lifecycle.test.ts
+++ b/test/registry-lifecycle.test.ts
@@ -710,4 +710,145 @@ describe("lazy provider lifecycle", () => {
       await disposeTempDir(directory);
     }
   });
+
+  it("cancels an admitted watch before cleaning up a materializing provider", async () => {
+    let releaseFactory: (() => void) | undefined;
+    const factoryBlocked = new Promise<void>((resolve) => {
+      releaseFactory = resolve;
+    });
+    const events: string[] = [];
+    const concrete: ProviderAdapter = {
+      id: "test",
+      platform: "loopback",
+      status: "ready",
+      supports: ["agent"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      async probe() {
+        return { details: [], healthy: true };
+      },
+      async send() {
+        return { accepted: true, messageId: "sent", threadId: "thread" };
+      },
+      async waitForInbound() {
+        return null;
+      },
+      async *watch() {
+        events.push("watch");
+        yield* [];
+      },
+      beginCleanup() {
+        events.push("beginCleanup");
+      },
+      async cleanup() {
+        events.push("cleanup");
+      },
+    };
+    const provider = new LazyProviderAdapter({
+      adapterName: "test",
+      factory: async () => {
+        await factoryBlocked;
+        return concrete;
+      },
+      id: "test",
+      normalizeTarget: concrete.normalizeTarget.bind(concrete),
+      platform: "loopback",
+      status: "ready",
+      supports: ["agent"],
+    });
+    const { context } = createTelegramManifest("/tmp/unused.jsonl");
+    const iterator = provider.watch(context)[Symbol.asyncIterator]();
+    const pending = iterator.next();
+    const cleanup = provider.cleanup();
+
+    await Promise.resolve();
+    expect(events).toEqual([]);
+
+    releaseFactory?.();
+    await expect(pending).resolves.toEqual({ done: true, value: undefined });
+    await expect(cleanup).resolves.toBeUndefined();
+    expect(events).toEqual(["beginCleanup", "cleanup"]);
+  });
+
+  it("attempts every teardown and reports watch and provider cleanup failures", async () => {
+    const watchCloseError = new Error("watch close failed");
+    const beginCleanupError = new Error("begin cleanup failed");
+    let markWatchStarted: (() => void) | undefined;
+    const watchStarted = new Promise<void>((resolve) => {
+      markWatchStarted = resolve;
+    });
+    const cleanup = vi.fn(async () => undefined);
+    const concrete: ProviderAdapter = {
+      id: "test",
+      platform: "loopback",
+      status: "ready",
+      supports: ["agent"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      async probe() {
+        return { details: [], healthy: true };
+      },
+      async send() {
+        return { accepted: true, messageId: "sent", threadId: "thread" };
+      },
+      async waitForInbound() {
+        return null;
+      },
+      watch(_context) {
+        return {
+          [Symbol.asyncIterator]() {
+            return {
+              async next() {
+                markWatchStarted?.();
+                return {
+                  done: false as const,
+                  value: {
+                    author: "assistant" as const,
+                    id: "watch-event",
+                    provider: "test",
+                    sentAt: new Date().toISOString(),
+                    text: "watch event",
+                    threadId: "thread",
+                  },
+                };
+              },
+              async return() {
+                throw watchCloseError;
+              },
+            };
+          },
+        };
+      },
+      beginCleanup() {
+        throw beginCleanupError;
+      },
+      cleanup,
+    };
+    const provider = new LazyProviderAdapter({
+      adapterName: "test",
+      factory: async () => concrete,
+      id: "test",
+      normalizeTarget: concrete.normalizeTarget.bind(concrete),
+      platform: "loopback",
+      status: "ready",
+      supports: ["agent"],
+    });
+    const { context } = createTelegramManifest("/tmp/unused.jsonl");
+    const iterator = provider.watch(context)[Symbol.asyncIterator]();
+    const pending = iterator.next();
+    await watchStarted;
+    await expect(pending).resolves.toMatchObject({
+      done: false,
+      value: { id: "watch-event" },
+    });
+
+    const cleanupResult = provider.cleanup();
+
+    await expect(cleanupResult).rejects.toMatchObject({
+      errors: expect.arrayContaining([beginCleanupError, watchCloseError]),
+    });
+    expect(cleanup).toHaveBeenCalledOnce();
+  });
 });

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -42,6 +42,22 @@ describe("registry", () => {
     expect(provider.status).toBe("ready");
   });
 
+  it("does not execute providers marked as planned", () => {
+    const plannedManifest: ManifestDefinition = {
+      ...manifest,
+      providers: {
+        local: {
+          ...manifest.providers.local!,
+          status: "planned",
+        },
+      },
+    };
+
+    expect(() =>
+      createRegistry(plannedManifest, "/tmp/crabline.yaml").resolve("local", "fixture"),
+    ).toThrow('Provider "local" is planned and cannot run.');
+  });
+
   it("uses configured capabilities and concrete target normalization before loading adapters", () => {
     const config: ProviderConfig = {
       adapter: "telegram",

--- a/test/release-workflow.test.ts
+++ b/test/release-workflow.test.ts
@@ -51,13 +51,20 @@ describe("release workflow", () => {
     await expect(
       runResolveTag(resolveStep, "v1.2.3", {
         eventName: "workflow_dispatch",
-        refName: "main",
-        refType: "branch",
+        refName: "v1.2.3",
+        refType: "tag",
       }),
     ).resolves.toEqual({
       tag: "v1.2.3",
       version: "1.2.3",
     });
+    await expect(
+      runResolveTag(resolveStep, "v1.2.3", {
+        eventName: "workflow_dispatch",
+        refName: "main",
+        refType: "branch",
+      }),
+    ).rejects.toThrow(/Command failed/u);
     await expect(runResolveTag(resolveStep, "v1.2.3-beta.1")).rejects.toThrow(/Command failed/u);
     await expect(runResolveTag(resolveStep, "v1.2.3.preview")).rejects.toThrow(/Command failed/u);
     await expect(
@@ -68,6 +75,7 @@ describe("release workflow", () => {
     ).rejects.toThrow(/Command failed/u);
     expect(checkoutStep?.with?.ref).toBe("refs/tags/${{ steps.release.outputs.tag }}");
     expect(verifyCheckoutStep).toContain("refs/tags/${RELEASE_TAG}^{commit}");
+    expect(verifyCheckoutStep).toContain('"$release_commit" == "$GITHUB_EVENT_SHA"');
   });
 
   it("pins tooling and makes package and GitHub publication retry-safe", async () => {
@@ -85,8 +93,13 @@ describe("release workflow", () => {
 
     expect(workflow.concurrency).toEqual({
       "cancel-in-progress": false,
-      group: "release-${{ inputs.tag_name || github.ref_name }}",
+      group: "release",
     });
+    expect(
+      verifySteps.find((step) => step.uses?.startsWith("actions/setup-node@"))?.with?.[
+        "node-version"
+      ],
+    ).toBe(22);
     expect(commands).toContain("npm install -g npm@12.0.1");
     for (const jobName of ["verify", "publish"]) {
       const jobCommands = jobSteps(workflow, jobName)

--- a/test/run.retry-timeout.test.ts
+++ b/test/run.retry-timeout.test.ts
@@ -211,4 +211,53 @@ describe("runFixtureCommand retries", () => {
     expect(waitCalls).toBe(1);
     expect(cleanupCalls).toBe(1);
   });
+
+  it("bounds cleanup after an inbound wait ignores cancellation", async () => {
+    let releaseWait: (() => void) | undefined;
+    const provider: ProviderAdapter = {
+      id: "mock",
+      platform: "loopback",
+      status: "ready",
+      supports: ["probe", "send", "roundtrip", "agent"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      async probe() {
+        return { details: [], healthy: true };
+      },
+      async send() {
+        return { accepted: true, messageId: "sent-1", threadId: "thread-1" };
+      },
+      async waitForInbound() {
+        return await new Promise<null>((resolve) => {
+          releaseWait = () => resolve(null);
+        });
+      },
+      async cleanup() {
+        await new Promise(() => undefined);
+      },
+    };
+    const registry: Registry = {
+      catalog: OPENCLAW_SUPPORT_CATALOG,
+      resolve() {
+        return provider;
+      },
+    };
+
+    try {
+      const result = await runFixtureCommand({
+        fixtureId: "fixture",
+        manifest,
+        manifestPath: "/tmp/crabline.yaml",
+        registry,
+      });
+
+      expect(result).toMatchObject({ failureKind: "inbound", ok: false });
+      expect(result.diagnostics).toContain(
+        "cleanup failed: Provider cleanup did not settle within 250ms after an aborted inbound wait.",
+      );
+    } finally {
+      releaseWait?.();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- preserve provider registry lifecycle, retry, and timeout semantics
- make OpenClaw artifact/private-file publication atomic and rollback-safe
- harden release/package gates and document the supported configuration

## Verification
- `pnpm verify`
- autoreview: clean on exact branch head with `gpt-5.6-sol` / high
- Crabbox: exact source `b27d40ec5ada95dc856f19d9bf3eb3931a203196`, 50 files / 505 tests passed

## Changelog
- added under Unreleased