### PR TITLE
fix(servers): preserve native delivery and lifecycle contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Harden release, CI, config, CLI, package, and OpenClaw artifact and process-identity boundaries.
 - Restore provider-native callbacks and authentication, preserve conversation targets and recorder progress, and harden local mock lifecycle and parsing.
+- Preserve native server sync, webhook, request-validation, backpressure, and shutdown semantics across Matrix, Mattermost, Signal, Slack, Telegram, and Zalo.
 - Preserve Zalo polling updates across disconnects and webhook changes, reject future Matrix sync tokens, normalize JSON media types, and bound Signal SSE clients and buffers.
 - Authenticate configured Discord interactions, answer native PING requests, exclude outbound mock records from inbound matching, filter WhatsApp webhooks by phone number, and validate loopback pagination limits.
 - Bound WhatsApp binary-node complexity and signal bundles, align encoder and decoder limits, preserve coherent X25519 fallback behavior, validate queue startup before listening, keep reconnect delivery FIFO, and accept bounded legacy group JIDs.

--- a/src/servers/http.ts
+++ b/src/servers/http.ts
@@ -211,23 +211,35 @@ export async function startHttpJsonServer(params: {
   port: number;
   serverName: string;
 }): Promise<{ baseUrl: string; close(): Promise<void>; server: Server }> {
-  const server = createServer(async (request, response) => {
+  const handleRequest = async (request: IncomingMessage, response: ServerResponse) => {
     try {
       await writeResponse(response, await params.handle(request));
     } catch (error) {
-      const handled = params.handleError?.(error, request);
-      await writeResponse(
-        response,
-        handled ??
-          jsonResponse(
-            {
-              error: "internal server error",
-              ok: false,
-            },
-            500,
-          ),
-      );
+      let handled: Response | undefined;
+      try {
+        handled = params.handleError?.(error, request);
+      } catch {
+        handled = undefined;
+      }
+      try {
+        await writeResponse(
+          response,
+          handled ??
+            jsonResponse(
+              {
+                error: "internal server error",
+                ok: false,
+              },
+              500,
+            ),
+        );
+      } catch {
+        response.destroy();
+      }
     }
+  };
+  const server = createServer((request, response) => {
+    void handleRequest(request, response);
   });
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject);

--- a/src/servers/matrix.ts
+++ b/src/servers/matrix.ts
@@ -35,10 +35,10 @@ type MatrixRoom = {
     sequence: number;
   }>;
   id: string;
+  lastDroppedTimelineSequence: number | undefined;
   name: string;
   state: MatrixEvent[];
   timeline: Array<{ sequence: number; event: MatrixEvent }>;
-  timelineDropped: boolean;
   typingTimeouts: Map<string, NodeJS.Timeout>;
   typingUsers: Set<string>;
   users: Map<string, { avatar_url?: string; display_name?: string }>;
@@ -186,10 +186,10 @@ function createRoom(params: {
     createdSequence: params.createdSequence,
     ephemeral: [],
     id: params.id,
+    lastDroppedTimelineSequence: undefined,
     name: params.name,
     state: [],
     timeline: [],
-    timelineDropped: false,
     typingTimeouts: new Map(),
     typingUsers: new Set(),
     users: new Map([[params.botUserId, { display_name: "OpenClaw QA" }]]),
@@ -233,8 +233,8 @@ function appendTimelineEvent(
 ): void {
   room.timeline.push(entry);
   if (room.timeline.length > MAX_MATRIX_TIMELINE_EVENTS) {
-    room.timelineDropped = true;
-    room.timeline.splice(0, room.timeline.length - MAX_MATRIX_TIMELINE_EVENTS);
+    const dropped = room.timeline.splice(0, room.timeline.length - MAX_MATRIX_TIMELINE_EVENTS);
+    room.lastDroppedTimelineSequence = dropped.at(-1)?.sequence;
   }
 }
 
@@ -312,11 +312,9 @@ function syncRoom(room: MatrixRoom, since: number | undefined, timelineLimit: nu
       ? available
       : available.slice(Math.max(0, available.length - timelineLimit));
   const firstSequence = timeline[0]?.sequence;
-  const retainedFirstSequence = room.timeline[0]?.sequence;
   const historyWasTrimmed =
-    room.timelineDropped &&
-    retainedFirstSequence !== undefined &&
-    (since === undefined || since < retainedFirstSequence - 1);
+    room.lastDroppedTimelineSequence !== undefined &&
+    (since === undefined || since < room.lastDroppedTimelineSequence);
   return {
     account_data: { events: [] },
     ephemeral: {

--- a/src/servers/matrix.ts
+++ b/src/servers/matrix.ts
@@ -30,10 +30,17 @@ type MatrixEvent = {
 
 type MatrixRoom = {
   createdSequence: number;
+  ephemeral: Array<{
+    event: { content: Record<string, unknown>; type: "m.receipt" | "m.typing" };
+    sequence: number;
+  }>;
   id: string;
   name: string;
   state: MatrixEvent[];
   timeline: Array<{ sequence: number; event: MatrixEvent }>;
+  timelineDropped: boolean;
+  typingTimeouts: Map<string, NodeJS.Timeout>;
+  typingUsers: Set<string>;
   users: Map<string, { avatar_url?: string; display_name?: string }>;
 };
 
@@ -58,6 +65,10 @@ type MatrixServerState = {
   syncWaiters: Set<() => void>;
   transactions: Map<string, MatrixTransactionResponse>;
 };
+
+const MAX_MATRIX_TIMELINE_EVENTS = 1_000;
+// Preserve idempotency within a bounded replay window instead of retaining every transaction.
+const MAX_MATRIX_TRANSACTION_RESPONSES = 1_000;
 
 export type MatrixServerManifest = {
   accessToken: string;
@@ -173,10 +184,14 @@ function createRoom(params: {
 }): MatrixRoom {
   const room: MatrixRoom = {
     createdSequence: params.createdSequence,
+    ephemeral: [],
     id: params.id,
     name: params.name,
     state: [],
     timeline: [],
+    timelineDropped: false,
+    typingTimeouts: new Map(),
+    typingUsers: new Set(),
     users: new Map([[params.botUserId, { display_name: "OpenClaw QA" }]]),
   };
   room.state.push(
@@ -212,15 +227,104 @@ function createRoom(params: {
   return room;
 }
 
-function syncRoom(room: MatrixRoom, since: number | undefined) {
-  const events = room.timeline
-    .filter((entry) => since === undefined || entry.sequence > since)
-    .map((entry) => entry.event);
+function appendTimelineEvent(
+  room: MatrixRoom,
+  entry: { event: MatrixEvent; sequence: number },
+): void {
+  room.timeline.push(entry);
+  if (room.timeline.length > MAX_MATRIX_TIMELINE_EVENTS) {
+    room.timelineDropped = true;
+    room.timeline.splice(0, room.timeline.length - MAX_MATRIX_TIMELINE_EVENTS);
+  }
+}
+
+function appendEphemeralEvent(
+  room: MatrixRoom,
+  entry: {
+    event: { content: Record<string, unknown>; type: "m.receipt" | "m.typing" };
+    sequence: number;
+  },
+): void {
+  room.ephemeral.push(entry);
+  if (room.ephemeral.length > MAX_MATRIX_TIMELINE_EVENTS) {
+    room.ephemeral.splice(0, room.ephemeral.length - MAX_MATRIX_TIMELINE_EVENTS);
+  }
+}
+
+function publishTypingState(state: MatrixServerState, room: MatrixRoom): void {
+  appendEphemeralEvent(room, {
+    event: { content: { user_ids: [...room.typingUsers] }, type: "m.typing" },
+    sequence: state.nextSequence++,
+  });
+  notifySyncWaiters(state);
+}
+
+function rememberTransaction(
+  state: MatrixServerState,
+  key: string,
+  response: MatrixTransactionResponse,
+): void {
+  state.transactions.set(key, response);
+  if (state.transactions.size > MAX_MATRIX_TRANSACTION_RESPONSES) {
+    const oldest = state.transactions.keys().next().value;
+    if (oldest !== undefined) {
+      state.transactions.delete(oldest);
+    }
+  }
+}
+
+function readTimelineLimit(filter: Record<string, unknown> | undefined): number | undefined {
+  const room = filter?.room;
+  const timeline = isJsonObject(room) ? room.timeline : undefined;
+  const limit = isJsonObject(timeline) ? readInteger(timeline.limit) : undefined;
+  return limit === undefined ? undefined : Math.max(0, limit);
+}
+
+function resolveSyncFilter(
+  url: URL,
+  state: MatrixServerState,
+): Record<string, unknown> | Response | undefined {
+  const value = url.searchParams.get("filter");
+  if (value === null) {
+    return undefined;
+  }
+  const stored = state.filters.get(value);
+  if (stored) {
+    return stored;
+  }
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return isJsonObject(parsed) ? parsed : matrixError("M_INVALID_PARAM", "Invalid filter", 400);
+  } catch {
+    return matrixError("M_INVALID_PARAM", "Unknown filter", 400);
+  }
+}
+
+function syncRoom(room: MatrixRoom, since: number | undefined, timelineLimit: number | undefined) {
+  const available = room.timeline.filter((entry) => since === undefined || entry.sequence > since);
+  const timeline =
+    timelineLimit === undefined
+      ? available
+      : available.slice(Math.max(0, available.length - timelineLimit));
+  const firstSequence = timeline[0]?.sequence;
+  const retainedFirstSequence = room.timeline[0]?.sequence;
+  const historyWasTrimmed =
+    room.timelineDropped &&
+    retainedFirstSequence !== undefined &&
+    (since === undefined || since < retainedFirstSequence - 1);
   return {
     account_data: { events: [] },
-    ephemeral: { events: [] },
+    ephemeral: {
+      events: room.ephemeral
+        .filter((entry) => since === undefined || entry.sequence > since)
+        .map((entry) => entry.event),
+    },
     state: { events: since === undefined || room.createdSequence > since ? room.state : [] },
-    timeline: { events, limited: false, prev_batch: `s${since ?? 0}` },
+    timeline: {
+      events: timeline.map((entry) => entry.event),
+      limited: historyWasTrimmed || timeline.length < available.length,
+      prev_batch: `s${firstSequence === undefined ? (since ?? 0) : firstSequence - 1}`,
+    },
     unread_notifications: { highlight_count: 0, notification_count: 0 },
   };
 }
@@ -242,15 +346,22 @@ async function handleSync(url: URL, state: MatrixServerState): Promise<Response>
   if (since === null || (since !== undefined && since > state.nextSequence - 1)) {
     return matrixError("M_UNKNOWN_POS", "Unknown position", 400);
   }
+  const filter = resolveSyncFilter(url, state);
+  if (filter instanceof Response) {
+    return filter;
+  }
+  const timelineLimit = readTimelineLimit(filter);
   const timeout = Math.min(readInteger(url.searchParams.get("timeout")) ?? 0, 1_000);
   const hasNewEvents = [...state.rooms.values()].some((room) =>
-    room.timeline.some((entry) => since === undefined || entry.sequence > since),
+    [...room.timeline, ...room.ephemeral].some(
+      (entry) => since === undefined || entry.sequence > since,
+    ),
   );
   if (since !== undefined && !hasNewEvents && timeout > 0) {
     await waitForSyncEvent(state, timeout);
   }
   const join = Object.fromEntries(
-    [...state.rooms.values()].map((room) => [room.id, syncRoom(room, since)]),
+    [...state.rooms.values()].map((room) => [room.id, syncRoom(room, since, timelineLimit)]),
   );
   return jsonResponse({
     account_data: { events: [] },
@@ -305,9 +416,32 @@ async function handleAdminInbound(params: {
       type: "m.room.member",
     });
     room.state.push(membership);
-    room.timeline.push({ event: membership, sequence: params.state.nextSequence++ });
+    appendTimelineEvent(room, { event: membership, sequence: params.state.nextSequence++ });
   } else if (senderName) {
-    room.users.set(sender, { display_name: senderName });
+    const profile = room.users.get(sender);
+    if (profile?.display_name !== senderName) {
+      room.users.set(sender, { ...profile, display_name: senderName });
+      const membership = createEvent({
+        content: { membership: "join", displayname: senderName },
+        roomId,
+        sender,
+        state: params.state,
+        stateKey: sender,
+        type: "m.room.member",
+      });
+      const stateIndex = room.state.findIndex(
+        (event) => event.type === "m.room.member" && event.state_key === sender,
+      );
+      if (stateIndex >= 0) {
+        room.state[stateIndex] = membership;
+      } else {
+        room.state.push(membership);
+      }
+      appendTimelineEvent(room, {
+        event: membership,
+        sequence: params.state.nextSequence++,
+      });
+    }
   }
   const content: Record<string, unknown> = { body: text, msgtype: "m.text" };
   const threadId = readTrimmedString(params.body.threadId);
@@ -326,7 +460,7 @@ async function handleAdminInbound(params: {
     state: params.state,
     type: "m.room.message",
   });
-  room.timeline.push({ event, sequence: params.state.nextSequence++ });
+  appendTimelineEvent(room, { event, sequence: params.state.nextSequence++ });
   notifySyncWaiters(params.state);
   return jsonResponse({ event, ok: true });
 }
@@ -437,7 +571,7 @@ async function handleMatrixApi(params: {
     const room = findRoom(params.state, match[1]!);
     if (!room) {
       const body = { errcode: "M_NOT_FOUND", error: "Unknown room" };
-      params.state.transactions.set(transactionKey, { body, status: 404 });
+      rememberTransaction(params.state, transactionKey, { body, status: 404 });
       return jsonResponse(body, 404);
     }
     const event = createEvent({
@@ -448,19 +582,79 @@ async function handleMatrixApi(params: {
       transactionId: decodeURIComponent(match[3]!),
       type: decodeURIComponent(match[2]!),
     });
-    room.timeline.push({ event, sequence: params.state.nextSequence++ });
+    appendTimelineEvent(room, { event, sequence: params.state.nextSequence++ });
     const body = { event_id: event.event_id };
-    params.state.transactions.set(transactionKey, { body, status: 200 });
+    rememberTransaction(params.state, transactionKey, { body, status: 200 });
     notifySyncWaiters(params.state);
     return jsonResponse(body);
   }
 
   match = /^\/rooms\/([^/]+)\/typing\/([^/]+)$/u.exec(relativePath);
   if (params.method === "PUT" && match) {
+    const room = findRoom(params.state, match[1]!);
+    if (!room) {
+      return matrixError("M_NOT_FOUND", "Unknown room", 404);
+    }
+    const userId = decodeURIComponent(match[2]!);
+    if (typeof params.body.typing !== "boolean") {
+      return matrixError("M_BAD_JSON", "typing must be a boolean", 400);
+    }
+    const timeout =
+      params.body.typing &&
+      typeof params.body.timeout === "number" &&
+      Number.isSafeInteger(params.body.timeout)
+        ? params.body.timeout
+        : undefined;
+    if (params.body.typing && (timeout === undefined || timeout < 1)) {
+      return matrixError("M_BAD_JSON", "timeout must be a positive integer", 400);
+    }
+    const existingTimeout = room.typingTimeouts.get(userId);
+    if (existingTimeout) {
+      clearTimeout(existingTimeout);
+      room.typingTimeouts.delete(userId);
+    }
+    if (params.body.typing) {
+      room.typingUsers.add(userId);
+      const timer = setTimeout(() => {
+        room.typingTimeouts.delete(userId);
+        if (room.typingUsers.delete(userId)) {
+          publishTypingState(params.state, room);
+        }
+      }, timeout!);
+      timer.unref();
+      room.typingTimeouts.set(userId, timer);
+    } else {
+      room.typingUsers.delete(userId);
+    }
+    publishTypingState(params.state, room);
     return jsonResponse({});
   }
   match = /^\/rooms\/([^/]+)\/receipt\/m\.read\/([^/]+)$/u.exec(relativePath);
   if (params.method === "POST" && match) {
+    const room = findRoom(params.state, match[1]!);
+    if (!room) {
+      return matrixError("M_NOT_FOUND", "Unknown room", 404);
+    }
+    const receiptEventId = decodeURIComponent(match[2]!);
+    appendEphemeralEvent(room, {
+      event: {
+        content: {
+          [receiptEventId]: {
+            "m.read": {
+              [params.state.botUserId]: {
+                ts: Date.now(),
+                ...(readTrimmedString(params.body.thread_id)
+                  ? { thread_id: readTrimmedString(params.body.thread_id) }
+                  : {}),
+              },
+            },
+          },
+        },
+        type: "m.receipt",
+      },
+      sequence: params.state.nextSequence++,
+    });
+    notifySyncWaiters(params.state);
     return jsonResponse({});
   }
 
@@ -577,7 +771,15 @@ export async function startMatrixServer(
 
   const clientApiRoot = `${server.baseUrl}/_matrix/client/v3`;
   return {
-    close: server.close,
+    async close() {
+      for (const room of state.rooms.values()) {
+        for (const timer of room.typingTimeouts.values()) {
+          clearTimeout(timer);
+        }
+        room.typingTimeouts.clear();
+      }
+      await server.close();
+    },
     manifest: {
       accessToken: state.accessToken,
       adminToken: state.adminToken,

--- a/src/servers/matrix.ts
+++ b/src/servers/matrix.ts
@@ -67,7 +67,6 @@ type MatrixServerState = {
 };
 
 const MAX_MATRIX_TIMELINE_EVENTS = 1_000;
-// Preserve idempotency within a bounded replay window instead of retaining every transaction.
 const MAX_MATRIX_TRANSACTION_RESPONSES = 1_000;
 const MAX_NODE_TIMER_DELAY_MS = 2_147_483_647;
 
@@ -266,12 +265,17 @@ function rememberTransaction(
   response: MatrixTransactionResponse,
 ): void {
   state.transactions.set(key, response);
-  if (state.transactions.size > MAX_MATRIX_TRANSACTION_RESPONSES) {
-    const oldest = state.transactions.keys().next().value;
-    if (oldest !== undefined) {
-      state.transactions.delete(oldest);
-    }
-  }
+}
+
+function matrixTransactionCapacityError(): Response {
+  return jsonResponse(
+    {
+      admin_contact: "mailto:admin@example.invalid",
+      errcode: "M_RESOURCE_LIMIT_EXCEEDED",
+      error: "Transaction response capacity has been reached",
+    },
+    503,
+  );
 }
 
 function readTimelineLimit(filter: Record<string, unknown> | undefined): number | undefined {
@@ -566,6 +570,9 @@ async function handleMatrixApi(params: {
     const existingResponse = params.state.transactions.get(transactionKey);
     if (existingResponse) {
       return jsonResponse(existingResponse.body, existingResponse.status);
+    }
+    if (params.state.transactions.size >= MAX_MATRIX_TRANSACTION_RESPONSES) {
+      return matrixTransactionCapacityError();
     }
     const room = findRoom(params.state, match[1]!);
     if (!room) {

--- a/src/servers/matrix.ts
+++ b/src/servers/matrix.ts
@@ -69,6 +69,7 @@ type MatrixServerState = {
 const MAX_MATRIX_TIMELINE_EVENTS = 1_000;
 // Preserve idempotency within a bounded replay window instead of retaining every transaction.
 const MAX_MATRIX_TRANSACTION_RESPONSES = 1_000;
+const MAX_NODE_TIMER_DELAY_MS = 2_147_483_647;
 
 export type MatrixServerManifest = {
   accessToken: string;
@@ -596,6 +597,9 @@ async function handleMatrixApi(params: {
       return matrixError("M_NOT_FOUND", "Unknown room", 404);
     }
     const userId = decodeURIComponent(match[2]!);
+    if (userId !== params.state.botUserId) {
+      return matrixError("M_FORBIDDEN", "Cannot set typing state for another user", 403);
+    }
     if (typeof params.body.typing !== "boolean") {
       return matrixError("M_BAD_JSON", "typing must be a boolean", 400);
     }
@@ -605,8 +609,15 @@ async function handleMatrixApi(params: {
       Number.isSafeInteger(params.body.timeout)
         ? params.body.timeout
         : undefined;
-    if (params.body.typing && (timeout === undefined || timeout < 1)) {
-      return matrixError("M_BAD_JSON", "timeout must be a positive integer", 400);
+    if (
+      params.body.typing &&
+      (timeout === undefined || timeout < 1 || timeout > MAX_NODE_TIMER_DELAY_MS)
+    ) {
+      return matrixError(
+        "M_BAD_JSON",
+        `timeout must be a positive integer no greater than ${MAX_NODE_TIMER_DELAY_MS}`,
+        400,
+      );
     }
     const existingTimeout = room.typingTimeouts.get(userId);
     if (existingTimeout) {

--- a/src/servers/matrix.ts
+++ b/src/servers/matrix.ts
@@ -403,7 +403,8 @@ async function handleAdminInbound(params: {
     });
   params.state.rooms.set(roomId, room);
   const senderName = readTrimmedString(params.body.senderName);
-  if (!room.users.has(sender)) {
+  const existingProfile = room.users.get(sender);
+  if (existingProfile === undefined) {
     room.users.set(sender, senderName ? { display_name: senderName } : {});
     const membership = createEvent({
       content: {
@@ -418,31 +419,28 @@ async function handleAdminInbound(params: {
     });
     room.state.push(membership);
     appendTimelineEvent(room, { event: membership, sequence: params.state.nextSequence++ });
-  } else if (senderName) {
-    const profile = room.users.get(sender);
-    if (profile?.display_name !== senderName) {
-      room.users.set(sender, { ...profile, display_name: senderName });
-      const membership = createEvent({
-        content: { membership: "join", displayname: senderName },
-        roomId,
-        sender,
-        state: params.state,
-        stateKey: sender,
-        type: "m.room.member",
-      });
-      const stateIndex = room.state.findIndex(
-        (event) => event.type === "m.room.member" && event.state_key === sender,
-      );
-      if (stateIndex >= 0) {
-        room.state[stateIndex] = membership;
-      } else {
-        room.state.push(membership);
-      }
-      appendTimelineEvent(room, {
-        event: membership,
-        sequence: params.state.nextSequence++,
-      });
+  } else if (senderName && existingProfile.display_name !== senderName) {
+    room.users.set(sender, { ...existingProfile, display_name: senderName });
+    const membership = createEvent({
+      content: { membership: "join", displayname: senderName },
+      roomId,
+      sender,
+      state: params.state,
+      stateKey: sender,
+      type: "m.room.member",
+    });
+    const stateIndex = room.state.findIndex(
+      (event) => event.type === "m.room.member" && event.state_key === sender,
+    );
+    if (stateIndex >= 0) {
+      room.state[stateIndex] = membership;
+    } else {
+      room.state.push(membership);
     }
+    appendTimelineEvent(room, {
+      event: membership,
+      sequence: params.state.nextSequence++,
+    });
   }
   const content: Record<string, unknown> = { body: text, msgtype: "m.text" };
   const threadId = readTrimmedString(params.body.threadId);

--- a/src/servers/mattermost.ts
+++ b/src/servers/mattermost.ts
@@ -520,7 +520,7 @@ function attachWebSocketServer(params: {
       params.state.websocketClients.delete(client);
     });
     if (unauthenticatedClients.size >= params.maxUnauthenticatedClients) {
-      client.close(1013, "too many unauthenticated clients");
+      client.terminate();
       return;
     }
     unauthenticatedClients.add(client);

--- a/src/servers/mattermost.ts
+++ b/src/servers/mattermost.ts
@@ -23,13 +23,15 @@ import { closeWebSocketServer } from "./websocket.js";
 
 const DEFAULT_WEBSOCKET_AUTHENTICATION_TIMEOUT_MS = 5_000;
 const DEFAULT_MAX_WEBSOCKET_BUFFERED_BYTES = 1024 * 1024;
+const DEFAULT_MAX_WEBSOCKET_MESSAGE_BYTES = 64 * 1024;
+const DEFAULT_MAX_UNAUTHENTICATED_WEBSOCKET_CLIENTS = 32;
 
-function resolveMaxWebSocketBufferedBytes(value: number | undefined): number {
+function resolvePositiveLimit(value: number | undefined, name: string, fallback: number): number {
   if (value === undefined) {
-    return DEFAULT_MAX_WEBSOCKET_BUFFERED_BYTES;
+    return fallback;
   }
   if (!Number.isSafeInteger(value) || value < 1) {
-    throw new Error("maxWebSocketBufferedBytes must be a positive safe integer.");
+    throw new Error(`${name} must be a positive safe integer.`);
   }
   return value;
 }
@@ -107,6 +109,8 @@ export type StartMattermostServerParams = {
   recorderPath?: string | undefined;
   maxPendingInboundEvents?: number | undefined;
   maxWebSocketBufferedBytes?: number | undefined;
+  maxWebSocketMessageBytes?: number | undefined;
+  maxUnauthenticatedWebSocketClients?: number | undefined;
   websocketAuthenticationTimeoutMs?: number | undefined;
 };
 
@@ -198,7 +202,11 @@ function sendEvent(
   return true;
 }
 
-function broadcast(state: MattermostServerState, event: MattermostWebSocketEvent): boolean {
+function broadcast(
+  state: MattermostServerState,
+  event: MattermostWebSocketEvent,
+  queueIfUndelivered = true,
+): boolean {
   if (
     Buffer.byteLength(JSON.stringify({ ...event, seq: 0 }), "utf8") >
     state.maxWebSocketBufferedBytes
@@ -215,6 +223,9 @@ function broadcast(state: MattermostServerState, event: MattermostWebSocketEvent
   }
   if (delivered) {
     return true;
+  }
+  if (!queueIfUndelivered) {
+    return false;
   }
   if (state.pendingEvents.length >= state.maxPendingInboundEvents) {
     return false;
@@ -272,6 +283,9 @@ async function handleAdminInbound(params: {
   }
   const senderName = readTrimmedString(params.body.senderName) ?? senderId;
   const channelType = readTrimmedString(params.body.channelType) ?? "D";
+  const previousUser = params.state.users.get(senderId);
+  const previousChannel = params.state.channels.get(channelId);
+  const previousNextPost = params.state.nextPost;
   params.state.users.set(senderId, { id: senderId, update_at: Date.now(), username: senderName });
   params.state.channels.set(channelId, {
     display_name: channelId,
@@ -288,6 +302,17 @@ async function handleAdminInbound(params: {
   });
   if (!broadcast(params.state, postEvent("posted", post, senderName, channelType))) {
     params.state.posts.delete(post.id);
+    params.state.nextPost = previousNextPost;
+    if (previousUser) {
+      params.state.users.set(senderId, previousUser);
+    } else {
+      params.state.users.delete(senderId);
+    }
+    if (previousChannel) {
+      params.state.channels.set(channelId, previousChannel);
+    } else {
+      params.state.channels.delete(channelId);
+    }
     return pendingQueueFullResponse(params.state);
   }
   return jsonResponse({ ok: true, post });
@@ -337,8 +362,12 @@ async function handleApi(params: {
     if (!channelId) {
       return mattermostError("channel_id is required", 400);
     }
-    if (
-      !broadcast(state, {
+    if (!state.channels.has(channelId)) {
+      return mattermostError("Channel not found", 404);
+    }
+    broadcast(
+      state,
+      {
         broadcast: eventBroadcast({
           channelId,
           omitUsers: { [state.botUserId]: true },
@@ -351,10 +380,9 @@ async function handleApi(params: {
           user_id: state.botUserId,
         },
         event: "typing",
-      })
-    ) {
-      return pendingQueueFullResponse(state);
-    }
+      },
+      false,
+    );
     return jsonResponse({});
   }
   if (method === "POST" && apiPath === "/posts") {
@@ -363,6 +391,10 @@ async function handleApi(params: {
     if (!channelId || !message) {
       return mattermostError("channel_id and message are required", 400);
     }
+    const channel = state.channels.get(channelId);
+    if (!channel) {
+      return mattermostError("Channel not found", 404);
+    }
     const post = createPost({
       channelId,
       message,
@@ -370,11 +402,7 @@ async function handleApi(params: {
       state,
       userId: state.botUserId,
     });
-    const channelType = state.channels.get(channelId)?.type ?? "O";
-    if (!broadcast(state, postEvent("posted", post, state.botUsername, channelType))) {
-      state.posts.delete(post.id);
-      return pendingQueueFullResponse(state);
-    }
+    broadcast(state, postEvent("posted", post, state.botUsername, channel.type), false);
     return jsonResponse(post, 201);
   }
   const postMatch = /^\/posts\/([^/]+)$/u.exec(apiPath);
@@ -385,20 +413,16 @@ async function handleApi(params: {
     }
     const updated = { ...post, message: readTrimmedString(body.message) ?? post.message };
     state.posts.set(updated.id, updated);
-    if (
-      !broadcast(
-        state,
-        postEvent(
-          "post_edited",
-          updated,
-          state.botUsername,
-          state.channels.get(updated.channel_id)?.type ?? "O",
-        ),
-      )
-    ) {
-      state.posts.set(post.id, post);
-      return pendingQueueFullResponse(state);
-    }
+    broadcast(
+      state,
+      postEvent(
+        "post_edited",
+        updated,
+        state.botUsername,
+        state.channels.get(updated.channel_id)?.type ?? "O",
+      ),
+      false,
+    );
     return jsonResponse(updated);
   }
   if (postMatch?.[1] && method === "DELETE") {
@@ -407,20 +431,16 @@ async function handleApi(params: {
       return mattermostError("Post not found", 404);
     }
     state.posts.delete(post.id);
-    if (
-      !broadcast(
-        state,
-        postEvent(
-          "post_deleted",
-          post,
-          state.botUsername,
-          state.channels.get(post.channel_id)?.type ?? "O",
-        ),
-      )
-    ) {
-      state.posts.set(post.id, post);
-      return pendingQueueFullResponse(state);
-    }
+    broadcast(
+      state,
+      postEvent(
+        "post_deleted",
+        post,
+        state.botUsername,
+        state.channels.get(post.channel_id)?.type ?? "O",
+      ),
+      false,
+    );
     return new Response(null, { status: 204 });
   }
   return mattermostError("Not found", 404);
@@ -470,10 +490,16 @@ async function handleRequest(request: IncomingMessage, state: MattermostServerSt
 
 function attachWebSocketServer(params: {
   authenticationTimeoutMs: number;
+  maxMessageBytes: number;
+  maxUnauthenticatedClients: number;
   state: MattermostServerState;
   server: import("node:http").Server;
 }) {
-  const websocketServer = new WebSocketServer({ noServer: true });
+  const websocketServer = new WebSocketServer({
+    maxPayload: params.maxMessageBytes,
+    noServer: true,
+  });
+  const unauthenticatedClients = new Set<WebSocket>();
   const onUpgrade = (
     request: IncomingMessage,
     socket: import("node:stream").Duplex,
@@ -489,6 +515,15 @@ function attachWebSocketServer(params: {
   };
   params.server.on("upgrade", onUpgrade);
   websocketServer.on("connection", (client) => {
+    client.on("error", () => {
+      unauthenticatedClients.delete(client);
+      params.state.websocketClients.delete(client);
+    });
+    if (unauthenticatedClients.size >= params.maxUnauthenticatedClients) {
+      client.close(1013, "too many unauthenticated clients");
+      return;
+    }
+    unauthenticatedClients.add(client);
     let authenticationOpen = true;
     const authenticationTimeout = setTimeout(() => {
       authenticationOpen = false;
@@ -504,6 +539,10 @@ function attachWebSocketServer(params: {
       try {
         message = JSON.parse(raw.toString()) as typeof message;
       } catch {
+        client.close(1003, "invalid json");
+        return;
+      }
+      if (!isJsonObject(message)) {
         client.close(1003, "invalid json");
         return;
       }
@@ -529,6 +568,7 @@ function attachWebSocketServer(params: {
         }
         clearTimeout(authenticationTimeout);
         authenticationOpen = false;
+        unauthenticatedClients.delete(client);
         params.state.websocketClients.set(client, 0);
         client.send(JSON.stringify({ seq_reply: seq, status: "OK" }));
         sendEvent(params.state, client, {
@@ -578,6 +618,7 @@ function attachWebSocketServer(params: {
     client.once("close", () => {
       authenticationOpen = false;
       clearTimeout(authenticationTimeout);
+      unauthenticatedClients.delete(client);
       params.state.websocketClients.delete(client);
     });
   });
@@ -593,6 +634,16 @@ export async function startMattermostServer(
   const host = params.host ?? "127.0.0.1";
   const botUserId = params.botUserId ?? mattermostId("crabline-mattermost-bot");
   const botUsername = params.botUsername ?? "crabline_bot";
+  const maxWebSocketMessageBytes = resolvePositiveLimit(
+    params.maxWebSocketMessageBytes,
+    "maxWebSocketMessageBytes",
+    DEFAULT_MAX_WEBSOCKET_MESSAGE_BYTES,
+  );
+  const maxUnauthenticatedWebSocketClients = resolvePositiveLimit(
+    params.maxUnauthenticatedWebSocketClients,
+    "maxUnauthenticatedWebSocketClients",
+    DEFAULT_MAX_UNAUTHENTICATED_WEBSOCKET_CLIENTS,
+  );
   const state: MattermostServerState = {
     adminToken: params.adminToken ?? randomBytes(24).toString("base64url"),
     botToken:
@@ -602,7 +653,11 @@ export async function startMattermostServer(
     botUsername,
     channels: new Map(),
     maxPendingInboundEvents: resolveMaxPendingInboundEvents(params.maxPendingInboundEvents),
-    maxWebSocketBufferedBytes: resolveMaxWebSocketBufferedBytes(params.maxWebSocketBufferedBytes),
+    maxWebSocketBufferedBytes: resolvePositiveLimit(
+      params.maxWebSocketBufferedBytes,
+      "maxWebSocketBufferedBytes",
+      DEFAULT_MAX_WEBSOCKET_BUFFERED_BYTES,
+    ),
     nextPost: 1,
     onEvent: params.onEvent,
     pendingEvents: [],
@@ -629,6 +684,8 @@ export async function startMattermostServer(
   const closeMattermostWebSocketServer = attachWebSocketServer({
     authenticationTimeoutMs:
       params.websocketAuthenticationTimeoutMs ?? DEFAULT_WEBSOCKET_AUTHENTICATION_TIMEOUT_MS,
+    maxMessageBytes: maxWebSocketMessageBytes,
+    maxUnauthenticatedClients: maxUnauthenticatedWebSocketClients,
     server: httpServer.server,
     state,
   });

--- a/src/servers/mattermost.ts
+++ b/src/servers/mattermost.ts
@@ -265,10 +265,10 @@ function createPost(params: {
   return post;
 }
 
-async function handleAdminInbound(params: {
+function handleAdminInbound(params: {
   body: Record<string, unknown>;
   state: MattermostServerState;
-}): Promise<Response> {
+}): Response {
   const channelId = readTrimmedString(params.body.channelId ?? params.body.channel_id);
   const senderId = readTrimmedString(params.body.senderId ?? params.body.user_id);
   const text = readTrimmedString(params.body.text ?? params.body.message);
@@ -466,7 +466,7 @@ async function handleRequest(request: IncomingMessage, state: MattermostServerSt
       query: queryRecord(url),
       type: "admin",
     });
-    return await handleAdminInbound({ body, state });
+    return handleAdminInbound({ body, state });
   }
   if (!url.pathname.startsWith("/api/v4/")) {
     return new Response("not found", { status: 404 });

--- a/src/servers/signal.ts
+++ b/src/servers/signal.ts
@@ -138,7 +138,10 @@ function queueSignalClientEvent(
 ): SignalSseWriteResult {
   const buffer = state.clientBuffers.get(client);
   const eventBytes = Buffer.byteLength(event);
-  if (!buffer || buffer.bytes + eventBytes > MAX_SIGNAL_SSE_BUFFER_BYTES) {
+  if (
+    !buffer ||
+    state.pendingEventBytes + buffer.bytes + eventBytes > MAX_SIGNAL_SSE_BUFFER_BYTES
+  ) {
     evictSignalClient(state, client);
     return "rejected";
   }
@@ -179,11 +182,20 @@ function writeSignalSse(
   return "accepted";
 }
 
+function maxSignalClientBufferBytes(state: SignalServerState): number {
+  let maxBytes = 0;
+  for (const buffer of state.clientBuffers.values()) {
+    maxBytes = Math.max(maxBytes, buffer.bytes);
+  }
+  return maxBytes;
+}
+
 function queueSignalEvent(state: SignalServerState, event: string): boolean {
   const eventBytes = Buffer.byteLength(event);
   if (
     eventBytes > MAX_SIGNAL_SSE_BUFFER_BYTES ||
-    state.pendingEventBytes + eventBytes > MAX_SIGNAL_SSE_BUFFER_BYTES ||
+    state.pendingEventBytes + maxSignalClientBufferBytes(state) + eventBytes >
+      MAX_SIGNAL_SSE_BUFFER_BYTES ||
     state.pendingEvents.length >= state.maxPendingInboundEvents
   ) {
     return false;

--- a/src/servers/signal.ts
+++ b/src/servers/signal.ts
@@ -24,19 +24,21 @@ type SignalServerState = {
   account: string;
   adminToken: string;
   clients: Set<ServerResponse>;
-  drainingClients: WeakSet<ServerResponse>;
+  clientBuffers: Map<ServerResponse, { bytes: number; draining: boolean; events: string[] }>;
   maxPendingInboundEvents: number;
   maxSseClients: number;
   nextTimestamp: number;
   onEvent: ServerEventObserver | undefined;
+  pendingEventBytes: number;
   pendingEvents: string[];
+  pendingSseClients: number;
   recorderPath: string;
 };
 
 const SIGNAL_CLI_SSE_KEEPALIVE_MS = 15_000;
 const DEFAULT_MAX_SIGNAL_SSE_CLIENTS = 32;
 const MAX_SIGNAL_SSE_BUFFER_BYTES = 2 * 1024 * 1024;
-type SignalSseWriteResult = "accepted" | "backpressured" | "rejected";
+type SignalSseWriteResult = "accepted" | "queued" | "rejected";
 
 export type SignalServerManifest = {
   account: string;
@@ -91,19 +93,40 @@ function rpcError(code: number, message: string, id: unknown = null, status = 40
 
 function evictSignalClient(state: SignalServerState, client: ServerResponse): void {
   state.clients.delete(client);
-  state.drainingClients.delete(client);
+  state.clientBuffers.delete(client);
   client.destroy();
 }
 
 function scheduleSignalDrain(state: SignalServerState, client: ServerResponse): void {
-  if (state.drainingClients.has(client) || client.destroyed || client.writableEnded) {
+  const buffer = state.clientBuffers.get(client);
+  if (!buffer || buffer.draining || client.destroyed || client.writableEnded) {
     return;
   }
-  state.drainingClients.add(client);
+  buffer.draining = true;
   client.once("drain", () => {
-    state.drainingClients.delete(client);
-    flushPendingSignalEvents(state, client);
+    const current = state.clientBuffers.get(client);
+    if (current) {
+      current.draining = false;
+      flushSignalClientEvents(state, client);
+    }
   });
+}
+
+function queueSignalClientEvent(
+  state: SignalServerState,
+  client: ServerResponse,
+  event: string,
+): SignalSseWriteResult {
+  const buffer = state.clientBuffers.get(client);
+  const eventBytes = Buffer.byteLength(event);
+  if (!buffer || buffer.bytes + eventBytes > MAX_SIGNAL_SSE_BUFFER_BYTES) {
+    evictSignalClient(state, client);
+    return "rejected";
+  }
+  buffer.events.push(event);
+  buffer.bytes += eventBytes;
+  scheduleSignalDrain(state, client);
+  return "queued";
 }
 
 function writeSignalSse(
@@ -123,9 +146,9 @@ function writeSignalSse(
   if (eventBytes > MAX_SIGNAL_SSE_BUFFER_BYTES) {
     return "rejected";
   }
-  if (client.writableNeedDrain) {
-    evictSignalClient(state, client);
-    return "rejected";
+  const buffer = state.clientBuffers.get(client);
+  if (client.writableNeedDrain || buffer?.draining || buffer?.events.length) {
+    return queueSignalClientEvent(state, client, event);
   }
   if (client.writableLength + eventBytes > MAX_SIGNAL_SSE_BUFFER_BYTES) {
     evictSignalClient(state, client);
@@ -133,31 +156,48 @@ function writeSignalSse(
   }
   if (!client.write(event)) {
     scheduleSignalDrain(state, client);
-    return "backpressured";
   }
   return "accepted";
 }
 
 function queueSignalEvent(state: SignalServerState, event: string): boolean {
+  const eventBytes = Buffer.byteLength(event);
   if (
-    Buffer.byteLength(event) > MAX_SIGNAL_SSE_BUFFER_BYTES ||
+    eventBytes > MAX_SIGNAL_SSE_BUFFER_BYTES ||
+    state.pendingEventBytes + eventBytes > MAX_SIGNAL_SSE_BUFFER_BYTES ||
     state.pendingEvents.length >= state.maxPendingInboundEvents
   ) {
     return false;
   }
   state.pendingEvents.push(event);
+  state.pendingEventBytes += eventBytes;
   return true;
+}
+
+function flushSignalClientEvents(state: SignalServerState, client: ServerResponse): void {
+  while (!client.writableNeedDrain) {
+    const buffer = state.clientBuffers.get(client);
+    if (!buffer || buffer.events.length === 0) {
+      break;
+    }
+    const event = buffer.events.shift()!;
+    buffer.bytes -= Buffer.byteLength(event);
+    if (!client.write(event)) {
+      scheduleSignalDrain(state, client);
+      break;
+    }
+  }
 }
 
 function flushPendingSignalEvents(state: SignalServerState, client: ServerResponse): void {
   while (state.pendingEvents.length > 0) {
     const result = writeSignalSse(state, client, state.pendingEvents[0]!);
-    if (result === "accepted") {
-      state.pendingEvents.shift();
-      continue;
-    }
-    if (result === "backpressured") {
-      state.pendingEvents.shift();
+    if (result === "accepted" || result === "queued") {
+      const event = state.pendingEvents.shift()!;
+      state.pendingEventBytes -= Buffer.byteLength(event);
+      if (result === "accepted") {
+        continue;
+      }
     }
     break;
   }
@@ -171,7 +211,7 @@ function emitSignalEvent(state: SignalServerState, payload: unknown): boolean {
   let delivered = false;
   for (const client of state.clients) {
     const result = writeSignalSse(state, client, event);
-    delivered = result === "accepted" || result === "backpressured" || delivered;
+    delivered = result === "accepted" || result === "queued" || delivered;
   }
   return delivered || queueSignalEvent(state, event);
 }
@@ -219,10 +259,16 @@ async function handleRpc(params: {
   if (!method) {
     return rpcError(-32600, "Invalid Request", params.body.id);
   }
+  if (params.body.jsonrpc !== "2.0") {
+    return rpcError(-32600, "Invalid Request", params.body.id);
+  }
   if (method === "version") {
     return rpcResponse(params.body.id, { version: "crabline-signal-1" });
   }
   if (["send", "sendReaction", "sendReceipt", "sendTyping"].includes(method)) {
+    if (!validSignalRpcParams(method, params.body.params)) {
+      return rpcError(-32602, "Invalid params", params.body.id);
+    }
     const timestamp = params.state.nextTimestamp++;
     return rpcResponse(params.body.id, method === "sendTyping" ? {} : { timestamp });
   }
@@ -233,6 +279,70 @@ async function handleRpc(params: {
   });
 }
 
+function hasRecipients(params: Record<string, unknown>): boolean {
+  const values = [params.recipient, params.groupId, params.username];
+  return (
+    params.noteToSelf === true ||
+    values.some(
+      (value) =>
+        (typeof value === "string" && value.trim().length > 0) ||
+        (Array.isArray(value) &&
+          value.length > 0 &&
+          value.every((entry) => typeof entry === "string" && entry.trim().length > 0)),
+    )
+  );
+}
+
+function hasTypingRecipients(params: Record<string, unknown>): boolean {
+  if (
+    params.noteToSelf !== undefined ||
+    params.username !== undefined ||
+    (params.stop !== undefined && typeof params.stop !== "boolean")
+  ) {
+    return false;
+  }
+  return [params.recipient, params.groupId].some(
+    (value) =>
+      (typeof value === "string" && value.trim().length > 0) ||
+      (Array.isArray(value) &&
+        value.length > 0 &&
+        value.every((entry) => typeof entry === "string" && entry.trim().length > 0)),
+  );
+}
+
+function validTimestamp(value: unknown): boolean {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function validSignalRpcParams(method: string, value: unknown): boolean {
+  if (!isJsonObject(value)) {
+    return false;
+  }
+  if (method === "send") {
+    return hasRecipients(value) && readTrimmedString(value.message) !== undefined;
+  }
+  if (method === "sendReaction") {
+    return (
+      hasRecipients(value) &&
+      readTrimmedString(value.emoji) !== undefined &&
+      readTrimmedString(value.targetAuthor) !== undefined &&
+      validTimestamp(value.targetTimestamp)
+    );
+  }
+  if (method === "sendReceipt") {
+    const timestamps = Array.isArray(value.targetTimestamp)
+      ? value.targetTimestamp
+      : [value.targetTimestamp];
+    return (
+      readTrimmedString(value.recipient) !== undefined &&
+      timestamps.length > 0 &&
+      timestamps.every(validTimestamp) &&
+      (value.type === undefined || value.type === "read" || value.type === "viewed")
+    );
+  }
+  return method === "sendTyping" && hasTypingRecipients(value);
+}
+
 async function handleRequest(params: {
   request: IncomingMessage;
   response: ServerResponse;
@@ -240,20 +350,28 @@ async function handleRequest(params: {
 }): Promise<void> {
   const url = new URL(params.request.url ?? "/", "http://localhost");
   if (url.pathname === "/api/v1/events" && params.request.method === "GET") {
-    if (params.state.clients.size >= params.state.maxSseClients) {
+    if (params.state.clients.size + params.state.pendingSseClients >= params.state.maxSseClients) {
       await writeResponse(
         params.response,
         jsonResponse({ error: "Too many event stream clients", ok: false }, 503),
       );
       return;
     }
-    await appendEvent(params.state, {
-      at: new Date().toISOString(),
-      method: "GET",
-      path: url.pathname,
-      query: queryRecord(url),
-      type: "api",
-    });
+    params.state.pendingSseClients += 1;
+    try {
+      await appendEvent(params.state, {
+        at: new Date().toISOString(),
+        method: "GET",
+        path: url.pathname,
+        query: queryRecord(url),
+        type: "api",
+      });
+    } finally {
+      params.state.pendingSseClients -= 1;
+    }
+    if (params.request.destroyed || params.response.destroyed) {
+      return;
+    }
     params.response.writeHead(200, {
       "cache-control": "no-cache",
       connection: "keep-alive",
@@ -262,9 +380,10 @@ async function handleRequest(params: {
     params.response.flushHeaders();
     params.response.once("close", () => {
       params.state.clients.delete(params.response);
-      params.state.drainingClients.delete(params.response);
+      params.state.clientBuffers.delete(params.response);
     });
     params.state.clients.add(params.response);
+    params.state.clientBuffers.set(params.response, { bytes: 0, draining: false, events: [] });
     flushPendingSignalEvents(params.state, params.response);
     return;
   }
@@ -331,7 +450,7 @@ export async function startSignalServer(
     account: params.account ?? "+15550000000",
     adminToken: params.adminToken ?? randomBytes(24).toString("base64url"),
     clients: new Set(),
-    drainingClients: new WeakSet(),
+    clientBuffers: new Map(),
     maxPendingInboundEvents: resolveMaxPendingInboundEvents(params.maxPendingInboundEvents),
     maxSseClients:
       Number.isSafeInteger(params.maxSseClients) && (params.maxSseClients ?? 0) > 0
@@ -339,7 +458,9 @@ export async function startSignalServer(
         : DEFAULT_MAX_SIGNAL_SSE_CLIENTS,
     nextTimestamp: Date.now(),
     onEvent: params.onEvent,
+    pendingEventBytes: 0,
     pendingEvents: [],
+    pendingSseClients: 0,
     recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "signal.jsonl"),
   };
   const host = params.host ?? "127.0.0.1";
@@ -358,10 +479,7 @@ export async function startSignalServer(
             ? jsonResponse({ error: "Request body is too large", ok: false }, 413)
             : rpcError(-32600, "Request body is too large", null, 413);
         } else {
-          errorResponse = jsonResponse(
-            { error: error instanceof Error ? error.message : String(error), ok: false },
-            500,
-          );
+          errorResponse = jsonResponse({ error: "internal server error", ok: false }, 500);
         }
         await writeResponse(response, errorResponse);
       } else {

--- a/src/servers/signal.ts
+++ b/src/servers/signal.ts
@@ -299,7 +299,14 @@ async function handleRpc(params: {
 }
 
 function hasRecipients(params: Record<string, unknown>): boolean {
-  const values = [params.recipient, params.groupId, params.username];
+  const values = [
+    params.recipient,
+    params.recipients,
+    params.groupId,
+    params.groupIds,
+    params.username,
+    params.usernames,
+  ];
   return (
     params.noteToSelf === true ||
     values.some(
@@ -316,11 +323,12 @@ function hasTypingRecipients(params: Record<string, unknown>): boolean {
   if (
     params.noteToSelf !== undefined ||
     params.username !== undefined ||
+    params.usernames !== undefined ||
     (params.stop !== undefined && typeof params.stop !== "boolean")
   ) {
     return false;
   }
-  return [params.recipient, params.groupId].some(
+  return [params.recipient, params.recipients, params.groupId, params.groupIds].some(
     (value) =>
       (typeof value === "string" && value.trim().length > 0) ||
       (Array.isArray(value) &&
@@ -348,7 +356,9 @@ function validSignalRpcParams(method: string, value: unknown): boolean {
   if (method === "send") {
     return (
       hasRecipients(value) &&
-      (readTrimmedString(value.message) !== undefined || hasStringArray(value.attachments))
+      (readTrimmedString(value.message) !== undefined ||
+        readTrimmedString(value.attachment) !== undefined ||
+        hasStringArray(value.attachments))
     );
   }
   if (method === "sendReaction") {

--- a/src/servers/signal.ts
+++ b/src/servers/signal.ts
@@ -38,12 +38,12 @@ type SignalServerState = {
 
 type SignalClientBuffer = {
   bytes: number;
-  connectedAfterSequence: number;
   draining: boolean;
   events: SignalSseChunk[];
 };
 type SignalSseChunk = {
   data: string;
+  recipients?: Set<ServerResponse> | undefined;
   sequence?: number | undefined;
 };
 const SIGNAL_CLI_SSE_KEEPALIVE_MS = 15_000;
@@ -112,24 +112,20 @@ function removeSignalClient(
   state.clientBuffers.delete(client);
   if (buffer) {
     const undeliveredEvents = buffer.events.filter((event) => {
-      const sequence = event.sequence;
-      return (
-        sequence !== undefined &&
-        [...state.clientBuffers.values()].every(
-          (otherBuffer) => otherBuffer.connectedAfterSequence >= sequence,
-        )
-      );
+      event.recipients?.delete(client);
+      return event.sequence !== undefined && event.recipients?.size === 0;
     });
     if (undeliveredEvents.length > 0) {
-      state.pendingEvents.unshift(...undeliveredEvents);
+      state.pendingEvents.push(
+        ...undeliveredEvents.filter((event) => !state.pendingEvents.includes(event)),
+      );
+      state.pendingEvents.sort(
+        (left, right) => (left.sequence ?? Number.MAX_SAFE_INTEGER) - (right.sequence ?? 0),
+      );
       state.pendingEventBytes += undeliveredEvents.reduce(
         (total, event) => total + Buffer.byteLength(event.data),
         0,
       );
-      const replacement = state.clients.values().next().value;
-      if (replacement) {
-        flushPendingSignalEvents(state, replacement);
-      }
     }
   }
   if (destroy) {
@@ -167,8 +163,10 @@ function queueSignalClientEvent(
 ): SignalSseWriteResult {
   const buffer = state.clientBuffers.get(client);
   const eventBytes = Buffer.byteLength(event.data);
+  const alreadyBuffered = isSignalEventBuffered(state, event);
   if (
     !buffer ||
+    (!alreadyBuffered && signalBufferedEventCount(state) >= state.maxPendingInboundEvents) ||
     state.pendingEventBytes + buffer.bytes + eventBytes > MAX_SIGNAL_SSE_BUFFER_BYTES
   ) {
     evictSignalClient(state, client);
@@ -176,6 +174,7 @@ function queueSignalClientEvent(
   }
   buffer.events.push(event);
   buffer.bytes += eventBytes;
+  event.recipients?.add(client);
   scheduleSignalDrain(state, client);
   return "queued";
 }
@@ -205,7 +204,9 @@ function writeSignalSse(
     evictSignalClient(state, client);
     return "rejected";
   }
-  if (!client.write(event.data)) {
+  const accepted = client.write(event.data);
+  event.recipients?.add(client);
+  if (!accepted) {
     scheduleSignalDrain(state, client);
   }
   return "accepted";
@@ -219,19 +220,69 @@ function maxSignalClientBufferBytes(state: SignalServerState): number {
   return maxBytes;
 }
 
+function isSignalEventBuffered(state: SignalServerState, event: SignalSseChunk): boolean {
+  return (
+    state.pendingEvents.includes(event) ||
+    [...state.clientBuffers.values()].some((buffer) => buffer.events.includes(event))
+  );
+}
+
+function signalBufferedEventCount(state: SignalServerState): number {
+  const sequences = new Set<number>();
+  for (const event of state.pendingEvents) {
+    if (event.sequence !== undefined) {
+      sequences.add(event.sequence);
+    }
+  }
+  for (const buffer of state.clientBuffers.values()) {
+    for (const event of buffer.events) {
+      if (event.sequence !== undefined) {
+        sequences.add(event.sequence);
+      }
+    }
+  }
+  return sequences.size;
+}
+
 function queueSignalEvent(state: SignalServerState, event: SignalSseChunk): boolean {
   const eventBytes = Buffer.byteLength(event.data);
   if (
     eventBytes > MAX_SIGNAL_SSE_BUFFER_BYTES ||
     state.pendingEventBytes + maxSignalClientBufferBytes(state) + eventBytes >
       MAX_SIGNAL_SSE_BUFFER_BYTES ||
-    state.pendingEvents.length >= state.maxPendingInboundEvents
+    (!isSignalEventBuffered(state, event) &&
+      signalBufferedEventCount(state) >= state.maxPendingInboundEvents)
   ) {
     return false;
   }
   state.pendingEvents.push(event);
   state.pendingEventBytes += eventBytes;
   return true;
+}
+
+function replayExclusiveSignalEvents(state: SignalServerState, client: ServerResponse): void {
+  const events = new Map<number, SignalSseChunk>();
+  for (const [owner, buffer] of state.clientBuffers) {
+    if (owner === client) {
+      continue;
+    }
+    for (const event of buffer.events) {
+      if (
+        event.sequence !== undefined &&
+        event.recipients?.size === 1 &&
+        event.recipients.has(owner)
+      ) {
+        events.set(event.sequence, event);
+      }
+    }
+  }
+  for (const event of [...events.values()].sort(
+    (left, right) => left.sequence! - right.sequence!,
+  )) {
+    if (writeSignalSse(state, client, event) === "rejected") {
+      break;
+    }
+  }
 }
 
 function flushSignalClientEvents(state: SignalServerState, client: ServerResponse): void {
@@ -266,6 +317,7 @@ function flushPendingSignalEvents(state: SignalServerState, client: ServerRespon
 function emitSignalEvent(state: SignalServerState, payload: unknown): boolean {
   const event: SignalSseChunk = {
     data: `event:receive\ndata:${JSON.stringify(payload)}\n\n`,
+    recipients: new Set(),
     sequence: state.nextEventSequence++,
   };
   if (state.clients.size === 0 || state.pendingEvents.length > 0) {
@@ -469,11 +521,13 @@ async function handleRequest(params: {
     params.state.clients.add(params.response);
     params.state.clientBuffers.set(params.response, {
       bytes: 0,
-      connectedAfterSequence: params.state.nextEventSequence - 1,
       draining: false,
       events: [],
     });
-    flushPendingSignalEvents(params.state, params.response);
+    replayExclusiveSignalEvents(params.state, params.response);
+    if (params.state.clients.has(params.response)) {
+      flushPendingSignalEvents(params.state, params.response);
+    }
     return;
   }
 

--- a/src/servers/signal.ts
+++ b/src/servers/signal.ts
@@ -24,17 +24,28 @@ type SignalServerState = {
   account: string;
   adminToken: string;
   clients: Set<ServerResponse>;
-  clientBuffers: Map<ServerResponse, { bytes: number; draining: boolean; events: string[] }>;
+  clientBuffers: Map<ServerResponse, SignalClientBuffer>;
   maxPendingInboundEvents: number;
   maxSseClients: number;
+  nextEventSequence: number;
   nextTimestamp: number;
   onEvent: ServerEventObserver | undefined;
   pendingEventBytes: number;
-  pendingEvents: string[];
+  pendingEvents: SignalSseChunk[];
   pendingSseClients: number;
   recorderPath: string;
 };
 
+type SignalClientBuffer = {
+  bytes: number;
+  connectedAfterSequence: number;
+  draining: boolean;
+  events: SignalSseChunk[];
+};
+type SignalSseChunk = {
+  data: string;
+  sequence?: number | undefined;
+};
 const SIGNAL_CLI_SSE_KEEPALIVE_MS = 15_000;
 const DEFAULT_MAX_SIGNAL_SSE_CLIENTS = 32;
 const MAX_SIGNAL_SSE_BUFFER_BYTES = 2 * 1024 * 1024;
@@ -99,9 +110,27 @@ function removeSignalClient(
   const buffer = state.clientBuffers.get(client);
   state.clients.delete(client);
   state.clientBuffers.delete(client);
-  if (buffer && state.clients.size === 0 && buffer.events.length > 0) {
-    state.pendingEvents.unshift(...buffer.events);
-    state.pendingEventBytes += buffer.bytes;
+  if (buffer) {
+    const undeliveredEvents = buffer.events.filter((event) => {
+      const sequence = event.sequence;
+      return (
+        sequence !== undefined &&
+        [...state.clientBuffers.values()].every(
+          (otherBuffer) => otherBuffer.connectedAfterSequence >= sequence,
+        )
+      );
+    });
+    if (undeliveredEvents.length > 0) {
+      state.pendingEvents.unshift(...undeliveredEvents);
+      state.pendingEventBytes += undeliveredEvents.reduce(
+        (total, event) => total + Buffer.byteLength(event.data),
+        0,
+      );
+      const replacement = state.clients.values().next().value;
+      if (replacement) {
+        flushPendingSignalEvents(state, replacement);
+      }
+    }
   }
   if (destroy) {
     client.destroy();
@@ -134,10 +163,10 @@ function scheduleSignalDrain(state: SignalServerState, client: ServerResponse): 
 function queueSignalClientEvent(
   state: SignalServerState,
   client: ServerResponse,
-  event: string,
+  event: SignalSseChunk,
 ): SignalSseWriteResult {
   const buffer = state.clientBuffers.get(client);
-  const eventBytes = Buffer.byteLength(event);
+  const eventBytes = Buffer.byteLength(event.data);
   if (
     !buffer ||
     state.pendingEventBytes + buffer.bytes + eventBytes > MAX_SIGNAL_SSE_BUFFER_BYTES
@@ -154,17 +183,17 @@ function queueSignalClientEvent(
 function writeSignalSse(
   state: SignalServerState,
   client: ServerResponse,
-  event: string,
+  event: SignalSseChunk,
 ): SignalSseWriteResult {
   if (client.destroyed) {
-    state.clients.delete(client);
+    removeSignalClient(state, client, false);
     return "rejected";
   }
   if (client.writableEnded) {
     evictSignalClient(state, client);
     return "rejected";
   }
-  const eventBytes = Buffer.byteLength(event);
+  const eventBytes = Buffer.byteLength(event.data);
   if (eventBytes > MAX_SIGNAL_SSE_BUFFER_BYTES) {
     return "rejected";
   }
@@ -176,7 +205,7 @@ function writeSignalSse(
     evictSignalClient(state, client);
     return "rejected";
   }
-  if (!client.write(event)) {
+  if (!client.write(event.data)) {
     scheduleSignalDrain(state, client);
   }
   return "accepted";
@@ -190,8 +219,8 @@ function maxSignalClientBufferBytes(state: SignalServerState): number {
   return maxBytes;
 }
 
-function queueSignalEvent(state: SignalServerState, event: string): boolean {
-  const eventBytes = Buffer.byteLength(event);
+function queueSignalEvent(state: SignalServerState, event: SignalSseChunk): boolean {
+  const eventBytes = Buffer.byteLength(event.data);
   if (
     eventBytes > MAX_SIGNAL_SSE_BUFFER_BYTES ||
     state.pendingEventBytes + maxSignalClientBufferBytes(state) + eventBytes >
@@ -212,8 +241,8 @@ function flushSignalClientEvents(state: SignalServerState, client: ServerRespons
       break;
     }
     const event = buffer.events.shift()!;
-    buffer.bytes -= Buffer.byteLength(event);
-    if (!client.write(event)) {
+    buffer.bytes -= Buffer.byteLength(event.data);
+    if (!client.write(event.data)) {
       scheduleSignalDrain(state, client);
       break;
     }
@@ -225,7 +254,7 @@ function flushPendingSignalEvents(state: SignalServerState, client: ServerRespon
     const result = writeSignalSse(state, client, state.pendingEvents[0]!);
     if (result === "accepted" || result === "queued") {
       const event = state.pendingEvents.shift()!;
-      state.pendingEventBytes -= Buffer.byteLength(event);
+      state.pendingEventBytes -= Buffer.byteLength(event.data);
       if (result === "accepted") {
         continue;
       }
@@ -235,7 +264,10 @@ function flushPendingSignalEvents(state: SignalServerState, client: ServerRespon
 }
 
 function emitSignalEvent(state: SignalServerState, payload: unknown): boolean {
-  const event = `event:receive\ndata:${JSON.stringify(payload)}\n\n`;
+  const event: SignalSseChunk = {
+    data: `event:receive\ndata:${JSON.stringify(payload)}\n\n`,
+    sequence: state.nextEventSequence++,
+  };
   if (state.clients.size === 0 || state.pendingEvents.length > 0) {
     return queueSignalEvent(state, event);
   }
@@ -435,7 +467,12 @@ async function handleRequest(params: {
       removeSignalClient(params.state, params.response, false);
     });
     params.state.clients.add(params.response);
-    params.state.clientBuffers.set(params.response, { bytes: 0, draining: false, events: [] });
+    params.state.clientBuffers.set(params.response, {
+      bytes: 0,
+      connectedAfterSequence: params.state.nextEventSequence - 1,
+      draining: false,
+      events: [],
+    });
     flushPendingSignalEvents(params.state, params.response);
     return;
   }
@@ -508,6 +545,7 @@ export async function startSignalServer(
       Number.isSafeInteger(params.maxSseClients) && (params.maxSseClients ?? 0) > 0
         ? params.maxSseClients!
         : DEFAULT_MAX_SIGNAL_SSE_CLIENTS,
+    nextEventSequence: 1,
     nextTimestamp: Date.now(),
     onEvent: params.onEvent,
     pendingEventBytes: 0,
@@ -541,7 +579,7 @@ export async function startSignalServer(
   });
   const keepalive = setInterval(() => {
     for (const client of state.clients) {
-      writeSignalSse(state, client, ":\n");
+      writeSignalSse(state, client, { data: ":\n" });
     }
   }, SIGNAL_CLI_SSE_KEEPALIVE_MS);
   keepalive.unref();

--- a/src/servers/signal.ts
+++ b/src/servers/signal.ts
@@ -224,7 +224,7 @@ function flushPendingSignalEvents(state: SignalServerState, client: ServerRespon
 
 function emitSignalEvent(state: SignalServerState, payload: unknown): boolean {
   const event = `event:receive\ndata:${JSON.stringify(payload)}\n\n`;
-  if (state.clients.size === 0) {
+  if (state.clients.size === 0 || state.pendingEvents.length > 0) {
     return queueSignalEvent(state, event);
   }
   let delivered = false;
@@ -333,12 +333,23 @@ function validTimestamp(value: unknown): boolean {
   return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
 }
 
+function hasStringArray(value: unknown): boolean {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every((entry) => typeof entry === "string" && entry.trim().length > 0)
+  );
+}
+
 function validSignalRpcParams(method: string, value: unknown): boolean {
   if (!isJsonObject(value)) {
     return false;
   }
   if (method === "send") {
-    return hasRecipients(value) && readTrimmedString(value.message) !== undefined;
+    return (
+      hasRecipients(value) &&
+      (readTrimmedString(value.message) !== undefined || hasStringArray(value.attachments))
+    );
   }
   if (method === "sendReaction") {
     return (
@@ -349,11 +360,12 @@ function validSignalRpcParams(method: string, value: unknown): boolean {
     );
   }
   if (method === "sendReceipt") {
-    const timestamps = Array.isArray(value.targetTimestamp)
-      ? value.targetTimestamp
-      : [value.targetTimestamp];
+    const targetTimestamps = value.targetTimestamps ?? value.targetTimestamp;
+    const timestamps = Array.isArray(targetTimestamps) ? targetTimestamps : [targetTimestamps];
     return (
-      readTrimmedString(value.recipient) !== undefined &&
+      (readTrimmedString(value.recipient) !== undefined ||
+        readTrimmedString(value.username) !== undefined ||
+        hasStringArray(value.usernames)) &&
       timestamps.length > 0 &&
       timestamps.every(validTimestamp) &&
       (value.type === undefined || value.type === "read" || value.type === "viewed")

--- a/src/servers/signal.ts
+++ b/src/servers/signal.ts
@@ -164,10 +164,11 @@ function queueSignalClientEvent(
   const buffer = state.clientBuffers.get(client);
   const eventBytes = Buffer.byteLength(event.data);
   const alreadyBuffered = isSignalEventBuffered(state, event);
+  const pendingEventBytes = state.pendingEvents.includes(event) ? 0 : eventBytes;
   if (
     !buffer ||
     (!alreadyBuffered && signalBufferedEventCount(state) >= state.maxPendingInboundEvents) ||
-    state.pendingEventBytes + buffer.bytes + eventBytes > MAX_SIGNAL_SSE_BUFFER_BYTES
+    state.pendingEventBytes + buffer.bytes + pendingEventBytes > MAX_SIGNAL_SSE_BUFFER_BYTES
   ) {
     evictSignalClient(state, client);
     return "rejected";

--- a/src/servers/signal.ts
+++ b/src/servers/signal.ts
@@ -91,10 +91,25 @@ function rpcError(code: number, message: string, id: unknown = null, status = 40
   );
 }
 
-function evictSignalClient(state: SignalServerState, client: ServerResponse): void {
+function removeSignalClient(
+  state: SignalServerState,
+  client: ServerResponse,
+  destroy: boolean,
+): void {
+  const buffer = state.clientBuffers.get(client);
   state.clients.delete(client);
   state.clientBuffers.delete(client);
-  client.destroy();
+  if (buffer && state.clients.size === 0 && buffer.events.length > 0) {
+    state.pendingEvents.unshift(...buffer.events);
+    state.pendingEventBytes += buffer.bytes;
+  }
+  if (destroy) {
+    client.destroy();
+  }
+}
+
+function evictSignalClient(state: SignalServerState, client: ServerResponse): void {
+  removeSignalClient(state, client, true);
 }
 
 function scheduleSignalDrain(state: SignalServerState, client: ServerResponse): void {
@@ -108,6 +123,10 @@ function scheduleSignalDrain(state: SignalServerState, client: ServerResponse): 
     if (current) {
       current.draining = false;
       flushSignalClientEvents(state, client);
+      const remaining = state.clientBuffers.get(client);
+      if (remaining && remaining.events.length === 0 && !client.writableNeedDrain) {
+        flushPendingSignalEvents(state, client);
+      }
     }
   });
 }
@@ -379,8 +398,7 @@ async function handleRequest(params: {
     });
     params.response.flushHeaders();
     params.response.once("close", () => {
-      params.state.clients.delete(params.response);
-      params.state.clientBuffers.delete(params.response);
+      removeSignalClient(params.state, params.response, false);
     });
     params.state.clients.add(params.response);
     params.state.clientBuffers.set(params.response, { bytes: 0, draining: false, events: [] });

--- a/src/servers/slack.ts
+++ b/src/servers/slack.ts
@@ -147,8 +147,8 @@ function requireSlackToken(
 ): Response | undefined {
   const authorization = request.headers.authorization;
   const tokenFromHeader =
-    typeof authorization === "string" && authorization.startsWith("Bearer ")
-      ? authorization.slice("Bearer ".length).trim()
+    typeof authorization === "string"
+      ? /^Bearer\s+(.+)$/iu.exec(authorization.trim())?.[1]?.trim()
       : undefined;
   const token = tokenFromHeader ?? readTrimmedString(body.token);
   if (!token) {
@@ -224,6 +224,14 @@ function readStructuredValue(value: unknown): unknown {
   }
 }
 
+function readStructuredArray(value: unknown, error: string): unknown[] | Response | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const parsed = readStructuredValue(value);
+  return Array.isArray(parsed) ? parsed : slackError(error);
+}
+
 function hasStructuredMessageContent(value: unknown): boolean {
   if (Array.isArray(value)) {
     return value.length > 0;
@@ -243,7 +251,7 @@ function hasThreadParent(
   },
 ): boolean {
   return messagesForChannel(state, params.channel).some(
-    (message) => message.ts === params.threadTs || message.thread_ts === params.threadTs,
+    (message) => message.ts === params.threadTs && message.thread_ts === undefined,
   );
 }
 
@@ -290,7 +298,7 @@ function mpimChannelForUsers(
   return channel;
 }
 
-function requireSlackUsers(value: unknown): string[] | Response {
+function requireSlackUsers(value: unknown, botUserId: string): string[] | Response {
   const rawUsers = readTrimmedString(value);
   if (!rawUsers) {
     return slackError("users_list_not_supplied");
@@ -305,7 +313,18 @@ function requireSlackUsers(value: unknown): string[] | Response {
   if (new Set(users).size !== users.length) {
     return slackError("invalid_user_combination");
   }
+  if (users.includes(botUserId)) {
+    return slackError("invalid_user_combination");
+  }
   return users;
+}
+
+function requireSlackLimit(value: unknown): number | Response {
+  const limit = value === undefined ? 100 : readInteger(value);
+  if (limit === undefined || limit < 1 || limit > 1_000) {
+    return slackError("invalid_limit");
+  }
+  return limit;
 }
 
 function appendMessage(state: SlackServerState, message: SlackMessage): SlackMessage {
@@ -459,8 +478,14 @@ async function handleSlackApi(params: {
         return channel;
       }
       const text = readTrimmedString(params.body.text) ?? "";
-      const attachments = readStructuredValue(params.body.attachments);
-      const blocks = readStructuredValue(params.body.blocks);
+      const attachments = readStructuredArray(params.body.attachments, "invalid_attachments");
+      if (attachments instanceof Response) {
+        return attachments;
+      }
+      const blocks = readStructuredArray(params.body.blocks, "invalid_blocks");
+      if (blocks instanceof Response) {
+        return blocks;
+      }
       const metadata = readStructuredValue(params.body.metadata);
       if (
         !text &&
@@ -497,7 +522,7 @@ async function handleSlackApi(params: {
       return slackOk({ channel, message, ts: message.ts });
     }
     case "conversations.open": {
-      const users = requireSlackUsers(params.body.users);
+      const users = requireSlackUsers(params.body.users, params.state.botUserId);
       if (users instanceof Response) {
         return users;
       }
@@ -553,7 +578,10 @@ async function handleSlackApi(params: {
       if (latest instanceof Response) {
         return latest;
       }
-      const limit = readInteger(params.body.limit) ?? 100;
+      const limit = requireSlackLimit(params.body.limit);
+      if (limit instanceof Response) {
+        return limit;
+      }
       const messages = messagesForChannel(params.state, channel).filter((message) => {
         if (oldest && message.ts <= oldest) {
           return false;
@@ -580,7 +608,10 @@ async function handleSlackApi(params: {
       if (!ts) {
         return slackError("message_not_found");
       }
-      const limit = readInteger(params.body.limit) ?? 100;
+      const limit = requireSlackLimit(params.body.limit);
+      if (limit instanceof Response) {
+        return limit;
+      }
       const messages = messagesForChannel(params.state, channel).filter(
         (message) => message.ts === ts || message.thread_ts === ts,
       );
@@ -613,6 +644,9 @@ async function handleAdminInbound(params: {
   const threadTs = requireSlackThreadTs(params.body.threadTs ?? params.body.thread_ts);
   if (threadTs instanceof Response) {
     return threadTs;
+  }
+  if (threadTs && !hasThreadParent(params.state, { channel, threadTs })) {
+    return slackError("thread_not_found");
   }
   const ts = requireSlackThreadTs(params.body.ts);
   if (ts instanceof Response) {

--- a/src/servers/slack.ts
+++ b/src/servers/slack.ts
@@ -255,6 +255,19 @@ function hasThreadParent(
   );
 }
 
+function resolveThreadTs(
+  state: SlackServerState,
+  params: {
+    channel: string;
+    ts: string;
+  },
+): string | undefined {
+  const message = messagesForChannel(state, params.channel).find(
+    (candidate) => candidate.ts === params.ts,
+  );
+  return message?.thread_ts ?? message?.ts;
+}
+
 function nextSlackTs(state: SlackServerState): string {
   const index = state.nextTsIndex++;
   return `${1_700_000_000 + Math.floor(index / 1_000_000)}.${String(index % 1_000_000).padStart(6, "0")}`;
@@ -608,16 +621,17 @@ async function handleSlackApi(params: {
       if (!ts) {
         return slackError("message_not_found");
       }
+      const threadTs = resolveThreadTs(params.state, { channel, ts });
+      if (!threadTs) {
+        return slackError("thread_not_found");
+      }
       const limit = requireSlackLimit(params.body.limit);
       if (limit instanceof Response) {
         return limit;
       }
       const messages = messagesForChannel(params.state, channel).filter(
-        (message) => message.ts === ts || message.thread_ts === ts,
+        (message) => message.ts === threadTs || message.thread_ts === threadTs,
       );
-      if (messages.length === 0) {
-        return slackError("thread_not_found");
-      }
       return slackOk({ has_more: messages.length > limit, messages: messages.slice(0, limit) });
     }
     default:

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -481,14 +481,13 @@ async function flushTelegramWebhookUpdates(
     const controller = new AbortController();
     state.activeWebhookDeliveries.add(controller);
     try {
+      const headers = new Headers({ "content-type": "application/json" });
+      if (webhook.secretToken) {
+        headers.set("x-telegram-bot-api-secret-token", webhook.secretToken);
+      }
       const response = await fetch(webhook.url, {
         body: JSON.stringify(update),
-        headers: {
-          "content-type": "application/json",
-          ...(webhook.secretToken
-            ? { "x-telegram-bot-api-secret-token": webhook.secretToken }
-            : {}),
-        },
+        headers,
         method: "POST",
         signal: AbortSignal.any([controller.signal, AbortSignal.timeout(3_000)]),
       });

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -507,8 +507,6 @@ async function flushTelegramWebhookUpdates(
         state.updates.splice(deliveredIndex, 1);
       }
       if (state.webhook === webhook) {
-        delete webhook.lastErrorDate;
-        delete webhook.lastErrorMessage;
         state.webhookRetryAttempts = 0;
       }
     } catch {

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -259,7 +259,7 @@ async function appendEvent(state: TelegramServerState, event: TelegramServerEven
   await recordServerEvent({ event, onEvent: state.onEvent, recorderPath: state.recorderPath });
 }
 
-function redactTelegramBody(body: Record<string, unknown>): Record<string, unknown> {
+function redactTelegramSecrets<T>(body: Record<string, T>): Record<string, T | string> {
   return Object.fromEntries(
     Object.entries(body).map(([key, value]) => [
       key,
@@ -900,10 +900,10 @@ async function handleRequest(params: { request: IncomingMessage; state: Telegram
   }
   await appendEvent(params.state, {
     at: new Date().toISOString(),
-    body: redactTelegramBody(body),
+    body: redactTelegramSecrets(body),
     method: requestMethod,
     path: `/bot<redacted>/${botPath.method}`,
-    query: queryRecord(url),
+    query: redactTelegramSecrets(queryRecord(url)),
     type: "api",
   });
   return handleTelegramApi({

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -31,19 +31,31 @@ type TelegramServerEvent = {
   type: "admin" | "api";
 };
 
+type TelegramWebhook = {
+  lastErrorDate?: number;
+  lastErrorMessage?: string;
+  secretToken?: string;
+  url: string;
+};
+
 type TelegramServerState = {
   activeUpdatePoll: TelegramUpdatePoll | undefined;
+  activeWebhookDeliveries: Set<AbortController>;
   adminToken: string;
   botId: number;
   botToken: string;
   botUsername: string;
   closing: boolean;
+  inboundAdmission: Promise<void>;
   maxPendingInboundEvents: number;
   nextMessageId: number;
   nextUpdateId: number;
   onEvent: ServerEventObserver | undefined;
   recorderPath: string;
   updates: TelegramUpdate[];
+  webhook: TelegramWebhook | undefined;
+  webhookDelivery: Promise<Response | undefined> | undefined;
+  webhookRetryTimer: NodeJS.Timeout | undefined;
 };
 
 type TelegramUpdatePoll = {
@@ -165,49 +177,40 @@ async function parseRequestBody(request: IncomingMessage): Promise<unknown> {
   }
   const contentType = request.headers["content-type"] ?? "";
   const contentTypes = Array.isArray(contentType) ? contentType : [contentType];
-  if (contentTypes.some((entry) => entry.includes("json"))) {
+  if (contentTypes.some((entry) => entry.toLowerCase().includes("json"))) {
     try {
       return JSON.parse(body.toString("utf8")) as unknown;
     } catch (error) {
       throw new InvalidJsonBodyError(error);
     }
   }
-  const multipartType = contentTypes.find((entry) => entry.includes("multipart/form-data"));
+  const multipartType = contentTypes.find((entry) =>
+    entry.toLowerCase().includes("multipart/form-data"),
+  );
   if (multipartType) {
-    return parseMultipartFormDataBody(body, multipartType);
+    return await parseMultipartFormDataBody(body, multipartType);
   }
   const params = new URLSearchParams(body.toString("utf8"));
   return Object.fromEntries(params.entries());
 }
 
-function parseMultipartFormDataBody(body: Buffer, contentType: string): Record<string, unknown> {
-  const boundary = /(?:^|;\s*)boundary=(?:"([^"]+)"|([^;]+))/iu.exec(contentType);
-  const boundaryValue = boundary?.[1] ?? boundary?.[2];
-  if (!boundaryValue) {
-    return {};
+async function parseMultipartFormDataBody(
+  body: Buffer,
+  contentType: string,
+): Promise<Record<string, unknown>> {
+  let form: FormData;
+  try {
+    form = await new Request("http://localhost", {
+      body,
+      headers: { "content-type": contentType },
+      method: "POST",
+    }).formData();
+  } catch (error) {
+    throw new InvalidJsonBodyError(error);
   }
   const fields: Record<string, unknown> = {};
-  const delimiter = `--${boundaryValue}`;
-  for (const rawPart of body.toString("binary").split(delimiter)) {
-    const part = rawPart.replace(/^\r?\n/u, "").replace(/\r?\n$/u, "");
-    if (!part || part === "--") {
-      continue;
-    }
-    const separatorIndex = part.indexOf("\r\n\r\n");
-    if (separatorIndex < 0) {
-      continue;
-    }
-    const rawHeaders = part.slice(0, separatorIndex);
-    const rawContent = part.slice(separatorIndex + 4).replace(/\r?\n--$/u, "");
-    const disposition = rawHeaders
-      .split(/\r?\n/u)
-      .find((header) => header.toLowerCase().startsWith("content-disposition:"));
-    const name = /(?:^|;\s*)name="([^"]+)"/iu.exec(disposition ?? "")?.[1];
-    if (!name) {
-      continue;
-    }
-    const filename = /(?:^|;\s*)filename="([^"]*)"/iu.exec(disposition ?? "")?.[1];
-    fields[name] = filename && filename.length > 0 ? filename : rawContent;
+  for (const [name, value] of form) {
+    fields[name] = typeof value === "string" ? value : value.name;
   }
   return fields;
 }
@@ -236,6 +239,10 @@ function toIntegerValue(value: unknown): number | undefined {
   return Number(stringValue);
 }
 
+function toBooleanValue(value: unknown): boolean {
+  return value === true || (typeof value === "string" && value.toLowerCase() === "true");
+}
+
 function telegramChatId(value: unknown): number | string | undefined {
   const stringValue = toStringValue(value);
   if (!stringValue) {
@@ -246,6 +253,15 @@ function telegramChatId(value: unknown): number | string | undefined {
 
 async function appendEvent(state: TelegramServerState, event: TelegramServerEvent) {
   await recordServerEvent({ event, onEvent: state.onEvent, recorderPath: state.recorderPath });
+}
+
+function redactTelegramBody(body: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(body).map(([key, value]) => [
+      key,
+      key === "secret_token" ? "<redacted>" : value,
+    ]),
+  );
 }
 
 function createBotUser(state: TelegramServerState) {
@@ -375,12 +391,6 @@ function createInboundUpdate(
           typeof (entry as { type?: unknown }).type === "string",
       )
     : undefined;
-  if (messageId !== undefined) {
-    state.nextMessageId = Math.max(state.nextMessageId, messageId + 1);
-  }
-  if (updateId !== undefined) {
-    state.nextUpdateId = Math.max(state.nextUpdateId, updateId + 1);
-  }
   return {
     message: {
       chat: createChat(chatId),
@@ -391,13 +401,170 @@ function createInboundUpdate(
         is_bot: false,
         ...(fromUsername ? { username: fromUsername } : {}),
       },
-      message_id: messageId ?? state.nextMessageId++,
+      message_id: messageId ?? state.nextMessageId,
       ...(entities && entities.length > 0 ? { entities } : {}),
       ...(threadId !== undefined ? { message_thread_id: threadId } : {}),
       text,
     },
-    update_id: updateId ?? state.nextUpdateId++,
+    update_id: updateId ?? state.nextUpdateId,
   };
+}
+
+async function handleTelegramAdminInbound(params: {
+  body: Record<string, unknown>;
+  request: IncomingMessage;
+  state: TelegramServerState;
+  url: URL;
+}): Promise<Response> {
+  let releaseAdmission!: () => void;
+  const previousAdmission = params.state.inboundAdmission;
+  params.state.inboundAdmission = new Promise<void>((resolve) => {
+    releaseAdmission = resolve;
+  });
+  await previousAdmission;
+  try {
+    const nextMessageId = params.state.nextMessageId;
+    const nextUpdateId = params.state.nextUpdateId;
+    const update = createInboundUpdate(params.state, params.body);
+    params.state.nextMessageId = nextMessageId;
+    params.state.nextUpdateId = nextUpdateId;
+    if (!update) {
+      return telegramError("Bad Request: chatId and text are required");
+    }
+    if (params.state.updates.length >= params.state.maxPendingInboundEvents) {
+      return telegramError(
+        `Too Many Requests: pending inbound queue is full (${params.state.maxPendingInboundEvents} updates)`,
+        429,
+      );
+    }
+    params.state.nextMessageId = Math.max(
+      params.state.nextMessageId,
+      update.message.message_id + 1,
+    );
+    params.state.nextUpdateId = Math.max(params.state.nextUpdateId, update.update_id + 1);
+    try {
+      await appendEvent(params.state, {
+        at: new Date().toISOString(),
+        body: params.body,
+        method: params.request.method ?? "POST",
+        path: params.url.pathname,
+        query: queryRecord(params.url),
+        type: "admin",
+      });
+    } catch (error) {
+      params.state.nextMessageId = nextMessageId;
+      params.state.nextUpdateId = nextUpdateId;
+      throw error;
+    }
+    params.state.updates.push(update);
+    params.state.updates.sort((left, right) => left.update_id - right.update_id);
+    if (params.state.webhook) {
+      const deliveryError = await deliverTelegramWebhookUpdates(params.state);
+      return deliveryError ?? jsonResponse({ ok: true, update });
+    }
+    finishTelegramUpdatePoll(params.state, "update");
+    return jsonResponse({ ok: true, update });
+  } finally {
+    releaseAdmission();
+  }
+}
+
+async function flushTelegramWebhookUpdates(
+  state: TelegramServerState,
+): Promise<Response | undefined> {
+  if (!state.webhook) {
+    return undefined;
+  }
+  while (state.updates.length > 0 && state.webhook) {
+    const webhook: TelegramWebhook = state.webhook;
+    const update = state.updates[0]!;
+    const controller = new AbortController();
+    state.activeWebhookDeliveries.add(controller);
+    try {
+      const response = await fetch(webhook.url, {
+        body: JSON.stringify(update),
+        headers: {
+          "content-type": "application/json",
+          ...(webhook.secretToken
+            ? { "x-telegram-bot-api-secret-token": webhook.secretToken }
+            : {}),
+        },
+        method: "POST",
+        signal: AbortSignal.any([controller.signal, AbortSignal.timeout(3_000)]),
+      });
+      await response.body?.cancel();
+      if (!response.ok) {
+        if (state.webhook === webhook) {
+          webhook.lastErrorDate = Math.floor(Date.now() / 1_000);
+          webhook.lastErrorMessage = `Wrong response from the webhook: ${response.status}`;
+        }
+        return telegramError("Bad Gateway: webhook delivery failed", 502);
+      }
+      const deliveredIndex = state.updates.indexOf(update);
+      if (deliveredIndex >= 0) {
+        state.updates.splice(deliveredIndex, 1);
+      }
+      if (state.webhook === webhook) {
+        delete webhook.lastErrorDate;
+        delete webhook.lastErrorMessage;
+      }
+    } catch {
+      if (state.webhook === webhook) {
+        webhook.lastErrorDate = Math.floor(Date.now() / 1_000);
+        webhook.lastErrorMessage = "Webhook delivery failed";
+      }
+      return telegramError("Bad Gateway: webhook delivery failed", 502);
+    } finally {
+      state.activeWebhookDeliveries.delete(controller);
+    }
+  }
+  return undefined;
+}
+
+function clearTelegramWebhookRetry(state: TelegramServerState): void {
+  if (state.webhookRetryTimer) {
+    clearTimeout(state.webhookRetryTimer);
+    state.webhookRetryTimer = undefined;
+  }
+}
+
+function scheduleTelegramWebhookDelivery(state: TelegramServerState, delayMs: number): void {
+  if (
+    state.closing ||
+    !state.webhook ||
+    state.updates.length === 0 ||
+    state.webhookDelivery ||
+    state.webhookRetryTimer
+  ) {
+    return;
+  }
+  state.webhookRetryTimer = setTimeout(() => {
+    state.webhookRetryTimer = undefined;
+    void deliverTelegramWebhookUpdates(state);
+  }, delayMs);
+  state.webhookRetryTimer.unref();
+}
+
+async function deliverTelegramWebhookUpdates(
+  state: TelegramServerState,
+): Promise<Response | undefined> {
+  if (state.webhookDelivery) {
+    return await state.webhookDelivery;
+  }
+  const delivery = flushTelegramWebhookUpdates(state);
+  state.webhookDelivery = delivery;
+  let result: Response | undefined;
+  try {
+    result = await delivery;
+    return result;
+  } finally {
+    if (state.webhookDelivery === delivery) {
+      state.webhookDelivery = undefined;
+    }
+    if (state.webhook && state.updates.length > 0) {
+      scheduleTelegramWebhookDelivery(state, result ? 100 : 0);
+    }
+  }
 }
 
 async function handleTelegramApi(params: {
@@ -410,8 +577,6 @@ async function handleTelegramApi(params: {
   switch (method) {
     case "getme":
       return telegramOk(createBotUser(params.state));
-    case "deletewebhook":
-    case "setwebhook":
     case "setmycommands":
     case "deletemycommands":
     case "sendchataction":
@@ -422,6 +587,63 @@ async function handleTelegramApi(params: {
     case "setmessagereaction":
     case "editforumtopic":
       return telegramOk(true);
+    case "setwebhook": {
+      if (params.body.url === "") {
+        if (toBooleanValue(params.body.drop_pending_updates)) {
+          params.state.updates.length = 0;
+        }
+        clearTelegramWebhookRetry(params.state);
+        params.state.webhook = undefined;
+        return telegramOk(true);
+      }
+      const webhookUrl = toStringValue(params.body.url);
+      if (!webhookUrl) {
+        return telegramError("Bad Request: url is required");
+      }
+      let parsedUrl: URL;
+      try {
+        parsedUrl = new URL(webhookUrl);
+      } catch {
+        return telegramError("Bad Request: bad webhook URL");
+      }
+      if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+        return telegramError("Bad Request: bad webhook URL");
+      }
+      const secretToken = toStringValue(params.body.secret_token);
+      if (secretToken && !/^[A-Za-z0-9_-]{1,256}$/u.test(secretToken)) {
+        return telegramError("Bad Request: invalid secret token");
+      }
+      if (toBooleanValue(params.body.drop_pending_updates)) {
+        params.state.updates.length = 0;
+      }
+      params.state.webhook = {
+        ...(secretToken ? { secretToken } : {}),
+        url: parsedUrl.href,
+      };
+      finishTelegramUpdatePoll(params.state, "conflict");
+      clearTelegramWebhookRetry(params.state);
+      scheduleTelegramWebhookDelivery(params.state, 0);
+      return telegramOk(true);
+    }
+    case "deletewebhook":
+      if (toBooleanValue(params.body.drop_pending_updates)) {
+        params.state.updates.length = 0;
+      }
+      clearTelegramWebhookRetry(params.state);
+      params.state.webhook = undefined;
+      return telegramOk(true);
+    case "getwebhookinfo":
+      return telegramOk({
+        has_custom_certificate: false,
+        ...(params.state.webhook?.lastErrorDate
+          ? { last_error_date: params.state.webhook.lastErrorDate }
+          : {}),
+        ...(params.state.webhook?.lastErrorMessage
+          ? { last_error_message: params.state.webhook.lastErrorMessage }
+          : {}),
+        pending_update_count: params.state.updates.length,
+        url: params.state.webhook?.url ?? "",
+      });
     case "createforumtopic":
       return telegramOk({
         icon_color: 0x6fb9f0,
@@ -457,6 +679,9 @@ async function handleTelegramApi(params: {
         : telegramError(`Bad Request: chat_id and ${mediaKind} are required`);
     }
     case "getupdates":
+      if (params.state.webhook) {
+        return telegramError("Conflict: can't use getUpdates method while webhook is active", 409);
+      }
       return await handleTelegramGetUpdates(params);
     default:
       return telegramError(`Not Found: unsupported method ${params.method}`, 404);
@@ -602,28 +827,12 @@ async function handleRequest(params: { request: IncomingMessage; state: Telegram
     if (!isJsonObject(body)) {
       return telegramError("Bad Request: request body must be a JSON object");
     }
-    const update = createInboundUpdate(params.state, body);
-    if (!update) {
-      return telegramError("Bad Request: chatId and text are required");
-    }
-    if (params.state.updates.length >= params.state.maxPendingInboundEvents) {
-      return telegramError(
-        `Too Many Requests: pending inbound queue is full (${params.state.maxPendingInboundEvents} updates)`,
-        429,
-      );
-    }
-    await appendEvent(params.state, {
-      at: new Date().toISOString(),
+    return await handleTelegramAdminInbound({
       body,
-      method: params.request.method ?? "POST",
-      path: url.pathname,
-      query: queryRecord(url),
-      type: "admin",
+      request: params.request,
+      state: params.state,
+      url,
     });
-    params.state.updates.push(update);
-    params.state.updates.sort((left, right) => left.update_id - right.update_id);
-    finishTelegramUpdatePoll(params.state, "update");
-    return jsonResponse({ ok: true, update });
   }
 
   const botPath = requireTelegramBotPath(url.pathname);
@@ -642,7 +851,7 @@ async function handleRequest(params: { request: IncomingMessage; state: Telegram
   }
   await appendEvent(params.state, {
     at: new Date().toISOString(),
-    body,
+    body: redactTelegramBody(body),
     method: requestMethod,
     path: `/bot<redacted>/${botPath.method}`,
     query: queryRecord(url),
@@ -663,6 +872,7 @@ export async function startTelegramServer(
   const botId = params.botId ?? 424242;
   const state: TelegramServerState = {
     activeUpdatePoll: undefined,
+    activeWebhookDeliveries: new Set(),
     adminToken: params.adminToken ?? randomBytes(24).toString("hex"),
     botId,
     botToken:
@@ -671,6 +881,7 @@ export async function startTelegramServer(
         ? "424242:crabline-telegram-token"
         : `${botId}:${randomBytes(26).toString("base64url")}`),
     botUsername: params.botUsername ?? "crabline_bot",
+    inboundAdmission: Promise.resolve(),
     maxPendingInboundEvents: resolveMaxPendingInboundEvents(params.maxPendingInboundEvents),
     nextMessageId: 1,
     nextUpdateId: 1,
@@ -678,6 +889,9 @@ export async function startTelegramServer(
     recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "telegram.jsonl"),
     closing: false,
     updates: [],
+    webhook: undefined,
+    webhookDelivery: undefined,
+    webhookRetryTimer: undefined,
   };
   const port = params.port ?? 0;
   const server = createServer(async (request, response) => {
@@ -690,13 +904,7 @@ export async function startTelegramServer(
           ? telegramError("Bad Request: can't parse JSON object")
           : error instanceof RequestBodyTooLargeError
             ? telegramError("Request Entity Too Large", 413)
-            : jsonResponse(
-                {
-                  error: error instanceof Error ? error.message : String(error),
-                  ok: false,
-                },
-                500,
-              ),
+            : jsonResponse({ error: "internal server error", ok: false }, 500),
       );
     }
   });
@@ -718,6 +926,12 @@ export async function startTelegramServer(
     async close() {
       state.closing = true;
       finishTelegramUpdatePoll(state, "shutdown");
+      clearTelegramWebhookRetry(state);
+      for (const controller of state.activeWebhookDeliveries) {
+        controller.abort();
+      }
+      await state.webhookDelivery;
+      await state.inboundAdmission;
       await closeServer(server);
     },
     manifest: {

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -59,6 +59,7 @@ type TelegramServerState = {
   webhookDelivery: Promise<Response | undefined> | undefined;
   webhookRetryAttempts: number;
   webhookRetryTimer: NodeJS.Timeout | undefined;
+  webhookRetryUpdateId: number | undefined;
 };
 
 type TelegramUpdatePoll = {
@@ -479,6 +480,7 @@ async function flushTelegramWebhookUpdates(
     return undefined;
   }
   while (state.updates.length > 0 && state.webhook) {
+    syncTelegramWebhookRetryHead(state);
     const webhook: TelegramWebhook = state.webhook;
     const update = state.updates[0]!;
     const controller = new AbortController();
@@ -530,7 +532,18 @@ function clearTelegramWebhookRetry(state: TelegramServerState, resetAttempts = f
   }
   if (resetAttempts) {
     state.webhookRetryAttempts = 0;
+    state.webhookRetryUpdateId = undefined;
   }
+}
+
+function syncTelegramWebhookRetryHead(state: TelegramServerState): void {
+  const updateId = state.updates[0]?.update_id;
+  if (updateId === state.webhookRetryUpdateId) {
+    return;
+  }
+  clearTelegramWebhookRetry(state);
+  state.webhookRetryAttempts = 0;
+  state.webhookRetryUpdateId = updateId;
 }
 
 function scheduleTelegramWebhookDelivery(state: TelegramServerState, delayMs: number): void {
@@ -545,16 +558,24 @@ function scheduleTelegramWebhookDelivery(state: TelegramServerState, delayMs: nu
   }
   state.webhookRetryTimer = setTimeout(() => {
     state.webhookRetryTimer = undefined;
-    void deliverTelegramWebhookUpdates(state);
+    void deliverTelegramWebhookUpdates(state, true);
   }, delayMs);
   state.webhookRetryTimer.unref();
 }
 
 async function deliverTelegramWebhookUpdates(
   state: TelegramServerState,
+  scheduledRetry = false,
 ): Promise<Response | undefined> {
+  syncTelegramWebhookRetryHead(state);
   if (state.webhookDelivery) {
     return await state.webhookDelivery;
+  }
+  if (
+    !scheduledRetry &&
+    (state.webhookRetryTimer || state.webhookRetryAttempts >= TELEGRAM_WEBHOOK_MAX_RETRIES)
+  ) {
+    return telegramError("Bad Gateway: webhook delivery failed", 502);
   }
   const delivery = flushTelegramWebhookUpdates(state);
   state.webhookDelivery = delivery;
@@ -907,6 +928,7 @@ export async function startTelegramServer(
     webhookDelivery: undefined,
     webhookRetryAttempts: 0,
     webhookRetryTimer: undefined,
+    webhookRetryUpdateId: undefined,
   };
   const port = params.port ?? 0;
   const server = createServer(async (request, response) => {

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -492,6 +492,7 @@ async function flushTelegramWebhookUpdates(
         body: JSON.stringify(update),
         headers,
         method: "POST",
+        redirect: "manual",
         signal: AbortSignal.any([controller.signal, AbortSignal.timeout(3_000)]),
       });
       await response.body?.cancel();

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -567,10 +567,10 @@ async function deliverTelegramWebhookUpdates(
   state: TelegramServerState,
   scheduledRetry = false,
 ): Promise<Response | undefined> {
-  syncTelegramWebhookRetryHead(state);
   if (state.webhookDelivery) {
     return await state.webhookDelivery;
   }
+  syncTelegramWebhookRetryHead(state);
   if (
     !scheduledRetry &&
     (state.webhookRetryTimer || state.webhookRetryAttempts >= TELEGRAM_WEBHOOK_MAX_RETRIES)

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -21,6 +21,8 @@ import { recordServerEvent, type ServerEventObserver } from "./recorder.js";
 import { resolveMaxPendingInboundEvents } from "./pending-events.js";
 
 const TELEGRAM_MAX_REQUEST_BODY_BYTES = 50 * 1024 * 1024;
+const TELEGRAM_WEBHOOK_MAX_RETRIES = 5;
+const TELEGRAM_WEBHOOK_RETRY_BASE_MS = 100;
 
 type TelegramServerEvent = {
   at: string;
@@ -55,6 +57,7 @@ type TelegramServerState = {
   updates: TelegramUpdate[];
   webhook: TelegramWebhook | undefined;
   webhookDelivery: Promise<Response | undefined> | undefined;
+  webhookRetryAttempts: number;
   webhookRetryTimer: NodeJS.Timeout | undefined;
 };
 
@@ -506,6 +509,7 @@ async function flushTelegramWebhookUpdates(
       if (state.webhook === webhook) {
         delete webhook.lastErrorDate;
         delete webhook.lastErrorMessage;
+        state.webhookRetryAttempts = 0;
       }
     } catch {
       if (state.webhook === webhook) {
@@ -520,10 +524,13 @@ async function flushTelegramWebhookUpdates(
   return undefined;
 }
 
-function clearTelegramWebhookRetry(state: TelegramServerState): void {
+function clearTelegramWebhookRetry(state: TelegramServerState, resetAttempts = false): void {
   if (state.webhookRetryTimer) {
     clearTimeout(state.webhookRetryTimer);
     state.webhookRetryTimer = undefined;
+  }
+  if (resetAttempts) {
+    state.webhookRetryAttempts = 0;
   }
 }
 
@@ -561,7 +568,16 @@ async function deliverTelegramWebhookUpdates(
       state.webhookDelivery = undefined;
     }
     if (state.webhook && state.updates.length > 0) {
-      scheduleTelegramWebhookDelivery(state, result ? 100 : 0);
+      if (result) {
+        if (state.webhookRetryAttempts < TELEGRAM_WEBHOOK_MAX_RETRIES) {
+          const delayMs = TELEGRAM_WEBHOOK_RETRY_BASE_MS * 2 ** state.webhookRetryAttempts;
+          state.webhookRetryAttempts += 1;
+          scheduleTelegramWebhookDelivery(state, delayMs);
+        }
+      } else {
+        state.webhookRetryAttempts = 0;
+        scheduleTelegramWebhookDelivery(state, 0);
+      }
     }
   }
 }
@@ -591,7 +607,7 @@ async function handleTelegramApi(params: {
         if (toBooleanValue(params.body.drop_pending_updates)) {
           params.state.updates.length = 0;
         }
-        clearTelegramWebhookRetry(params.state);
+        clearTelegramWebhookRetry(params.state, true);
         params.state.webhook = undefined;
         return telegramOk(true);
       }
@@ -620,7 +636,7 @@ async function handleTelegramApi(params: {
         url: parsedUrl.href,
       };
       finishTelegramUpdatePoll(params.state, "conflict");
-      clearTelegramWebhookRetry(params.state);
+      clearTelegramWebhookRetry(params.state, true);
       scheduleTelegramWebhookDelivery(params.state, 0);
       return telegramOk(true);
     }
@@ -628,7 +644,7 @@ async function handleTelegramApi(params: {
       if (toBooleanValue(params.body.drop_pending_updates)) {
         params.state.updates.length = 0;
       }
-      clearTelegramWebhookRetry(params.state);
+      clearTelegramWebhookRetry(params.state, true);
       params.state.webhook = undefined;
       return telegramOk(true);
     case "getwebhookinfo":
@@ -890,6 +906,7 @@ export async function startTelegramServer(
     updates: [],
     webhook: undefined,
     webhookDelivery: undefined,
+    webhookRetryAttempts: 0,
     webhookRetryTimer: undefined,
   };
   const port = params.port ?? 0;

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -19,6 +19,11 @@ import {
 } from "./http.js";
 import { recordServerEvent, type ServerEventObserver } from "./recorder.js";
 import { resolveMaxPendingInboundEvents } from "./pending-events.js";
+import {
+  postWebhookRequest,
+  validateWebhookTarget,
+  type WebhookAddress,
+} from "./webhook-target.js";
 
 const TELEGRAM_MAX_REQUEST_BODY_BYTES = 50 * 1024 * 1024;
 const TELEGRAM_WEBHOOK_MAX_BACKOFF_EXPONENT = 5;
@@ -44,6 +49,7 @@ type TelegramServerState = {
   activeUpdatePoll: TelegramUpdatePoll | undefined;
   activeWebhookDeliveries: Set<AbortController>;
   adminToken: string;
+  allowLoopbackHttpWebhook: boolean;
   botId: number;
   botToken: string;
   botUsername: string;
@@ -54,6 +60,7 @@ type TelegramServerState = {
   nextUpdateId: number;
   onEvent: ServerEventObserver | undefined;
   recorderPath: string;
+  restrictWebhookTargets: boolean;
   updates: TelegramUpdate[];
   webhook: TelegramWebhook | undefined;
   webhookDelivery: Promise<Response | undefined> | undefined;
@@ -491,25 +498,19 @@ async function flushTelegramWebhookUpdates(
     const webhook: TelegramWebhook = state.webhook;
     const update = state.updates[0]!;
     onAttempt(update.update_id);
-    const controller = new AbortController();
-    state.activeWebhookDeliveries.add(controller);
     try {
-      const headers = new Headers({ "content-type": "application/json" });
-      if (webhook.secretToken) {
-        headers.set("x-telegram-bot-api-secret-token", webhook.secretToken);
-      }
-      const response = await fetch(webhook.url, {
-        body: JSON.stringify(update),
-        headers,
-        method: "POST",
-        redirect: "manual",
-        signal: AbortSignal.any([controller.signal, AbortSignal.timeout(3_000)]),
-      });
-      await response.body?.cancel();
-      if (!response.ok) {
+      const delivery = await postTelegramWebhook(state, webhook, update);
+      if ("error" in delivery) {
         if (state.webhook === webhook) {
           webhook.lastErrorDate = Math.floor(Date.now() / 1_000);
-          webhook.lastErrorMessage = `Wrong response from the webhook: ${response.status}`;
+          webhook.lastErrorMessage = delivery.error;
+        }
+        return telegramError("Bad Gateway: webhook delivery failed", 502);
+      }
+      if (delivery.status < 200 || delivery.status >= 300) {
+        if (state.webhook === webhook) {
+          webhook.lastErrorDate = Math.floor(Date.now() / 1_000);
+          webhook.lastErrorMessage = `Wrong response from the webhook: ${delivery.status}`;
         }
         return telegramError("Bad Gateway: webhook delivery failed", 502);
       }
@@ -526,11 +527,77 @@ async function flushTelegramWebhookUpdates(
         webhook.lastErrorMessage = "Webhook delivery failed";
       }
       return telegramError("Bad Gateway: webhook delivery failed", 502);
+    }
+  }
+  return undefined;
+}
+
+async function validateTelegramWebhookUrl(
+  state: Pick<TelegramServerState, "allowLoopbackHttpWebhook" | "restrictWebhookTargets">,
+  url: URL,
+): Promise<Response | { addresses: WebhookAddress[] | undefined }> {
+  const target = await validateWebhookTarget({
+    allowLoopbackHttp: state.allowLoopbackHttpWebhook,
+    restrictPrivateAddresses: state.restrictWebhookTargets,
+    url,
+  });
+  if (!("error" in target)) {
+    return target;
+  }
+  return target.error === "unresolvable"
+    ? telegramError("Bad Request: webhook host could not be resolved")
+    : target.error === "private-address"
+      ? telegramError("Bad Request: webhook URL must not target a private or link-local address")
+      : telegramError("Bad Request: webhook URL must use HTTPS");
+}
+
+async function postTelegramWebhook(
+  state: TelegramServerState,
+  webhook: TelegramWebhook,
+  update: TelegramUpdate,
+): Promise<{ error: string } | { status: number }> {
+  const url = new URL(webhook.url);
+  const target = await validateTelegramWebhookUrl(state, url);
+  if (target instanceof Response) {
+    return { error: "Webhook target is no longer allowed" };
+  }
+  const addresses: Array<WebhookAddress | undefined> =
+    target.addresses && target.addresses.length > 0 ? target.addresses : [undefined];
+  const deadlineAt = Date.now() + 3_000;
+  let lastError: unknown;
+  for (const [index, address] of addresses.entries()) {
+    if (state.closing) {
+      throw new Error("Telegram server is shutting down.");
+    }
+    const remainingMs = deadlineAt - Date.now();
+    if (remainingMs <= 0) {
+      throw new DOMException("Webhook delivery timed out after 3000ms", "TimeoutError");
+    }
+    const controller = new AbortController();
+    state.activeWebhookDeliveries.add(controller);
+    try {
+      const attemptsRemaining = addresses.length - index;
+      const status = await postWebhookRequest({
+        address,
+        body: JSON.stringify(update),
+        headerEntries: webhook.secretToken
+          ? [["x-telegram-bot-api-secret-token", webhook.secretToken]]
+          : undefined,
+        signal: controller.signal,
+        timeoutMs: Math.max(1, Math.floor(remainingMs / attemptsRemaining)),
+        url,
+      });
+      return { status };
+    } catch (error) {
+      lastError = error;
+      if (state.closing) {
+        throw error;
+      }
     } finally {
       state.activeWebhookDeliveries.delete(controller);
     }
   }
-  return undefined;
+  throw lastError;
 }
 
 function clearTelegramWebhookRetry(state: TelegramServerState, resetAttempts = false): void {
@@ -657,6 +724,10 @@ async function handleTelegramApi(params: {
       }
       if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
         return telegramError("Bad Request: bad webhook URL");
+      }
+      const target = await validateTelegramWebhookUrl(params.state, parsedUrl);
+      if (target instanceof Response) {
+        return target;
       }
       const secretToken = toStringValue(params.body.secret_token);
       if (secretToken && !/^[A-Za-z0-9_-]{1,256}$/u.test(secretToken)) {
@@ -923,6 +994,7 @@ export async function startTelegramServer(
     activeUpdatePoll: undefined,
     activeWebhookDeliveries: new Set(),
     adminToken: params.adminToken ?? randomBytes(24).toString("hex"),
+    allowLoopbackHttpWebhook: isLoopbackHost(host),
     botId,
     botToken:
       params.botToken ??
@@ -936,6 +1008,7 @@ export async function startTelegramServer(
     nextUpdateId: 1,
     onEvent: params.onEvent,
     recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "telegram.jsonl"),
+    restrictWebhookTargets: !isLoopbackHost(host),
     closing: false,
     updates: [],
     webhook: undefined,

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -28,6 +28,7 @@ import {
 const TELEGRAM_MAX_REQUEST_BODY_BYTES = 50 * 1024 * 1024;
 const TELEGRAM_WEBHOOK_MAX_BACKOFF_EXPONENT = 5;
 const TELEGRAM_WEBHOOK_RETRY_BASE_MS = 100;
+const TELEGRAM_WEBHOOK_DELIVERY_TIMEOUT_MS = 3_000;
 
 type TelegramServerEvent = {
   at: string;
@@ -48,6 +49,7 @@ type TelegramWebhook = {
 type TelegramServerState = {
   activeUpdatePoll: TelegramUpdatePoll | undefined;
   activeWebhookDeliveries: Set<AbortController>;
+  activeWebhookValidations: Set<AbortController>;
   adminToken: string;
   allowLoopbackHttpWebhook: boolean;
   botId: number;
@@ -63,6 +65,7 @@ type TelegramServerState = {
   restrictWebhookTargets: boolean;
   updates: TelegramUpdate[];
   webhook: TelegramWebhook | undefined;
+  webhookAdmission: Promise<void>;
   webhookDelivery: Promise<Response | undefined> | undefined;
   webhookRetryAttempts: number;
   webhookRetryTimer: NodeJS.Timeout | undefined;
@@ -514,6 +517,9 @@ async function flushTelegramWebhookUpdates(
         }
         return telegramError("Bad Gateway: webhook delivery failed", 502);
       }
+      if (state.webhook !== webhook) {
+        return undefined;
+      }
       const deliveredIndex = state.updates.indexOf(update);
       if (deliveredIndex >= 0) {
         state.updates.splice(deliveredIndex, 1);
@@ -535,12 +541,23 @@ async function flushTelegramWebhookUpdates(
 async function validateTelegramWebhookUrl(
   state: Pick<TelegramServerState, "allowLoopbackHttpWebhook" | "restrictWebhookTargets">,
   url: URL,
+  deadlineAt: number,
+  signal: AbortSignal,
 ): Promise<Response | { addresses: WebhookAddress[] | undefined }> {
-  const target = await validateWebhookTarget({
-    allowLoopbackHttp: state.allowLoopbackHttpWebhook,
-    restrictPrivateAddresses: state.restrictWebhookTargets,
-    url,
-  });
+  let target;
+  try {
+    target = await withTelegramWebhookDeadline(
+      validateWebhookTarget({
+        allowLoopbackHttp: state.allowLoopbackHttpWebhook,
+        restrictPrivateAddresses: state.restrictWebhookTargets,
+        url,
+      }),
+      deadlineAt,
+      signal,
+    );
+  } catch {
+    return telegramError("Bad Request: webhook host could not be resolved");
+  }
   if (!("error" in target)) {
     return target;
   }
@@ -551,53 +568,132 @@ async function validateTelegramWebhookUrl(
       : telegramError("Bad Request: webhook URL must use HTTPS");
 }
 
+/** @internal */
+export async function withTelegramWebhookDeadline<T>(
+  promise: Promise<T>,
+  deadlineAt: number,
+  signal: AbortSignal,
+): Promise<T> {
+  const remainingMs = deadlineAt - Date.now();
+  if (remainingMs <= 0) {
+    throw new DOMException("Webhook delivery timed out", "TimeoutError");
+  }
+  return await new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const finish = (callback: () => void) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+      callback();
+    };
+    const onAbort = () =>
+      finish(() =>
+        reject(
+          signal.reason instanceof Error
+            ? signal.reason
+            : new DOMException("Webhook delivery aborted", "AbortError"),
+        ),
+      );
+    const timer = setTimeout(
+      () => finish(() => reject(new DOMException("Webhook delivery timed out", "TimeoutError"))),
+      remainingMs,
+    );
+    timer.unref();
+    signal.addEventListener("abort", onAbort, { once: true });
+    if (signal.aborted) {
+      onAbort();
+      return;
+    }
+    promise.then(
+      (value) => finish(() => resolve(value)),
+      (error: unknown) => finish(() => reject(error)),
+    );
+  });
+}
+
 async function postTelegramWebhook(
   state: TelegramServerState,
   webhook: TelegramWebhook,
   update: TelegramUpdate,
 ): Promise<{ error: string } | { status: number }> {
   const url = new URL(webhook.url);
-  const target = await validateTelegramWebhookUrl(state, url);
-  if (target instanceof Response) {
-    return { error: "Webhook target is no longer allowed" };
-  }
-  const addresses: Array<WebhookAddress | undefined> =
-    target.addresses && target.addresses.length > 0 ? target.addresses : [undefined];
-  const deadlineAt = Date.now() + 3_000;
-  let lastError: unknown;
-  for (const [index, address] of addresses.entries()) {
-    if (state.closing) {
-      throw new Error("Telegram server is shutting down.");
+  const deadlineAt = Date.now() + TELEGRAM_WEBHOOK_DELIVERY_TIMEOUT_MS;
+  const controller = new AbortController();
+  state.activeWebhookDeliveries.add(controller);
+  try {
+    const target = await validateTelegramWebhookUrl(state, url, deadlineAt, controller.signal);
+    if (target instanceof Response) {
+      return { error: "Webhook target is no longer allowed" };
     }
-    const remainingMs = deadlineAt - Date.now();
-    if (remainingMs <= 0) {
-      throw new DOMException("Webhook delivery timed out after 3000ms", "TimeoutError");
-    }
-    const controller = new AbortController();
-    state.activeWebhookDeliveries.add(controller);
-    try {
-      const attemptsRemaining = addresses.length - index;
-      const status = await postWebhookRequest({
-        address,
-        body: JSON.stringify(update),
-        headerEntries: webhook.secretToken
-          ? [["x-telegram-bot-api-secret-token", webhook.secretToken]]
-          : undefined,
-        signal: controller.signal,
-        timeoutMs: Math.max(1, Math.floor(remainingMs / attemptsRemaining)),
-        url,
-      });
-      return { status };
-    } catch (error) {
-      lastError = error;
+    const addresses: Array<WebhookAddress | undefined> =
+      target.addresses && target.addresses.length > 0 ? target.addresses : [undefined];
+    let lastError: unknown;
+    for (const [index, address] of addresses.entries()) {
       if (state.closing) {
-        throw error;
+        throw new Error("Telegram server is shutting down.");
       }
-    } finally {
-      state.activeWebhookDeliveries.delete(controller);
+      const remainingMs = deadlineAt - Date.now();
+      if (remainingMs <= 0) {
+        throw new DOMException("Webhook delivery timed out", "TimeoutError");
+      }
+      try {
+        const attemptsRemaining = addresses.length - index;
+        const status = await postWebhookRequest({
+          address,
+          body: JSON.stringify(update),
+          headerEntries: webhook.secretToken
+            ? [["x-telegram-bot-api-secret-token", webhook.secretToken]]
+            : undefined,
+          signal: controller.signal,
+          timeoutMs: Math.max(1, Math.floor(remainingMs / attemptsRemaining)),
+          url,
+        });
+        return { status };
+      } catch (error) {
+        lastError = error;
+        if (state.closing || controller.signal.aborted) {
+          throw error;
+        }
+      }
     }
+    throw lastError;
+  } finally {
+    state.activeWebhookDeliveries.delete(controller);
   }
-  throw lastError;
+}
+
+async function replaceTelegramWebhook(
+  state: TelegramServerState,
+  webhook: TelegramWebhook | undefined,
+  dropPendingUpdates: boolean,
+): Promise<void> {
+  let releaseAdmission!: () => void;
+  const previousAdmission = state.webhookAdmission;
+  state.webhookAdmission = new Promise<void>((resolve) => {
+    releaseAdmission = resolve;
+  });
+  await previousAdmission;
+  try {
+    state.webhook = undefined;
+    clearTelegramWebhookRetry(state, true);
+    for (const controller of state.activeWebhookDeliveries) {
+      controller.abort();
+    }
+    await state.webhookDelivery;
+    if (dropPendingUpdates) {
+      state.updates.length = 0;
+    }
+    state.webhook = webhook;
+    if (webhook) {
+      finishTelegramUpdatePoll(state, "conflict");
+      scheduleTelegramWebhookDelivery(state, 0);
+    }
+  } finally {
+    releaseAdmission();
+  }
 }
 
 function clearTelegramWebhookRetry(state: TelegramServerState, resetAttempts = false): void {
@@ -705,11 +801,11 @@ async function handleTelegramApi(params: {
       return telegramOk(true);
     case "setwebhook": {
       if (params.body.url === "") {
-        if (toBooleanValue(params.body.drop_pending_updates)) {
-          params.state.updates.length = 0;
-        }
-        clearTelegramWebhookRetry(params.state, true);
-        params.state.webhook = undefined;
+        await replaceTelegramWebhook(
+          params.state,
+          undefined,
+          toBooleanValue(params.body.drop_pending_updates),
+        );
         return telegramOk(true);
       }
       const webhookUrl = toStringValue(params.body.url);
@@ -725,7 +821,16 @@ async function handleTelegramApi(params: {
       if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
         return telegramError("Bad Request: bad webhook URL");
       }
-      const target = await validateTelegramWebhookUrl(params.state, parsedUrl);
+      const validation = new AbortController();
+      params.state.activeWebhookValidations.add(validation);
+      const target = await validateTelegramWebhookUrl(
+        params.state,
+        parsedUrl,
+        Date.now() + TELEGRAM_WEBHOOK_DELIVERY_TIMEOUT_MS,
+        validation.signal,
+      ).finally(() => {
+        params.state.activeWebhookValidations.delete(validation);
+      });
       if (target instanceof Response) {
         return target;
       }
@@ -733,24 +838,22 @@ async function handleTelegramApi(params: {
       if (secretToken && !/^[A-Za-z0-9_-]{1,256}$/u.test(secretToken)) {
         return telegramError("Bad Request: invalid secret token");
       }
-      if (toBooleanValue(params.body.drop_pending_updates)) {
-        params.state.updates.length = 0;
-      }
-      params.state.webhook = {
-        ...(secretToken ? { secretToken } : {}),
-        url: parsedUrl.href,
-      };
-      finishTelegramUpdatePoll(params.state, "conflict");
-      clearTelegramWebhookRetry(params.state, true);
-      scheduleTelegramWebhookDelivery(params.state, 0);
+      await replaceTelegramWebhook(
+        params.state,
+        {
+          ...(secretToken ? { secretToken } : {}),
+          url: parsedUrl.href,
+        },
+        toBooleanValue(params.body.drop_pending_updates),
+      );
       return telegramOk(true);
     }
     case "deletewebhook":
-      if (toBooleanValue(params.body.drop_pending_updates)) {
-        params.state.updates.length = 0;
-      }
-      clearTelegramWebhookRetry(params.state, true);
-      params.state.webhook = undefined;
+      await replaceTelegramWebhook(
+        params.state,
+        undefined,
+        toBooleanValue(params.body.drop_pending_updates),
+      );
       return telegramOk(true);
     case "getwebhookinfo":
       return telegramOk({
@@ -993,6 +1096,7 @@ export async function startTelegramServer(
   const state: TelegramServerState = {
     activeUpdatePoll: undefined,
     activeWebhookDeliveries: new Set(),
+    activeWebhookValidations: new Set(),
     adminToken: params.adminToken ?? randomBytes(24).toString("hex"),
     allowLoopbackHttpWebhook: isLoopbackHost(host),
     botId,
@@ -1012,6 +1116,7 @@ export async function startTelegramServer(
     closing: false,
     updates: [],
     webhook: undefined,
+    webhookAdmission: Promise.resolve(),
     webhookDelivery: undefined,
     webhookRetryAttempts: 0,
     webhookRetryTimer: undefined,
@@ -1054,7 +1159,11 @@ export async function startTelegramServer(
       for (const controller of state.activeWebhookDeliveries) {
         controller.abort();
       }
+      for (const controller of state.activeWebhookValidations) {
+        controller.abort();
+      }
       await state.webhookDelivery;
+      await state.webhookAdmission;
       await state.inboundAdmission;
       await closeServer(server);
     },

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -446,6 +446,8 @@ async function handleTelegramAdminInbound(params: {
       update.message.message_id + 1,
     );
     params.state.nextUpdateId = Math.max(params.state.nextUpdateId, update.update_id + 1);
+    const reservedNextMessageId = params.state.nextMessageId;
+    const reservedNextUpdateId = params.state.nextUpdateId;
     try {
       await appendEvent(params.state, {
         at: new Date().toISOString(),
@@ -456,8 +458,12 @@ async function handleTelegramAdminInbound(params: {
         type: "admin",
       });
     } catch (error) {
-      params.state.nextMessageId = nextMessageId;
-      params.state.nextUpdateId = nextUpdateId;
+      if (params.state.nextMessageId === reservedNextMessageId) {
+        params.state.nextMessageId = nextMessageId;
+      }
+      if (params.state.nextUpdateId === reservedNextUpdateId) {
+        params.state.nextUpdateId = nextUpdateId;
+      }
       throw error;
     }
     params.state.updates.push(update);
@@ -475,6 +481,7 @@ async function handleTelegramAdminInbound(params: {
 
 async function flushTelegramWebhookUpdates(
   state: TelegramServerState,
+  onAttempt: (updateId: number) => void,
 ): Promise<Response | undefined> {
   if (!state.webhook) {
     return undefined;
@@ -483,6 +490,7 @@ async function flushTelegramWebhookUpdates(
     syncTelegramWebhookRetryHead(state);
     const webhook: TelegramWebhook = state.webhook;
     const update = state.updates[0]!;
+    onAttempt(update.update_id);
     const controller = new AbortController();
     state.activeWebhookDeliveries.add(controller);
     try {
@@ -577,7 +585,10 @@ async function deliverTelegramWebhookUpdates(
   ) {
     return telegramError("Bad Gateway: webhook delivery failed", 502);
   }
-  const delivery = flushTelegramWebhookUpdates(state);
+  let attemptedUpdateId: number | undefined;
+  const delivery = flushTelegramWebhookUpdates(state, (updateId) => {
+    attemptedUpdateId = updateId;
+  });
   state.webhookDelivery = delivery;
   let result: Response | undefined;
   try {
@@ -588,7 +599,10 @@ async function deliverTelegramWebhookUpdates(
       state.webhookDelivery = undefined;
     }
     if (state.webhook && state.updates.length > 0) {
-      if (result) {
+      if (state.updates[0]?.update_id !== attemptedUpdateId) {
+        syncTelegramWebhookRetryHead(state);
+        scheduleTelegramWebhookDelivery(state, 0);
+      } else if (result) {
         if (state.webhookRetryAttempts < TELEGRAM_WEBHOOK_MAX_RETRIES) {
           const delayMs = TELEGRAM_WEBHOOK_RETRY_BASE_MS * 2 ** state.webhookRetryAttempts;
           state.webhookRetryAttempts += 1;

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -21,7 +21,7 @@ import { recordServerEvent, type ServerEventObserver } from "./recorder.js";
 import { resolveMaxPendingInboundEvents } from "./pending-events.js";
 
 const TELEGRAM_MAX_REQUEST_BODY_BYTES = 50 * 1024 * 1024;
-const TELEGRAM_WEBHOOK_MAX_RETRIES = 5;
+const TELEGRAM_WEBHOOK_MAX_BACKOFF_EXPONENT = 5;
 const TELEGRAM_WEBHOOK_RETRY_BASE_MS = 100;
 
 type TelegramServerEvent = {
@@ -579,10 +579,7 @@ async function deliverTelegramWebhookUpdates(
     return await state.webhookDelivery;
   }
   syncTelegramWebhookRetryHead(state);
-  if (
-    !scheduledRetry &&
-    (state.webhookRetryTimer || state.webhookRetryAttempts >= TELEGRAM_WEBHOOK_MAX_RETRIES)
-  ) {
+  if (!scheduledRetry && state.webhookRetryTimer) {
     return telegramError("Bad Gateway: webhook delivery failed", 502);
   }
   let attemptedUpdateId: number | undefined;
@@ -603,11 +600,14 @@ async function deliverTelegramWebhookUpdates(
         syncTelegramWebhookRetryHead(state);
         scheduleTelegramWebhookDelivery(state, 0);
       } else if (result) {
-        if (state.webhookRetryAttempts < TELEGRAM_WEBHOOK_MAX_RETRIES) {
-          const delayMs = TELEGRAM_WEBHOOK_RETRY_BASE_MS * 2 ** state.webhookRetryAttempts;
-          state.webhookRetryAttempts += 1;
-          scheduleTelegramWebhookDelivery(state, delayMs);
-        }
+        const delayMs =
+          TELEGRAM_WEBHOOK_RETRY_BASE_MS *
+          2 ** Math.min(state.webhookRetryAttempts, TELEGRAM_WEBHOOK_MAX_BACKOFF_EXPONENT);
+        state.webhookRetryAttempts = Math.min(
+          state.webhookRetryAttempts + 1,
+          TELEGRAM_WEBHOOK_MAX_BACKOFF_EXPONENT,
+        );
+        scheduleTelegramWebhookDelivery(state, delayMs);
       } else {
         state.webhookRetryAttempts = 0;
         scheduleTelegramWebhookDelivery(state, 0);

--- a/src/servers/webhook-target.ts
+++ b/src/servers/webhook-target.ts
@@ -1,0 +1,177 @@
+import { lookup } from "node:dns/promises";
+import { request as requestHttp, type ClientRequest, type IncomingMessage } from "node:http";
+import { request as requestHttps } from "node:https";
+import { BlockList, isIP } from "node:net";
+import { isLoopbackHost } from "./http.js";
+
+export type WebhookAddress = {
+  address: string;
+  family: 4 | 6;
+};
+
+export type WebhookTargetError = "https-required" | "private-address" | "unresolvable";
+
+export type ValidatedWebhookTarget =
+  | { addresses: WebhookAddress[] | undefined }
+  | { error: WebhookTargetError };
+
+const BLOCKED_WEBHOOK_ADDRESSES = createBlockedWebhookAddresses();
+
+function createBlockedWebhookAddresses(): BlockList {
+  const blockList = new BlockList();
+  for (const [address, prefix] of [
+    ["0.0.0.0", 8],
+    ["10.0.0.0", 8],
+    ["100.64.0.0", 10],
+    ["127.0.0.0", 8],
+    ["169.254.0.0", 16],
+    ["172.16.0.0", 12],
+    ["192.168.0.0", 16],
+    ["224.0.0.0", 4],
+    ["240.0.0.0", 4],
+  ] as const) {
+    blockList.addSubnet(address, prefix, "ipv4");
+    const octets = address.split(".").map(Number);
+    const high = ((octets[0] ?? 0) << 8) | (octets[1] ?? 0);
+    const low = ((octets[2] ?? 0) << 8) | (octets[3] ?? 0);
+    blockList.addSubnet(`::ffff:${high.toString(16)}:${low.toString(16)}`, 96 + prefix, "ipv6");
+  }
+  for (const [address, prefix] of [
+    ["::", 128],
+    ["::1", 128],
+    ["fc00::", 7],
+    ["fe80::", 10],
+    ["ff00::", 8],
+  ] as const) {
+    blockList.addSubnet(address, prefix, "ipv6");
+  }
+  return blockList;
+}
+
+function normalizeHostname(hostname: string): string {
+  return hostname.replace(/^\[(.*)\]$/u, "$1").replace(/%25/gu, "%");
+}
+
+function isBlockedWebhookAddress(address: string): boolean {
+  const normalized = normalizeHostname(address);
+  const mappedIpv4 = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/iu.exec(normalized)?.[1];
+  if (mappedIpv4) {
+    return BLOCKED_WEBHOOK_ADDRESSES.check(mappedIpv4, "ipv4");
+  }
+  const family = isIP(normalized);
+  return family === 4
+    ? BLOCKED_WEBHOOK_ADDRESSES.check(normalized, "ipv4")
+    : family === 6
+      ? BLOCKED_WEBHOOK_ADDRESSES.check(normalized, "ipv6")
+      : false;
+}
+
+async function resolveWebhookAddresses(hostname: string): Promise<WebhookAddress[]> {
+  const normalized = normalizeHostname(hostname);
+  const family = isIP(normalized);
+  if (family === 4 || family === 6) {
+    return [{ address: normalized, family }];
+  }
+  return (await lookup(normalized, { all: true, verbatim: true })).flatMap((entry) =>
+    entry.family === 4 || entry.family === 6
+      ? [{ address: entry.address, family: entry.family }]
+      : [],
+  );
+}
+
+export async function validateWebhookTarget(params: {
+  allowLoopbackHttp: boolean;
+  restrictPrivateAddresses: boolean;
+  url: URL;
+}): Promise<ValidatedWebhookTarget> {
+  if (
+    params.url.protocol === "http:" &&
+    (!params.allowLoopbackHttp || !isLoopbackHost(params.url.hostname))
+  ) {
+    return { error: "https-required" };
+  }
+  if (params.url.protocol !== "http:" && params.url.protocol !== "https:") {
+    return { error: "https-required" };
+  }
+  if (!params.restrictPrivateAddresses) {
+    return { addresses: undefined };
+  }
+
+  let addresses: WebhookAddress[];
+  try {
+    addresses = await resolveWebhookAddresses(params.url.hostname);
+  } catch {
+    return { error: "unresolvable" };
+  }
+  if (addresses.length === 0) {
+    return { error: "unresolvable" };
+  }
+  if (addresses.some((entry) => isBlockedWebhookAddress(entry.address))) {
+    return { error: "private-address" };
+  }
+  return { addresses };
+}
+
+export async function postWebhookRequest(params: {
+  activeRequests?: Set<ClientRequest> | undefined;
+  address?: WebhookAddress | undefined;
+  body: string;
+  headerEntries?: ReadonlyArray<readonly [string, string]> | undefined;
+  signal?: AbortSignal | undefined;
+  timeoutMs: number;
+  url: URL;
+}): Promise<number> {
+  return await new Promise<number>((resolve, reject) => {
+    const address = params.address;
+    let settled = false;
+    let response: IncomingMessage | undefined;
+    let deadline: NodeJS.Timeout;
+    const finish = (callback: () => void) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(deadline);
+      params.activeRequests?.delete(request);
+      callback();
+    };
+    const send = params.url.protocol === "https:" ? requestHttps : requestHttp;
+    const request = send(
+      params.url,
+      {
+        ...(address ? { family: address.family } : {}),
+        headers: {
+          "content-length": String(Buffer.byteLength(params.body)),
+          "content-type": "application/json",
+          ...Object.fromEntries(params.headerEntries ?? []),
+        },
+        ...(address
+          ? {
+              lookup: (_hostname, _options, callback) =>
+                callback(null, address.address, address.family),
+            }
+          : {}),
+        method: "POST",
+        signal: params.signal,
+      },
+      (incoming) => {
+        response = incoming;
+        incoming.resume();
+        incoming.once("error", (error) => finish(() => reject(error)));
+        incoming.once("end", () => finish(() => resolve(incoming.statusCode ?? 0)));
+      },
+    );
+    params.activeRequests?.add(request);
+    deadline = setTimeout(() => {
+      const error = new DOMException(
+        `Webhook delivery timed out after ${params.timeoutMs}ms`,
+        "TimeoutError",
+      );
+      response?.destroy(error);
+      request.destroy(error);
+    }, params.timeoutMs);
+    deadline.unref();
+    request.once("error", (error) => finish(() => reject(error)));
+    request.end(params.body);
+  });
+}

--- a/src/servers/zalo.ts
+++ b/src/servers/zalo.ts
@@ -347,9 +347,9 @@ export async function postZaloWebhook(params: {
   activeRequests?: Set<ClientRequest>;
   addresses?: WebhookAddress[] | undefined;
   body: string;
-  secretToken: string;
   timeoutMs: number;
   url: URL;
+  verificationValue: string;
 }): Promise<number> {
   const activeRequests = params.activeRequests ?? new Set<ClientRequest>();
   const deadlineAt = Date.now() + params.timeoutMs;
@@ -367,7 +367,7 @@ export async function postZaloWebhook(params: {
       return await postWebhook(
         params.url,
         params.body,
-        params.secretToken,
+        params.verificationValue,
         attemptTimeoutMs,
         address,
         activeRequests,
@@ -492,9 +492,9 @@ async function deliverWebhookUpdate(
       activeRequests: state.activeWebhookRequests,
       addresses: target.addresses,
       body: JSON.stringify({ ok: true, result: update }),
-      secretToken: webhook.secretToken,
       timeoutMs: remainingMs,
       url,
+      verificationValue: webhook.secretToken,
     });
     if (status < 200 || status >= 300) {
       return zaloError(`Webhook delivery failed with HTTP ${status}`, 502);

--- a/src/servers/zalo.ts
+++ b/src/servers/zalo.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from "node:crypto";
 import { lookup } from "node:dns/promises";
-import { request as requestHttp, type IncomingMessage } from "node:http";
+import { request as requestHttp, type ClientRequest, type IncomingMessage } from "node:http";
 import { request as requestHttps } from "node:https";
 import { BlockList, isIP } from "node:net";
 import path from "node:path";
@@ -60,6 +60,7 @@ type ValidatedWebhookTarget = {
 };
 
 type ZaloServerState = {
+  activeWebhookRequests: Set<ClientRequest>;
   adminToken: string;
   allowLoopbackHttpWebhook: boolean;
   botId: string;
@@ -257,6 +258,7 @@ async function postWebhook(
   secretToken: string,
   timeoutMs: number,
   address: WebhookAddress | undefined,
+  activeRequests: Set<ClientRequest>,
 ): Promise<number> {
   return await new Promise<number>((resolve, reject) => {
     let settled = false;
@@ -268,6 +270,7 @@ async function postWebhook(
       }
       settled = true;
       clearTimeout(deadline);
+      activeRequests.delete(request);
       callback();
     };
     const send = url.protocol === "https:" ? requestHttps : requestHttp;
@@ -295,6 +298,7 @@ async function postWebhook(
         incoming.once("end", () => finish(() => resolve(incoming.statusCode ?? 0)));
       },
     );
+    activeRequests.add(request);
     deadline = setTimeout(() => {
       const error = new DOMException(
         `Webhook delivery timed out after ${timeoutMs}ms`,
@@ -307,6 +311,79 @@ async function postWebhook(
     request.once("error", (error) => finish(() => reject(error)));
     request.end(body);
   });
+}
+
+function webhookTimeoutError(timeoutMs: number): DOMException {
+  return new DOMException(`Webhook delivery timed out after ${timeoutMs}ms`, "TimeoutError");
+}
+
+async function withWebhookDeadline<T>(
+  promise: Promise<T>,
+  deadlineAt: number,
+  timeoutMs: number,
+): Promise<T> {
+  const remainingMs = deadlineAt - Date.now();
+  if (remainingMs <= 0) {
+    throw webhookTimeoutError(timeoutMs);
+  }
+  return await new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(webhookTimeoutError(timeoutMs)), remainingMs);
+    timer.unref();
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
+/** @internal */
+export async function postZaloWebhook(params: {
+  activeRequests?: Set<ClientRequest>;
+  addresses?: WebhookAddress[] | undefined;
+  body: string;
+  secretToken: string;
+  timeoutMs: number;
+  url: URL;
+}): Promise<number> {
+  const activeRequests = params.activeRequests ?? new Set<ClientRequest>();
+  const deadlineAt = Date.now() + params.timeoutMs;
+  const addresses =
+    params.addresses && params.addresses.length > 0 ? params.addresses : [undefined];
+  let lastError: unknown;
+  for (const [index, address] of addresses.entries()) {
+    const remainingMs = deadlineAt - Date.now();
+    if (remainingMs <= 0) {
+      throw webhookTimeoutError(params.timeoutMs);
+    }
+    const attemptsRemaining = addresses.length - index;
+    const attemptTimeoutMs = Math.max(1, Math.floor(remainingMs / attemptsRemaining));
+    try {
+      return await postWebhook(
+        params.url,
+        params.body,
+        params.secretToken,
+        attemptTimeoutMs,
+        address,
+        activeRequests,
+      );
+    } catch (error) {
+      lastError = error;
+      if (
+        error instanceof DOMException &&
+        error.name === "TimeoutError" &&
+        attemptsRemaining === 1
+      ) {
+        throw webhookTimeoutError(params.timeoutMs);
+      }
+    }
+  }
+  throw lastError;
 }
 
 function nextUpdate(state: ZaloServerState): Response | undefined {
@@ -388,19 +465,37 @@ async function deliverWebhookUpdate(
   webhook: NonNullable<ZaloServerState["webhook"]>,
   update: ZaloUpdate,
 ): Promise<Response | undefined> {
+  const deadlineAt = Date.now() + state.webhookDeliveryTimeoutMs;
   const url = new URL(webhook.url);
-  const target = await validateWebhookUrl(url, state);
+  let target: Response | ValidatedWebhookTarget;
+  try {
+    target = await withWebhookDeadline(
+      validateWebhookUrl(url, state),
+      deadlineAt,
+      state.webhookDeliveryTimeoutMs,
+    );
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "TimeoutError") {
+      return zaloError(`Webhook delivery timed out after ${state.webhookDeliveryTimeoutMs}ms`, 502);
+    }
+    throw error;
+  }
   if (target instanceof Response) {
     return target;
   }
   try {
-    const status = await postWebhook(
+    const remainingMs = deadlineAt - Date.now();
+    if (remainingMs <= 0) {
+      throw webhookTimeoutError(state.webhookDeliveryTimeoutMs);
+    }
+    const status = await postZaloWebhook({
+      activeRequests: state.activeWebhookRequests,
+      addresses: target.addresses,
+      body: JSON.stringify({ ok: true, result: update }),
+      secretToken: webhook.secretToken,
+      timeoutMs: remainingMs,
       url,
-      JSON.stringify({ ok: true, result: update }),
-      webhook.secretToken,
-      state.webhookDeliveryTimeoutMs,
-      target.addresses?.[0],
-    );
+    });
     if (status < 200 || status >= 300) {
       return zaloError(`Webhook delivery failed with HTTP ${status}`, 502);
     }
@@ -583,6 +678,7 @@ export async function startZaloServer(
 ): Promise<StartedZaloServer> {
   const host = params.host ?? "127.0.0.1";
   const state: ZaloServerState = {
+    activeWebhookRequests: new Set(),
     adminToken: params.adminToken ?? randomBytes(24).toString("hex"),
     allowLoopbackHttpWebhook: isLoopbackHost(host),
     botId: params.botId ?? "1459232241454765289",
@@ -648,6 +744,9 @@ export async function startZaloServer(
   };
   return {
     async close() {
+      for (const request of state.activeWebhookRequests) {
+        request.destroy(new Error("Zalo server is shutting down."));
+      }
       for (const pending of state.pendingRequests.splice(0)) {
         settlePendingUpdate(state, pending, zaloError("Server shutting down", 503));
       }

--- a/src/servers/zalo.ts
+++ b/src/servers/zalo.ts
@@ -1,8 +1,5 @@
 import { randomBytes } from "node:crypto";
-import { lookup } from "node:dns/promises";
-import { request as requestHttp, type ClientRequest, type IncomingMessage } from "node:http";
-import { request as requestHttps } from "node:https";
-import { BlockList, isIP } from "node:net";
+import type { ClientRequest, IncomingMessage } from "node:http";
 import path from "node:path";
 import {
   adminAuthError,
@@ -21,12 +18,16 @@ import {
 } from "./http.js";
 import { recordServerEvent, type ServerEventObserver } from "./recorder.js";
 import { resolveMaxPendingInboundEvents } from "./pending-events.js";
+import {
+  postWebhookRequest,
+  validateWebhookTarget,
+  type WebhookAddress,
+} from "./webhook-target.js";
 
 type ZaloChatType = "GROUP" | "PRIVATE";
 
 const DEFAULT_WEBHOOK_DELIVERY_TIMEOUT_MS = 5_000;
 const MAX_WEBHOOK_DELIVERY_TIMEOUT_MS = 30_000;
-const BLOCKED_WEBHOOK_ADDRESSES = createBlockedWebhookAddresses();
 
 type ZaloMessage = {
   chat: { chat_type: ZaloChatType; id: string };
@@ -48,11 +49,6 @@ type PendingUpdateRequest = {
   request: IncomingMessage;
   resolve(response: Response): void;
   timeout: NodeJS.Timeout | undefined;
-};
-
-type WebhookAddress = {
-  address: string;
-  family: 4 | 6;
 };
 
 type ValidatedWebhookTarget = {
@@ -162,156 +158,23 @@ function webhookDeliveryTimeoutMs(value: number | undefined): number {
   return Math.max(1, Math.min(Math.floor(value), MAX_WEBHOOK_DELIVERY_TIMEOUT_MS));
 }
 
-function createBlockedWebhookAddresses(): BlockList {
-  const blockList = new BlockList();
-  for (const [address, prefix] of [
-    ["0.0.0.0", 8],
-    ["10.0.0.0", 8],
-    ["100.64.0.0", 10],
-    ["127.0.0.0", 8],
-    ["169.254.0.0", 16],
-    ["172.16.0.0", 12],
-    ["192.168.0.0", 16],
-    ["224.0.0.0", 4],
-    ["240.0.0.0", 4],
-  ] as const) {
-    blockList.addSubnet(address, prefix, "ipv4");
-    const octets = address.split(".").map(Number);
-    const high = ((octets[0] ?? 0) << 8) | (octets[1] ?? 0);
-    const low = ((octets[2] ?? 0) << 8) | (octets[3] ?? 0);
-    blockList.addSubnet(`::ffff:${high.toString(16)}:${low.toString(16)}`, 96 + prefix, "ipv6");
-  }
-  for (const [address, prefix] of [
-    ["::", 128],
-    ["::1", 128],
-    ["fc00::", 7],
-    ["fe80::", 10],
-    ["ff00::", 8],
-  ] as const) {
-    blockList.addSubnet(address, prefix, "ipv6");
-  }
-  return blockList;
-}
-
-function normalizeHostname(hostname: string): string {
-  return hostname.replace(/^\[(.*)\]$/u, "$1").replace(/%25/gu, "%");
-}
-
-function isBlockedWebhookAddress(address: string): boolean {
-  const normalized = normalizeHostname(address);
-  const mappedIpv4 = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/iu.exec(normalized)?.[1];
-  if (mappedIpv4) {
-    return BLOCKED_WEBHOOK_ADDRESSES.check(mappedIpv4, "ipv4");
-  }
-  const family = isIP(normalized);
-  return family === 4
-    ? BLOCKED_WEBHOOK_ADDRESSES.check(normalized, "ipv4")
-    : family === 6
-      ? BLOCKED_WEBHOOK_ADDRESSES.check(normalized, "ipv6")
-      : false;
-}
-
-async function resolveWebhookAddresses(hostname: string): Promise<WebhookAddress[]> {
-  const normalized = normalizeHostname(hostname);
-  const family = isIP(normalized);
-  if (family === 4 || family === 6) {
-    return [{ address: normalized, family }];
-  }
-  return (await lookup(normalized, { all: true, verbatim: true })).flatMap((entry) =>
-    entry.family === 4 || entry.family === 6
-      ? [{ address: entry.address, family: entry.family }]
-      : [],
-  );
-}
-
 async function validateWebhookUrl(
   url: URL,
   state: Pick<ZaloServerState, "allowLoopbackHttpWebhook" | "restrictWebhookTargets">,
 ): Promise<Response | ValidatedWebhookTarget> {
-  if (
-    url.protocol === "http:" &&
-    (!state.allowLoopbackHttpWebhook || !isLoopbackHost(url.hostname))
-  ) {
-    return zaloError("url must use HTTPS", 400);
-  }
-  if (url.protocol !== "http:" && url.protocol !== "https:") {
-    return zaloError("url must use HTTPS", 400);
-  }
-  if (!state.restrictWebhookTargets) {
-    return { addresses: undefined };
-  }
-
-  let addresses: WebhookAddress[];
-  try {
-    addresses = await resolveWebhookAddresses(url.hostname);
-  } catch {
-    return zaloError("url host could not be resolved", 400);
-  }
-  if (addresses.length === 0 || addresses.some((entry) => isBlockedWebhookAddress(entry.address))) {
-    return zaloError("url must not target a private or link-local address", 400);
-  }
-  return { addresses };
-}
-
-async function postWebhook(
-  url: URL,
-  body: string,
-  secretToken: string,
-  timeoutMs: number,
-  address: WebhookAddress | undefined,
-  activeRequests: Set<ClientRequest>,
-): Promise<number> {
-  return await new Promise<number>((resolve, reject) => {
-    let settled = false;
-    let response: IncomingMessage | undefined;
-    let deadline: NodeJS.Timeout;
-    const finish = (callback: () => void) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      clearTimeout(deadline);
-      activeRequests.delete(request);
-      callback();
-    };
-    const send = url.protocol === "https:" ? requestHttps : requestHttp;
-    const request = send(
-      url,
-      {
-        ...(address ? { family: address.family } : {}),
-        headers: {
-          "content-length": String(Buffer.byteLength(body)),
-          "content-type": "application/json",
-          "x-bot-api-secret-token": secretToken,
-        },
-        ...(address
-          ? {
-              lookup: (_hostname, _options, callback) =>
-                callback(null, address.address, address.family),
-            }
-          : {}),
-        method: "POST",
-      },
-      (incoming) => {
-        response = incoming;
-        incoming.resume();
-        incoming.once("error", (error) => finish(() => reject(error)));
-        incoming.once("end", () => finish(() => resolve(incoming.statusCode ?? 0)));
-      },
-    );
-    activeRequests.add(request);
-    deadline = setTimeout(() => {
-      const error = new DOMException(
-        `Webhook delivery timed out after ${timeoutMs}ms`,
-        "TimeoutError",
-      );
-      response?.destroy(error);
-      request.destroy(error);
-    }, timeoutMs);
-    deadline.unref();
-    request.once("error", (error) => finish(() => reject(error)));
-    request.end(body);
+  const target = await validateWebhookTarget({
+    allowLoopbackHttp: state.allowLoopbackHttpWebhook,
+    restrictPrivateAddresses: state.restrictWebhookTargets,
+    url,
   });
+  if ("error" in target) {
+    return target.error === "unresolvable"
+      ? zaloError("url host could not be resolved", 400)
+      : target.error === "private-address"
+        ? zaloError("url must not target a private or link-local address", 400)
+        : zaloError("url must use HTTPS", 400);
+  }
+  return target;
 }
 
 function webhookTimeoutError(timeoutMs: number): DOMException {
@@ -369,14 +232,14 @@ export async function postZaloWebhook(params: {
     const attemptsRemaining = addresses.length - index;
     const attemptTimeoutMs = Math.max(1, Math.floor(remainingMs / attemptsRemaining));
     try {
-      return await postWebhook(
-        params.url,
-        params.body,
-        params.verificationValue,
-        attemptTimeoutMs,
-        address,
+      return await postWebhookRequest({
         activeRequests,
-      );
+        address,
+        body: params.body,
+        headerEntries: [["x-bot-api-secret-token", params.verificationValue]],
+        timeoutMs: attemptTimeoutMs,
+        url: params.url,
+      });
     } catch (error) {
       if (params.shouldCancel?.()) {
         throw error;

--- a/src/servers/zalo.ts
+++ b/src/servers/zalo.ts
@@ -66,6 +66,7 @@ type ZaloServerState = {
   botId: string;
   botName: string;
   botToken: string;
+  closing: boolean;
   maxPendingInboundEvents: number;
   nextMessage: number;
   onEvent: ServerEventObserver | undefined;
@@ -347,6 +348,7 @@ export async function postZaloWebhook(params: {
   activeRequests?: Set<ClientRequest>;
   addresses?: WebhookAddress[] | undefined;
   body: string;
+  shouldCancel?: (() => boolean) | undefined;
   timeoutMs: number;
   url: URL;
   verificationValue: string;
@@ -357,6 +359,9 @@ export async function postZaloWebhook(params: {
     params.addresses && params.addresses.length > 0 ? params.addresses : [undefined];
   let lastError: unknown;
   for (const [index, address] of addresses.entries()) {
+    if (params.shouldCancel?.()) {
+      throw new Error("Webhook delivery cancelled.");
+    }
     const remainingMs = deadlineAt - Date.now();
     if (remainingMs <= 0) {
       throw webhookTimeoutError(params.timeoutMs);
@@ -373,6 +378,9 @@ export async function postZaloWebhook(params: {
         activeRequests,
       );
     } catch (error) {
+      if (params.shouldCancel?.()) {
+        throw error;
+      }
       lastError = error;
       if (
         error instanceof DOMException &&
@@ -492,6 +500,7 @@ async function deliverWebhookUpdate(
       activeRequests: state.activeWebhookRequests,
       addresses: target.addresses,
       body: JSON.stringify({ ok: true, result: update }),
+      shouldCancel: () => state.closing,
       timeoutMs: remainingMs,
       url,
       verificationValue: webhook.secretToken,
@@ -686,6 +695,7 @@ export async function startZaloServer(
     botToken:
       params.botToken ??
       (isLoopbackHost(host) ? "crabline-zalo-bot-token" : randomBytes(32).toString("base64url")),
+    closing: false,
     maxPendingInboundEvents: resolveMaxPendingInboundEvents(params.maxPendingInboundEvents),
     nextMessage: 1,
     onEvent: params.onEvent,
@@ -744,6 +754,7 @@ export async function startZaloServer(
   };
   return {
     async close() {
+      state.closing = true;
       for (const request of state.activeWebhookRequests) {
         request.destroy(new Error("Zalo server is shutting down."));
       }

--- a/src/servers/zalo.ts
+++ b/src/servers/zalo.ts
@@ -51,7 +51,7 @@ type PendingUpdateRequest = {
   timeout: NodeJS.Timeout | undefined;
 };
 
-type ValidatedWebhookTarget = {
+type ZaloValidatedWebhookTarget = {
   addresses: WebhookAddress[] | undefined;
 };
 
@@ -161,7 +161,7 @@ function webhookDeliveryTimeoutMs(value: number | undefined): number {
 async function validateWebhookUrl(
   url: URL,
   state: Pick<ZaloServerState, "allowLoopbackHttpWebhook" | "restrictWebhookTargets">,
-): Promise<Response | ValidatedWebhookTarget> {
+): Promise<Response | ZaloValidatedWebhookTarget> {
   const target = await validateWebhookTarget({
     allowLoopbackHttp: state.allowLoopbackHttpWebhook,
     restrictPrivateAddresses: state.restrictWebhookTargets,
@@ -338,7 +338,7 @@ async function deliverWebhookUpdate(
 ): Promise<Response | undefined> {
   const deadlineAt = Date.now() + state.webhookDeliveryTimeoutMs;
   const url = new URL(webhook.url);
-  let target: Response | ValidatedWebhookTarget;
+  let target: Response | ZaloValidatedWebhookTarget;
   try {
     target = await withWebhookDeadline(
       validateWebhookUrl(url, state),

--- a/test/http-server.test.ts
+++ b/test/http-server.test.ts
@@ -81,4 +81,29 @@ describe("server HTTP body reader", () => {
       await server.close();
     }
   });
+
+  it("contains failures from custom error handlers", async () => {
+    const server = await startHttpJsonServer({
+      async handle() {
+        throw new Error("request failure");
+      },
+      handleError() {
+        throw new Error("error handler failure");
+      },
+      host: "127.0.0.1",
+      port: 0,
+      serverName: "test",
+    });
+
+    try {
+      const response = await fetch(server.baseUrl);
+      expect(response.status).toBe(500);
+      await expect(response.json()).resolves.toEqual({
+        error: "internal server error",
+        ok: false,
+      });
+    } finally {
+      await server.close();
+    }
+  });
 });

--- a/test/matrix-server.test.ts
+++ b/test/matrix-server.test.ts
@@ -206,7 +206,7 @@ describe("Matrix local provider server", () => {
         `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!filter:matrix.test")}/send/m.room.message/filter-${index}`,
         {
           body: JSON.stringify({ body: text, msgtype: "m.text" }),
-          headers: { ...auth("matrix-token"), "content-type": "application/json" },
+          headers: { ...auth("test-token-placeholder"), "content-type": "application/json" },
           method: "PUT",
         },
       );
@@ -214,7 +214,7 @@ describe("Matrix local provider server", () => {
     }
     const filteredSync = await fetch(
       `${server.manifest.endpoints.syncUrl}?filter=${createdBody.filter_id}`,
-      { headers: auth("matrix-token") },
+      { headers: auth("test-token-placeholder") },
     );
     const filteredSyncBody = (await filteredSync.json()) as {
       rooms: {
@@ -517,19 +517,19 @@ describe("Matrix local provider server", () => {
 
   it("publishes typing and receipt updates through room ephemeral sync", async () => {
     const server = await startMatrixServer({
-      accessToken: "matrix-token",
+      accessToken: "test-token-placeholder",
       roomId: "!ephemeral:matrix.test",
     });
     servers.push(server);
     const initial = (await (
-      await fetch(server.manifest.endpoints.syncUrl, { headers: auth("matrix-token") })
+      await fetch(server.manifest.endpoints.syncUrl, { headers: auth("test-token-placeholder") })
     ).json()) as { next_batch: string };
     const sent = (await (
       await fetch(
         `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!ephemeral:matrix.test")}/send/m.room.message/ephemeral-message`,
         {
           body: JSON.stringify({ body: "read me", msgtype: "m.text" }),
-          headers: { ...auth("matrix-token"), "content-type": "application/json" },
+          headers: { ...auth("test-token-placeholder"), "content-type": "application/json" },
           method: "PUT",
         },
       )
@@ -539,7 +539,7 @@ describe("Matrix local provider server", () => {
       `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!ephemeral:matrix.test")}/typing/${encodeURIComponent(server.manifest.botUserId)}`,
       {
         body: JSON.stringify({ timeout: 30_000, typing: true }),
-        headers: { ...auth("matrix-token"), "content-type": "application/json" },
+        headers: { ...auth("test-token-placeholder"), "content-type": "application/json" },
         method: "PUT",
       },
     );
@@ -548,7 +548,7 @@ describe("Matrix local provider server", () => {
       `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!ephemeral:matrix.test")}/typing/${encodeURIComponent(server.manifest.botUserId)}`,
       {
         body: JSON.stringify({ timeout: "30000", typing: true }),
-        headers: { ...auth("matrix-token"), "content-type": "application/json" },
+        headers: { ...auth("test-token-placeholder"), "content-type": "application/json" },
         method: "PUT",
       },
     );
@@ -557,7 +557,7 @@ describe("Matrix local provider server", () => {
       `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!ephemeral:matrix.test")}/receipt/m.read/${encodeURIComponent(sent.event_id)}`,
       {
         body: "{}",
-        headers: { ...auth("matrix-token"), "content-type": "application/json" },
+        headers: { ...auth("test-token-placeholder"), "content-type": "application/json" },
         method: "POST",
       },
     );
@@ -565,7 +565,7 @@ describe("Matrix local provider server", () => {
 
     const sync = (await (
       await fetch(`${server.manifest.endpoints.syncUrl}?since=${initial.next_batch}`, {
-        headers: auth("matrix-token"),
+        headers: auth("test-token-placeholder"),
       })
     ).json()) as {
       rooms: { join: Record<string, { ephemeral: { events: unknown[] } }> };
@@ -585,20 +585,20 @@ describe("Matrix local provider server", () => {
     ]);
 
     const beforeExpiry = (await (
-      await fetch(server.manifest.endpoints.syncUrl, { headers: auth("matrix-token") })
+      await fetch(server.manifest.endpoints.syncUrl, { headers: auth("test-token-placeholder") })
     ).json()) as { next_batch: string };
     await fetch(
       `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!ephemeral:matrix.test")}/typing/${encodeURIComponent(server.manifest.botUserId)}`,
       {
         body: JSON.stringify({ timeout: 10, typing: true }),
-        headers: { ...auth("matrix-token"), "content-type": "application/json" },
+        headers: { ...auth("test-token-placeholder"), "content-type": "application/json" },
         method: "PUT",
       },
     );
     await new Promise((resolve) => setTimeout(resolve, 25));
     const expired = (await (
       await fetch(`${server.manifest.endpoints.syncUrl}?since=${beforeExpiry.next_batch}`, {
-        headers: auth("matrix-token"),
+        headers: auth("test-token-placeholder"),
       })
     ).json()) as {
       rooms: { join: Record<string, { ephemeral: { events: unknown[] } }> };
@@ -611,8 +611,8 @@ describe("Matrix local provider server", () => {
 
   it("updates membership state when an inbound sender is renamed", async () => {
     const server = await startMatrixServer({
-      accessToken: "matrix-token",
-      adminToken: "admin-secret",
+      accessToken: "test-token-placeholder",
+      adminToken: "test-auth-token",
     });
     servers.push(server);
     const roomId = "!rename:matrix.test";
@@ -626,7 +626,7 @@ describe("Matrix local provider server", () => {
         }),
         headers: {
           "content-type": "application/json",
-          "x-crabline-admin-token": "admin-secret",
+          "x-crabline-admin-token": "test-auth-token",
         },
         method: "POST",
       });
@@ -635,7 +635,7 @@ describe("Matrix local provider server", () => {
 
     const membership = await fetch(
       `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent(roomId)}/state/m.room.member/${encodeURIComponent("@alice:matrix.test")}`,
-      { headers: auth("matrix-token") },
+      { headers: auth("test-token-placeholder") },
     );
     await expect(membership.json()).resolves.toEqual({
       displayname: "Alicia",
@@ -645,7 +645,7 @@ describe("Matrix local provider server", () => {
 
   it("bounds retained timelines and transaction responses", async () => {
     const server = await startMatrixServer({
-      accessToken: "matrix-token",
+      accessToken: "test-token-placeholder",
       roomId: "!bounded:matrix.test",
     });
     servers.push(server);
@@ -655,7 +655,7 @@ describe("Matrix local provider server", () => {
         `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!bounded:matrix.test")}/send/m.room.message/bounded-${index}`,
         {
           body: JSON.stringify({ body: `message ${index}`, msgtype: "m.text" }),
-          headers: { ...auth("matrix-token"), "content-type": "application/json" },
+          headers: { ...auth("test-token-placeholder"), "content-type": "application/json" },
           method: "PUT",
         },
       );
@@ -666,7 +666,7 @@ describe("Matrix local provider server", () => {
     }
 
     const sync = (await (
-      await fetch(server.manifest.endpoints.syncUrl, { headers: auth("matrix-token") })
+      await fetch(server.manifest.endpoints.syncUrl, { headers: auth("test-token-placeholder") })
     ).json()) as {
       rooms: { join: Record<string, { timeline: { events: unknown[]; limited: boolean } }> };
     };
@@ -679,7 +679,7 @@ describe("Matrix local provider server", () => {
       `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!bounded:matrix.test")}/send/m.room.message/bounded-0`,
       {
         body: JSON.stringify({ body: "transaction was evicted", msgtype: "m.text" }),
-        headers: { ...auth("matrix-token"), "content-type": "application/json" },
+        headers: { ...auth("test-token-placeholder"), "content-type": "application/json" },
         method: "PUT",
       },
     );

--- a/test/matrix-server.test.ts
+++ b/test/matrix-server.test.ts
@@ -719,10 +719,10 @@ describe("Matrix local provider server", () => {
         senderId: "@alice:matrix.test",
         text: "advance the bounded timeline",
       }),
-      headers: {
-        "content-type": "application/json",
-        "x-crabline-admin-token": server.manifest.adminToken,
-      },
+      headers: new Headers([
+        ["content-type", "application/json"],
+        ["x-crabline-admin-token", server.manifest.adminToken],
+      ]),
       method: "POST",
     });
     expect(inbound.status).toBe(200);

--- a/test/matrix-server.test.ts
+++ b/test/matrix-server.test.ts
@@ -635,8 +635,13 @@ describe("Matrix local provider server", () => {
     });
     servers.push(server);
     const roomId = "!rename:matrix.test";
-    for (const senderName of ["Alice", "Alicia"]) {
-      const response = await fetch(server.manifest.endpoints.adminInboundUrl, {
+    const initial = (await (
+      await fetch(server.manifest.endpoints.syncUrl, {
+        headers: auth("test-token-placeholder"),
+      })
+    ).json()) as { next_batch: string };
+    const sendInbound = (senderName: string) =>
+      fetch(server.manifest.endpoints.adminInboundUrl, {
         body: JSON.stringify({
           roomId,
           senderId: "@alice:matrix.test",
@@ -649,8 +654,20 @@ describe("Matrix local provider server", () => {
         },
         method: "POST",
       });
-      expect(response.status).toBe(200);
-    }
+    expect((await sendInbound("Alice")).status).toBe(200);
+    const firstSync = (await (
+      await fetch(`${server.manifest.endpoints.syncUrl}?since=${initial.next_batch}`, {
+        headers: auth("test-token-placeholder"),
+      })
+    ).json()) as {
+      rooms: { join: Record<string, { timeline: { events: Array<{ type: string }> } }> };
+    };
+    expect(
+      firstSync.rooms.join[roomId]?.timeline.events.filter(
+        (event) => event.type === "m.room.member",
+      ),
+    ).toHaveLength(1);
+    expect((await sendInbound("Alicia")).status).toBe(200);
 
     const membership = await fetch(
       `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent(roomId)}/state/m.room.member/${encodeURIComponent("@alice:matrix.test")}`,

--- a/test/matrix-server.test.ts
+++ b/test/matrix-server.test.ts
@@ -181,9 +181,10 @@ describe("Matrix local provider server", () => {
     const server = await startMatrixServer({
       accessToken: "test-token-placeholder",
       recorderPath: path.join(directory, "matrix-filter-owner.jsonl"),
+      roomId: "!filter:matrix.test",
     });
     servers.push(server);
-    const filter = { room: { timeline: { limit: 10 } } };
+    const filter = { room: { timeline: { limit: 1 } } };
     const created = await fetch(
       `${server.manifest.endpoints.clientApiRoot}/user/${encodeURIComponent(server.manifest.botUserId)}/filter`,
       {
@@ -199,6 +200,34 @@ describe("Matrix local provider server", () => {
       { headers: auth("test-token-placeholder") },
     );
     await expect(owned.json()).resolves.toEqual(filter);
+
+    for (const [index, text] of ["first", "second"].entries()) {
+      const sent = await fetch(
+        `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!filter:matrix.test")}/send/m.room.message/filter-${index}`,
+        {
+          body: JSON.stringify({ body: text, msgtype: "m.text" }),
+          headers: { ...auth("matrix-token"), "content-type": "application/json" },
+          method: "PUT",
+        },
+      );
+      expect(sent.status).toBe(200);
+    }
+    const filteredSync = await fetch(
+      `${server.manifest.endpoints.syncUrl}?filter=${createdBody.filter_id}`,
+      { headers: auth("matrix-token") },
+    );
+    const filteredSyncBody = (await filteredSync.json()) as {
+      rooms: {
+        join: Record<
+          string,
+          { timeline: { events: Array<{ content: { body?: string } }>; limited: boolean } }
+        >;
+      };
+    };
+    expect(Object.values(filteredSyncBody.rooms.join)[0]?.timeline).toMatchObject({
+      events: [{ content: { body: "second" } }],
+      limited: true,
+    });
 
     const forged = await fetch(
       `${server.manifest.endpoints.clientApiRoot}/user/${encodeURIComponent("@other:matrix.test")}/filter/${createdBody.filter_id}`,
@@ -484,5 +513,176 @@ describe("Matrix local provider server", () => {
       is_direct: true,
       membership: "join",
     });
+  });
+
+  it("publishes typing and receipt updates through room ephemeral sync", async () => {
+    const server = await startMatrixServer({
+      accessToken: "matrix-token",
+      roomId: "!ephemeral:matrix.test",
+    });
+    servers.push(server);
+    const initial = (await (
+      await fetch(server.manifest.endpoints.syncUrl, { headers: auth("matrix-token") })
+    ).json()) as { next_batch: string };
+    const sent = (await (
+      await fetch(
+        `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!ephemeral:matrix.test")}/send/m.room.message/ephemeral-message`,
+        {
+          body: JSON.stringify({ body: "read me", msgtype: "m.text" }),
+          headers: { ...auth("matrix-token"), "content-type": "application/json" },
+          method: "PUT",
+        },
+      )
+    ).json()) as { event_id: string };
+
+    const typing = await fetch(
+      `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!ephemeral:matrix.test")}/typing/${encodeURIComponent(server.manifest.botUserId)}`,
+      {
+        body: JSON.stringify({ timeout: 30_000, typing: true }),
+        headers: { ...auth("matrix-token"), "content-type": "application/json" },
+        method: "PUT",
+      },
+    );
+    expect(typing.status).toBe(200);
+    const stringTimeout = await fetch(
+      `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!ephemeral:matrix.test")}/typing/${encodeURIComponent(server.manifest.botUserId)}`,
+      {
+        body: JSON.stringify({ timeout: "30000", typing: true }),
+        headers: { ...auth("matrix-token"), "content-type": "application/json" },
+        method: "PUT",
+      },
+    );
+    expect(stringTimeout.status).toBe(400);
+    const receipt = await fetch(
+      `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!ephemeral:matrix.test")}/receipt/m.read/${encodeURIComponent(sent.event_id)}`,
+      {
+        body: "{}",
+        headers: { ...auth("matrix-token"), "content-type": "application/json" },
+        method: "POST",
+      },
+    );
+    expect(receipt.status).toBe(200);
+
+    const sync = (await (
+      await fetch(`${server.manifest.endpoints.syncUrl}?since=${initial.next_batch}`, {
+        headers: auth("matrix-token"),
+      })
+    ).json()) as {
+      rooms: { join: Record<string, { ephemeral: { events: unknown[] } }> };
+    };
+    expect(sync.rooms.join["!ephemeral:matrix.test"]?.ephemeral.events).toEqual([
+      { content: { user_ids: [server.manifest.botUserId] }, type: "m.typing" },
+      {
+        content: {
+          [sent.event_id]: {
+            "m.read": {
+              [server.manifest.botUserId]: { ts: expect.any(Number) },
+            },
+          },
+        },
+        type: "m.receipt",
+      },
+    ]);
+
+    const beforeExpiry = (await (
+      await fetch(server.manifest.endpoints.syncUrl, { headers: auth("matrix-token") })
+    ).json()) as { next_batch: string };
+    await fetch(
+      `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!ephemeral:matrix.test")}/typing/${encodeURIComponent(server.manifest.botUserId)}`,
+      {
+        body: JSON.stringify({ timeout: 10, typing: true }),
+        headers: { ...auth("matrix-token"), "content-type": "application/json" },
+        method: "PUT",
+      },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    const expired = (await (
+      await fetch(`${server.manifest.endpoints.syncUrl}?since=${beforeExpiry.next_batch}`, {
+        headers: auth("matrix-token"),
+      })
+    ).json()) as {
+      rooms: { join: Record<string, { ephemeral: { events: unknown[] } }> };
+    };
+    expect(expired.rooms.join["!ephemeral:matrix.test"]?.ephemeral.events).toEqual([
+      { content: { user_ids: [server.manifest.botUserId] }, type: "m.typing" },
+      { content: { user_ids: [] }, type: "m.typing" },
+    ]);
+  });
+
+  it("updates membership state when an inbound sender is renamed", async () => {
+    const server = await startMatrixServer({
+      accessToken: "matrix-token",
+      adminToken: "admin-secret",
+    });
+    servers.push(server);
+    const roomId = "!rename:matrix.test";
+    for (const senderName of ["Alice", "Alicia"]) {
+      const response = await fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({
+          roomId,
+          senderId: "@alice:matrix.test",
+          senderName,
+          text: `hello from ${senderName}`,
+        }),
+        headers: {
+          "content-type": "application/json",
+          "x-crabline-admin-token": "admin-secret",
+        },
+        method: "POST",
+      });
+      expect(response.status).toBe(200);
+    }
+
+    const membership = await fetch(
+      `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent(roomId)}/state/m.room.member/${encodeURIComponent("@alice:matrix.test")}`,
+      { headers: auth("matrix-token") },
+    );
+    await expect(membership.json()).resolves.toEqual({
+      displayname: "Alicia",
+      membership: "join",
+    });
+  });
+
+  it("bounds retained timelines and transaction responses", async () => {
+    const server = await startMatrixServer({
+      accessToken: "matrix-token",
+      roomId: "!bounded:matrix.test",
+    });
+    servers.push(server);
+    let firstEventId = "";
+    for (let index = 0; index <= 1_000; index += 1) {
+      const response = await fetch(
+        `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!bounded:matrix.test")}/send/m.room.message/bounded-${index}`,
+        {
+          body: JSON.stringify({ body: `message ${index}`, msgtype: "m.text" }),
+          headers: { ...auth("matrix-token"), "content-type": "application/json" },
+          method: "PUT",
+        },
+      );
+      const body = (await response.json()) as { event_id: string };
+      if (index === 0) {
+        firstEventId = body.event_id;
+      }
+    }
+
+    const sync = (await (
+      await fetch(server.manifest.endpoints.syncUrl, { headers: auth("matrix-token") })
+    ).json()) as {
+      rooms: { join: Record<string, { timeline: { events: unknown[]; limited: boolean } }> };
+    };
+    expect(sync.rooms.join["!bounded:matrix.test"]?.timeline).toMatchObject({
+      limited: true,
+    });
+    expect(sync.rooms.join["!bounded:matrix.test"]?.timeline.events).toHaveLength(1_000);
+
+    const retried = await fetch(
+      `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!bounded:matrix.test")}/send/m.room.message/bounded-0`,
+      {
+        body: JSON.stringify({ body: "transaction was evicted", msgtype: "m.text" }),
+        headers: { ...auth("matrix-token"), "content-type": "application/json" },
+        method: "PUT",
+      },
+    );
+    await expect(retried.json()).resolves.not.toEqual({ event_id: firstEventId });
   });
 });

--- a/test/matrix-server.test.ts
+++ b/test/matrix-server.test.ts
@@ -686,6 +686,8 @@ describe("Matrix local provider server", () => {
     });
     servers.push(server);
     let firstEventId = "";
+    let firstBatch = "";
+    let typingStatus: number | undefined;
     for (let index = 0; index < 1_000; index += 1) {
       const response = await fetch(
         `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!bounded:matrix.test")}/send/m.room.message/bounded-${index}`,
@@ -698,8 +700,27 @@ describe("Matrix local provider server", () => {
       const body = (await response.json()) as { event_id: string };
       if (index === 0) {
         firstEventId = body.event_id;
+        const sync = (await (
+          await fetch(server.manifest.endpoints.syncUrl, {
+            headers: auth("test-token-placeholder"),
+          })
+        ).json()) as { next_batch: string };
+        firstBatch = sync.next_batch;
+        const typing = await fetch(
+          `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!bounded:matrix.test")}/typing/${encodeURIComponent(server.manifest.botUserId)}`,
+          {
+            body: JSON.stringify({ typing: false }),
+            headers: {
+              ...auth("test-token-placeholder"),
+              "content-type": "application/json",
+            },
+            method: "PUT",
+          },
+        );
+        typingStatus = typing.status;
       }
     }
+    expect(typingStatus).toBe(200);
     const exhausted = await fetch(
       `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!bounded:matrix.test")}/send/m.room.message/bounded-1000`,
       {
@@ -716,7 +737,7 @@ describe("Matrix local provider server", () => {
     const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
       body: JSON.stringify({
         roomId: "!bounded:matrix.test",
-        senderId: "@alice:matrix.test",
+        senderId: server.manifest.botUserId,
         text: "advance the bounded timeline",
       }),
       headers: new Headers([
@@ -736,6 +757,14 @@ describe("Matrix local provider server", () => {
       limited: true,
     });
     expect(sync.rooms.join["!bounded:matrix.test"]?.timeline.events).toHaveLength(1_000);
+    const resumed = (await (
+      await fetch(`${server.manifest.endpoints.syncUrl}?since=${firstBatch}`, {
+        headers: auth("test-token-placeholder"),
+      })
+    ).json()) as {
+      rooms: { join: Record<string, { timeline: { limited: boolean } }> };
+    };
+    expect(resumed.rooms.join["!bounded:matrix.test"]?.timeline.limited).toBe(false);
 
     const retried = await fetch(
       `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!bounded:matrix.test")}/send/m.room.message/bounded-0`,

--- a/test/matrix-server.test.ts
+++ b/test/matrix-server.test.ts
@@ -553,6 +553,25 @@ describe("Matrix local provider server", () => {
       },
     );
     expect(stringTimeout.status).toBe(400);
+    const foreignUser = await fetch(
+      `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!ephemeral:matrix.test")}/typing/${encodeURIComponent("@alice:matrix.test")}`,
+      {
+        body: JSON.stringify({ timeout: 30_000, typing: true }),
+        headers: { ...auth("test-token-placeholder"), "content-type": "application/json" },
+        method: "PUT",
+      },
+    );
+    expect(foreignUser.status).toBe(403);
+    await expect(foreignUser.json()).resolves.toMatchObject({ errcode: "M_FORBIDDEN" });
+    const oversizedTimeout = await fetch(
+      `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!ephemeral:matrix.test")}/typing/${encodeURIComponent(server.manifest.botUserId)}`,
+      {
+        body: JSON.stringify({ timeout: 2_147_483_648, typing: true }),
+        headers: { ...auth("test-token-placeholder"), "content-type": "application/json" },
+        method: "PUT",
+      },
+    );
+    expect(oversizedTimeout.status).toBe(400);
     const receipt = await fetch(
       `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!ephemeral:matrix.test")}/receipt/m.read/${encodeURIComponent(sent.event_id)}`,
       {

--- a/test/matrix-server.test.ts
+++ b/test/matrix-server.test.ts
@@ -679,14 +679,14 @@ describe("Matrix local provider server", () => {
     });
   });
 
-  it("bounds retained timelines and transaction responses", async () => {
+  it("bounds timelines without evicting accepted transaction responses", async () => {
     const server = await startMatrixServer({
       accessToken: "test-token-placeholder",
       roomId: "!bounded:matrix.test",
     });
     servers.push(server);
     let firstEventId = "";
-    for (let index = 0; index <= 1_000; index += 1) {
+    for (let index = 0; index < 1_000; index += 1) {
       const response = await fetch(
         `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!bounded:matrix.test")}/send/m.room.message/bounded-${index}`,
         {
@@ -700,6 +700,32 @@ describe("Matrix local provider server", () => {
         firstEventId = body.event_id;
       }
     }
+    const exhausted = await fetch(
+      `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!bounded:matrix.test")}/send/m.room.message/bounded-1000`,
+      {
+        body: JSON.stringify({ body: "over capacity", msgtype: "m.text" }),
+        headers: { ...auth("test-token-placeholder"), "content-type": "application/json" },
+        method: "PUT",
+      },
+    );
+    expect(exhausted.status).toBe(503);
+    await expect(exhausted.json()).resolves.toMatchObject({
+      admin_contact: "mailto:admin@example.invalid",
+      errcode: "M_RESOURCE_LIMIT_EXCEEDED",
+    });
+    const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({
+        roomId: "!bounded:matrix.test",
+        senderId: "@alice:matrix.test",
+        text: "advance the bounded timeline",
+      }),
+      headers: {
+        "content-type": "application/json",
+        "x-crabline-admin-token": server.manifest.adminToken,
+      },
+      method: "POST",
+    });
+    expect(inbound.status).toBe(200);
 
     const sync = (await (
       await fetch(server.manifest.endpoints.syncUrl, { headers: auth("test-token-placeholder") })
@@ -714,11 +740,11 @@ describe("Matrix local provider server", () => {
     const retried = await fetch(
       `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!bounded:matrix.test")}/send/m.room.message/bounded-0`,
       {
-        body: JSON.stringify({ body: "transaction was evicted", msgtype: "m.text" }),
+        body: JSON.stringify({ body: "transaction remains idempotent", msgtype: "m.text" }),
         headers: { ...auth("test-token-placeholder"), "content-type": "application/json" },
         method: "PUT",
       },
     );
-    await expect(retried.json()).resolves.not.toEqual({ event_id: firstEventId });
+    await expect(retried.json()).resolves.toEqual({ event_id: firstEventId });
   });
 });

--- a/test/mattermost-server.test.ts
+++ b/test/mattermost-server.test.ts
@@ -443,10 +443,11 @@ describe("Mattermost local provider server", () => {
     const second = new WebSocket(server.manifest.endpoints.websocketUrl);
     const secondClosed = waitForSocketClose(second);
     await waitForSocketOpen(second);
-    await expect(secondClosed).resolves.toEqual({
-      code: 1013,
-      reason: "too many unauthenticated clients",
-    });
+    await expect(secondClosed).resolves.toMatchObject({ code: 1006 });
+    const third = new WebSocket(server.manifest.endpoints.websocketUrl);
+    const thirdClosed = waitForSocketClose(third);
+    await waitForSocketOpen(third);
+    await expect(thirdClosed).resolves.toMatchObject({ code: 1006 });
 
     const firstClosed = waitForSocketClose(first);
     first.send(JSON.stringify({ action: "x".repeat(64) }));

--- a/test/mattermost-server.test.ts
+++ b/test/mattermost-server.test.ts
@@ -310,6 +310,60 @@ describe("Mattermost local provider server", () => {
     });
   });
 
+  it("keeps REST mutations independent from disconnected WebSocket delivery", async () => {
+    const server = await startMattermostServer({
+      adminToken: "admin",
+      botToken: "bot-secret",
+      maxPendingInboundEvents: 1,
+    });
+    servers.push(server);
+    const direct = await fetch(`${server.manifest.endpoints.apiRoot}/channels/direct`, {
+      body: JSON.stringify([server.manifest.botUserId, "user-1"]),
+      headers: { authorization: "Bearer bot-secret", "content-type": "application/json" },
+      method: "POST",
+    });
+    const channel = (await direct.json()) as { id: string };
+
+    for (const message of ["first REST post", "second REST post"]) {
+      const response = await fetch(`${server.manifest.endpoints.apiRoot}/posts`, {
+        body: JSON.stringify({ channel_id: channel.id, message }),
+        headers: { authorization: "Bearer bot-secret", "content-type": "application/json" },
+        method: "POST",
+      });
+      expect(response.status).toBe(201);
+    }
+
+    const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({ channelId: channel.id, senderId: "user-1", text: "queued inbound" }),
+      headers: {
+        "content-type": "application/json",
+        "x-crabline-admin-token": "admin",
+      },
+      method: "POST",
+    });
+    expect(inbound.status).toBe(200);
+  });
+
+  it("rejects posts and typing for unknown channels", async () => {
+    const server = await startMattermostServer({ botToken: "bot-secret" });
+    servers.push(server);
+    for (const [apiPath, body] of [
+      ["/posts", { channel_id: "missing", message: "hello" }],
+      ["/users/me/typing", { channel_id: "missing" }],
+    ] as const) {
+      const response = await fetch(`${server.manifest.endpoints.apiRoot}${apiPath}`, {
+        body: JSON.stringify(body),
+        headers: { authorization: "Bearer bot-secret", "content-type": "application/json" },
+        method: "POST",
+      });
+      expect(response.status).toBe(404);
+      await expect(response.json()).resolves.toMatchObject({
+        message: "Channel not found",
+        status_code: 404,
+      });
+    }
+  });
+
   it("disconnects slow WebSocket clients and queues undelivered events", async () => {
     const server = await startMattermostServer({
       adminToken: "admin",
@@ -342,13 +396,67 @@ describe("Mattermost local provider server", () => {
 
     expect((await sendInbound("x".repeat(2_000))).status).toBe(503);
     await expect(closed).resolves.toEqual({ code: 1013, reason: "client too slow" });
+    for (const apiPath of ["/users/user-1", "/channels/channel-1"]) {
+      const response = await fetch(`${server.manifest.endpoints.apiRoot}${apiPath}`, {
+        headers: { authorization: "Bearer test-token-placeholder" },
+      });
+      expect(response.status).toBe(404);
+    }
     expect((await sendInbound("queued after oversized event")).status).toBe(200);
     expect((await sendInbound("queue is full")).status).toBe(503);
   });
 
-  it("validates the WebSocket delivery buffer limit", async () => {
+  it("bounds unauthenticated clients and inbound WebSocket messages", async () => {
+    const server = await startMattermostServer({
+      botToken: "test-token-placeholder",
+      maxUnauthenticatedWebSocketClients: 1,
+      maxWebSocketMessageBytes: 32,
+    });
+    servers.push(server);
+
+    const first = new WebSocket(server.manifest.endpoints.websocketUrl);
+    await waitForSocketOpen(first);
+    const second = new WebSocket(server.manifest.endpoints.websocketUrl);
+    const secondClosed = waitForSocketClose(second);
+    await waitForSocketOpen(second);
+    await expect(secondClosed).resolves.toEqual({
+      code: 1013,
+      reason: "too many unauthenticated clients",
+    });
+
+    const firstClosed = waitForSocketClose(first);
+    first.send(JSON.stringify({ action: "x".repeat(64) }));
+    await expect(firstClosed).resolves.toMatchObject({ code: 1009 });
+    const me = await fetch(`${server.manifest.endpoints.apiRoot}/users/me`, {
+      headers: { authorization: "Bearer test-token-placeholder" },
+    });
+    expect(me.status).toBe(200);
+  });
+
+  it("rejects non-object WebSocket messages without crashing", async () => {
+    const server = await startMattermostServer({ botToken: "bot-secret" });
+    servers.push(server);
+    const socket = new WebSocket(server.manifest.endpoints.websocketUrl);
+    const closed = waitForSocketClose(socket);
+    await waitForSocketOpen(socket);
+    socket.send("null");
+    await expect(closed).resolves.toEqual({ code: 1003, reason: "invalid json" });
+
+    const me = await fetch(`${server.manifest.endpoints.apiRoot}/users/me`, {
+      headers: { authorization: "Bearer bot-secret" },
+    });
+    expect(me.status).toBe(200);
+  });
+
+  it("validates WebSocket resource limits", async () => {
     await expect(startMattermostServer({ maxWebSocketBufferedBytes: 0 })).rejects.toThrow(
       "maxWebSocketBufferedBytes must be a positive safe integer.",
+    );
+    await expect(startMattermostServer({ maxWebSocketMessageBytes: 0 })).rejects.toThrow(
+      "maxWebSocketMessageBytes must be a positive safe integer.",
+    );
+    await expect(startMattermostServer({ maxUnauthenticatedWebSocketClients: 0 })).rejects.toThrow(
+      "maxUnauthenticatedWebSocketClients must be a positive safe integer.",
     );
   });
 

--- a/test/mattermost-server.test.ts
+++ b/test/mattermost-server.test.ts
@@ -66,7 +66,10 @@ describe("Mattermost local provider server", () => {
     for (const scalarBody of ["null", '"scalar"', "42", "true", "[]"]) {
       const invalid = await fetch(postsUrl, {
         body: scalarBody,
-        headers: { authorization: "Bearer fake", "content-type": "application/json" },
+        headers: {
+          authorization: "Bearer fake",
+          "content-type": "application/json",
+        },
         method: "POST",
       });
       expect(invalid.status).toBe(400);
@@ -78,7 +81,10 @@ describe("Mattermost local provider server", () => {
 
     const malformed = await fetch(postsUrl, {
       body: "{",
-      headers: { authorization: "Bearer fake", "content-type": "application/json" },
+      headers: {
+        authorization: "Bearer fake",
+        "content-type": "application/json",
+      },
       method: "POST",
     });
     expect(malformed.status).toBe(400);
@@ -203,7 +209,10 @@ describe("Mattermost local provider server", () => {
         channel_id: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
         message: "assistant nonce-1",
       }),
-      headers: { authorization: "Bearer fake", "content-type": "application/json" },
+      headers: {
+        authorization: "Bearer fake",
+        "content-type": "application/json",
+      },
       method: "POST",
     });
     expect(send.status).toBe(201);
@@ -221,7 +230,10 @@ describe("Mattermost local provider server", () => {
 
     const direct = await fetch(`${server.manifest.endpoints.apiRoot}/channels/direct`, {
       body: JSON.stringify([server.manifest.botUserId, "bbbbbbbbbbbbbbbbbbbbbbbbbb"]),
-      headers: { authorization: "bearer fake", "content-type": "application/json" },
+      headers: {
+        authorization: "bearer fake",
+        "content-type": "application/json",
+      },
       method: "POST",
     });
     expect(direct.status).toBe(201);
@@ -232,7 +244,10 @@ describe("Mattermost local provider server", () => {
     const editedEvent = nextMessage(socket);
     const edited = await fetch(`${server.manifest.endpoints.apiRoot}/posts/${postId}`, {
       body: JSON.stringify({ message: "assistant edited" }),
-      headers: { authorization: "Bearer fake", "content-type": "application/json" },
+      headers: {
+        authorization: "Bearer fake",
+        "content-type": "application/json",
+      },
       method: "PUT",
     });
     expect(edited.status).toBe(200);
@@ -254,7 +269,7 @@ describe("Mattermost local provider server", () => {
 
   it("expires silent and invalid WebSocket authentication", async () => {
     const server = await startMattermostServer({
-      botToken: "test-token-placeholder",
+      botToken: "fake",
       websocketAuthenticationTimeoutMs: 25,
     });
     servers.push(server);
@@ -313,13 +328,16 @@ describe("Mattermost local provider server", () => {
   it("keeps REST mutations independent from disconnected WebSocket delivery", async () => {
     const server = await startMattermostServer({
       adminToken: "admin",
-      botToken: "bot-secret",
+      botToken: "fake",
       maxPendingInboundEvents: 1,
     });
     servers.push(server);
     const direct = await fetch(`${server.manifest.endpoints.apiRoot}/channels/direct`, {
       body: JSON.stringify([server.manifest.botUserId, "user-1"]),
-      headers: { authorization: "Bearer bot-secret", "content-type": "application/json" },
+      headers: {
+        authorization: "Bearer fake",
+        "content-type": "application/json",
+      },
       method: "POST",
     });
     const channel = (await direct.json()) as { id: string };
@@ -327,7 +345,10 @@ describe("Mattermost local provider server", () => {
     for (const message of ["first REST post", "second REST post"]) {
       const response = await fetch(`${server.manifest.endpoints.apiRoot}/posts`, {
         body: JSON.stringify({ channel_id: channel.id, message }),
-        headers: { authorization: "Bearer bot-secret", "content-type": "application/json" },
+        headers: {
+          authorization: "Bearer fake",
+          "content-type": "application/json",
+        },
         method: "POST",
       });
       expect(response.status).toBe(201);
@@ -345,7 +366,7 @@ describe("Mattermost local provider server", () => {
   });
 
   it("rejects posts and typing for unknown channels", async () => {
-    const server = await startMattermostServer({ botToken: "bot-secret" });
+    const server = await startMattermostServer({ botToken: "fake" });
     servers.push(server);
     for (const [apiPath, body] of [
       ["/posts", { channel_id: "missing", message: "hello" }],
@@ -353,7 +374,10 @@ describe("Mattermost local provider server", () => {
     ] as const) {
       const response = await fetch(`${server.manifest.endpoints.apiRoot}${apiPath}`, {
         body: JSON.stringify(body),
-        headers: { authorization: "Bearer bot-secret", "content-type": "application/json" },
+        headers: {
+          authorization: "Bearer fake",
+          "content-type": "application/json",
+        },
         method: "POST",
       });
       expect(response.status).toBe(404);
@@ -367,7 +391,7 @@ describe("Mattermost local provider server", () => {
   it("disconnects slow WebSocket clients and queues undelivered events", async () => {
     const server = await startMattermostServer({
       adminToken: "admin",
-      botToken: "test-token-placeholder",
+      botToken: "fake",
       maxPendingInboundEvents: 1,
       maxWebSocketBufferedBytes: 512,
     });
@@ -378,7 +402,7 @@ describe("Mattermost local provider server", () => {
     socket.send(
       JSON.stringify({
         action: "authentication_challenge",
-        data: { token: "test-token-placeholder" },
+        data: { token: "fake" },
         seq: 1,
       }),
     );
@@ -398,7 +422,7 @@ describe("Mattermost local provider server", () => {
     await expect(closed).resolves.toEqual({ code: 1013, reason: "client too slow" });
     for (const apiPath of ["/users/user-1", "/channels/channel-1"]) {
       const response = await fetch(`${server.manifest.endpoints.apiRoot}${apiPath}`, {
-        headers: { authorization: "Bearer test-token-placeholder" },
+        headers: { authorization: "Bearer fake" },
       });
       expect(response.status).toBe(404);
     }
@@ -408,7 +432,7 @@ describe("Mattermost local provider server", () => {
 
   it("bounds unauthenticated clients and inbound WebSocket messages", async () => {
     const server = await startMattermostServer({
-      botToken: "test-token-placeholder",
+      botToken: "fake",
       maxUnauthenticatedWebSocketClients: 1,
       maxWebSocketMessageBytes: 32,
     });
@@ -428,13 +452,13 @@ describe("Mattermost local provider server", () => {
     first.send(JSON.stringify({ action: "x".repeat(64) }));
     await expect(firstClosed).resolves.toMatchObject({ code: 1009 });
     const me = await fetch(`${server.manifest.endpoints.apiRoot}/users/me`, {
-      headers: { authorization: "Bearer test-token-placeholder" },
+      headers: { authorization: "Bearer fake" },
     });
     expect(me.status).toBe(200);
   });
 
   it("rejects non-object WebSocket messages without crashing", async () => {
-    const server = await startMattermostServer({ botToken: "bot-secret" });
+    const server = await startMattermostServer({ botToken: "fake" });
     servers.push(server);
     const socket = new WebSocket(server.manifest.endpoints.websocketUrl);
     const closed = waitForSocketClose(socket);
@@ -443,7 +467,7 @@ describe("Mattermost local provider server", () => {
     await expect(closed).resolves.toEqual({ code: 1003, reason: "invalid json" });
 
     const me = await fetch(`${server.manifest.endpoints.apiRoot}/users/me`, {
-      headers: { authorization: "Bearer bot-secret" },
+      headers: { authorization: "Bearer fake" },
     });
     expect(me.status).toBe(200);
   });

--- a/test/signal-server.test.ts
+++ b/test/signal-server.test.ts
@@ -317,6 +317,67 @@ describe("signal local provider server", () => {
     }
   });
 
+  it("moves near-capacity pending events into a client buffer without double-counting", async () => {
+    const server = await startSignalServer({
+      adminToken: "admin",
+      maxPendingInboundEvents: 2,
+    });
+    servers.push(server);
+    const sendInbound = (text: string) =>
+      fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({ sourceNumber: "+15557654321", text }),
+        headers: {
+          "content-type": "application/json",
+          "x-crabline-admin-token": "admin",
+        },
+        method: "POST",
+      });
+    expect((await sendInbound("first event")).status).toBe(200);
+    const largeText = `large-${"x".repeat(1_048_450)}`;
+    expect((await sendInbound(largeText)).status).toBe(200);
+
+    const originalWrite = ServerResponse.prototype.write;
+    let backpressuredResponse: ServerResponse | undefined;
+    const write = vi.spyOn(ServerResponse.prototype, "write").mockImplementation(function (
+      this: ServerResponse,
+      ...args: Parameters<typeof originalWrite>
+    ) {
+      const accepted = Reflect.apply(originalWrite, this, args) as boolean;
+      if (
+        backpressuredResponse === undefined &&
+        typeof args[0] === "string" &&
+        args[0].includes("first event")
+      ) {
+        backpressuredResponse = this;
+        return false;
+      }
+      return accepted;
+    });
+    const controller = new AbortController();
+    try {
+      const events = await fetch(server.manifest.endpoints.eventsUrl, {
+        signal: controller.signal,
+      });
+      await vi.waitFor(() => expect(backpressuredResponse).toBeDefined());
+      backpressuredResponse!.emit("drain");
+
+      const reader = events.body!.getReader();
+      const decoder = new TextDecoder();
+      let received = "";
+      while (!received.includes(largeText)) {
+        const chunk = await reader.read();
+        if (chunk.done) {
+          break;
+        }
+        received += decoder.decode(chunk.value, { stream: true });
+      }
+      expect(received).toContain(largeText);
+    } finally {
+      controller.abort();
+      write.mockRestore();
+    }
+  });
+
   it("restores buffered events when the only SSE client disconnects", async () => {
     const server = await startSignalServer({ adminToken: "admin" });
     servers.push(server);

--- a/test/signal-server.test.ts
+++ b/test/signal-server.test.ts
@@ -120,8 +120,18 @@ describe("signal local provider server", () => {
       result: { timestamp: expect.any(Number) },
     });
     for (const [method, params] of [
-      ["send", { attachments: ["/tmp/test-attachment-placeholder"], recipient: ["+15551234567"] }],
+      ["send", { attachment: "/tmp/test-attachment-placeholder", recipients: ["+15551234567"] }],
       ["sendReceipt", { targetTimestamps: [1_700_000_000_000], usernames: ["alice"] }],
+      [
+        "sendReaction",
+        {
+          emoji: "👍",
+          recipients: ["+15551234567"],
+          targetAuthor: "+15557654321",
+          targetTimestamp: 1_700_000_000_000,
+        },
+      ],
+      ["sendTyping", { recipients: ["+15551234567"] }],
     ] as const) {
       const nativeAlternative = await fetch(server.manifest.endpoints.rpcUrl, {
         body: JSON.stringify({

--- a/test/signal-server.test.ts
+++ b/test/signal-server.test.ts
@@ -382,6 +382,53 @@ describe("signal local provider server", () => {
     }
   });
 
+  it("bounds pending events together with reconnectable client buffers", async () => {
+    const server = await startSignalServer({
+      adminToken: "admin",
+      maxPendingInboundEvents: 10,
+    });
+    servers.push(server);
+    const sendInbound = (text: string) =>
+      fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({ sourceNumber: "+15557654321", text }),
+        headers: {
+          "content-type": "application/json",
+          "x-crabline-admin-token": "admin",
+        },
+        method: "POST",
+      });
+    expect((await sendInbound("first")).status).toBe(200);
+    expect((await sendInbound(`second-${"x".repeat(700_000)}`)).status).toBe(200);
+    expect((await sendInbound(`third-${"x".repeat(700_000)}`)).status).toBe(200);
+
+    const originalWrite = ServerResponse.prototype.write;
+    let backpressuredResponse: ServerResponse | undefined;
+    const write = vi.spyOn(ServerResponse.prototype, "write").mockImplementation(function (
+      this: ServerResponse,
+      ...args: Parameters<typeof originalWrite>
+    ) {
+      const accepted = Reflect.apply(originalWrite, this, args) as boolean;
+      if (
+        backpressuredResponse === undefined &&
+        typeof args[0] === "string" &&
+        args[0].startsWith("event:receive")
+      ) {
+        backpressuredResponse = this;
+        return false;
+      }
+      return accepted;
+    });
+    const controller = new AbortController();
+    try {
+      await fetch(server.manifest.endpoints.eventsUrl, { signal: controller.signal });
+      await vi.waitFor(() => expect(backpressuredResponse).toBeDefined());
+      expect((await sendInbound(`fourth-${"x".repeat(700_000)}`)).status).toBe(503);
+    } finally {
+      controller.abort();
+      write.mockRestore();
+    }
+  });
+
   it("bounds concurrent event stream clients", async () => {
     const server = await startSignalServer({ maxSseClients: 1 });
     servers.push(server);

--- a/test/signal-server.test.ts
+++ b/test/signal-server.test.ts
@@ -382,7 +382,7 @@ describe("signal local provider server", () => {
     }
   });
 
-  it("restores buffered events when a newer SSE client remains connected", async () => {
+  it("replays exclusively buffered events before newer broadcasts", async () => {
     const server = await startSignalServer({ adminToken: "admin" });
     servers.push(server);
     const originalWrite = ServerResponse.prototype.write;
@@ -425,13 +425,11 @@ describe("signal local provider server", () => {
         signal: secondController.signal,
       });
       expect((await sendInbound("shared event")).status).toBe(200);
-      firstController.abort();
-      await firstEvents.body?.cancel().catch(() => undefined);
 
       const reader = secondEvents.body!.getReader();
       const decoder = new TextDecoder();
       let received = "";
-      while (!received.includes("buffered event")) {
+      while (!received.includes("shared event")) {
         const chunk = await reader.read();
         if (chunk.done) {
           break;
@@ -439,10 +437,58 @@ describe("signal local provider server", () => {
         received += decoder.decode(chunk.value, { stream: true });
       }
       expect(received).toContain("buffered event");
+      expect(received.indexOf("buffered event")).toBeLessThan(received.indexOf("shared event"));
       expect(received.match(/shared event/gu)).toHaveLength(1);
+      firstController.abort();
+      await firstEvents.body?.cancel().catch(() => undefined);
     } finally {
       firstController.abort();
       secondController.abort();
+      write.mockRestore();
+    }
+  });
+
+  it("counts reconnectable client buffers against the pending event limit", async () => {
+    const server = await startSignalServer({
+      adminToken: "admin",
+      maxPendingInboundEvents: 1,
+    });
+    servers.push(server);
+    const sendInbound = (text: string) =>
+      fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({ sourceNumber: "+15557654321", text }),
+        headers: {
+          "content-type": "application/json",
+          "x-crabline-admin-token": "admin",
+        },
+        method: "POST",
+      });
+    const originalWrite = ServerResponse.prototype.write;
+    let backpressuredResponse: ServerResponse | undefined;
+    const write = vi.spyOn(ServerResponse.prototype, "write").mockImplementation(function (
+      this: ServerResponse,
+      ...args: Parameters<typeof originalWrite>
+    ) {
+      const accepted = Reflect.apply(originalWrite, this, args) as boolean;
+      if (
+        backpressuredResponse === undefined &&
+        typeof args[0] === "string" &&
+        args[0].includes("first event")
+      ) {
+        backpressuredResponse = this;
+        return false;
+      }
+      return accepted;
+    });
+    const controller = new AbortController();
+    try {
+      await fetch(server.manifest.endpoints.eventsUrl, { signal: controller.signal });
+      expect((await sendInbound("first event")).status).toBe(200);
+      await vi.waitFor(() => expect(backpressuredResponse).toBeDefined());
+      expect((await sendInbound("buffered event")).status).toBe(200);
+      expect((await sendInbound("over capacity")).status).toBe(503);
+    } finally {
+      controller.abort();
       write.mockRestore();
     }
   });

--- a/test/signal-server.test.ts
+++ b/test/signal-server.test.ts
@@ -238,6 +238,7 @@ describe("signal local provider server", () => {
       });
     expect((await sendInbound("first queued")).status).toBe(200);
     expect((await sendInbound("second queued")).status).toBe(200);
+    expect((await sendInbound("third queued")).status).toBe(200);
 
     const originalWrite = ServerResponse.prototype.write;
     let backpressuredResponse: ServerResponse | undefined;
@@ -267,7 +268,7 @@ describe("signal local provider server", () => {
       const reader = events.body!.getReader();
       const decoder = new TextDecoder();
       let received = "";
-      while (!received.includes("second queued")) {
+      while (!received.includes("third queued")) {
         const chunk = await reader.read();
         if (chunk.done) {
           break;
@@ -276,8 +277,74 @@ describe("signal local provider server", () => {
       }
       expect(received).toContain("first queued");
       expect(received).toContain("second queued");
+      expect(received).toContain("third queued");
     } finally {
       controller.abort();
+      write.mockRestore();
+    }
+  });
+
+  it("restores buffered events when the only SSE client disconnects", async () => {
+    const server = await startSignalServer({ adminToken: "admin" });
+    servers.push(server);
+    const originalWrite = ServerResponse.prototype.write;
+    let backpressuredResponse: ServerResponse | undefined;
+    const write = vi.spyOn(ServerResponse.prototype, "write").mockImplementation(function (
+      this: ServerResponse,
+      ...args: Parameters<typeof originalWrite>
+    ) {
+      const accepted = Reflect.apply(originalWrite, this, args) as boolean;
+      if (
+        backpressuredResponse === undefined &&
+        typeof args[0] === "string" &&
+        args[0].includes("first event")
+      ) {
+        backpressuredResponse = this;
+        return false;
+      }
+      return accepted;
+    });
+    const firstController = new AbortController();
+    try {
+      const firstEvents = await fetch(server.manifest.endpoints.eventsUrl, {
+        signal: firstController.signal,
+      });
+      const sendInbound = (text: string) =>
+        fetch(server.manifest.endpoints.adminInboundUrl, {
+          body: JSON.stringify({ sourceNumber: "+15557654321", text }),
+          headers: {
+            "content-type": "application/json",
+            "x-crabline-admin-token": "admin",
+          },
+          method: "POST",
+        });
+      expect((await sendInbound("first event")).status).toBe(200);
+      await vi.waitFor(() => expect(backpressuredResponse).toBeDefined());
+      expect((await sendInbound("buffered event")).status).toBe(200);
+      firstController.abort();
+      await firstEvents.body?.cancel().catch(() => undefined);
+
+      const secondController = new AbortController();
+      try {
+        const secondEvents = await fetch(server.manifest.endpoints.eventsUrl, {
+          signal: secondController.signal,
+        });
+        const reader = secondEvents.body!.getReader();
+        const decoder = new TextDecoder();
+        let received = "";
+        while (!received.includes("buffered event")) {
+          const chunk = await reader.read();
+          if (chunk.done) {
+            break;
+          }
+          received += decoder.decode(chunk.value, { stream: true });
+        }
+        expect(received).toContain("buffered event");
+      } finally {
+        secondController.abort();
+      }
+    } finally {
+      firstController.abort();
       write.mockRestore();
     }
   });

--- a/test/signal-server.test.ts
+++ b/test/signal-server.test.ts
@@ -119,6 +119,26 @@ describe("signal local provider server", () => {
       jsonrpc: "2.0",
       result: { timestamp: expect.any(Number) },
     });
+    for (const [method, params] of [
+      ["send", { attachments: ["/tmp/test-attachment-placeholder"], recipient: ["+15551234567"] }],
+      ["sendReceipt", { targetTimestamps: [1_700_000_000_000], usernames: ["alice"] }],
+    ] as const) {
+      const nativeAlternative = await fetch(server.manifest.endpoints.rpcUrl, {
+        body: JSON.stringify({
+          id: `native-${method}`,
+          jsonrpc: "2.0",
+          method,
+          params,
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      await expect(nativeAlternative.json()).resolves.toMatchObject({
+        id: `native-${method}`,
+        jsonrpc: "2.0",
+        result: expect.anything(),
+      });
+    }
 
     for (const [method, params] of [
       ["send", {}],
@@ -263,12 +283,13 @@ describe("signal local provider server", () => {
         signal: controller.signal,
       });
       await vi.waitFor(() => expect(backpressuredResponse).toBeDefined());
+      expect((await sendInbound("fourth queued")).status).toBe(200);
       backpressuredResponse!.emit("drain");
 
       const reader = events.body!.getReader();
       const decoder = new TextDecoder();
       let received = "";
-      while (!received.includes("third queued")) {
+      while (!received.includes("fourth queued")) {
         const chunk = await reader.read();
         if (chunk.done) {
           break;
@@ -278,6 +299,8 @@ describe("signal local provider server", () => {
       expect(received).toContain("first queued");
       expect(received).toContain("second queued");
       expect(received).toContain("third queued");
+      expect(received).toContain("fourth queued");
+      expect(received.indexOf("third queued")).toBeLessThan(received.indexOf("fourth queued"));
     } finally {
       controller.abort();
       write.mockRestore();

--- a/test/signal-server.test.ts
+++ b/test/signal-server.test.ts
@@ -120,6 +120,27 @@ describe("signal local provider server", () => {
       result: { timestamp: expect.any(Number) },
     });
 
+    for (const [method, params] of [
+      ["send", {}],
+      ["sendReaction", { emoji: "👍", recipient: ["+15551234567"] }],
+      ["sendReceipt", { recipient: "+15551234567", targetTimestamp: [] }],
+      ["sendTyping", null],
+      ["sendTyping", { username: ["alice"] }],
+      ["sendTyping", { noteToSelf: true }],
+      ["sendTyping", { recipient: ["+15551234567"], stop: "yes" }],
+    ] as const) {
+      const invalid = await fetch(server.manifest.endpoints.rpcUrl, {
+        body: JSON.stringify({ id: `invalid-${method}`, jsonrpc: "2.0", method, params }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      await expect(invalid.json()).resolves.toEqual({
+        error: { code: -32602, message: "Invalid params" },
+        id: `invalid-${method}`,
+        jsonrpc: "2.0",
+      });
+    }
+
     const rejected = await fetch(server.manifest.endpoints.adminInboundUrl, {
       body: JSON.stringify({ sourceNumber: "+15557654321", text: "nope" }),
       headers: { "content-type": "application/json" },
@@ -180,6 +201,27 @@ describe("signal local provider server", () => {
       error: "Pending inbound queue is full (1 events)",
       ok: false,
     });
+  });
+
+  it("bounds the disconnected event queue by encoded bytes", async () => {
+    const server = await startSignalServer({
+      adminToken: "admin",
+      maxPendingInboundEvents: 10,
+    });
+    servers.push(server);
+    const sendInbound = (text: string) =>
+      fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({ sourceNumber: "+15557654321", text }),
+        headers: {
+          "content-type": "application/json",
+          "x-crabline-admin-token": "admin",
+        },
+        method: "POST",
+      });
+
+    expect((await sendInbound("a".repeat(700_000))).status).toBe(200);
+    expect((await sendInbound("b".repeat(700_000))).status).toBe(200);
+    expect((await sendInbound("c".repeat(700_000))).status).toBe(503);
   });
 
   it("resumes queued event delivery after SSE backpressure drains", async () => {
@@ -256,6 +298,52 @@ describe("signal local provider server", () => {
       ok: false,
     });
     controller.abort();
+  });
+
+  it("reserves event stream capacity before awaited recording", async () => {
+    let releaseRecording!: () => void;
+    const recordingBlocked = new Promise<void>((resolve) => {
+      releaseRecording = resolve;
+    });
+    let observeRecording!: () => void;
+    const recordingStarted = new Promise<void>((resolve) => {
+      observeRecording = resolve;
+    });
+    const server = await startSignalServer({
+      maxSseClients: 1,
+      async onEvent(event) {
+        if (event.path === "/api/v1/events") {
+          observeRecording();
+          await recordingBlocked;
+        }
+      },
+    });
+    servers.push(server);
+
+    const controller = new AbortController();
+    const first = fetch(server.manifest.endpoints.eventsUrl, { signal: controller.signal });
+    await recordingStarted;
+    const overloaded = await fetch(server.manifest.endpoints.eventsUrl);
+    expect(overloaded.status).toBe(503);
+    releaseRecording();
+    expect((await first).status).toBe(200);
+    controller.abort();
+  });
+
+  it("hides observer failures from public error responses", async () => {
+    const server = await startSignalServer({
+      onEvent() {
+        throw new Error("sensitive Signal observer detail");
+      },
+    });
+    servers.push(server);
+
+    const response = await fetch(`${server.manifest.baseUrl}/api/v1/check`);
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: "internal server error",
+      ok: false,
+    });
   });
 
   it("drains unauthenticated admin request bodies", async () => {

--- a/test/signal-server.test.ts
+++ b/test/signal-server.test.ts
@@ -382,6 +382,71 @@ describe("signal local provider server", () => {
     }
   });
 
+  it("restores buffered events when a newer SSE client remains connected", async () => {
+    const server = await startSignalServer({ adminToken: "admin" });
+    servers.push(server);
+    const originalWrite = ServerResponse.prototype.write;
+    let backpressuredResponse: ServerResponse | undefined;
+    const write = vi.spyOn(ServerResponse.prototype, "write").mockImplementation(function (
+      this: ServerResponse,
+      ...args: Parameters<typeof originalWrite>
+    ) {
+      const accepted = Reflect.apply(originalWrite, this, args) as boolean;
+      if (
+        backpressuredResponse === undefined &&
+        typeof args[0] === "string" &&
+        args[0].includes("first event")
+      ) {
+        backpressuredResponse = this;
+        return false;
+      }
+      return accepted;
+    });
+    const firstController = new AbortController();
+    const secondController = new AbortController();
+    try {
+      const firstEvents = await fetch(server.manifest.endpoints.eventsUrl, {
+        signal: firstController.signal,
+      });
+      const sendInbound = (text: string) =>
+        fetch(server.manifest.endpoints.adminInboundUrl, {
+          body: JSON.stringify({ sourceNumber: "+15557654321", text }),
+          headers: {
+            "content-type": "application/json",
+            "x-crabline-admin-token": "admin",
+          },
+          method: "POST",
+        });
+      expect((await sendInbound("first event")).status).toBe(200);
+      await vi.waitFor(() => expect(backpressuredResponse).toBeDefined());
+      expect((await sendInbound("buffered event")).status).toBe(200);
+
+      const secondEvents = await fetch(server.manifest.endpoints.eventsUrl, {
+        signal: secondController.signal,
+      });
+      expect((await sendInbound("shared event")).status).toBe(200);
+      firstController.abort();
+      await firstEvents.body?.cancel().catch(() => undefined);
+
+      const reader = secondEvents.body!.getReader();
+      const decoder = new TextDecoder();
+      let received = "";
+      while (!received.includes("buffered event")) {
+        const chunk = await reader.read();
+        if (chunk.done) {
+          break;
+        }
+        received += decoder.decode(chunk.value, { stream: true });
+      }
+      expect(received).toContain("buffered event");
+      expect(received.match(/shared event/gu)).toHaveLength(1);
+    } finally {
+      firstController.abort();
+      secondController.abort();
+      write.mockRestore();
+    }
+  });
+
   it("bounds pending events together with reconnectable client buffers", async () => {
     const server = await startSignalServer({
       adminToken: "admin",

--- a/test/slack-server.test.ts
+++ b/test/slack-server.test.ts
@@ -326,6 +326,17 @@ describe("slack local provider server", () => {
       messages: [{ text: "hello fake slack" }, { text: "thread reply" }],
       ok: true,
     });
+    await expect(
+      (
+        await slackApi(server, "conversations.replies", {
+          channel: "C1234567890",
+          ts: reply.ts,
+        })
+      ).json(),
+    ).resolves.toMatchObject({
+      messages: [{ text: "hello fake slack" }, { text: "thread reply" }],
+      ok: true,
+    });
 
     await expect(
       (

--- a/test/slack-server.test.ts
+++ b/test/slack-server.test.ts
@@ -68,6 +68,11 @@ describe("slack local provider server", () => {
       team_id: "TCRABLINE",
       user_id: "UCRABBOT",
     });
+    const lowerCaseBearer = await fetch(`${server.manifest.endpoints.apiRoot}auth.test`, {
+      headers: { authorization: "bearer xoxb-fake" },
+      method: "POST",
+    });
+    await expect(lowerCaseBearer.json()).resolves.toMatchObject({ ok: true });
 
     const unauthenticated = await fetch(`${server.manifest.endpoints.apiRoot}auth.test`, {
       method: "POST",
@@ -170,6 +175,14 @@ describe("slack local provider server", () => {
     });
     await expect(tooMany.json()).resolves.toEqual({
       error: "too_many_users",
+      ok: false,
+    });
+
+    const selfConversation = await slackApi(server, "conversations.open", {
+      users: "UCRABBOT",
+    });
+    await expect(selfConversation.json()).resolves.toEqual({
+      error: "invalid_user_combination",
       ok: false,
     });
   });
@@ -275,21 +288,31 @@ describe("slack local provider server", () => {
       unfurl_links: false,
     });
 
-    await expect(
-      (
-        await slackApi(server, "chat.postMessage", {
-          channel: "C1234567890",
-          text: "thread reply",
-          thread_ts: parent.ts,
-        })
-      ).json(),
-    ).resolves.toMatchObject({
+    const replyResponse = await slackApi(server, "chat.postMessage", {
+      channel: "C1234567890",
+      text: "thread reply",
+      thread_ts: parent.ts,
+    });
+    const reply = (await replyResponse.json()) as { ts: string };
+    expect(reply).toMatchObject({
       channel: "C1234567890",
       message: {
         text: "thread reply",
         thread_ts: parent.ts,
       },
       ok: true,
+    });
+    await expect(
+      (
+        await slackApi(server, "chat.postMessage", {
+          channel: "C1234567890",
+          text: "nested reply",
+          thread_ts: reply.ts,
+        })
+      ).json(),
+    ).resolves.toEqual({
+      error: "thread_not_found",
+      ok: false,
     });
 
     await expect(
@@ -317,6 +340,42 @@ describe("slack local provider server", () => {
       messages: [{ text: "thread reply" }],
       ok: true,
     });
+
+    for (const limit of [0, -1]) {
+      await expect(
+        (
+          await slackApi(server, "conversations.history", {
+            channel: "C1234567890",
+            limit,
+          })
+        ).json(),
+      ).resolves.toEqual({
+        error: "invalid_limit",
+        ok: false,
+      });
+    }
+  });
+
+  it("rejects malformed blocks and attachments", async () => {
+    const server = await startTestSlackServer();
+    for (const [field, value, error] of [
+      ["blocks", { type: "section" }, "invalid_blocks"],
+      ["blocks", "not-json", "invalid_blocks"],
+      ["attachments", { text: "attachment" }, "invalid_attachments"],
+      ["attachments", '{"text":"attachment"}', "invalid_attachments"],
+    ] as const) {
+      const response = await slackApi(server, "chat.postMessage", {
+        channel: "C1234567890",
+        [field]: value,
+        text: "must not persist",
+      });
+      await expect(response.json()).resolves.toEqual({ error, ok: false });
+    }
+
+    const history = await slackApi(server, "conversations.history", {
+      channel: "C1234567890",
+    });
+    await expect(history.json()).resolves.toMatchObject({ messages: [], ok: true });
   });
 
   it("delivers authenticated admin inbound through signed Slack Events API requests", async () => {

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -618,6 +618,11 @@ describe("telegram local provider server", () => {
       await expect.poll(() => attempts, { timeout: 5_000 }).toBe(6);
       await new Promise((resolve) => setTimeout(resolve, 500));
       expect(attempts).toBe(6);
+      expect((await injectUpdate(server, { chatId: 42, text: "do not retry head" })).status).toBe(
+        502,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      expect(attempts).toBe(6);
       const info = await fetch(
         `${server.manifest.baseUrl}/bottest-token-placeholder/getWebhookInfo`,
       );
@@ -625,7 +630,7 @@ describe("telegram local provider server", () => {
         result: {
           last_error_date: expect.any(Number),
           last_error_message: "Wrong response from the webhook: 503",
-          pending_update_count: 1,
+          pending_update_count: 2,
         },
       });
     } finally {

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -615,7 +615,9 @@ describe("telegram local provider server", () => {
         method: "POST",
       });
       expect((await injectUpdate(server, { chatId: 42, text: "retry me" })).status).toBe(502);
-      await expect.poll(() => attempts).toBeGreaterThan(1);
+      await expect.poll(() => attempts, { timeout: 5_000 }).toBe(6);
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      expect(attempts).toBe(6);
       const info = await fetch(
         `${server.manifest.baseUrl}/bottest-token-placeholder/getWebhookInfo`,
       );

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -414,6 +414,57 @@ describe("telegram local provider server", () => {
     });
   });
 
+  it("does not rewind message IDs when an inbound observer fails during an API send", async () => {
+    let releaseInbound!: () => void;
+    const inboundBlocked = new Promise<void>((resolve) => {
+      releaseInbound = resolve;
+    });
+    let observeInbound!: () => void;
+    const inboundObserved = new Promise<void>((resolve) => {
+      observeInbound = resolve;
+    });
+    const server = await startTelegramServer({
+      botToken: "test-token-placeholder",
+      async onEvent(event) {
+        if (event.type === "admin") {
+          observeInbound();
+          await inboundBlocked;
+          throw new Error("observer rejected inbound update");
+        }
+      },
+    });
+    servers.push(server);
+
+    const inbound = injectUpdate(server, { chatId: 42, text: "rejected inbound" });
+    await inboundObserved;
+    const firstSend = await fetch(
+      `${server.manifest.baseUrl}/bottest-token-placeholder/sendMessage`,
+      {
+        body: JSON.stringify({ chat_id: 42, text: "first API send" }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      },
+    );
+    const firstBody = (await firstSend.json()) as {
+      result: { message_id: number };
+    };
+    releaseInbound();
+    expect((await inbound).status).toBe(500);
+
+    const secondSend = await fetch(
+      `${server.manifest.baseUrl}/bottest-token-placeholder/sendMessage`,
+      {
+        body: JSON.stringify({ chat_id: 42, text: "second API send" }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      },
+    );
+    const secondBody = (await secondSend.json()) as {
+      result: { message_id: number };
+    };
+    expect(secondBody.result.message_id).toBeGreaterThan(firstBody.result.message_id);
+  });
+
   it("delivers webhook updates with secret headers and blocks polling", async () => {
     const delivered: Array<{ body: unknown; secret: string | undefined }> = [];
     const webhook = createServer(async (request, response) => {
@@ -596,13 +647,13 @@ describe("telegram local provider server", () => {
 
   it("resets the retry budget when a lower update becomes head during delivery", async () => {
     const attemptedUpdateIds: number[] = [];
-    let releaseFirst!: () => void;
-    const firstBlocked = new Promise<void>((resolve) => {
-      releaseFirst = resolve;
+    let releaseFinal!: () => void;
+    const finalBlocked = new Promise<void>((resolve) => {
+      releaseFinal = resolve;
     });
-    let observeFirst!: () => void;
-    const firstObserved = new Promise<void>((resolve) => {
-      observeFirst = resolve;
+    let observeFinal!: () => void;
+    const finalObserved = new Promise<void>((resolve) => {
+      observeFinal = resolve;
     });
     const webhook = createServer(async (request, response) => {
       const chunks: Buffer[] = [];
@@ -613,9 +664,9 @@ describe("telegram local provider server", () => {
         update_id: number;
       };
       attemptedUpdateIds.push(update.update_id);
-      if (attemptedUpdateIds.length === 1) {
-        observeFirst();
-        await firstBlocked;
+      if (attemptedUpdateIds.filter((updateId) => updateId === 10).length === 6) {
+        observeFinal();
+        await finalBlocked;
       }
       response.statusCode = 503;
       response.end();
@@ -643,7 +694,7 @@ describe("telegram local provider server", () => {
         headers: { "content-type": "application/json" },
         method: "POST",
       });
-      await firstObserved;
+      await finalObserved;
 
       const lowerUpdate = injectUpdate(server, {
         chatId: 42,
@@ -651,7 +702,7 @@ describe("telegram local provider server", () => {
         updateId: 5,
       });
       await new Promise((resolve) => setTimeout(resolve, 25));
-      releaseFirst();
+      releaseFinal();
 
       expect((await lowerUpdate).status).toBe(502);
       await expect
@@ -659,14 +710,14 @@ describe("telegram local provider server", () => {
           timeout: 5_000,
         })
         .toBe(6);
-      expect(attemptedUpdateIds[0]).toBe(10);
+      expect(attemptedUpdateIds.filter((updateId) => updateId === 10)).toHaveLength(6);
     } finally {
-      releaseFirst();
+      releaseFinal();
       await new Promise<void>((resolve, reject) =>
         webhook.close((error) => (error ? reject(error) : resolve())),
       );
     }
-  });
+  }, 10_000);
 
   it("reports webhook delivery failures without exposing observer errors", async () => {
     let attempts = 0;

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -690,6 +690,61 @@ describe("telegram local provider server", () => {
     }
   });
 
+  it("does not follow webhook redirects", async () => {
+    let redirectedRequests = 0;
+    const destination = createServer((_request, response) => {
+      redirectedRequests += 1;
+      response.statusCode = 200;
+      response.end();
+    });
+    await new Promise<void>((resolve) => destination.listen(0, "127.0.0.1", resolve));
+    const destinationAddress = destination.address();
+    if (!destinationAddress || typeof destinationAddress === "string") {
+      throw new Error("Unable to resolve Telegram redirect destination.");
+    }
+    const webhook = createServer((_request, response) => {
+      response.statusCode = 302;
+      response.setHeader("location", `http://127.0.0.1:${destinationAddress.port}/redirected`);
+      response.end();
+    });
+    await new Promise<void>((resolve) => webhook.listen(0, "127.0.0.1", resolve));
+    const address = webhook.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Unable to resolve Telegram webhook receiver.");
+    }
+    const server = await startTelegramServer({ botToken: "test-token-placeholder" });
+    servers.push(server);
+    try {
+      await fetch(`${server.manifest.baseUrl}/bottest-token-placeholder/setWebhook`, {
+        body: JSON.stringify({ url: `http://127.0.0.1:${address.port}/telegram` }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      expect((await injectUpdate(server, { chatId: 42, text: "do not redirect" })).status).toBe(
+        502,
+      );
+      expect(redirectedRequests).toBe(0);
+      const info = await fetch(
+        `${server.manifest.baseUrl}/bottest-token-placeholder/getWebhookInfo`,
+      );
+      await expect(info.json()).resolves.toMatchObject({
+        result: {
+          last_error_message: "Wrong response from the webhook: 302",
+          pending_update_count: 1,
+        },
+      });
+    } finally {
+      await Promise.all([
+        new Promise<void>((resolve, reject) =>
+          webhook.close((error) => (error ? reject(error) : resolve())),
+        ),
+        new Promise<void>((resolve, reject) =>
+          destination.close((error) => (error ? reject(error) : resolve())),
+        ),
+      ]);
+    }
+  });
+
   it("rejects unauthenticated inbound updates", async () => {
     const directory = await createTempDir();
     directories.push(directory);

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -650,6 +650,46 @@ describe("telegram local provider server", () => {
     });
   });
 
+  it("retains the most recent webhook error after a successful retry", async () => {
+    let attempts = 0;
+    const webhook = createServer((_request, response) => {
+      attempts += 1;
+      response.statusCode = attempts === 1 ? 503 : 200;
+      response.end();
+    });
+    await new Promise<void>((resolve) => webhook.listen(0, "127.0.0.1", resolve));
+    const address = webhook.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Unable to resolve Telegram webhook receiver.");
+    }
+    const server = await startTelegramServer({ botToken: "test-token-placeholder" });
+    servers.push(server);
+    try {
+      await fetch(`${server.manifest.baseUrl}/bottest-token-placeholder/setWebhook`, {
+        body: JSON.stringify({ url: `http://127.0.0.1:${address.port}/telegram` }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      expect((await injectUpdate(server, { chatId: 42, text: "recover me" })).status).toBe(502);
+      await expect.poll(() => attempts).toBe(2);
+
+      const info = await fetch(
+        `${server.manifest.baseUrl}/bottest-token-placeholder/getWebhookInfo`,
+      );
+      await expect(info.json()).resolves.toMatchObject({
+        result: {
+          last_error_date: expect.any(Number),
+          last_error_message: "Wrong response from the webhook: 503",
+          pending_update_count: 0,
+        },
+      });
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        webhook.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+
   it("rejects unauthenticated inbound updates", async () => {
     const directory = await createTempDir();
     directories.push(directory);

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -1248,7 +1248,7 @@ describe("telegram local provider server", () => {
     });
   });
 
-  it("redacts the bot token from recorded API paths", async () => {
+  it("redacts the bot token and webhook secrets from recorded API requests", async () => {
     const directory = await createTempDir();
     directories.push(directory);
     const botToken = "987654:distinctive-secret-token";
@@ -1258,10 +1258,23 @@ describe("telegram local provider server", () => {
 
     const response = await fetch(`${server.manifest.baseUrl}/bot${botToken}/getMe`);
     await expect(response.json()).resolves.toMatchObject({ ok: true });
+    const webhookSecret = "test-auth-token";
+    const webhookUrl = new URL(`${server.manifest.baseUrl}/bot${botToken}/setWebhook`);
+    webhookUrl.searchParams.set("url", "https://example.invalid/telegram");
+    webhookUrl.searchParams.set("secret_token", webhookSecret);
+    const webhook = await fetch(webhookUrl);
+    await expect(webhook.json()).resolves.toMatchObject({ ok: true });
 
     const recordedEvents = await fs.readFile(recorderPath, "utf8");
     expect(recordedEvents).not.toContain(botToken);
+    expect(recordedEvents).not.toContain(webhookSecret);
     expect(recordedEvents).toContain('"path":"/bot<redacted>/getMe"');
+    const setWebhookEvent = recordedEvents
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { path?: string; query?: Record<string, string> })
+      .find((event) => event.path?.endsWith("/setWebhook"));
+    expect(setWebhookEvent?.query?.secret_token).toBe("<redacted>");
   });
 
   it("notifies observers after recording each event", async () => {

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -594,6 +594,80 @@ describe("telegram local provider server", () => {
     }
   });
 
+  it("resets the retry budget when a lower update becomes head during delivery", async () => {
+    const attemptedUpdateIds: number[] = [];
+    let releaseFirst!: () => void;
+    const firstBlocked = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let observeFirst!: () => void;
+    const firstObserved = new Promise<void>((resolve) => {
+      observeFirst = resolve;
+    });
+    const webhook = createServer(async (request, response) => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of request) {
+        chunks.push(Buffer.from(chunk));
+      }
+      const update = JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
+        update_id: number;
+      };
+      attemptedUpdateIds.push(update.update_id);
+      if (attemptedUpdateIds.length === 1) {
+        observeFirst();
+        await firstBlocked;
+      }
+      response.statusCode = 503;
+      response.end();
+    });
+    await new Promise<void>((resolve) => webhook.listen(0, "127.0.0.1", resolve));
+    const address = webhook.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Unable to resolve Telegram webhook receiver.");
+    }
+    const server = await startTelegramServer({ botToken: "test-token-placeholder" });
+    servers.push(server);
+
+    try {
+      expect(
+        (
+          await injectUpdate(server, {
+            chatId: 42,
+            text: "queued first",
+            updateId: 10,
+          })
+        ).status,
+      ).toBe(200);
+      await fetch(`${server.manifest.baseUrl}/bottest-token-placeholder/setWebhook`, {
+        body: JSON.stringify({ url: `http://127.0.0.1:${address.port}/telegram` }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      await firstObserved;
+
+      const lowerUpdate = injectUpdate(server, {
+        chatId: 42,
+        text: "lower update id",
+        updateId: 5,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      releaseFirst();
+
+      expect((await lowerUpdate).status).toBe(502);
+      await expect
+        .poll(() => attemptedUpdateIds.filter((updateId) => updateId === 5).length, {
+          timeout: 5_000,
+        })
+        .toBe(6);
+      expect(attemptedUpdateIds[0]).toBe(10);
+    } finally {
+      releaseFirst();
+      await new Promise<void>((resolve, reject) =>
+        webhook.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+
   it("reports webhook delivery failures without exposing observer errors", async () => {
     let attempts = 0;
     const webhook = createServer((_request, response) => {

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -3,7 +3,7 @@ import { Agent, createServer, request as httpRequest, type IncomingMessage } fro
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { startTelegramServer, type StartedTelegramServer } from "../src/index.js";
-import { handleTelegramGetUpdates } from "../src/servers/telegram.js";
+import { handleTelegramGetUpdates, withTelegramWebhookDeadline } from "../src/servers/telegram.js";
 import { createTempDir, disposeTempDir, requestHttp } from "./test-helpers.js";
 
 const servers: StartedTelegramServer[] = [];
@@ -570,6 +570,122 @@ describe("telegram local provider server", () => {
         result: [],
       });
     } finally {
+      await new Promise<void>((resolve, reject) =>
+        webhook.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+
+  it("revokes an in-flight webhook before delivering queued updates to its replacement", async () => {
+    let observeOldRequest!: () => void;
+    const oldRequestObserved = new Promise<void>((resolve) => {
+      observeOldRequest = resolve;
+    });
+    const oldWebhook = createServer(() => {
+      observeOldRequest();
+    });
+    const delivered: number[] = [];
+    const newWebhook = createServer(async (request, response) => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of request) {
+        chunks.push(Buffer.from(chunk));
+      }
+      const update = JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
+        update_id: number;
+      };
+      delivered.push(update.update_id);
+      response.statusCode = 200;
+      response.end();
+    });
+    await Promise.all([
+      new Promise<void>((resolve) => oldWebhook.listen(0, "127.0.0.1", resolve)),
+      new Promise<void>((resolve) => newWebhook.listen(0, "127.0.0.1", resolve)),
+    ]);
+    const oldAddress = oldWebhook.address();
+    const newAddress = newWebhook.address();
+    if (
+      !oldAddress ||
+      typeof oldAddress === "string" ||
+      !newAddress ||
+      typeof newAddress === "string"
+    ) {
+      throw new Error("Unable to resolve Telegram webhook receivers.");
+    }
+    const server = await startTelegramServer({ botToken: "test-token-placeholder" });
+    servers.push(server);
+
+    try {
+      await fetch(`${server.manifest.baseUrl}/bottest-token-placeholder/setWebhook`, {
+        body: JSON.stringify({ url: `http://127.0.0.1:${oldAddress.port}/telegram` }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      const inbound = injectUpdate(server, { chatId: 42, text: "replace delivery" });
+      await oldRequestObserved;
+      const replaced = await fetch(
+        `${server.manifest.baseUrl}/bottest-token-placeholder/setWebhook`,
+        {
+          body: JSON.stringify({ url: `http://127.0.0.1:${newAddress.port}/telegram` }),
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        },
+      );
+      expect(replaced.status).toBe(200);
+      expect((await inbound).status).toBe(502);
+      await expect.poll(() => delivered).toEqual([1]);
+    } finally {
+      oldWebhook.closeAllConnections();
+      newWebhook.closeAllConnections();
+      await Promise.all([
+        new Promise<void>((resolve, reject) =>
+          oldWebhook.close((error) => (error ? reject(error) : resolve())),
+        ),
+        new Promise<void>((resolve, reject) =>
+          newWebhook.close((error) => (error ? reject(error) : resolve())),
+        ),
+      ]);
+    }
+  });
+
+  it("revokes an in-flight webhook without dropping its update on deletion", async () => {
+    let observeRequest!: () => void;
+    const requestObserved = new Promise<void>((resolve) => {
+      observeRequest = resolve;
+    });
+    const webhook = createServer(() => {
+      observeRequest();
+    });
+    await new Promise<void>((resolve) => webhook.listen(0, "127.0.0.1", resolve));
+    const address = webhook.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Unable to resolve Telegram webhook receiver.");
+    }
+    const server = await startTelegramServer({ botToken: "test-token-placeholder" });
+    servers.push(server);
+
+    try {
+      await fetch(`${server.manifest.baseUrl}/bottest-token-placeholder/setWebhook`, {
+        body: JSON.stringify({ url: `http://127.0.0.1:${address.port}/telegram` }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      const inbound = injectUpdate(server, { chatId: 42, text: "delete delivery" });
+      await requestObserved;
+      const deleted = await fetch(
+        `${server.manifest.baseUrl}/bottest-token-placeholder/deleteWebhook`,
+        {
+          body: "{}",
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        },
+      );
+      expect(deleted.status).toBe(200);
+      expect((await inbound).status).toBe(502);
+      await expect((await getUpdates(server, {})).json()).resolves.toMatchObject({
+        result: [{ message: { text: "delete delivery" }, update_id: 1 }],
+      });
+    } finally {
+      webhook.closeAllConnections();
       await new Promise<void>((resolve, reject) =>
         webhook.close((error) => (error ? reject(error) : resolve())),
       );
@@ -1361,5 +1477,16 @@ describe("telegram local provider server", () => {
     expect(observedEvents).toEqual([
       expect.objectContaining({ method: "GET", path: "/bot<redacted>/getMe", type: "api" }),
     ]);
+  });
+
+  it("bounds webhook DNS validation with the delivery deadline", async () => {
+    const controller = new AbortController();
+    await expect(
+      withTelegramWebhookDeadline(
+        new Promise<never>(() => undefined),
+        Date.now() + 25,
+        controller.signal,
+      ),
+    ).rejects.toMatchObject({ name: "TimeoutError" });
   });
 });

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -436,7 +436,7 @@ describe("telegram local provider server", () => {
     if (!address || typeof address === "string") {
       throw new Error("Unable to resolve Telegram webhook receiver.");
     }
-    const server = await startTelegramServer({ botToken: "test-token" });
+    const server = await startTelegramServer({ botToken: "test-token-placeholder" });
     servers.push(server);
 
     try {
@@ -446,14 +446,17 @@ describe("telegram local provider server", () => {
       });
       expect(queued.status).toBe(200);
 
-      const configured = await fetch(`${server.manifest.baseUrl}/bottest-token/setWebhook`, {
-        body: JSON.stringify({
-          secret_token: "telegram-secret",
-          url: `http://127.0.0.1:${address.port}/telegram`,
-        }),
-        headers: { "content-type": "application/json" },
-        method: "POST",
-      });
+      const configured = await fetch(
+        `${server.manifest.baseUrl}/bottest-token-placeholder/setWebhook`,
+        {
+          body: JSON.stringify({
+            secret_token: "test-auth-token",
+            url: `http://127.0.0.1:${address.port}/telegram`,
+          }),
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        },
+      );
       await expect(configured.json()).resolves.toEqual({ ok: true, result: true });
       await expect.poll(() => delivered.length).toBe(1);
 
@@ -468,18 +471,20 @@ describe("telegram local provider server", () => {
             message: expect.objectContaining({ text: "queued before webhook" }),
             update_id: 1,
           }),
-          secret: "telegram-secret",
+          secret: "test-auth-token",
         },
         {
           body: expect.objectContaining({
             message: expect.objectContaining({ text: "webhook update" }),
             update_id: 2,
           }),
-          secret: "telegram-secret",
+          secret: "test-auth-token",
         },
       ]);
 
-      const info = await fetch(`${server.manifest.baseUrl}/bottest-token/getWebhookInfo`);
+      const info = await fetch(
+        `${server.manifest.baseUrl}/bottest-token-placeholder/getWebhookInfo`,
+      );
       await expect(info.json()).resolves.toMatchObject({
         ok: true,
         result: {
@@ -488,20 +493,26 @@ describe("telegram local provider server", () => {
         },
       });
 
-      const removed = await fetch(`${server.manifest.baseUrl}/bottest-token/setWebhook`, {
-        body: JSON.stringify({ url: "" }),
-        headers: { "content-type": "application/json" },
-        method: "POST",
-      });
+      const removed = await fetch(
+        `${server.manifest.baseUrl}/bottest-token-placeholder/setWebhook`,
+        {
+          body: JSON.stringify({ url: "" }),
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        },
+      );
       await expect(removed.json()).resolves.toEqual({ ok: true, result: true });
       expect((await injectUpdate(server, { chatId: 42, text: "drop this update" })).status).toBe(
         200,
       );
-      const dropped = await fetch(`${server.manifest.baseUrl}/bottest-token/setWebhook`, {
-        body: JSON.stringify({ drop_pending_updates: true, url: "" }),
-        headers: { "content-type": "application/json" },
-        method: "POST",
-      });
+      const dropped = await fetch(
+        `${server.manifest.baseUrl}/bottest-token-placeholder/setWebhook`,
+        {
+          body: JSON.stringify({ drop_pending_updates: true, url: "" }),
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        },
+      );
       await expect(dropped.json()).resolves.toEqual({ ok: true, result: true });
       await expect((await getUpdates(server, {})).json()).resolves.toEqual({
         ok: true,
@@ -545,7 +556,7 @@ describe("telegram local provider server", () => {
     if (!address || typeof address === "string") {
       throw new Error("Unable to resolve Telegram webhook receiver.");
     }
-    const server = await startTelegramServer({ botToken: "test-token" });
+    const server = await startTelegramServer({ botToken: "test-token-placeholder" });
     servers.push(server);
 
     try {
@@ -558,7 +569,7 @@ describe("telegram local provider server", () => {
           })
         ).status,
       ).toBe(200);
-      await fetch(`${server.manifest.baseUrl}/bottest-token/setWebhook`, {
+      await fetch(`${server.manifest.baseUrl}/bottest-token-placeholder/setWebhook`, {
         body: JSON.stringify({ url: `http://127.0.0.1:${address.port}/telegram` }),
         headers: { "content-type": "application/json" },
         method: "POST",
@@ -595,17 +606,19 @@ describe("telegram local provider server", () => {
     if (!address || typeof address === "string") {
       throw new Error("Unable to resolve Telegram webhook receiver.");
     }
-    const server = await startTelegramServer({ botToken: "test-token" });
+    const server = await startTelegramServer({ botToken: "test-token-placeholder" });
     servers.push(server);
     try {
-      await fetch(`${server.manifest.baseUrl}/bottest-token/setWebhook`, {
+      await fetch(`${server.manifest.baseUrl}/bottest-token-placeholder/setWebhook`, {
         body: JSON.stringify({ url: `http://127.0.0.1:${address.port}/telegram` }),
         headers: { "content-type": "application/json" },
         method: "POST",
       });
       expect((await injectUpdate(server, { chatId: 42, text: "retry me" })).status).toBe(502);
       await expect.poll(() => attempts).toBeGreaterThan(1);
-      const info = await fetch(`${server.manifest.baseUrl}/bottest-token/getWebhookInfo`);
+      const info = await fetch(
+        `${server.manifest.baseUrl}/bottest-token-placeholder/getWebhookInfo`,
+      );
       await expect(info.json()).resolves.toMatchObject({
         result: {
           last_error_date: expect.any(Number),

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -870,6 +870,73 @@ describe("telegram local provider server", () => {
     }
   });
 
+  it("requires HTTPS except for loopback HTTP on loopback-bound servers", async () => {
+    const server = await startTelegramServer({ botToken: "test-token-placeholder" });
+    servers.push(server);
+
+    const rejected = await fetch(
+      `${server.manifest.baseUrl}/bottest-token-placeholder/setWebhook`,
+      {
+        body: JSON.stringify({ url: "http://192.168.1.10/telegram" }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      },
+    );
+    expect(rejected.status).toBe(400);
+    await expect(rejected.json()).resolves.toEqual({
+      description: "Bad Request: webhook URL must use HTTPS",
+      error_code: 400,
+      ok: false,
+    });
+  });
+
+  it("blocks private and link-local webhook targets when remotely bound", async () => {
+    const server = await startTelegramServer({
+      botToken: "test-token-placeholder",
+      host: "0.0.0.0",
+    });
+    servers.push(server);
+    const apiRoot = server.manifest.baseUrl.replace("0.0.0.0", "127.0.0.1");
+
+    for (const url of [
+      "https://10.0.0.1/telegram",
+      "https://127.0.0.1/telegram",
+      "https://169.254.169.254/latest/meta-data",
+      "https://[::1]/telegram",
+      "https://[::ffff:7f00:1]/telegram",
+    ]) {
+      const response = await fetch(`${apiRoot}/bottest-token-placeholder/setWebhook`, {
+        body: JSON.stringify({ url }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({
+        description: "Bad Request: webhook URL must not target a private or link-local address",
+        error_code: 400,
+        ok: false,
+      });
+    }
+
+    const http = await fetch(`${apiRoot}/bottest-token-placeholder/setWebhook`, {
+      body: JSON.stringify({ url: "http://93.184.216.34/telegram" }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    expect(http.status).toBe(400);
+    await expect(http.json()).resolves.toMatchObject({
+      description: "Bad Request: webhook URL must use HTTPS",
+      ok: false,
+    });
+
+    const publicHttps = await fetch(`${apiRoot}/bottest-token-placeholder/setWebhook`, {
+      body: JSON.stringify({ url: "https://93.184.216.34/telegram" }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    expect(publicHttps.status).toBe(200);
+  });
+
   it("rejects unauthenticated inbound updates", async () => {
     const directory = await createTempDir();
     directories.push(directory);

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -719,11 +719,11 @@ describe("telegram local provider server", () => {
     }
   }, 10_000);
 
-  it("reports webhook delivery failures without exposing observer errors", async () => {
+  it("continues bounded webhook retries and drains updates after recovery", async () => {
     let attempts = 0;
     const webhook = createServer((_request, response) => {
       attempts += 1;
-      response.statusCode = 503;
+      response.statusCode = attempts <= 6 ? 503 : 200;
       response.end();
     });
     await new Promise<void>((resolve) => webhook.listen(0, "127.0.0.1", resolve));
@@ -740,14 +740,9 @@ describe("telegram local provider server", () => {
         method: "POST",
       });
       expect((await injectUpdate(server, { chatId: 42, text: "retry me" })).status).toBe(502);
-      await expect.poll(() => attempts, { timeout: 5_000 }).toBe(6);
-      await new Promise((resolve) => setTimeout(resolve, 500));
-      expect(attempts).toBe(6);
-      expect((await injectUpdate(server, { chatId: 42, text: "do not retry head" })).status).toBe(
-        502,
-      );
-      await new Promise((resolve) => setTimeout(resolve, 500));
-      expect(attempts).toBe(6);
+      await expect.poll(() => attempts, { timeout: 8_000 }).toBe(7);
+      expect((await injectUpdate(server, { chatId: 42, text: "after recovery" })).status).toBe(200);
+      expect(attempts).toBe(8);
       const info = await fetch(
         `${server.manifest.baseUrl}/bottest-token-placeholder/getWebhookInfo`,
       );
@@ -755,7 +750,7 @@ describe("telegram local provider server", () => {
         result: {
           last_error_date: expect.any(Number),
           last_error_message: "Wrong response from the webhook: 503",
-          pending_update_count: 2,
+          pending_update_count: 0,
         },
       });
     } finally {
@@ -778,7 +773,7 @@ describe("telegram local provider server", () => {
       error: "internal server error",
       ok: false,
     });
-  });
+  }, 10_000);
 
   it("retains the most recent webhook error after a successful retry", async () => {
     let attempts = 0;

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs/promises";
-import { Agent, request as httpRequest, type IncomingMessage } from "node:http";
+import { Agent, createServer, request as httpRequest, type IncomingMessage } from "node:http";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { startTelegramServer, type StartedTelegramServer } from "../src/index.js";
@@ -164,6 +164,21 @@ describe("telegram local provider server", () => {
       });
     }
 
+    const malformedMultipart = await fetch(
+      `${server.manifest.baseUrl}/bot123456:fake-token/sendPhoto`,
+      {
+        body: "malformed multipart",
+        headers: { "content-type": "Multipart/Form-Data" },
+        method: "POST",
+      },
+    );
+    expect(malformedMultipart.status).toBe(400);
+    await expect(malformedMultipart.json()).resolves.toEqual({
+      description: "Bad Request: can't parse JSON object",
+      error_code: 400,
+      ok: false,
+    });
+
     const oversized = await requestHttp({
       headers: {
         "content-length": String(50 * 1024 * 1024 + 1),
@@ -185,7 +200,7 @@ describe("telegram local provider server", () => {
         message_thread_id: 42,
         text: "hello fake telegram",
       }),
-      headers: { "content-type": "application/json" },
+      headers: { "content-type": "Application/JSON; Charset=UTF-8" },
       method: "POST",
     });
     await expect(sendMessage.json()).resolves.toMatchObject({
@@ -214,6 +229,40 @@ describe("telegram local provider server", () => {
         message_thread_id: 42,
         photo: [{ height: 1, width: 1 }],
       },
+    });
+
+    const boundary = "CrablineBoundary";
+    const unicodeCaption = "\u4f60\u597d, Telegram";
+    const multipart = Buffer.from(
+      [
+        `--${boundary}`,
+        'Content-Disposition: form-data; name="chat_id"',
+        "",
+        "-1001234567890",
+        `--${boundary}`,
+        'Content-Disposition: form-data; name="caption"',
+        "",
+        unicodeCaption,
+        `--${boundary}`,
+        'Content-Disposition: form-data; name="photo"; filename="fixture.png"',
+        "Content-Type: image/png",
+        "",
+        "png",
+        `--${boundary}--`,
+        "",
+      ].join("\r\n"),
+      "utf8",
+    );
+    const unicodePhoto = await fetch(`${server.manifest.baseUrl}/bot123456:fake-token/sendPhoto`, {
+      body: multipart,
+      headers: {
+        "content-type": `Multipart/Form-Data; Boundary=${boundary}`,
+      },
+      method: "POST",
+    });
+    await expect(unicodePhoto.json()).resolves.toMatchObject({
+      ok: true,
+      result: { caption: unicodeCaption },
     });
 
     for (const [method, field] of [
@@ -320,6 +369,268 @@ describe("telegram local provider server", () => {
     await expect(overloaded.json()).resolves.toEqual({
       description: "Too Many Requests: pending inbound queue is full (1 updates)",
       error_code: 429,
+      ok: false,
+    });
+  });
+
+  it("serializes concurrent inbound admission without consuming rejected IDs", async () => {
+    let releaseFirst!: () => void;
+    const firstBlocked = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let observeFirst!: () => void;
+    const firstObserved = new Promise<void>((resolve) => {
+      observeFirst = resolve;
+    });
+    let observed = false;
+    const server = await startTelegramServer({
+      adminToken: "admin",
+      maxPendingInboundEvents: 1,
+      async onEvent(event) {
+        if (event.type === "admin" && !observed) {
+          observed = true;
+          observeFirst();
+          await firstBlocked;
+        }
+      },
+    });
+    servers.push(server);
+
+    const first = injectUpdate(server, { chatId: 42, text: "first" });
+    await firstObserved;
+    const second = injectUpdate(server, { chatId: 42, text: "second" });
+    releaseFirst();
+    expect((await first).status).toBe(200);
+    expect((await second).status).toBe(429);
+
+    const drained = await getUpdates(server, {});
+    await expect(drained.json()).resolves.toMatchObject({
+      result: [{ message: { message_id: 1 }, update_id: 1 }],
+    });
+    await getUpdates(server, { offset: 2 });
+    const third = await injectUpdate(server, { chatId: 42, text: "third" });
+    await expect(third.json()).resolves.toMatchObject({
+      update: { message: { message_id: 2 }, update_id: 2 },
+    });
+  });
+
+  it("delivers webhook updates with secret headers and blocks polling", async () => {
+    const delivered: Array<{ body: unknown; secret: string | undefined }> = [];
+    const webhook = createServer(async (request, response) => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of request) {
+        chunks.push(Buffer.from(chunk));
+      }
+      delivered.push({
+        body: JSON.parse(Buffer.concat(chunks).toString("utf8")) as unknown,
+        secret:
+          typeof request.headers["x-telegram-bot-api-secret-token"] === "string"
+            ? request.headers["x-telegram-bot-api-secret-token"]
+            : undefined,
+      });
+      response.statusCode = 200;
+      response.end();
+    });
+    await new Promise<void>((resolve) => webhook.listen(0, "127.0.0.1", resolve));
+    const address = webhook.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Unable to resolve Telegram webhook receiver.");
+    }
+    const server = await startTelegramServer({ botToken: "test-token" });
+    servers.push(server);
+
+    try {
+      const queued = await injectUpdate(server, {
+        chatId: 42,
+        text: "queued before webhook",
+      });
+      expect(queued.status).toBe(200);
+
+      const configured = await fetch(`${server.manifest.baseUrl}/bottest-token/setWebhook`, {
+        body: JSON.stringify({
+          secret_token: "telegram-secret",
+          url: `http://127.0.0.1:${address.port}/telegram`,
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      await expect(configured.json()).resolves.toEqual({ ok: true, result: true });
+      await expect.poll(() => delivered.length).toBe(1);
+
+      const blocked = await getUpdates(server, {});
+      expect(blocked.status).toBe(409);
+
+      const inbound = await injectUpdate(server, { chatId: 42, text: "webhook update" });
+      expect(inbound.status).toBe(200);
+      expect(delivered).toEqual([
+        {
+          body: expect.objectContaining({
+            message: expect.objectContaining({ text: "queued before webhook" }),
+            update_id: 1,
+          }),
+          secret: "telegram-secret",
+        },
+        {
+          body: expect.objectContaining({
+            message: expect.objectContaining({ text: "webhook update" }),
+            update_id: 2,
+          }),
+          secret: "telegram-secret",
+        },
+      ]);
+
+      const info = await fetch(`${server.manifest.baseUrl}/bottest-token/getWebhookInfo`);
+      await expect(info.json()).resolves.toMatchObject({
+        ok: true,
+        result: {
+          pending_update_count: 0,
+          url: `http://127.0.0.1:${address.port}/telegram`,
+        },
+      });
+
+      const removed = await fetch(`${server.manifest.baseUrl}/bottest-token/setWebhook`, {
+        body: JSON.stringify({ url: "" }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      await expect(removed.json()).resolves.toEqual({ ok: true, result: true });
+      expect((await injectUpdate(server, { chatId: 42, text: "drop this update" })).status).toBe(
+        200,
+      );
+      const dropped = await fetch(`${server.manifest.baseUrl}/bottest-token/setWebhook`, {
+        body: JSON.stringify({ drop_pending_updates: true, url: "" }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      await expect(dropped.json()).resolves.toEqual({ ok: true, result: true });
+      await expect((await getUpdates(server, {})).json()).resolves.toEqual({
+        ok: true,
+        result: [],
+      });
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        webhook.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+
+  it("dequeues the delivered webhook update when pending updates reorder", async () => {
+    const delivered: number[] = [];
+    let releaseFirst!: () => void;
+    const firstBlocked = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let observeFirst!: () => void;
+    const firstObserved = new Promise<void>((resolve) => {
+      observeFirst = resolve;
+    });
+    const webhook = createServer(async (request, response) => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of request) {
+        chunks.push(Buffer.from(chunk));
+      }
+      const update = JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
+        update_id: number;
+      };
+      delivered.push(update.update_id);
+      if (delivered.length === 1) {
+        observeFirst();
+        await firstBlocked;
+      }
+      response.statusCode = 200;
+      response.end();
+    });
+    await new Promise<void>((resolve) => webhook.listen(0, "127.0.0.1", resolve));
+    const address = webhook.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Unable to resolve Telegram webhook receiver.");
+    }
+    const server = await startTelegramServer({ botToken: "test-token" });
+    servers.push(server);
+
+    try {
+      expect(
+        (
+          await injectUpdate(server, {
+            chatId: 42,
+            text: "queued first",
+            updateId: 10,
+          })
+        ).status,
+      ).toBe(200);
+      await fetch(`${server.manifest.baseUrl}/bottest-token/setWebhook`, {
+        body: JSON.stringify({ url: `http://127.0.0.1:${address.port}/telegram` }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      await firstObserved;
+
+      const lowerUpdate = injectUpdate(server, {
+        chatId: 42,
+        text: "lower update id",
+        updateId: 5,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      releaseFirst();
+
+      expect((await lowerUpdate).status).toBe(200);
+      expect(delivered).toEqual([10, 5]);
+    } finally {
+      releaseFirst();
+      await new Promise<void>((resolve, reject) =>
+        webhook.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+
+  it("reports webhook delivery failures without exposing observer errors", async () => {
+    let attempts = 0;
+    const webhook = createServer((_request, response) => {
+      attempts += 1;
+      response.statusCode = 503;
+      response.end();
+    });
+    await new Promise<void>((resolve) => webhook.listen(0, "127.0.0.1", resolve));
+    const address = webhook.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Unable to resolve Telegram webhook receiver.");
+    }
+    const server = await startTelegramServer({ botToken: "test-token" });
+    servers.push(server);
+    try {
+      await fetch(`${server.manifest.baseUrl}/bottest-token/setWebhook`, {
+        body: JSON.stringify({ url: `http://127.0.0.1:${address.port}/telegram` }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      expect((await injectUpdate(server, { chatId: 42, text: "retry me" })).status).toBe(502);
+      await expect.poll(() => attempts).toBeGreaterThan(1);
+      const info = await fetch(`${server.manifest.baseUrl}/bottest-token/getWebhookInfo`);
+      await expect(info.json()).resolves.toMatchObject({
+        result: {
+          last_error_date: expect.any(Number),
+          last_error_message: "Wrong response from the webhook: 503",
+          pending_update_count: 1,
+        },
+      });
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        webhook.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+
+    const failing = await startTelegramServer({
+      onEvent() {
+        throw new Error("sensitive Telegram observer detail");
+      },
+    });
+    servers.push(failing);
+    const response = await fetch(
+      `${failing.manifest.baseUrl}/bot${failing.manifest.botToken}/getMe`,
+    );
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: "internal server error",
       ok: false,
     });
   });

--- a/test/zalo-server.test.ts
+++ b/test/zalo-server.test.ts
@@ -418,12 +418,12 @@ describe("Zalo local provider server", () => {
     if (!address || typeof address === "string") {
       throw new Error("Unable to resolve webhook test server address.");
     }
-    const server = await startZaloServer({ botToken: "zalo-token" });
+    const server = await startZaloServer({ botToken: "test-token-placeholder" });
     servers.push(server);
     try {
-      await fetch(`${server.manifest.baseUrl}/botzalo-token/setWebhook`, {
+      await fetch(`${server.manifest.baseUrl}/bottest-token-placeholder/setWebhook`, {
         body: JSON.stringify({
-          secret_token: "webhook-secret",
+          secret_token: "test-auth-token",
           url: `http://127.0.0.1:${address.port}/zalo`,
         }),
         headers: { "content-type": "application/json" },

--- a/test/zalo-server.test.ts
+++ b/test/zalo-server.test.ts
@@ -392,9 +392,9 @@ describe("Zalo local provider server", () => {
             { address: "127.0.0.1", family: 4 },
           ],
           body: '{"ok":true}',
-          secretToken: "secret",
           timeoutMs: 1_000,
           url: new URL(`http://webhook.test:${address.port}/zalo`),
+          verificationValue: "secret",
         }),
       ).resolves.toBe(200);
       expect(received).toEqual(['{"ok":true}']);

--- a/test/zalo-server.test.ts
+++ b/test/zalo-server.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { startZaloServer, type StartedZaloServer } from "../src/index.js";
+import { postZaloWebhook } from "../src/servers/zalo.js";
 import { createTempDir, disposeTempDir, requestHttp } from "./test-helpers.js";
 
 const servers: StartedZaloServer[] = [];
@@ -359,6 +360,84 @@ describe("Zalo local provider server", () => {
         error_code: 502,
         ok: false,
       });
+    } finally {
+      webhook.closeAllConnections();
+      await new Promise<void>((resolve, reject) =>
+        webhook.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+
+  it("tries each validated webhook address until one connects", async () => {
+    const received: string[] = [];
+    const webhook = createServer(async (request, response) => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of request) {
+        chunks.push(Buffer.from(chunk));
+      }
+      received.push(Buffer.concat(chunks).toString("utf8"));
+      response.statusCode = 200;
+      response.end();
+    });
+    await new Promise<void>((resolve) => webhook.listen(0, "127.0.0.1", resolve));
+    const address = webhook.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Unable to resolve webhook test server address.");
+    }
+    try {
+      await expect(
+        postZaloWebhook({
+          addresses: [
+            { address: "127.0.0.2", family: 4 },
+            { address: "127.0.0.1", family: 4 },
+          ],
+          body: '{"ok":true}',
+          secretToken: "secret",
+          timeoutMs: 1_000,
+          url: new URL(`http://webhook.test:${address.port}/zalo`),
+        }),
+      ).resolves.toBe(200);
+      expect(received).toEqual(['{"ok":true}']);
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        webhook.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+
+  it("closes active webhook requests during server shutdown", async () => {
+    let observeRequest!: () => void;
+    const requestObserved = new Promise<void>((resolve) => {
+      observeRequest = resolve;
+    });
+    const webhook = createServer((_request, _response) => {
+      observeRequest();
+    });
+    await new Promise<void>((resolve) => webhook.listen(0, "127.0.0.1", resolve));
+    const address = webhook.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Unable to resolve webhook test server address.");
+    }
+    const server = await startZaloServer({ botToken: "zalo-token" });
+    servers.push(server);
+    try {
+      await fetch(`${server.manifest.baseUrl}/botzalo-token/setWebhook`, {
+        body: JSON.stringify({
+          secret_token: "webhook-secret",
+          url: `http://127.0.0.1:${address.port}/zalo`,
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      const inbound = fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({ chatId: "chat-1", senderId: "user-1", text: "hello" }),
+        headers: adminHeaders(server),
+        method: "POST",
+      });
+      await requestObserved;
+      await server.close();
+      servers.splice(servers.indexOf(server), 1);
+      expect((await inbound).status).toBe(502);
     } finally {
       webhook.closeAllConnections();
       await new Promise<void>((resolve, reject) =>

--- a/test/zalo-server.test.ts
+++ b/test/zalo-server.test.ts
@@ -1,4 +1,4 @@
-import { Agent, createServer } from "node:http";
+import { Agent, createServer, type ClientRequest } from "node:http";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -399,6 +399,52 @@ describe("Zalo local provider server", () => {
       ).resolves.toBe(200);
       expect(received).toEqual(['{"ok":true}']);
     } finally {
+      await new Promise<void>((resolve, reject) =>
+        webhook.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+
+  it("does not try another webhook address after cancellation", async () => {
+    let requests = 0;
+    let observeRequest!: () => void;
+    const requestObserved = new Promise<void>((resolve) => {
+      observeRequest = resolve;
+    });
+    const webhook = createServer(() => {
+      requests += 1;
+      observeRequest();
+    });
+    await new Promise<void>((resolve) => webhook.listen(0, "127.0.0.1", resolve));
+    const address = webhook.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Unable to resolve webhook test server address.");
+    }
+    const activeRequests = new Set<ClientRequest>();
+    let cancelled = false;
+    try {
+      const delivery = postZaloWebhook({
+        activeRequests,
+        addresses: [
+          { address: "127.0.0.1", family: 4 },
+          { address: "127.0.0.1", family: 4 },
+        ],
+        body: '{"ok":true}',
+        shouldCancel: () => cancelled,
+        timeoutMs: 1_000,
+        url: new URL(`http://webhook.test:${address.port}/zalo`),
+        verificationValue: "secret",
+      });
+      await requestObserved;
+      cancelled = true;
+      for (const request of activeRequests) {
+        request.destroy(new Error("test cancellation"));
+      }
+      await expect(delivery).rejects.toThrow("test cancellation");
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      expect(requests).toBe(1);
+    } finally {
+      webhook.closeAllConnections();
       await new Promise<void>((resolve, reject) =>
         webhook.close((error) => (error ? reject(error) : resolve())),
       );


### PR DESCRIPTION
## Summary
- preserve provider-native delivery ordering, replay, and backpressure behavior across Matrix, Mattermost, Signal, Slack, Telegram, and Zalo
- validate and pin outbound webhook targets while bounding retries, shutdown, and unauthenticated socket lifetimes
- add regression coverage for resource limits, retry ownership, transaction replay, and shutdown cancellation
- document the user-visible fidelity fixes in the changelog

## Verification
- `pnpm exec vitest run test/mattermost-server.test.ts test/matrix-server.test.ts test/signal-server.test.ts test/telegram-server.test.ts test/zalo-server.test.ts` (79 tests)
- `pnpm lint`
- `pnpm build`
- autoreview: `gpt-5.6-sol`, high reasoning, clean on `9281567b438cea6d64e83b527db35a428c953e7f`
- Crabbox `run_f4744461c2ca`: exact source `9281567b438cea6d64e83b527db35a428c953e7f`, full `pnpm verify`, 52 files / 588 tests, exit 0