### PR TITLE
fix(whatsapp): bound native transport and validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Harden release, CI, config, CLI, package, and OpenClaw artifact and process-identity boundaries.
 - Restore provider-native callbacks and authentication, preserve conversation targets and recorder progress, and harden local mock lifecycle and parsing.
 - Preserve native server sync, webhook, request-validation, backpressure, and shutdown semantics across Matrix, Mattermost, Signal, Slack, Telegram, and Zalo.
+- Bound WhatsApp WebSocket flow control, validate native auth and JID roles, and reject low-order X25519 peers.
 - Preserve Zalo polling updates across disconnects and webhook changes, reject future Matrix sync tokens, normalize JSON media types, and bound Signal SSE clients and buffers.
 - Authenticate configured Discord interactions, answer native PING requests, exclude outbound mock records from inbound matching, filter WhatsApp webhooks by phone number, and validate loopback pagination limits.
 - Bound WhatsApp binary-node complexity and signal bundles, align encoder and decoder limits, preserve coherent X25519 fallback behavior, validate queue startup before listening, keep reconnect delivery FIFO, and accept bounded legacy group JIDs.

--- a/src/servers/whatsapp-baileys-websocket.ts
+++ b/src/servers/whatsapp-baileys-websocket.ts
@@ -22,7 +22,7 @@ import {
 } from "./whatsapp-wire/binary-node.js";
 import { decodeHandshakeMessage, encodeHandshakeMessage } from "./whatsapp-wire/handshake.js";
 import { KEY_BUNDLE_TYPE, xmppPreKey, xmppSignedPreKey } from "./whatsapp-wire/signal.js";
-import { WebSocket, WebSocketServer, type RawData, type ServerOptions } from "ws";
+import { WebSocket, WebSocketServer, type ServerOptions } from "ws";
 import type { ServerRequestEvent } from "./http.js";
 import { closeWebSocketServer } from "./websocket.js";
 
@@ -43,6 +43,13 @@ export const MAX_WHATSAPP_WEBSOCKET_FRAGMENTS = 1_024;
 export const MAX_WHATSAPP_SIGNAL_BUNDLES = 1_024;
 const SIGNAL_BUNDLE_JID_RE = /^\d{7,15}(?::\d+)?@(?:s\.whatsapp\.net|lid)$/iu;
 type NodeBuffer = Buffer<ArrayBufferLike>;
+type WhatsAppWebSocketRawData = NodeBuffer | ArrayBuffer | NodeBuffer[];
+type WhatsAppWebSocketSendTarget = {
+  bufferedAmount: number;
+  readyState: number;
+  send(data: Uint8Array, callback: (error?: Error) => void): void;
+  terminate(): void;
+};
 const WHATSAPP_NOISE_CERT_CHAIN = Buffer.from(
   "CncKMwjjAhADGiCRKg7Kg1iu4CSulwLBaxX51Tefw6VXGgZqcr5OEbXIRiDQ04bOBijQjZ/TBhJA34Bj82jAHhLpCWBNVBlGnFDieamd8+138S57uMt9ke9mrn5r4+VepwBPKEgHjob6bR70rlCmWDkxZv+CfVjIAxJ2CjIIAxAAGiAcUamsMDmUxsjQuS6hh4pTNHZZnMWZ++o1mX2aqQzOYiCAka6+Bij/3rfcBhJAJw8pRkhTn+1IcOJQVN1OlZg6uikYnCumyO7acFVVX3U3QPXsGSq2TCbCbWrebSC593Su43EgprIDlfU8ZgWFBw==",
   "base64",
@@ -210,7 +217,7 @@ export class WhatsAppNoiseFrameDecoder {
     return this.#bufferedBytes;
   }
 
-  decodeFrames(data: RawData): NodeBuffer[] {
+  decodeFrames(data: WhatsAppWebSocketRawData): NodeBuffer[] {
     let chunk = rawDataToBuffer(data);
     if (this.#expectIntro) {
       chunk = removeNoiseIntroHeader(chunk);
@@ -342,7 +349,7 @@ class BaileysNoiseServer {
     this.#authenticate(NOISE_WA_HEADER);
   }
 
-  decodeFrames(data: RawData): NodeBuffer[] {
+  decodeFrames(data: WhatsAppWebSocketRawData): NodeBuffer[] {
     return this.#frames.decodeFrames(data);
   }
 
@@ -441,7 +448,7 @@ class BaileysNoiseServer {
 
 class WhatsAppBaileysWebSocketSession {
   #handshakeState: "client-finish" | "client-hello" | "open" = "client-hello";
-  readonly #handleSerializedMessage: (data: RawData) => Promise<void>;
+  readonly #handleSerializedMessage: (data: WhatsAppWebSocketRawData) => Promise<void>;
   readonly #noise = new BaileysNoiseServer();
 
   constructor(
@@ -469,7 +476,7 @@ class WhatsAppBaileysWebSocketSession {
     return this.#handshakeState === "open" && this.socket.readyState === WebSocket.OPEN;
   }
 
-  handleMessage(data: RawData): void {
+  handleMessage(data: WhatsAppWebSocketRawData): void {
     void this.#handleSerializedMessage(data);
   }
 
@@ -486,7 +493,7 @@ class WhatsAppBaileysWebSocketSession {
     }
   }
 
-  async #handleMessage(data: RawData): Promise<void> {
+  async #handleMessage(data: WhatsAppWebSocketRawData): Promise<void> {
     for (const frame of this.#noise.decodeFrames(data)) {
       if (this.#handshakeState === "client-hello") {
         await sendWhatsAppWebSocketPayload(this.socket, this.#noise.createServerHello(frame));
@@ -737,7 +744,7 @@ class WhatsAppBaileysWebSocketSession {
 }
 
 export async function sendWhatsAppWebSocketPayload(
-  socket: Pick<WebSocket, "bufferedAmount" | "readyState" | "send" | "terminate">,
+  socket: WhatsAppWebSocketSendTarget,
   payload: Uint8Array,
 ): Promise<void> {
   if (socket.readyState !== WebSocket.OPEN) {
@@ -917,14 +924,14 @@ export function parseWhatsAppWebSocketUpgradeUrl(
   }
 }
 
-function rawDataByteLength(data: RawData): number {
+function rawDataByteLength(data: WhatsAppWebSocketRawData): number {
   if (Array.isArray(data)) {
     return data.reduce((total, chunk) => total + chunk.byteLength, 0);
   }
   return data.byteLength;
 }
 
-function rawDataToBuffer(data: RawData): NodeBuffer {
+function rawDataToBuffer(data: WhatsAppWebSocketRawData): NodeBuffer {
   if (Buffer.isBuffer(data)) {
     return data;
   }

--- a/src/servers/whatsapp-baileys-websocket.ts
+++ b/src/servers/whatsapp-baileys-websocket.ts
@@ -39,7 +39,7 @@ export const MAX_WHATSAPP_NOISE_FRAMES_PER_MESSAGE = 1_024;
 export const WHATSAPP_WEBSOCKET_SEND_TIMEOUT_MS = 5_000;
 const MAX_PENDING_WEBSOCKET_BYTES = 8 * 1024 * 1024;
 const MAX_PENDING_WEBSOCKET_MESSAGES = 32;
-const MAX_WEBSOCKET_FRAGMENTS = 1_024;
+export const MAX_WHATSAPP_WEBSOCKET_FRAGMENTS = 1_024;
 export const MAX_WHATSAPP_SIGNAL_BUNDLES = 1_024;
 const SIGNAL_BUNDLE_JID_RE = /^\d{7,15}(?::\d+)?@(?:s\.whatsapp\.net|lid)$/iu;
 type NodeBuffer = Buffer<ArrayBufferLike>;
@@ -789,8 +789,8 @@ export function attachWhatsAppBaileysWebSocketServer(
     maxBufferedChunks: number;
     maxFragments: number;
   } = {
-    maxBufferedChunks: MAX_WEBSOCKET_FRAGMENTS,
-    maxFragments: MAX_WEBSOCKET_FRAGMENTS,
+    maxBufferedChunks: MAX_WHATSAPP_WEBSOCKET_FRAGMENTS,
+    maxFragments: MAX_WHATSAPP_WEBSOCKET_FRAGMENTS,
     maxPayload: MAX_WHATSAPP_WEBSOCKET_MESSAGE_BYTES,
     noServer: true,
   };

--- a/src/servers/whatsapp-baileys-websocket.ts
+++ b/src/servers/whatsapp-baileys-websocket.ts
@@ -35,6 +35,7 @@ export const MAX_WHATSAPP_NOISE_FRAME_BYTES = 2 * 1024 * 1024;
 export const MAX_WHATSAPP_WEBSOCKET_BUFFERED_BYTES = 4 * 1024 * 1024;
 export const MAX_WHATSAPP_WEBSOCKET_MESSAGE_BYTES = 4 * 1024 * 1024;
 export const MAX_WHATSAPP_NOISE_BUFFER_CHUNKS = 1_024;
+export const MAX_WHATSAPP_NOISE_FRAMES_PER_MESSAGE = 1_024;
 export const WHATSAPP_WEBSOCKET_SEND_TIMEOUT_MS = 5_000;
 const MAX_PENDING_WEBSOCKET_BYTES = 8 * 1024 * 1024;
 const MAX_PENDING_WEBSOCKET_MESSAGES = 32;
@@ -233,6 +234,11 @@ export class WhatsAppNoiseFrameDecoder {
       }
       if (this.#bufferedBytes < size + 3) {
         break;
+      }
+      if (frames.length >= MAX_WHATSAPP_NOISE_FRAMES_PER_MESSAGE) {
+        throw new Error(
+          `WhatsApp Noise message exceeds ${MAX_WHATSAPP_NOISE_FRAMES_PER_MESSAGE} frames.`,
+        );
       }
       this.#consume(3);
       frames.push(this.#read(size));

--- a/src/servers/whatsapp-baileys-websocket.ts
+++ b/src/servers/whatsapp-baileys-websocket.ts
@@ -22,7 +22,7 @@ import {
 } from "./whatsapp-wire/binary-node.js";
 import { decodeHandshakeMessage, encodeHandshakeMessage } from "./whatsapp-wire/handshake.js";
 import { KEY_BUNDLE_TYPE, xmppPreKey, xmppSignedPreKey } from "./whatsapp-wire/signal.js";
-import { WebSocket, WebSocketServer, type RawData } from "ws";
+import { WebSocket, WebSocketServer, type RawData, type ServerOptions } from "ws";
 import type { ServerRequestEvent } from "./http.js";
 import { closeWebSocketServer } from "./websocket.js";
 
@@ -31,6 +31,14 @@ import { closeWebSocketServer } from "./websocket.js";
 const EMPTY_BUFFER = Buffer.alloc(0);
 const IV_LENGTH = 12;
 const MAX_PENDING_INBOUND_MESSAGES = 1_000;
+export const MAX_WHATSAPP_NOISE_FRAME_BYTES = 2 * 1024 * 1024;
+export const MAX_WHATSAPP_WEBSOCKET_BUFFERED_BYTES = 4 * 1024 * 1024;
+export const MAX_WHATSAPP_WEBSOCKET_MESSAGE_BYTES = 4 * 1024 * 1024;
+export const MAX_WHATSAPP_NOISE_BUFFER_CHUNKS = 1_024;
+export const WHATSAPP_WEBSOCKET_SEND_TIMEOUT_MS = 5_000;
+const MAX_PENDING_WEBSOCKET_BYTES = 8 * 1024 * 1024;
+const MAX_PENDING_WEBSOCKET_MESSAGES = 32;
+const MAX_WEBSOCKET_FRAGMENTS = 1_024;
 export const MAX_WHATSAPP_SIGNAL_BUNDLES = 1_024;
 const SIGNAL_BUNDLE_JID_RE = /^\d{7,15}(?::\d+)?@(?:s\.whatsapp\.net|lid)$/iu;
 type NodeBuffer = Buffer<ArrayBufferLike>;
@@ -57,7 +65,7 @@ export type WhatsAppBaileysWebSocketServerParams = {
 
 export type PreparedWhatsAppBaileysInboundDelivery = {
   cancel(): void;
-  commit(): "delivered" | "queued";
+  commit(): Promise<"delivered" | "queued">;
 };
 
 export type WhatsAppBaileysInboundMessage = {
@@ -140,23 +148,152 @@ export class WhatsAppSignalBundleStore {
 export function createSerializedMessageHandler<T>(
   processMessage: (message: T) => Promise<void>,
   onError: (error: unknown) => void,
+  options: {
+    maxPendingBytes?: number | undefined;
+    maxPendingMessages?: number | undefined;
+    sizeOf?: ((message: T) => number) | undefined;
+  } = {},
 ): (message: T) => Promise<void> {
+  const maxPendingBytes = options.maxPendingBytes ?? MAX_PENDING_WEBSOCKET_BYTES;
+  const maxPendingMessages = options.maxPendingMessages ?? MAX_PENDING_WEBSOCKET_MESSAGES;
+  const sizeOf = options.sizeOf ?? (() => 1);
   let failed = false;
+  let pendingBytes = 0;
+  let pendingMessages = 0;
   let pending = Promise.resolve();
+  const fail = (error: unknown) => {
+    if (!failed) {
+      failed = true;
+      onError(error);
+    }
+  };
   return (message) => {
-    const next = pending.then(async () => {
-      if (!failed) {
-        await processMessage(message);
-      }
-    });
+    if (failed) {
+      return pending;
+    }
+    const messageBytes = sizeOf(message);
+    if (!Number.isSafeInteger(messageBytes) || messageBytes < 0) {
+      fail(new Error("WhatsApp WebSocket message size must be a non-negative safe integer."));
+      return pending;
+    }
+    if (pendingMessages >= maxPendingMessages || pendingBytes + messageBytes > maxPendingBytes) {
+      fail(new Error("WhatsApp WebSocket inbound backlog limit exceeded."));
+      return pending;
+    }
+    pendingMessages += 1;
+    pendingBytes += messageBytes;
+    const next = pending
+      .then(async () => {
+        if (!failed) {
+          await processMessage(message);
+        }
+      })
+      .finally(() => {
+        pendingMessages -= 1;
+        pendingBytes -= messageBytes;
+      });
     pending = next.catch((error: unknown) => {
-      if (!failed) {
-        failed = true;
-        onError(error);
-      }
+      fail(error);
     });
     return pending;
   };
+}
+
+export class WhatsAppNoiseFrameDecoder {
+  #bufferedBytes = 0;
+  readonly #chunks: NodeBuffer[] = [];
+  #expectIntro = true;
+  #offset = 0;
+
+  get bufferedBytes(): number {
+    return this.#bufferedBytes;
+  }
+
+  decodeFrames(data: RawData): NodeBuffer[] {
+    let chunk = rawDataToBuffer(data);
+    if (this.#expectIntro) {
+      chunk = removeNoiseIntroHeader(chunk);
+      this.#expectIntro = false;
+    }
+    if (chunk.length > 0) {
+      if (this.#chunks.length >= MAX_WHATSAPP_NOISE_BUFFER_CHUNKS) {
+        throw new Error(
+          `WhatsApp Noise buffer exceeds ${MAX_WHATSAPP_NOISE_BUFFER_CHUNKS} chunks.`,
+        );
+      }
+      this.#chunks.push(chunk);
+      this.#bufferedBytes += chunk.length;
+    }
+
+    const frames: NodeBuffer[] = [];
+    while (this.#bufferedBytes >= 3) {
+      const size = (this.#peekByte(0) << 16) | (this.#peekByte(1) << 8) | this.#peekByte(2);
+      if (size > MAX_WHATSAPP_NOISE_FRAME_BYTES) {
+        throw new Error(`WhatsApp Noise frame exceeds ${MAX_WHATSAPP_NOISE_FRAME_BYTES} bytes.`);
+      }
+      if (this.#bufferedBytes < size + 3) {
+        break;
+      }
+      this.#consume(3);
+      frames.push(this.#read(size));
+    }
+    return frames;
+  }
+
+  #consume(length: number): void {
+    let remaining = length;
+    while (remaining > 0) {
+      const chunk = this.#chunks[0];
+      if (!chunk) {
+        throw new Error("Unexpected end of WhatsApp Noise frame buffer.");
+      }
+      const available = chunk.length - this.#offset;
+      const consumed = Math.min(available, remaining);
+      this.#offset += consumed;
+      this.#bufferedBytes -= consumed;
+      remaining -= consumed;
+      if (this.#offset === chunk.length) {
+        this.#chunks.shift();
+        this.#offset = 0;
+      }
+    }
+  }
+
+  #peekByte(index: number): number {
+    let remaining = index + this.#offset;
+    for (const chunk of this.#chunks) {
+      if (remaining < chunk.length) {
+        return chunk[remaining]!;
+      }
+      remaining -= chunk.length;
+    }
+    throw new Error("Unexpected end of WhatsApp Noise frame buffer.");
+  }
+
+  #read(length: number): NodeBuffer {
+    const result = Buffer.allocUnsafe(length);
+    let resultOffset = 0;
+    while (resultOffset < length) {
+      const chunk = this.#chunks[0];
+      if (!chunk) {
+        throw new Error("Unexpected end of WhatsApp Noise frame buffer.");
+      }
+      const copied = chunk.copy(
+        result,
+        resultOffset,
+        this.#offset,
+        Math.min(chunk.length, this.#offset + length - resultOffset),
+      );
+      this.#offset += copied;
+      this.#bufferedBytes -= copied;
+      resultOffset += copied;
+      if (this.#offset === chunk.length) {
+        this.#chunks.shift();
+        this.#offset = 0;
+      }
+    }
+    return result;
+  }
 }
 
 class TransportState {
@@ -183,9 +320,8 @@ class BaileysNoiseServer {
   #counter = 0;
   #decKey: NodeBuffer;
   #encKey: NodeBuffer;
-  #expectIntro = true;
+  readonly #frames = new WhatsAppNoiseFrameDecoder();
   #hash: NodeBuffer;
-  #inBytes: NodeBuffer = Buffer.alloc(0);
   #salt: NodeBuffer;
   #serverEphemeralKey: KeyPair | undefined;
   #serverStaticKey: KeyPair | undefined;
@@ -201,30 +337,7 @@ class BaileysNoiseServer {
   }
 
   decodeFrames(data: RawData): NodeBuffer[] {
-    let chunk: NodeBuffer = Buffer.from(
-      Buffer.isBuffer(data) ? data : Buffer.from(data as ArrayBuffer),
-    );
-    if (this.#expectIntro) {
-      chunk = this.#removeIntroHeader(chunk);
-      this.#expectIntro = false;
-    }
-    this.#inBytes = this.#inBytes.length ? Buffer.concat([this.#inBytes, chunk]) : chunk;
-    const frames: NodeBuffer[] = [];
-    while (this.#inBytes.length >= 3) {
-      const head0 = this.#inBytes[0];
-      const head1 = this.#inBytes[1];
-      const head2 = this.#inBytes[2];
-      if (head0 === undefined || head1 === undefined || head2 === undefined) {
-        break;
-      }
-      const size = (head0 << 16) | (head1 << 8) | head2;
-      if (this.#inBytes.length < size + 3) {
-        break;
-      }
-      frames.push(this.#inBytes.subarray(3, size + 3));
-      this.#inBytes = this.#inBytes.subarray(size + 3);
-    }
-    return frames;
+    return this.#frames.decodeFrames(data);
   }
 
   async decodeTransportNode(frame: Uint8Array): Promise<BinaryNode> {
@@ -318,26 +431,6 @@ class BaileysNoiseServer {
     this.#decKey = readKey;
     this.#counter = 0;
   }
-
-  #removeIntroHeader(chunk: NodeBuffer): NodeBuffer {
-    if (chunk.subarray(0, NOISE_WA_HEADER.length).equals(NOISE_WA_HEADER)) {
-      return chunk.subarray(NOISE_WA_HEADER.length);
-    }
-    if (chunk.length >= 11 && chunk.subarray(0, 2).toString("utf8") === "ED" && chunk[3] === 1) {
-      const routingInfoPrefix = chunk[4];
-      if (routingInfoPrefix === undefined) {
-        throw new Error("Invalid Baileys Noise routing header.");
-      }
-      const routingInfoLength = (routingInfoPrefix << 16) | chunk.readUInt16BE(5);
-      const headerLength = 7 + routingInfoLength + NOISE_WA_HEADER.length;
-      if (
-        chunk.subarray(headerLength - NOISE_WA_HEADER.length, headerLength).equals(NOISE_WA_HEADER)
-      ) {
-        return chunk.subarray(headerLength);
-      }
-    }
-    throw new Error("Invalid Baileys Noise intro header.");
-  }
 }
 
 class WhatsAppBaileysWebSocketSession {
@@ -360,6 +453,9 @@ class WhatsAppBaileysWebSocketSession {
       (error) => {
         this.socket.close(1011, error instanceof Error ? error.message : String(error));
       },
+      {
+        sizeOf: rawDataByteLength,
+      },
     );
   }
 
@@ -371,32 +467,37 @@ class WhatsAppBaileysWebSocketSession {
     void this.#handleSerializedMessage(data);
   }
 
-  deliverInboundMessage(message: WhatsAppBaileysInboundMessage): boolean {
+  async deliverInboundMessage(message: WhatsAppBaileysInboundMessage): Promise<boolean> {
     if (!this.isOpen) {
       return false;
     }
-    this.#sendNode(createInboundMessageNode(message));
-    return true;
+    try {
+      await this.#sendNode(createInboundMessageNode(message));
+      return true;
+    } catch {
+      this.socket.terminate();
+      return false;
+    }
   }
 
   async #handleMessage(data: RawData): Promise<void> {
     for (const frame of this.#noise.decodeFrames(data)) {
       if (this.#handshakeState === "client-hello") {
-        this.socket.send(this.#noise.createServerHello(frame));
+        await sendWhatsAppWebSocketPayload(this.socket, this.#noise.createServerHello(frame));
         this.#handshakeState = "client-finish";
         continue;
       }
       if (this.#handshakeState === "client-finish") {
         this.#noise.finishClientHandshake(frame);
         this.#handshakeState = "open";
-        this.#sendNode({
+        await this.#sendNode({
           attrs: {
             lid: lidForJid(this.params.selfJid),
             t: unixSeconds(),
           },
           tag: "success",
         });
-        this.#sendNode({
+        await this.#sendNode({
           attrs: {},
           content: [{ attrs: { count: "0" }, tag: "offline" }],
           tag: "ib",
@@ -411,12 +512,12 @@ class WhatsAppBaileysWebSocketSession {
   async #handleNode(node: BinaryNode): Promise<void> {
     await this.#recordNode(node);
     if (node.tag === "iq") {
-      this.#sendNode(this.#createIqResult(node));
+      await this.#sendNode(this.#createIqResult(node));
       return;
     }
     if (node.tag === "message") {
       const peer = requireAttr(node, "to");
-      this.#sendNode({
+      await this.#sendNode({
         attrs: {
           class: "message",
           from: peer,
@@ -624,9 +725,46 @@ class WhatsAppBaileysWebSocketSession {
     });
   }
 
-  #sendNode(node: BinaryNode): void {
-    this.socket.send(this.#noise.encodeNode(node));
+  async #sendNode(node: BinaryNode): Promise<void> {
+    await sendWhatsAppWebSocketPayload(this.socket, this.#noise.encodeNode(node));
   }
+}
+
+export async function sendWhatsAppWebSocketPayload(
+  socket: Pick<WebSocket, "bufferedAmount" | "readyState" | "send" | "terminate">,
+  payload: Uint8Array,
+): Promise<void> {
+  if (socket.readyState !== WebSocket.OPEN) {
+    throw new Error("WhatsApp WebSocket is not open.");
+  }
+  if (socket.bufferedAmount + payload.byteLength > MAX_WHATSAPP_WEBSOCKET_BUFFERED_BYTES) {
+    socket.terminate();
+    throw new Error("WhatsApp WebSocket outbound buffer limit exceeded.");
+  }
+  await new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const finish = (error?: Error) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    };
+    const timeout = setTimeout(() => {
+      socket.terminate();
+      finish(new Error("WhatsApp WebSocket send timed out."));
+    }, WHATSAPP_WEBSOCKET_SEND_TIMEOUT_MS);
+    try {
+      socket.send(payload, finish);
+    } catch (error) {
+      finish(error instanceof Error ? error : new Error(String(error)));
+    }
+  });
 }
 
 export function attachWhatsAppBaileysWebSocketServer(
@@ -639,25 +777,52 @@ export function attachWhatsAppBaileysWebSocketServer(
     params.maxPendingInboundMessages,
   );
   let pendingReservations = 0;
-  const wss = new WebSocketServer({ noServer: true });
-  const flushPendingMessages = (session: WhatsAppBaileysWebSocketSession) => {
-    while (pendingMessages.length > 0) {
-      const message = pendingMessages[0];
-      if (!message || !session.deliverInboundMessage(message)) {
-        return;
+  let closing = false;
+  let flushPromise = Promise.resolve();
+  const webSocketServerOptions: ServerOptions & {
+    maxBufferedChunks: number;
+    maxFragments: number;
+  } = {
+    maxBufferedChunks: MAX_WEBSOCKET_FRAGMENTS,
+    maxFragments: MAX_WEBSOCKET_FRAGMENTS,
+    maxPayload: MAX_WHATSAPP_WEBSOCKET_MESSAGE_BYTES,
+    noServer: true,
+  };
+  const wss = new WebSocketServer(webSocketServerOptions);
+  const flushPendingMessages = (): Promise<void> => {
+    const next = flushPromise.then(async () => {
+      while (pendingMessages.length > 0) {
+        if (closing) {
+          return;
+        }
+        const message = pendingMessages[0];
+        if (!message) {
+          return;
+        }
+        const results = await Promise.all(
+          [...sessions].map((session) => session.deliverInboundMessage(message)),
+        );
+        if (!results.some(Boolean)) {
+          return;
+        }
+        pendingMessages.shift();
       }
-      pendingMessages.shift();
-    }
+    });
+    flushPromise = next.catch(() => undefined);
+    return next;
   };
   const handleUpgrade = (request: IncomingMessage, socket: Duplex, head: Buffer) => {
-    const url = new URL(request.url ?? "/", "http://127.0.0.1");
+    const url = parseWhatsAppWebSocketUpgradeUrl(request.url);
+    if (!url) {
+      socket.end("HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n");
+      return;
+    }
     if (url.pathname !== params.path) {
       socket.destroy();
       return;
     }
     if (url.searchParams.get("access_token") !== params.accessToken) {
-      socket.write("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n");
-      socket.destroy();
+      socket.end("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n");
       return;
     }
     wss.handleUpgrade(request, socket, head, (ws) => {
@@ -668,8 +833,8 @@ export function attachWhatsAppBaileysWebSocketServer(
   wss.on("connection", (socket: WebSocket) => {
     const session = new WhatsAppBaileysWebSocketSession(socket, {
       appendEvent: params.appendEvent,
-      onOpen: (openSession) => {
-        flushPendingMessages(openSession);
+      onOpen: () => {
+        void flushPendingMessages();
       },
       path: params.path,
       selfJid: params.selfJid,
@@ -685,9 +850,11 @@ export function attachWhatsAppBaileysWebSocketServer(
   });
   return {
     async close() {
+      closing = true;
       params.httpServer.off("upgrade", handleUpgrade);
       pendingMessages.length = 0;
       await closeWebSocketServer(wss);
+      await flushPromise;
     },
     prepareInboundMessage(message) {
       if (pendingMessages.length + pendingReservations >= maxPendingInboundMessages) {
@@ -709,38 +876,19 @@ export function attachWhatsAppBaileysWebSocketServer(
             releaseReservation();
           }
         },
-        commit() {
+        async commit() {
           if (settled) {
             throw new Error("WhatsApp inbound delivery reservation is already settled.");
           }
           settled = true;
           try {
-            if (pendingMessages.length > 0) {
-              releaseReservation();
-              if (pendingMessages.length >= maxPendingInboundMessages) {
-                throw new Error("WhatsApp inbound delivery reservation exceeded queue capacity.");
-              }
-              pendingMessages.push(message);
-              for (const session of sessions) {
-                flushPendingMessages(session);
-              }
-              return pendingMessages.includes(message) ? "queued" : "delivered";
-            }
-            let delivered = false;
-            for (const session of sessions) {
-              if (session.deliverInboundMessage(message)) {
-                delivered = true;
-              }
-            }
-            if (delivered) {
-              return "delivered";
-            }
             releaseReservation();
             if (pendingMessages.length >= maxPendingInboundMessages) {
               throw new Error("WhatsApp inbound delivery reservation exceeded queue capacity.");
             }
             pendingMessages.push(message);
-            return "queued";
+            await flushPendingMessages();
+            return pendingMessages.includes(message) ? "queued" : "delivered";
           } finally {
             releaseReservation();
           }
@@ -748,6 +896,53 @@ export function attachWhatsAppBaileysWebSocketServer(
       };
     },
   };
+}
+
+export function parseWhatsAppWebSocketUpgradeUrl(
+  requestTarget: string | undefined,
+): URL | undefined {
+  try {
+    return new URL(requestTarget ?? "/", "http://127.0.0.1");
+  } catch {
+    return undefined;
+  }
+}
+
+function rawDataByteLength(data: RawData): number {
+  if (Array.isArray(data)) {
+    return data.reduce((total, chunk) => total + chunk.byteLength, 0);
+  }
+  return data.byteLength;
+}
+
+function rawDataToBuffer(data: RawData): NodeBuffer {
+  if (Buffer.isBuffer(data)) {
+    return data;
+  }
+  if (Array.isArray(data)) {
+    return Buffer.concat(data);
+  }
+  return Buffer.from(data);
+}
+
+function removeNoiseIntroHeader(chunk: NodeBuffer): NodeBuffer {
+  if (chunk.subarray(0, NOISE_WA_HEADER.length).equals(NOISE_WA_HEADER)) {
+    return chunk.subarray(NOISE_WA_HEADER.length);
+  }
+  if (chunk.length >= 11 && chunk.subarray(0, 2).toString("utf8") === "ED" && chunk[3] === 1) {
+    const routingInfoPrefix = chunk[4];
+    if (routingInfoPrefix === undefined) {
+      throw new Error("Invalid Baileys Noise routing header.");
+    }
+    const routingInfoLength = (routingInfoPrefix << 16) | chunk.readUInt16BE(5);
+    const headerLength = 7 + routingInfoLength + NOISE_WA_HEADER.length;
+    if (
+      chunk.subarray(headerLength - NOISE_WA_HEADER.length, headerLength).equals(NOISE_WA_HEADER)
+    ) {
+      return chunk.subarray(headerLength);
+    }
+  }
+  throw new Error("Invalid Baileys Noise intro header.");
 }
 
 function children(node: BinaryNode): BinaryNode[] {

--- a/src/servers/whatsapp-baileys-websocket.ts
+++ b/src/servers/whatsapp-baileys-websocket.ts
@@ -811,10 +811,13 @@ export function attachWhatsAppBaileysWebSocketServer(
     flushPromise = next.catch(() => undefined);
     return next;
   };
+  const rejectUpgrade = (socket: Duplex, response: string) => {
+    socket.end(response, () => socket.destroy());
+  };
   const handleUpgrade = (request: IncomingMessage, socket: Duplex, head: Buffer) => {
     const url = parseWhatsAppWebSocketUpgradeUrl(request.url);
     if (!url) {
-      socket.end("HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n");
+      rejectUpgrade(socket, "HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n");
       return;
     }
     if (url.pathname !== params.path) {
@@ -822,7 +825,7 @@ export function attachWhatsAppBaileysWebSocketServer(
       return;
     }
     if (url.searchParams.get("access_token") !== params.accessToken) {
-      socket.end("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n");
+      rejectUpgrade(socket, "HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n");
       return;
     }
     wss.handleUpgrade(request, socket, head, (ws) => {

--- a/src/servers/whatsapp-wire/crypto.ts
+++ b/src/servers/whatsapp-wire/crypto.ts
@@ -118,7 +118,7 @@ export function createCurve(nativeBackend: NativeCurveBackend = nativeCurveBacke
       }
       if (nativeAvailable) {
         try {
-          return nativeBackend.sharedKey(privateKey, rawPublicKey);
+          return requireValidX25519SharedKey(nativeBackend.sharedKey(privateKey, rawPublicKey));
         } catch (error) {
           if (!isUnsupportedNativeCurveError(error)) {
             throw error;
@@ -126,13 +126,23 @@ export function createCurve(nativeBackend: NativeCurveBackend = nativeCurveBacke
           nativeAvailable = false;
         }
       }
-      return Buffer.from(curve25519.sharedKey(Buffer.from(privateKey), rawPublicKey));
+      return requireValidX25519SharedKey(
+        curve25519.sharedKey(Buffer.from(privateKey), rawPublicKey),
+      );
     },
 
     sign(privateKey: Uint8Array, message: Uint8Array): Buffer {
       return Buffer.from(curve25519.sign(Buffer.from(privateKey), Buffer.from(message)));
     },
   };
+}
+
+function requireValidX25519SharedKey(sharedKey: Uint8Array): Buffer {
+  const result = Buffer.from(sharedKey);
+  if (result.every((byte) => byte === 0)) {
+    throw new Error("X25519 failed during derivation for an invalid peer key.");
+  }
+  return result;
 }
 
 export const Curve = createCurve();

--- a/src/servers/whatsapp.ts
+++ b/src/servers/whatsapp.ts
@@ -151,21 +151,34 @@ async function appendEvent(state: WhatsAppServerState, event: ServerRequestEvent
   await recordServerEvent({ event, onEvent: state.onEvent, recorderPath: state.recorderPath });
 }
 
-function isWhatsAppJid(value: string): boolean {
+function isWhatsAppUserJid(value: string): boolean {
   return (
     WHATSAPP_USER_JID_RE.test(value) ||
     WHATSAPP_LEGACY_USER_JID_RE.test(value) ||
-    WHATSAPP_GROUP_JID_RE.test(value) ||
     WHATSAPP_LID_RE.test(value)
   );
 }
 
-function requireWhatsAppJid(value: unknown, label: string): string | Response {
+function requireWhatsAppChatJid(value: unknown): string | Response {
   const stringValue = readTrimmedString(value);
-  if (!stringValue || !isWhatsAppJid(stringValue)) {
+  if (
+    !stringValue ||
+    (!isWhatsAppUserJid(stringValue) && !WHATSAPP_GROUP_JID_RE.test(stringValue))
+  ) {
     return graphParameterError(
-      `(#100) Invalid parameter: ${label}`,
-      `${label} must be a WhatsApp JID such as 15551234567@s.whatsapp.net or 120363001234567890@g.us.`,
+      "(#100) Invalid parameter: chatJid",
+      "chatJid must be a WhatsApp user or group JID.",
+    );
+  }
+  return stringValue;
+}
+
+function requireWhatsAppSenderJid(value: unknown): string | Response {
+  const stringValue = readTrimmedString(value);
+  if (!stringValue || !isWhatsAppUserJid(stringValue)) {
+    return graphParameterError(
+      "(#100) Invalid parameter: senderJid",
+      "senderJid must be a WhatsApp user JID.",
     );
   }
   return stringValue;
@@ -184,9 +197,11 @@ function requireCloudRecipient(value: unknown): string | Response {
 
 function requireAuth(request: IncomingMessage, state: WhatsAppServerState): boolean {
   const authorization = request.headers.authorization;
-  return (
-    typeof authorization === "string" && authorization.trim() === `Bearer ${state.accessToken}`
-  );
+  if (typeof authorization !== "string") {
+    return false;
+  }
+  const match = /^Bearer +(.+)$/iu.exec(authorization.trimStart());
+  return match?.[1] === state.accessToken;
 }
 
 function nextMessageId(state: WhatsAppServerState): string {
@@ -195,6 +210,13 @@ function nextMessageId(state: WhatsAppServerState): string {
 
 function waIdFromJid(jid: string): string {
   return jid.split("@", 1)[0]?.split(":", 1)[0] ?? jid;
+}
+
+function directPeerIdentity(jid: string): string {
+  const separator = jid.lastIndexOf("@");
+  const user = jid.slice(0, separator).split(":", 1)[0] ?? jid;
+  const server = jid.slice(separator + 1);
+  return `${user}@${server === "c.us" ? "s.whatsapp.net" : server}`;
 }
 
 function requireMessagingProduct(body: Record<string, unknown>): Response | undefined {
@@ -210,7 +232,13 @@ function requireMessagingProduct(body: Record<string, unknown>): Response | unde
 
 function readTextMessageBody(body: Record<string, unknown>): string | Response {
   const type = readTrimmedString(body.type);
-  if (type && type !== "text") {
+  if (!type) {
+    return graphParameterError(
+      "(#100) Missing required parameter: type",
+      'A WhatsApp text send requires type to be "text".',
+    );
+  }
+  if (type !== "text") {
     return graphParameterError(
       "(#100) Unsupported message type",
       "This test API currently supports WhatsApp text message sends.",
@@ -318,13 +346,22 @@ async function handleAdminInbound(params: {
   body: Record<string, unknown>;
   state: WhatsAppServerState;
 }): Promise<WhatsAppAdminInboundResult> {
-  const chatJid = requireWhatsAppJid(params.body.chatJid ?? params.body.chatId, "chatJid");
+  const chatJid = requireWhatsAppChatJid(params.body.chatJid ?? params.body.chatId);
   if (chatJid instanceof Response) {
     return { response: chatJid };
   }
-  const senderJid = requireWhatsAppJid(params.body.senderJid ?? params.body.from, "senderJid");
+  const senderJid = requireWhatsAppSenderJid(params.body.senderJid ?? params.body.from);
   if (senderJid instanceof Response) {
     return { response: senderJid };
+  }
+  const isGroupChat = WHATSAPP_GROUP_JID_RE.test(chatJid);
+  if (!isGroupChat && directPeerIdentity(chatJid) !== directPeerIdentity(senderJid)) {
+    return {
+      response: graphParameterError(
+        "(#100) Invalid parameter: senderJid",
+        "senderJid must identify the direct chat peer.",
+      ),
+    };
   }
   const text = readMessageText(params.body.text);
   if (text === undefined) {
@@ -340,7 +377,7 @@ async function handleAdminInbound(params: {
     id: readTrimmedString(params.body.messageId) ?? nextMessageId(params.state),
     pushName: readTrimmedString(params.body.pushName) ?? "Test User",
     remoteJid: chatJid,
-    senderJid,
+    senderJid: isGroupChat ? senderJid : undefined,
     text,
   });
   const timestamp = String(message.messageTimestamp);
@@ -434,7 +471,7 @@ async function handleRequest(params: { request: IncomingMessage; state: WhatsApp
       throw error;
     }
     if (result.message && preparedDelivery) {
-      const delivery = preparedDelivery.commit();
+      const delivery = await preparedDelivery.commit();
       return whatsappOk({ delivery, message: result.message, webhook: result.webhook });
     }
     return graphParameterError("(#100) Invalid inbound WhatsApp event");
@@ -494,6 +531,9 @@ export async function startWhatsAppServer(
   params: StartWhatsAppServerParams = {},
 ): Promise<StartedWhatsAppServer> {
   const host = params.host ?? "127.0.0.1";
+  if (params.accessToken !== undefined && !params.accessToken.trim()) {
+    throw new Error("WhatsApp accessToken must not be empty.");
+  }
   const graphVersion = params.graphVersion ?? DEFAULT_GRAPH_VERSION;
   if (!WHATSAPP_GRAPH_VERSION_RE.test(graphVersion)) {
     throw new Error(`Invalid WhatsApp Graph API version: ${graphVersion}.`);

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -177,6 +177,9 @@ afterEach(async () => {
 
 describe("whatsapp local provider server", () => {
   it("validates inbound queue limits before binding the HTTP port", async () => {
+    await expect(startWhatsAppServer({ accessToken: "" })).rejects.toThrow(
+      "accessToken must not be empty",
+    );
     const port = await resolveFreePort();
     await expect(startWhatsAppServer({ maxPendingInboundMessages: 0, port })).rejects.toThrow(
       "must be a positive safe integer",
@@ -206,7 +209,7 @@ describe("whatsapp local provider server", () => {
     expect(baileysWebSocketUrl.searchParams.get("access_token")).toBe("fake-whatsapp-token");
     expect(server.manifest.endpoints.messagesUrl).toMatch(/\/v25\.0\/100000000000000\/messages$/u);
     const phoneNumber = await fetch(server.manifest.endpoints.phoneNumberUrl, {
-      headers: { authorization: "Bearer fake-whatsapp-token" },
+      headers: { authorization: "bearer fake-whatsapp-token" },
     });
     await expect(phoneNumber.json()).resolves.toMatchObject({
       display_phone_number: "15550000000",
@@ -271,6 +274,25 @@ describe("whatsapp local provider server", () => {
           messaging_product: "whatsapp",
         },
         type: "OAuthException",
+      },
+    });
+
+    const missingType = await fetch(server.manifest.endpoints.messagesUrl, {
+      body: JSON.stringify({
+        messaging_product: "whatsapp",
+        text: { body: "missing type" },
+        to: "15551234567",
+      }),
+      headers: {
+        authorization: "Bearer fake-whatsapp-token",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+    expect(missingType.status).toBe(400);
+    await expect(missingType.json()).resolves.toMatchObject({
+      error: {
+        message: "(#100) Missing required parameter: type",
       },
     });
 
@@ -399,6 +421,74 @@ describe("whatsapp local provider server", () => {
     const recorder = await fs.readFile(server.manifest.recorderPath, "utf8");
     expect(recorder).not.toContain("forged user nonce");
     expect(recorder).toContain('"path":"/_crabline/admin/whatsapp/inbound"');
+  });
+
+  it("enforces sender and chat JID roles for admin inbound messages", async () => {
+    const server = await startWhatsAppServer({ adminToken: "admin" });
+    servers.push(server);
+    const sendInbound = (body: Record<string, unknown>) =>
+      fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({ text: "identity check", ...body }),
+        headers: {
+          "content-type": "application/json",
+          [ADMIN_TOKEN_HEADER]: "admin",
+        },
+        method: "POST",
+      });
+
+    const groupSender = await sendInbound({
+      chatJid: "120363001234567890@g.us",
+      senderJid: "120363009876543210@g.us",
+    });
+    expect(groupSender.status).toBe(400);
+    await expect(groupSender.json()).resolves.toMatchObject({
+      error: { message: "(#100) Invalid parameter: senderJid" },
+    });
+
+    const mismatchedDirectSender = await sendInbound({
+      chatJid: "15551234567@s.whatsapp.net",
+      senderJid: "15557654321@s.whatsapp.net",
+    });
+    expect(mismatchedDirectSender.status).toBe(400);
+    await expect(mismatchedDirectSender.json()).resolves.toMatchObject({
+      error: { message: "(#100) Invalid parameter: senderJid" },
+    });
+
+    const mismatchedLidSender = await sendInbound({
+      chatJid: "15551234567@lid",
+      senderJid: "15551234567@s.whatsapp.net",
+    });
+    expect(mismatchedLidSender.status).toBe(400);
+
+    const direct = await sendInbound({
+      chatJid: "15551234567@c.us",
+      senderJid: "15551234567:2@s.whatsapp.net",
+    });
+    expect(direct.status).toBe(200);
+    const directBody = (await direct.json()) as {
+      message: { key: Record<string, unknown> };
+    };
+    expect(directBody).toMatchObject({
+      message: {
+        key: {
+          remoteJid: "15551234567@c.us",
+        },
+      },
+      webhook: {
+        entry: [
+          {
+            changes: [
+              {
+                value: {
+                  messages: [{ from: "15551234567" }],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    });
+    expect(directBody.message.key).not.toHaveProperty("participant");
   });
 
   it("authenticates Graph requests before reading or recording their bodies", async () => {
@@ -767,7 +857,7 @@ describe("whatsapp local provider server", () => {
     }
   });
 
-  it("releases inbound capacity when a live Baileys delivery throws", async () => {
+  it("queues inbound when a live Baileys delivery throws", async () => {
     const directory = await createTempDir();
     directories.push(directory);
     const server = await startWhatsAppServer({
@@ -811,7 +901,8 @@ describe("whatsapp local provider server", () => {
       });
 
       const failed = await sendInbound("failed live delivery");
-      expect(failed.status).toBe(500);
+      expect(failed.status).toBe(200);
+      await expect(failed.json()).resolves.toMatchObject({ delivery: "queued", ok: true });
       send.mockRestore();
       socket.end(undefined);
       await waitForCondition(
@@ -825,9 +916,8 @@ describe("whatsapp local provider server", () => {
         "Baileys connection close",
       );
 
-      const accepted = await sendInbound("accepted after failure");
-      expect(accepted.status).toBe(200);
-      await expect(accepted.json()).resolves.toMatchObject({ delivery: "queued", ok: true });
+      const rejected = await sendInbound("rejected after failure");
+      expect(rejected.status).toBe(503);
     } finally {
       socket.end(undefined);
     }

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -13,6 +13,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocket } from "ws";
 import { startWhatsAppServer, type StartedWhatsAppServer } from "../src/index.js";
 import { ADMIN_TOKEN_HEADER } from "../src/servers/http.js";
+import { MAX_WHATSAPP_WEBSOCKET_FRAGMENTS } from "../src/servers/whatsapp-baileys-websocket.js";
 import { createTempDir, disposeTempDir, requestHttp } from "./test-helpers.js";
 
 const servers: StartedWhatsAppServer[] = [];
@@ -646,6 +647,33 @@ describe("whatsapp local provider server", () => {
     const wrongTokenUrl = new URL(server.manifest.endpoints.baileysWebSocketUrl);
     wrongTokenUrl.searchParams.set("access_token", "wrong-token");
     await expect(expectWebSocketUpgradeRejected(wrongTokenUrl.toString())).resolves.toBeUndefined();
+  });
+
+  it("closes Baileys sockets that exceed the WebSocket fragment limit", async () => {
+    const server = await startWhatsAppServer();
+    servers.push(server);
+    const socket = new WebSocket(server.manifest.endpoints.baileysWebSocketUrl);
+    await new Promise<void>((resolve, reject) => {
+      socket.once("open", resolve);
+      socket.once("error", reject);
+    });
+    const closed = new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        socket.terminate();
+        reject(new Error("Expected fragmented WebSocket message to be rejected."));
+      }, 2_000);
+      socket.once("error", () => undefined);
+      socket.once("close", () => {
+        clearTimeout(timeout);
+        resolve();
+      });
+    });
+
+    for (let index = 0; index <= MAX_WHATSAPP_WEBSOCKET_FRAGMENTS; index += 1) {
+      socket.send(Buffer.from([index & 0xff]), { binary: true, fin: false });
+    }
+
+    await expect(closed).resolves.toBeUndefined();
   });
 
   it("accepts a real Baileys socket over waWebSocketUrl and records outbound stanzas", async () => {

--- a/test/whatsapp-wire.test.ts
+++ b/test/whatsapp-wire.test.ts
@@ -1,6 +1,7 @@
 import { deflateSync } from "node:zlib";
 import { Curve as BaileysCurve } from "baileys";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { WebSocket } from "ws";
 import {
   decodeBinaryNode,
   encodeBinaryNode,
@@ -15,10 +16,18 @@ import {
   createCurve,
   Curve,
   encodeBigEndian,
+  NOISE_WA_HEADER,
 } from "../src/servers/whatsapp-wire/crypto.js";
 import { decodeHandshakeMessage } from "../src/servers/whatsapp-wire/handshake.js";
 import {
   createSerializedMessageHandler,
+  MAX_WHATSAPP_NOISE_BUFFER_CHUNKS,
+  MAX_WHATSAPP_NOISE_FRAME_BYTES,
+  MAX_WHATSAPP_WEBSOCKET_BUFFERED_BYTES,
+  parseWhatsAppWebSocketUpgradeUrl,
+  sendWhatsAppWebSocketPayload,
+  WHATSAPP_WEBSOCKET_SEND_TIMEOUT_MS,
+  WhatsAppNoiseFrameDecoder,
   WhatsAppSignalBundleStore,
 } from "../src/servers/whatsapp-baileys-websocket.js";
 
@@ -78,6 +87,27 @@ describe("WhatsApp X25519 agreement", () => {
       curve.sharedKey(bob.private, alice.public),
     );
     expect(nativeSharedKeyCalls).toBe(0);
+  });
+
+  it("rejects low-order peers when the JS backend derives an all-zero secret", () => {
+    const curve = createCurve({
+      generateKeyPair() {
+        throw new Error("native X25519 unavailable");
+      },
+      sharedKey() {
+        throw new Error("native shared key should not run");
+      },
+    });
+    curve.generateKeyPair();
+    const lowOrderPeer = Buffer.alloc(32);
+    lowOrderPeer[0] = 1;
+
+    expect(() => curve.sharedKey(RFC_7748_ALICE_PRIVATE, lowOrderPeer)).toThrow(
+      "failed during derivation",
+    );
+    expect(() =>
+      curve.sharedKey(RFC_7748_ALICE_PRIVATE, Buffer.concat([Buffer.from([5]), lowOrderPeer])),
+    ).toThrow("failed during derivation");
   });
 });
 
@@ -150,6 +180,145 @@ describe("WhatsApp WebSocket message processing", () => {
     await Promise.all([first, second]);
 
     expect(events).toEqual(["start:1", "end:1", "start:2", "end:2"]);
+  });
+
+  it("closes a serialized handler when its bounded backlog is exceeded", async () => {
+    let releaseFirstFrame: () => void = () => undefined;
+    let markFirstFrameStarted: () => void = () => undefined;
+    const firstFrameBlocked = new Promise<void>((resolve) => {
+      releaseFirstFrame = resolve;
+    });
+    const firstFrameStarted = new Promise<void>((resolve) => {
+      markFirstFrameStarted = resolve;
+    });
+    const errors: unknown[] = [];
+    const processed: number[] = [];
+    const handleMessage = createSerializedMessageHandler<Buffer>(
+      async (frame) => {
+        processed.push(frame[0]!);
+        markFirstFrameStarted();
+        await firstFrameBlocked;
+      },
+      (error) => errors.push(error),
+      {
+        maxPendingBytes: 2,
+        maxPendingMessages: 2,
+        sizeOf: (frame) => frame.byteLength,
+      },
+    );
+
+    const first = handleMessage(Buffer.from([1]));
+    await firstFrameStarted;
+    const second = handleMessage(Buffer.from([2]));
+    const overflow = handleMessage(Buffer.from([3]));
+
+    expect(errors).toEqual([
+      expect.objectContaining({ message: expect.stringContaining("backlog") }),
+    ]);
+    releaseFirstFrame();
+    await Promise.all([first, second, overflow]);
+    expect(processed).toEqual([1]);
+  });
+
+  it("decodes fragmented Noise frames without retaining concatenated input", () => {
+    const decoder = new WhatsAppNoiseFrameDecoder();
+    const frames = [Buffer.from([0, 0, 3, 1, 2, 3]), Buffer.from([0, 0, 2, 4, 5])];
+    const input = Buffer.concat([NOISE_WA_HEADER, ...frames]);
+    const decoded = [
+      ...decoder.decodeFrames(input.subarray(0, 6)),
+      ...decoder.decodeFrames(input.subarray(6, 10)),
+      ...decoder.decodeFrames(input.subarray(10)),
+    ];
+
+    expect(decoded).toEqual([Buffer.from([1, 2, 3]), Buffer.from([4, 5])]);
+    expect(decoder.bufferedBytes).toBe(0);
+  });
+
+  it("rejects Noise frames above the stable frame limit", () => {
+    const decoder = new WhatsAppNoiseFrameDecoder();
+    const size = MAX_WHATSAPP_NOISE_FRAME_BYTES + 1;
+    const prefix = Buffer.from([(size >>> 16) & 0xff, (size >>> 8) & 0xff, size & 0xff]);
+
+    expect(() => decoder.decodeFrames(Buffer.concat([NOISE_WA_HEADER, prefix]))).toThrow(
+      `exceeds ${MAX_WHATSAPP_NOISE_FRAME_BYTES} bytes`,
+    );
+  });
+
+  it("rejects excessive fragmented Noise buffering", () => {
+    const decoder = new WhatsAppNoiseFrameDecoder();
+    decoder.decodeFrames(Buffer.concat([NOISE_WA_HEADER, Buffer.from([0, 0x08, 0])]));
+    for (let index = 1; index < MAX_WHATSAPP_NOISE_BUFFER_CHUNKS; index += 1) {
+      decoder.decodeFrames(Buffer.from([index & 0xff]));
+    }
+
+    expect(() => decoder.decodeFrames(Buffer.from([0]))).toThrow(
+      `exceeds ${MAX_WHATSAPP_NOISE_BUFFER_CHUNKS} chunks`,
+    );
+  });
+
+  it("waits for WebSocket writes and rejects buffered payloads", async () => {
+    let completeWrite: ((error?: Error) => void) | undefined;
+    const send = vi.fn((_payload: unknown, callback: (error?: Error) => void) => {
+      completeWrite = callback;
+    });
+    const terminate = vi.fn();
+    const socket = {
+      bufferedAmount: 0,
+      readyState: WebSocket.OPEN,
+      send,
+      terminate,
+    } as unknown as Parameters<typeof sendWhatsAppWebSocketPayload>[0];
+    let completed = false;
+    const write = sendWhatsAppWebSocketPayload(socket, Buffer.from("payload")).then(() => {
+      completed = true;
+    });
+
+    await Promise.resolve();
+    expect(completed).toBe(false);
+    completeWrite?.();
+    await write;
+    expect(completed).toBe(true);
+
+    const backedUpSocket = {
+      ...socket,
+      bufferedAmount: MAX_WHATSAPP_WEBSOCKET_BUFFERED_BYTES,
+    };
+    await expect(sendWhatsAppWebSocketPayload(backedUpSocket, Buffer.from([1]))).rejects.toThrow(
+      "outbound buffer limit",
+    );
+    expect(terminate).toHaveBeenCalledOnce();
+  });
+
+  it("terminates WebSocket writes that never complete", async () => {
+    vi.useFakeTimers();
+    try {
+      const terminate = vi.fn();
+      const socket = {
+        bufferedAmount: 0,
+        readyState: WebSocket.OPEN,
+        send: vi.fn(),
+        terminate,
+      } as unknown as Parameters<typeof sendWhatsAppWebSocketPayload>[0];
+      const write = sendWhatsAppWebSocketPayload(socket, Buffer.from("payload")).then(
+        () => ({ error: undefined }),
+        (error: unknown) => ({ error }),
+      );
+
+      await vi.advanceTimersByTimeAsync(WHATSAPP_WEBSOCKET_SEND_TIMEOUT_MS);
+      await expect(write).resolves.toEqual({
+        error: expect.objectContaining({ message: "WhatsApp WebSocket send timed out." }),
+      });
+      expect(terminate).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("rejects malformed absolute WebSocket request targets", () => {
+    expect(parseWhatsAppWebSocketUpgradeUrl("http://[invalid")).toBeUndefined();
+    expect(parseWhatsAppWebSocketUpgradeUrl("/ws/chat?access_token=fake")?.pathname).toBe(
+      "/ws/chat",
+    );
   });
 });
 

--- a/test/whatsapp-wire.test.ts
+++ b/test/whatsapp-wire.test.ts
@@ -23,6 +23,7 @@ import {
   createSerializedMessageHandler,
   MAX_WHATSAPP_NOISE_BUFFER_CHUNKS,
   MAX_WHATSAPP_NOISE_FRAME_BYTES,
+  MAX_WHATSAPP_NOISE_FRAMES_PER_MESSAGE,
   MAX_WHATSAPP_WEBSOCKET_BUFFERED_BYTES,
   parseWhatsAppWebSocketUpgradeUrl,
   sendWhatsAppWebSocketPayload,
@@ -241,6 +242,15 @@ describe("WhatsApp WebSocket message processing", () => {
 
     expect(() => decoder.decodeFrames(Buffer.concat([NOISE_WA_HEADER, prefix]))).toThrow(
       `exceeds ${MAX_WHATSAPP_NOISE_FRAME_BYTES} bytes`,
+    );
+  });
+
+  it("rejects excessive Noise frame counts in one message", () => {
+    const decoder = new WhatsAppNoiseFrameDecoder();
+    const emptyFrames = Buffer.alloc((MAX_WHATSAPP_NOISE_FRAMES_PER_MESSAGE + 1) * 3);
+
+    expect(() => decoder.decodeFrames(Buffer.concat([NOISE_WA_HEADER, emptyFrames]))).toThrow(
+      `exceeds ${MAX_WHATSAPP_NOISE_FRAMES_PER_MESSAGE} frames`,
     );
   });
 


### PR DESCRIPTION
## Summary
- bound WebSocket, Noise frame, queue, and signal-bundle resources while preserving serialized delivery
- validate native auth and JID roles, reject invalid X25519 peers, and close rejected upgrades cleanly
- keep public package declarations independent of dev-only `@types/ws`
- add live fragmentation, transport, crypto, queue, and production-package regression coverage
- document the user-visible WhatsApp fidelity hardening in the changelog

## Verification
- `pnpm exec vitest run test/whatsapp-server.test.ts test/whatsapp-wire.test.ts test/package-production.test.ts` (46 tests)
- `pnpm lint`
- `pnpm build`
- autoreview: `gpt-5.6-sol`, high reasoning, clean on `fbde47fabe788df3aef04cde8e3facee00946bfe`
- Crabbox `run_2f197da0fc8d`: exact source `fbde47fabe788df3aef04cde8e3facee00946bfe`, full `pnpm verify`, 52 files / 599 tests, exit 0