### PR TITLE
fix(providers): preserve native authentication and delivery state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Harden release, CI, config, CLI, package, and OpenClaw artifact and process-identity boundaries.
+- Restore provider-native callbacks and authentication, preserve conversation targets and recorder progress, and harden local mock lifecycle and parsing.
 - Preserve Zalo polling updates across disconnects and webhook changes, reject future Matrix sync tokens, normalize JSON media types, and bound Signal SSE clients and buffers.
 - Authenticate configured Discord interactions, answer native PING requests, exclude outbound mock records from inbound matching, filter WhatsApp webhooks by phone number, and validate loopback pagination limits.
 - Bound WhatsApp binary-node complexity and signal bundles, align encoder and decoder limits, preserve coherent X25519 fallback behavior, validate queue startup before listening, keep reconnect delivery FIFO, and accept bounded legacy group JIDs.

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -430,8 +430,10 @@ as `telegram:`, `discord:`, or `slack:`.
 - Slack threads: `1700000000.000100`
 - Telegram chats: `-1001234567890` or `@channelusername`
 - Telegram topics: `42`
-- WhatsApp users: `15551234567@s.whatsapp.net`
-- WhatsApp groups: `120363001234567890@g.us`
+- Built-in WhatsApp Cloud API users: digits-only `wa_id` values such as
+  `15551234567`
+- OpenClaw WhatsApp bridge users: `15551234567@s.whatsapp.net`
+- OpenClaw WhatsApp bridge groups: `120363001234567890@g.us`
 - Discord channels and threads: Discord snowflake ids such as
   `123456789012345678`
 - Google Chat spaces: `spaces/AAAABbbbCCC`

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -80,6 +80,12 @@ header before JSON parsing or recorder writes:
 
 - Discord `publicKey` or `DISCORD_PUBLIC_KEY` verifies
   `X-Signature-Ed25519` over `X-Signature-Timestamp` plus the raw request body.
+- Google Chat `endpointUrl` verifies Google ID tokens for the configured HTTP
+  audience. `googleChatProjectNumber` selects project-number JWT verification
+  instead. Pub/Sub delivery uses `pubsubAudience` and
+  `credentials.client_email`.
+- Microsoft Teams `appId` or `TEAMS_APP_ID` verifies Bot Connector bearer
+  tokens, including the activity channel and exact `serviceUrl`.
 - Slack `signingSecret` or `SLACK_SIGNING_SECRET` verifies
   `X-Slack-Request-Timestamp` and `X-Slack-Signature`.
 - Telegram `secretToken` or `TELEGRAM_WEBHOOK_SECRET_TOKEN` verifies

--- a/src/openclaw/bridges/slack.ts
+++ b/src/openclaw/bridges/slack.ts
@@ -23,6 +23,19 @@ function requireSlackSendTargetId(value: string, label: string): string {
   return trimmed;
 }
 
+function requireSlackTargetKind(
+  parsed: { kind: "direct" | "group"; native: boolean },
+  targetId: string,
+): void {
+  if (parsed.native) {
+    return;
+  }
+  const nativeKind = /^[DUW]/u.test(targetId) ? "direct" : "group";
+  if (parsed.kind !== nativeKind) {
+    throw new Error("Slack target kind does not match the native conversation id.");
+  }
+}
+
 function requireSlackChannelId(value: string, label: string): string {
   const trimmed = value.trim();
   if (!SLACK_CHANNEL_ID_RULE.pattern.test(trimmed)) {
@@ -116,6 +129,7 @@ export const SLACK_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablinePro
       },
       createAgentDelivery(parsed) {
         const to = requireSlackSendTargetId(parsed.id, "Slack target");
+        requireSlackTargetKind(parsed, to);
         const threadTs = requireSlackThreadTs(parsed.threadId, "Slack target thread");
         return {
           channel: "slack",

--- a/src/openclaw/bridges/telegram.ts
+++ b/src/openclaw/bridges/telegram.ts
@@ -34,6 +34,9 @@ function normalizeTelegramChatId(kind: "direct" | "group", id: string): string {
     }
     return value;
   }
+  if (kind === "group" && /^@[A-Za-z][A-Za-z0-9_]{4,31}$/u.test(value)) {
+    return value;
+  }
   const hash = createHash("sha256").update(`${kind}:${value}`).digest().readBigUInt64BE();
   if (kind === "group") {
     return String(-(TELEGRAM_SYMBOLIC_GROUP_ID_BASE + (hash % TELEGRAM_SYMBOLIC_GROUP_ID_RANGE)));
@@ -72,12 +75,12 @@ function parseTelegramThreadTargetId(value: unknown): number | undefined {
     return undefined;
   }
   const trimmed = readString(value);
-  if (!trimmed || !/^\d+$/u.test(trimmed)) {
-    throw new Error("Telegram thread target must be a safe non-negative integer.");
+  if (!trimmed || !/^[1-9]\d*$/u.test(trimmed)) {
+    throw new Error("Telegram thread target must be a safe positive integer.");
   }
   const threadId = Number(trimmed);
   if (!Number.isSafeInteger(threadId)) {
-    throw new Error("Telegram thread target must be a safe non-negative integer.");
+    throw new Error("Telegram thread target must be a safe positive integer.");
   }
   return threadId;
 }
@@ -157,7 +160,12 @@ export const TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
         };
       },
       createAgentDelivery(parsed) {
-        const kind = parsed.native && /^-\d+$/u.test(parsed.id.trim()) ? "group" : parsed.kind;
+        const kind =
+          parsed.native &&
+          (/^-\d+$/u.test(parsed.id.trim()) ||
+            /^@[A-Za-z][A-Za-z0-9_]{4,31}$/u.test(parsed.id.trim()))
+            ? "group"
+            : parsed.kind;
         const chatId = normalizeTelegramChatId(kind, parsed.id);
         const threadId = parseTelegramThreadTargetId(parsed.threadId);
         const to = telegramTargetKey(chatId, threadId);

--- a/src/openclaw/bridges/whatsapp.ts
+++ b/src/openclaw/bridges/whatsapp.ts
@@ -19,6 +19,19 @@ function requireWhatsAppJid(value: string, label: string): string {
   return trimmed;
 }
 
+function requireWhatsAppTargetKind(
+  parsed: { kind: "direct" | "group"; native: boolean },
+  targetId: string,
+): void {
+  if (parsed.native) {
+    return;
+  }
+  const nativeKind = targetId.endsWith("@g.us") ? "group" : "direct";
+  if (parsed.kind !== nativeKind) {
+    throw new Error("WhatsApp target kind does not match the native JID.");
+  }
+}
+
 export const WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablineProviderBridge({
   provider: "whatsapp",
   createAdapter(whatsapp) {
@@ -83,6 +96,7 @@ export const WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
           throw new Error("WhatsApp does not support thread targets.");
         }
         const to = requireWhatsAppJid(parsed.id, "WhatsApp target");
+        requireWhatsAppTargetKind(parsed, to);
         return {
           channel: "whatsapp",
           to,

--- a/src/providers/builtin/discord.ts
+++ b/src/providers/builtin/discord.ts
@@ -124,6 +124,19 @@ function normalizeDiscordWebhookPayload(payload: unknown) {
   };
 }
 
+export function createDiscordInteractionResponse(payload: unknown): Response {
+  if (!isRecord(payload)) {
+    return Response.json({ type: 5 }, { status: 200 });
+  }
+  if (payload.type === 3) {
+    return Response.json({ type: 6 }, { status: 200 });
+  }
+  if (payload.type === 4) {
+    return Response.json({ data: { choices: [] }, type: 8 }, { status: 200 });
+  }
+  return Response.json({ type: 5 }, { status: 200 });
+}
+
 export class DiscordProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, userName: string) {
     const resolvedConfig = resolveDiscordAdapterConfigValue(config, userName);
@@ -146,6 +159,7 @@ export class DiscordProviderAdapter extends LocalMockProviderAdapter implements 
           path: "/discord/interactions",
           port: 8788,
         },
+        createWebhookSuccessResponse: createDiscordInteractionResponse,
         endpointLabel: "interactions endpoint",
         handleWebhookPayload: (payload) =>
           isRecord(payload) && payload.type === 1

--- a/src/providers/builtin/feishu.ts
+++ b/src/providers/builtin/feishu.ts
@@ -27,6 +27,17 @@ export function resolveFeishuAdapterConfig(
   };
 }
 
+export function handleFeishuWebhookPayload(payload: unknown): Response | undefined {
+  if (
+    isRecord(payload) &&
+    payload.type === "url_verification" &&
+    typeof payload.challenge === "string"
+  ) {
+    return Response.json({ challenge: payload.challenge });
+  }
+  return undefined;
+}
+
 export class FeishuProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
     super({
@@ -36,6 +47,7 @@ export class FeishuProviderAdapter extends LocalMockProviderAdapter implements P
       options: {
         defaultWebhook: { host: "127.0.0.1", path: "/feishu/webhook", port: 8795 },
         endpointLabel: "webhook endpoint",
+        handleWebhookPayload: handleFeishuWebhookPayload,
         normalizeWebhookPayload: normalizeFeishuWebhookPayload,
         platform: "feishu",
         publicUrl: config.feishu?.webhook.publicUrl,
@@ -64,10 +76,16 @@ export function normalizeFeishuWebhookPayload(payload: unknown) {
   }
 
   const chatId = optionalString(message, "chat_id");
+  const messageType = optionalString(message, "message_type");
   const messageId = optionalString(message, "message_id");
   const rootId = optionalString(message, "root_id");
   const rawContent = optionalString(message, "content");
   const text = parseFeishuText(rawContent);
+  if (messageType !== "text") {
+    throw new CrablineError("Feishu event payload requires message.message_type=text", {
+      kind: "inbound",
+    });
+  }
   if (!chatId || !text) {
     throw new CrablineError("Feishu event payload requires message.chat_id and message.content", {
       kind: "inbound",

--- a/src/providers/builtin/googlechat.ts
+++ b/src/providers/builtin/googlechat.ts
@@ -1,8 +1,10 @@
+import { createPublicKey } from "node:crypto";
 import path from "node:path";
 import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
 import { LocalMockProviderAdapter } from "../local-mock.js";
 import type { ProviderAdapter } from "../types.js";
+import { readBearerToken, verifySignedJwt } from "../signed-jwt.js";
 import {
   getBuiltinTargetCodec,
   GOOGLE_CHAT_SPACE_RULE,
@@ -28,15 +30,136 @@ export function resolveGoogleChatAdapterConfig(
   };
 }
 
+const GOOGLE_CHAT_ISSUER = "chat@system.gserviceaccount.com";
+const GOOGLE_OAUTH_CERTS_URL = "https://www.googleapis.com/oauth2/v1/certs";
+const GOOGLE_CHAT_CERTS_URL =
+  "https://www.googleapis.com/service_accounts/v1/metadata/x509/chat@system.gserviceaccount.com";
+
+type GoogleChatAuthRuntime = {
+  fetch?: typeof fetch | undefined;
+  now?: (() => number) | undefined;
+};
+
+export function createGoogleChatWebhookAuthenticator(
+  config: ProviderConfig,
+  runtime: GoogleChatAuthRuntime = {},
+) {
+  if (config.googlechat?.disableSignatureVerification) {
+    return undefined;
+  }
+  const projectAudience = config.googlechat?.googleChatProjectNumber;
+  const pubsubAudience = config.googlechat?.pubsubAudience;
+  const pubsubServiceAccount = config.googlechat?.credentials?.client_email;
+  if (!(projectAudience || pubsubAudience)) {
+    return undefined;
+  }
+
+  const fetchImpl = runtime.fetch ?? fetch;
+  const cachedCertificates = new Map<
+    string,
+    { expiresAt: number; values: Record<string, string> }
+  >();
+  return async (request: Request, rawBody: string): Promise<Response | undefined> => {
+    const token = readBearerToken(request);
+    if (!token) {
+      return new Response("unauthorized", {
+        headers: { "www-authenticate": "Bearer" },
+        status: 401,
+      });
+    }
+    try {
+      let payload: unknown;
+      try {
+        payload = JSON.parse(rawBody) as unknown;
+      } catch {
+        return undefined;
+      }
+      const isPubsub =
+        isRecord(payload) &&
+        isRecord(payload.message) &&
+        typeof payload.message.data === "string" &&
+        typeof payload.subscription === "string";
+      const audience = isPubsub ? pubsubAudience : projectAudience;
+      if (!audience) {
+        throw new Error("Google Chat verification is not configured for this transport.");
+      }
+      const certificateUrl = isPubsub ? GOOGLE_OAUTH_CERTS_URL : GOOGLE_CHAT_CERTS_URL;
+      const claims = await verifySignedJwt({
+        audience,
+        issuers: isPubsub
+          ? ["accounts.google.com", "https://accounts.google.com"]
+          : [GOOGLE_CHAT_ISSUER],
+        now: runtime.now,
+        async resolveKey(header) {
+          const now = runtime.now?.() ?? Date.now();
+          let certificates = cachedCertificates.get(certificateUrl);
+          if (!certificates || certificates.expiresAt <= now) {
+            const response = await fetchImpl(certificateUrl);
+            if (!response.ok) {
+              throw new Error(`Google certificate fetch failed with HTTP ${response.status}.`);
+            }
+            const values = (await response.json()) as Record<string, string>;
+            certificates = { expiresAt: now + 60 * 60 * 1000, values };
+            cachedCertificates.set(certificateUrl, certificates);
+          }
+          const certificate = certificates.values[header.kid];
+          if (!certificate) {
+            throw new Error("Google JWT signing key is unknown.");
+          }
+          return createPublicKey(certificate);
+        },
+        token,
+      });
+      if (!isPubsub && claims.email !== GOOGLE_CHAT_ISSUER) {
+        throw new Error("Google Chat token identity is invalid.");
+      }
+      if (
+        isPubsub &&
+        (!pubsubServiceAccount ||
+          claims.email !== pubsubServiceAccount ||
+          claims.email_verified !== true)
+      ) {
+        throw new Error("Google Pub/Sub token identity is invalid.");
+      }
+      return undefined;
+    } catch {
+      return new Response("unauthorized", {
+        headers: { "www-authenticate": "Bearer" },
+        status: 401,
+      });
+    }
+  };
+}
+
+export function matchesGoogleChatThread(
+  candidateThreadId: string,
+  expectedThreadId: string | undefined,
+): boolean {
+  if (!expectedThreadId) {
+    return true;
+  }
+  return (
+    candidateThreadId === expectedThreadId ||
+    (GOOGLE_CHAT_SPACE_RULE.pattern.test(expectedThreadId) &&
+      candidateThreadId.startsWith(`${expectedThreadId}/threads/`))
+  );
+}
+
 export class GoogleChatProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
-  constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
+  constructor(id: string, config: ProviderConfig, _userName: string, runtime?: unknown) {
+    const authenticateWebhookRequest = createGoogleChatWebhookAuthenticator(
+      config,
+      (runtime as GoogleChatAuthRuntime | undefined) ?? {},
+    );
     super({
       codec: getBuiltinTargetCodec("googlechat"),
       config,
       id,
       options: {
+        ...(authenticateWebhookRequest ? { authenticateWebhookRequest } : {}),
         defaultWebhook: { host: "127.0.0.1", path: "/googlechat/webhook", port: 8792 },
         endpointLabel: "webhook endpoint",
+        matchesThread: matchesGoogleChatThread,
         normalizeWebhookPayload: normalizeGoogleChatWebhookPayload,
         platform: "googlechat",
         publicUrl: config.googlechat?.webhook.publicUrl,

--- a/src/providers/builtin/googlechat.ts
+++ b/src/providers/builtin/googlechat.ts
@@ -30,7 +30,7 @@ export function resolveGoogleChatAdapterConfig(
   };
 }
 
-const GOOGLE_CHAT_ISSUER = "chat@system.gserviceaccount.com";
+const GOOGLE_CHAT_SERVICE_ACCOUNT = "chat@system.gserviceaccount.com";
 const GOOGLE_OAUTH_CERTS_URL = "https://www.googleapis.com/oauth2/v1/certs";
 const GOOGLE_CHAT_CERTS_URL =
   "https://www.googleapis.com/service_accounts/v1/metadata/x509/chat@system.gserviceaccount.com";
@@ -47,10 +47,11 @@ export function createGoogleChatWebhookAuthenticator(
   if (config.googlechat?.disableSignatureVerification) {
     return undefined;
   }
+  const endpointAudience = config.googlechat?.endpointUrl;
   const projectAudience = config.googlechat?.googleChatProjectNumber;
   const pubsubAudience = config.googlechat?.pubsubAudience;
   const pubsubServiceAccount = config.googlechat?.credentials?.client_email;
-  if (!(projectAudience || pubsubAudience)) {
+  if (!(endpointAudience || projectAudience || pubsubAudience)) {
     return undefined;
   }
 
@@ -79,16 +80,19 @@ export function createGoogleChatWebhookAuthenticator(
         isRecord(payload.message) &&
         typeof payload.message.data === "string" &&
         typeof payload.subscription === "string";
-      const audience = isPubsub ? pubsubAudience : projectAudience;
+      const audience = isPubsub ? pubsubAudience : (endpointAudience ?? projectAudience);
       if (!audience) {
         throw new Error("Google Chat verification is not configured for this transport.");
       }
-      const certificateUrl = isPubsub ? GOOGLE_OAUTH_CERTS_URL : GOOGLE_CHAT_CERTS_URL;
+      const usesGoogleIdentityToken = isPubsub || endpointAudience !== undefined;
+      const certificateUrl = usesGoogleIdentityToken
+        ? GOOGLE_OAUTH_CERTS_URL
+        : GOOGLE_CHAT_CERTS_URL;
       const claims = await verifySignedJwt({
         audience,
-        issuers: isPubsub
+        issuers: usesGoogleIdentityToken
           ? ["accounts.google.com", "https://accounts.google.com"]
-          : [GOOGLE_CHAT_ISSUER],
+          : [GOOGLE_CHAT_SERVICE_ACCOUNT],
         now: runtime.now,
         async resolveKey(header) {
           const now = runtime.now?.() ?? Date.now();
@@ -117,6 +121,13 @@ export function createGoogleChatWebhookAuthenticator(
           claims.email_verified !== true)
       ) {
         throw new Error("Google Pub/Sub token identity is invalid.");
+      }
+      if (
+        !isPubsub &&
+        endpointAudience &&
+        (claims.email !== GOOGLE_CHAT_SERVICE_ACCOUNT || claims.email_verified !== true)
+      ) {
+        throw new Error("Google Chat ID token identity is invalid.");
       }
       return undefined;
     } catch {

--- a/src/providers/builtin/googlechat.ts
+++ b/src/providers/builtin/googlechat.ts
@@ -4,7 +4,7 @@ import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
 import { LocalMockProviderAdapter } from "../local-mock.js";
 import type { ProviderAdapter } from "../types.js";
-import { readBearerToken, verifySignedJwt } from "../signed-jwt.js";
+import { readBearerToken, resolveHttpCacheExpiry, verifySignedJwt } from "../signed-jwt.js";
 import {
   getBuiltinTargetCodec,
   GOOGLE_CHAT_SPACE_RULE,
@@ -60,6 +60,23 @@ export function createGoogleChatWebhookAuthenticator(
     string,
     { expiresAt: number; values: Record<string, string> }
   >();
+  const loadCertificates = async (certificateUrl: string, force: boolean) => {
+    const now = runtime.now?.() ?? Date.now();
+    const cached = cachedCertificates.get(certificateUrl);
+    if (!force && cached && cached.expiresAt > now) {
+      return cached;
+    }
+    const response = await fetchImpl(certificateUrl);
+    if (!response.ok) {
+      throw new Error(`Google certificate fetch failed with HTTP ${response.status}.`);
+    }
+    const certificates = {
+      expiresAt: resolveHttpCacheExpiry(response, now),
+      values: (await response.json()) as Record<string, string>,
+    };
+    cachedCertificates.set(certificateUrl, certificates);
+    return certificates;
+  };
   return async (request: Request, rawBody: string): Promise<Response | undefined> => {
     const token = readBearerToken(request);
     if (!token) {
@@ -80,11 +97,12 @@ export function createGoogleChatWebhookAuthenticator(
         isRecord(payload.message) &&
         typeof payload.message.data === "string" &&
         typeof payload.subscription === "string";
-      const audience = isPubsub ? pubsubAudience : (endpointAudience ?? projectAudience);
+      const audience = isPubsub ? pubsubAudience : (projectAudience ?? endpointAudience);
       if (!audience) {
         throw new Error("Google Chat verification is not configured for this transport.");
       }
-      const usesGoogleIdentityToken = isPubsub || endpointAudience !== undefined;
+      const usesGoogleIdentityToken =
+        isPubsub || (projectAudience === undefined && endpointAudience !== undefined);
       const certificateUrl = usesGoogleIdentityToken
         ? GOOGLE_OAUTH_CERTS_URL
         : GOOGLE_CHAT_CERTS_URL;
@@ -95,18 +113,12 @@ export function createGoogleChatWebhookAuthenticator(
           : [GOOGLE_CHAT_SERVICE_ACCOUNT],
         now: runtime.now,
         async resolveKey(header) {
-          const now = runtime.now?.() ?? Date.now();
-          let certificates = cachedCertificates.get(certificateUrl);
-          if (!certificates || certificates.expiresAt <= now) {
-            const response = await fetchImpl(certificateUrl);
-            if (!response.ok) {
-              throw new Error(`Google certificate fetch failed with HTTP ${response.status}.`);
-            }
-            const values = (await response.json()) as Record<string, string>;
-            certificates = { expiresAt: now + 60 * 60 * 1000, values };
-            cachedCertificates.set(certificateUrl, certificates);
+          let certificates = await loadCertificates(certificateUrl, false);
+          let certificate = certificates.values[header.kid];
+          if (!certificate) {
+            certificates = await loadCertificates(certificateUrl, true);
+            certificate = certificates.values[header.kid];
           }
-          const certificate = certificates.values[header.kid];
           if (!certificate) {
             throw new Error("Google JWT signing key is unknown.");
           }
@@ -124,7 +136,7 @@ export function createGoogleChatWebhookAuthenticator(
       }
       if (
         !isPubsub &&
-        endpointAudience &&
+        usesGoogleIdentityToken &&
         (claims.email !== GOOGLE_CHAT_SERVICE_ACCOUNT || claims.email_verified !== true)
       ) {
         throw new Error("Google Chat ID token identity is invalid.");

--- a/src/providers/builtin/googlechat.ts
+++ b/src/providers/builtin/googlechat.ts
@@ -110,9 +110,6 @@ export function createGoogleChatWebhookAuthenticator(
         },
         token,
       });
-      if (!isPubsub && claims.email !== GOOGLE_CHAT_ISSUER) {
-        throw new Error("Google Chat token identity is invalid.");
-      }
       if (
         isPubsub &&
         (!pubsubServiceAccount ||

--- a/src/providers/builtin/imessage.ts
+++ b/src/providers/builtin/imessage.ts
@@ -33,6 +33,7 @@ export class IMessageProviderAdapter extends LocalMockProviderAdapter implements
       options: {
         defaultWebhook: { host: "127.0.0.1", path: "/imessage/webhook", port: 8796 },
         endpointLabel: "webhook endpoint",
+        matchesThread: matchesIMessageThread,
         normalizeWebhookPayload: normalizeIMessageWebhookPayload,
         platform: "imessage",
         publicUrl: config.imessage?.webhook.publicUrl,
@@ -43,6 +44,18 @@ export class IMessageProviderAdapter extends LocalMockProviderAdapter implements
       },
     });
   }
+}
+
+export function matchesIMessageThread(
+  candidateThreadId: string,
+  expectedThreadId: string | undefined,
+  target: { id: string },
+): boolean {
+  return (
+    expectedThreadId === undefined ||
+    candidateThreadId === expectedThreadId ||
+    candidateThreadId === target.id
+  );
 }
 
 function normalizeIMessageWebhookPayload(payload: unknown) {
@@ -59,7 +72,7 @@ function normalizeIMessageWebhookPayload(payload: unknown) {
   }
 
   const data = optionalRecord(payload, "data") ?? payload;
-  const threadId = optionalString(data, "chatGuid") ?? optionalString(data, "chatIdentifier");
+  const threadId = optionalString(data, "chatIdentifier") ?? optionalString(data, "chatGuid");
   const text = optionalString(data, "text") ?? optionalString(data, "message");
   if (!threadId || !text) {
     throw new CrablineError("iMessage webhook payload requires chatGuid and text", {

--- a/src/providers/builtin/imessage.ts
+++ b/src/providers/builtin/imessage.ts
@@ -72,7 +72,7 @@ function normalizeIMessageWebhookPayload(payload: unknown) {
   }
 
   const data = optionalRecord(payload, "data") ?? payload;
-  const threadId = optionalString(data, "chatIdentifier") ?? optionalString(data, "chatGuid");
+  const threadId = optionalString(data, "chatGuid") ?? optionalString(data, "chatIdentifier");
   const text = optionalString(data, "text") ?? optionalString(data, "message");
   if (!threadId || !text) {
     throw new CrablineError("iMessage webhook payload requires chatGuid and text", {

--- a/src/providers/builtin/loopback.ts
+++ b/src/providers/builtin/loopback.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
 import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
 import { LocalMockProviderAdapter } from "../local-mock.js";
@@ -162,7 +164,18 @@ export class LoopbackChatAdapter {
       return Promise.resolve(result);
     }
 
+    if (!/^[1-9]\d*$/u.test(options.cursor)) {
+      throw new CrablineError("Loopback message cursor must be a positive safe integer.", {
+        kind: "config",
+      });
+    }
     const offset = Number(options.cursor);
+    if (!Number.isSafeInteger(offset) || offset > messages.length) {
+      throw new CrablineError(
+        "Loopback message cursor must be a positive safe integer within message history.",
+        { kind: "config" },
+      );
+    }
     const result: { messages: LoopbackMessage[]; nextCursor?: string } = {
       messages: messages.slice(Math.max(0, offset - limit), offset).map(cloneMessage),
     };
@@ -272,9 +285,10 @@ export class LoopbackProviderAdapter extends LocalMockProviderAdapter implements
       config,
       id,
       options: {
-        defaultWebhook: { host: "127.0.0.1", path: "/loopback/webhook", port: 8786 },
+        defaultWebhook: { host: "127.0.0.1", path: "/loopback/webhook", port: 0 },
         endpointLabel: "webhook endpoint",
         platform: "loopback",
+        recorderPath: path.resolve(".crabline", "recorders", `${id}-${randomUUID()}.jsonl`),
       },
     });
   }

--- a/src/providers/builtin/matrix.ts
+++ b/src/providers/builtin/matrix.ts
@@ -35,7 +35,9 @@ export function resolveMatrixAdapterConfig(
 }
 
 export class MatrixProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
-  constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
+  constructor(id: string, config: ProviderConfig, userName: string, _runtime?: unknown) {
+    const resolvedConfig = resolveMatrixAdapterConfig(config, userName);
+    const botUserId = resolvedConfig.auth.userID;
     super({
       codec: getBuiltinTargetCodec("matrix"),
       config,
@@ -43,7 +45,8 @@ export class MatrixProviderAdapter extends LocalMockProviderAdapter implements P
       options: {
         defaultWebhook: { host: "127.0.0.1", path: "/matrix/webhook", port: 8797 },
         endpointLabel: "webhook endpoint",
-        normalizeWebhookPayload: normalizeMatrixWebhookPayload,
+        matchesThread: matchesMatrixThread,
+        normalizeWebhookPayload: (payload) => normalizeMatrixWebhookPayload(payload, botUserId),
         platform: "matrix",
         publicUrl: config.matrix?.webhook.publicUrl,
         recorderPath: config.matrix?.recorder.path
@@ -55,7 +58,31 @@ export class MatrixProviderAdapter extends LocalMockProviderAdapter implements P
   }
 }
 
-export function normalizeMatrixWebhookPayload(payload: unknown) {
+function matrixThreadKey(roomId: string, threadId: string): string {
+  return `${roomId}:thread:${threadId}`;
+}
+
+export function matchesMatrixThread(
+  candidateThreadId: string,
+  expectedThreadId: string | undefined,
+  target: { channelId?: string | undefined },
+): boolean {
+  if (!expectedThreadId) {
+    return true;
+  }
+  const scopedExpected =
+    target.channelId && MATRIX_EVENT_ID_RULE.pattern.test(expectedThreadId)
+      ? matrixThreadKey(target.channelId, expectedThreadId)
+      : expectedThreadId;
+  return (
+    candidateThreadId === expectedThreadId ||
+    candidateThreadId === scopedExpected ||
+    (MATRIX_ROOM_ID_RULE.pattern.test(scopedExpected) &&
+      candidateThreadId.startsWith(`${scopedExpected}:thread:`))
+  );
+}
+
+export function normalizeMatrixWebhookPayload(payload: unknown, botUserId?: string) {
   if (!isRecord(payload)) {
     throw new CrablineError("Matrix webhook payload must be an object", { kind: "inbound" });
   }
@@ -71,6 +98,7 @@ export function normalizeMatrixWebhookPayload(payload: unknown) {
   const content = optionalRecord(payload, "content");
   const roomId = optionalString(payload, "room_id");
   const eventId = optionalString(payload, "event_id");
+  const senderId = optionalString(payload, "sender");
   const text = content ? optionalString(content, "body") : undefined;
   if (!roomId || !text) {
     throw new CrablineError("Matrix event payload requires room_id and content.body", {
@@ -85,14 +113,17 @@ export function normalizeMatrixWebhookPayload(payload: unknown) {
       : undefined;
 
   return {
-    author: authorFromBotFlag(false),
+    author: authorFromBotFlag(senderId !== undefined && senderId === botUserId),
     ...(eventId
       ? { id: requireNativeInboundId(eventId, MATRIX_EVENT_ID_RULE, "Matrix event_id") }
       : {}),
     raw: payload,
     text,
     threadId: threadRootId
-      ? requireNativeInboundId(threadRootId, MATRIX_EVENT_ID_RULE, "Matrix thread root event_id")
+      ? matrixThreadKey(
+          requireNativeInboundId(roomId, MATRIX_ROOM_ID_RULE, "Matrix room_id"),
+          requireNativeInboundId(threadRootId, MATRIX_EVENT_ID_RULE, "Matrix thread root event_id"),
+        )
       : requireNativeInboundId(roomId, MATRIX_ROOM_ID_RULE, "Matrix room_id"),
   };
 }

--- a/src/providers/builtin/mattermost.ts
+++ b/src/providers/builtin/mattermost.ts
@@ -33,6 +33,7 @@ export class MattermostProviderAdapter extends LocalMockProviderAdapter implemen
       options: {
         defaultWebhook: { host: "127.0.0.1", path: "/mattermost/webhook", port: 8793 },
         endpointLabel: "webhook endpoint",
+        matchesThread: matchesMattermostThread,
         normalizeWebhookPayload: normalizeMattermostWebhookPayload,
         platform: "mattermost",
         publicUrl: config.mattermost?.webhook.publicUrl,
@@ -45,7 +46,33 @@ export class MattermostProviderAdapter extends LocalMockProviderAdapter implemen
   }
 }
 
-function normalizeMattermostWebhookPayload(payload: unknown) {
+function mattermostThreadKey(channelId: string, rootId: string): string {
+  return `${channelId}:thread:${rootId}`;
+}
+
+export function matchesMattermostThread(
+  candidateThreadId: string,
+  expectedThreadId: string | undefined,
+  target: { channelId?: string | undefined },
+): boolean {
+  if (!expectedThreadId) {
+    return true;
+  }
+  const scopedExpected =
+    target.channelId &&
+    MATTERMOST_ID_RULE.pattern.test(expectedThreadId) &&
+    expectedThreadId !== target.channelId
+      ? mattermostThreadKey(target.channelId, expectedThreadId)
+      : expectedThreadId;
+  return (
+    candidateThreadId === expectedThreadId ||
+    candidateThreadId === scopedExpected ||
+    (MATTERMOST_ID_RULE.pattern.test(scopedExpected) &&
+      candidateThreadId.startsWith(`${scopedExpected}:thread:`))
+  );
+}
+
+export function normalizeMattermostWebhookPayload(payload: unknown) {
   if (!isRecord(payload)) {
     throw new CrablineError("Mattermost webhook payload must be an object", { kind: "inbound" });
   }
@@ -59,9 +86,9 @@ function normalizeMattermostWebhookPayload(payload: unknown) {
   }
 
   const channelId = optionalString(payload, "channel_id");
-  const threadId = optionalString(payload, "root_id") ?? channelId;
+  const rootId = optionalString(payload, "root_id");
   const text = optionalString(payload, "text");
-  if (!channelId || !threadId || !text) {
+  if (!channelId || !text) {
     throw new CrablineError("Mattermost webhook payload requires channel_id and text", {
       kind: "inbound",
     });
@@ -72,6 +99,11 @@ function normalizeMattermostWebhookPayload(payload: unknown) {
     ...(optionalString(payload, "post_id") ? { id: optionalString(payload, "post_id") } : {}),
     raw: payload,
     text,
-    threadId: requireNativeInboundId(threadId, MATTERMOST_ID_RULE, "Mattermost root_id"),
+    threadId: rootId
+      ? mattermostThreadKey(
+          requireNativeInboundId(channelId, MATTERMOST_ID_RULE, "Mattermost channel_id"),
+          requireNativeInboundId(rootId, MATTERMOST_ID_RULE, "Mattermost root_id"),
+        )
+      : requireNativeInboundId(channelId, MATTERMOST_ID_RULE, "Mattermost channel_id"),
   };
 }

--- a/src/providers/builtin/msteams.ts
+++ b/src/providers/builtin/msteams.ts
@@ -61,14 +61,16 @@ export function createMsTeamsWebhookAuthenticator(
       });
     }
     try {
-      let channelId: string | undefined;
-      try {
-        const payload: unknown = JSON.parse(rawBody);
-        channelId = isRecord(payload) ? optionalString(payload, "channelId") : undefined;
-      } catch {
-        // Authentication does not depend on the activity body.
+      const payload: unknown = JSON.parse(rawBody);
+      if (!isRecord(payload)) {
+        throw new Error("Bot Connector activity must be an object.");
       }
-      await verifySignedJwt({
+      const channelId = optionalString(payload, "channelId");
+      const serviceUrl = optionalString(payload, "serviceUrl");
+      if (!serviceUrl) {
+        throw new Error("Bot Connector activity omitted serviceUrl.");
+      }
+      const claims = await verifySignedJwt({
         audience: appId,
         issuers: [BOT_CONNECTOR_ISSUER],
         now: runtime.now,
@@ -116,6 +118,12 @@ export function createMsTeamsWebhookAuthenticator(
         },
         token,
       });
+      if (
+        typeof claims.serviceurl !== "string" ||
+        claims.serviceurl.localeCompare(serviceUrl, undefined, { sensitivity: "accent" }) !== 0
+      ) {
+        throw new Error("Bot Connector serviceurl claim does not match the activity.");
+      }
       return undefined;
     } catch {
       return new Response("unauthorized", {

--- a/src/providers/builtin/msteams.ts
+++ b/src/providers/builtin/msteams.ts
@@ -1,8 +1,10 @@
+import { createPublicKey, type JsonWebKey } from "node:crypto";
 import path from "node:path";
 import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
 import { LocalMockProviderAdapter } from "../local-mock.js";
 import type { ProviderAdapter } from "../types.js";
+import { readBearerToken, verifySignedJwt } from "../signed-jwt.js";
 import { getBuiltinTargetCodec, MSTEAMS_CONVERSATION_ID_RULE } from "../target-normalizers.js";
 import {
   authorFromBotFlag,
@@ -26,13 +28,116 @@ export function resolveMsTeamsAdapterConfig(
   };
 }
 
+const BOT_CONNECTOR_ISSUER = "https://api.botframework.com";
+const BOT_CONNECTOR_OPENID_URL =
+  "https://login.botframework.com/v1/.well-known/openidconfiguration";
+
+type MsTeamsAuthRuntime = {
+  fetch?: typeof fetch | undefined;
+  now?: (() => number) | undefined;
+};
+
+export function createMsTeamsWebhookAuthenticator(
+  config: ProviderConfig,
+  runtime: MsTeamsAuthRuntime = {},
+) {
+  const appId = config.msteams?.appId ?? process.env.TEAMS_APP_ID;
+  if (!appId) {
+    return undefined;
+  }
+  const fetchImpl = runtime.fetch ?? fetch;
+  let cachedKeys:
+    | {
+        expiresAt: number;
+        values: Array<JsonWebKey & { endorsements?: string[] | undefined; kid?: string }>;
+      }
+    | undefined;
+  return async (request: Request, rawBody: string): Promise<Response | undefined> => {
+    const token = readBearerToken(request);
+    if (!token) {
+      return new Response("unauthorized", {
+        headers: { "www-authenticate": "Bearer" },
+        status: 401,
+      });
+    }
+    try {
+      let channelId: string | undefined;
+      try {
+        const payload: unknown = JSON.parse(rawBody);
+        channelId = isRecord(payload) ? optionalString(payload, "channelId") : undefined;
+      } catch {
+        // Authentication does not depend on the activity body.
+      }
+      await verifySignedJwt({
+        audience: appId,
+        issuers: [BOT_CONNECTOR_ISSUER],
+        now: runtime.now,
+        async resolveKey(header) {
+          const now = runtime.now?.() ?? Date.now();
+          if (!cachedKeys || cachedKeys.expiresAt <= now) {
+            const metadataResponse = await fetchImpl(BOT_CONNECTOR_OPENID_URL);
+            if (!metadataResponse.ok) {
+              throw new Error(
+                `Bot Connector metadata fetch failed with HTTP ${metadataResponse.status}.`,
+              );
+            }
+            const metadata = (await metadataResponse.json()) as { jwks_uri?: unknown };
+            if (typeof metadata.jwks_uri !== "string") {
+              throw new Error("Bot Connector metadata omitted jwks_uri.");
+            }
+            const keysResponse = await fetchImpl(metadata.jwks_uri);
+            if (!keysResponse.ok) {
+              throw new Error(`Bot Connector key fetch failed with HTTP ${keysResponse.status}.`);
+            }
+            const keys = (await keysResponse.json()) as { keys?: unknown };
+            if (!Array.isArray(keys.keys)) {
+              throw new Error("Bot Connector key response omitted keys.");
+            }
+            cachedKeys = {
+              expiresAt: now + 60 * 60 * 1000,
+              values: keys.keys as Array<
+                JsonWebKey & { endorsements?: string[] | undefined; kid?: string }
+              >,
+            };
+          }
+          const key = cachedKeys.values.find((candidate) => candidate.kid === header.kid);
+          if (!key) {
+            throw new Error("Bot Connector JWT signing key is unknown.");
+          }
+          if (
+            channelId &&
+            key.endorsements &&
+            key.endorsements.length > 0 &&
+            !key.endorsements.includes(channelId)
+          ) {
+            throw new Error("Bot Connector JWT key does not endorse the activity channel.");
+          }
+          return createPublicKey({ format: "jwk", key });
+        },
+        token,
+      });
+      return undefined;
+    } catch {
+      return new Response("unauthorized", {
+        headers: { "www-authenticate": "Bearer" },
+        status: 401,
+      });
+    }
+  };
+}
+
 export class MsTeamsProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
-  constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
+  constructor(id: string, config: ProviderConfig, _userName: string, runtime?: unknown) {
+    const authenticateWebhookRequest = createMsTeamsWebhookAuthenticator(
+      config,
+      (runtime as MsTeamsAuthRuntime | undefined) ?? {},
+    );
     super({
       codec: getBuiltinTargetCodec("msteams"),
       config,
       id,
       options: {
+        ...(authenticateWebhookRequest ? { authenticateWebhookRequest } : {}),
         defaultWebhook: { host: "127.0.0.1", path: "/msteams/webhook", port: 8791 },
         endpointLabel: "webhook endpoint",
         normalizeWebhookPayload: normalizeMsTeamsWebhookPayload,
@@ -47,7 +152,7 @@ export class MsTeamsProviderAdapter extends LocalMockProviderAdapter implements 
   }
 }
 
-function normalizeMsTeamsWebhookPayload(payload: unknown) {
+export function normalizeMsTeamsWebhookPayload(payload: unknown) {
   if (!isRecord(payload)) {
     throw new CrablineError("Microsoft Teams webhook payload must be an object", {
       kind: "inbound",
@@ -62,6 +167,11 @@ function normalizeMsTeamsWebhookPayload(payload: unknown) {
     });
   }
 
+  if (optionalString(payload, "type") !== "message") {
+    throw new CrablineError("Microsoft Teams activity payload requires type=message", {
+      kind: "inbound",
+    });
+  }
   const conversation = optionalRecord(payload, "conversation");
   const from = optionalRecord(payload, "from");
   const conversationId = conversation ? optionalString(conversation, "id") : undefined;

--- a/src/providers/builtin/msteams.ts
+++ b/src/providers/builtin/msteams.ts
@@ -4,7 +4,7 @@ import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
 import { LocalMockProviderAdapter } from "../local-mock.js";
 import type { ProviderAdapter } from "../types.js";
-import { readBearerToken, verifySignedJwt } from "../signed-jwt.js";
+import { readBearerToken, resolveHttpCacheExpiry, verifySignedJwt } from "../signed-jwt.js";
 import { getBuiltinTargetCodec, MSTEAMS_CONVERSATION_ID_RULE } from "../target-normalizers.js";
 import {
   authorFromBotFlag,
@@ -52,6 +52,37 @@ export function createMsTeamsWebhookAuthenticator(
         values: Array<JsonWebKey & { endorsements?: string[] | undefined; kid?: string }>;
       }
     | undefined;
+  const loadKeys = async (force: boolean) => {
+    const now = runtime.now?.() ?? Date.now();
+    if (!force && cachedKeys && cachedKeys.expiresAt > now) {
+      return cachedKeys;
+    }
+    const metadataResponse = await fetchImpl(BOT_CONNECTOR_OPENID_URL);
+    if (!metadataResponse.ok) {
+      throw new Error(`Bot Connector metadata fetch failed with HTTP ${metadataResponse.status}.`);
+    }
+    const metadataExpiry = resolveHttpCacheExpiry(metadataResponse, now);
+    const metadata = (await metadataResponse.json()) as { jwks_uri?: unknown };
+    if (typeof metadata.jwks_uri !== "string") {
+      throw new Error("Bot Connector metadata omitted jwks_uri.");
+    }
+    const keysResponse = await fetchImpl(metadata.jwks_uri);
+    if (!keysResponse.ok) {
+      throw new Error(`Bot Connector key fetch failed with HTTP ${keysResponse.status}.`);
+    }
+    const keyExpiry = resolveHttpCacheExpiry(keysResponse, now);
+    const keys = (await keysResponse.json()) as { keys?: unknown };
+    if (!Array.isArray(keys.keys)) {
+      throw new Error("Bot Connector key response omitted keys.");
+    }
+    cachedKeys = {
+      expiresAt: Math.min(metadataExpiry, keyExpiry),
+      values: keys.keys as Array<
+        JsonWebKey & { endorsements?: string[] | undefined; kid?: string }
+      >,
+    };
+    return cachedKeys;
+  };
   return async (request: Request, rawBody: string): Promise<Response | undefined> => {
     const token = readBearerToken(request);
     if (!token) {
@@ -75,34 +106,12 @@ export function createMsTeamsWebhookAuthenticator(
         issuers: [BOT_CONNECTOR_ISSUER],
         now: runtime.now,
         async resolveKey(header) {
-          const now = runtime.now?.() ?? Date.now();
-          if (!cachedKeys || cachedKeys.expiresAt <= now) {
-            const metadataResponse = await fetchImpl(BOT_CONNECTOR_OPENID_URL);
-            if (!metadataResponse.ok) {
-              throw new Error(
-                `Bot Connector metadata fetch failed with HTTP ${metadataResponse.status}.`,
-              );
-            }
-            const metadata = (await metadataResponse.json()) as { jwks_uri?: unknown };
-            if (typeof metadata.jwks_uri !== "string") {
-              throw new Error("Bot Connector metadata omitted jwks_uri.");
-            }
-            const keysResponse = await fetchImpl(metadata.jwks_uri);
-            if (!keysResponse.ok) {
-              throw new Error(`Bot Connector key fetch failed with HTTP ${keysResponse.status}.`);
-            }
-            const keys = (await keysResponse.json()) as { keys?: unknown };
-            if (!Array.isArray(keys.keys)) {
-              throw new Error("Bot Connector key response omitted keys.");
-            }
-            cachedKeys = {
-              expiresAt: now + 60 * 60 * 1000,
-              values: keys.keys as Array<
-                JsonWebKey & { endorsements?: string[] | undefined; kid?: string }
-              >,
-            };
+          let keys = await loadKeys(false);
+          let key = keys.values.find((candidate) => candidate.kid === header.kid);
+          if (!key) {
+            keys = await loadKeys(true);
+            key = keys.values.find((candidate) => candidate.kid === header.kid);
           }
-          const key = cachedKeys.values.find((candidate) => candidate.kid === header.kid);
           if (!key) {
             throw new Error("Bot Connector JWT signing key is unknown.");
           }

--- a/src/providers/builtin/msteams.ts
+++ b/src/providers/builtin/msteams.ts
@@ -67,8 +67,8 @@ export function createMsTeamsWebhookAuthenticator(
       }
       const channelId = optionalString(payload, "channelId");
       const serviceUrl = optionalString(payload, "serviceUrl");
-      if (!serviceUrl) {
-        throw new Error("Bot Connector activity omitted serviceUrl.");
+      if (!channelId || !serviceUrl) {
+        throw new Error("Bot Connector activity omitted channelId or serviceUrl.");
       }
       const claims = await verifySignedJwt({
         audience: appId,
@@ -107,7 +107,6 @@ export function createMsTeamsWebhookAuthenticator(
             throw new Error("Bot Connector JWT signing key is unknown.");
           }
           if (
-            channelId &&
             key.endorsements &&
             key.endorsements.length > 0 &&
             !key.endorsements.includes(channelId)
@@ -118,10 +117,7 @@ export function createMsTeamsWebhookAuthenticator(
         },
         token,
       });
-      if (
-        typeof claims.serviceurl !== "string" ||
-        claims.serviceurl.localeCompare(serviceUrl, undefined, { sensitivity: "accent" }) !== 0
-      ) {
+      if (claims.serviceurl !== serviceUrl) {
         throw new Error("Bot Connector serviceurl claim does not match the activity.");
       }
       return undefined;

--- a/src/providers/builtin/script.ts
+++ b/src/providers/builtin/script.ts
@@ -125,7 +125,13 @@ function redactSensitiveEnvironmentValues(detail: string): string {
     .sort((left, right) => right.length - left.length);
 
   for (const value of new Set(values)) {
-    redacted = redacted.split(value).join("[redacted environment value]");
+    for (const representation of [
+      value,
+      JSON.stringify(value),
+      JSON.stringify(value).slice(1, -1),
+    ]) {
+      redacted = redacted.split(representation).join("[redacted environment value]");
+    }
   }
   return redacted;
 }
@@ -248,6 +254,9 @@ function runScript<T>(params: {
   timeoutGraceMs?: number | undefined;
   timeoutMs: number;
 }): Promise<T> {
+  if (params.signal?.aborted) {
+    return Promise.reject(params.signal.reason ?? new Error("Script command aborted."));
+  }
   return new Promise((resolve, reject) => {
     const child = spawn(params.command, {
       cwd: params.cwd ? path.resolve(params.cwd) : process.cwd(),
@@ -412,6 +421,12 @@ function watchScript(params: {
   shell?: string | undefined;
 }): AsyncGenerator<InboundEnvelope> {
   return (async function* () {
+    if (params.cancelSignal.aborted) {
+      return;
+    }
+    if (params.context.signal?.aborted) {
+      throw params.context.signal.reason ?? new Error("Script watch command aborted.");
+    }
     const payload = {
       ...createPayload(params.context),
       watch: {

--- a/src/providers/builtin/slack.ts
+++ b/src/providers/builtin/slack.ts
@@ -167,6 +167,17 @@ function matchesSlackThread(
   );
 }
 
+export function handleSlackWebhookPayload(payload: unknown): Response | undefined {
+  if (
+    isRecord(payload) &&
+    payload.type === "url_verification" &&
+    typeof payload.challenge === "string"
+  ) {
+    return Response.json({ challenge: payload.challenge });
+  }
+  return undefined;
+}
+
 export class SlackProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
     const resolvedConfig = resolveSlackAdapterConfig(config);
@@ -184,6 +195,7 @@ export class SlackProviderAdapter extends LocalMockProviderAdapter implements Pr
           : {}),
         defaultWebhook: { host: "127.0.0.1", path: "/slack/events", port: 8787 },
         endpointLabel: "events endpoint",
+        handleWebhookPayload: handleSlackWebhookPayload,
         matchesThread: matchesSlackThread,
         normalizeWebhookPayload: normalizeSlackEventsPayload,
         platform: "slack",

--- a/src/providers/builtin/whatsapp.ts
+++ b/src/providers/builtin/whatsapp.ts
@@ -6,8 +6,11 @@ import type { ProviderConfig } from "../../config/schema.js";
 import { LocalMockProviderAdapter, type LocalMockWebhookConfig } from "../local-mock.js";
 import {
   appendRecordedInbound,
+  cloneRecordedInboundCursor,
+  createRecordedInboundCursor,
   waitForRecordedInbound,
   watchRecordedInbound,
+  type RecordedInboundCursor,
 } from "../recorder.js";
 import type {
   InboundEnvelope,
@@ -53,6 +56,7 @@ const DEFAULT_WHATSAPP_WEBHOOK = {
   path: "/whatsapp/webhook",
   port: 8789,
 } as const;
+const MAX_WAIT_CURSORS = 64;
 
 export function resolveWhatsAppAdapterConfig(
   config: ProviderConfig,
@@ -76,6 +80,10 @@ export function resolveWhatsAppAdapterConfig(
 }
 
 type ResolvedWhatsAppAdapterConfig = ReturnType<typeof resolveWhatsAppAdapterConfig>;
+type WaitCursorState = {
+  active: number;
+  cursor?: RecordedInboundCursor | undefined;
+};
 
 export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   readonly #config: ProviderConfig;
@@ -87,6 +95,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
   #cleanupPromise: Promise<void> | null = null;
   readonly #inFlightSends = new Set<Promise<SendResult>>();
   readonly #inFlightWebhookRequests = new Set<Promise<Response>>();
+  readonly #waitCursors = new Map<string, WaitCursorState>();
   #server: StartedWebhookServer | null = null;
   #serverClosing: Promise<void> | null = null;
   #serverStarting: Promise<StartedWebhookServer> | null = null;
@@ -153,19 +162,53 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
   override async waitForInbound(context: WaitContext): Promise<InboundEnvelope | null> {
     await this.#ensureWebhookServer();
     const target = this.normalizeTarget(context.fixture.target);
-    return await waitForRecordedInbound({
-      filePath: this.#recorderPath,
-      matches: (event) =>
-        event.provider === this.id &&
-        isAddressInChannel(
-          event.threadId,
-          context.threadId ?? target.threadId ?? target.channelId ?? target.id,
-        ) &&
-        matchesInbound(event, context.fixture.inboundMatch, context.nonce),
-      since: context.since,
-      signal: context.signal,
-      timeoutMs: context.timeoutMs,
-    });
+    const channelId = context.threadId ?? target.threadId ?? target.channelId ?? target.id;
+    const cursorKey = JSON.stringify([
+      context.nonce,
+      context.since,
+      channelId,
+      context.fixture.inboundMatch,
+    ]);
+    const cursorState = this.#waitCursors.get(cursorKey) ?? { active: 0 };
+    const cursor = cursorState.cursor
+      ? cloneRecordedInboundCursor(cursorState.cursor)
+      : createRecordedInboundCursor();
+    cursorState.active++;
+    this.#waitCursors.delete(cursorKey);
+    this.#waitCursors.set(cursorKey, cursorState);
+    while (this.#waitCursors.size > MAX_WAIT_CURSORS) {
+      const oldestKey = this.#waitCursors.keys().next().value;
+      if (oldestKey !== undefined) {
+        this.#waitCursors.delete(oldestKey);
+      }
+    }
+    try {
+      const event = await waitForRecordedInbound({
+        cursor,
+        filePath: this.#recorderPath,
+        matches: (candidate) =>
+          candidate.provider === this.id &&
+          !isOutboundRecord(candidate) &&
+          isAddressInChannel(candidate.threadId, channelId) &&
+          matchesInbound(candidate, context.fixture.inboundMatch, context.nonce),
+        since: context.since,
+        signal: context.signal,
+        timeoutMs: context.timeoutMs,
+      });
+      if (event && this.#waitCursors.get(cursorKey) === cursorState) {
+        cursorState.cursor = cursor;
+      }
+      return event;
+    } finally {
+      cursorState.active--;
+      if (
+        cursorState.active === 0 &&
+        !cursorState.cursor &&
+        this.#waitCursors.get(cursorKey) === cursorState
+      ) {
+        this.#waitCursors.delete(cursorKey);
+      }
+    }
   }
 
   override async *watch(context: WatchContext): AsyncIterable<InboundEnvelope> {
@@ -175,6 +218,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
       filePath: this.#recorderPath,
       matches: (entry) =>
         entry.provider === this.id &&
+        !isOutboundRecord(entry) &&
         isAddressInChannel(entry.threadId, target.threadId ?? target.channelId ?? target.id),
       signal: context.signal,
       since: context.since,
@@ -195,6 +239,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
   override async cleanup(): Promise<void> {
     this.beginCleanup();
     this.#cleanedUp = true;
+    this.#waitCursors.clear();
     this.#cleanupPromise ??= (async () => {
       await Promise.allSettled([...this.#inFlightSends, ...this.#inFlightWebhookRequests]);
       const errors: unknown[] = [];
@@ -557,4 +602,13 @@ function isAddressInChannel(threadId: string, channelId?: string): boolean {
     return true;
   }
   return threadId === channelId || threadId.startsWith(`${channelId}:`);
+}
+
+function isOutboundRecord(event: InboundEnvelope): boolean {
+  return (
+    event.raw !== null &&
+    typeof event.raw === "object" &&
+    "direction" in event.raw &&
+    event.raw.direction === "outbound"
+  );
 }

--- a/src/providers/builtin/whatsapp.ts
+++ b/src/providers/builtin/whatsapp.ts
@@ -85,6 +85,17 @@ type WaitCursorState = {
   cursor?: RecordedInboundCursor | undefined;
 };
 
+function pruneInactiveWaitCursors(cursors: Map<string, WaitCursorState>): void {
+  for (const [key, state] of cursors) {
+    if (cursors.size <= MAX_WAIT_CURSORS) {
+      return;
+    }
+    if (state.active === 0) {
+      cursors.delete(key);
+    }
+  }
+}
+
 export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   readonly #config: ProviderConfig;
   readonly #publicUrl: string | undefined;
@@ -176,12 +187,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
     cursorState.active++;
     this.#waitCursors.delete(cursorKey);
     this.#waitCursors.set(cursorKey, cursorState);
-    while (this.#waitCursors.size > MAX_WAIT_CURSORS) {
-      const oldestKey = this.#waitCursors.keys().next().value;
-      if (oldestKey !== undefined) {
-        this.#waitCursors.delete(oldestKey);
-      }
-    }
+    pruneInactiveWaitCursors(this.#waitCursors);
     try {
       const event = await waitForRecordedInbound({
         cursor,

--- a/src/providers/builtin/zalo.ts
+++ b/src/providers/builtin/zalo.ts
@@ -74,23 +74,31 @@ export function normalizeZaloWebhookPayload(payload: unknown) {
     });
   }
 
-  const sender = optionalRecord(payload, "sender");
-  const message = optionalRecord(payload, "message");
+  const wrapped = optionalRecord(payload, "result") ?? payload;
+  const message = optionalRecord(wrapped, "message");
+  const sender = optionalRecord(message ?? {}, "from") ?? optionalRecord(wrapped, "sender");
+  const chat = message ? optionalRecord(message, "chat") : undefined;
   const senderId = sender ? optionalString(sender, "id") : undefined;
+  const chatId = chat ? optionalString(chat, "id") : senderId;
   const text = message ? optionalString(message, "text") : undefined;
-  if (!senderId || !text) {
-    throw new CrablineError("Zalo webhook payload requires sender.id and message.text", {
-      kind: "inbound",
-    });
+  if (!senderId || !chatId || !text) {
+    throw new CrablineError(
+      "Zalo webhook payload requires sender identity, chat identity, and text",
+      {
+        kind: "inbound",
+      },
+    );
   }
 
   return {
-    author: authorFromBotFlag(false),
-    ...(message && optionalString(message, "msg_id")
-      ? { id: optionalString(message, "msg_id") }
-      : {}),
+    author: authorFromBotFlag(sender?.is_bot === true),
+    ...(optionalString(message ?? {}, "message_id")
+      ? { id: optionalString(message ?? {}, "message_id") }
+      : optionalString(message ?? {}, "msg_id")
+        ? { id: optionalString(message ?? {}, "msg_id") }
+        : {}),
     raw: payload,
     text,
-    threadId: requireNativeInboundId(senderId, ZALO_ID_RULE, "Zalo sender.id"),
+    threadId: requireNativeInboundId(chatId, ZALO_ID_RULE, "Zalo chat.id"),
   };
 }

--- a/src/providers/local-mock.ts
+++ b/src/providers/local-mock.ts
@@ -3,6 +3,7 @@ import { CrablineError, ensureErrorMessage } from "../core/errors.js";
 import type { ProviderConfig, ProviderPlatform } from "../config/schema.js";
 import {
   appendRecordedInbound,
+  cloneRecordedInboundCursor,
   createRecordedInboundCursor,
   waitForRecordedInbound,
   watchRecordedInbound,
@@ -35,6 +36,7 @@ export type LocalMockAdapterOptions = {
     request: Request,
     rawBody: string,
   ) => Promise<Response | undefined> | Response | undefined;
+  createWebhookSuccessResponse?: (payload: unknown, id: string) => Promise<Response> | Response;
   defaultWebhook: Required<Pick<LocalMockWebhookConfig, "host" | "path" | "port">>;
   endpointLabel: string;
   matchesThread?: (
@@ -51,6 +53,11 @@ export type LocalMockAdapterOptions = {
 };
 
 const MAX_WAIT_CURSORS = 64;
+
+type WaitCursorState = {
+  active: number;
+  cursor?: RecordedInboundCursor | undefined;
+};
 
 export type LocalMockTargetCodec = {
   normalize(target: ProviderContext["fixture"]["target"]): NormalizedTarget;
@@ -134,9 +141,10 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
   readonly #options: LocalMockAdapterOptions;
   readonly #publicUrl: string | undefined;
   readonly #recorderPath: string;
-  readonly #waitCursors = new Map<string, RecordedInboundCursor>();
+  readonly #waitCursors = new Map<string, WaitCursorState>();
+  #cleanupBegun = false;
+  #cleanupPromise: Promise<void> | null = null;
   #server: StartedWebhookServer | null = null;
-  #serverClosing: Promise<void> | null = null;
   #serverStarting: Promise<StartedWebhookServer> | null = null;
 
   constructor(params: {
@@ -226,13 +234,14 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
     const target = this.normalizeTarget(context.fixture.target);
     const expectedAuthor = context.fixture.inboundMatch.author;
     const channelId = context.threadId ?? target.threadId ?? target.channelId;
-    const cursorKey = JSON.stringify([context.nonce, context.since, channelId]);
-    const existingCursor = this.#waitCursors.get(cursorKey);
-    if (existingCursor) {
-      this.#waitCursors.delete(cursorKey);
-    }
-    const cursor = existingCursor ?? createRecordedInboundCursor();
-    this.#waitCursors.set(cursorKey, cursor);
+    const cursorKey = JSON.stringify([context.nonce, context.since, channelId, expectedAuthor]);
+    const cursorState = this.#waitCursors.get(cursorKey) ?? { active: 0 };
+    const cursor = cursorState.cursor
+      ? cloneRecordedInboundCursor(cursorState.cursor)
+      : createRecordedInboundCursor();
+    cursorState.active++;
+    this.#waitCursors.delete(cursorKey);
+    this.#waitCursors.set(cursorKey, cursorState);
     while (this.#waitCursors.size > MAX_WAIT_CURSORS) {
       const oldestKey = this.#waitCursors.keys().next().value;
       if (oldestKey !== undefined) {
@@ -257,13 +266,19 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
         signal: context.signal,
         timeoutMs: context.timeoutMs,
       });
-      if (!event) {
-        this.#waitCursors.delete(cursorKey);
+      if (event && this.#waitCursors.get(cursorKey) === cursorState) {
+        cursorState.cursor = cursor;
       }
       return event;
-    } catch (error) {
-      this.#waitCursors.delete(cursorKey);
-      throw error;
+    } finally {
+      cursorState.active--;
+      if (
+        cursorState.active === 0 &&
+        !cursorState.cursor &&
+        this.#waitCursors.get(cursorKey) === cursorState
+      ) {
+        this.#waitCursors.delete(cursorKey);
+      }
     }
   }
 
@@ -288,21 +303,12 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
   }
 
   async cleanup(): Promise<void> {
-    this.#waitCursors.clear();
-    if (this.#serverClosing) {
-      await this.#serverClosing;
-      return;
+    if (!this.#cleanupBegun) {
+      this.#cleanupBegun = true;
+      this.#waitCursors.clear();
     }
-
-    const closing = this.#closeWebhookServer();
-    this.#serverClosing = closing;
-    try {
-      await closing;
-    } finally {
-      if (this.#serverClosing === closing) {
-        this.#serverClosing = null;
-      }
-    }
+    this.#cleanupPromise ??= this.#closeWebhookServer();
+    await this.#cleanupPromise;
   }
 
   async #handleWebhook(request: Request): Promise<Response> {
@@ -310,28 +316,36 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
     if (mediaType !== "application/json") {
       return new Response("expected application/json", { status: 415 });
     }
+    const rawBody = await request.text();
+    const authenticationFailure = await this.#options.authenticateWebhookRequest?.(
+      request,
+      rawBody,
+    );
+    if (authenticationFailure) {
+      return authenticationFailure;
+    }
+    let rawPayload: unknown;
+    try {
+      rawPayload = JSON.parse(rawBody) as unknown;
+    } catch {
+      return new Response("invalid JSON", { status: 400 });
+    }
+    const directResponse = await this.#options.handleWebhookPayload?.(rawPayload);
+    if (directResponse) {
+      return directResponse;
+    }
     let payload: MockWebhookPayload;
     try {
-      const rawBody = await request.text();
-      const authenticationFailure = await this.#options.authenticateWebhookRequest?.(
-        request,
-        rawBody,
-      );
-      if (authenticationFailure) {
-        return authenticationFailure;
-      }
-      const rawPayload = JSON.parse(rawBody) as unknown;
-      const directResponse = await this.#options.handleWebhookPayload?.(rawPayload);
-      if (directResponse) {
-        return directResponse;
-      }
       payload = normalizeWebhookPayload(
         this.#options.normalizeWebhookPayload
           ? this.#options.normalizeWebhookPayload(rawPayload)
           : rawPayload,
       );
     } catch (error) {
-      return new Response(ensureErrorMessage(error), { status: 400 });
+      if (error instanceof CrablineError && error.kind === "inbound") {
+        return new Response(ensureErrorMessage(error), { status: 400 });
+      }
+      throw error;
     }
 
     const id = payload.message?.id ?? payload.id ?? createMessageId(this.platform);
@@ -350,15 +364,18 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
       text,
       threadId,
     });
-    return new Response(JSON.stringify({ ok: true, id }), {
-      headers: { "content-type": "application/json" },
-      status: 200,
-    });
+    return (
+      (await this.#options.createWebhookSuccessResponse?.(rawPayload, id)) ??
+      new Response(JSON.stringify({ ok: true, id }), {
+        headers: { "content-type": "application/json" },
+        status: 200,
+      })
+    );
   }
 
   async #ensureWebhookServer(): Promise<StartedWebhookServer> {
-    if (this.#serverClosing) {
-      await this.#serverClosing;
+    if (this.#cleanupBegun) {
+      throw this.#cleanedUpError();
     }
     if (this.#server) {
       return this.#server;
@@ -390,6 +407,9 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
 
     try {
       const server = await starting;
+      if (this.#cleanupBegun) {
+        throw this.#cleanedUpError();
+      }
       this.#server = server;
       return server;
     } finally {
@@ -416,5 +436,9 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
       this.#server = null;
     }
     await server.close();
+  }
+
+  #cleanedUpError(): CrablineError {
+    return new CrablineError(`Provider "${this.id}" has been cleaned up.`, { kind: "config" });
   }
 }

--- a/src/providers/local-mock.ts
+++ b/src/providers/local-mock.ts
@@ -59,6 +59,17 @@ type WaitCursorState = {
   cursor?: RecordedInboundCursor | undefined;
 };
 
+function pruneInactiveWaitCursors(cursors: Map<string, WaitCursorState>): void {
+  for (const [key, state] of cursors) {
+    if (cursors.size <= MAX_WAIT_CURSORS) {
+      return;
+    }
+    if (state.active === 0) {
+      cursors.delete(key);
+    }
+  }
+}
+
 export type LocalMockTargetCodec = {
   normalize(target: ProviderContext["fixture"]["target"]): NormalizedTarget;
   resolveThreadId(target: ProviderContext["fixture"]["target"]): string;
@@ -242,12 +253,7 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
     cursorState.active++;
     this.#waitCursors.delete(cursorKey);
     this.#waitCursors.set(cursorKey, cursorState);
-    while (this.#waitCursors.size > MAX_WAIT_CURSORS) {
-      const oldestKey = this.#waitCursors.keys().next().value;
-      if (oldestKey !== undefined) {
-        this.#waitCursors.delete(oldestKey);
-      }
-    }
+    pruneInactiveWaitCursors(this.#waitCursors);
 
     try {
       const event = await waitForRecordedInbound({

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -43,6 +43,7 @@ export type RecordedInboundCursor = {
 };
 
 const CONTINUITY_BYTES = 4096;
+const MAX_PENDING_RECORD_BYTES = 1024 * 1024;
 
 function createIncrementalReadState(): IncrementalReadState {
   return {
@@ -58,6 +59,19 @@ export function createRecordedInboundCursor(): RecordedInboundCursor {
     buffered: [],
     readState: createIncrementalReadState(),
     seen: new Set(),
+  };
+}
+
+export function cloneRecordedInboundCursor(cursor: RecordedInboundCursor): RecordedInboundCursor {
+  return {
+    buffered: [...cursor.buffered],
+    readState: {
+      continuity: Buffer.from(cursor.readState.continuity),
+      identity: cursor.readState.identity ? { ...cursor.readState.identity } : undefined,
+      offset: cursor.readState.offset,
+      pending: Buffer.from(cursor.readState.pending),
+    },
+    seen: new Set(cursor.seen),
   };
 }
 
@@ -167,14 +181,27 @@ async function readRecordedInboundAppend(
     state.offset = position;
     state.continuity = Buffer.concat([state.continuity, ...chunks]).subarray(-CONTINUITY_BYTES);
 
+    if (chunks.length === 0) {
+      return [];
+    }
     const raw = Buffer.concat([state.pending, ...chunks]);
     const lastNewline = raw.lastIndexOf(0x0a);
     if (lastNewline < 0) {
+      if (raw.length > MAX_PENDING_RECORD_BYTES) {
+        throw new Error(
+          `Recorder record exceeded ${MAX_PENDING_RECORD_BYTES} bytes without a newline.`,
+        );
+      }
       state.pending = raw;
       return [];
     }
 
     state.pending = raw.subarray(lastNewline + 1);
+    if (state.pending.length > MAX_PENDING_RECORD_BYTES) {
+      throw new Error(
+        `Recorder record exceeded ${MAX_PENDING_RECORD_BYTES} bytes without a newline.`,
+      );
+    }
     const lines = raw
       .subarray(0, lastNewline)
       .toString("utf8")
@@ -218,18 +245,21 @@ export async function readRecordedInbound(filePath: string): Promise<RecordedInb
     throw error;
   }
 
-  const lines = raw.split("\n").filter((line) => line.trim().length > 0);
+  const lastNewline = raw.lastIndexOf("\n");
+  const completed = lastNewline >= 0 ? raw.slice(0, lastNewline) : "";
+  const tail = raw.slice(lastNewline + 1);
   const events: RecordedInboundEnvelope[] = [];
-  const hasUnterminatedTail = !raw.endsWith("\n");
 
-  for (const [index, line] of lines.entries()) {
-    try {
+  for (const line of completed.split("\n")) {
+    if (line.trim()) {
       events.push(JSON.parse(line) as RecordedInboundEnvelope);
-    } catch (error) {
-      if (hasUnterminatedTail && index === lines.length - 1) {
-        continue;
-      }
-      throw error;
+    }
+  }
+  if (tail.trim()) {
+    try {
+      events.push(JSON.parse(tail) as RecordedInboundEnvelope);
+    } catch {
+      // Ignore a partial final append; completed lines remain strict.
     }
   }
 

--- a/src/providers/signed-jwt.ts
+++ b/src/providers/signed-jwt.ts
@@ -37,6 +37,16 @@ export function readBearerToken(request: Request): string | undefined {
   return match?.[1];
 }
 
+export function resolveHttpCacheExpiry(response: Response, now: number): number {
+  const cacheControl = response.headers.get("cache-control");
+  const maxAge = /(?:^|,)\s*max-age=(\d+)/iu.exec(cacheControl ?? "");
+  if (maxAge) {
+    return now + Number(maxAge[1]) * 1_000;
+  }
+  const expires = Date.parse(response.headers.get("expires") ?? "");
+  return Number.isFinite(expires) && expires > now ? expires : now + 60 * 60 * 1_000;
+}
+
 export async function verifySignedJwt(params: {
   audience: string;
   clockSkewSeconds?: number | undefined;

--- a/src/providers/signed-jwt.ts
+++ b/src/providers/signed-jwt.ts
@@ -1,0 +1,80 @@
+import { verify, type KeyObject } from "node:crypto";
+
+type JwtHeader = {
+  alg: string;
+  kid: string;
+};
+
+export type JwtClaims = Record<string, unknown>;
+
+function decodeJsonPart(value: string): Record<string, unknown> {
+  const decoded: unknown = JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+  if (!decoded || typeof decoded !== "object" || Array.isArray(decoded)) {
+    throw new Error("JWT part must be a JSON object.");
+  }
+  return decoded as Record<string, unknown>;
+}
+
+function readHeader(value: Record<string, unknown>): JwtHeader {
+  if (value.alg !== "RS256" || typeof value.kid !== "string" || !value.kid) {
+    throw new Error("JWT must use RS256 and include a key id.");
+  }
+  return { alg: value.alg, kid: value.kid };
+}
+
+function hasAudience(claim: unknown, expected: string): boolean {
+  return claim === expected || (Array.isArray(claim) && claim.includes(expected));
+}
+
+function numericClaim(claims: JwtClaims, name: string): number | undefined {
+  const value = claims[name];
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+export function readBearerToken(request: Request): string | undefined {
+  const authorization = request.headers.get("authorization");
+  const match = /^Bearer\s+(\S+)$/iu.exec(authorization ?? "");
+  return match?.[1];
+}
+
+export async function verifySignedJwt(params: {
+  audience: string;
+  clockSkewSeconds?: number | undefined;
+  issuers: readonly string[];
+  now?: (() => number) | undefined;
+  resolveKey(header: JwtHeader): Promise<KeyObject>;
+  token: string;
+}): Promise<JwtClaims> {
+  const parts = params.token.split(".");
+  if (parts.length !== 3) {
+    throw new Error("JWT must contain three parts.");
+  }
+  const [encodedHeader, encodedClaims, encodedSignature] = parts as [string, string, string];
+  const header = readHeader(decodeJsonPart(encodedHeader));
+  const claims = decodeJsonPart(encodedClaims);
+  const key = await params.resolveKey(header);
+  const signature = Buffer.from(encodedSignature, "base64url");
+  if (!verify("RSA-SHA256", Buffer.from(`${encodedHeader}.${encodedClaims}`), key, signature)) {
+    throw new Error("JWT signature is invalid.");
+  }
+
+  if (!params.issuers.includes(String(claims.iss ?? ""))) {
+    throw new Error("JWT issuer is invalid.");
+  }
+  if (!hasAudience(claims.aud, params.audience)) {
+    throw new Error("JWT audience is invalid.");
+  }
+
+  const now = Math.floor((params.now?.() ?? Date.now()) / 1000);
+  const skew = params.clockSkewSeconds ?? 300;
+  const expiresAt = numericClaim(claims, "exp");
+  if (expiresAt === undefined || expiresAt < now - skew) {
+    throw new Error("JWT is expired.");
+  }
+  const notBefore = numericClaim(claims, "nbf");
+  if (notBefore !== undefined && notBefore > now + skew) {
+    throw new Error("JWT is not active.");
+  }
+
+  return claims;
+}

--- a/src/providers/target-normalizers.ts
+++ b/src/providers/target-normalizers.ts
@@ -71,13 +71,13 @@ export const MSTEAMS_CONVERSATION_ID_RULE: NativeIdRule = {
 export const TELEGRAM_CHAT_ID_RULE: NativeIdRule = {
   example: "-1001234567890 or @channelusername",
   name: "Telegram chat id",
-  pattern: /^(?:-?\d+|@[A-Za-z][A-Za-z0-9_]{4,31})$/u,
+  pattern: /^(?:-?[1-9]\d*|@[A-Za-z][A-Za-z0-9_]{4,31})$/u,
 };
 
 export const TELEGRAM_MESSAGE_THREAD_ID_RULE: NativeIdRule = {
   example: "42",
   name: "Telegram message_thread_id",
-  pattern: /^\d+$/u,
+  pattern: /^[1-9]\d*$/u,
 };
 
 export const WHATSAPP_WA_ID_RULE: NativeIdRule = {

--- a/src/providers/webhook-server.ts
+++ b/src/providers/webhook-server.ts
@@ -47,9 +47,11 @@ async function readRequestBody(request: IncomingMessage, maxBodyBytes: number): 
   });
 }
 
-async function toFetchRequest(request: IncomingMessage, maxBodyBytes: number): Promise<Request> {
-  const host = request.headers.host ?? "127.0.0.1";
-  const url = new URL(request.url ?? "/", `http://${host}`);
+async function toFetchRequest(
+  request: IncomingMessage,
+  url: URL,
+  maxBodyBytes: number,
+): Promise<Request> {
   const body =
     request.method === "GET" || request.method === "HEAD"
       ? undefined
@@ -117,13 +119,16 @@ export async function startWebhookServer(params: {
   const maxBodyBytes = params.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES;
   const server = createServer(async (request, response) => {
     try {
-      const fetchRequest = await toFetchRequest(request, maxBodyBytes);
-      const pathname = new URL(fetchRequest.url).pathname;
-      if (!methods.has(fetchRequest.method) || pathname !== params.path) {
+      const method = request.method ?? "GET";
+      const host = request.headers.host ?? "127.0.0.1";
+      const url = new URL(request.url ?? "/", `http://${host}`);
+      if (!methods.has(method) || url.pathname !== params.path) {
+        request.resume();
         await writeFetchResponse(response, new Response("not found", { status: 404 }));
         return;
       }
 
+      const fetchRequest = await toFetchRequest(request, url, maxBodyBytes);
       await writeFetchResponse(response, await params.handle(fetchRequest));
     } catch (error) {
       const status = error instanceof RequestBodyTooLargeError ? 413 : 500;

--- a/test/discord-provider.test.ts
+++ b/test/discord-provider.test.ts
@@ -3,13 +3,25 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { createServer } from "node:net";
 import { afterEach, describe, expect, it } from "vitest";
-import { DiscordProviderAdapter } from "../src/providers/builtin/discord.js";
+import {
+  createDiscordInteractionResponse,
+  DiscordProviderAdapter,
+} from "../src/providers/builtin/discord.js";
 import type { ProviderConfig } from "../src/config/schema.js";
 import type { ProviderContext } from "../src/providers/types.js";
 import { createTempDir, disposeTempDir } from "./test-helpers.js";
 
 const directories: string[] = [];
 const providers: DiscordProviderAdapter[] = [];
+
+describe("Discord interaction responses", () => {
+  it("returns a native component acknowledgement", async () => {
+    const response = createDiscordInteractionResponse({ type: 3 });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ type: 6 });
+  });
+});
 
 afterEach(async () => {
   await Promise.all(providers.splice(0).map((provider) => provider.cleanup()));
@@ -322,6 +334,7 @@ describe("discord provider", () => {
     });
 
     expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ type: 6 });
     await expect(
       provider.waitForInbound({
         ...context,

--- a/test/feishu-provider.test.ts
+++ b/test/feishu-provider.test.ts
@@ -1,11 +1,22 @@
 import { describe, expect, it } from "vitest";
 import {
   FeishuProviderAdapter,
+  handleFeishuWebhookPayload,
   normalizeFeishuWebhookPayload,
 } from "../src/providers/builtin/feishu.js";
 import { runLocalMockProviderContract } from "./local-mock-provider-helpers.js";
 
 describe("Feishu webhook normalizer", () => {
+  it("answers URL verification challenges", async () => {
+    const response = handleFeishuWebhookPayload({
+      challenge: "challenge-token",
+      type: "url_verification",
+    });
+
+    expect(response?.status).toBe(200);
+    await expect(response?.json()).resolves.toEqual({ challenge: "challenge-token" });
+  });
+
   it("uses the chat for ordinary messages and preserves message_id as the event id", () => {
     const payload = {
       event: {
@@ -13,6 +24,7 @@ describe("Feishu webhook normalizer", () => {
           chat_id: "oc_abc123",
           content: JSON.stringify({ text: "hello" }),
           message_id: "om_message123",
+          message_type: "text",
         },
       },
     };
@@ -30,6 +42,7 @@ describe("Feishu webhook normalizer", () => {
           chat_id: "oc_abc123",
           content: JSON.stringify({ text: "topic reply" }),
           message_id: "om_reply123",
+          message_type: "text",
           root_id: "om_root123",
         },
       },
@@ -39,6 +52,21 @@ describe("Feishu webhook normalizer", () => {
       id: "om_reply123",
       threadId: "om_root123",
     });
+  });
+
+  it("rejects non-text native messages", () => {
+    expect(() =>
+      normalizeFeishuWebhookPayload({
+        event: {
+          message: {
+            chat_id: "oc_abc123",
+            content: JSON.stringify({ text: "not really text" }),
+            message_id: "om_message123",
+            message_type: "image",
+          },
+        },
+      }),
+    ).toThrow(/message_type=text/u);
   });
 });
 
@@ -62,6 +90,7 @@ runLocalMockProviderContract({
         chat_id: "oc_abc123",
         content: JSON.stringify({ text: "reply nonce-2" }),
         message_id: "om_abc123",
+        message_type: "text",
       },
     },
   },

--- a/test/googlechat-provider.test.ts
+++ b/test/googlechat-provider.test.ts
@@ -25,6 +25,52 @@ function signedJwt(
 }
 
 describe("Google Chat webhook authentication", () => {
+  it("verifies HTTP endpoint audience ID tokens", async () => {
+    const config = await createLocalMockConfig("googlechat", "/googlechat/webhook");
+    config.googlechat!.endpointUrl = "https://chat.example.test/googlechat/webhook";
+    const keys = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const now = Date.now();
+    const authenticate = createGoogleChatWebhookAuthenticator(config, {
+      fetch: async () =>
+        Response.json({
+          "test-key": keys.publicKey.export({ format: "pem", type: "spki" }).toString(),
+        }),
+      now: () => now,
+    });
+    const body = JSON.stringify({ chat: { messagePayload: {} } });
+    const signedRequest = signedJwt(keys.privateKey, {
+      aud: config.googlechat!.endpointUrl,
+      email: "chat@system.gserviceaccount.com",
+      email_verified: true,
+      exp: Math.floor(now / 1000) + 60,
+      iss: "https://accounts.google.com",
+    });
+    await expect(
+      authenticate!(
+        new Request(config.googlechat!.endpointUrl, {
+          headers: { authorization: `Bearer ${signedRequest}` },
+        }),
+        body,
+      ),
+    ).resolves.toBeUndefined();
+
+    const wrongIdentity = signedJwt(keys.privateKey, {
+      aud: config.googlechat!.endpointUrl,
+      email: "other@example.iam.gserviceaccount.com",
+      email_verified: true,
+      exp: Math.floor(now / 1000) + 60,
+      iss: "https://accounts.google.com",
+    });
+    await expect(
+      authenticate!(
+        new Request(config.googlechat!.endpointUrl, {
+          headers: { authorization: `Bearer ${wrongIdentity}` },
+        }),
+        body,
+      ),
+    ).resolves.toMatchObject({ status: 401 });
+  });
+
   it("verifies configured direct webhook bearer tokens", async () => {
     const config = await createLocalMockConfig("googlechat", "/googlechat/webhook");
     config.googlechat!.googleChatProjectNumber = "1234567890";

--- a/test/googlechat-provider.test.ts
+++ b/test/googlechat-provider.test.ts
@@ -1,5 +1,123 @@
-import { GoogleChatProviderAdapter } from "../src/providers/builtin/googlechat.js";
-import { runLocalMockProviderContract } from "./local-mock-provider-helpers.js";
+import { generateKeyPairSync, sign } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import {
+  createGoogleChatWebhookAuthenticator,
+  GoogleChatProviderAdapter,
+  matchesGoogleChatThread,
+} from "../src/providers/builtin/googlechat.js";
+import {
+  createLocalMockConfig,
+  runLocalMockProviderContract,
+} from "./local-mock-provider-helpers.js";
+
+function signedJwt(
+  privateKey: ReturnType<typeof generateKeyPairSync>["privateKey"],
+  claims: Record<string, unknown>,
+): string {
+  const header = Buffer.from(JSON.stringify({ alg: "RS256", kid: "test-key" })).toString(
+    "base64url",
+  );
+  const payload = Buffer.from(JSON.stringify(claims)).toString("base64url");
+  const signature = sign("RSA-SHA256", Buffer.from(`${header}.${payload}`), privateKey).toString(
+    "base64url",
+  );
+  return `${header}.${payload}.${signature}`;
+}
+
+describe("Google Chat webhook authentication", () => {
+  it("verifies configured direct webhook bearer tokens", async () => {
+    const config = await createLocalMockConfig("googlechat", "/googlechat/webhook");
+    config.googlechat!.googleChatProjectNumber = "1234567890";
+    const keys = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const now = Date.now();
+    const authenticate = createGoogleChatWebhookAuthenticator(config, {
+      fetch: async () =>
+        Response.json({
+          "test-key": keys.publicKey.export({ format: "pem", type: "spki" }).toString(),
+        }),
+      now: () => now,
+    });
+    expect(authenticate).toBeDefined();
+    const url = "https://chat.example.test/googlechat/webhook";
+    const body = JSON.stringify({ chat: { messagePayload: {} } });
+    expect((await authenticate!(new Request(url), body))?.status).toBe(401);
+
+    const jwt = signedJwt(keys.privateKey, {
+      aud: config.googlechat!.googleChatProjectNumber,
+      email: "chat@system.gserviceaccount.com",
+      exp: Math.floor(now / 1000) + 60,
+      iss: "chat@system.gserviceaccount.com",
+    });
+    await expect(
+      authenticate!(
+        new Request(url, {
+          headers: { authorization: `Bearer ${jwt}` },
+        }),
+        body,
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("uses the configured Pub/Sub audience for push deliveries", async () => {
+    const config = await createLocalMockConfig("googlechat", "/googlechat/webhook");
+    config.googlechat!.pubsubAudience = "https://chat.example.test/pubsub";
+    config.googlechat!.credentials = {
+      client_email: "chat-push@example.iam.gserviceaccount.com",
+      private_key: "unused",
+    };
+    const keys = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const now = Date.now();
+    const authenticate = createGoogleChatWebhookAuthenticator(config, {
+      fetch: async () =>
+        Response.json({
+          "test-key": keys.publicKey.export({ format: "pem", type: "spki" }).toString(),
+        }),
+      now: () => now,
+    });
+    const body = JSON.stringify({
+      message: { data: Buffer.from("{}").toString("base64") },
+      subscription: "projects/example/subscriptions/chat",
+    });
+    const jwt = signedJwt(keys.privateKey, {
+      aud: config.googlechat!.pubsubAudience,
+      email: config.googlechat!.credentials.client_email,
+      email_verified: true,
+      exp: Math.floor(now / 1000) + 60,
+      iss: "https://accounts.google.com",
+    });
+
+    await expect(
+      authenticate!(
+        new Request("https://chat.example.test/googlechat/webhook", {
+          headers: { authorization: `Bearer ${jwt}` },
+        }),
+        body,
+      ),
+    ).resolves.toBeUndefined();
+
+    const wrongIdentityJwt = signedJwt(keys.privateKey, {
+      aud: config.googlechat!.pubsubAudience,
+      email: "other@example.iam.gserviceaccount.com",
+      email_verified: true,
+      exp: Math.floor(now / 1000) + 60,
+      iss: "https://accounts.google.com",
+    });
+    await expect(
+      authenticate!(
+        new Request("https://chat.example.test/googlechat/webhook", {
+          headers: { authorization: `Bearer ${wrongIdentityJwt}` },
+        }),
+        body,
+      ),
+    ).resolves.toMatchObject({ status: 401 });
+  });
+
+  it("matches native threads while waiting at space scope", async () => {
+    expect(
+      matchesGoogleChatThread("spaces/AAAABbbbCCC/threads/BBBBccccDDD", "spaces/AAAABbbbCCC"),
+    ).toBe(true);
+  });
+});
 
 runLocalMockProviderContract({
   Adapter: GoogleChatProviderAdapter,

--- a/test/googlechat-provider.test.ts
+++ b/test/googlechat-provider.test.ts
@@ -13,10 +13,9 @@ import {
 function signedJwt(
   privateKey: ReturnType<typeof generateKeyPairSync>["privateKey"],
   claims: Record<string, unknown>,
+  kid = "test-key",
 ): string {
-  const header = Buffer.from(JSON.stringify({ alg: "RS256", kid: "test-key" })).toString(
-    "base64url",
-  );
+  const header = Buffer.from(JSON.stringify({ alg: "RS256", kid })).toString("base64url");
   const payload = Buffer.from(JSON.stringify(claims)).toString("base64url");
   const signature = sign("RSA-SHA256", Buffer.from(`${header}.${payload}`), privateKey).toString(
     "base64url",
@@ -29,12 +28,23 @@ describe("Google Chat webhook authentication", () => {
     const config = await createLocalMockConfig("googlechat", "/googlechat/webhook");
     config.googlechat!.endpointUrl = "https://chat.example.test/googlechat/webhook";
     const keys = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const rotatedKeys = generateKeyPairSync("rsa", { modulusLength: 2048 });
     const now = Date.now();
+    let certificateFetches = 0;
     const authenticate = createGoogleChatWebhookAuthenticator(config, {
-      fetch: async () =>
-        Response.json({
+      fetch: async () => {
+        certificateFetches += 1;
+        return Response.json({
           "test-key": keys.publicKey.export({ format: "pem", type: "spki" }).toString(),
-        }),
+          ...(certificateFetches > 1
+            ? {
+                "rotated-key": rotatedKeys.publicKey
+                  .export({ format: "pem", type: "spki" })
+                  .toString(),
+              }
+            : {}),
+        });
+      },
       now: () => now,
     });
     const body = JSON.stringify({ chat: { messagePayload: {} } });
@@ -69,10 +79,32 @@ describe("Google Chat webhook authentication", () => {
         body,
       ),
     ).resolves.toMatchObject({ status: 401 });
+
+    const rotatedRequest = signedJwt(
+      rotatedKeys.privateKey,
+      {
+        aud: config.googlechat!.endpointUrl,
+        email: "chat@system.gserviceaccount.com",
+        email_verified: true,
+        exp: Math.floor(now / 1000) + 60,
+        iss: "https://accounts.google.com",
+      },
+      "rotated-key",
+    );
+    await expect(
+      authenticate!(
+        new Request(config.googlechat!.endpointUrl, {
+          headers: { authorization: `Bearer ${rotatedRequest}` },
+        }),
+        body,
+      ),
+    ).resolves.toBeUndefined();
+    expect(certificateFetches).toBe(2);
   });
 
   it("verifies configured direct webhook bearer tokens", async () => {
     const config = await createLocalMockConfig("googlechat", "/googlechat/webhook");
+    config.googlechat!.endpointUrl = "https://chat.example.test/googlechat/webhook";
     config.googlechat!.googleChatProjectNumber = "1234567890";
     const keys = generateKeyPairSync("rsa", { modulusLength: 2048 });
     const now = Date.now();

--- a/test/googlechat-provider.test.ts
+++ b/test/googlechat-provider.test.ts
@@ -44,7 +44,6 @@ describe("Google Chat webhook authentication", () => {
 
     const jwt = signedJwt(keys.privateKey, {
       aud: config.googlechat!.googleChatProjectNumber,
-      email: "chat@system.gserviceaccount.com",
       exp: Math.floor(now / 1000) + 60,
       iss: "chat@system.gserviceaccount.com",
     });

--- a/test/imessage-provider.test.ts
+++ b/test/imessage-provider.test.ts
@@ -1,5 +1,19 @@
-import { IMessageProviderAdapter } from "../src/providers/builtin/imessage.js";
+import {
+  IMessageProviderAdapter,
+  matchesIMessageThread,
+} from "../src/providers/builtin/imessage.js";
 import { runLocalMockProviderContract } from "./local-mock-provider-helpers.js";
+import { describe, expect, it } from "vitest";
+
+describe("iMessage thread matching", () => {
+  it("matches GUID targets when payloads also provide a public recipient", () => {
+    expect(
+      matchesIMessageThread("+15551234567", "iMessage;-;chat-guid-1", {
+        id: "+15551234567",
+      }),
+    ).toBe(true);
+  });
+});
 
 runLocalMockProviderContract({
   Adapter: IMessageProviderAdapter,
@@ -16,10 +30,11 @@ runLocalMockProviderContract({
   },
   webhookExpected: { author: "user", id: "imsg-guid-1", text: "reply nonce-2" },
   webhookPayload: {
+    chatIdentifier: "+15551234567",
     chatGuid: "iMessage;-;chat-guid-1",
     guid: "imsg-guid-1",
     isFromMe: false,
     text: "reply nonce-2",
   },
-  webhookThreadId: "iMessage;-;chat-guid-1",
+  webhookThreadId: "+15551234567",
 });

--- a/test/imessage-provider.test.ts
+++ b/test/imessage-provider.test.ts
@@ -36,5 +36,5 @@ runLocalMockProviderContract({
     isFromMe: false,
     text: "reply nonce-2",
   },
-  webhookThreadId: "+15551234567",
+  webhookThreadId: "iMessage;-;chat-guid-1",
 });

--- a/test/local-mock-provider.test.ts
+++ b/test/local-mock-provider.test.ts
@@ -517,6 +517,61 @@ describe("local mock provider", () => {
     await expect(provider.waitForInbound(contexts.at(-1)!)).resolves.toBeNull();
   });
 
+  it("does not evict active wait cursors when concurrency exceeds the retained limit", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const recorderPath = path.join(directory, "active-waits.jsonl");
+    const config = createConfig();
+    const provider = new LocalMockProviderAdapter({
+      codec: createGenericLocalMockTargetCodec("slack"),
+      config,
+      id: "provider-a",
+      options: {
+        defaultWebhook: { host: "127.0.0.1", path: "/slack/events", port: 0 },
+        endpointLabel: "events endpoint",
+        platform: "slack",
+        recorderPath,
+      },
+    });
+    providers.push(provider);
+    const contexts = Array.from({ length: 65 }, (_, index) => {
+      const context = createContext(config);
+      context.fixture.target = { id: `channel-${index}`, metadata: {} };
+      return {
+        ...context,
+        nonce: `active-${index}`,
+        since: new Date(0).toISOString(),
+        threadId: `channel-${index}`,
+        timeoutMs: 1_000,
+      };
+    });
+    const waits = contexts.map((context) => provider.waitForInbound(context));
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    for (const [index, context] of contexts.entries()) {
+      await appendRecordedInbound(recorderPath, {
+        author: "assistant",
+        id: `first-${index}`,
+        provider: "provider-a",
+        sentAt: new Date().toISOString(),
+        text: `first ${index}`,
+        threadId: context.threadId,
+      });
+    }
+    await expect(Promise.all(waits)).resolves.toHaveLength(65);
+
+    await appendRecordedInbound(recorderPath, {
+      author: "assistant",
+      id: "second-0",
+      provider: "provider-a",
+      sentAt: new Date().toISOString(),
+      text: "second 0",
+      threadId: contexts[0]!.threadId,
+    });
+    await expect(provider.waitForInbound(contexts[0]!)).resolves.toMatchObject({
+      id: "second-0",
+    });
+  });
+
   it("keeps concurrent same-key waits on independent cursors", async () => {
     const directory = await createTempDir();
     directories.push(directory);

--- a/test/local-mock-provider.test.ts
+++ b/test/local-mock-provider.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ManifestDefinition, ProviderConfig } from "../src/config/schema.js";
 import { runFixtureCommand } from "../src/core/run.js";
 import { SlackProviderAdapter } from "../src/providers/builtin/slack.js";
+import { LoopbackProviderAdapter } from "../src/providers/builtin/loopback.js";
 import { OPENCLAW_SUPPORT_CATALOG } from "../src/providers/catalog.js";
 import {
   createGenericLocalMockTargetCodec,
@@ -158,6 +159,35 @@ describe("local mock provider", () => {
     expect(close).toHaveBeenCalledTimes(1);
   });
 
+  it("closes a listener that finishes starting after cleanup begins", async () => {
+    let resolveStart:
+      | ((server: { close(): Promise<void>; endpointUrl: string }) => void)
+      | undefined;
+    const close = vi.fn(async () => undefined);
+    webhookMocks.startWebhookServer.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveStart = resolve;
+      }),
+    );
+    const config = createConfig();
+    const provider = new SlackProviderAdapter("provider-a", config, "crabline");
+    providers.push(provider);
+    const probe = provider.probe(createContext(config));
+    await vi.waitFor(() => expect(webhookMocks.startWebhookServer).toHaveBeenCalledTimes(1));
+    const cleanup = provider.cleanup();
+
+    resolveStart?.({
+      close,
+      endpointUrl: "http://127.0.0.1:43210/slack/events",
+    });
+
+    await expect(probe).rejects.toThrow('Provider "provider-a" has been cleaned up.');
+    await expect(cleanup).resolves.toBeUndefined();
+    expect(close).toHaveBeenCalledTimes(1);
+    await expect(provider.probe(createContext(config))).rejects.toThrow(/cleaned up/u);
+    expect(webhookMocks.startWebhookServer).toHaveBeenCalledTimes(1);
+  });
+
   it("falls back to the webhook public URL and gives the top-level option precedence", async () => {
     const config = createConfig();
     const context = createContext(config);
@@ -200,6 +230,54 @@ describe("local mock provider", () => {
       "public webhook https://webhook.example.test/slack/events",
     );
   });
+
+  it.each(["authenticateWebhookRequest", "handleWebhookPayload"] as const)(
+    "does not expose arbitrary %s failures as public 400 responses",
+    async (hook) => {
+      let handleRequest: ((request: Request) => Promise<Response>) | undefined;
+      webhookMocks.startWebhookServer.mockImplementationOnce(async (params) => {
+        handleRequest = params.handle;
+        return {
+          async close() {},
+          endpointUrl: "http://127.0.0.1:43210/slack/events",
+        };
+      });
+      const config = createConfig();
+      const provider = new LocalMockProviderAdapter({
+        codec: createGenericLocalMockTargetCodec("slack"),
+        config,
+        id: "provider-a",
+        options: {
+          ...(hook === "authenticateWebhookRequest"
+            ? {
+                authenticateWebhookRequest() {
+                  throw new Error("sensitive auth failure");
+                },
+              }
+            : {
+                handleWebhookPayload() {
+                  throw new Error("sensitive hook failure");
+                },
+              }),
+          defaultWebhook: { host: "127.0.0.1", path: "/slack/events", port: 0 },
+          endpointLabel: "events endpoint",
+          platform: "slack",
+        },
+      });
+      providers.push(provider);
+      await provider.probe(createContext(config));
+
+      await expect(
+        handleRequest!(
+          new Request("http://127.0.0.1:43210/slack/events", {
+            body: "{}",
+            headers: { "content-type": "application/json" },
+            method: "POST",
+          }),
+        ),
+      ).rejects.toThrow(/sensitive/u);
+    },
+  );
 
   it("does not watch events from another provider sharing its recorder", async () => {
     const directory = await createTempDir();
@@ -437,5 +515,143 @@ describe("local mock provider", () => {
       id: "event-0",
     });
     await expect(provider.waitForInbound(contexts.at(-1)!)).resolves.toBeNull();
+  });
+
+  it("keeps concurrent same-key waits on independent cursors", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const recorderPath = path.join(directory, "concurrent-waits.jsonl");
+    const config = createConfig();
+    config.slack!.recorder.path = recorderPath;
+    const provider = new SlackProviderAdapter("provider-a", config, "crabline");
+    providers.push(provider);
+    const context = {
+      ...createContext(config),
+      nonce: "same-key",
+      since: new Date(0).toISOString(),
+      threadId: "C1234567890",
+      timeoutMs: 500,
+    };
+    await appendRecordedInbound(recorderPath, {
+      author: "assistant",
+      id: "initial",
+      provider: "provider-a",
+      sentAt: new Date().toISOString(),
+      text: "initial",
+      threadId: "C1234567890",
+    });
+    await expect(provider.waitForInbound(context)).resolves.toMatchObject({ id: "initial" });
+
+    const firstWait = provider.waitForInbound(context);
+    const secondWait = provider.waitForInbound(context);
+    await appendRecordedInbound(recorderPath, {
+      author: "assistant",
+      id: "first",
+      provider: "provider-a",
+      sentAt: new Date().toISOString(),
+      text: "first",
+      threadId: "C1234567890",
+    });
+    await appendRecordedInbound(recorderPath, {
+      author: "assistant",
+      id: "second",
+      provider: "provider-a",
+      sentAt: new Date().toISOString(),
+      text: "second",
+      threadId: "C1234567890",
+    });
+
+    await expect(Promise.all([firstWait, secondWait])).resolves.toEqual([
+      expect.objectContaining({ id: "first" }),
+      expect.objectContaining({ id: "first" }),
+    ]);
+    await expect(provider.waitForInbound(context)).resolves.toMatchObject({ id: "second" });
+  });
+
+  it("keeps progress when a newer same-key wait is aborted", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const recorderPath = path.join(directory, "aborted-concurrent-wait.jsonl");
+    const config = createConfig();
+    config.slack!.recorder.path = recorderPath;
+    const provider = new SlackProviderAdapter("provider-a", config, "crabline");
+    providers.push(provider);
+    const context = {
+      ...createContext(config),
+      nonce: "same-key",
+      since: new Date(0).toISOString(),
+      threadId: "C1234567890",
+      timeoutMs: 500,
+    };
+    const olderWait = provider.waitForInbound(context);
+    const abortController = new AbortController();
+    const newerWait = provider.waitForInbound({
+      ...context,
+      signal: abortController.signal,
+    });
+    abortController.abort();
+    await expect(newerWait).resolves.toBeNull();
+
+    await appendRecordedInbound(recorderPath, {
+      author: "assistant",
+      id: "after-abort",
+      provider: "provider-a",
+      sentAt: new Date().toISOString(),
+      text: "after abort",
+      threadId: "C1234567890",
+    });
+    await expect(olderWait).resolves.toMatchObject({ id: "after-abort" });
+    await expect(provider.waitForInbound({ ...context, timeoutMs: 30 })).resolves.toBeNull();
+  });
+
+  it("isolates same-id loopback provider listeners and recorders", async () => {
+    const config: ProviderConfig = {
+      adapter: "loopback",
+      capabilities: ["probe", "send", "roundtrip", "agent"],
+      env: [],
+      loopback: { delayMs: 0 },
+      platform: "loopback",
+      status: "active",
+    };
+    const first = new LoopbackProviderAdapter("loopback", config, "crabline");
+    const second = new LoopbackProviderAdapter("loopback", config, "crabline");
+    providers.push(first, second);
+    const context: ProviderContext = {
+      config,
+      fixture: {
+        env: [],
+        id: "loopback-agent",
+        inboundMatch: { author: "assistant", nonce: "ignore", strategy: "contains" },
+        mode: "agent",
+        provider: "loopback",
+        retries: 0,
+        tags: [],
+        target: { id: "recipient", metadata: {} },
+        timeoutMs: 50,
+      },
+      manifestPath: "/tmp/crabline.yaml",
+      providerId: "loopback",
+      userName: "crabline",
+    };
+
+    const [firstProbe, secondProbe] = await Promise.all([
+      first.probe(context),
+      second.probe(context),
+    ]);
+    expect(webhookMocks.startWebhookServer).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ port: 0 }),
+    );
+    expect(webhookMocks.startWebhookServer).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ port: 0 }),
+    );
+    const firstRecorder = firstProbe.details.find((detail) => detail.startsWith("recorder path "));
+    const secondRecorder = secondProbe.details.find((detail) =>
+      detail.startsWith("recorder path "),
+    );
+    expect(firstRecorder).toBeDefined();
+    expect(secondRecorder).toBeDefined();
+    expect(firstRecorder).not.toBe(secondRecorder);
   });
 });

--- a/test/loopback-adapter.test.ts
+++ b/test/loopback-adapter.test.ts
@@ -70,6 +70,18 @@ describe("loopback chat adapter", () => {
     expect(() => adapter!.fetchMessages("thread-1", { limit })).toThrow(/positive safe integer/u);
   });
 
+  it.each(["0", "-1", "1.5", "not-a-cursor", "9007199254740992"])(
+    "rejects invalid message cursors: %s",
+    (cursor) => {
+      adapter = new LoopbackChatAdapter("crabline");
+      const threadId = adapter.encodeThreadId({ id: "user-1" });
+      adapter.ingestUserMessage(threadId, "first");
+      expect(() => adapter!.fetchMessages(threadId, { cursor, limit: 1 })).toThrow(
+        /positive safe integer/u,
+      );
+    },
+  );
+
   it("isolates stored messages from mutable inputs and returns", async () => {
     adapter = new LoopbackChatAdapter("crabline");
     const threadId = adapter.encodeThreadId({ id: "user-1" });

--- a/test/matrix-provider.test.ts
+++ b/test/matrix-provider.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   MatrixProviderAdapter,
+  matchesMatrixThread,
   normalizeMatrixWebhookPayload,
 } from "../src/providers/builtin/matrix.js";
 import { runLocalMockProviderContract } from "./local-mock-provider-helpers.js";
@@ -14,7 +15,8 @@ describe("Matrix webhook normalizer", () => {
       type: "m.room.message",
     };
 
-    expect(normalizeMatrixWebhookPayload(payload)).toMatchObject({
+    expect(normalizeMatrixWebhookPayload(payload, "@bot:matrix.org")).toMatchObject({
+      author: "user",
       id: "$event123:matrix.org",
       threadId: "!abc123:matrix.org",
     });
@@ -35,10 +37,33 @@ describe("Matrix webhook normalizer", () => {
       type: "m.room.message",
     };
 
-    expect(normalizeMatrixWebhookPayload(payload)).toMatchObject({
+    expect(normalizeMatrixWebhookPayload(payload, "@bot:matrix.org")).toMatchObject({
       id: "$reply123:matrix.org",
-      threadId: "$root123:matrix.org",
+      threadId: "!abc123:matrix.org:thread:$root123:matrix.org",
     });
+  });
+
+  it("attributes events from the configured Matrix user to the assistant", () => {
+    expect(
+      normalizeMatrixWebhookPayload(
+        {
+          content: { body: "bot reply", msgtype: "m.text" },
+          event_id: "$bot123:matrix.org",
+          room_id: "!abc123:matrix.org",
+          sender: "@bot:matrix.org",
+          type: "m.room.message",
+        },
+        "@bot:matrix.org",
+      ),
+    ).toMatchObject({ author: "assistant" });
+  });
+
+  it("matches local thread replies before native room scoping", () => {
+    expect(
+      matchesMatrixThread("$event123:matrix.org", "$event123:matrix.org", {
+        channelId: "!abc123:matrix.org",
+      }),
+    ).toBe(true);
   });
 });
 

--- a/test/mattermost-provider.test.ts
+++ b/test/mattermost-provider.test.ts
@@ -1,5 +1,32 @@
-import { MattermostProviderAdapter } from "../src/providers/builtin/mattermost.js";
+import { describe, expect, it } from "vitest";
+import {
+  MattermostProviderAdapter,
+  matchesMattermostThread,
+  normalizeMattermostWebhookPayload,
+} from "../src/providers/builtin/mattermost.js";
 import { runLocalMockProviderContract } from "./local-mock-provider-helpers.js";
+
+describe("Mattermost webhook normalizer", () => {
+  it("preserves the channel when normalizing thread replies", () => {
+    expect(
+      normalizeMattermostWebhookPayload({
+        channel_id: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+        root_id: "bbbbbbbbbbbbbbbbbbbbbbbbbb",
+        text: "thread reply",
+      }),
+    ).toMatchObject({
+      threadId: "aaaaaaaaaaaaaaaaaaaaaaaaaa:thread:bbbbbbbbbbbbbbbbbbbbbbbbbb",
+    });
+  });
+
+  it("matches local thread replies before native channel scoping", () => {
+    expect(
+      matchesMattermostThread("bbbbbbbbbbbbbbbbbbbbbbbbbb", "bbbbbbbbbbbbbbbbbbbbbbbbbb", {
+        channelId: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+      }),
+    ).toBe(true);
+  });
+});
 
 runLocalMockProviderContract({
   Adapter: MattermostProviderAdapter,
@@ -21,5 +48,5 @@ runLocalMockProviderContract({
     root_id: "bbbbbbbbbbbbbbbbbbbbbbbbbb",
     text: "reply nonce-2",
   },
-  webhookThreadId: "bbbbbbbbbbbbbbbbbbbbbbbbbb",
+  webhookThreadId: "aaaaaaaaaaaaaaaaaaaaaaaaaa:thread:bbbbbbbbbbbbbbbbbbbbbbbbbb",
 });

--- a/test/msteams-provider.test.ts
+++ b/test/msteams-provider.test.ts
@@ -94,6 +94,32 @@ describe("Microsoft Teams webhook authentication", () => {
         body,
       ),
     ).resolves.toMatchObject({ status: 401 });
+
+    const caseMismatchedBody = JSON.stringify({
+      ...JSON.parse(body),
+      serviceUrl: "https://smba.trafficmanager.net/EMEA/",
+    });
+    await expect(
+      authenticate!(
+        new Request(url, {
+          headers: { authorization: `Bearer ${header}.${payload}.${signature}` },
+        }),
+        caseMismatchedBody,
+      ),
+    ).resolves.toMatchObject({ status: 401 });
+
+    const missingChannelBody = JSON.stringify({
+      ...JSON.parse(body),
+      channelId: undefined,
+    });
+    await expect(
+      authenticate!(
+        new Request(url, {
+          headers: { authorization: `Bearer ${header}.${payload}.${signature}` },
+        }),
+        missingChannelBody,
+      ),
+    ).resolves.toMatchObject({ status: 401 });
   });
 });
 

--- a/test/msteams-provider.test.ts
+++ b/test/msteams-provider.test.ts
@@ -54,6 +54,7 @@ describe("Microsoft Teams webhook authentication", () => {
         aud: "teams-app-id",
         exp: Math.floor(now / 1000) + 60,
         iss: "https://api.botframework.com",
+        serviceurl: serviceUrl,
       }),
     ).toString("base64url");
     const signature = sign(
@@ -69,6 +70,30 @@ describe("Microsoft Teams webhook authentication", () => {
         body,
       ),
     ).resolves.toBeUndefined();
+
+    const mismatchedPayload = Buffer.from(
+      JSON.stringify({
+        aud: "teams-app-id",
+        exp: Math.floor(now / 1000) + 60,
+        iss: "https://api.botframework.com",
+        serviceurl: "https://smba.trafficmanager.net/amer/",
+      }),
+    ).toString("base64url");
+    const mismatchedSignature = sign(
+      "RSA-SHA256",
+      Buffer.from(`${header}.${mismatchedPayload}`),
+      keys.privateKey,
+    ).toString("base64url");
+    await expect(
+      authenticate!(
+        new Request(url, {
+          headers: {
+            authorization: `Bearer ${header}.${mismatchedPayload}.${mismatchedSignature}`,
+          },
+        }),
+        body,
+      ),
+    ).resolves.toMatchObject({ status: 401 });
   });
 });
 

--- a/test/msteams-provider.test.ts
+++ b/test/msteams-provider.test.ts
@@ -22,13 +22,30 @@ describe("Microsoft Teams webhook authentication", () => {
     const config = await createLocalMockConfig("msteams", "/msteams/webhook");
     config.msteams!.appId = "teams-app-id";
     const keys = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const rotatedKeys = generateKeyPairSync("rsa", { modulusLength: 2048 });
     const now = Date.now();
     const jwk = keys.publicKey.export({ format: "jwk" });
+    const rotatedJwk = rotatedKeys.publicKey.export({ format: "jwk" });
+    let keyFetches = 0;
     const authenticate = createMsTeamsWebhookAuthenticator(config, {
-      fetch: async (input: string | URL | Request) =>
-        String(input).includes("openidconfiguration")
-          ? Response.json({ jwks_uri: "https://login.example.test/keys" })
-          : Response.json({ keys: [{ ...jwk, kid: "test-key" }] }),
+      fetch: async (input: string | URL | Request) => {
+        if (String(input).includes("openidconfiguration")) {
+          return Response.json(
+            { jwks_uri: "https://login.example.test/keys" },
+            { headers: { "cache-control": "max-age=3600" } },
+          );
+        }
+        keyFetches += 1;
+        return Response.json(
+          {
+            keys: [
+              { ...jwk, kid: "test-key" },
+              ...(keyFetches > 1 ? [{ ...rotatedJwk, kid: "rotated-key" }] : []),
+            ],
+          },
+          { headers: { "cache-control": "max-age=3600" } },
+        );
+      },
       now: () => now,
     });
     expect(authenticate).toBeDefined();
@@ -70,6 +87,26 @@ describe("Microsoft Teams webhook authentication", () => {
         body,
       ),
     ).resolves.toBeUndefined();
+
+    const rotatedHeader = Buffer.from(
+      JSON.stringify({ alg: "RS256", kid: "rotated-key" }),
+    ).toString("base64url");
+    const rotatedSignature = sign(
+      "RSA-SHA256",
+      Buffer.from(`${rotatedHeader}.${payload}`),
+      rotatedKeys.privateKey,
+    ).toString("base64url");
+    await expect(
+      authenticate!(
+        new Request(url, {
+          headers: {
+            authorization: `Bearer ${rotatedHeader}.${payload}.${rotatedSignature}`,
+          },
+        }),
+        body,
+      ),
+    ).resolves.toBeUndefined();
+    expect(keyFetches).toBe(2);
 
     const mismatchedPayload = Buffer.from(
       JSON.stringify({

--- a/test/msteams-provider.test.ts
+++ b/test/msteams-provider.test.ts
@@ -1,7 +1,76 @@
-import { MsTeamsProviderAdapter } from "../src/providers/builtin/msteams.js";
-import { runLocalMockProviderContract } from "./local-mock-provider-helpers.js";
+import { generateKeyPairSync, sign } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import {
+  createMsTeamsWebhookAuthenticator,
+  MsTeamsProviderAdapter,
+  normalizeMsTeamsWebhookPayload,
+} from "../src/providers/builtin/msteams.js";
+import {
+  createLocalMockConfig,
+  runLocalMockProviderContract,
+} from "./local-mock-provider-helpers.js";
 
 const conversationId = "a:opaque-conversation-id";
+describe("Microsoft Teams webhook authentication", () => {
+  it("rejects non-message activities", () => {
+    expect(() => normalizeMsTeamsWebhookPayload({ type: "conversationUpdate" })).toThrow(
+      /type=message/u,
+    );
+  });
+
+  it("verifies Bot Connector bearer tokens for configured app identities", async () => {
+    const config = await createLocalMockConfig("msteams", "/msteams/webhook");
+    config.msteams!.appId = "teams-app-id";
+    const keys = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const now = Date.now();
+    const jwk = keys.publicKey.export({ format: "jwk" });
+    const authenticate = createMsTeamsWebhookAuthenticator(config, {
+      fetch: async (input: string | URL | Request) =>
+        String(input).includes("openidconfiguration")
+          ? Response.json({ jwks_uri: "https://login.example.test/keys" })
+          : Response.json({ keys: [{ ...jwk, kid: "test-key" }] }),
+      now: () => now,
+    });
+    expect(authenticate).toBeDefined();
+    const serviceUrl = "https://smba.trafficmanager.net/emea/";
+    const body = JSON.stringify({
+      channelId: "msteams",
+      conversation: { id: conversationId },
+      from: { role: "user" },
+      id: "teams-auth",
+      serviceUrl,
+      text: "authenticated",
+      type: "message",
+    });
+
+    const url = "https://bot.example.test/msteams/webhook";
+    expect((await authenticate!(new Request(url), body))?.status).toBe(401);
+
+    const header = Buffer.from(JSON.stringify({ alg: "RS256", kid: "test-key" })).toString(
+      "base64url",
+    );
+    const payload = Buffer.from(
+      JSON.stringify({
+        aud: "teams-app-id",
+        exp: Math.floor(now / 1000) + 60,
+        iss: "https://api.botframework.com",
+      }),
+    ).toString("base64url");
+    const signature = sign(
+      "RSA-SHA256",
+      Buffer.from(`${header}.${payload}`),
+      keys.privateKey,
+    ).toString("base64url");
+    await expect(
+      authenticate!(
+        new Request(url, {
+          headers: { authorization: `Bearer ${header}.${payload}.${signature}` },
+        }),
+        body,
+      ),
+    ).resolves.toBeUndefined();
+  });
+});
 
 runLocalMockProviderContract({
   Adapter: MsTeamsProviderAdapter,
@@ -16,6 +85,7 @@ runLocalMockProviderContract({
     from: { role: "user" },
     id: "teams-activity-1",
     text: "reply nonce-2",
+    type: "message",
   },
   webhookThreadId: conversationId,
 });

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -777,6 +777,12 @@ describe("OpenClaw local provider bridge", () => {
     expect(createOpenClawCrablineAgentDelivery({ manifest, target: "group:-100123" }).to).toBe(
       "-100123",
     );
+    expect(
+      createOpenClawCrablineAgentDelivery({ manifest, target: "channel:@channelusername" }).to,
+    ).toBe("@channelusername");
+    expect(createOpenClawCrablineAgentDelivery({ manifest, target: "@channelusername" }).to).toBe(
+      "@channelusername",
+    );
     expect(createOpenClawCrablineAgentDelivery({ manifest, target: "-100123" }).to).toBe("-100123");
     expect(createOpenClawCrablineAgentDelivery({ manifest, target: "thread:-100123/42" }).to).toBe(
       "-100123:topic:42",
@@ -1084,7 +1090,7 @@ describe("OpenClaw local provider bridge", () => {
       target: "group:alice",
     }).to;
 
-    for (const threadId of ["0", "42", String(Number.MAX_SAFE_INTEGER)]) {
+    for (const threadId of ["42", String(Number.MAX_SAFE_INTEGER)]) {
       expect(
         createOpenClawCrablineAgentDelivery({
           manifest,
@@ -1094,6 +1100,7 @@ describe("OpenClaw local provider bridge", () => {
     }
 
     for (const threadId of [
+      "0",
       "not-a-number",
       "-1",
       String(Number.MAX_SAFE_INTEGER + 1),
@@ -1104,10 +1111,10 @@ describe("OpenClaw local provider bridge", () => {
           manifest,
           target: `thread:alice/${threadId}`,
         }),
-      ).toThrow("Telegram thread target must be a safe non-negative integer.");
+      ).toThrow("Telegram thread target must be a safe positive integer.");
     }
 
-    for (const threadId of ["-1", "not-a-number", String(Number.MAX_SAFE_INTEGER + 1)]) {
+    for (const threadId of ["0", "-1", "not-a-number", String(Number.MAX_SAFE_INTEGER + 1)]) {
       expect(() =>
         createOpenClawCrablineInbound({
           manifest,
@@ -1118,7 +1125,7 @@ describe("OpenClaw local provider bridge", () => {
             threadId,
           },
         }),
-      ).toThrow("Telegram thread target must be a safe non-negative integer.");
+      ).toThrow("Telegram thread target must be a safe positive integer.");
     }
   });
 
@@ -1143,6 +1150,18 @@ describe("OpenClaw local provider bridge", () => {
       to: "15551234567-1234567890@g.us",
       replyTo: "15551234567-1234567890@g.us",
     });
+    expect(() =>
+      createOpenClawCrablineAgentDelivery({
+        manifest: whatsappManifest,
+        target: "dm:120363001234567890@g.us",
+      }),
+    ).toThrow("WhatsApp target kind does not match the native JID.");
+    expect(() =>
+      createOpenClawCrablineAgentDelivery({
+        manifest: whatsappManifest,
+        target: "group:15551234567@s.whatsapp.net",
+      }),
+    ).toThrow("WhatsApp target kind does not match the native JID.");
     expect(() =>
       createOpenClawCrablineAgentDelivery({
         manifest: whatsappManifest,
@@ -1267,6 +1286,18 @@ describe("OpenClaw local provider bridge", () => {
       replyChannel: "slack",
       replyTo: "C1234567890:thread:1700000000.000100",
     });
+    expect(() =>
+      createOpenClawCrablineAgentDelivery({
+        manifest: slackManifest,
+        target: "dm:C1234567890",
+      }),
+    ).toThrow("Slack target kind does not match the native conversation id.");
+    expect(() =>
+      createOpenClawCrablineAgentDelivery({
+        manifest: slackManifest,
+        target: "group:D1234567890",
+      }),
+    ).toThrow("Slack target kind does not match the native conversation id.");
 
     const inbound = createOpenClawCrablineInbound({
       manifest: slackManifest,

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -78,6 +78,22 @@ describe("recorder", () => {
     });
   });
 
+  it("reads a valid final record without a trailing newline", async () => {
+    const filePath = await createRecorderPath();
+    const event = {
+      author: "assistant",
+      id: "evt-final",
+      provider: "slack",
+      recordedAt: new Date().toISOString(),
+      sentAt: new Date().toISOString(),
+      text: "complete",
+      threadId: "slack:C123",
+    } as const;
+    await writeFile(filePath, JSON.stringify(event), "utf8");
+
+    await expect(readRecordedInbound(filePath)).resolves.toEqual([event]);
+  });
+
   it("rejects a malformed final record once it is newline terminated", async () => {
     const filePath = await createRecorderPath();
     await appendFile(filePath, '{"id":"malformed"} trailing\n', "utf8");
@@ -97,6 +113,13 @@ describe("recorder", () => {
       pollMs: 10,
     })[Symbol.asyncIterator]();
     await expect(iterator.next()).rejects.toThrow(SyntaxError);
+  });
+
+  it("does not hide a completed malformed record behind a blank tail", async () => {
+    const filePath = await createRecorderPath();
+    await appendFile(filePath, '{"id":"malformed"} trailing\n   ', "utf8");
+
+    await expect(readRecordedInbound(filePath)).rejects.toThrow(SyntaxError);
   });
 
   it("waits for a matching inbound event", async () => {
@@ -359,6 +382,20 @@ describe("recorder", () => {
     } finally {
       fileHandlePrototype.read = originalRead;
     }
+  });
+
+  it("bounds unterminated recorder records", async () => {
+    const filePath = await createRecorderPath();
+    await writeFile(filePath, "x".repeat(1024 * 1024 + 1), "utf8");
+
+    await expect(
+      waitForRecordedInbound({
+        filePath,
+        matches: () => false,
+        pollMs: 10,
+        timeoutMs: 30,
+      }),
+    ).rejects.toThrow(/exceeded 1048576 bytes without a newline/u);
   });
 
   it("resets incremental reads when the recorder is atomically replaced", async () => {

--- a/test/script-provider.test.ts
+++ b/test/script-provider.test.ts
@@ -228,6 +228,31 @@ describe("script provider", () => {
     await expect(waitForProcessExit(pid, 2000)).resolves.toBe(true);
   });
 
+  it("does not spawn commands for already-aborted signals", async () => {
+    const context = await createContext();
+    const markerPath = path.join(path.dirname(context.manifestPath), "aborted-spawned");
+    const command = `node -e ${JSON.stringify(`require("node:fs").writeFileSync(${JSON.stringify(markerPath)},"spawned")`)}`;
+    context.config.script!.commands.waitForInbound = command;
+    context.config.script!.commands.watch = command;
+    const provider = new ScriptProviderAdapter(context);
+    const controller = new AbortController();
+    controller.abort(new Error("already aborted"));
+
+    await expect(
+      provider.waitForInbound({
+        ...context,
+        nonce: "nonce",
+        signal: controller.signal,
+        since: new Date().toISOString(),
+        timeoutMs: 100,
+      }),
+    ).rejects.toThrow("already aborted");
+    await expect(provider.watch({ ...context, signal: controller.signal }).next()).rejects.toThrow(
+      "already aborted",
+    );
+    await expect(readFile(markerPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it.skipIf(process.platform === "win32")(
     "stops descendants that hold watch pipes after the leader exits",
     async () => {
@@ -582,7 +607,7 @@ describe("script provider", () => {
       const failingScript = path.join(path.dirname(context.manifestPath), "send-env-secret.mjs");
       await writeText(
         failingScript,
-        'process.stderr.write(`failed: ${process.env[["GITHUB","PAT"].join("")]} ${process.env[["SIGNING","KEY"].join("_")]} ${process.env[["ACCESS","TOKEN"].join("")]} ${process.env[["DB","PWD"].join("_")]}`);process.exitCode=7;',
+        'process.stderr.write(`failed: ${JSON.stringify(process.env[["GITHUB","PAT"].join("")])} ${process.env[["SIGNING","KEY"].join("_")]} ${process.env[["ACCESS","TOKEN"].join("")]} ${process.env[["DB","PWD"].join("_")]}`);process.exitCode=7;',
       );
       context.config.script!.commands.send = `node ${JSON.stringify(failingScript)}`;
       const provider = new ScriptProviderAdapter(context);

--- a/test/slack-provider.test.ts
+++ b/test/slack-provider.test.ts
@@ -2,13 +2,25 @@ import { createHmac } from "node:crypto";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import type { ProviderConfig } from "../src/config/schema.js";
-import { SlackProviderAdapter } from "../src/providers/builtin/slack.js";
+import { handleSlackWebhookPayload, SlackProviderAdapter } from "../src/providers/builtin/slack.js";
 import { appendRecordedInbound } from "../src/providers/recorder.js";
 import type { ProviderContext } from "../src/providers/types.js";
 import { createTempDir, disposeTempDir } from "./test-helpers.js";
 
 const directories: string[] = [];
 const providers: SlackProviderAdapter[] = [];
+
+describe("Slack URL verification", () => {
+  it("echoes the challenge", async () => {
+    const response = handleSlackWebhookPayload({
+      challenge: "challenge-token",
+      type: "url_verification",
+    });
+
+    expect(response?.status).toBe(200);
+    await expect(response?.json()).resolves.toEqual({ challenge: "challenge-token" });
+  });
+});
 
 afterEach(async () => {
   await Promise.all(providers.splice(0).map((provider) => provider.cleanup()));

--- a/test/webhook-server.test.ts
+++ b/test/webhook-server.test.ts
@@ -136,4 +136,22 @@ describe("webhook server", () => {
     expect(response.status).toBe(413);
     expect(handlerInvoked).toBe(false);
   });
+
+  it("rejects a wrong route before reading an oversized body", async () => {
+    const server = await startWebhookServer({
+      handle: async () => new Response("ok"),
+      host: "127.0.0.1",
+      maxBodyBytes: 4,
+      path: "/slack/events",
+      port: 0,
+    });
+    cleanups.push(() => server.close());
+
+    const response = await fetch(server.endpointUrl.replace("/slack/events", "/wrong"), {
+      body: "12345",
+      method: "POST",
+    });
+
+    expect(response.status).toBe(404);
+  });
 });

--- a/test/whatsapp-provider-cursor.test.ts
+++ b/test/whatsapp-provider-cursor.test.ts
@@ -1,0 +1,122 @@
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WhatsAppProviderAdapter } from "../src/providers/builtin/whatsapp.js";
+import { appendRecordedInbound } from "../src/providers/recorder.js";
+import { createLocalMockConfig, createProviderContext } from "./local-mock-provider-helpers.js";
+
+const webhookMocks = vi.hoisted(() => ({
+  startWebhookServer: vi.fn(),
+}));
+
+vi.mock("../src/providers/webhook-server.js", () => ({
+  startWebhookServer: webhookMocks.startWebhookServer,
+}));
+
+const providers: WhatsAppProviderAdapter[] = [];
+
+beforeEach(() => {
+  webhookMocks.startWebhookServer.mockReset();
+  webhookMocks.startWebhookServer.mockResolvedValue({
+    async close() {},
+    endpointUrl: "http://127.0.0.1:0/whatsapp/webhook",
+  });
+});
+
+afterEach(async () => {
+  await Promise.all(providers.splice(0).map((provider) => provider.cleanup()));
+});
+
+describe("WhatsApp provider recorder cursors", () => {
+  it("advances sequential waits and excludes outbound records", async () => {
+    const config = await createLocalMockConfig("whatsapp", "/whatsapp/webhook");
+    const provider = new WhatsAppProviderAdapter("whatsapp", config, "crabline");
+    providers.push(provider);
+    const context = createProviderContext("whatsapp", config, {
+      id: "15551234567",
+      metadata: {},
+    });
+    context.fixture.inboundMatch = { author: "any", nonce: "ignore", strategy: "contains" };
+    const recorderPath = path.resolve(config.whatsapp!.recorder.path!);
+    const waitContext = {
+      ...context,
+      nonce: "cursor",
+      since: new Date(0).toISOString(),
+      threadId: "15551234567",
+      timeoutMs: 100,
+    };
+    await appendRecordedInbound(recorderPath, {
+      author: "user",
+      id: "outbound",
+      provider: "whatsapp",
+      raw: { direction: "outbound" },
+      sentAt: new Date().toISOString(),
+      text: "outbound",
+      threadId: "15551234567",
+    });
+    await appendRecordedInbound(recorderPath, {
+      author: "user",
+      id: "first",
+      provider: "whatsapp",
+      sentAt: new Date().toISOString(),
+      text: "first",
+      threadId: "15551234567",
+    });
+    await appendRecordedInbound(recorderPath, {
+      author: "user",
+      id: "second",
+      provider: "whatsapp",
+      sentAt: new Date().toISOString(),
+      text: "second",
+      threadId: "15551234567",
+    });
+
+    await expect(provider.waitForInbound(waitContext)).resolves.toMatchObject({ id: "first" });
+    await expect(provider.waitForInbound(waitContext)).resolves.toMatchObject({ id: "second" });
+
+    await appendRecordedInbound(recorderPath, {
+      author: "user",
+      id: "third",
+      provider: "whatsapp",
+      sentAt: new Date().toISOString(),
+      text: "third",
+      threadId: "15551234567",
+    });
+    await appendRecordedInbound(recorderPath, {
+      author: "user",
+      id: "fourth",
+      provider: "whatsapp",
+      sentAt: new Date().toISOString(),
+      text: "fourth",
+      threadId: "15551234567",
+    });
+    const firstConcurrentWait = provider.waitForInbound(waitContext);
+    const secondConcurrentWait = provider.waitForInbound(waitContext);
+
+    await expect(Promise.all([firstConcurrentWait, secondConcurrentWait])).resolves.toEqual([
+      expect.objectContaining({ id: "third" }),
+      expect.objectContaining({ id: "third" }),
+    ]);
+    await expect(provider.waitForInbound(waitContext)).resolves.toMatchObject({ id: "fourth" });
+
+    const cancellationWaitContext = { ...waitContext, timeoutMs: 500 };
+    const olderWait = provider.waitForInbound(cancellationWaitContext);
+    const abortController = new AbortController();
+    const newerWait = provider.waitForInbound({
+      ...cancellationWaitContext,
+      signal: abortController.signal,
+    });
+    abortController.abort();
+    await expect(newerWait).resolves.toBeNull();
+    await appendRecordedInbound(recorderPath, {
+      author: "user",
+      id: "fifth",
+      provider: "whatsapp",
+      sentAt: new Date().toISOString(),
+      text: "fifth",
+      threadId: "15551234567",
+    });
+
+    await expect(olderWait).resolves.toMatchObject({ id: "fifth" });
+    await expect(provider.waitForInbound({ ...waitContext, timeoutMs: 30 })).resolves.toBeNull();
+  });
+});

--- a/test/whatsapp-provider-cursor.test.ts
+++ b/test/whatsapp-provider-cursor.test.ts
@@ -119,4 +119,59 @@ describe("WhatsApp provider recorder cursors", () => {
     await expect(olderWait).resolves.toMatchObject({ id: "fifth" });
     await expect(provider.waitForInbound({ ...waitContext, timeoutMs: 30 })).resolves.toBeNull();
   });
+
+  it("does not evict cursor state while distinct waits are active", async () => {
+    const config = await createLocalMockConfig("whatsapp", "/whatsapp/webhook");
+    const provider = new WhatsAppProviderAdapter("whatsapp", config, "crabline");
+    providers.push(provider);
+    const baseContext = createProviderContext("whatsapp", config, {
+      id: "15551234567",
+      metadata: {},
+    });
+    const recorderPath = path.resolve(config.whatsapp!.recorder.path!);
+    const controllers = Array.from({ length: 65 }, () => new AbortController());
+    const contexts = controllers.map((controller, index) => ({
+      ...baseContext,
+      fixture: {
+        ...baseContext.fixture,
+        inboundMatch: {
+          author: "any" as const,
+          nonce: "ignore" as const,
+          pattern: `cursor-message-${index}`,
+          strategy: "contains" as const,
+        },
+      },
+      nonce: `cursor-${index}`,
+      signal: controller.signal,
+      since: new Date(0).toISOString(),
+      threadId: "15551234567",
+      timeoutMs: 2_000,
+    }));
+    const waits = contexts.map((context) => provider.waitForInbound(context));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    await appendRecordedInbound(recorderPath, {
+      author: "user",
+      id: "first-cursor-event",
+      provider: "whatsapp",
+      sentAt: new Date().toISOString(),
+      text: "cursor-message-0",
+      threadId: "15551234567",
+    });
+    await expect(waits[0]).resolves.toMatchObject({ id: "first-cursor-event" });
+
+    const repeatedWait = provider.waitForInbound(contexts[0]!);
+    await appendRecordedInbound(recorderPath, {
+      author: "user",
+      id: "second-cursor-event",
+      provider: "whatsapp",
+      sentAt: new Date().toISOString(),
+      text: "cursor-message-0",
+      threadId: "15551234567",
+    });
+    await expect(repeatedWait).resolves.toMatchObject({ id: "second-cursor-event" });
+
+    controllers.slice(1).forEach((controller) => controller.abort());
+    await Promise.all(waits.slice(1));
+  });
 });

--- a/test/zalo-provider.test.ts
+++ b/test/zalo-provider.test.ts
@@ -22,6 +22,28 @@ describe("Zalo webhook normalizer", () => {
     });
   });
 
+  it("normalizes wrapped native updates with chat identity", () => {
+    const payload = {
+      ok: true,
+      result: {
+        event_name: "message.text.received",
+        message: {
+          chat: { chat_type: "GROUP", id: "987654321012" },
+          from: { display_name: "Alice", id: "123456789012", is_bot: false },
+          message_id: "zalo-msg-native",
+          text: "hello group",
+        },
+      },
+    };
+
+    expect(normalizeZaloWebhookPayload(payload)).toMatchObject({
+      author: "user",
+      id: "zalo-msg-native",
+      text: "hello group",
+      threadId: "987654321012",
+    });
+  });
+
   it.each([
     ["not-an-object", "Zalo webhook payload must be an object"],
     [{ sender: { id: "123456789012" }, message: {} }, "requires"],


### PR DESCRIPTION
## Summary
- restore provider-native webhook authentication and callback contracts
- preserve recorder cursors, conversation identities, and active waits under concurrency
- keep OpenClaw target translation at the bridge boundary
- document Google Chat and Teams inbound authentication modes

## Verification
- focused provider tests, `pnpm lint`, and `pnpm build`
- autoreview: clean on exact branch head with `gpt-5.6-sol` / high
- Crabbox: exact source `da9ff45cd31b164d6412da0366af2fd015b732e5`, 52 files / 555 tests passed with coverage

## Changelog
- added under Unreleased