### PR TITLE
fix(providers): preserve Matrix and Signal delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bound signed-JWT key refreshes and authenticate, decode, or suppress Google Chat, Teams, Feishu, and Discord webhook ingress according to provider contracts.
 - Bound recorder tail memory, harden shared provider cleanup and inbound matching, and reject non-global webhook targets.
+- Recover backpressured Signal events without recording rejected RPC calls.
 - Preserve bounded Matrix transaction replay and limited-sync state, and honor environment identity.
 - Harden release, CI, config, CLI, package, and OpenClaw artifact and process-identity boundaries.
 - Restore provider-native callbacks and authentication, preserve conversation targets and recorder progress, and harden local mock lifecycle and parsing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bound signed-JWT key refreshes and authenticate, decode, or suppress Google Chat, Teams, Feishu, and Discord webhook ingress according to provider contracts.
 - Bound recorder tail memory, harden shared provider cleanup and inbound matching, and reject non-global webhook targets.
+- Preserve bounded Matrix transaction replay and limited-sync state, and honor environment identity.
 - Harden release, CI, config, CLI, package, and OpenClaw artifact and process-identity boundaries.
 - Restore provider-native callbacks and authentication, preserve conversation targets and recorder progress, and harden local mock lifecycle and parsing.
 - Preserve native server sync, webhook, request-validation, backpressure, and shutdown semantics across Matrix, Mattermost, Signal, Slack, Telegram, and Zalo.

--- a/src/providers/builtin/matrix.ts
+++ b/src/providers/builtin/matrix.ts
@@ -26,7 +26,7 @@ export function resolveMatrixAdapterConfig(
     auth: config.matrix?.auth ?? {
       accessToken: env.MATRIX_ACCESS_TOKEN ?? "local-mock-matrix-token",
       type: "accessToken" as const,
-      userID: `@${userName}:matrix.local`,
+      userID: env.MATRIX_USER_ID?.trim() || `@${userName}:matrix.local`,
     },
     baseURL: config.matrix?.baseURL ?? env.MATRIX_BASE_URL ?? "http://matrix.local",
     commandPrefix: config.matrix?.commandPrefix,

--- a/src/servers/matrix.ts
+++ b/src/servers/matrix.ts
@@ -38,6 +38,7 @@ type MatrixRoom = {
   lastDroppedTimelineSequence: number | undefined;
   name: string;
   state: MatrixEvent[];
+  stateBeforeTimeline: Map<string, MatrixEvent>;
   timeline: Array<{ sequence: number; event: MatrixEvent }>;
   typingTimeouts: Map<string, NodeJS.Timeout>;
   typingUsers: Set<string>;
@@ -46,6 +47,7 @@ type MatrixRoom = {
 
 type MatrixTransactionResponse = {
   body: Record<string, unknown>;
+  expiresAt: number;
   status: number;
 };
 
@@ -68,7 +70,15 @@ type MatrixServerState = {
 
 const MAX_MATRIX_TIMELINE_EVENTS = 1_000;
 const MAX_MATRIX_TRANSACTION_RESPONSES = 1_000;
+const MATRIX_TRANSACTION_RETENTION_MS = 10 * 60_000;
 const MAX_NODE_TIMER_DELAY_MS = 2_147_483_647;
+
+class InvalidMatrixPathEncodingError extends Error {
+  constructor() {
+    super("Matrix request path contains invalid percent encoding.");
+    this.name = "InvalidMatrixPathEncodingError";
+  }
+}
 
 export type MatrixServerManifest = {
   accessToken: string;
@@ -125,6 +135,14 @@ function authorized(request: IncomingMessage, token: string): boolean {
 
 function matrixError(errcode: string, error: string, status: number): Response {
   return jsonResponse({ errcode, error }, status);
+}
+
+function decodeMatrixPathSegment(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    throw new InvalidMatrixPathEncodingError();
+  }
 }
 
 function eventId(state: MatrixServerState): string {
@@ -189,6 +207,7 @@ function createRoom(params: {
     lastDroppedTimelineSequence: undefined,
     name: params.name,
     state: [],
+    stateBeforeTimeline: new Map(),
     timeline: [],
     typingTimeouts: new Map(),
     typingUsers: new Set(),
@@ -224,7 +243,14 @@ function createRoom(params: {
       type: "m.room.name",
     }),
   );
+  for (const event of room.state) {
+    room.stateBeforeTimeline.set(matrixStateKey(event), event);
+  }
   return room;
+}
+
+function matrixStateKey(event: MatrixEvent): string {
+  return JSON.stringify([event.type, event.state_key ?? ""]);
 }
 
 function appendTimelineEvent(
@@ -235,6 +261,11 @@ function appendTimelineEvent(
   if (room.timeline.length > MAX_MATRIX_TIMELINE_EVENTS) {
     const dropped = room.timeline.splice(0, room.timeline.length - MAX_MATRIX_TIMELINE_EVENTS);
     room.lastDroppedTimelineSequence = dropped.at(-1)?.sequence;
+    for (const droppedEntry of dropped) {
+      if (droppedEntry.event.state_key !== undefined) {
+        room.stateBeforeTimeline.set(matrixStateKey(droppedEntry.event), droppedEntry.event);
+      }
+    }
   }
 }
 
@@ -264,18 +295,40 @@ function rememberTransaction(
   key: string,
   response: MatrixTransactionResponse,
 ): void {
+  forgetExpiredTransactions(state);
   state.transactions.set(key, response);
+  while (state.transactions.size > MAX_MATRIX_TRANSACTION_RESPONSES) {
+    const oldestKey = state.transactions.keys().next().value;
+    if (oldestKey === undefined) {
+      break;
+    }
+    state.transactions.delete(oldestKey);
+  }
 }
 
-function matrixTransactionCapacityError(): Response {
-  return jsonResponse(
-    {
-      admin_contact: "mailto:admin@example.invalid",
-      errcode: "M_RESOURCE_LIMIT_EXCEEDED",
-      error: "Transaction response capacity has been reached",
-    },
-    503,
-  );
+function forgetExpiredTransactions(state: MatrixServerState): void {
+  const now = Date.now();
+  for (const [key, response] of state.transactions) {
+    if (response.expiresAt > now) {
+      break;
+    }
+    state.transactions.delete(key);
+  }
+}
+
+function transactionResponse(
+  state: MatrixServerState,
+  key: string,
+): MatrixTransactionResponse | undefined {
+  forgetExpiredTransactions(state);
+  const response = state.transactions.get(key);
+  if (!response) {
+    return undefined;
+  }
+  state.transactions.delete(key);
+  response.expiresAt = Date.now() + MATRIX_TRANSACTION_RETENTION_MS;
+  state.transactions.set(key, response);
+  return response;
 }
 
 function readTimelineLimit(filter: Record<string, unknown> | undefined): number | undefined {
@@ -315,6 +368,19 @@ function syncRoom(room: MatrixRoom, since: number | undefined, timelineLimit: nu
   const historyWasTrimmed =
     room.lastDroppedTimelineSequence !== undefined &&
     (since === undefined || since < room.lastDroppedTimelineSequence);
+  const limited = historyWasTrimmed || timeline.length < available.length;
+  const omittedTimeline = available.slice(0, available.length - timeline.length);
+  const omittedState = new Map<string, MatrixEvent>();
+  if (historyWasTrimmed) {
+    for (const [key, event] of room.stateBeforeTimeline) {
+      omittedState.set(key, event);
+    }
+  }
+  for (const entry of omittedTimeline) {
+    if (entry.event.state_key !== undefined) {
+      omittedState.set(matrixStateKey(entry.event), entry.event);
+    }
+  }
   return {
     account_data: { events: [] },
     ephemeral: {
@@ -322,10 +388,17 @@ function syncRoom(room: MatrixRoom, since: number | undefined, timelineLimit: nu
         .filter((entry) => since === undefined || entry.sequence > since)
         .map((entry) => entry.event),
     },
-    state: { events: since === undefined || room.createdSequence > since ? room.state : [] },
+    state: {
+      events:
+        since === undefined || room.createdSequence > since
+          ? room.state
+          : limited
+            ? [...omittedState.values()]
+            : [],
+    },
     timeline: {
       events: timeline.map((entry) => entry.event),
-      limited: historyWasTrimmed || timeline.length < available.length,
+      limited,
       prev_batch: `s${firstSequence === undefined ? (since ?? 0) : firstSequence - 1}`,
     },
     unread_notifications: { highlight_count: 0, notification_count: 0 },
@@ -378,7 +451,7 @@ async function handleSync(url: URL, state: MatrixServerState): Promise<Response>
 }
 
 function findRoom(state: MatrixServerState, encodedRoomId: string): MatrixRoom | undefined {
-  return state.rooms.get(decodeURIComponent(encodedRoomId));
+  return state.rooms.get(decodeMatrixPathSegment(encodedRoomId));
 }
 
 async function handleAdminInbound(params: {
@@ -489,7 +562,7 @@ async function handleMatrixApi(params: {
   }
   let match = /^\/profile\/([^/]+)$/u.exec(relativePath);
   if (params.method === "GET" && match) {
-    const userId = decodeURIComponent(match[1]!);
+    const userId = decodeMatrixPathSegment(match[1]!);
     const member = [...params.state.rooms.values()]
       .map((room) => room.users.get(userId))
       .find((profile) => profile !== undefined);
@@ -510,7 +583,7 @@ async function handleMatrixApi(params: {
 
   match = /^\/user\/([^/]+)\/filter$/u.exec(relativePath);
   if (params.method === "POST" && match) {
-    const userId = decodeURIComponent(match[1]!);
+    const userId = decodeMatrixPathSegment(match[1]!);
     if (userId !== params.state.botUserId) {
       return matrixError("M_FORBIDDEN", "Cannot create a filter for another user", 403);
     }
@@ -521,11 +594,11 @@ async function handleMatrixApi(params: {
 
   match = /^\/user\/([^/]+)\/filter\/([^/]+)$/u.exec(relativePath);
   if (params.method === "GET" && match) {
-    const userId = decodeURIComponent(match[1]!);
+    const userId = decodeMatrixPathSegment(match[1]!);
     if (userId !== params.state.botUserId) {
       return matrixError("M_FORBIDDEN", "Cannot get filters for another user", 403);
     }
-    const filter = params.state.filters.get(decodeURIComponent(match[2]!));
+    const filter = params.state.filters.get(decodeMatrixPathSegment(match[2]!));
     return filter ? jsonResponse(filter) : matrixError("M_NOT_FOUND", "Unknown filter", 404);
   }
 
@@ -543,8 +616,8 @@ async function handleMatrixApi(params: {
     if (!room) {
       return matrixError("M_NOT_FOUND", "Unknown room", 404);
     }
-    const eventType = decodeURIComponent(match[2]!);
-    const stateKey = decodeURIComponent(match[3] ?? "");
+    const eventType = decodeMatrixPathSegment(match[2]!);
+    const stateKey = decodeMatrixPathSegment(match[3] ?? "");
     if (eventType === "m.room.name" && stateKey === "") {
       return jsonResponse({ name: room.name });
     }
@@ -564,18 +637,27 @@ async function handleMatrixApi(params: {
 
   match = /^\/rooms\/([^/]+)\/send\/([^/]+)\/([^/]+)$/u.exec(relativePath);
   if (params.method === "PUT" && match) {
-    const transactionKey = relativePath;
-    const existingResponse = params.state.transactions.get(transactionKey);
+    const roomId = decodeMatrixPathSegment(match[1]!);
+    const eventType = decodeMatrixPathSegment(match[2]!);
+    const transactionId = decodeMatrixPathSegment(match[3]!);
+    const transactionKey = JSON.stringify([
+      params.state.botUserId,
+      roomId,
+      eventType,
+      transactionId,
+    ]);
+    const existingResponse = transactionResponse(params.state, transactionKey);
     if (existingResponse) {
       return jsonResponse(existingResponse.body, existingResponse.status);
     }
-    if (params.state.transactions.size >= MAX_MATRIX_TRANSACTION_RESPONSES) {
-      return matrixTransactionCapacityError();
-    }
-    const room = findRoom(params.state, match[1]!);
+    const room = params.state.rooms.get(roomId);
     if (!room) {
       const body = { errcode: "M_NOT_FOUND", error: "Unknown room" };
-      rememberTransaction(params.state, transactionKey, { body, status: 404 });
+      rememberTransaction(params.state, transactionKey, {
+        body,
+        expiresAt: Date.now() + MATRIX_TRANSACTION_RETENTION_MS,
+        status: 404,
+      });
       return jsonResponse(body, 404);
     }
     const event = createEvent({
@@ -583,12 +665,16 @@ async function handleMatrixApi(params: {
       roomId: room.id,
       sender: params.state.botUserId,
       state: params.state,
-      transactionId: decodeURIComponent(match[3]!),
-      type: decodeURIComponent(match[2]!),
+      transactionId,
+      type: eventType,
     });
     appendTimelineEvent(room, { event, sequence: params.state.nextSequence++ });
     const body = { event_id: event.event_id };
-    rememberTransaction(params.state, transactionKey, { body, status: 200 });
+    rememberTransaction(params.state, transactionKey, {
+      body,
+      expiresAt: Date.now() + MATRIX_TRANSACTION_RETENTION_MS,
+      status: 200,
+    });
     notifySyncWaiters(params.state);
     return jsonResponse(body);
   }
@@ -599,7 +685,7 @@ async function handleMatrixApi(params: {
     if (!room) {
       return matrixError("M_NOT_FOUND", "Unknown room", 404);
     }
-    const userId = decodeURIComponent(match[2]!);
+    const userId = decodeMatrixPathSegment(match[2]!);
     if (userId !== params.state.botUserId) {
       return matrixError("M_FORBIDDEN", "Cannot set typing state for another user", 403);
     }
@@ -649,7 +735,7 @@ async function handleMatrixApi(params: {
     if (!room) {
       return matrixError("M_NOT_FOUND", "Unknown room", 404);
     }
-    const receiptEventId = decodeURIComponent(match[2]!);
+    const receiptEventId = decodeMatrixPathSegment(match[2]!);
     appendEphemeralEvent(room, {
       event: {
         content: {
@@ -716,6 +802,9 @@ export async function startMatrixServer(
       }
       if (error instanceof RequestBodyTooLargeError) {
         return matrixError("M_TOO_LARGE", "Request body is too large", 413);
+      }
+      if (error instanceof InvalidMatrixPathEncodingError) {
+        return matrixError("M_INVALID_PARAM", "Invalid request path encoding", 400);
       }
       return matrixError("M_UNKNOWN", "Internal server error", 500);
     },

--- a/src/servers/matrix.ts
+++ b/src/servers/matrix.ts
@@ -295,15 +295,7 @@ function rememberTransaction(
   key: string,
   response: MatrixTransactionResponse,
 ): void {
-  forgetExpiredTransactions(state);
   state.transactions.set(key, response);
-  while (state.transactions.size > MAX_MATRIX_TRANSACTION_RESPONSES) {
-    const oldestKey = state.transactions.keys().next().value;
-    if (oldestKey === undefined) {
-      break;
-    }
-    state.transactions.delete(oldestKey);
-  }
 }
 
 function forgetExpiredTransactions(state: MatrixServerState): void {
@@ -649,6 +641,9 @@ async function handleMatrixApi(params: {
     const existingResponse = transactionResponse(params.state, transactionKey);
     if (existingResponse) {
       return jsonResponse(existingResponse.body, existingResponse.status);
+    }
+    if (params.state.transactions.size >= MAX_MATRIX_TRANSACTION_RESPONSES) {
+      return matrixError("M_LIMIT_EXCEEDED", "Too many retained transaction responses", 429);
     }
     const room = params.state.rooms.get(roomId);
     if (!room) {

--- a/src/servers/signal.ts
+++ b/src/servers/signal.ts
@@ -40,6 +40,7 @@ type SignalClientBuffer = {
   bytes: number;
   draining: boolean;
   events: SignalSseChunk[];
+  inFlight: SignalSseChunk[];
 };
 type SignalSseChunk = {
   data: string;
@@ -50,6 +51,10 @@ const SIGNAL_CLI_SSE_KEEPALIVE_MS = 15_000;
 const DEFAULT_MAX_SIGNAL_SSE_CLIENTS = 32;
 const MAX_SIGNAL_SSE_BUFFER_BYTES = 2 * 1024 * 1024;
 type SignalSseWriteResult = "accepted" | "queued" | "rejected";
+type SignalRpcResult = {
+  record: boolean;
+  response: Response;
+};
 
 export type SignalServerManifest = {
   account: string;
@@ -111,18 +116,19 @@ function removeSignalClient(
   state.clients.delete(client);
   state.clientBuffers.delete(client);
   if (buffer) {
-    const undeliveredEvents = buffer.events.filter((event) => {
+    const undeliveredEvents = [...buffer.inFlight, ...buffer.events].filter((event) => {
       event.recipients?.delete(client);
       return event.sequence !== undefined && event.recipients?.size === 0;
     });
-    if (undeliveredEvents.length > 0) {
-      state.pendingEvents.push(
-        ...undeliveredEvents.filter((event) => !state.pendingEvents.includes(event)),
-      );
+    const restoredEvents = undeliveredEvents.filter(
+      (event) => !state.pendingEvents.includes(event),
+    );
+    if (restoredEvents.length > 0) {
+      state.pendingEvents.push(...restoredEvents);
       state.pendingEvents.sort(
         (left, right) => (left.sequence ?? Number.MAX_SAFE_INTEGER) - (right.sequence ?? 0),
       );
-      state.pendingEventBytes += undeliveredEvents.reduce(
+      state.pendingEventBytes += restoredEvents.reduce(
         (total, event) => total + Buffer.byteLength(event.data),
         0,
       );
@@ -146,6 +152,11 @@ function scheduleSignalDrain(state: SignalServerState, client: ServerResponse): 
   client.once("drain", () => {
     const current = state.clientBuffers.get(client);
     if (current) {
+      current.bytes -= current.inFlight.reduce(
+        (total, event) => total + Buffer.byteLength(event.data),
+        0,
+      );
+      current.inFlight.length = 0;
       current.draining = false;
       flushSignalClientEvents(state, client);
       const remaining = state.clientBuffers.get(client);
@@ -208,6 +219,10 @@ function writeSignalSse(
   const accepted = client.write(event.data);
   event.recipients?.add(client);
   if (!accepted) {
+    if (buffer) {
+      buffer.inFlight.push(event);
+      buffer.bytes += eventBytes;
+    }
     scheduleSignalDrain(state, client);
   }
   return "accepted";
@@ -224,7 +239,9 @@ function maxSignalClientBufferBytes(state: SignalServerState): number {
 function isSignalEventBuffered(state: SignalServerState, event: SignalSseChunk): boolean {
   return (
     state.pendingEvents.includes(event) ||
-    [...state.clientBuffers.values()].some((buffer) => buffer.events.includes(event))
+    [...state.clientBuffers.values()].some(
+      (buffer) => buffer.inFlight.includes(event) || buffer.events.includes(event),
+    )
   );
 }
 
@@ -236,7 +253,7 @@ function signalBufferedEventCount(state: SignalServerState): number {
     }
   }
   for (const buffer of state.clientBuffers.values()) {
-    for (const event of buffer.events) {
+    for (const event of [...buffer.inFlight, ...buffer.events]) {
       if (event.sequence !== undefined) {
         sequences.add(event.sequence);
       }
@@ -267,7 +284,7 @@ function replayExclusiveSignalEvents(state: SignalServerState, client: ServerRes
     if (owner === client) {
       continue;
     }
-    for (const event of buffer.events) {
+    for (const event of [...buffer.inFlight, ...buffer.events]) {
       if (
         event.sequence !== undefined &&
         event.recipients?.size === 1 &&
@@ -293,11 +310,12 @@ function flushSignalClientEvents(state: SignalServerState, client: ServerRespons
       break;
     }
     const event = buffer.events.shift()!;
-    buffer.bytes -= Buffer.byteLength(event.data);
     if (!client.write(event.data)) {
+      buffer.inFlight.push(event);
       scheduleSignalDrain(state, client);
       break;
     }
+    buffer.bytes -= Buffer.byteLength(event.data);
   }
 }
 
@@ -370,29 +388,47 @@ async function handleAdminInbound(params: {
 async function handleRpc(params: {
   body: Record<string, unknown>;
   state: SignalServerState;
-}): Promise<Response> {
+}): Promise<SignalRpcResult> {
   const method = readTrimmedString(params.body.method);
   if (!method) {
-    return rpcError(-32600, "Invalid Request", params.body.id);
+    return {
+      record: false,
+      response: rpcError(-32600, "Invalid Request", params.body.id),
+    };
   }
   if (params.body.jsonrpc !== "2.0") {
-    return rpcError(-32600, "Invalid Request", params.body.id);
+    return {
+      record: false,
+      response: rpcError(-32600, "Invalid Request", params.body.id),
+    };
   }
   if (method === "version") {
-    return rpcResponse(params.body.id, { version: "crabline-signal-1" });
+    return {
+      record: true,
+      response: rpcResponse(params.body.id, { version: "crabline-signal-1" }),
+    };
   }
   if (["send", "sendReaction", "sendReceipt", "sendTyping"].includes(method)) {
     if (!validSignalRpcParams(method, params.body.params)) {
-      return rpcError(-32602, "Invalid params", params.body.id);
+      return {
+        record: false,
+        response: rpcError(-32602, "Invalid params", params.body.id),
+      };
     }
     const timestamp = params.state.nextTimestamp++;
-    return rpcResponse(params.body.id, method === "sendTyping" ? {} : { timestamp });
+    return {
+      record: true,
+      response: rpcResponse(params.body.id, method === "sendTyping" ? {} : { timestamp }),
+    };
   }
-  return jsonResponse({
-    error: { code: -32601, message: `Method not found: ${method}` },
-    id: params.body.id ?? null,
-    jsonrpc: "2.0",
-  });
+  return {
+    record: false,
+    response: jsonResponse({
+      error: { code: -32601, message: `Method not found: ${method}` },
+      id: params.body.id ?? null,
+      jsonrpc: "2.0",
+    }),
+  };
 }
 
 function hasRecipients(params: Record<string, unknown>): boolean {
@@ -524,6 +560,7 @@ async function handleRequest(params: {
       bytes: 0,
       draining: false,
       events: [],
+      inFlight: [],
     });
     replayExclusiveSignalEvents(params.state, params.response);
     if (params.state.clients.has(params.response)) {
@@ -572,15 +609,18 @@ async function handleRequest(params: {
       await writeResponse(params.response, rpcError(-32600, "Invalid Request"));
       return;
     }
-    await appendEvent(params.state, {
-      at: new Date().toISOString(),
-      body,
-      method: "POST",
-      path: url.pathname,
-      query: queryRecord(url),
-      type: "api",
-    });
-    fetchResponse = await handleRpc({ body, state: params.state });
+    const rpc = await handleRpc({ body, state: params.state });
+    if (rpc.record) {
+      await appendEvent(params.state, {
+        at: new Date().toISOString(),
+        body,
+        method: "POST",
+        path: url.pathname,
+        query: queryRecord(url),
+        type: "api",
+      });
+    }
+    fetchResponse = rpc.response;
   } else {
     fetchResponse = new Response("not found", { status: 404 });
   }
@@ -632,12 +672,6 @@ export async function startSignalServer(
       }
     });
   });
-  const keepalive = setInterval(() => {
-    for (const client of state.clients) {
-      writeSignalSse(state, client, { data: ":\n" });
-    }
-  }, SIGNAL_CLI_SSE_KEEPALIVE_MS);
-  keepalive.unref();
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject);
     server.listen(params.port ?? 0, host, () => {
@@ -650,6 +684,12 @@ export async function startSignalServer(
     await closeServer(server);
     throw new Error("Unable to resolve Signal local server address.");
   }
+  const keepalive = setInterval(() => {
+    for (const client of state.clients) {
+      writeSignalSse(state, client, { data: ":\n" });
+    }
+  }, SIGNAL_CLI_SSE_KEEPALIVE_MS);
+  keepalive.unref();
   const baseUrl = `http://${host.includes(":") ? `[${host}]` : host}:${address.port}`;
   return {
     async close() {

--- a/test/matrix-provider.default-runtime.test.ts
+++ b/test/matrix-provider.default-runtime.test.ts
@@ -40,12 +40,12 @@ describe("matrix provider default runtime", () => {
 
   it("uses MATRIX_USER_ID for event attribution with environment auth", () => {
     const resolved = resolveMatrixAdapterConfig(createConfig(), "crabline", {
-      MATRIX_ACCESS_TOKEN: "env-access-token",
+      MATRIX_ACCESS_TOKEN: "test-token-placeholder",
       MATRIX_USER_ID: "@env-bot:example.com",
     });
 
     expect(resolved.auth).toEqual({
-      accessToken: "env-access-token",
+      accessToken: "test-token-placeholder",
       type: "accessToken",
       userID: "@env-bot:example.com",
     });

--- a/test/matrix-provider.default-runtime.test.ts
+++ b/test/matrix-provider.default-runtime.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { resolveMatrixAdapterConfig } from "../src/providers/builtin/matrix.js";
+import {
+  normalizeMatrixWebhookPayload,
+  resolveMatrixAdapterConfig,
+} from "../src/providers/builtin/matrix.js";
 import type { ProviderConfig } from "../src/config/schema.js";
 
 function createConfig(matrix?: Partial<NonNullable<ProviderConfig["matrix"]>>): ProviderConfig {
@@ -33,6 +36,31 @@ describe("matrix provider default runtime", () => {
       commandPrefix: undefined,
       recoveryKey: undefined,
     });
+  });
+
+  it("uses MATRIX_USER_ID for event attribution with environment auth", () => {
+    const resolved = resolveMatrixAdapterConfig(createConfig(), "crabline", {
+      MATRIX_ACCESS_TOKEN: "env-access-token",
+      MATRIX_USER_ID: "@env-bot:example.com",
+    });
+
+    expect(resolved.auth).toEqual({
+      accessToken: "env-access-token",
+      type: "accessToken",
+      userID: "@env-bot:example.com",
+    });
+    expect(
+      normalizeMatrixWebhookPayload(
+        {
+          content: { body: "environment bot reply", msgtype: "m.text" },
+          event_id: "$env-reply:example.com",
+          room_id: "!room:example.com",
+          sender: "@env-bot:example.com",
+          type: "m.room.message",
+        },
+        resolved.auth.userID,
+      ),
+    ).toMatchObject({ author: "assistant" });
   });
 
   it("preserves configured Matrix metadata when provided", () => {

--- a/test/matrix-server.test.ts
+++ b/test/matrix-server.test.ts
@@ -468,6 +468,46 @@ describe("Matrix local provider server", () => {
     });
   });
 
+  it("canonicalizes decoded transaction keys and rejects malformed path encoding", async () => {
+    const server = await startMatrixServer({
+      accessToken: "test-token-placeholder",
+      roomId: "!canonical:matrix.test",
+    });
+    servers.push(server);
+    const first = await fetch(
+      `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!canonical:matrix.test")}/send/m.room.%6dessage/canonical%2Dtransaction`,
+      {
+        body: JSON.stringify({ body: "canonical body", msgtype: "m.text" }),
+        headers: { ...auth("test-token-placeholder"), "content-type": "application/json" },
+        method: "PUT",
+      },
+    );
+    const firstBody = (await first.json()) as { event_id: string };
+    const replay = await fetch(
+      `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!canonical:matrix.test")}/send/m.room.message/canonical-transaction`,
+      {
+        body: JSON.stringify({ body: "must be ignored", msgtype: "m.text" }),
+        headers: { ...auth("test-token-placeholder"), "content-type": "application/json" },
+        method: "PUT",
+      },
+    );
+    await expect(replay.json()).resolves.toEqual(firstBody);
+
+    const malformed = await fetch(
+      `${server.manifest.endpoints.clientApiRoot}/rooms/%E0%A4%A/send/m.room.message/malformed`,
+      {
+        body: JSON.stringify({ body: "not sent", msgtype: "m.text" }),
+        headers: { ...auth("test-token-placeholder"), "content-type": "application/json" },
+        method: "PUT",
+      },
+    );
+    expect(malformed.status).toBe(400);
+    await expect(malformed.json()).resolves.toEqual({
+      errcode: "M_INVALID_PARAM",
+      error: "Invalid request path encoding",
+    });
+  });
+
   it("provisions direct rooms with native Matrix membership evidence", async () => {
     const directory = await createTempDir();
     directories.push(directory);
@@ -679,7 +719,65 @@ describe("Matrix local provider server", () => {
     });
   });
 
-  it("bounds timelines without evicting accepted transaction responses", async () => {
+  it("includes omitted state changes when an incremental timeline is limited", async () => {
+    const server = await startMatrixServer({
+      accessToken: "test-token-placeholder",
+      adminToken: "test-auth-token",
+    });
+    servers.push(server);
+    const roomId = "!limited-state:matrix.test";
+    const sendInbound = (senderName: string) =>
+      fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({
+          roomId,
+          senderId: "@alice:matrix.test",
+          senderName,
+          text: `hello from ${senderName}`,
+        }),
+        headers: {
+          "content-type": "application/json",
+          "x-crabline-admin-token": "test-auth-token",
+        },
+        method: "POST",
+      });
+    expect((await sendInbound("Alice")).status).toBe(200);
+    const initial = (await (
+      await fetch(server.manifest.endpoints.syncUrl, {
+        headers: auth("test-token-placeholder"),
+      })
+    ).json()) as { next_batch: string };
+    expect((await sendInbound("Alicia")).status).toBe(200);
+
+    const filter = encodeURIComponent(JSON.stringify({ room: { timeline: { limit: 1 } } }));
+    const sync = (await (
+      await fetch(
+        `${server.manifest.endpoints.syncUrl}?since=${initial.next_batch}&filter=${filter}`,
+        { headers: auth("test-token-placeholder") },
+      )
+    ).json()) as {
+      rooms: {
+        join: Record<
+          string,
+          {
+            state: { events: MatrixEvent[] };
+            timeline: { events: MatrixEvent[]; limited: boolean };
+          }
+        >;
+      };
+    };
+    const room = sync.rooms.join[roomId];
+    expect(room?.timeline.limited).toBe(true);
+    expect(room?.timeline.events).toHaveLength(1);
+    expect(room?.state.events).toContainEqual(
+      expect.objectContaining({
+        content: { displayname: "Alicia", membership: "join" },
+        state_key: "@alice:matrix.test",
+        type: "m.room.member",
+      }),
+    );
+  });
+
+  it("bounds timelines and retains recently replayed transactions", async () => {
     const server = await startMatrixServer({
       accessToken: "test-token-placeholder",
       roomId: "!bounded:matrix.test",
@@ -721,19 +819,24 @@ describe("Matrix local provider server", () => {
       }
     }
     expect(typingStatus).toBe(200);
-    const exhausted = await fetch(
-      `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!bounded:matrix.test")}/send/m.room.message/bounded-1000`,
+    const refreshed = await fetch(
+      `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!bounded:matrix.test")}/send/m.room.message/bounded-0`,
       {
-        body: JSON.stringify({ body: "over capacity", msgtype: "m.text" }),
+        body: JSON.stringify({ body: "transaction remains idempotent", msgtype: "m.text" }),
         headers: { ...auth("test-token-placeholder"), "content-type": "application/json" },
         method: "PUT",
       },
     );
-    expect(exhausted.status).toBe(503);
-    await expect(exhausted.json()).resolves.toMatchObject({
-      admin_contact: "mailto:admin@example.invalid",
-      errcode: "M_RESOURCE_LIMIT_EXCEEDED",
-    });
+    await expect(refreshed.json()).resolves.toEqual({ event_id: firstEventId });
+    const admitted = await fetch(
+      `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!bounded:matrix.test")}/send/m.room.message/bounded-1000`,
+      {
+        body: JSON.stringify({ body: "after capacity", msgtype: "m.text" }),
+        headers: { ...auth("test-token-placeholder"), "content-type": "application/json" },
+        method: "PUT",
+      },
+    );
+    expect(admitted.status).toBe(200);
     const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
       body: JSON.stringify({
         roomId: "!bounded:matrix.test",
@@ -764,7 +867,7 @@ describe("Matrix local provider server", () => {
     ).json()) as {
       rooms: { join: Record<string, { timeline: { limited: boolean } }> };
     };
-    expect(resumed.rooms.join["!bounded:matrix.test"]?.timeline.limited).toBe(false);
+    expect(resumed.rooms.join["!bounded:matrix.test"]?.timeline.limited).toBe(true);
 
     const retried = await fetch(
       `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!bounded:matrix.test")}/send/m.room.message/bounded-0`,

--- a/test/matrix-server.test.ts
+++ b/test/matrix-server.test.ts
@@ -784,6 +784,7 @@ describe("Matrix local provider server", () => {
     });
     servers.push(server);
     let firstEventId = "";
+    let secondEventId = "";
     let firstBatch = "";
     let typingStatus: number | undefined;
     for (let index = 0; index < 1_000; index += 1) {
@@ -817,6 +818,9 @@ describe("Matrix local provider server", () => {
         );
         typingStatus = typing.status;
       }
+      if (index === 1) {
+        secondEventId = body.event_id;
+      }
     }
     expect(typingStatus).toBe(200);
     const refreshed = await fetch(
@@ -836,20 +840,26 @@ describe("Matrix local provider server", () => {
         method: "PUT",
       },
     );
-    expect(admitted.status).toBe(200);
-    const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
-      body: JSON.stringify({
-        roomId: "!bounded:matrix.test",
-        senderId: server.manifest.botUserId,
-        text: "advance the bounded timeline",
-      }),
-      headers: new Headers([
-        ["content-type", "application/json"],
-        ["x-crabline-admin-token", server.manifest.adminToken],
-      ]),
-      method: "POST",
+    expect(admitted.status).toBe(429);
+    await expect(admitted.json()).resolves.toEqual({
+      errcode: "M_LIMIT_EXCEEDED",
+      error: "Too many retained transaction responses",
     });
-    expect(inbound.status).toBe(200);
+    for (const text of ["advance the bounded timeline", "overflow the bounded timeline"]) {
+      const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({
+          roomId: "!bounded:matrix.test",
+          senderId: server.manifest.botUserId,
+          text,
+        }),
+        headers: new Headers([
+          ["content-type", "application/json"],
+          ["x-crabline-admin-token", server.manifest.adminToken],
+        ]),
+        method: "POST",
+      });
+      expect(inbound.status).toBe(200);
+    }
 
     const sync = (await (
       await fetch(server.manifest.endpoints.syncUrl, { headers: auth("test-token-placeholder") })
@@ -878,5 +888,14 @@ describe("Matrix local provider server", () => {
       },
     );
     await expect(retried.json()).resolves.toEqual({ event_id: firstEventId });
+    const untouchedRetry = await fetch(
+      `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!bounded:matrix.test")}/send/m.room.message/bounded-1`,
+      {
+        body: JSON.stringify({ body: "transaction remains idempotent", msgtype: "m.text" }),
+        headers: { ...auth("test-token-placeholder"), "content-type": "application/json" },
+        method: "PUT",
+      },
+    );
+    await expect(untouchedRetry.json()).resolves.toEqual({ event_id: secondEventId });
   });
 });

--- a/test/signal-server.test.ts
+++ b/test/signal-server.test.ts
@@ -170,6 +170,21 @@ describe("signal local provider server", () => {
         jsonrpc: "2.0",
       });
     }
+    const invalidVersion = await fetch(server.manifest.endpoints.rpcUrl, {
+      body: JSON.stringify({
+        id: "invalid-jsonrpc-send",
+        jsonrpc: "1.0",
+        method: "send",
+        params: { message: "must not be recorded", recipient: ["+15551234567"] },
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    await expect(invalidVersion.json()).resolves.toEqual({
+      error: { code: -32600, message: "Invalid Request" },
+      id: "invalid-jsonrpc-send",
+      jsonrpc: "2.0",
+    });
 
     const rejected = await fetch(server.manifest.endpoints.adminInboundUrl, {
       body: JSON.stringify({ sourceNumber: "+15557654321", text: "nope" }),
@@ -205,6 +220,8 @@ describe("signal local provider server", () => {
 
     const recorded = await fs.readFile(recorderPath, "utf8");
     expect(recorded).toContain('"method":"send"');
+    expect(recorded).not.toContain("invalid-jsonrpc-send");
+    expect(recorded).not.toContain("must not be recorded");
     expect(recorded).toContain('"path":"/crabline/signal/inbound"');
   });
 
@@ -443,6 +460,69 @@ describe("signal local provider server", () => {
     }
   });
 
+  it("replays the first backpressured event exactly once after disconnect", async () => {
+    const server = await startSignalServer({ adminToken: "admin" });
+    servers.push(server);
+    const originalWrite = ServerResponse.prototype.write;
+    let backpressuredResponse: ServerResponse | undefined;
+    const write = vi.spyOn(ServerResponse.prototype, "write").mockImplementation(function (
+      this: ServerResponse,
+      ...args: Parameters<typeof originalWrite>
+    ) {
+      const accepted = Reflect.apply(originalWrite, this, args) as boolean;
+      if (
+        backpressuredResponse === undefined &&
+        typeof args[0] === "string" &&
+        args[0].includes("first backpressured event")
+      ) {
+        backpressuredResponse = this;
+        return false;
+      }
+      return accepted;
+    });
+    const firstController = new AbortController();
+    const secondController = new AbortController();
+    try {
+      const firstEvents = await fetch(server.manifest.endpoints.eventsUrl, {
+        signal: firstController.signal,
+      });
+      const sent = await fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({
+          sourceNumber: "+15557654321",
+          text: "first backpressured event",
+        }),
+        headers: {
+          "content-type": "application/json",
+          "x-crabline-admin-token": "admin",
+        },
+        method: "POST",
+      });
+      expect(sent.status).toBe(200);
+      await vi.waitFor(() => expect(backpressuredResponse).toBeDefined());
+      firstController.abort();
+      await firstEvents.body?.cancel().catch(() => undefined);
+
+      const secondEvents = await fetch(server.manifest.endpoints.eventsUrl, {
+        signal: secondController.signal,
+      });
+      const reader = secondEvents.body!.getReader();
+      const decoder = new TextDecoder();
+      let received = "";
+      while (!received.includes("first backpressured event")) {
+        const chunk = await reader.read();
+        if (chunk.done) {
+          break;
+        }
+        received += decoder.decode(chunk.value, { stream: true });
+      }
+      expect(received.match(/first backpressured event/gu)).toHaveLength(1);
+    } finally {
+      firstController.abort();
+      secondController.abort();
+      write.mockRestore();
+    }
+  });
+
   it("replays exclusively buffered events before newer broadcasts", async () => {
     const server = await startSignalServer({ adminToken: "admin" });
     servers.push(server);
@@ -512,7 +592,7 @@ describe("signal local provider server", () => {
   it("counts reconnectable client buffers against the pending event limit", async () => {
     const server = await startSignalServer({
       adminToken: "admin",
-      maxPendingInboundEvents: 1,
+      maxPendingInboundEvents: 2,
     });
     servers.push(server);
     const sendInbound = (text: string) =>
@@ -691,6 +771,19 @@ describe("signal local provider server", () => {
       expect(check.status).toBe(200);
     } finally {
       agent.destroy();
+    }
+  });
+
+  it("does not start the SSE keepalive when listen fails", async () => {
+    const occupied = await startSignalServer();
+    servers.push(occupied);
+    const port = Number(new URL(occupied.manifest.baseUrl).port);
+    const setInterval = vi.spyOn(globalThis, "setInterval");
+    try {
+      await expect(startSignalServer({ port })).rejects.toMatchObject({ code: "EADDRINUSE" });
+      expect(setInterval).not.toHaveBeenCalled();
+    } finally {
+      setInterval.mockRestore();
     }
   });
 });


### PR DESCRIPTION
## Summary
- bound Matrix transaction replay while preserving recent idempotency and sync state
- honor configured Matrix user identity and decode canonical client routes safely
- preserve accepted Signal SSE delivery under backpressure and avoid recording rejected RPC calls

## Validation
- `pnpm exec vitest run --configLoader runner test/matrix-provider.default-runtime.test.ts test/matrix-server.test.ts test/signal-server.test.ts` (33 tests)
- Crabbox `pnpm verify` (604 tests, run `run_3a610c05d983`)
- gpt-5.6-sol high autoreview pending before merge

## Release notes
- includes `CHANGELOG.md` entry