### PR TITLE
fix(providers): preserve WhatsApp and Zalo delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Validate Mattermost roots, direct users, typing, and post ownership before mutation or delivery.
 - Enforce safe Telegram identities while acknowledging valid unsupported updates.
 - Align Slack callback, thread-history, and message-text behavior with its native protocol.
+- Canonicalize WhatsApp identities and accepted-send evidence, make webhook batches atomic and retry-idempotent, and preserve Zalo updates across disconnects and concurrent polls.
 - Harden release, CI, config, CLI, package, and OpenClaw artifact and process-identity boundaries.
 - Restore provider-native callbacks and authentication, preserve conversation targets and recorder progress, and harden local mock lifecycle and parsing.
 - Preserve native server sync, webhook, request-validation, backpressure, and shutdown semantics across Matrix, Mattermost, Signal, Slack, Telegram, and Zalo.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Validate Mattermost roots, direct users, typing, and post ownership before mutation or delivery.
 - Enforce safe Telegram identities while acknowledging valid unsupported updates.
 - Align Slack callback, thread-history, and message-text behavior with its native protocol.
-- Canonicalize WhatsApp identities and accepted-send evidence, make webhook batches atomic and retry-idempotent, and preserve Zalo updates across disconnects and concurrent polls.
+- Canonicalize WhatsApp identities and accepted-send evidence, publish webhook batches atomically with bounded retry deduplication, and preserve Zalo updates across disconnects and concurrent polls.
 - Harden release, CI, config, CLI, package, and OpenClaw artifact and process-identity boundaries.
 - Restore provider-native callbacks and authentication, preserve conversation targets and recorder progress, and harden local mock lifecycle and parsing.
 - Preserve native server sync, webhook, request-validation, backpressure, and shutdown semantics across Matrix, Mattermost, Signal, Slack, Telegram, and Zalo.

--- a/README.md
+++ b/README.md
@@ -272,7 +272,8 @@ The JSON manifest contains:
 - `accessToken`: bearer token for local provider requests
 - `adminToken`: send this as the `X-Crabline-Admin-Token` header when posting
   test user messages
-- `selfJid`: local authenticated WhatsApp user JID
+- `selfJid`: canonical local authenticated WhatsApp user JID; legacy `@c.us`
+  input is normalized to `@s.whatsapp.net`
 - `env.CLOUD_API_ACCESS_TOKEN`: same value as `accessToken`
 - `env.CLOUD_API_VERSION`: Graph API version used by the local server
 - `env.WA_BASE_URL`: local Graph API origin
@@ -319,7 +320,8 @@ single-update long polling through `getUpdates`, `sendMessage`, `sendPhoto`,
 `sendChatAction`, and webhook registration, inspection, and deletion. These Bot
 API methods accept GET query parameters or POST requests. Admin
 ingress injects a native Zalo update into the active polling or webhook
-transport. OpenClaw-specific endpoint, config, and target mapping remain in the
+transport. Webhook delivery posts the native `{ event_name, message }` update
+directly. OpenClaw-specific endpoint, config, and target mapping remain in the
 isolated bridge.
 
 The admin ingress accepts JSON like:

--- a/README.md
+++ b/README.md
@@ -409,6 +409,11 @@ and `agent` modes, the local mock also records a deterministic assistant reply:
 live service latency, external credentials, webhooks exposed to the internet, or
 provider SDK state.
 
+Recorder files remain JSONL. Individual events use one object per line; an
+accepted multi-message webhook is committed as one versioned batch object so
+readers never observe a partial batch. Crabline's recorder APIs flatten those
+batch objects back into their individual events.
+
 ## More Setup Detail
 
 See [Channel Setup](docs/channel-setup.md) for the provider matrix, webhook

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -336,7 +336,8 @@ Manifest fields:
 - `endpoints.messagesUrl`: provider-native Cloud API message and status endpoint
 - `endpoints.statusUrl`: alias for the same provider-native status endpoint
 - `recorderPath`: JSONL provider traffic recorder for HTTP traffic and Baileys
-  WebSocket stanzas
+  WebSocket stanzas. Multi-message webhook deliveries use one versioned batch
+  line that Crabline's recorder APIs flatten into individual events.
 
 Pass `endpoints.baileysWebSocketUrl` to Baileys as `waWebSocketUrl` when a
 runtime needs to connect through the local provider. Cloud API-compatible

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -325,7 +325,8 @@ Manifest fields:
   `waWebSocketUrl`, including the local provider access token query parameter
 - `accessToken`: bearer token for local provider requests
 - `adminToken`: value for the `X-Crabline-Admin-Token` header on admin ingress
-- `selfJid`: local authenticated WhatsApp user JID
+- `selfJid`: canonical local authenticated WhatsApp user JID; legacy `@c.us`
+  input is normalized to `@s.whatsapp.net`
 - `env.CLOUD_API_ACCESS_TOKEN`: same value as `accessToken`
 - `env.CLOUD_API_VERSION`: Graph API version used by the local server
 - `env.WA_BASE_URL`: local Graph API origin
@@ -379,7 +380,7 @@ adapter.
 The server accepts the provider-native `/bot<TOKEN>/<METHOD>` API shape over
 GET or POST. It implements bot identity, single-update long polling, text and
 photo sends, chat actions, and webhook lifecycle calls. A configured webhook
-receives the native Zalo `{ ok, result }` event envelope with
+receives the native Zalo `{ event_name, message }` update directly with
 `X-Bot-Api-Secret-Token`;
 otherwise injected messages are returned by `getUpdates`. Provider errors use
 Zalo's `{ ok, error_code, description }` shape.
@@ -447,6 +448,7 @@ as `telegram:`, `discord:`, or `slack:`.
 - Built-in WhatsApp Cloud API users: digits-only `wa_id` values such as
   `15551234567`
 - OpenClaw WhatsApp bridge users: `15551234567@s.whatsapp.net`
+  (legacy `15551234567@c.us` inputs are accepted and canonicalized)
 - OpenClaw WhatsApp bridge groups: `120363001234567890@g.us`
 - Discord channels and threads: Discord snowflake ids such as
   `123456789012345678`

--- a/src/openclaw/bridges/whatsapp.ts
+++ b/src/openclaw/bridges/whatsapp.ts
@@ -7,16 +7,19 @@ import {
   readNonBlankString,
   readString,
 } from "../shared.js";
+import {
+  canonicalizeWhatsAppChatJid,
+  canonicalizeWhatsAppUserJid,
+} from "../../servers/whatsapp-jid.js";
 
-const WHATSAPP_JID_RE =
-  /^(?:\d{7,15}(?::\d+)?@s\.whatsapp\.net|\d{7,15}@c\.us|\d{5,20}(?:-\d{5,20})?@g\.us|\d{7,15}@lid)$/iu;
-
-function requireWhatsAppJid(value: string, label: string): string {
-  const trimmed = value.trim();
-  if (!WHATSAPP_JID_RE.test(trimmed)) {
+function requireWhatsAppJid(value: string, label: string, userOnly = false): string {
+  const canonical = userOnly
+    ? canonicalizeWhatsAppUserJid(value)
+    : canonicalizeWhatsAppChatJid(value);
+  if (!canonical) {
     throw new Error(`${label} must be a native WhatsApp JID.`);
   }
-  return trimmed;
+  return canonical;
 }
 
 function requireWhatsAppTargetKind(
@@ -109,7 +112,7 @@ export const WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
           throw new Error("WhatsApp does not support thread targets.");
         }
         const chatJid = requireWhatsAppJid(input.conversation.id, "WhatsApp conversation");
-        const senderJid = requireWhatsAppJid(input.senderId, "WhatsApp sender");
+        const senderJid = requireWhatsAppJid(input.senderId, "WhatsApp sender", true);
         return {
           ...createAdminInboundRequest(whatsapp),
           providerBody: {
@@ -119,7 +122,10 @@ export const WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
             text: input.text,
           },
           providerTargetKey: chatJid,
-          qaTarget: qaTargetForInbound(input),
+          qaTarget: qaTargetForInbound({
+            ...input,
+            conversation: { ...input.conversation, id: chatJid },
+          }),
           stateConversation: {
             id: chatJid,
             kind: chatJid.endsWith("@g.us") ? "group" : "direct",
@@ -127,7 +133,12 @@ export const WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
         };
       },
       createOutboundFromRecorderEvent({ event, targetByProviderTarget }) {
-        if (!isRecord(event) || event.type !== "api" || typeof event.path !== "string") {
+        if (
+          !isRecord(event) ||
+          event.type !== "api" ||
+          event.accepted !== true ||
+          typeof event.path !== "string"
+        ) {
           return null;
         }
         if (event.path !== messagesPath || !isRecord(event.body)) {

--- a/src/providers/builtin/whatsapp.ts
+++ b/src/providers/builtin/whatsapp.ts
@@ -5,7 +5,7 @@ import { matchesInbound } from "../../core/matcher.js";
 import type { ProviderConfig } from "../../config/schema.js";
 import { LocalMockProviderAdapter, type LocalMockWebhookConfig } from "../local-mock.js";
 import {
-  appendRecordedInbound,
+  appendRecordedInboundBatch,
   cloneRecordedInboundCursor,
   createRecordedInboundCursor,
   waitForRecordedInbound,
@@ -43,10 +43,12 @@ type NormalizedWhatsAppWebhookMessage = {
     authorIsBot?: boolean;
     id?: string;
     raw?: unknown;
+    sentAt?: string;
     text?: string;
     threadId?: string;
   };
   raw?: unknown;
+  sentAt?: string;
   text?: string;
   threadId?: string;
 };
@@ -98,6 +100,7 @@ function pruneInactiveWaitCursors(cursors: Map<string, WaitCursorState>): void {
 
 export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   readonly #config: ProviderConfig;
+  readonly #lifecycleAbort = new AbortController();
   readonly #publicUrl: string | undefined;
   readonly #recorderPath: string;
   readonly #webhook: LocalMockWebhookConfig | undefined;
@@ -158,7 +161,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
   }
 
   override async send(context: SendContext): Promise<SendResult> {
-    if (this.#cleanedUp) {
+    if (this.#cleanupBegun || this.#cleanedUp) {
       throw this.#cleanedUpError();
     }
     const sending = super.send(context);
@@ -198,7 +201,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
           isAddressInChannel(candidate.threadId, channelId) &&
           matchesInbound(candidate, context.fixture.inboundMatch, context.nonce),
         since: context.since,
-        signal: context.signal,
+        signal: this.#operationSignal(context.signal),
         timeoutMs: context.timeoutMs,
       });
       if (event && this.#waitCursors.get(cursorKey) === cursorState) {
@@ -226,7 +229,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
         entry.provider === this.id &&
         !isOutboundRecord(entry) &&
         isAddressInChannel(entry.threadId, target.threadId ?? target.channelId ?? target.id),
-      signal: context.signal,
+      signal: this.#operationSignal(context.signal),
       since: context.since,
     })) {
       yield event;
@@ -238,6 +241,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
       return;
     }
     this.#cleanupBegun = true;
+    this.#lifecycleAbort.abort(this.#cleanedUpError());
     this.#serverClosing = this.#closeWebhookServer();
     void this.#serverClosing.catch(() => undefined);
   }
@@ -330,6 +334,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
     }
 
     const ids: string[] = [];
+    const records: InboundEnvelope[] = [];
     for (const message of messages) {
       const id = message.message?.id ?? message.id ?? createMessageId();
       const threadId = message.message?.threadId ?? message.threadId;
@@ -338,17 +343,18 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
         return new Response("payload requires message.threadId and message.text", { status: 400 });
       }
 
-      await appendRecordedInbound(this.#recorderPath, {
+      records.push({
         author: authorFromPayload(message),
         id,
         provider: this.id,
         raw: message.message?.raw ?? message.raw ?? message,
-        sentAt: new Date().toISOString(),
+        sentAt: message.message?.sentAt ?? message.sentAt ?? new Date().toISOString(),
         text,
         threadId,
       });
       ids.push(id);
     }
+    await appendRecordedInboundBatch(this.#recorderPath, records);
 
     return new Response(
       JSON.stringify(ids.length === 1 ? { id: ids[0], ok: true } : { ids, ok: true }),
@@ -435,6 +441,12 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
   #cleanedUpResponse(): Response {
     return new Response(`Provider "${this.id}" has been cleaned up.`, { status: 503 });
   }
+
+  #operationSignal(signal: AbortSignal | undefined): AbortSignal {
+    return signal
+      ? AbortSignal.any([signal, this.#lifecycleAbort.signal])
+      : this.#lifecycleAbort.signal;
+  }
 }
 
 export function normalizeWhatsAppWebhookPayload(
@@ -515,6 +527,10 @@ function normalizeWhatsAppFallback(
   if (threadId) {
     normalized.threadId = threadId;
   }
+  const sentAt = optionalString(fallback, "sentAt");
+  if (sentAt) {
+    normalized.sentAt = sentAt;
+  }
 
   const message = optionalRecord(fallback, "message");
   if (message) {
@@ -532,6 +548,10 @@ function normalizeWhatsAppFallback(
     }
     if (message.raw !== undefined) {
       normalizedMessage.raw = message.raw;
+    }
+    const messageSentAt = optionalString(message, "sentAt");
+    if (messageSentAt) {
+      normalizedMessage.sentAt = messageSentAt;
     }
     const messageText = optionalString(message, "text");
     if (messageText) {
@@ -565,13 +585,32 @@ function normalizeWhatsAppMessage(
   }
 
   const messageId = optionalString(message, "id");
+  const timestamp = optionalString(message, "timestamp");
   return {
     author: authorFromBotFlag(false),
     ...(messageId ? { id: messageId } : {}),
     raw: message,
+    ...(timestamp ? { sentAt: whatsAppTimestampToIso(timestamp) } : {}),
     text: body,
     threadId: requireNativeInboundId(from, WHATSAPP_WA_ID_RULE, "WhatsApp messages[].from"),
   };
+}
+
+function whatsAppTimestampToIso(timestamp: string): string {
+  if (!/^\d+$/u.test(timestamp)) {
+    throw new CrablineError("WhatsApp messages[].timestamp must be Unix seconds", {
+      kind: "inbound",
+    });
+  }
+  const milliseconds = Number(timestamp) * 1000;
+  if (!Number.isSafeInteger(milliseconds)) {
+    throw new CrablineError("WhatsApp messages[].timestamp is out of range", { kind: "inbound" });
+  }
+  const date = new Date(milliseconds);
+  if (Number.isNaN(date.getTime())) {
+    throw new CrablineError("WhatsApp messages[].timestamp is invalid", { kind: "inbound" });
+  }
+  return date.toISOString();
 }
 
 function authorFromPayload(payload: NormalizedWhatsAppWebhookMessage): InboundEnvelope["author"] {

--- a/src/providers/builtin/whatsapp.ts
+++ b/src/providers/builtin/whatsapp.ts
@@ -499,11 +499,12 @@ export function normalizeWhatsAppWebhookPayload(
     payload,
     threadRule: WHATSAPP_WA_ID_RULE,
   }) as Record<string, unknown>;
-  return [normalizeWhatsAppFallback(fallback)];
+  return [normalizeWhatsAppFallback(fallback, payload)];
 }
 
 function normalizeWhatsAppFallback(
   fallback: Record<string, unknown>,
+  source: Record<string, unknown>,
 ): NormalizedWhatsAppWebhookMessage {
   const normalized: NormalizedWhatsAppWebhookMessage = {
     raw: fallback.raw ?? fallback,
@@ -527,13 +528,14 @@ function normalizeWhatsAppFallback(
   if (threadId) {
     normalized.threadId = threadId;
   }
-  const sentAt = optionalString(fallback, "sentAt");
+  const sentAt = optionalString(source, "sentAt");
   if (sentAt) {
-    normalized.sentAt = sentAt;
+    normalized.sentAt = whatsAppFallbackTimestampToIso(sentAt, "sentAt");
   }
 
   const message = optionalRecord(fallback, "message");
   if (message) {
+    const sourceMessage = optionalRecord(source, "message");
     const normalizedMessage: NonNullable<NormalizedWhatsAppWebhookMessage["message"]> = {};
     const messageAuthor = normalizeAuthor(message.author);
     if (messageAuthor) {
@@ -549,9 +551,9 @@ function normalizeWhatsAppFallback(
     if (message.raw !== undefined) {
       normalizedMessage.raw = message.raw;
     }
-    const messageSentAt = optionalString(message, "sentAt");
+    const messageSentAt = sourceMessage ? optionalString(sourceMessage, "sentAt") : undefined;
     if (messageSentAt) {
-      normalizedMessage.sentAt = messageSentAt;
+      normalizedMessage.sentAt = whatsAppFallbackTimestampToIso(messageSentAt, "message.sentAt");
     }
     const messageText = optionalString(message, "text");
     if (messageText) {
@@ -609,6 +611,16 @@ function whatsAppTimestampToIso(timestamp: string): string {
   const date = new Date(milliseconds);
   if (Number.isNaN(date.getTime())) {
     throw new CrablineError("WhatsApp messages[].timestamp is invalid", { kind: "inbound" });
+  }
+  return date.toISOString();
+}
+
+function whatsAppFallbackTimestampToIso(timestamp: string, field: string): string {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) {
+    throw new CrablineError(`WhatsApp fallback ${field} must be a valid timestamp`, {
+      kind: "inbound",
+    });
   }
   return date.toISOString();
 }

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -208,8 +208,8 @@ function consumeRecordedChunk(
 }
 
 async function appendJsonLine(filePath: string, line: string): Promise<void> {
-  await serializeAppend(filePath, async (publicationPath) => {
-    await appendCommittedLine(publicationPath, line, false);
+  await serializeAppend(filePath, async (publicationPath, logicalPath) => {
+    await appendCommittedLine(publicationPath, logicalPath, line, false);
   });
 }
 
@@ -288,6 +288,7 @@ async function prepareRecorderTailForAppend(
 
 async function appendCommittedLine(
   publicationPath: string,
+  logicalPath: string,
   line: string,
   durable: boolean,
 ): Promise<void> {
@@ -306,7 +307,7 @@ async function appendCommittedLine(
   if (
     !sameRecorderFileIdentity(
       { dev: identity.dev, ino: identity.ino },
-      await readRecorderFileIdentity(publicationPath),
+      await readRecorderFileIdentity(await resolveRecorderPublicationPath(logicalPath)),
     )
   ) {
     throw new Error("Recorder rotated while appending a committed line.");
@@ -362,15 +363,16 @@ async function withRecorderLock<T>(filePath: string, operation: () => Promise<T>
 
 async function serializeAppend<T>(
   filePath: string,
-  operation: (publicationPath: string) => Promise<T>,
+  operation: (publicationPath: string, logicalPath: string) => Promise<T>,
 ): Promise<T> {
-  const key = await resolveRecorderPublicationPath(filePath);
+  const logicalPath = path.resolve(filePath);
+  const key = await resolveRecorderPublicationPath(logicalPath);
   const previous = pendingAppends.get(key) ?? Promise.resolve();
   let result: T;
   const current = previous
     .catch(() => {})
     .then(async () => {
-      result = await withRecorderLock(key, async () => await operation(key));
+      result = await withRecorderLock(key, async () => await operation(key, logicalPath));
     });
   pendingAppends.set(key, current);
 
@@ -467,7 +469,7 @@ export async function appendRecordedInboundBatch(
   events: InboundEnvelope[],
 ): Promise<RecordedInboundEnvelope[]> {
   await mkdir(path.dirname(filePath), { recursive: true });
-  return await serializeAppend(filePath, async (publicationPath) => {
+  return await serializeAppend(filePath, async (publicationPath, logicalPath) => {
     const seen = await syncRecordIdentityIndex(publicationPath);
     const pendingIdentities = new Set<string>();
     const recorded: RecordedInboundEnvelope[] = [];
@@ -488,7 +490,7 @@ export async function appendRecordedInboundBatch(
         recordType: "crabline.recorder.batch",
         recorderBatchVersion: RECORDER_BATCH_VERSION,
       } satisfies RecordedInboundBatchLine;
-      await appendCommittedLine(publicationPath, `${JSON.stringify(batch)}\n`, true);
+      await appendCommittedLine(publicationPath, logicalPath, `${JSON.stringify(batch)}\n`, true);
       await syncRecordIdentityIndex(publicationPath);
     }
     return recorded;

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -253,15 +253,15 @@ async function resolveRecorderPublicationPath(filePath: string): Promise<string>
 
 async function prepareRecorderTailForAppend(
   handle: Awaited<ReturnType<typeof open>>,
-): Promise<void> {
+): Promise<boolean> {
   const stats = await handle.stat();
   if (stats.size === 0) {
-    return;
+    return false;
   }
 
   const finalByte = await readBufferAt(handle, 1, stats.size - 1);
   if (finalByte[0] === 0x0a) {
-    return;
+    return false;
   }
 
   const windowSize = Math.min(stats.size, MAX_PENDING_RECORD_BYTES + 1);
@@ -278,11 +278,39 @@ async function prepareRecorderTailForAppend(
   try {
     JSON.parse(tail);
     await handle.writeFile("\n", "utf8");
+    return true;
   } catch (error) {
     if (!(error instanceof SyntaxError)) {
       throw error;
     }
     await handle.truncate(tailStart);
+    return true;
+  }
+}
+
+async function prepareRecorderPathForAppend(
+  publicationPath: string,
+  logicalPath: string,
+  durable: boolean,
+): Promise<void> {
+  const handle = await open(publicationPath, "a+");
+  const identity = await handle.stat({ bigint: true });
+  try {
+    const changed = await prepareRecorderTailForAppend(handle);
+    if (changed && durable) {
+      await handle.sync();
+    }
+  } finally {
+    await handle.close();
+  }
+
+  if (
+    !sameRecorderFileIdentity(
+      { dev: identity.dev, ino: identity.ino },
+      await readRecorderFileIdentity(await resolveRecorderPublicationPath(logicalPath)),
+    )
+  ) {
+    throw new Error("Recorder rotated while preparing a committed line.");
   }
 }
 
@@ -470,6 +498,7 @@ export async function appendRecordedInboundBatch(
 ): Promise<RecordedInboundEnvelope[]> {
   await mkdir(path.dirname(filePath), { recursive: true });
   return await serializeAppend(filePath, async (publicationPath, logicalPath) => {
+    await prepareRecorderPathForAppend(publicationPath, logicalPath, true);
     const seen = await syncRecordIdentityIndex(publicationPath);
     const pendingIdentities = new Set<string>();
     const recorded: RecordedInboundEnvelope[] = [];

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -26,11 +26,13 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
 }
 
 const pendingAppends = new Map<string, Promise<void>>();
+const recordIdentityIndexes = new Map<string, RecordIdentityIndex>();
 const MAX_RECENT_RECORD_KEYS = 4096;
 
 type IncrementalReadState = {
   caughtUp: boolean;
   continuity: Buffer;
+  generation: number;
   identity:
     | {
         dev: number;
@@ -39,6 +41,11 @@ type IncrementalReadState = {
     | undefined;
   offset: number;
   pending: Buffer;
+};
+
+type RecordIdentityIndex = {
+  readState: IncrementalReadState;
+  seen: Set<string>;
 };
 
 export type RecordedInboundCursor = {
@@ -55,6 +62,7 @@ function createIncrementalReadState(): IncrementalReadState {
   return {
     caughtUp: true,
     continuity: Buffer.alloc(0),
+    generation: 0,
     identity: undefined,
     offset: 0,
     pending: Buffer.alloc(0),
@@ -75,6 +83,7 @@ export function cloneRecordedInboundCursor(cursor: RecordedInboundCursor): Recor
     readState: {
       caughtUp: cursor.readState.caughtUp,
       continuity: Buffer.from(cursor.readState.continuity),
+      generation: cursor.readState.generation,
       identity: cursor.readState.identity ? { ...cursor.readState.identity } : undefined,
       offset: cursor.readState.offset,
       pending: Buffer.from(cursor.readState.pending),
@@ -96,6 +105,14 @@ function rememberRecentRecord(seen: Set<string>, event: InboundEnvelope): boolea
 }
 
 function resetIncrementalReadState(state: IncrementalReadState): void {
+  if (
+    state.identity !== undefined ||
+    state.offset > 0 ||
+    state.pending.length > 0 ||
+    state.continuity.length > 0
+  ) {
+    state.generation += 1;
+  }
   state.caughtUp = true;
   state.continuity = Buffer.alloc(0);
   state.offset = 0;
@@ -265,8 +282,7 @@ export async function appendRecordedInboundBatch(
 ): Promise<RecordedInboundEnvelope[]> {
   await mkdir(path.dirname(filePath), { recursive: true });
   return await serializeAppend(filePath, async () => {
-    const existing = await readRecordedInbound(filePath);
-    const seen = new Set(existing.map(recordIdentity));
+    const seen = await syncRecordIdentityIndex(filePath);
     const recorded: RecordedInboundEnvelope[] = [];
     for (const event of events) {
       const identity = recordIdentity(event);
@@ -285,6 +301,7 @@ export async function appendRecordedInboundBatch(
         recorded.map((event) => `${JSON.stringify(event)}\n`).join(""),
         "utf8",
       );
+      await syncRecordIdentityIndex(filePath);
     }
     return recorded;
   });
@@ -292,6 +309,25 @@ export async function appendRecordedInboundBatch(
 
 function recordIdentity(event: Pick<InboundEnvelope, "id" | "provider" | "threadId">): string {
   return JSON.stringify([event.provider, event.threadId, event.id]);
+}
+
+async function syncRecordIdentityIndex(filePath: string): Promise<Set<string>> {
+  const key = path.resolve(filePath);
+  let index = recordIdentityIndexes.get(key);
+  if (!index) {
+    index = { readState: createIncrementalReadState(), seen: new Set() };
+    recordIdentityIndexes.set(key, index);
+  }
+
+  const generation = index.readState.generation;
+  const appended = await readRecordedInboundAppend(filePath, index.readState);
+  if (index.readState.generation !== generation) {
+    index.seen.clear();
+  }
+  for (const event of appended) {
+    index.seen.add(recordIdentity(event));
+  }
+  return index.seen;
 }
 
 export async function readRecordedInbound(filePath: string): Promise<RecordedInboundEnvelope[]> {

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -1,4 +1,16 @@
-import { appendFile, mkdir, open, readFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { constants } from "node:fs";
+import {
+  appendFile,
+  copyFile,
+  lstat,
+  mkdir,
+  open,
+  readFile,
+  realpath,
+  rename,
+  rm,
+} from "node:fs/promises";
 import path from "node:path";
 import type { InboundEnvelope } from "./types.js";
 
@@ -27,6 +39,7 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
 
 const pendingAppends = new Map<string, Promise<void>>();
 const recordIdentityIndexes = new Map<string, RecordIdentityIndex>();
+const MAX_RECORD_IDENTITY_INDEXES = 128;
 const MAX_RECENT_RECORD_KEYS = 4096;
 
 type IncrementalReadState = {
@@ -46,6 +59,14 @@ type IncrementalReadState = {
 type RecordIdentityIndex = {
   readState: IncrementalReadState;
   seen: Set<string>;
+};
+
+type RecorderFileIdentity = {
+  ctimeNs: bigint;
+  dev: bigint;
+  ino: bigint;
+  mtimeNs: bigint;
+  size: bigint;
 };
 
 export type RecordedInboundCursor = {
@@ -177,30 +198,142 @@ async function appendJsonLine(filePath: string, line: string): Promise<void> {
   await serializeAppend(filePath, () => appendFile(filePath, line, "utf8"));
 }
 
-function recorderBatchRollbackError(writeError: unknown, rollbackError: unknown): AggregateError {
-  return new AggregateError(
-    [writeError, rollbackError],
-    "Recorder batch append and rollback both failed.",
-    { cause: rollbackError },
+async function readRecorderFileIdentity(
+  filePath: string,
+): Promise<RecorderFileIdentity | undefined> {
+  try {
+    const stats = await lstat(filePath, { bigint: true });
+    if (!stats.isFile()) {
+      throw new Error(`Recorder path is not a regular file: ${filePath}`);
+    }
+    return {
+      ctimeNs: stats.ctimeNs,
+      dev: stats.dev,
+      ino: stats.ino,
+      mtimeNs: stats.mtimeNs,
+      size: stats.size,
+    };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+function sameRecorderFileIdentity(
+  left: RecorderFileIdentity | undefined,
+  right: RecorderFileIdentity | undefined,
+): boolean {
+  return (
+    left?.ctimeNs === right?.ctimeNs &&
+    left?.dev === right?.dev &&
+    left?.ino === right?.ino &&
+    left?.mtimeNs === right?.mtimeNs &&
+    left?.size === right?.size
   );
 }
 
-async function appendJsonLinesTransactional(filePath: string, lines: string): Promise<void> {
-  const handle = await open(filePath, "a+");
-  const originalSize = (await handle.stat()).size;
+async function resolveRecorderPublicationPath(filePath: string): Promise<string> {
   try {
-    try {
-      await handle.writeFile(lines, "utf8");
-    } catch (writeError) {
-      try {
-        await handle.truncate(originalSize);
-      } catch (rollbackError) {
-        throw recorderBatchRollbackError(writeError, rollbackError);
-      }
-      throw writeError;
+    return await realpath(filePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
     }
+    return path.join(await realpath(path.dirname(filePath)), path.basename(filePath));
+  }
+}
+
+async function prepareRecorderTailForAppend(
+  handle: Awaited<ReturnType<typeof open>>,
+): Promise<void> {
+  const stats = await handle.stat();
+  if (stats.size === 0) {
+    return;
+  }
+
+  const windowSize = Math.min(stats.size, MAX_PENDING_RECORD_BYTES + 1);
+  const tailWindow = await readBufferAt(handle, windowSize, stats.size - windowSize);
+  if (tailWindow.at(-1) === 0x0a) {
+    return;
+  }
+
+  const lastNewline = tailWindow.lastIndexOf(0x0a);
+  if (lastNewline < 0 && stats.size > MAX_PENDING_RECORD_BYTES) {
+    throw new Error(
+      `Recorder record exceeded ${MAX_PENDING_RECORD_BYTES} bytes without a newline.`,
+    );
+  }
+
+  const tailStart = stats.size - windowSize + lastNewline + 1;
+  const tail = tailWindow.subarray(lastNewline + 1).toString("utf8");
+  try {
+    JSON.parse(tail);
+    await handle.writeFile("\n", "utf8");
+  } catch (error) {
+    if (!(error instanceof SyntaxError)) {
+      throw error;
+    }
+    await handle.truncate(tailStart);
+  }
+}
+
+async function syncRecorderParentDirectory(filePath: string): Promise<void> {
+  if (process.platform === "win32") {
+    return;
+  }
+  const handle = await open(path.dirname(filePath), "r");
+  try {
+    await handle.sync();
   } finally {
     await handle.close();
+  }
+}
+
+async function appendJsonLinesAtomically(filePath: string, lines: string): Promise<void> {
+  const publicationPath = await resolveRecorderPublicationPath(filePath);
+  const temporaryPath = path.join(
+    path.dirname(publicationPath),
+    `.${path.basename(publicationPath)}.${process.pid}.${randomUUID()}.tmp`,
+  );
+  const expectedIdentity = await readRecorderFileIdentity(publicationPath);
+  let published = false;
+
+  try {
+    if (expectedIdentity) {
+      await copyFile(publicationPath, temporaryPath, constants.COPYFILE_EXCL);
+    } else {
+      const empty = await open(temporaryPath, "wx");
+      await empty.close();
+    }
+    if (
+      !sameRecorderFileIdentity(expectedIdentity, await readRecorderFileIdentity(publicationPath))
+    ) {
+      throw new Error("Recorder changed while preparing an atomic batch append.");
+    }
+
+    const handle = await open(temporaryPath, "a+");
+    try {
+      await prepareRecorderTailForAppend(handle);
+      await handle.writeFile(lines, "utf8");
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+
+    if (
+      !sameRecorderFileIdentity(expectedIdentity, await readRecorderFileIdentity(publicationPath))
+    ) {
+      throw new Error("Recorder changed before publishing an atomic batch append.");
+    }
+    await rename(temporaryPath, publicationPath);
+    published = true;
+    await syncRecorderParentDirectory(publicationPath);
+  } finally {
+    if (!published) {
+      await rm(temporaryPath, { force: true }).catch(() => undefined);
+    }
   }
 }
 
@@ -324,7 +457,7 @@ export async function appendRecordedInboundBatch(
       });
     }
     if (recorded.length > 0) {
-      await appendJsonLinesTransactional(
+      await appendJsonLinesAtomically(
         filePath,
         recorded.map((event) => `${JSON.stringify(event)}\n`).join(""),
       );
@@ -344,16 +477,25 @@ async function syncRecordIdentityIndex(filePath: string): Promise<Set<string>> {
   if (!index) {
     index = { readState: createIncrementalReadState(), seen: new Set() };
     recordIdentityIndexes.set(key, index);
+    if (recordIdentityIndexes.size > MAX_RECORD_IDENTITY_INDEXES) {
+      recordIdentityIndexes.delete(recordIdentityIndexes.keys().next().value!);
+    }
+  } else {
+    recordIdentityIndexes.delete(key);
+    recordIdentityIndexes.set(key, index);
   }
 
-  const generation = index.readState.generation;
-  const appended = await readRecordedInboundAppend(filePath, index.readState);
-  if (index.readState.generation !== generation) {
-    index.seen.clear();
-  }
-  for (const event of appended) {
-    index.seen.add(recordIdentity(event));
-  }
+  let generation = index.readState.generation;
+  do {
+    const appended = await readRecordedInboundAppend(filePath, index.readState);
+    if (index.readState.generation !== generation) {
+      index.seen.clear();
+      generation = index.readState.generation;
+    }
+    for (const event of appended) {
+      rememberRecentRecord(index.seen, event);
+    }
+  } while (!index.readState.caughtUp);
   return index.seen;
 }
 

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -1,17 +1,6 @@
-import { randomUUID } from "node:crypto";
-import { constants } from "node:fs";
-import {
-  appendFile,
-  copyFile,
-  lstat,
-  mkdir,
-  open,
-  readFile,
-  realpath,
-  rename,
-  rm,
-} from "node:fs/promises";
+import { lstat, mkdir, open, readFile, realpath } from "node:fs/promises";
 import path from "node:path";
+import { lock } from "proper-lockfile";
 import type { InboundEnvelope } from "./types.js";
 
 export type RecordableInboundEnvelope = InboundEnvelope & {
@@ -41,6 +30,9 @@ const pendingAppends = new Map<string, Promise<void>>();
 const recordIdentityIndexes = new Map<string, RecordIdentityIndex>();
 const MAX_RECORD_IDENTITY_INDEXES = 128;
 const MAX_RECENT_RECORD_KEYS = 4096;
+const RECORDER_BATCH_VERSION = 1;
+const RECORDER_LOCK_STALE_MS = 30_000;
+const RECORDER_LOCK_UPDATE_MS = 10_000;
 
 type IncrementalReadState = {
   caughtUp: boolean;
@@ -62,11 +54,14 @@ type RecordIdentityIndex = {
 };
 
 type RecorderFileIdentity = {
-  ctimeNs: bigint;
   dev: bigint;
   ino: bigint;
-  mtimeNs: bigint;
-  size: bigint;
+};
+
+type RecordedInboundBatchLine = {
+  events: RecordedInboundEnvelope[];
+  recordType: "crabline.recorder.batch";
+  recorderBatchVersion: typeof RECORDER_BATCH_VERSION;
 };
 
 export type RecordedInboundCursor = {
@@ -77,7 +72,7 @@ export type RecordedInboundCursor = {
 
 const CONTINUITY_BYTES = 4096;
 const MAX_INCREMENTAL_READ_BYTES = 256 * 1024;
-const MAX_PENDING_RECORD_BYTES = 1024 * 1024;
+const MAX_PENDING_RECORD_BYTES = 4 * 1024 * 1024;
 
 function createIncrementalReadState(): IncrementalReadState {
   return {
@@ -123,6 +118,24 @@ function rememberRecentRecord(seen: Set<string>, event: InboundEnvelope): boolea
     seen.delete(seen.values().next().value!);
   }
   return true;
+}
+
+function parseRecordedLine(line: string): RecordedInboundEnvelope[] {
+  const parsed = JSON.parse(line) as unknown;
+  if (
+    typeof parsed === "object" &&
+    parsed !== null &&
+    !Array.isArray(parsed) &&
+    "recordType" in parsed &&
+    parsed.recordType === "crabline.recorder.batch" &&
+    "recorderBatchVersion" in parsed &&
+    parsed.recorderBatchVersion === RECORDER_BATCH_VERSION &&
+    "events" in parsed &&
+    Array.isArray(parsed.events)
+  ) {
+    return parsed.events as RecordedInboundEnvelope[];
+  }
+  return [parsed as RecordedInboundEnvelope];
 }
 
 function resetIncrementalReadState(state: IncrementalReadState): void {
@@ -188,14 +201,16 @@ function consumeRecordedChunk(
   const events: RecordedInboundEnvelope[] = [];
   for (const line of raw.subarray(0, lastNewline).toString("utf8").split("\n")) {
     if (line.trim()) {
-      events.push(JSON.parse(line) as RecordedInboundEnvelope);
+      events.push(...parseRecordedLine(line));
     }
   }
   return events;
 }
 
 async function appendJsonLine(filePath: string, line: string): Promise<void> {
-  await serializeAppend(filePath, () => appendFile(filePath, line, "utf8"));
+  await serializeAppend(filePath, async (publicationPath) => {
+    await appendCommittedLine(publicationPath, line, false);
+  });
 }
 
 async function readRecorderFileIdentity(
@@ -207,11 +222,8 @@ async function readRecorderFileIdentity(
       throw new Error(`Recorder path is not a regular file: ${filePath}`);
     }
     return {
-      ctimeNs: stats.ctimeNs,
       dev: stats.dev,
       ino: stats.ino,
-      mtimeNs: stats.mtimeNs,
-      size: stats.size,
     };
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
@@ -225,13 +237,7 @@ function sameRecorderFileIdentity(
   left: RecorderFileIdentity | undefined,
   right: RecorderFileIdentity | undefined,
 ): boolean {
-  return (
-    left?.ctimeNs === right?.ctimeNs &&
-    left?.dev === right?.dev &&
-    left?.ino === right?.ino &&
-    left?.mtimeNs === right?.mtimeNs &&
-    left?.size === right?.size
-  );
+  return left?.dev === right?.dev && left?.ino === right?.ino;
 }
 
 async function resolveRecorderPublicationPath(filePath: string): Promise<string> {
@@ -253,12 +259,13 @@ async function prepareRecorderTailForAppend(
     return;
   }
 
-  const windowSize = Math.min(stats.size, MAX_PENDING_RECORD_BYTES + 1);
-  const tailWindow = await readBufferAt(handle, windowSize, stats.size - windowSize);
-  if (tailWindow.at(-1) === 0x0a) {
+  const finalByte = await readBufferAt(handle, 1, stats.size - 1);
+  if (finalByte[0] === 0x0a) {
     return;
   }
 
+  const windowSize = Math.min(stats.size, MAX_PENDING_RECORD_BYTES + 1);
+  const tailWindow = await readBufferAt(handle, windowSize, stats.size - windowSize);
   const lastNewline = tailWindow.lastIndexOf(0x0a);
   if (lastNewline < 0 && stats.size > MAX_PENDING_RECORD_BYTES) {
     throw new Error(
@@ -279,72 +286,91 @@ async function prepareRecorderTailForAppend(
   }
 }
 
-async function syncRecorderParentDirectory(filePath: string): Promise<void> {
-  if (process.platform === "win32") {
-    return;
-  }
-  const handle = await open(path.dirname(filePath), "r");
+async function appendCommittedLine(
+  publicationPath: string,
+  line: string,
+  durable: boolean,
+): Promise<void> {
+  const handle = await open(publicationPath, "a+");
+  const identity = await handle.stat({ bigint: true });
   try {
-    await handle.sync();
+    await prepareRecorderTailForAppend(handle);
+    await handle.writeFile(line, "utf8");
+    if (durable) {
+      await handle.sync();
+    }
   } finally {
     await handle.close();
   }
-}
 
-async function appendJsonLinesAtomically(filePath: string, lines: string): Promise<void> {
-  const publicationPath = await resolveRecorderPublicationPath(filePath);
-  const temporaryPath = path.join(
-    path.dirname(publicationPath),
-    `.${path.basename(publicationPath)}.${process.pid}.${randomUUID()}.tmp`,
-  );
-  const expectedIdentity = await readRecorderFileIdentity(publicationPath);
-  let published = false;
-
-  try {
-    if (expectedIdentity) {
-      await copyFile(publicationPath, temporaryPath, constants.COPYFILE_EXCL);
-    } else {
-      const empty = await open(temporaryPath, "wx");
-      await empty.close();
-    }
-    if (
-      !sameRecorderFileIdentity(expectedIdentity, await readRecorderFileIdentity(publicationPath))
-    ) {
-      throw new Error("Recorder changed while preparing an atomic batch append.");
-    }
-
-    const handle = await open(temporaryPath, "a+");
-    try {
-      await prepareRecorderTailForAppend(handle);
-      await handle.writeFile(lines, "utf8");
-      await handle.sync();
-    } finally {
-      await handle.close();
-    }
-
-    if (
-      !sameRecorderFileIdentity(expectedIdentity, await readRecorderFileIdentity(publicationPath))
-    ) {
-      throw new Error("Recorder changed before publishing an atomic batch append.");
-    }
-    await rename(temporaryPath, publicationPath);
-    published = true;
-    await syncRecorderParentDirectory(publicationPath);
-  } finally {
-    if (!published) {
-      await rm(temporaryPath, { force: true }).catch(() => undefined);
-    }
+  if (
+    !sameRecorderFileIdentity(
+      { dev: identity.dev, ino: identity.ino },
+      await readRecorderFileIdentity(publicationPath),
+    )
+  ) {
+    throw new Error("Recorder rotated while appending a committed line.");
   }
 }
 
-async function serializeAppend<T>(filePath: string, operation: () => Promise<T>): Promise<T> {
-  const key = path.resolve(filePath);
+function recorderLockReleaseError(
+  filePath: string,
+  operationError: unknown,
+  releaseError: unknown,
+): AggregateError {
+  return new AggregateError(
+    [operationError, releaseError],
+    `Recorder append and lock release both failed for "${filePath}".`,
+    { cause: operationError },
+  );
+}
+
+async function withRecorderLock<T>(filePath: string, operation: () => Promise<T>): Promise<T> {
+  const release = await lock(filePath, {
+    realpath: false,
+    retries: {
+      factor: 1,
+      maxTimeout: 10,
+      minTimeout: 10,
+      retries: 500,
+    },
+    stale: RECORDER_LOCK_STALE_MS,
+    update: RECORDER_LOCK_UPDATE_MS,
+  });
+  let operationFailed = false;
+  let operationError: unknown;
+  let result: T | undefined;
+  try {
+    result = await operation();
+  } catch (error) {
+    operationFailed = true;
+    operationError = error;
+  }
+  try {
+    await release();
+  } catch (releaseError) {
+    if (operationFailed) {
+      throw recorderLockReleaseError(filePath, operationError, releaseError);
+    }
+    throw releaseError;
+  }
+  if (operationFailed) {
+    throw operationError;
+  }
+  return result as T;
+}
+
+async function serializeAppend<T>(
+  filePath: string,
+  operation: (publicationPath: string) => Promise<T>,
+): Promise<T> {
+  const key = await resolveRecorderPublicationPath(filePath);
   const previous = pendingAppends.get(key) ?? Promise.resolve();
   let result: T;
   const current = previous
     .catch(() => {})
     .then(async () => {
-      result = await operation();
+      result = await withRecorderLock(key, async () => await operation(key));
     });
   pendingAppends.set(key, current);
 
@@ -441,8 +467,8 @@ export async function appendRecordedInboundBatch(
   events: InboundEnvelope[],
 ): Promise<RecordedInboundEnvelope[]> {
   await mkdir(path.dirname(filePath), { recursive: true });
-  return await serializeAppend(filePath, async () => {
-    const seen = await syncRecordIdentityIndex(filePath);
+  return await serializeAppend(filePath, async (publicationPath) => {
+    const seen = await syncRecordIdentityIndex(publicationPath);
     const pendingIdentities = new Set<string>();
     const recorded: RecordedInboundEnvelope[] = [];
     for (const event of events) {
@@ -457,11 +483,13 @@ export async function appendRecordedInboundBatch(
       });
     }
     if (recorded.length > 0) {
-      await appendJsonLinesAtomically(
-        filePath,
-        recorded.map((event) => `${JSON.stringify(event)}\n`).join(""),
-      );
-      await syncRecordIdentityIndex(filePath);
+      const batch = {
+        events: recorded,
+        recordType: "crabline.recorder.batch",
+        recorderBatchVersion: RECORDER_BATCH_VERSION,
+      } satisfies RecordedInboundBatchLine;
+      await appendCommittedLine(publicationPath, `${JSON.stringify(batch)}\n`, true);
+      await syncRecordIdentityIndex(publicationPath);
     }
     return recorded;
   });
@@ -519,12 +547,12 @@ export async function readRecordedInbound(filePath: string): Promise<RecordedInb
 
   for (const line of completed.split("\n")) {
     if (line.trim()) {
-      events.push(JSON.parse(line) as RecordedInboundEnvelope);
+      events.push(...parseRecordedLine(line));
     }
   }
   if (tail.trim()) {
     try {
-      events.push(JSON.parse(tail) as RecordedInboundEnvelope);
+      events.push(...parseRecordedLine(tail));
     } catch {
       // Ignore a partial final append; completed lines remain strict.
     }

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -157,13 +157,23 @@ function consumeRecordedChunk(
 }
 
 async function appendJsonLine(filePath: string, line: string): Promise<void> {
+  await serializeAppend(filePath, () => appendFile(filePath, line, "utf8"));
+}
+
+async function serializeAppend<T>(filePath: string, operation: () => Promise<T>): Promise<T> {
   const key = path.resolve(filePath);
   const previous = pendingAppends.get(key) ?? Promise.resolve();
-  const current = previous.catch(() => {}).then(() => appendFile(filePath, line, "utf8"));
+  let result: T;
+  const current = previous
+    .catch(() => {})
+    .then(async () => {
+      result = await operation();
+    });
   pendingAppends.set(key, current);
 
   try {
     await current;
+    return result!;
   } finally {
     if (pendingAppends.get(key) === current) {
       pendingAppends.delete(key);
@@ -247,6 +257,41 @@ export async function appendRecordedInbound(
 
   await appendJsonLine(filePath, `${JSON.stringify(recorded)}\n`);
   return recorded;
+}
+
+export async function appendRecordedInboundBatch(
+  filePath: string,
+  events: InboundEnvelope[],
+): Promise<RecordedInboundEnvelope[]> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  return await serializeAppend(filePath, async () => {
+    const existing = await readRecordedInbound(filePath);
+    const seen = new Set(existing.map(recordIdentity));
+    const recorded: RecordedInboundEnvelope[] = [];
+    for (const event of events) {
+      const identity = recordIdentity(event);
+      if (seen.has(identity)) {
+        continue;
+      }
+      seen.add(identity);
+      recorded.push({
+        ...event,
+        recordedAt: new Date().toISOString(),
+      });
+    }
+    if (recorded.length > 0) {
+      await appendFile(
+        filePath,
+        recorded.map((event) => `${JSON.stringify(event)}\n`).join(""),
+        "utf8",
+      );
+    }
+    return recorded;
+  });
+}
+
+function recordIdentity(event: Pick<InboundEnvelope, "id" | "provider" | "threadId">): string {
+  return JSON.stringify([event.provider, event.threadId, event.id]);
 }
 
 export async function readRecordedInbound(filePath: string): Promise<RecordedInboundEnvelope[]> {

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -496,6 +496,9 @@ export async function appendRecordedInboundBatch(
   filePath: string,
   events: InboundEnvelope[],
 ): Promise<RecordedInboundEnvelope[]> {
+  if (events.length === 0) {
+    return [];
+  }
   await mkdir(path.dirname(filePath), { recursive: true });
   return await serializeAppend(filePath, async (publicationPath, logicalPath) => {
     await prepareRecorderPathForAppend(publicationPath, logicalPath, true);

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -177,6 +177,33 @@ async function appendJsonLine(filePath: string, line: string): Promise<void> {
   await serializeAppend(filePath, () => appendFile(filePath, line, "utf8"));
 }
 
+function recorderBatchRollbackError(writeError: unknown, rollbackError: unknown): AggregateError {
+  return new AggregateError(
+    [writeError, rollbackError],
+    "Recorder batch append and rollback both failed.",
+    { cause: rollbackError },
+  );
+}
+
+async function appendJsonLinesTransactional(filePath: string, lines: string): Promise<void> {
+  const handle = await open(filePath, "a+");
+  const originalSize = (await handle.stat()).size;
+  try {
+    try {
+      await handle.writeFile(lines, "utf8");
+    } catch (writeError) {
+      try {
+        await handle.truncate(originalSize);
+      } catch (rollbackError) {
+        throw recorderBatchRollbackError(writeError, rollbackError);
+      }
+      throw writeError;
+    }
+  } finally {
+    await handle.close();
+  }
+}
+
 async function serializeAppend<T>(filePath: string, operation: () => Promise<T>): Promise<T> {
   const key = path.resolve(filePath);
   const previous = pendingAppends.get(key) ?? Promise.resolve();
@@ -283,23 +310,23 @@ export async function appendRecordedInboundBatch(
   await mkdir(path.dirname(filePath), { recursive: true });
   return await serializeAppend(filePath, async () => {
     const seen = await syncRecordIdentityIndex(filePath);
+    const pendingIdentities = new Set<string>();
     const recorded: RecordedInboundEnvelope[] = [];
     for (const event of events) {
       const identity = recordIdentity(event);
-      if (seen.has(identity)) {
+      if (seen.has(identity) || pendingIdentities.has(identity)) {
         continue;
       }
-      seen.add(identity);
+      pendingIdentities.add(identity);
       recorded.push({
         ...event,
         recordedAt: new Date().toISOString(),
       });
     }
     if (recorded.length > 0) {
-      await appendFile(
+      await appendJsonLinesTransactional(
         filePath,
         recorded.map((event) => `${JSON.stringify(event)}\n`).join(""),
-        "utf8",
       );
       await syncRecordIdentityIndex(filePath);
     }

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -33,6 +33,9 @@ const MAX_RECENT_RECORD_KEYS = 4096;
 const RECORDER_BATCH_VERSION = 1;
 const RECORDER_LOCK_STALE_MS = 30_000;
 const RECORDER_LOCK_UPDATE_MS = 10_000;
+const RECORDER_ROTATION_ATTEMPTS = 3;
+
+class RecorderRotatedError extends Error {}
 
 type IncrementalReadState = {
   caughtUp: boolean;
@@ -292,9 +295,10 @@ async function prepareRecorderPathForAppend(
   publicationPath: string,
   logicalPath: string,
   durable: boolean,
-): Promise<void> {
+): Promise<RecorderFileIdentity> {
   const handle = await open(publicationPath, "a+");
   const identity = await handle.stat({ bigint: true });
+  const recorderIdentity = { dev: identity.dev, ino: identity.ino };
   try {
     const changed = await prepareRecorderTailForAppend(handle);
     if (changed && durable) {
@@ -306,12 +310,13 @@ async function prepareRecorderPathForAppend(
 
   if (
     !sameRecorderFileIdentity(
-      { dev: identity.dev, ino: identity.ino },
+      recorderIdentity,
       await readRecorderFileIdentity(await resolveRecorderPublicationPath(logicalPath)),
     )
   ) {
-    throw new Error("Recorder rotated while preparing a committed line.");
+    throw new RecorderRotatedError("Recorder rotated while preparing a committed line.");
   }
+  return recorderIdentity;
 }
 
 async function appendCommittedLine(
@@ -319,10 +324,18 @@ async function appendCommittedLine(
   logicalPath: string,
   line: string,
   durable: boolean,
+  expectedIdentity?: RecorderFileIdentity,
 ): Promise<void> {
   const handle = await open(publicationPath, "a+");
   const identity = await handle.stat({ bigint: true });
+  const recorderIdentity = { dev: identity.dev, ino: identity.ino };
   try {
+    if (
+      expectedIdentity !== undefined &&
+      !sameRecorderFileIdentity(expectedIdentity, recorderIdentity)
+    ) {
+      throw new RecorderRotatedError("Recorder rotated before appending a committed line.");
+    }
     await prepareRecorderTailForAppend(handle);
     await handle.writeFile(line, "utf8");
     if (durable) {
@@ -334,11 +347,11 @@ async function appendCommittedLine(
 
   if (
     !sameRecorderFileIdentity(
-      { dev: identity.dev, ino: identity.ino },
+      recorderIdentity,
       await readRecorderFileIdentity(await resolveRecorderPublicationPath(logicalPath)),
     )
   ) {
-    throw new Error("Recorder rotated while appending a committed line.");
+    throw new RecorderRotatedError("Recorder rotated while appending a committed line.");
   }
 }
 
@@ -500,33 +513,54 @@ export async function appendRecordedInboundBatch(
     return [];
   }
   await mkdir(path.dirname(filePath), { recursive: true });
-  return await serializeAppend(filePath, async (publicationPath, logicalPath) => {
-    await prepareRecorderPathForAppend(publicationPath, logicalPath, true);
-    const seen = await syncRecordIdentityIndex(publicationPath);
-    const pendingIdentities = new Set<string>();
-    const recorded: RecordedInboundEnvelope[] = [];
-    for (const event of events) {
-      const identity = recordIdentity(event);
-      if (seen.has(identity) || pendingIdentities.has(identity)) {
-        continue;
-      }
-      pendingIdentities.add(identity);
-      recorded.push({
-        ...event,
-        recordedAt: new Date().toISOString(),
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await serializeAppend(filePath, async (publicationPath, logicalPath) => {
+        const generation = await prepareRecorderPathForAppend(publicationPath, logicalPath, true);
+        const seen = await syncRecordIdentityIndex(publicationPath);
+        const pendingIdentities = new Set<string>();
+        const recorded: RecordedInboundEnvelope[] = [];
+        for (const event of events) {
+          const identity = recordIdentity(event);
+          if (seen.has(identity) || pendingIdentities.has(identity)) {
+            continue;
+          }
+          pendingIdentities.add(identity);
+          recorded.push({
+            ...event,
+            recordedAt: new Date().toISOString(),
+          });
+        }
+        if (recorded.length > 0) {
+          const batch = {
+            events: recorded,
+            recordType: "crabline.recorder.batch",
+            recorderBatchVersion: RECORDER_BATCH_VERSION,
+          } satisfies RecordedInboundBatchLine;
+          await appendCommittedLine(
+            publicationPath,
+            logicalPath,
+            `${JSON.stringify(batch)}\n`,
+            true,
+            generation,
+          );
+          await syncRecordIdentityIndex(publicationPath);
+        } else if (
+          !sameRecorderFileIdentity(
+            generation,
+            await readRecorderFileIdentity(await resolveRecorderPublicationPath(logicalPath)),
+          )
+        ) {
+          throw new RecorderRotatedError("Recorder rotated before confirming a duplicate batch.");
+        }
+        return recorded;
       });
+    } catch (error) {
+      if (!(error instanceof RecorderRotatedError) || attempt + 1 >= RECORDER_ROTATION_ATTEMPTS) {
+        throw error;
+      }
     }
-    if (recorded.length > 0) {
-      const batch = {
-        events: recorded,
-        recordType: "crabline.recorder.batch",
-        recorderBatchVersion: RECORDER_BATCH_VERSION,
-      } satisfies RecordedInboundBatchLine;
-      await appendCommittedLine(publicationPath, logicalPath, `${JSON.stringify(batch)}\n`, true);
-      await syncRecordIdentityIndex(publicationPath);
-    }
-    return recorded;
-  });
+  }
 }
 
 function recordIdentity(event: Pick<InboundEnvelope, "id" | "provider" | "threadId">): string {

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -1,4 +1,4 @@
-import { lstat, mkdir, open, readFile, realpath } from "node:fs/promises";
+import { lstat, mkdir, open, readFile, readlink, realpath } from "node:fs/promises";
 import path from "node:path";
 import { lock } from "proper-lockfile";
 import type { InboundEnvelope } from "./types.js";
@@ -250,8 +250,20 @@ async function resolveRecorderPublicationPath(filePath: string): Promise<string>
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
       throw error;
     }
-    return path.join(await realpath(path.dirname(filePath)), path.basename(filePath));
   }
+
+  try {
+    const stats = await lstat(filePath);
+    if (stats.isSymbolicLink()) {
+      const target = await readlink(filePath);
+      return await resolveRecorderPublicationPath(path.resolve(path.dirname(filePath), target));
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
+  return path.join(await realpath(path.dirname(filePath)), path.basename(filePath));
 }
 
 async function prepareRecorderTailForAppend(
@@ -537,13 +549,13 @@ export async function appendRecordedInboundBatch(
             recordType: "crabline.recorder.batch",
             recorderBatchVersion: RECORDER_BATCH_VERSION,
           } satisfies RecordedInboundBatchLine;
-          await appendCommittedLine(
-            publicationPath,
-            logicalPath,
-            `${JSON.stringify(batch)}\n`,
-            true,
-            generation,
-          );
+          const line = `${JSON.stringify(batch)}\n`;
+          if (Buffer.byteLength(line) > MAX_PENDING_RECORD_BYTES) {
+            throw new Error(
+              `Recorder record exceeded ${MAX_PENDING_RECORD_BYTES} bytes without a newline.`,
+            );
+          }
+          await appendCommittedLine(publicationPath, logicalPath, line, true, generation);
           await syncRecordIdentityIndex(publicationPath);
         } else if (
           !sameRecorderFileIdentity(

--- a/src/servers/http.ts
+++ b/src/servers/http.ts
@@ -205,7 +205,7 @@ export function closeServer(
 }
 
 export async function startHttpJsonServer(params: {
-  handle: (request: IncomingMessage) => Promise<Response>;
+  handle: (request: IncomingMessage, response: ServerResponse) => Promise<Response>;
   handleError?: (error: unknown, request: IncomingMessage) => Response | undefined;
   host: string;
   port: number;
@@ -213,7 +213,7 @@ export async function startHttpJsonServer(params: {
 }): Promise<{ baseUrl: string; close(): Promise<void>; server: Server }> {
   const handleRequest = async (request: IncomingMessage, response: ServerResponse) => {
     try {
-      await writeResponse(response, await params.handle(request));
+      await writeResponse(response, await params.handle(request, response));
     } catch (error) {
       let handled: Response | undefined;
       try {

--- a/src/servers/http.ts
+++ b/src/servers/http.ts
@@ -11,6 +11,14 @@ export type ServerRequestEvent = {
   type: "admin" | "api";
 };
 
+export type HttpJsonHandlerResult =
+  | Response
+  | {
+      onWriteFailure?(): Promise<void> | void;
+      onWriteSuccess?(): Promise<void> | void;
+      response: Response;
+    };
+
 export const ADMIN_TOKEN_HEADER = "x-crabline-admin-token";
 export const DEFAULT_MAX_REQUEST_BODY_BYTES = 1024 * 1024;
 export const DEFAULT_SERVER_SHUTDOWN_GRACE_MS = 250;
@@ -177,7 +185,49 @@ export async function writeResponse(
   for (const [name, value] of fetchResponse.headers) {
     response.setHeader(name, value);
   }
-  response.end(Buffer.from(await fetchResponse.arrayBuffer()));
+  const body = Buffer.from(await fetchResponse.arrayBuffer());
+  await new Promise<void>((resolve, reject) => {
+    if (
+      response.destroyed ||
+      response.req?.aborted ||
+      response.req?.socket.destroyed ||
+      response.socket?.destroyed
+    ) {
+      reject(new Error("HTTP response closed before delivery completed."));
+      return;
+    }
+    const cleanup = () => {
+      response.off("close", onClose);
+      response.off("error", onError);
+      response.off("finish", onFinish);
+    };
+    const onClose = () => {
+      if (response.writableFinished) {
+        cleanup();
+        resolve();
+        return;
+      }
+      cleanup();
+      reject(new Error("HTTP response closed before delivery completed."));
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const onFinish = () => {
+      cleanup();
+      resolve();
+    };
+    response.once("close", onClose);
+    response.once("error", onError);
+    response.once("finish", onFinish);
+    try {
+      response.end(body);
+    } catch (error) {
+      cleanup();
+      reject(error);
+    }
+  });
 }
 
 export function closeServer(
@@ -205,7 +255,7 @@ export function closeServer(
 }
 
 export async function startHttpJsonServer(params: {
-  handle: (request: IncomingMessage, response: ServerResponse) => Promise<Response>;
+  handle: (request: IncomingMessage, response: ServerResponse) => Promise<HttpJsonHandlerResult>;
   handleError?: (error: unknown, request: IncomingMessage) => Response | undefined;
   host: string;
   port: number;
@@ -213,7 +263,15 @@ export async function startHttpJsonServer(params: {
 }): Promise<{ baseUrl: string; close(): Promise<void>; server: Server }> {
   const handleRequest = async (request: IncomingMessage, response: ServerResponse) => {
     try {
-      await writeResponse(response, await params.handle(request, response));
+      const result = await params.handle(request, response);
+      const handled = result instanceof Response ? { response: result } : result;
+      try {
+        await writeResponse(response, handled.response);
+      } catch (error) {
+        await handled.onWriteFailure?.();
+        throw error;
+      }
+      await handled.onWriteSuccess?.();
     } catch (error) {
       let handled: Response | undefined;
       try {

--- a/src/servers/whatsapp-baileys-websocket.ts
+++ b/src/servers/whatsapp-baileys-websocket.ts
@@ -25,6 +25,7 @@ import { KEY_BUNDLE_TYPE, xmppPreKey, xmppSignedPreKey } from "./whatsapp-wire/s
 import { WebSocket, WebSocketServer, type ServerOptions } from "ws";
 import type { ServerRequestEvent } from "./http.js";
 import { closeWebSocketServer } from "./websocket.js";
+import { canonicalizeWhatsAppUserJid } from "./whatsapp-jid.js";
 
 // Keep the local server independent from Baileys at runtime. Tests use Baileys
 // as a black-box client to verify this narrow WhatsApp Web wire subset.
@@ -41,7 +42,7 @@ const MAX_PENDING_WEBSOCKET_BYTES = 8 * 1024 * 1024;
 const MAX_PENDING_WEBSOCKET_MESSAGES = 32;
 export const MAX_WHATSAPP_WEBSOCKET_FRAGMENTS = 1_024;
 export const MAX_WHATSAPP_SIGNAL_BUNDLES = 1_024;
-const SIGNAL_BUNDLE_JID_RE = /^\d{7,15}(?::\d+)?@(?:s\.whatsapp\.net|lid)$/iu;
+export const MAX_WHATSAPP_WEBSOCKET_CLOSE_REASON_BYTES = 123;
 type NodeBuffer = Buffer<ArrayBufferLike>;
 type WhatsAppWebSocketRawData = NodeBuffer | ArrayBuffer | NodeBuffer[];
 type WhatsAppWebSocketSendTarget = {
@@ -121,18 +122,21 @@ export class WhatsAppSignalBundleStore {
 
   resolveMany(jids: string[]): MockSignalBundle[] {
     const uniqueNewJids = new Set<string>();
+    const canonicalJids: string[] = [];
     for (const jid of jids) {
-      if (!SIGNAL_BUNDLE_JID_RE.test(jid)) {
+      const canonical = canonicalizeWhatsAppUserJid(jid);
+      if (!canonical) {
         throw new Error(`Invalid WhatsApp signal bundle JID: ${jid}.`);
       }
-      if (!this.#bundles.has(jid)) {
-        uniqueNewJids.add(jid);
+      canonicalJids.push(canonical);
+      if (!this.#bundles.has(canonical)) {
+        uniqueNewJids.add(canonical);
       }
     }
     if (this.#bundles.size + uniqueNewJids.size > this.maxBundles) {
       throw new Error(`WhatsApp signal bundle limit exceeded (${this.maxBundles}).`);
     }
-    return jids.map((jid) => this.#resolve(jid));
+    return canonicalJids.map((jid) => this.#resolve(jid));
   }
 
   #resolve(jid: string): MockSignalBundle {
@@ -464,7 +468,8 @@ class WhatsAppBaileysWebSocketSession {
     this.#handleSerializedMessage = createSerializedMessageHandler(
       (data) => this.#handleMessage(data),
       (error) => {
-        this.socket.close(1011, error instanceof Error ? error.message : String(error));
+        const close = resolveWhatsAppWebSocketClose(error);
+        this.socket.close(close.code, close.reason);
       },
       {
         sizeOf: rawDataByteLength,
@@ -778,6 +783,32 @@ export async function sendWhatsAppWebSocketPayload(
       finish(error instanceof Error ? error : new Error(String(error)));
     }
   });
+}
+
+export function resolveWhatsAppWebSocketClose(error: unknown): {
+  code: 1002 | 1009 | 1011;
+  reason: string;
+} {
+  const message = error instanceof Error ? error.message : String(error);
+  const code = /(?:backlog|exceeds|limit|payload is too large|too many)/iu.test(message)
+    ? 1009
+    : /(?:baileys|binary node|handshake|noise|protocol|unexpected end|unsupported|invalid)/iu.test(
+          message,
+        )
+      ? 1002
+      : 1011;
+  return { code, reason: truncateWebSocketCloseReason(message) };
+}
+
+function truncateWebSocketCloseReason(reason: string): string {
+  let result = "";
+  for (const character of reason) {
+    if (Buffer.byteLength(result + character) > MAX_WHATSAPP_WEBSOCKET_CLOSE_REASON_BYTES) {
+      break;
+    }
+    result += character;
+  }
+  return result;
 }
 
 export function attachWhatsAppBaileysWebSocketServer(

--- a/src/servers/whatsapp-jid.ts
+++ b/src/servers/whatsapp-jid.ts
@@ -1,0 +1,27 @@
+const WHATSAPP_USER_JID_RE = /^(\d{7,15})(?::(\d+))?@(c\.us|lid|s\.whatsapp\.net)$/iu;
+const WHATSAPP_GROUP_JID_RE = /^(\d{5,20}(?:-\d{5,20})?)@g\.us$/iu;
+
+export function canonicalizeWhatsAppUserJid(value: string): string | undefined {
+  const match = WHATSAPP_USER_JID_RE.exec(value.trim());
+  if (!match) {
+    return undefined;
+  }
+  const user = match[1]!;
+  const device = match[2];
+  const rawServer = match[3]!.toLowerCase();
+  const server = rawServer === "c.us" ? "s.whatsapp.net" : rawServer;
+  return `${user}${device === undefined ? "" : `:${device}`}@${server}`;
+}
+
+export function canonicalizeWhatsAppGroupJid(value: string): string | undefined {
+  const match = WHATSAPP_GROUP_JID_RE.exec(value.trim());
+  return match ? `${match[1]}@g.us` : undefined;
+}
+
+export function canonicalizeWhatsAppChatJid(value: string): string | undefined {
+  return canonicalizeWhatsAppUserJid(value) ?? canonicalizeWhatsAppGroupJid(value);
+}
+
+export function isWhatsAppGroupJid(value: string): boolean {
+  return canonicalizeWhatsAppGroupJid(value) !== undefined;
+}

--- a/src/servers/whatsapp-wire/binary-node.ts
+++ b/src/servers/whatsapp-wire/binary-node.ts
@@ -415,7 +415,7 @@ function decodeDecompressedBinaryNode(
   if (listSize === 0 || !tag) {
     throw new Error("Invalid WhatsApp binary node header.");
   }
-  const attrs: Record<string, string> = {};
+  const attrs = Object.create(null) as Record<string, string>;
   for (let index = 0; index < (listSize - 1) >> 1; index += 1) {
     attrs[readString(readByte())] = readString(readByte());
   }

--- a/src/servers/whatsapp-wire/handshake.ts
+++ b/src/servers/whatsapp-wire/handshake.ts
@@ -21,7 +21,7 @@ export function decodeHandshakeMessage(data: Uint8Array): HandshakeMessage {
   const reader = new ProtoReader(data);
   const message: HandshakeMessage = {};
   while (!reader.done()) {
-    const tag = reader.uint32();
+    const tag = reader.tag();
     const field = tag >>> 3;
     if (field === 2) {
       requireBytesWireType(tag, field);
@@ -48,7 +48,7 @@ function decodeClientHello(data: Uint8Array): NonNullable<HandshakeMessage["clie
   const reader = new ProtoReader(data);
   let ephemeral: BytesField;
   while (!reader.done()) {
-    const tag = reader.uint32();
+    const tag = reader.tag();
     if (tag >>> 3 === 1) {
       requireBytesWireType(tag, 1);
       ephemeral = reader.bytes();
@@ -64,7 +64,7 @@ function decodeClientFinish(data: Uint8Array): NonNullable<HandshakeMessage["cli
   let payload: BytesField;
   let staticKey: BytesField;
   while (!reader.done()) {
-    const tag = reader.uint32();
+    const tag = reader.tag();
     const field = tag >>> 3;
     if (field === 1) {
       requireBytesWireType(tag, field);
@@ -141,6 +141,14 @@ class ProtoReader {
       return;
     }
     throw new Error(`Unsupported WhatsApp handshake wire type: ${wireType}.`);
+  }
+
+  tag(): number {
+    const tag = this.uint32();
+    if (tag >>> 3 === 0) {
+      throw new Error("Invalid WhatsApp handshake protobuf field number 0.");
+    }
+    return tag;
   }
 
   uint32(): number {

--- a/src/servers/whatsapp.ts
+++ b/src/servers/whatsapp.ts
@@ -524,9 +524,10 @@ async function handleRequest(params: { request: IncomingMessage; state: WhatsApp
     } else {
       const prepared = prepareSendMessage({ body, state: params.state });
       if (!(prepared instanceof Response)) {
+        response = prepared.commit();
         event.accepted = true;
         await appendEvent(params.state, event);
-        return prepared.commit();
+        return response;
       }
       response = prepared;
     }

--- a/src/servers/whatsapp.ts
+++ b/src/servers/whatsapp.ts
@@ -273,10 +273,14 @@ function createWhatsAppMessage(params: {
   };
 }
 
-async function handleSendMessage(params: {
+type PreparedWhatsAppSend = {
+  commit(): Response;
+};
+
+function prepareSendMessage(params: {
   body: Record<string, unknown>;
   state: WhatsAppServerState;
-}): Promise<Response> {
+}): PreparedWhatsAppSend | Response {
   const productError = requireMessagingProduct(params.body);
   if (productError) {
     return productError;
@@ -296,22 +300,26 @@ async function handleSendMessage(params: {
   if (text instanceof Response) {
     return text;
   }
-  const message = createWhatsAppMessage({
-    fromMe: true,
-    id: nextMessageId(params.state),
-    remoteJid: `${to}@s.whatsapp.net`,
-    text,
-  });
-  return jsonResponse({
-    contacts: [
-      {
-        input: to,
-        wa_id: to,
-      },
-    ],
-    messages: [{ id: message.key.id }],
-    messaging_product: "whatsapp",
-  });
+  return {
+    commit() {
+      const message = createWhatsAppMessage({
+        fromMe: true,
+        id: nextMessageId(params.state),
+        remoteJid: `${to}@s.whatsapp.net`,
+        text,
+      });
+      return jsonResponse({
+        contacts: [
+          {
+            input: to,
+            wa_id: to,
+          },
+        ],
+        messages: [{ id: message.key.id }],
+        messaging_product: "whatsapp",
+      });
+    },
+  };
 }
 
 function handleMessageStatus(body: Record<string, unknown>): Response {
@@ -514,7 +522,13 @@ async function handleRequest(params: { request: IncomingMessage; state: WhatsApp
     } else if ("status" in body || "message_id" in body) {
       response = handleMessageStatus(body);
     } else {
-      response = await handleSendMessage({ body, state: params.state });
+      const prepared = prepareSendMessage({ body, state: params.state });
+      if (!(prepared instanceof Response)) {
+        event.accepted = true;
+        await appendEvent(params.state, event);
+        return prepared.commit();
+      }
+      response = prepared;
     }
     event.accepted = response.ok;
     await appendEvent(params.state, event);

--- a/src/servers/whatsapp.ts
+++ b/src/servers/whatsapp.ts
@@ -531,7 +531,7 @@ async function handleRequest(params: { request: IncomingMessage; state: WhatsApp
       }
       response = prepared;
     }
-    event.accepted = response.ok;
+    event.accepted = false;
     await appendEvent(params.state, event);
     return response;
   }

--- a/src/servers/whatsapp.ts
+++ b/src/servers/whatsapp.ts
@@ -22,11 +22,12 @@ import {
   type PreparedWhatsAppBaileysInboundDelivery,
   type WhatsAppBaileysInboundMessage,
 } from "./whatsapp-baileys-websocket.js";
+import {
+  canonicalizeWhatsAppChatJid,
+  canonicalizeWhatsAppUserJid,
+  isWhatsAppGroupJid,
+} from "./whatsapp-jid.js";
 
-const WHATSAPP_USER_JID_RE = /^\d{7,15}(?::\d+)?@s\.whatsapp\.net$/iu;
-const WHATSAPP_LEGACY_USER_JID_RE = /^\d{7,15}@c\.us$/iu;
-const WHATSAPP_GROUP_JID_RE = /^\d{5,}(?:-\d{5,})?@g\.us$/iu;
-const WHATSAPP_LID_RE = /^\d{7,15}@lid$/iu;
 const WHATSAPP_CLOUD_RECIPIENT_RE = /^\d{7,15}$/u;
 const WHATSAPP_GRAPH_VERSION_RE = /^v\d+\.\d+$/u;
 const DEFAULT_GRAPH_VERSION = "v25.0";
@@ -100,6 +101,7 @@ type WhatsAppAdminInboundResult = {
 };
 
 type WhatsAppRecorderEvent = ServerRequestEvent & {
+  accepted?: boolean | undefined;
   message?: WhatsAppBaileysMessage | undefined;
 };
 
@@ -151,37 +153,28 @@ async function appendEvent(state: WhatsAppServerState, event: ServerRequestEvent
   await recordServerEvent({ event, onEvent: state.onEvent, recorderPath: state.recorderPath });
 }
 
-function isWhatsAppUserJid(value: string): boolean {
-  return (
-    WHATSAPP_USER_JID_RE.test(value) ||
-    WHATSAPP_LEGACY_USER_JID_RE.test(value) ||
-    WHATSAPP_LID_RE.test(value)
-  );
-}
-
 function requireWhatsAppChatJid(value: unknown): string | Response {
   const stringValue = readTrimmedString(value);
-  if (
-    !stringValue ||
-    (!isWhatsAppUserJid(stringValue) && !WHATSAPP_GROUP_JID_RE.test(stringValue))
-  ) {
+  const canonical = stringValue ? canonicalizeWhatsAppChatJid(stringValue) : undefined;
+  if (!canonical) {
     return graphParameterError(
       "(#100) Invalid parameter: chatJid",
       "chatJid must be a WhatsApp user or group JID.",
     );
   }
-  return stringValue;
+  return canonical;
 }
 
 function requireWhatsAppSenderJid(value: unknown): string | Response {
   const stringValue = readTrimmedString(value);
-  if (!stringValue || !isWhatsAppUserJid(stringValue)) {
+  const canonical = stringValue ? canonicalizeWhatsAppUserJid(stringValue) : undefined;
+  if (!canonical) {
     return graphParameterError(
       "(#100) Invalid parameter: senderJid",
       "senderJid must be a WhatsApp user JID.",
     );
   }
-  return stringValue;
+  return canonical;
 }
 
 function requireCloudRecipient(value: unknown): string | Response {
@@ -215,8 +208,7 @@ function waIdFromJid(jid: string): string {
 function directPeerIdentity(jid: string): string {
   const separator = jid.lastIndexOf("@");
   const user = jid.slice(0, separator).split(":", 1)[0] ?? jid;
-  const server = jid.slice(separator + 1);
-  return `${user}@${server === "c.us" ? "s.whatsapp.net" : server}`;
+  return `${user}@${jid.slice(separator + 1).toLowerCase()}`;
 }
 
 function requireMessagingProduct(body: Record<string, unknown>): Response | undefined {
@@ -354,7 +346,7 @@ async function handleAdminInbound(params: {
   if (senderJid instanceof Response) {
     return { response: senderJid };
   }
-  const isGroupChat = WHATSAPP_GROUP_JID_RE.test(chatJid);
+  const isGroupChat = isWhatsAppGroupJid(chatJid);
   if (!isGroupChat && directPeerIdentity(chatJid) !== directPeerIdentity(senderJid)) {
     return {
       response: graphParameterError(
@@ -505,24 +497,28 @@ async function handleRequest(params: { request: IncomingMessage; state: WhatsApp
       return new Response("not found", { status: 404 });
     }
     const body = await parseUnknownRequestBody(params.request);
-    await appendEvent(params.state, {
+    const event: WhatsAppRecorderEvent = {
       at: new Date().toISOString(),
       body,
       method: params.request.method,
       path: url.pathname,
       query: queryRecord(url),
       type: "api",
-    });
+    };
+    let response: Response;
     if (!isJsonObject(body)) {
-      return graphParameterError(
+      response = graphParameterError(
         "(#100) Invalid parameter: request body",
         "The request body must be a JSON object.",
       );
+    } else if ("status" in body || "message_id" in body) {
+      response = handleMessageStatus(body);
+    } else {
+      response = await handleSendMessage({ body, state: params.state });
     }
-    if ("status" in body || "message_id" in body) {
-      return handleMessageStatus(body);
-    }
-    return await handleSendMessage({ body, state: params.state });
+    event.accepted = response.ok;
+    await appendEvent(params.state, event);
+    return response;
   }
   return new Response("not found", { status: 404 });
 }
@@ -533,6 +529,9 @@ export async function startWhatsAppServer(
   const host = params.host ?? "127.0.0.1";
   if (params.accessToken !== undefined && !params.accessToken.trim()) {
     throw new Error("WhatsApp accessToken must not be empty.");
+  }
+  if (params.adminToken !== undefined && !params.adminToken.trim()) {
+    throw new Error("WhatsApp adminToken must not be empty.");
   }
   const graphVersion = params.graphVersion ?? DEFAULT_GRAPH_VERSION;
   if (!WHATSAPP_GRAPH_VERSION_RE.test(graphVersion)) {
@@ -545,6 +544,10 @@ export async function startWhatsAppServer(
   const maxPendingInboundMessages = resolveMaxPendingWhatsAppInboundMessages(
     params.maxPendingInboundMessages,
   );
+  const selfJid = canonicalizeWhatsAppUserJid(params.selfJid ?? "15550000000@s.whatsapp.net");
+  if (!selfJid) {
+    throw new Error("WhatsApp selfJid must be a WhatsApp user JID.");
+  }
   const state: WhatsAppServerState = {
     accessToken:
       params.accessToken ??
@@ -559,7 +562,7 @@ export async function startWhatsAppServer(
     onEvent: params.onEvent,
     phoneNumberId,
     recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "whatsapp.jsonl"),
-    selfJid: params.selfJid ?? "15550000000@s.whatsapp.net",
+    selfJid,
   };
   const httpServer = await startHttpJsonServer({
     handle: (request) => handleRequest({ request, state }),

--- a/src/servers/zalo.ts
+++ b/src/servers/zalo.ts
@@ -474,6 +474,14 @@ async function waitForUpdate(
 
 function deliverPollingUpdate(state: ZaloServerState, update: ZaloUpdate): boolean {
   pollingUpdateOrder(state, update);
+  if (state.updates.length > 0) {
+    if (state.updates.length + state.reservedUpdateOrders.size >= state.maxPendingInboundEvents) {
+      return false;
+    }
+    queuePollingUpdate(state, update);
+    flushPendingPollingUpdate(state);
+    return true;
+  }
   const pending = state.pendingRequest;
   if (pending) {
     if (isPendingUpdateRequestLive(pending)) {

--- a/src/servers/zalo.ts
+++ b/src/servers/zalo.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from "node:crypto";
-import type { ClientRequest, IncomingMessage } from "node:http";
+import type { ClientRequest, IncomingMessage, ServerResponse } from "node:http";
 import path from "node:path";
 import {
   adminAuthError,
@@ -43,11 +43,14 @@ type ZaloUpdate = {
   message: ZaloMessage;
 };
 
+type PendingUpdateResult = "conflict" | "disconnect" | "shutdown" | "timeout" | "update";
+
 type PendingUpdateRequest = {
   active: boolean;
   onDisconnect(): void;
   request: IncomingMessage;
-  resolve(response: Response): void;
+  response: ServerResponse;
+  resolve(result: PendingUpdateResult): void;
   timeout: NodeJS.Timeout | undefined;
 };
 
@@ -66,7 +69,7 @@ type ZaloServerState = {
   maxPendingInboundEvents: number;
   nextMessage: number;
   onEvent: ServerEventObserver | undefined;
-  pendingRequests: PendingUpdateRequest[];
+  pendingRequest: PendingUpdateRequest | undefined;
   recorderPath: string;
   restrictWebhookTargets: boolean;
   updates: ZaloUpdate[];
@@ -138,9 +141,26 @@ function redactParams(params: Record<string, unknown>): Record<string, unknown> 
   return Object.fromEntries(
     Object.entries(params).map(([key, value]) => [
       key,
-      key === "secret_token" ? "<redacted>" : value,
+      key === "secret_token"
+        ? "<redacted>"
+        : key === "url" && typeof value === "string"
+          ? redactUrlCredentials(value)
+          : value,
     ]),
   );
+}
+
+function redactUrlCredentials(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return value;
+  }
+  if (!url.username && !url.password) {
+    return value;
+  }
+  return `${url.protocol}//<redacted>@${url.host}${url.pathname}${url.search}${url.hash}`;
 }
 
 function requireParam(body: Record<string, unknown>, name: string): string | Response {
@@ -257,7 +277,14 @@ export async function postZaloWebhook(params: {
   throw lastError;
 }
 
-function nextUpdate(state: ZaloServerState): Response | undefined {
+function nextUpdate(
+  request: IncomingMessage,
+  response: ServerResponse,
+  state: ZaloServerState,
+): Response | undefined {
+  if (request.aborted || request.socket.destroyed || response.destroyed) {
+    return undefined;
+  }
   const update = state.updates.shift();
   return update ? zaloOk(update) : undefined;
 }
@@ -265,69 +292,98 @@ function nextUpdate(state: ZaloServerState): Response | undefined {
 function settlePendingUpdate(
   state: ZaloServerState,
   pending: PendingUpdateRequest,
-  response: Response,
+  result: PendingUpdateResult,
 ): boolean {
   if (!pending.active) {
     return false;
   }
   pending.active = false;
-  const index = state.pendingRequests.indexOf(pending);
-  if (index >= 0) {
-    state.pendingRequests.splice(index, 1);
+  if (state.pendingRequest === pending) {
+    state.pendingRequest = undefined;
   }
   if (pending.timeout) {
     clearTimeout(pending.timeout);
   }
   pending.request.socket.off("close", pending.onDisconnect);
-  pending.resolve(response);
+  pending.request.off("aborted", pending.onDisconnect);
+  pending.response.off("close", pending.onDisconnect);
+  pending.resolve(result);
   return true;
 }
 
-function waitForUpdate(
+async function waitForUpdate(
   request: IncomingMessage,
+  response: ServerResponse,
   state: ZaloServerState,
   timeoutSeconds: number,
 ): Promise<Response> {
-  const queued = nextUpdate(state);
+  const previous = state.pendingRequest;
+  if (previous) {
+    settlePendingUpdate(state, previous, "conflict");
+  }
+  if (request.aborted || request.socket.destroyed || response.destroyed) {
+    return zaloError("Client closed request", 499);
+  }
+  const queued = nextUpdate(request, response, state);
   if (queued) {
-    return Promise.resolve(queued);
+    return queued;
   }
   if (timeoutSeconds <= 0) {
-    return Promise.resolve(zaloError("Request timeout", 408));
+    return zaloError("Request timeout", 408);
   }
-  return new Promise((resolve) => {
+  const result = await new Promise<PendingUpdateResult>((resolve) => {
     const pending: PendingUpdateRequest = {
       active: true,
       onDisconnect: () => {
-        settlePendingUpdate(state, pending, zaloError("Client closed request", 499));
+        settlePendingUpdate(state, pending, "disconnect");
       },
       request,
+      response,
       resolve,
       timeout: undefined,
     };
-    state.pendingRequests.push(pending);
+    state.pendingRequest = pending;
+    request.once("aborted", pending.onDisconnect);
     request.socket.once("close", pending.onDisconnect);
+    response.once("close", pending.onDisconnect);
     pending.timeout = setTimeout(() => {
-      settlePendingUpdate(state, pending, zaloError("Request timeout", 408));
+      settlePendingUpdate(state, pending, "timeout");
     }, timeoutSeconds * 1000);
     pending.timeout.unref();
-    if (request.socket.destroyed) {
+    if (request.socket.destroyed || response.destroyed) {
       pending.onDisconnect();
     }
   });
+  if (result === "conflict") {
+    return zaloError("Conflict: terminated by other getUpdates request", 409);
+  }
+  if (result === "disconnect") {
+    return zaloError("Client closed request", 499);
+  }
+  if (result === "shutdown") {
+    return zaloError("Server shutting down", 503);
+  }
+  if (result === "timeout") {
+    return zaloError("Request timeout", 408);
+  }
+  return nextUpdate(request, response, state) ?? zaloError("Client closed request", 499);
 }
 
 function deliverPollingUpdate(state: ZaloServerState, update: ZaloUpdate): boolean {
-  while (state.pendingRequests.length > 0) {
-    const pending = state.pendingRequests[0]!;
-    if (settlePendingUpdate(state, pending, zaloOk(update))) {
-      return true;
-    }
-  }
   if (state.updates.length >= state.maxPendingInboundEvents) {
     return false;
   }
   state.updates.push(update);
+  const pending = state.pendingRequest;
+  if (pending) {
+    settlePendingUpdate(
+      state,
+      pending,
+      pending.request.aborted || pending.request.socket.destroyed || pending.response.destroyed
+        ? "disconnect"
+        : "update",
+    );
+  }
   return true;
 }
 
@@ -362,7 +418,7 @@ async function deliverWebhookUpdate(
     const status = await postZaloWebhook({
       activeRequests: state.activeWebhookRequests,
       addresses: target.addresses,
-      body: JSON.stringify({ ok: true, result: update }),
+      body: JSON.stringify(update),
       shouldCancel: () => state.closing,
       timeoutMs: remainingMs,
       url,
@@ -417,11 +473,7 @@ async function handleAdminInbound(
       text,
     },
   };
-  if (
-    !state.webhook?.url &&
-    state.pendingRequests.length === 0 &&
-    state.updates.length >= state.maxPendingInboundEvents
-  ) {
+  if (!state.webhook?.url && state.updates.length >= state.maxPendingInboundEvents) {
     return zaloError(
       `Pending inbound queue is full (${state.maxPendingInboundEvents} updates)`,
       429,
@@ -453,6 +505,7 @@ async function handleAdminInbound(
 
 async function handleZaloMethod(
   request: IncomingMessage,
+  response: ServerResponse,
   state: ZaloServerState,
   url: URL,
   method: string,
@@ -485,7 +538,7 @@ async function handleZaloMethod(
     }
     const parsedTimeout = Number(readTrimmedString(body.timeout) ?? "30");
     const timeout = Number.isFinite(parsedTimeout) ? Math.max(0, Math.min(parsedTimeout, 50)) : 30;
-    return await waitForUpdate(request, state, timeout);
+    return await waitForUpdate(request, response, state, timeout);
   }
   if (method === "sendMessage" || method === "sendPhoto") {
     const chatId = requireParam(body, "chat_id");
@@ -529,6 +582,9 @@ async function handleZaloMethod(
       return target;
     }
     const webhook = { secretToken, updatedAt: Date.now(), url: parsedUrl.href };
+    if (state.pendingRequest) {
+      settlePendingUpdate(state, state.pendingRequest, "conflict");
+    }
     state.webhook = webhook;
     return zaloOk({ updated_at: webhook.updatedAt, url: webhook.url });
   }
@@ -562,7 +618,7 @@ export async function startZaloServer(
     maxPendingInboundEvents: resolveMaxPendingInboundEvents(params.maxPendingInboundEvents),
     nextMessage: 1,
     onEvent: params.onEvent,
-    pendingRequests: [],
+    pendingRequest: undefined,
     recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "zalo.jsonl"),
     restrictWebhookTargets: !isLoopbackHost(host),
     updates: [],
@@ -570,7 +626,7 @@ export async function startZaloServer(
     webhookDeliveryTimeoutMs: webhookDeliveryTimeoutMs(params.webhookDeliveryTimeoutMs),
   };
   const httpServer = await startHttpJsonServer({
-    handle: async (request) => {
+    handle: async (request, response) => {
       const url = new URL(request.url ?? "/", `http://${request.headers.host ?? host}`);
       if (request.method === "POST" && url.pathname === "/crabline/zalo/inbound") {
         return await handleAdminInbound(request, state, url);
@@ -583,7 +639,7 @@ export async function startZaloServer(
         drainRequestBody(request);
         return zaloError("Unauthorized", 401);
       }
-      return await handleZaloMethod(request, state, url, match[2] ?? "");
+      return await handleZaloMethod(request, response, state, url, match[2] ?? "");
     },
     handleError: (error) => {
       if (error instanceof InvalidJsonBodyError) {
@@ -621,8 +677,8 @@ export async function startZaloServer(
       for (const request of state.activeWebhookRequests) {
         request.destroy(new Error("Zalo server is shutting down."));
       }
-      for (const pending of state.pendingRequests.splice(0)) {
-        settlePendingUpdate(state, pending, zaloError("Server shutting down", 503));
+      if (state.pendingRequest) {
+        settlePendingUpdate(state, state.pendingRequest, "shutdown");
       }
       await httpServer.close();
     },

--- a/src/servers/zalo.ts
+++ b/src/servers/zalo.ts
@@ -14,6 +14,7 @@ import {
   readTrimmedString,
   RequestBodyTooLargeError,
   startHttpJsonServer,
+  type HttpJsonHandlerResult,
   type ServerRequestEvent,
 } from "./http.js";
 import { recordServerEvent, type ServerEventObserver } from "./recorder.js";
@@ -73,6 +74,7 @@ type ZaloServerState = {
   onEvent: ServerEventObserver | undefined;
   pendingRequest: PendingUpdateRequest | undefined;
   recorderPath: string;
+  reservedUpdates: number;
   restrictWebhookTargets: boolean;
   updates: ZaloUpdate[];
   webhook: { secretToken: string; updatedAt: number; url: string } | undefined;
@@ -157,7 +159,7 @@ function redactUrlCredentials(value: string): string {
   try {
     url = new URL(value);
   } catch {
-    return value;
+    return value.replace(/^([a-z][a-z0-9+.-]*:\/\/)[^/?#]*@/iu, "$1<redacted>@");
   }
   if (!url.username && !url.password) {
     return value;
@@ -283,12 +285,42 @@ function nextUpdate(
   request: IncomingMessage,
   response: ServerResponse,
   state: ZaloServerState,
-): Response | undefined {
+): HttpJsonHandlerResult | undefined {
   if (request.aborted || request.socket.destroyed || response.destroyed) {
     return undefined;
   }
   const update = state.updates.shift();
-  return update ? zaloOk(update) : undefined;
+  if (!update) {
+    return undefined;
+  }
+  state.reservedUpdates++;
+  return reservedUpdateResponse(state, update);
+}
+
+function reservedUpdateResponse(state: ZaloServerState, update: ZaloUpdate): HttpJsonHandlerResult {
+  let settled = false;
+  const release = () => {
+    if (settled) {
+      return false;
+    }
+    settled = true;
+    state.reservedUpdates--;
+    return true;
+  };
+  return {
+    onWriteFailure() {
+      if (!release()) {
+        return;
+      }
+      if (!deliverPollingUpdate(state, update)) {
+        state.updates.unshift(update);
+      }
+    },
+    onWriteSuccess() {
+      release();
+    },
+    response: zaloOk(update),
+  };
 }
 
 function settlePendingUpdate(
@@ -313,12 +345,18 @@ function settlePendingUpdate(
   return true;
 }
 
+function isPendingUpdateRequestLive(pending: PendingUpdateRequest): boolean {
+  return (
+    !pending.request.aborted && !pending.request.socket.destroyed && !pending.response.destroyed
+  );
+}
+
 async function waitForUpdate(
   request: IncomingMessage,
   response: ServerResponse,
   state: ZaloServerState,
   timeoutSeconds: number,
-): Promise<Response> {
+): Promise<HttpJsonHandlerResult> {
   const previous = state.pendingRequest;
   if (previous) {
     settlePendingUpdate(state, previous, { kind: "conflict" });
@@ -366,24 +404,21 @@ async function waitForUpdate(
     case "timeout":
       return zaloError("Request timeout", 408);
     case "update":
-      return zaloOk(result.update);
+      return reservedUpdateResponse(state, result.update);
   }
 }
 
 function deliverPollingUpdate(state: ZaloServerState, update: ZaloUpdate): boolean {
   const pending = state.pendingRequest;
   if (pending) {
-    if (
-      !pending.request.aborted &&
-      !pending.request.socket.destroyed &&
-      !pending.response.destroyed
-    ) {
+    if (isPendingUpdateRequestLive(pending)) {
+      state.reservedUpdates++;
       settlePendingUpdate(state, pending, { kind: "update", update });
       return true;
     }
     settlePendingUpdate(state, pending, { kind: "disconnect" });
   }
-  if (state.updates.length >= state.maxPendingInboundEvents) {
+  if (state.updates.length + state.reservedUpdates >= state.maxPendingInboundEvents) {
     return false;
   }
   state.updates.push(update);
@@ -476,7 +511,11 @@ async function handleAdminInbound(
       text,
     },
   };
-  if (!state.webhook?.url && state.updates.length >= state.maxPendingInboundEvents) {
+  if (
+    !state.webhook?.url &&
+    !(state.pendingRequest && isPendingUpdateRequestLive(state.pendingRequest)) &&
+    state.updates.length + state.reservedUpdates >= state.maxPendingInboundEvents
+  ) {
     return zaloError(
       `Pending inbound queue is full (${state.maxPendingInboundEvents} updates)`,
       429,
@@ -512,7 +551,7 @@ async function handleZaloMethod(
   state: ZaloServerState,
   url: URL,
   method: string,
-): Promise<Response> {
+): Promise<HttpJsonHandlerResult> {
   const parsedBody = await parseUnknownRequestBody(request);
   if (!isJsonObject(parsedBody)) {
     return zaloError("Bad Request: can't parse JSON object", 400);
@@ -623,6 +662,7 @@ export async function startZaloServer(
     onEvent: params.onEvent,
     pendingRequest: undefined,
     recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "zalo.jsonl"),
+    reservedUpdates: 0,
     restrictWebhookTargets: !isLoopbackHost(host),
     updates: [],
     webhook: undefined,

--- a/src/servers/zalo.ts
+++ b/src/servers/zalo.ts
@@ -43,7 +43,9 @@ type ZaloUpdate = {
   message: ZaloMessage;
 };
 
-type PendingUpdateResult = "conflict" | "disconnect" | "shutdown" | "timeout" | "update";
+type PendingUpdateResult =
+  | { kind: "conflict" | "disconnect" | "shutdown" | "timeout" }
+  | { kind: "update"; update: ZaloUpdate };
 
 type PendingUpdateRequest = {
   active: boolean;
@@ -319,7 +321,7 @@ async function waitForUpdate(
 ): Promise<Response> {
   const previous = state.pendingRequest;
   if (previous) {
-    settlePendingUpdate(state, previous, "conflict");
+    settlePendingUpdate(state, previous, { kind: "conflict" });
   }
   if (request.aborted || request.socket.destroyed || response.destroyed) {
     return zaloError("Client closed request", 499);
@@ -335,7 +337,7 @@ async function waitForUpdate(
     const pending: PendingUpdateRequest = {
       active: true,
       onDisconnect: () => {
-        settlePendingUpdate(state, pending, "disconnect");
+        settlePendingUpdate(state, pending, { kind: "disconnect" });
       },
       request,
       response,
@@ -347,43 +349,44 @@ async function waitForUpdate(
     request.socket.once("close", pending.onDisconnect);
     response.once("close", pending.onDisconnect);
     pending.timeout = setTimeout(() => {
-      settlePendingUpdate(state, pending, "timeout");
+      settlePendingUpdate(state, pending, { kind: "timeout" });
     }, timeoutSeconds * 1000);
     pending.timeout.unref();
     if (request.socket.destroyed || response.destroyed) {
       pending.onDisconnect();
     }
   });
-  if (result === "conflict") {
-    return zaloError("Conflict: terminated by other getUpdates request", 409);
+  switch (result.kind) {
+    case "conflict":
+      return zaloError("Conflict: terminated by other getUpdates request", 409);
+    case "disconnect":
+      return zaloError("Client closed request", 499);
+    case "shutdown":
+      return zaloError("Server shutting down", 503);
+    case "timeout":
+      return zaloError("Request timeout", 408);
+    case "update":
+      return zaloOk(result.update);
   }
-  if (result === "disconnect") {
-    return zaloError("Client closed request", 499);
-  }
-  if (result === "shutdown") {
-    return zaloError("Server shutting down", 503);
-  }
-  if (result === "timeout") {
-    return zaloError("Request timeout", 408);
-  }
-  return nextUpdate(request, response, state) ?? zaloError("Client closed request", 499);
 }
 
 function deliverPollingUpdate(state: ZaloServerState, update: ZaloUpdate): boolean {
+  const pending = state.pendingRequest;
+  if (pending) {
+    if (
+      !pending.request.aborted &&
+      !pending.request.socket.destroyed &&
+      !pending.response.destroyed
+    ) {
+      settlePendingUpdate(state, pending, { kind: "update", update });
+      return true;
+    }
+    settlePendingUpdate(state, pending, { kind: "disconnect" });
+  }
   if (state.updates.length >= state.maxPendingInboundEvents) {
     return false;
   }
   state.updates.push(update);
-  const pending = state.pendingRequest;
-  if (pending) {
-    settlePendingUpdate(
-      state,
-      pending,
-      pending.request.aborted || pending.request.socket.destroyed || pending.response.destroyed
-        ? "disconnect"
-        : "update",
-    );
-  }
   return true;
 }
 
@@ -583,7 +586,7 @@ async function handleZaloMethod(
     }
     const webhook = { secretToken, updatedAt: Date.now(), url: parsedUrl.href };
     if (state.pendingRequest) {
-      settlePendingUpdate(state, state.pendingRequest, "conflict");
+      settlePendingUpdate(state, state.pendingRequest, { kind: "conflict" });
     }
     state.webhook = webhook;
     return zaloOk({ updated_at: webhook.updatedAt, url: webhook.url });
@@ -678,7 +681,7 @@ export async function startZaloServer(
         request.destroy(new Error("Zalo server is shutting down."));
       }
       if (state.pendingRequest) {
-        settlePendingUpdate(state, state.pendingRequest, "shutdown");
+        settlePendingUpdate(state, state.pendingRequest, { kind: "shutdown" });
       }
       await httpServer.close();
     },

--- a/src/servers/zalo.ts
+++ b/src/servers/zalo.ts
@@ -72,11 +72,13 @@ type ZaloServerState = {
   inboundAdmission: Promise<void>;
   maxPendingInboundEvents: number;
   nextMessage: number;
+  nextUpdateOrder: number;
   onEvent: ServerEventObserver | undefined;
   pendingRequest: PendingUpdateRequest | undefined;
   recorderPath: string;
   reservedUpdates: number;
   restrictWebhookTargets: boolean;
+  updateOrders: WeakMap<ZaloUpdate, number>;
   updates: ZaloUpdate[];
   webhook: { secretToken: string; updatedAt: number; url: string } | undefined;
   webhookDeliveryTimeoutMs: number;
@@ -298,6 +300,28 @@ function nextUpdate(
   return reservedUpdateResponse(state, update);
 }
 
+function pollingUpdateOrder(state: ZaloServerState, update: ZaloUpdate): number {
+  const existing = state.updateOrders.get(update);
+  if (existing !== undefined) {
+    return existing;
+  }
+  const order = state.nextUpdateOrder++;
+  state.updateOrders.set(update, order);
+  return order;
+}
+
+function queuePollingUpdate(state: ZaloServerState, update: ZaloUpdate): void {
+  const order = pollingUpdateOrder(state, update);
+  const insertionIndex = state.updates.findIndex(
+    (queued) => pollingUpdateOrder(state, queued) > order,
+  );
+  if (insertionIndex < 0) {
+    state.updates.push(update);
+  } else {
+    state.updates.splice(insertionIndex, 0, update);
+  }
+}
+
 function reservedUpdateResponse(state: ZaloServerState, update: ZaloUpdate): HttpJsonHandlerResult {
   let settled = false;
   const release = () => {
@@ -314,7 +338,7 @@ function reservedUpdateResponse(state: ZaloServerState, update: ZaloUpdate): Htt
         return;
       }
       if (!deliverPollingUpdate(state, update)) {
-        state.updates.unshift(update);
+        queuePollingUpdate(state, update);
       }
     },
     onWriteSuccess() {
@@ -410,6 +434,7 @@ async function waitForUpdate(
 }
 
 function deliverPollingUpdate(state: ZaloServerState, update: ZaloUpdate): boolean {
+  pollingUpdateOrder(state, update);
   const pending = state.pendingRequest;
   if (pending) {
     if (isPendingUpdateRequestLive(pending)) {
@@ -422,7 +447,7 @@ function deliverPollingUpdate(state: ZaloServerState, update: ZaloUpdate): boole
   if (state.updates.length + state.reservedUpdates >= state.maxPendingInboundEvents) {
     return false;
   }
-  state.updates.push(update);
+  queuePollingUpdate(state, update);
   return true;
 }
 
@@ -668,11 +693,13 @@ export async function startZaloServer(
     inboundAdmission: Promise.resolve(),
     maxPendingInboundEvents: resolveMaxPendingInboundEvents(params.maxPendingInboundEvents),
     nextMessage: 1,
+    nextUpdateOrder: 1,
     onEvent: params.onEvent,
     pendingRequest: undefined,
     recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "zalo.jsonl"),
     reservedUpdates: 0,
     restrictWebhookTargets: !isLoopbackHost(host),
+    updateOrders: new WeakMap(),
     updates: [],
     webhook: undefined,
     webhookDeliveryTimeoutMs: webhookDeliveryTimeoutMs(params.webhookDeliveryTimeoutMs),

--- a/src/servers/zalo.ts
+++ b/src/servers/zalo.ts
@@ -162,7 +162,7 @@ function redactUrlCredentials(value: string): string {
   try {
     url = new URL(value);
   } catch {
-    return value.replace(/^([a-z][a-z0-9+.-]*:\/\/)[^/?#]*@/iu, "$1<redacted>@");
+    return value.replace(/^((?:[a-z][a-z0-9+.-]*:)?\/\/)[^/?#]*@/iu, "$1<redacted>@");
   }
   if (!url.username && !url.password) {
     return value;
@@ -655,6 +655,9 @@ async function handleZaloMethod(
     const target = await validateWebhookUrl(parsedUrl, state);
     if (target instanceof Response) {
       return target;
+    }
+    if (state.reservedUpdates > 0) {
+      return zaloError("Polling deliveries are still in progress", 409);
     }
     const webhook = { secretToken, updatedAt: Date.now(), url: parsedUrl.href };
     if (state.pendingRequest) {

--- a/src/servers/zalo.ts
+++ b/src/servers/zalo.ts
@@ -69,6 +69,7 @@ type ZaloServerState = {
   botName: string;
   botToken: string;
   closing: boolean;
+  failedUpdateOrders: Set<number>;
   inboundAdmission: Promise<void>;
   maxPendingInboundEvents: number;
   nextMessage: number;
@@ -76,7 +77,7 @@ type ZaloServerState = {
   onEvent: ServerEventObserver | undefined;
   pendingRequest: PendingUpdateRequest | undefined;
   recorderPath: string;
-  reservedUpdates: number;
+  reservedUpdateOrders: Set<number>;
   restrictWebhookTargets: boolean;
   updateOrders: WeakMap<ZaloUpdate, number>;
   updates: ZaloUpdate[];
@@ -292,11 +293,19 @@ function nextUpdate(
   if (request.aborted || request.socket.destroyed || response.destroyed) {
     return undefined;
   }
-  const update = state.updates.shift();
+  const update = state.updates[0];
   if (!update) {
     return undefined;
   }
-  state.reservedUpdates++;
+  const order = pollingUpdateOrder(state, update);
+  if (
+    state.failedUpdateOrders.has(order) &&
+    [...state.reservedUpdateOrders].some((reservedOrder) => reservedOrder < order)
+  ) {
+    return undefined;
+  }
+  state.updates.shift();
+  reservePollingUpdate(state, update);
   return reservedUpdateResponse(state, update);
 }
 
@@ -322,6 +331,34 @@ function queuePollingUpdate(state: ZaloServerState, update: ZaloUpdate): void {
   }
 }
 
+function reservePollingUpdate(state: ZaloServerState, update: ZaloUpdate): void {
+  const order = pollingUpdateOrder(state, update);
+  state.failedUpdateOrders.delete(order);
+  state.reservedUpdateOrders.add(order);
+}
+
+function flushPendingPollingUpdate(state: ZaloServerState): void {
+  const pending = state.pendingRequest;
+  const update = state.updates[0];
+  if (!pending || !update) {
+    return;
+  }
+  if (!isPendingUpdateRequestLive(pending)) {
+    settlePendingUpdate(state, pending, { kind: "disconnect" });
+    return;
+  }
+  const order = pollingUpdateOrder(state, update);
+  if (
+    state.failedUpdateOrders.has(order) &&
+    [...state.reservedUpdateOrders].some((reservedOrder) => reservedOrder < order)
+  ) {
+    return;
+  }
+  state.updates.shift();
+  reservePollingUpdate(state, update);
+  settlePendingUpdate(state, pending, { kind: "update", update });
+}
+
 function reservedUpdateResponse(state: ZaloServerState, update: ZaloUpdate): HttpJsonHandlerResult {
   let settled = false;
   const release = () => {
@@ -329,7 +366,7 @@ function reservedUpdateResponse(state: ZaloServerState, update: ZaloUpdate): Htt
       return false;
     }
     settled = true;
-    state.reservedUpdates--;
+    state.reservedUpdateOrders.delete(pollingUpdateOrder(state, update));
     return true;
   };
   return {
@@ -337,12 +374,14 @@ function reservedUpdateResponse(state: ZaloServerState, update: ZaloUpdate): Htt
       if (!release()) {
         return;
       }
-      if (!deliverPollingUpdate(state, update)) {
-        queuePollingUpdate(state, update);
-      }
+      state.failedUpdateOrders.add(pollingUpdateOrder(state, update));
+      queuePollingUpdate(state, update);
+      flushPendingPollingUpdate(state);
     },
     onWriteSuccess() {
-      release();
+      if (release()) {
+        flushPendingPollingUpdate(state);
+      }
     },
     response: zaloOk(update),
   };
@@ -438,13 +477,13 @@ function deliverPollingUpdate(state: ZaloServerState, update: ZaloUpdate): boole
   const pending = state.pendingRequest;
   if (pending) {
     if (isPendingUpdateRequestLive(pending)) {
-      state.reservedUpdates++;
+      reservePollingUpdate(state, update);
       settlePendingUpdate(state, pending, { kind: "update", update });
       return true;
     }
     settlePendingUpdate(state, pending, { kind: "disconnect" });
   }
-  if (state.updates.length + state.reservedUpdates >= state.maxPendingInboundEvents) {
+  if (state.updates.length + state.reservedUpdateOrders.size >= state.maxPendingInboundEvents) {
     return false;
   }
   queuePollingUpdate(state, update);
@@ -532,7 +571,7 @@ async function handleAdminInbound(
   try {
     if (
       !state.webhook?.url &&
-      state.updates.length + state.reservedUpdates >= state.maxPendingInboundEvents
+      state.updates.length + state.reservedUpdateOrders.size >= state.maxPendingInboundEvents
     ) {
       return zaloError(
         `Pending inbound queue is full (${state.maxPendingInboundEvents} updates)`,
@@ -656,7 +695,7 @@ async function handleZaloMethod(
     if (target instanceof Response) {
       return target;
     }
-    if (state.reservedUpdates > 0) {
+    if (state.reservedUpdateOrders.size > 0) {
       return zaloError("Polling deliveries are still in progress", 409);
     }
     const webhook = { secretToken, updatedAt: Date.now(), url: parsedUrl.href };
@@ -693,6 +732,7 @@ export async function startZaloServer(
       params.botToken ??
       (isLoopbackHost(host) ? "crabline-zalo-bot-token" : randomBytes(32).toString("base64url")),
     closing: false,
+    failedUpdateOrders: new Set(),
     inboundAdmission: Promise.resolve(),
     maxPendingInboundEvents: resolveMaxPendingInboundEvents(params.maxPendingInboundEvents),
     nextMessage: 1,
@@ -700,7 +740,7 @@ export async function startZaloServer(
     onEvent: params.onEvent,
     pendingRequest: undefined,
     recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "zalo.jsonl"),
-    reservedUpdates: 0,
+    reservedUpdateOrders: new Set(),
     restrictWebhookTargets: !isLoopbackHost(host),
     updateOrders: new WeakMap(),
     updates: [],

--- a/src/servers/zalo.ts
+++ b/src/servers/zalo.ts
@@ -163,7 +163,7 @@ function redactUrlCredentials(value: string): string {
   try {
     url = new URL(value);
   } catch {
-    return value.replace(/^((?:[a-z][a-z0-9+.-]*:)?\/\/)[^/?#]*@/iu, "$1<redacted>@");
+    return value.replace(/^(\s*)((?:[a-z][a-z0-9+.-]*:)?\/\/)[^/?#]*@/iu, "$1$2<redacted>@");
   }
   if (!url.username && !url.password) {
     return value;

--- a/src/servers/zalo.ts
+++ b/src/servers/zalo.ts
@@ -69,6 +69,7 @@ type ZaloServerState = {
   botName: string;
   botToken: string;
   closing: boolean;
+  inboundAdmission: Promise<void>;
   maxPendingInboundEvents: number;
   nextMessage: number;
   onEvent: ServerEventObserver | undefined;
@@ -357,12 +358,12 @@ async function waitForUpdate(
   state: ZaloServerState,
   timeoutSeconds: number,
 ): Promise<HttpJsonHandlerResult> {
+  if (request.aborted || request.socket.destroyed || response.destroyed) {
+    return zaloError("Client closed request", 499);
+  }
   const previous = state.pendingRequest;
   if (previous) {
     settlePendingUpdate(state, previous, { kind: "conflict" });
-  }
-  if (request.aborted || request.socket.destroyed || response.destroyed) {
-    return zaloError("Client closed request", 499);
   }
   const queued = nextUpdate(request, response, state);
   if (queued) {
@@ -497,52 +498,59 @@ async function handleAdminInbound(
   if (chatId instanceof Response || senderId instanceof Response || text instanceof Response) {
     return [chatId, senderId, text].find((value) => value instanceof Response) as Response;
   }
-  const update: ZaloUpdate = {
-    event_name: "message.text.received",
-    message: {
-      chat: { chat_type: readChatType(body.chatType), id: chatId },
-      date: Date.now(),
-      from: {
-        display_name: readTrimmedString(body.senderName) ?? senderId,
-        id: senderId,
-        is_bot: false,
-      },
-      message_id: messageId(state),
-      text,
-    },
-  };
-  if (
-    !state.webhook?.url &&
-    !(state.pendingRequest && isPendingUpdateRequestLive(state.pendingRequest)) &&
-    state.updates.length + state.reservedUpdates >= state.maxPendingInboundEvents
-  ) {
-    return zaloError(
-      `Pending inbound queue is full (${state.maxPendingInboundEvents} updates)`,
-      429,
-    );
-  }
-  await appendEvent(state, {
-    at: new Date().toISOString(),
-    body,
-    method: request.method ?? "POST",
-    path: url.pathname,
-    query: queryRecord(url),
-    type: "admin",
+  let releaseAdmission!: () => void;
+  const previousAdmission = state.inboundAdmission;
+  state.inboundAdmission = new Promise<void>((resolve) => {
+    releaseAdmission = resolve;
   });
-  if (state.webhook?.url) {
-    const error = await deliverWebhookUpdate(state, state.webhook, update);
-    if (error) {
-      return error;
-    }
-  } else {
-    if (!deliverPollingUpdate(state, update)) {
+  await previousAdmission;
+  try {
+    if (
+      !state.webhook?.url &&
+      state.updates.length + state.reservedUpdates >= state.maxPendingInboundEvents
+    ) {
       return zaloError(
         `Pending inbound queue is full (${state.maxPendingInboundEvents} updates)`,
         429,
       );
     }
+    const update: ZaloUpdate = {
+      event_name: "message.text.received",
+      message: {
+        chat: { chat_type: readChatType(body.chatType), id: chatId },
+        date: Date.now(),
+        from: {
+          display_name: readTrimmedString(body.senderName) ?? senderId,
+          id: senderId,
+          is_bot: false,
+        },
+        message_id: messageId(state),
+        text,
+      },
+    };
+    await appendEvent(state, {
+      at: new Date().toISOString(),
+      body,
+      method: request.method ?? "POST",
+      path: url.pathname,
+      query: queryRecord(url),
+      type: "admin",
+    });
+    if (state.webhook?.url) {
+      const error = await deliverWebhookUpdate(state, state.webhook, update);
+      if (error) {
+        return error;
+      }
+    } else if (!deliverPollingUpdate(state, update)) {
+      return zaloError(
+        `Pending inbound queue is full (${state.maxPendingInboundEvents} updates)`,
+        429,
+      );
+    }
+    return zaloOk(update);
+  } finally {
+    releaseAdmission();
   }
-  return zaloOk(update);
 }
 
 async function handleZaloMethod(
@@ -657,6 +665,7 @@ export async function startZaloServer(
       params.botToken ??
       (isLoopbackHost(host) ? "crabline-zalo-bot-token" : randomBytes(32).toString("base64url")),
     closing: false,
+    inboundAdmission: Promise.resolve(),
     maxPendingInboundEvents: resolveMaxPendingInboundEvents(params.maxPendingInboundEvents),
     nextMessage: 1,
     onEvent: params.onEvent,

--- a/test/http-server.test.ts
+++ b/test/http-server.test.ts
@@ -1,4 +1,4 @@
-import type { IncomingMessage } from "node:http";
+import { get, type IncomingMessage } from "node:http";
 import { PassThrough } from "node:stream";
 import { describe, expect, it } from "vitest";
 import {
@@ -102,6 +102,55 @@ describe("server HTTP body reader", () => {
         error: "internal server error",
         ok: false,
       });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("reports response delivery failure to transactional handlers", async () => {
+    let releaseHandler: (() => void) | undefined;
+    let observeHandler: (() => void) | undefined;
+    let observeAbort: (() => void) | undefined;
+    const handlerObserved = new Promise<void>((resolve) => {
+      observeHandler = resolve;
+    });
+    const handlerBlocked = new Promise<void>((resolve) => {
+      releaseHandler = resolve;
+    });
+    const requestAborted = new Promise<void>((resolve) => {
+      observeAbort = resolve;
+    });
+    let failed = 0;
+    let succeeded = 0;
+    const server = await startHttpJsonServer({
+      async handle(request) {
+        request.once("aborted", () => observeAbort?.());
+        observeHandler?.();
+        await handlerBlocked;
+        return {
+          onWriteFailure() {
+            failed++;
+          },
+          onWriteSuccess() {
+            succeeded++;
+          },
+          response: Response.json({ ok: true }),
+        };
+      },
+      host: "127.0.0.1",
+      port: 0,
+      serverName: "test",
+    });
+
+    try {
+      const request = get(server.baseUrl);
+      request.on("error", () => {});
+      await handlerObserved;
+      request.destroy();
+      await requestAborted;
+      releaseHandler?.();
+      await expect.poll(() => failed).toBe(1);
+      expect(succeeded).toBe(0);
     } finally {
       await server.close();
     }

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -1133,7 +1133,7 @@ describe("OpenClaw local provider bridge", () => {
     expect(
       createOpenClawCrablineAgentDelivery({
         manifest: whatsappManifest,
-        target: "dm:15551234567@s.whatsapp.net",
+        target: "dm:15551234567@C.US",
       }),
     ).toEqual({
       channel: "whatsapp",
@@ -1183,8 +1183,8 @@ describe("OpenClaw local provider bridge", () => {
     const inbound = createOpenClawCrablineInbound({
       manifest: whatsappManifest,
       input: {
-        conversation: { id: "120363001234567890@g.us", kind: "group" },
-        senderId: "15551234567@s.whatsapp.net",
+        conversation: { id: "120363001234567890@G.US", kind: "group" },
+        senderId: "15551234567@C.US",
         senderName: "Alice",
         text: "hello",
       },
@@ -1241,6 +1241,7 @@ describe("OpenClaw local provider bridge", () => {
         manifest: whatsappManifest,
         targetByProviderTarget: new Map([["15551234567@s.whatsapp.net", "dm:alice"]]),
         event: {
+          accepted: true,
           type: "api",
           path: "/v25.0/100000000000000/messages",
           body: {
@@ -1256,6 +1257,21 @@ describe("OpenClaw local provider bridge", () => {
       text: "hello from openclaw",
       to: "dm:alice",
     });
+    expect(
+      createOpenClawCrablineOutboundFromRecorderEvent({
+        manifest: whatsappManifest,
+        targetByProviderTarget: new Map(),
+        event: {
+          accepted: false,
+          type: "api",
+          path: "/v25.0/100000000000000/messages",
+          body: {
+            to: "15551234567",
+            text: { body: "rejected send" },
+          },
+        },
+      }),
+    ).toBeNull();
     for (const body of [
       { jid: "15551234567@s.whatsapp.net", text: "rejected legacy shape" },
       { text: "rejected flat text", to: "15551234567" },
@@ -1478,6 +1494,7 @@ describe("OpenClaw local provider bridge", () => {
         name: "WhatsApp",
         manifest: whatsappManifest,
         event: (text) => ({
+          accepted: true,
           body: { text: { body: text }, to: "15551234567@s.whatsapp.net" },
           path: new URL(whatsappManifest.endpoints.messagesUrl).pathname,
           type: "api",

--- a/test/recorder-concurrency.test.ts
+++ b/test/recorder-concurrency.test.ts
@@ -1,15 +1,29 @@
 import path from "node:path";
+import { rm } from "node:fs/promises";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { appendRecordedInbound } from "../src/providers/recorder.js";
 import { recordServerEvent } from "../src/servers/recorder.js";
 
 const fsMocks = vi.hoisted(() => ({
   appendFile: vi.fn<(filePath: string, data: string, encoding: string) => Promise<void>>(),
+  providerWrite: vi.fn<(filePath: string, data: string) => Promise<void>>(),
 }));
 
 vi.mock("node:fs/promises", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs/promises")>();
-  return { ...actual, appendFile: fsMocks.appendFile };
+  return {
+    ...actual,
+    appendFile: fsMocks.appendFile,
+    open: async (...args: Parameters<typeof actual.open>) => {
+      const handle = await actual.open(...args);
+      if (args[1] === "a+" && String(args[0]).includes("crabline-provider-recorder")) {
+        handle.writeFile = async (data) => {
+          await fsMocks.providerWrite(String(args[0]), String(data));
+        };
+      }
+      return handle;
+    },
+  };
 });
 
 type PendingWrite = {
@@ -22,7 +36,14 @@ let pendingWrites: PendingWrite[] = [];
 beforeEach(() => {
   pendingWrites = [];
   fsMocks.appendFile.mockReset();
+  fsMocks.providerWrite.mockReset();
   fsMocks.appendFile.mockImplementation(
+    async (_filePath, data) =>
+      await new Promise<void>((resolve) => {
+        pendingWrites.push({ data, resolve });
+      }),
+  );
+  fsMocks.providerWrite.mockImplementation(
     async (_filePath, data) =>
       await new Promise<void>((resolve) => {
         pendingWrites.push({ data, resolve });
@@ -30,12 +51,16 @@ beforeEach(() => {
   );
 });
 
-async function expectSerializedWrites(first: Promise<unknown>, second: Promise<unknown>) {
-  await vi.waitFor(() => expect(fsMocks.appendFile).toHaveBeenCalledTimes(1));
+async function expectSerializedWrites(
+  write: { mock: { calls: unknown[][] } },
+  first: Promise<unknown>,
+  second: Promise<unknown>,
+) {
+  await vi.waitFor(() => expect(write.mock.calls).toHaveLength(1));
   expect(pendingWrites).toHaveLength(1);
 
   pendingWrites[0]!.resolve();
-  await vi.waitFor(() => expect(fsMocks.appendFile).toHaveBeenCalledTimes(2));
+  await vi.waitFor(() => expect(write.mock.calls).toHaveLength(2));
   expect(pendingWrites).toHaveLength(2);
 
   pendingWrites[1]!.resolve();
@@ -69,7 +94,7 @@ describe("recorder append serialization", () => {
       recorderPath,
     });
 
-    await expectSerializedWrites(first, second);
+    await expectSerializedWrites(fsMocks.appendFile, first, second);
     expect(pendingWrites.map((write) => write.data)).toEqual([
       `${JSON.stringify(firstEvent)}\n`,
       `${JSON.stringify(secondEvent)}\n`,
@@ -77,7 +102,10 @@ describe("recorder append serialization", () => {
   });
 
   it("serializes provider inbound appends to the same JSONL file", async () => {
-    const recorderPath = path.join("/tmp", "crabline-provider-recorder.jsonl");
+    const recorderPath = path.join(
+      "/tmp",
+      `crabline-provider-recorder-${process.pid}-${Date.now()}.jsonl`,
+    );
     const firstEvent = {
       author: "assistant" as const,
       id: "first",
@@ -93,13 +121,17 @@ describe("recorder append serialization", () => {
     };
 
     const first = appendRecordedInbound(recorderPath, firstEvent);
-    await vi.waitFor(() => expect(fsMocks.appendFile).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(fsMocks.providerWrite).toHaveBeenCalledTimes(1));
     const second = appendRecordedInbound(recorderPath, secondEvent);
 
-    await expectSerializedWrites(first, second);
-    expect(pendingWrites.map((write) => JSON.parse(write.data) as { id: string })).toEqual([
-      expect.objectContaining({ id: "first" }),
-      expect.objectContaining({ id: "second" }),
-    ]);
+    try {
+      await expectSerializedWrites(fsMocks.providerWrite, first, second);
+      expect(pendingWrites.map((write) => JSON.parse(write.data) as { id: string })).toEqual([
+        expect.objectContaining({ id: "first" }),
+        expect.objectContaining({ id: "second" }),
+      ]);
+    } finally {
+      await rm(recorderPath, { force: true });
+    }
   });
 });

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -131,6 +131,28 @@ describe("recorder", () => {
     ]);
   });
 
+  it("rejects a batch record larger than the incremental reader limit", async () => {
+    const filePath = await createRecorderPath();
+    const event = {
+      author: "user" as const,
+      id: "oversized-batch",
+      provider: "whatsapp",
+      sentAt: new Date().toISOString(),
+      text: "x".repeat(4 * 1024 * 1024),
+      threadId: "15551234567",
+    };
+
+    await expect(appendRecordedInboundBatch(filePath, [event])).rejects.toThrow(
+      "Recorder record exceeded",
+    );
+    await expect(
+      appendRecordedInboundBatch(filePath, [{ ...event, id: "after-oversized", text: "small" }]),
+    ).resolves.toEqual([expect.objectContaining({ id: "after-oversized" })]);
+    await expect(readRecordedInbound(filePath)).resolves.toEqual([
+      expect.objectContaining({ id: "after-oversized" }),
+    ]);
+  });
+
   it("hides partial batch appends before retrying", async () => {
     const filePath = await createRecorderPath();
     const sentAt = new Date().toISOString();
@@ -322,6 +344,65 @@ describe("recorder", () => {
     ]);
     await expect(readRecordedInbound(firstTarget)).resolves.toEqual([
       expect.objectContaining({ id: "symlink-batch" }),
+    ]);
+  });
+
+  it("serializes the first batch through a dangling recorder symlink", async () => {
+    const filePath = await createRecorderPath();
+    const targetPath = path.join(path.dirname(filePath), "dangling-target.jsonl");
+    await symlink(targetPath, filePath, "file");
+    const event = {
+      author: "user" as const,
+      id: "dangling-symlink-batch",
+      provider: "whatsapp",
+      sentAt: new Date().toISOString(),
+      text: "deduplicate the first concurrent append",
+      threadId: "15551234567",
+    };
+
+    const probeHandle = await open(path.dirname(filePath), "r");
+    const fileHandlePrototype = Object.getPrototypeOf(probeHandle) as {
+      writeFile(data: string, encoding: BufferEncoding): Promise<void>;
+    };
+    await probeHandle.close();
+    const originalWriteFile = fileHandlePrototype.writeFile;
+    let releaseFirstWrite!: () => void;
+    let reportFirstWrite!: () => void;
+    const firstWriteReported = new Promise<void>((resolve) => {
+      reportFirstWrite = resolve;
+    });
+    const firstWriteReleased = new Promise<void>((resolve) => {
+      releaseFirstWrite = resolve;
+    });
+    let pauseFirstBatch = true;
+    fileHandlePrototype.writeFile = async function (
+      this: FileHandle,
+      data: string,
+      encoding: BufferEncoding,
+    ) {
+      if (pauseFirstBatch && data.includes('"recorderBatchVersion"')) {
+        pauseFirstBatch = false;
+        reportFirstWrite();
+        await firstWriteReleased;
+      }
+      await originalWriteFile.call(this, data, encoding);
+    };
+
+    const first = appendRecordedInboundBatch(filePath, [event]);
+    try {
+      await firstWriteReported;
+      const second = appendRecordedInboundBatch(filePath, [event]);
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      releaseFirstWrite();
+      const results = await Promise.all([first, second]);
+      expect(results.map((result) => result.length).toSorted()).toEqual([0, 1]);
+    } finally {
+      releaseFirstWrite();
+      fileHandlePrototype.writeFile = originalWriteFile;
+    }
+
+    await expect(readRecordedInbound(filePath)).resolves.toEqual([
+      expect.objectContaining({ id: event.id }),
     ]);
   });
 

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   appendRecordedInbound,
+  appendRecordedInboundBatch,
   createRecordedInboundCursor,
   readRecordedInbound,
   waitForRecordedInbound,
@@ -44,6 +45,39 @@ describe("recorder", () => {
     expect(events).toHaveLength(1);
     expect(events[0]?.recordedAt).toBeTypeOf("string");
     expect(events[0]?.text).toBe("hello");
+  });
+
+  it("appends retry-idempotent batches without partial duplicates", async () => {
+    const filePath = await createRecorderPath();
+    const sentAt = new Date().toISOString();
+    const batch = [
+      {
+        author: "user" as const,
+        id: "evt-batch-1",
+        provider: "whatsapp",
+        sentAt,
+        text: "first",
+        threadId: "15551234567",
+      },
+      {
+        author: "user" as const,
+        id: "evt-batch-2",
+        provider: "whatsapp",
+        sentAt,
+        text: "second",
+        threadId: "15551234567",
+      },
+    ];
+
+    const results = await Promise.all([
+      appendRecordedInboundBatch(filePath, batch),
+      appendRecordedInboundBatch(filePath, batch),
+    ]);
+    expect(results.map((result) => result.length).toSorted()).toEqual([0, 2]);
+    await expect(readRecordedInbound(filePath)).resolves.toEqual([
+      expect.objectContaining({ id: "evt-batch-1" }),
+      expect.objectContaining({ id: "evt-batch-2" }),
+    ]);
   });
 
   it("keeps valid events when the final record is truncated", async () => {

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -96,6 +96,35 @@ describe("recorder", () => {
     });
   });
 
+  it("deduplicates a valid recorder tail that is missing its final newline", async () => {
+    const filePath = await createRecorderPath();
+    const sentAt = new Date().toISOString();
+    const event = {
+      author: "user" as const,
+      id: "unterminated-retry",
+      provider: "whatsapp",
+      sentAt,
+      text: "retry",
+      threadId: "15551234567",
+    };
+    await writeFile(
+      filePath,
+      JSON.stringify({
+        ...event,
+        recordedAt: sentAt,
+      }),
+      "utf8",
+    );
+
+    await expect(appendRecordedInboundBatch(filePath, [event])).resolves.toEqual([]);
+    expect(await readFile(filePath, "utf8")).toBe(
+      `${JSON.stringify({ ...event, recordedAt: sentAt })}\n`,
+    );
+    await expect(readRecordedInbound(filePath)).resolves.toEqual([
+      expect.objectContaining({ id: "unterminated-retry" }),
+    ]);
+  });
+
   it("hides partial batch appends before retrying", async () => {
     const filePath = await createRecorderPath();
     const sentAt = new Date().toISOString();

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -1,4 +1,13 @@
-import { appendFile, open, readFile, rename, writeFile, type FileHandle } from "node:fs/promises";
+import {
+  appendFile,
+  open,
+  readFile,
+  rename,
+  rm,
+  symlink,
+  writeFile,
+  type FileHandle,
+} from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -212,6 +221,68 @@ describe("recorder", () => {
     await expect(readRecordedInbound(rotatedPath)).resolves.toEqual([
       expect.objectContaining({ id: "existing" }),
       expect.objectContaining({ id: "rotated-batch" }),
+    ]);
+  });
+
+  it("detects a symlinked recorder retargeted during a batch append", async () => {
+    const filePath = await createRecorderPath();
+    const firstTarget = path.join(path.dirname(filePath), "first-target.jsonl");
+    const secondTarget = path.join(path.dirname(filePath), "second-target.jsonl");
+    await writeFile(firstTarget, "", "utf8");
+    await writeFile(secondTarget, "", "utf8");
+    await symlink(firstTarget, filePath, "file");
+    const event = {
+      author: "user" as const,
+      id: "symlink-batch",
+      provider: "whatsapp",
+      sentAt: new Date().toISOString(),
+      text: "detect retargeting",
+      threadId: "15551234567",
+    };
+
+    const probeHandle = await open(firstTarget, "a+");
+    const fileHandlePrototype = Object.getPrototypeOf(probeHandle) as {
+      writeFile(data: string, encoding: BufferEncoding): Promise<void>;
+    };
+    await probeHandle.close();
+    const originalWriteFile = fileHandlePrototype.writeFile;
+    let releaseWrite!: () => void;
+    let reportWrite!: () => void;
+    const writeReported = new Promise<void>((resolve) => {
+      reportWrite = resolve;
+    });
+    const writeReleased = new Promise<void>((resolve) => {
+      releaseWrite = resolve;
+    });
+    let interceptBatch = true;
+    fileHandlePrototype.writeFile = async function (
+      this: FileHandle,
+      data: string,
+      encoding: BufferEncoding,
+    ) {
+      await originalWriteFile.call(this, data, encoding);
+      if (interceptBatch && data.includes('"recorderBatchVersion"')) {
+        interceptBatch = false;
+        reportWrite();
+        await writeReleased;
+      }
+    };
+
+    const append = appendRecordedInboundBatch(filePath, [event]);
+    try {
+      await writeReported;
+      await rm(filePath);
+      await symlink(secondTarget, filePath, "file");
+      releaseWrite();
+      await expect(append).rejects.toThrow("Recorder rotated");
+    } finally {
+      releaseWrite();
+      fileHandlePrototype.writeFile = originalWriteFile;
+    }
+
+    await expect(readRecordedInbound(filePath)).resolves.toEqual([]);
+    await expect(readRecordedInbound(firstTarget)).resolves.toEqual([
+      expect.objectContaining({ id: "symlink-batch" }),
     ]);
   });
 

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -100,6 +100,14 @@ describe("recorder", () => {
     await probeHandle.close();
     const originalWriteFile = fileHandlePrototype.writeFile;
     let failNextWrite = true;
+    let releasePartialWrite!: () => void;
+    let reportPartialWrite!: () => void;
+    const partialWriteReported = new Promise<void>((resolve) => {
+      reportPartialWrite = resolve;
+    });
+    const partialWriteReleased = new Promise<void>((resolve) => {
+      releasePartialWrite = resolve;
+    });
     fileHandlePrototype.writeFile = async function (
       this: FileHandle,
       data: string,
@@ -108,17 +116,24 @@ describe("recorder", () => {
       if (failNextWrite) {
         failNextWrite = false;
         await originalWriteFile.call(this, data.slice(0, Math.ceil(data.length / 2)), encoding);
+        reportPartialWrite();
+        await partialWriteReleased;
         throw Object.assign(new Error("simulated partial append"), { code: "ENOSPC" });
       }
       await originalWriteFile.call(this, data, encoding);
     };
 
     const batch = [event("retry-1"), event("retry-2")];
+    const failedAppend = appendRecordedInboundBatch(filePath, batch);
     try {
-      await expect(appendRecordedInboundBatch(filePath, batch)).rejects.toThrow(
-        "simulated partial append",
-      );
+      await partialWriteReported;
+      await expect(readRecordedInbound(filePath)).resolves.toEqual([
+        expect.objectContaining({ id: "existing" }),
+      ]);
+      releasePartialWrite();
+      await expect(failedAppend).rejects.toThrow("simulated partial append");
     } finally {
+      releasePartialWrite();
       fileHandlePrototype.writeFile = originalWriteFile;
     }
 
@@ -131,6 +146,48 @@ describe("recorder", () => {
       expect.objectContaining({ id: "retry-1" }),
       expect.objectContaining({ id: "retry-2" }),
     ]);
+  });
+
+  it("repairs an interrupted recorder tail before publishing a batch", async () => {
+    const filePath = await createRecorderPath();
+    const sentAt = new Date().toISOString();
+    const event = (id: string) => ({
+      author: "user" as const,
+      id,
+      provider: "whatsapp",
+      sentAt,
+      text: id,
+      threadId: "15551234567",
+    });
+    await appendRecordedInboundBatch(filePath, [event("existing")]);
+    await appendFile(filePath, '{"id":"interrupted"', "utf8");
+
+    await appendRecordedInboundBatch(filePath, [event("after-recovery")]);
+
+    await expect(readRecordedInbound(filePath)).resolves.toEqual([
+      expect.objectContaining({ id: "existing" }),
+      expect.objectContaining({ id: "after-recovery" }),
+    ]);
+  });
+
+  it("bounds batch identity memory to a recent retry window", async () => {
+    const filePath = await createRecorderPath();
+    const sentAt = new Date().toISOString();
+    const event = (id: string) => ({
+      author: "user" as const,
+      id,
+      provider: "whatsapp",
+      sentAt,
+      text: id,
+      threadId: "15551234567",
+    });
+    const history = Array.from({ length: 4097 }, (_, index) => event(`history-${index}`));
+
+    await expect(appendRecordedInboundBatch(filePath, history)).resolves.toHaveLength(
+      history.length,
+    );
+    await expect(appendRecordedInboundBatch(filePath, [history[0]!])).resolves.toHaveLength(1);
+    await expect(appendRecordedInboundBatch(filePath, [history.at(-1)!])).resolves.toEqual([]);
   });
 
   it("indexes batch identities without rescanning completed recorder history", async () => {

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -78,9 +78,16 @@ describe("recorder", () => {
       expect.objectContaining({ id: "evt-batch-1" }),
       expect.objectContaining({ id: "evt-batch-2" }),
     ]);
+    const lines = (await readFile(filePath, "utf8")).trim().split("\n");
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0]!)).toMatchObject({
+      events: [{ id: "evt-batch-1" }, { id: "evt-batch-2" }],
+      recordType: "crabline.recorder.batch",
+      recorderBatchVersion: 1,
+    });
   });
 
-  it("rolls back partial batch appends before retrying", async () => {
+  it("hides partial batch appends before retrying", async () => {
     const filePath = await createRecorderPath();
     const sentAt = new Date().toISOString();
     const event = (id: string) => ({
@@ -145,6 +152,66 @@ describe("recorder", () => {
       expect.objectContaining({ id: "existing" }),
       expect.objectContaining({ id: "retry-1" }),
       expect.objectContaining({ id: "retry-2" }),
+    ]);
+  });
+
+  it("does not overwrite a recorder rotated during a batch append", async () => {
+    const filePath = await createRecorderPath();
+    const rotatedPath = `${filePath}.rotated`;
+    const event = {
+      author: "user" as const,
+      id: "rotated-batch",
+      provider: "whatsapp",
+      sentAt: new Date().toISOString(),
+      text: "preserve both generations",
+      threadId: "15551234567",
+    };
+    await appendRecordedInboundBatch(filePath, [{ ...event, id: "existing", text: "existing" }]);
+
+    const probeHandle = await open(filePath, "a+");
+    const fileHandlePrototype = Object.getPrototypeOf(probeHandle) as {
+      writeFile(data: string, encoding: BufferEncoding): Promise<void>;
+    };
+    await probeHandle.close();
+    const originalWriteFile = fileHandlePrototype.writeFile;
+    let releaseWrite!: () => void;
+    let reportWrite!: () => void;
+    const writeReported = new Promise<void>((resolve) => {
+      reportWrite = resolve;
+    });
+    const writeReleased = new Promise<void>((resolve) => {
+      releaseWrite = resolve;
+    });
+    let interceptBatch = true;
+    fileHandlePrototype.writeFile = async function (
+      this: FileHandle,
+      data: string,
+      encoding: BufferEncoding,
+    ) {
+      await originalWriteFile.call(this, data, encoding);
+      if (interceptBatch && data.includes('"recorderBatchVersion"')) {
+        interceptBatch = false;
+        reportWrite();
+        await writeReleased;
+      }
+    };
+
+    const append = appendRecordedInboundBatch(filePath, [event]);
+    try {
+      await writeReported;
+      await rename(filePath, rotatedPath);
+      await writeFile(filePath, "", "utf8");
+      releaseWrite();
+      await expect(append).rejects.toThrow("Recorder rotated");
+    } finally {
+      releaseWrite();
+      fileHandlePrototype.writeFile = originalWriteFile;
+    }
+
+    await expect(readRecordedInbound(filePath)).resolves.toEqual([]);
+    await expect(readRecordedInbound(rotatedPath)).resolves.toEqual([
+      expect.objectContaining({ id: "existing" }),
+      expect.objectContaining({ id: "rotated-batch" }),
     ]);
   });
 
@@ -628,16 +695,16 @@ describe("recorder", () => {
 
   it("bounds unterminated recorder records", async () => {
     const filePath = await createRecorderPath();
-    await writeFile(filePath, "x".repeat(1024 * 1024 + 1), "utf8");
+    await writeFile(filePath, "x".repeat(4 * 1024 * 1024 + 1), "utf8");
 
     await expect(
       waitForRecordedInbound({
         filePath,
         matches: () => false,
         pollMs: 10,
-        timeoutMs: 30,
+        timeoutMs: 1000,
       }),
-    ).rejects.toThrow(/exceeded 1048576 bytes without a newline/u);
+    ).rejects.toThrow(/exceeded 4194304 bytes without a newline/u);
   });
 
   it("resets incremental reads when the recorder is atomically replaced", async () => {

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -80,6 +80,59 @@ describe("recorder", () => {
     ]);
   });
 
+  it("rolls back partial batch appends before retrying", async () => {
+    const filePath = await createRecorderPath();
+    const sentAt = new Date().toISOString();
+    const event = (id: string) => ({
+      author: "user" as const,
+      id,
+      provider: "whatsapp",
+      sentAt,
+      text: id,
+      threadId: "15551234567",
+    });
+    await appendRecordedInboundBatch(filePath, [event("existing")]);
+
+    const probeHandle = await open(filePath, "a+");
+    const fileHandlePrototype = Object.getPrototypeOf(probeHandle) as {
+      writeFile(data: string, encoding: BufferEncoding): Promise<void>;
+    };
+    await probeHandle.close();
+    const originalWriteFile = fileHandlePrototype.writeFile;
+    let failNextWrite = true;
+    fileHandlePrototype.writeFile = async function (
+      this: FileHandle,
+      data: string,
+      encoding: BufferEncoding,
+    ) {
+      if (failNextWrite) {
+        failNextWrite = false;
+        await originalWriteFile.call(this, data.slice(0, Math.ceil(data.length / 2)), encoding);
+        throw Object.assign(new Error("simulated partial append"), { code: "ENOSPC" });
+      }
+      await originalWriteFile.call(this, data, encoding);
+    };
+
+    const batch = [event("retry-1"), event("retry-2")];
+    try {
+      await expect(appendRecordedInboundBatch(filePath, batch)).rejects.toThrow(
+        "simulated partial append",
+      );
+    } finally {
+      fileHandlePrototype.writeFile = originalWriteFile;
+    }
+
+    await expect(appendRecordedInboundBatch(filePath, batch)).resolves.toEqual([
+      expect.objectContaining({ id: "retry-1" }),
+      expect.objectContaining({ id: "retry-2" }),
+    ]);
+    await expect(readRecordedInbound(filePath)).resolves.toEqual([
+      expect.objectContaining({ id: "existing" }),
+      expect.objectContaining({ id: "retry-1" }),
+      expect.objectContaining({ id: "retry-2" }),
+    ]);
+  });
+
   it("indexes batch identities without rescanning completed recorder history", async () => {
     const filePath = await createRecorderPath();
     const sentAt = new Date().toISOString();

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -38,6 +38,12 @@ describe("recorder", () => {
     await expect(readRecordedInbound(filePath)).resolves.toEqual([]);
   });
 
+  it("does not create a recorder for an empty batch", async () => {
+    const filePath = await createRecorderPath();
+    await expect(appendRecordedInboundBatch(filePath, [])).resolves.toEqual([]);
+    await expect(readFile(filePath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("appends and reads recorded inbound events", async () => {
     const filePath = await createRecorderPath();
 

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -1,4 +1,4 @@
-import { appendFile, open, rename, writeFile, type FileHandle } from "node:fs/promises";
+import { appendFile, open, readFile, rename, writeFile, type FileHandle } from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -77,6 +77,55 @@ describe("recorder", () => {
     await expect(readRecordedInbound(filePath)).resolves.toEqual([
       expect.objectContaining({ id: "evt-batch-1" }),
       expect.objectContaining({ id: "evt-batch-2" }),
+    ]);
+  });
+
+  it("indexes batch identities without rescanning completed recorder history", async () => {
+    const filePath = await createRecorderPath();
+    const sentAt = new Date().toISOString();
+    const event = (id: string) => ({
+      author: "user" as const,
+      id,
+      provider: "whatsapp",
+      sentAt,
+      text: "x".repeat(128),
+      threadId: "15551234567",
+    });
+    await appendRecordedInboundBatch(
+      filePath,
+      Array.from({ length: 64 }, (_, index) => event(`history-${index}`)),
+    );
+    await appendRecordedInboundBatch(filePath, [event("tail-1")]);
+
+    const handle = await open(filePath, "r+");
+    try {
+      await handle.write("!", 0, "utf8");
+    } finally {
+      await handle.close();
+    }
+
+    await expect(appendRecordedInboundBatch(filePath, [event("tail-2")])).resolves.toEqual([
+      expect.objectContaining({ id: "tail-2" }),
+    ]);
+    expect(await readFile(filePath, "utf8")).toContain('"id":"tail-2"');
+  });
+
+  it("resets batch identities when the recorder is replaced", async () => {
+    const filePath = await createRecorderPath();
+    const event = {
+      author: "user" as const,
+      id: "reused-after-rotation",
+      provider: "whatsapp",
+      sentAt: new Date().toISOString(),
+      text: "accepted in each recorder generation",
+      threadId: "15551234567",
+    };
+    await appendRecordedInboundBatch(filePath, [event]);
+    await rename(filePath, `${filePath}.old`);
+    await writeFile(filePath, "", "utf8");
+
+    await expect(appendRecordedInboundBatch(filePath, [event])).resolves.toEqual([
+      expect.objectContaining({ id: event.id }),
     ]);
   });
 

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -199,7 +199,7 @@ describe("recorder", () => {
     ]);
   });
 
-  it("does not overwrite a recorder rotated during a batch append", async () => {
+  it("retries a batch against a recorder rotated during append", async () => {
     const filePath = await createRecorderPath();
     const rotatedPath = `${filePath}.rotated`;
     const event = {
@@ -246,20 +246,22 @@ describe("recorder", () => {
       await rename(filePath, rotatedPath);
       await writeFile(filePath, "", "utf8");
       releaseWrite();
-      await expect(append).rejects.toThrow("Recorder rotated");
+      await expect(append).resolves.toEqual([expect.objectContaining({ id: "rotated-batch" })]);
     } finally {
       releaseWrite();
       fileHandlePrototype.writeFile = originalWriteFile;
     }
 
-    await expect(readRecordedInbound(filePath)).resolves.toEqual([]);
+    await expect(readRecordedInbound(filePath)).resolves.toEqual([
+      expect.objectContaining({ id: "rotated-batch" }),
+    ]);
     await expect(readRecordedInbound(rotatedPath)).resolves.toEqual([
       expect.objectContaining({ id: "existing" }),
       expect.objectContaining({ id: "rotated-batch" }),
     ]);
   });
 
-  it("detects a symlinked recorder retargeted during a batch append", async () => {
+  it("retries against a symlinked recorder retargeted during append", async () => {
     const filePath = await createRecorderPath();
     const firstTarget = path.join(path.dirname(filePath), "first-target.jsonl");
     const secondTarget = path.join(path.dirname(filePath), "second-target.jsonl");
@@ -309,13 +311,15 @@ describe("recorder", () => {
       await rm(filePath);
       await symlink(secondTarget, filePath, "file");
       releaseWrite();
-      await expect(append).rejects.toThrow("Recorder rotated");
+      await expect(append).resolves.toEqual([expect.objectContaining({ id: "symlink-batch" })]);
     } finally {
       releaseWrite();
       fileHandlePrototype.writeFile = originalWriteFile;
     }
 
-    await expect(readRecordedInbound(filePath)).resolves.toEqual([]);
+    await expect(readRecordedInbound(filePath)).resolves.toEqual([
+      expect.objectContaining({ id: "symlink-batch" }),
+    ]);
     await expect(readRecordedInbound(firstTarget)).resolves.toEqual([
       expect.objectContaining({ id: "symlink-batch" }),
     ]);
@@ -408,6 +412,60 @@ describe("recorder", () => {
     await writeFile(filePath, "", "utf8");
 
     await expect(appendRecordedInboundBatch(filePath, [event])).resolves.toEqual([
+      expect.objectContaining({ id: event.id }),
+    ]);
+  });
+
+  it("retries duplicate suppression when the recorder rotates during indexing", async () => {
+    const filePath = await createRecorderPath();
+    const rotatedPath = `${filePath}.old`;
+    const event = {
+      author: "user" as const,
+      id: "duplicate-during-rotation",
+      provider: "whatsapp",
+      sentAt: new Date().toISOString(),
+      text: "preserve the acknowledged event",
+      threadId: "15551234567",
+    };
+    await appendRecordedInboundBatch(filePath, [event]);
+
+    const probeHandle = await open(filePath, "r");
+    const fileHandlePrototype = Object.getPrototypeOf(probeHandle) as {
+      stat(...args: unknown[]): Promise<unknown>;
+    };
+    await probeHandle.close();
+    const originalStat = fileHandlePrototype.stat;
+    let statCalls = 0;
+    let releaseIndexStat!: () => void;
+    let reportIndexStat!: () => void;
+    const indexStatReported = new Promise<void>((resolve) => {
+      reportIndexStat = resolve;
+    });
+    const indexStatReleased = new Promise<void>((resolve) => {
+      releaseIndexStat = resolve;
+    });
+    fileHandlePrototype.stat = async function (...args: unknown[]) {
+      const stats = await Reflect.apply(originalStat, this, args);
+      if (++statCalls === 3) {
+        reportIndexStat();
+        await indexStatReleased;
+      }
+      return stats;
+    };
+
+    const append = appendRecordedInboundBatch(filePath, [event]);
+    try {
+      await indexStatReported;
+      await rename(filePath, rotatedPath);
+      await writeFile(filePath, "", "utf8");
+      releaseIndexStat();
+      await expect(append).resolves.toEqual([expect.objectContaining({ id: event.id })]);
+    } finally {
+      releaseIndexStat();
+      fileHandlePrototype.stat = originalStat;
+    }
+
+    await expect(readRecordedInbound(filePath)).resolves.toEqual([
       expect.objectContaining({ id: event.id }),
     ]);
   });

--- a/test/whatsapp-provider-lifecycle.test.ts
+++ b/test/whatsapp-provider-lifecycle.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ProviderConfig } from "../src/config/schema.js";
 import { WhatsAppProviderAdapter } from "../src/providers/builtin/whatsapp.js";
 import { LocalMockProviderAdapter } from "../src/providers/local-mock.js";
+import { readRecordedInbound } from "../src/providers/recorder.js";
 import type { ProviderContext, SendContext } from "../src/providers/types.js";
 import { createTempDir, disposeTempDir } from "./test-helpers.js";
 
@@ -397,7 +398,7 @@ describe("WhatsApp provider lifecycle", () => {
       await expect(request).resolves.toMatchObject({ status: 200 });
       await cleanup;
       const contentsAfterCleanup = await readFile(recorderPath, "utf8");
-      expect(contentsAfterCleanup.trim().split("\n")).toHaveLength(2);
+      await expect(readRecordedInbound(recorderPath)).resolves.toHaveLength(2);
       await Promise.resolve();
       expect(await readFile(recorderPath, "utf8")).toBe(contentsAfterCleanup);
     } finally {

--- a/test/whatsapp-provider-lifecycle.test.ts
+++ b/test/whatsapp-provider-lifecycle.test.ts
@@ -9,6 +9,8 @@ import type { ProviderContext, SendContext } from "../src/providers/types.js";
 import { createTempDir, disposeTempDir } from "./test-helpers.js";
 
 type AppendRecordedInbound = typeof import("../src/providers/recorder.js").appendRecordedInbound;
+type AppendRecordedInboundBatch =
+  typeof import("../src/providers/recorder.js").appendRecordedInboundBatch;
 type WebhookHandler = Parameters<
   typeof import("../src/providers/webhook-server.js").startWebhookServer
 >[0]["handle"];
@@ -18,7 +20,9 @@ const webhookMocks = vi.hoisted(() => ({
 }));
 const recorderMocks = vi.hoisted(() => ({
   actualAppendRecordedInbound: undefined as AppendRecordedInbound | undefined,
+  actualAppendRecordedInboundBatch: undefined as AppendRecordedInboundBatch | undefined,
   appendRecordedInbound: vi.fn<AppendRecordedInbound>(),
+  appendRecordedInboundBatch: vi.fn<AppendRecordedInboundBatch>(),
 }));
 
 vi.mock("../src/providers/webhook-server.js", () => ({
@@ -27,10 +31,13 @@ vi.mock("../src/providers/webhook-server.js", () => ({
 vi.mock("../src/providers/recorder.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../src/providers/recorder.js")>();
   recorderMocks.actualAppendRecordedInbound = actual.appendRecordedInbound;
+  recorderMocks.actualAppendRecordedInboundBatch = actual.appendRecordedInboundBatch;
   recorderMocks.appendRecordedInbound.mockImplementation(actual.appendRecordedInbound);
+  recorderMocks.appendRecordedInboundBatch.mockImplementation(actual.appendRecordedInboundBatch);
   return {
     ...actual,
     appendRecordedInbound: recorderMocks.appendRecordedInbound,
+    appendRecordedInboundBatch: recorderMocks.appendRecordedInboundBatch,
   };
 });
 
@@ -39,6 +46,10 @@ beforeEach(() => {
   recorderMocks.appendRecordedInbound.mockReset();
   recorderMocks.appendRecordedInbound.mockImplementation(
     recorderMocks.actualAppendRecordedInbound!,
+  );
+  recorderMocks.appendRecordedInboundBatch.mockReset();
+  recorderMocks.appendRecordedInboundBatch.mockImplementation(
+    recorderMocks.actualAppendRecordedInboundBatch!,
   );
 });
 
@@ -204,6 +215,46 @@ describe("WhatsApp provider lifecycle", () => {
     }
   });
 
+  it("aborts direct waits and watches and fences sends when cleanup begins", async () => {
+    const close = vi.fn(async () => undefined);
+    webhookMocks.startWebhookServer.mockResolvedValueOnce({
+      close,
+      endpointUrl: "http://127.0.0.1:43210/whatsapp/webhook",
+    });
+    const config = createConfig();
+    const provider = new WhatsAppProviderAdapter("whatsapp", config, "crabline");
+    const context = createContext(config);
+    const waiting = provider.waitForInbound({
+      ...context,
+      nonce: "cleanup-abort",
+      since: new Date(0).toISOString(),
+      timeoutMs: 30_000,
+    });
+    const stream = provider.watch({
+      ...context,
+      since: new Date(0).toISOString(),
+    });
+    const watching = stream[Symbol.asyncIterator]();
+    const next = watching.next();
+    await vi.waitFor(() => expect(webhookMocks.startWebhookServer).toHaveBeenCalledTimes(1));
+
+    provider.beginCleanup();
+
+    await expect(waiting).resolves.toBeNull();
+    await expect(next).resolves.toEqual({ done: true, value: undefined });
+    await expect(
+      provider.send({
+        ...context,
+        mode: "send",
+        nonce: "cleanup-fenced",
+        text: "must not be sent",
+      }),
+    ).rejects.toThrow(/has been cleaned up/u);
+    await provider.cleanup();
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(recorderMocks.appendRecordedInbound).not.toHaveBeenCalled();
+  });
+
   it("waits for an admitted send before cleanup resolves", async () => {
     const directory = await createTempDir();
     const recorderPath = path.join(directory, "whatsapp.jsonl");
@@ -275,9 +326,9 @@ describe("WhatsApp provider lifecycle", () => {
         endpointUrl: "http://127.0.0.1:43210/whatsapp/webhook",
       };
     });
-    recorderMocks.appendRecordedInbound.mockImplementationOnce(async (...args) => {
+    recorderMocks.appendRecordedInboundBatch.mockImplementationOnce(async (...args) => {
       await appendBlocked;
-      return await recorderMocks.actualAppendRecordedInbound!(...args);
+      return await recorderMocks.actualAppendRecordedInboundBatch!(...args);
     });
 
     try {
@@ -315,7 +366,9 @@ describe("WhatsApp provider lifecycle", () => {
           ],
         }),
       );
-      await vi.waitFor(() => expect(recorderMocks.appendRecordedInbound).toHaveBeenCalledTimes(1));
+      await vi.waitFor(() =>
+        expect(recorderMocks.appendRecordedInboundBatch).toHaveBeenCalledTimes(1),
+      );
 
       let cleanupResolved = false;
       cleanup = provider.cleanup().then(() => {
@@ -338,7 +391,7 @@ describe("WhatsApp provider lifecycle", () => {
           }),
         ),
       ).resolves.toMatchObject({ status: 503 });
-      expect(recorderMocks.appendRecordedInbound).toHaveBeenCalledTimes(1);
+      expect(recorderMocks.appendRecordedInboundBatch).toHaveBeenCalledTimes(1);
 
       releaseAppend?.();
       await expect(request).resolves.toMatchObject({ status: 200 });

--- a/test/whatsapp-provider.test.ts
+++ b/test/whatsapp-provider.test.ts
@@ -115,6 +115,35 @@ describe("WhatsApp webhook normalizer", () => {
     ]);
   });
 
+  it("validates and canonicalizes generic fallback timestamps", () => {
+    expect(
+      normalizeWhatsAppWebhookPayload({
+        message: { sentAt: "2023-11-14T23:13:20+01:00", text: "nested" },
+        sentAt: "2023-11-14T23:13:20+01:00",
+        threadId: "15551234567",
+      }),
+    ).toMatchObject([
+      {
+        message: { sentAt: "2023-11-14T22:13:20.000Z" },
+        sentAt: "2023-11-14T22:13:20.000Z",
+      },
+    ]);
+
+    expect(() =>
+      normalizeWhatsAppWebhookPayload({
+        sentAt: "not-a-timestamp",
+        text: "invalid",
+        threadId: "15551234567",
+      }),
+    ).toThrow("WhatsApp fallback sentAt must be a valid timestamp");
+    expect(() =>
+      normalizeWhatsAppWebhookPayload({
+        message: { sentAt: "not-a-timestamp", text: "invalid" },
+        threadId: "15551234567",
+      }),
+    ).toThrow("WhatsApp fallback message.sentAt must be a valid timestamp");
+  });
+
   it("rejects a malformed batch without recording valid siblings", async () => {
     const config = await createLocalMockConfig("whatsapp", "/whatsapp/webhook");
     const provider = new WhatsAppProviderAdapter("whatsapp", config, "crabline");

--- a/test/whatsapp-provider.test.ts
+++ b/test/whatsapp-provider.test.ts
@@ -22,6 +22,7 @@ describe("WhatsApp webhook normalizer", () => {
       from: "15551234567",
       id: "wamid.abc123",
       text: { body: "hello" },
+      timestamp: "1700000000",
     };
     const payload = {
       entry: [
@@ -42,6 +43,7 @@ describe("WhatsApp webhook normalizer", () => {
         author: "user",
         id: "wamid.abc123",
         raw: message,
+        sentAt: "2023-11-14T22:13:20.000Z",
         text: "hello",
         threadId: "15551234567",
       },
@@ -213,6 +215,7 @@ describe("WhatsApp webhook normalizer", () => {
                       from: "15551234567",
                       id: "wamid.signed",
                       text: { body: "signed webhook" },
+                      timestamp: "1700000000",
                       type: "text",
                     },
                   ],
@@ -258,6 +261,25 @@ describe("WhatsApp webhook normalizer", () => {
         method: "POST",
       });
       expect(signed.status).toBe(200);
+      const retried = await fetch(endpoint!, {
+        body,
+        headers: {
+          "content-type": "application/json",
+          "x-hub-signature-256": whatsappSignature(body, signingKey),
+        },
+        method: "POST",
+      });
+      expect(retried.status).toBe(200);
+      const records = (await readFile(config.whatsapp!.recorder.path!, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as { id: string; sentAt: string });
+      expect(records).toEqual([
+        expect.objectContaining({
+          id: "wamid.signed",
+          sentAt: "2023-11-14T22:13:20.000Z",
+        }),
+      ]);
     } finally {
       await provider.cleanup();
     }

--- a/test/whatsapp-provider.test.ts
+++ b/test/whatsapp-provider.test.ts
@@ -5,7 +5,7 @@ import {
   normalizeWhatsAppWebhookPayload,
   WhatsAppProviderAdapter,
 } from "../src/providers/builtin/whatsapp.js";
-import { appendRecordedInbound } from "../src/providers/recorder.js";
+import { appendRecordedInbound, readRecordedInbound } from "../src/providers/recorder.js";
 import {
   createLocalMockConfig,
   createProviderContext,
@@ -299,10 +299,7 @@ describe("WhatsApp webhook normalizer", () => {
         method: "POST",
       });
       expect(retried.status).toBe(200);
-      const records = (await readFile(config.whatsapp!.recorder.path!, "utf8"))
-        .trim()
-        .split("\n")
-        .map((line) => JSON.parse(line) as { id: string; sentAt: string });
+      const records = await readRecordedInbound(config.whatsapp!.recorder.path!);
       expect(records).toEqual([
         expect.objectContaining({
           id: "wamid.signed",

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -595,7 +595,7 @@ describe("whatsapp local provider server", () => {
     ]);
   });
 
-  it("records accepted sends before consuming their message IDs", async () => {
+  it("commits accepted sends before publishing their evidence", async () => {
     const directory = await createTempDir();
     directories.push(directory);
     let failAcceptedEvent = true;
@@ -632,7 +632,7 @@ describe("whatsapp local provider server", () => {
     const retried = await send();
     expect(retried.status).toBe(200);
     await expect(retried.json()).resolves.toMatchObject({
-      messages: [{ id: "wamid.FAKE00000001" }],
+      messages: [{ id: "wamid.FAKE00000002" }],
     });
   });
 

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -636,6 +636,43 @@ describe("whatsapp local provider server", () => {
     });
   });
 
+  it("does not mark successful status requests as accepted sends", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const observed: Array<{ accepted?: boolean; body?: unknown }> = [];
+    const server = await startWhatsAppServer({
+      accessToken: "fake",
+      onEvent: (event) => {
+        observed.push(event);
+      },
+      recorderPath: path.join(directory, "whatsapp-status-evidence.jsonl"),
+    });
+    servers.push(server);
+
+    const response = await fetch(server.manifest.endpoints.messagesUrl, {
+      body: JSON.stringify({
+        message_id: "wamid.status",
+        messaging_product: "whatsapp",
+        status: "read",
+        text: { body: "not a send" },
+        to: "15551234567",
+      }),
+      headers: {
+        authorization: "Bearer fake",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(200);
+    expect(observed).toContainEqual(
+      expect.objectContaining({
+        accepted: false,
+        body: expect.objectContaining({ message_id: "wamid.status", status: "read" }),
+      }),
+    );
+  });
+
   it("does not accept admin inbound messages when recorder append fails", async () => {
     const directory = await createTempDir();
     directories.push(directory);

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -181,6 +181,12 @@ describe("whatsapp local provider server", () => {
     await expect(startWhatsAppServer({ accessToken: "" })).rejects.toThrow(
       "accessToken must not be empty",
     );
+    await expect(startWhatsAppServer({ adminToken: " \n\t" })).rejects.toThrow(
+      "adminToken must not be empty",
+    );
+    await expect(startWhatsAppServer({ selfJid: "not-a-whatsapp-jid" })).rejects.toThrow(
+      "selfJid must be a WhatsApp user JID",
+    );
     const port = await resolveFreePort();
     await expect(startWhatsAppServer({ maxPendingInboundMessages: 0, port })).rejects.toThrow(
       "must be a positive safe integer",
@@ -198,6 +204,7 @@ describe("whatsapp local provider server", () => {
       adminToken: "fake-whatsapp-admin-token",
       accessToken: "fake-whatsapp-token",
       recorderPath: path.join(directory, "whatsapp.jsonl"),
+      selfJid: "15550000000@C.US",
     });
     servers.push(server);
 
@@ -209,6 +216,7 @@ describe("whatsapp local provider server", () => {
     });
     expect(baileysWebSocketUrl.searchParams.get("access_token")).toBe("fake-whatsapp-token");
     expect(server.manifest.endpoints.messagesUrl).toMatch(/\/v25\.0\/100000000000000\/messages$/u);
+    expect(server.manifest.selfJid).toBe("15550000000@s.whatsapp.net");
     const phoneNumber = await fetch(server.manifest.endpoints.phoneNumberUrl, {
       headers: { authorization: "bearer fake-whatsapp-token" },
     });
@@ -422,6 +430,26 @@ describe("whatsapp local provider server", () => {
     const recorder = await fs.readFile(server.manifest.recorderPath, "utf8");
     expect(recorder).not.toContain("forged user nonce");
     expect(recorder).toContain('"path":"/_crabline/admin/whatsapp/inbound"');
+    const events = recorder
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { accepted?: boolean; path: string });
+    expect(
+      events.find(
+        (event) => event.path === new URL(server.manifest.endpoints.messagesUrl).pathname,
+      ),
+    ).toMatchObject({ accepted: true });
+    expect(
+      events.find(
+        (event) =>
+          event.accepted === false &&
+          (
+            event as {
+              body?: { messaging_product?: string };
+            }
+          ).body?.messaging_product === "messenger",
+      ),
+    ).toBeDefined();
   });
 
   it("enforces sender and chat JID roles for admin inbound messages", async () => {
@@ -472,7 +500,7 @@ describe("whatsapp local provider server", () => {
     expect(directBody).toMatchObject({
       message: {
         key: {
-          remoteJid: "15551234567@c.us",
+          remoteJid: "15551234567@s.whatsapp.net",
         },
       },
       webhook: {

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -595,6 +595,47 @@ describe("whatsapp local provider server", () => {
     ]);
   });
 
+  it("records accepted sends before consuming their message IDs", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    let failAcceptedEvent = true;
+    const server = await startWhatsAppServer({
+      accessToken: "fake",
+      onEvent: (event) => {
+        if (
+          failAcceptedEvent &&
+          event.path === new URL(server.manifest.endpoints.messagesUrl).pathname
+        ) {
+          failAcceptedEvent = false;
+          throw new Error("simulated recorder observer failure");
+        }
+      },
+      recorderPath: path.join(directory, "whatsapp-send-order.jsonl"),
+    });
+    servers.push(server);
+    const send = () =>
+      fetch(server.manifest.endpoints.messagesUrl, {
+        body: JSON.stringify({
+          messaging_product: "whatsapp",
+          text: { body: "send once" },
+          to: "15551234567",
+          type: "text",
+        }),
+        headers: {
+          authorization: "Bearer fake",
+          "content-type": "application/json",
+        },
+        method: "POST",
+      });
+
+    expect((await send()).status).toBe(500);
+    const retried = await send();
+    expect(retried.status).toBe(200);
+    await expect(retried.json()).resolves.toMatchObject({
+      messages: [{ id: "wamid.FAKE00000001" }],
+    });
+  });
+
   it("does not accept admin inbound messages when recorder append fails", async () => {
     const directory = await createTempDir();
     directories.push(directory);

--- a/test/whatsapp-wire.test.ts
+++ b/test/whatsapp-wire.test.ts
@@ -25,7 +25,9 @@ import {
   MAX_WHATSAPP_NOISE_FRAME_BYTES,
   MAX_WHATSAPP_NOISE_FRAMES_PER_MESSAGE,
   MAX_WHATSAPP_WEBSOCKET_BUFFERED_BYTES,
+  MAX_WHATSAPP_WEBSOCKET_CLOSE_REASON_BYTES,
   parseWhatsAppWebSocketUpgradeUrl,
+  resolveWhatsAppWebSocketClose,
   sendWhatsAppWebSocketPayload,
   WHATSAPP_WEBSOCKET_SEND_TIMEOUT_MS,
   WhatsAppNoiseFrameDecoder,
@@ -330,6 +332,23 @@ describe("WhatsApp WebSocket message processing", () => {
       "/ws/chat",
     );
   });
+
+  it("maps bounded close reasons to protocol, capacity, and internal status codes", () => {
+    expect(resolveWhatsAppWebSocketClose(new Error("Invalid Baileys handshake"))).toMatchObject({
+      code: 1002,
+    });
+    expect(
+      resolveWhatsAppWebSocketClose(new Error("inbound backlog limit exceeded")),
+    ).toMatchObject({ code: 1009 });
+    expect(resolveWhatsAppWebSocketClose(new Error("recorder append failed"))).toMatchObject({
+      code: 1011,
+    });
+
+    const bounded = resolveWhatsAppWebSocketClose(new Error("x".repeat(200) + "🦊".repeat(50)));
+    expect(Buffer.byteLength(bounded.reason)).toBeLessThanOrEqual(
+      MAX_WHATSAPP_WEBSOCKET_CLOSE_REASON_BYTES,
+    );
+  });
 });
 
 describe("WhatsApp handshake protobufs", () => {
@@ -366,6 +385,11 @@ describe("WhatsApp handshake protobufs", () => {
     for (const message of oversizedUint32s) {
       expect(() => decodeHandshakeMessage(message)).toThrow("Invalid WhatsApp handshake varint.");
     }
+  });
+
+  it("rejects protobuf field number zero at every handshake level", () => {
+    expect(() => decodeHandshakeMessage(Buffer.from([0x00]))).toThrow("field number 0");
+    expect(() => decodeHandshakeMessage(Buffer.from([0x12, 0x01, 0x00]))).toThrow("field number 0");
   });
 });
 
@@ -437,6 +461,15 @@ describe("WhatsApp binary nodes", () => {
       `WhatsApp binary node count exceeds ${WHATSAPP_BINARY_NODE_MAX_NODES}.`,
     );
   });
+
+  it("decodes attributes into a null-prototype record", async () => {
+    const attrs = Object.fromEntries([["__proto__", "polluted"]]);
+    const decoded = await decodeBinaryNode(encodeBinaryNode({ attrs, tag: "message" }));
+
+    expect(Object.getPrototypeOf(decoded.attrs)).toBeNull();
+    expect(decoded.attrs["__proto__"]).toBe("polluted");
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
 });
 
 describe("WhatsApp signal bundle store", () => {
@@ -445,6 +478,7 @@ describe("WhatsApp signal bundle store", () => {
     const first = store.resolveMany(["15551234567@s.whatsapp.net"]);
     expect(first).toHaveLength(1);
     expect(store.resolveMany(["15551234567@s.whatsapp.net"])[0]).toBe(first[0]);
+    expect(store.resolveMany(["15551234567@c.us"])[0]).toBe(first[0]);
     expect(store.size).toBe(1);
     expect(() => store.resolveMany(["not-a-jid"])).toThrow(/Invalid WhatsApp signal bundle JID/u);
     expect(() => store.resolveMany(["15557654321@s.whatsapp.net"])).toThrow(

--- a/test/zalo-provider.test.ts
+++ b/test/zalo-provider.test.ts
@@ -22,17 +22,14 @@ describe("Zalo webhook normalizer", () => {
     });
   });
 
-  it("normalizes wrapped native updates with chat identity", () => {
+  it("normalizes direct native webhook updates with chat identity", () => {
     const payload = {
-      ok: true,
-      result: {
-        event_name: "message.text.received",
-        message: {
-          chat: { chat_type: "GROUP", id: "987654321012" },
-          from: { display_name: "Alice", id: "123456789012", is_bot: false },
-          message_id: "zalo-msg-native",
-          text: "hello group",
-        },
+      event_name: "message.text.received",
+      message: {
+        chat: { chat_type: "GROUP", id: "987654321012" },
+        from: { display_name: "Alice", id: "123456789012", is_bot: false },
+        message_id: "zalo-msg-native",
+        text: "hello group",
       },
     };
 

--- a/test/zalo-server.test.ts
+++ b/test/zalo-server.test.ts
@@ -182,7 +182,7 @@ describe("Zalo local provider server", () => {
         {
           body: JSON.stringify({
             secret_token: "test-auth-token",
-            url: `http://127.0.0.1:${address.port}/zalo`,
+            url: `http://alice:sample@127.0.0.1:${address.port}/zalo?mode=test`,
           }),
           headers: { "content-type": "application/json" },
           method: "POST",
@@ -199,11 +199,8 @@ describe("Zalo local provider server", () => {
       expect(received).toHaveLength(1);
       expect(received[0]).toMatchObject({
         body: {
-          ok: true,
-          result: {
-            event_name: "message.text.received",
-            message: { text: "hello" },
-          },
+          event_name: "message.text.received",
+          message: { text: "hello" },
         },
         secret: "test-auth-token",
       });
@@ -216,7 +213,10 @@ describe("Zalo local provider server", () => {
 
       const recorder = await fs.readFile(recorderPath, "utf8");
       expect(recorder).toContain('"secret_token":"<redacted>"');
+      expect(recorder).toContain(`http://<redacted>@127.0.0.1:${address.port}/zalo?mode=test`);
       expect(recorder).not.toContain("test-auth-token");
+      expect(recorder).not.toContain("alice");
+      expect(recorder).not.toContain("sample");
     } finally {
       await new Promise<void>((resolve, reject) =>
         webhook.close((error) => (error ? reject(error) : resolve())),
@@ -275,20 +275,32 @@ describe("Zalo local provider server", () => {
     }
   });
 
-  it("does not deliver updates to disconnected long polls", async () => {
+  it("does not dequeue queued updates for disconnected long polls", async () => {
     let observePoll: (() => void) | undefined;
+    let releasePoll: (() => void) | undefined;
     const pollObserved = new Promise<void>((resolve) => {
       observePoll = resolve;
+    });
+    const pollBlocked = new Promise<void>((resolve) => {
+      releasePoll = resolve;
     });
     const server = await startZaloServer({
       botToken: "sample",
       onEvent: async (event) => {
         if (event.path === "/bot<redacted>/getUpdates") {
           observePoll?.();
+          await pollBlocked;
         }
       },
     });
     servers.push(server);
+    const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({ chatId: "chat-1", senderId: "user-1", text: "queued first" }),
+      headers: adminHeaders(server),
+      method: "POST",
+    });
+    expect(inbound.status).toBe(200);
+
     const controller = new AbortController();
     const pending = fetch(`${server.manifest.baseUrl}/botsample/getUpdates?timeout=30`, {
       signal: controller.signal,
@@ -296,20 +308,55 @@ describe("Zalo local provider server", () => {
     await pollObserved;
     controller.abort();
     await expect(pending).rejects.toThrow(/aborted/u);
-
-    const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
-      body: JSON.stringify({ chatId: "chat-1", senderId: "user-1", text: "after disconnect" }),
-      headers: adminHeaders(server),
-      method: "POST",
-    });
-    expect(inbound.status).toBe(200);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    releasePoll?.();
 
     const updates = await fetch(`${server.manifest.baseUrl}/botsample/getUpdates?timeout=0`, {
       method: "POST",
     });
     await expect(updates.json()).resolves.toMatchObject({
       ok: true,
-      result: { message: { text: "after disconnect" } },
+      result: { message: { text: "queued first" } },
+    });
+  });
+
+  it("supersedes concurrent long polls and delivers to the current request", async () => {
+    let observeFirstPoll: (() => void) | undefined;
+    const firstPollReady = new Promise<void>((resolve) => {
+      observeFirstPoll = resolve;
+    });
+    let polls = 0;
+    const server = await startZaloServer({
+      botToken: "sample",
+      onEvent: (event) => {
+        if (event.path === "/bot<redacted>/getUpdates" && ++polls === 1) {
+          setImmediate(() => observeFirstPoll?.());
+        }
+      },
+    });
+    servers.push(server);
+
+    const first = fetch(`${server.manifest.baseUrl}/botsample/getUpdates?timeout=30`);
+    await firstPollReady;
+    const second = fetch(`${server.manifest.baseUrl}/botsample/getUpdates?timeout=30`);
+
+    const firstResponse = await first;
+    expect(firstResponse.status).toBe(409);
+    await expect(firstResponse.json()).resolves.toMatchObject({
+      description: "Conflict: terminated by other getUpdates request",
+      error_code: 409,
+      ok: false,
+    });
+
+    const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({ chatId: "chat-1", senderId: "user-1", text: "current poll" }),
+      headers: adminHeaders(server),
+      method: "POST",
+    });
+    expect(inbound.status).toBe(200);
+    await expect((await second).json()).resolves.toMatchObject({
+      ok: true,
+      result: { message: { text: "current poll" } },
     });
   });
 

--- a/test/zalo-server.test.ts
+++ b/test/zalo-server.test.ts
@@ -375,10 +375,20 @@ describe("Zalo local provider server", () => {
     };
     const originalEnd = responsePrototype.end;
     let failedResponses = 0;
+    let reportLaterFailure!: () => void;
+    const laterFailureReported = new Promise<void>((resolve) => {
+      reportLaterFailure = resolve;
+    });
     responsePrototype.end = function (this: ServerResponse, ...args: unknown[]) {
       if (this.req?.url?.includes("/getUpdates") && failedResponses < 2) {
-        const delayMs = failedResponses++ === 0 ? 20 : 10;
-        setTimeout(() => this.destroy(new Error("simulated response failure")), delayMs);
+        const responseIndex = failedResponses++;
+        const delayMs = responseIndex === 0 ? 100 : 10;
+        setTimeout(() => {
+          if (responseIndex === 1) {
+            reportLaterFailure();
+          }
+          this.destroy(new Error("simulated response failure"));
+        }, delayMs);
         return this;
       }
       return Reflect.apply(originalEnd, this, args) as ServerResponse;
@@ -399,6 +409,13 @@ describe("Zalo local provider server", () => {
         method: "GET",
         url: `${server.manifest.baseUrl}/botsample/getUpdates?timeout=1`,
       });
+      await laterFailureReported;
+      const thirdInbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({ chatId: "chat-1", senderId: "user-1", text: "third" }),
+        headers: adminHeaders(server),
+        method: "POST",
+      });
+      expect(thirdInbound.status).toBe(200);
       const waitingResponse = await waitingPoll;
       expect(JSON.parse(waitingResponse.body)).toMatchObject({
         ok: true,
@@ -409,11 +426,13 @@ describe("Zalo local provider server", () => {
       responsePrototype.end = originalEnd;
     }
 
-    const update = await fetch(`${server.manifest.baseUrl}/botsample/getUpdates?timeout=0`);
-    await expect(update.json()).resolves.toMatchObject({
-      ok: true,
-      result: { message: { text: "second" } },
-    });
+    for (const text of ["second", "third"]) {
+      const update = await fetch(`${server.manifest.baseUrl}/botsample/getUpdates?timeout=0`);
+      await expect(update.json()).resolves.toMatchObject({
+        ok: true,
+        result: { message: { text } },
+      });
+    }
   });
 
   it("rejects webhook activation while a poll delivery is reserved", async () => {

--- a/test/zalo-server.test.ts
+++ b/test/zalo-server.test.ts
@@ -210,6 +210,18 @@ describe("Zalo local provider server", () => {
         { method: "POST" },
       );
       expect(blockedPolling.status).toBe(400);
+      const invalidWebhook = await fetch(
+        `${server.manifest.baseUrl}/bottest-token-placeholder/setWebhook`,
+        {
+          body: JSON.stringify({
+            secret_token: "invalid-auth",
+            url: "http://user:leaked-secret@127.0.0.1:bad/zalo",
+          }),
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        },
+      );
+      expect(invalidWebhook.status).toBe(400);
 
       const recorder = await fs.readFile(recorderPath, "utf8");
       expect(recorder).toContain('"secret_token":"<redacted>"');
@@ -217,6 +229,8 @@ describe("Zalo local provider server", () => {
       expect(recorder).not.toContain("test-auth-token");
       expect(recorder).not.toContain("alice");
       expect(recorder).not.toContain("sample");
+      expect(recorder).not.toContain("invalid-auth");
+      expect(recorder).not.toContain("leaked-secret");
     } finally {
       await new Promise<void>((resolve, reject) =>
         webhook.close((error) => (error ? reject(error) : resolve())),

--- a/test/zalo-server.test.ts
+++ b/test/zalo-server.test.ts
@@ -229,14 +229,32 @@ describe("Zalo local provider server", () => {
         },
       );
       expect(invalidWebhook.status).toBe(400);
+      const protocolRelativeCredential = [
+        "//protocol-user:",
+        "protocol-relative-credential-placeholder",
+        "@example.com/hook",
+      ].join("");
+      const invalidProtocolRelativeWebhook = await fetch(
+        `${server.manifest.baseUrl}/bottest-token-placeholder/setWebhook`,
+        {
+          body: JSON.stringify({
+            url: protocolRelativeCredential,
+          }),
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        },
+      );
+      expect(invalidProtocolRelativeWebhook.status).toBe(400);
 
       const recorder = await fs.readFile(recorderPath, "utf8");
       expect(recorder).toContain('"secret_token":"<redacted>"');
       expect(recorder).toContain(`http://<redacted>@127.0.0.1:${address.port}/zalo?mode=test`);
+      expect(recorder).toContain("//<redacted>@example.com/hook");
       expect(recorder).not.toContain("test-auth-token");
       expect(recorder).not.toContain("alice");
       expect(recorder).not.toContain("sample");
       expect(recorder).not.toContain("credential-placeholder");
+      expect(recorder).not.toContain("protocol-user");
     } finally {
       await new Promise<void>((resolve, reject) =>
         webhook.close((error) => (error ? reject(error) : resolve())),
@@ -387,6 +405,93 @@ describe("Zalo local provider server", () => {
         ok: true,
         result: { message: { text } },
       });
+    }
+  });
+
+  it("rejects webhook activation while a poll delivery is reserved", async () => {
+    const webhook = createServer((_request, response) => {
+      response.statusCode = 200;
+      response.end("ok");
+    });
+    await new Promise<void>((resolve) => webhook.listen(0, "127.0.0.1", resolve));
+    const address = webhook.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Unable to resolve webhook test server address.");
+    }
+    const server = await startZaloServer({ botToken: "sample" });
+    servers.push(server);
+    const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({ chatId: "chat-1", senderId: "user-1", text: "reserved" }),
+      headers: adminHeaders(server),
+      method: "POST",
+    });
+    expect(inbound.status).toBe(200);
+
+    const responsePrototype = ServerResponse.prototype as unknown as {
+      end: (...args: unknown[]) => ServerResponse;
+    };
+    const originalEnd = responsePrototype.end;
+    let releaseResponse!: () => void;
+    let reportResponse!: () => void;
+    const responseReported = new Promise<void>((resolve) => {
+      reportResponse = resolve;
+    });
+    const responseReleased = new Promise<void>((resolve) => {
+      releaseResponse = resolve;
+    });
+    responsePrototype.end = function (this: ServerResponse, ...args: unknown[]) {
+      if (this.req?.url?.includes("/getUpdates")) {
+        reportResponse();
+        void responseReleased.then(() => this.destroy(new Error("simulated response failure")));
+        return this;
+      }
+      return Reflect.apply(originalEnd, this, args) as ServerResponse;
+    };
+
+    const poll = requestHttp({
+      method: "GET",
+      url: `${server.manifest.baseUrl}/botsample/getUpdates?timeout=0`,
+    });
+    try {
+      await responseReported;
+      const blocked = await fetch(`${server.manifest.baseUrl}/botsample/setWebhook`, {
+        body: JSON.stringify({
+          secret_token: "secret-token",
+          url: `http://127.0.0.1:${address.port}/zalo`,
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      expect(blocked.status).toBe(409);
+      await expect(blocked.json()).resolves.toMatchObject({
+        description: "Polling deliveries are still in progress",
+      });
+      releaseResponse();
+      await Promise.allSettled([poll]);
+    } finally {
+      releaseResponse();
+      responsePrototype.end = originalEnd;
+    }
+
+    try {
+      const configured = await fetch(`${server.manifest.baseUrl}/botsample/setWebhook`, {
+        body: JSON.stringify({
+          secret_token: "secret-token",
+          url: `http://127.0.0.1:${address.port}/zalo`,
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      expect(configured.status).toBe(200);
+      await fetch(`${server.manifest.baseUrl}/botsample/deleteWebhook`, { method: "POST" });
+      const restored = await fetch(`${server.manifest.baseUrl}/botsample/getUpdates?timeout=0`);
+      await expect(restored.json()).resolves.toMatchObject({
+        result: { message: { text: "reserved" } },
+      });
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        webhook.close((error) => (error ? reject(error) : resolve())),
+      );
     }
   });
 

--- a/test/zalo-server.test.ts
+++ b/test/zalo-server.test.ts
@@ -210,12 +210,19 @@ describe("Zalo local provider server", () => {
         { method: "POST" },
       );
       expect(blockedPolling.status).toBe(400);
+      const malformedCredentialUrl = [
+        "http://",
+        "user",
+        ":",
+        "credential-placeholder",
+        "@",
+        "127.0.0.1:bad/zalo",
+      ].join("");
       const invalidWebhook = await fetch(
         `${server.manifest.baseUrl}/bottest-token-placeholder/setWebhook`,
         {
           body: JSON.stringify({
-            secret_token: "invalid-auth",
-            url: "http://user:leaked-secret@127.0.0.1:bad/zalo",
+            url: malformedCredentialUrl,
           }),
           headers: { "content-type": "application/json" },
           method: "POST",
@@ -229,8 +236,7 @@ describe("Zalo local provider server", () => {
       expect(recorder).not.toContain("test-auth-token");
       expect(recorder).not.toContain("alice");
       expect(recorder).not.toContain("sample");
-      expect(recorder).not.toContain("invalid-auth");
-      expect(recorder).not.toContain("leaked-secret");
+      expect(recorder).not.toContain("credential-placeholder");
     } finally {
       await new Promise<void>((resolve, reject) =>
         webhook.close((error) => (error ? reject(error) : resolve())),

--- a/test/zalo-server.test.ts
+++ b/test/zalo-server.test.ts
@@ -358,7 +358,7 @@ describe("Zalo local provider server", () => {
     });
   });
 
-  it("restores concurrently failed poll responses in FIFO order", async () => {
+  it("restores reverse-order poll failures ahead of a waiting poll", async () => {
     const server = await startZaloServer({ botToken: "sample" });
     servers.push(server);
     for (const text of ["first", "second"]) {
@@ -377,7 +377,7 @@ describe("Zalo local provider server", () => {
     let failedResponses = 0;
     responsePrototype.end = function (this: ServerResponse, ...args: unknown[]) {
       if (this.req?.url?.includes("/getUpdates") && failedResponses < 2) {
-        const delayMs = 10 + failedResponses++ * 10;
+        const delayMs = failedResponses++ === 0 ? 20 : 10;
         setTimeout(() => this.destroy(new Error("simulated response failure")), delayMs);
         return this;
       }
@@ -385,7 +385,7 @@ describe("Zalo local provider server", () => {
     };
 
     try {
-      await Promise.allSettled([
+      const failedPolls = Promise.allSettled([
         requestHttp({
           method: "GET",
           url: `${server.manifest.baseUrl}/botsample/getUpdates?timeout=0`,
@@ -395,17 +395,25 @@ describe("Zalo local provider server", () => {
           url: `${server.manifest.baseUrl}/botsample/getUpdates?timeout=0`,
         }),
       ]);
+      const waitingPoll = requestHttp({
+        method: "GET",
+        url: `${server.manifest.baseUrl}/botsample/getUpdates?timeout=1`,
+      });
+      const waitingResponse = await waitingPoll;
+      expect(JSON.parse(waitingResponse.body)).toMatchObject({
+        ok: true,
+        result: { message: { text: "first" } },
+      });
+      await failedPolls;
     } finally {
       responsePrototype.end = originalEnd;
     }
 
-    for (const text of ["first", "second"]) {
-      const update = await fetch(`${server.manifest.baseUrl}/botsample/getUpdates?timeout=0`);
-      await expect(update.json()).resolves.toMatchObject({
-        ok: true,
-        result: { message: { text } },
-      });
-    }
+    const update = await fetch(`${server.manifest.baseUrl}/botsample/getUpdates?timeout=0`);
+    await expect(update.json()).resolves.toMatchObject({
+      ok: true,
+      result: { message: { text: "second" } },
+    });
   });
 
   it("rejects webhook activation while a poll delivery is reserved", async () => {

--- a/test/zalo-server.test.ts
+++ b/test/zalo-server.test.ts
@@ -230,7 +230,7 @@ describe("Zalo local provider server", () => {
       );
       expect(invalidWebhook.status).toBe(400);
       const protocolRelativeCredential = [
-        "//protocol-user:",
+        " \t//protocol-user:",
         "protocol-relative-credential-placeholder",
         "@example.com/hook",
       ].join("");
@@ -249,7 +249,7 @@ describe("Zalo local provider server", () => {
       const recorder = await fs.readFile(recorderPath, "utf8");
       expect(recorder).toContain('"secret_token":"<redacted>"');
       expect(recorder).toContain(`http://<redacted>@127.0.0.1:${address.port}/zalo?mode=test`);
-      expect(recorder).toContain("//<redacted>@example.com/hook");
+      expect(recorder).toContain("<redacted>@example.com/hook");
       expect(recorder).not.toContain("test-auth-token");
       expect(recorder).not.toContain("alice");
       expect(recorder).not.toContain("sample");

--- a/test/zalo-server.test.ts
+++ b/test/zalo-server.test.ts
@@ -380,6 +380,61 @@ describe("Zalo local provider server", () => {
     });
   });
 
+  it("does not let a disconnected replacement terminate the active poll", async () => {
+    let observeFirstPoll: (() => void) | undefined;
+    let observeSecondPoll: (() => void) | undefined;
+    let releaseSecondPoll: (() => void) | undefined;
+    const firstPollReady = new Promise<void>((resolve) => {
+      observeFirstPoll = resolve;
+    });
+    const secondPollObserved = new Promise<void>((resolve) => {
+      observeSecondPoll = resolve;
+    });
+    const secondPollBlocked = new Promise<void>((resolve) => {
+      releaseSecondPoll = resolve;
+    });
+    let polls = 0;
+    const server = await startZaloServer({
+      botToken: "sample",
+      onEvent: async (event) => {
+        if (event.path !== "/bot<redacted>/getUpdates") {
+          return;
+        }
+        polls++;
+        if (polls === 1) {
+          observeFirstPoll?.();
+        } else if (polls === 2) {
+          observeSecondPoll?.();
+          await secondPollBlocked;
+        }
+      },
+    });
+    servers.push(server);
+
+    const first = fetch(`${server.manifest.baseUrl}/botsample/getUpdates?timeout=30`);
+    await firstPollReady;
+    const controller = new AbortController();
+    const second = fetch(`${server.manifest.baseUrl}/botsample/getUpdates?timeout=30`, {
+      signal: controller.signal,
+    });
+    await secondPollObserved;
+    controller.abort();
+    await expect(second).rejects.toThrow(/aborted/u);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    releaseSecondPoll?.();
+
+    const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({ chatId: "chat-1", senderId: "user-1", text: "active poll" }),
+      headers: adminHeaders(server),
+      method: "POST",
+    });
+    expect(inbound.status).toBe(200);
+    await expect((await first).json()).resolves.toMatchObject({
+      ok: true,
+      result: { message: { text: "active poll" } },
+    });
+  });
+
   it("enforces an absolute webhook delivery deadline while responses trickle", async () => {
     const webhook = createServer((_request, response) => {
       response.writeHead(200, { "content-type": "text/plain" });

--- a/test/zalo-server.test.ts
+++ b/test/zalo-server.test.ts
@@ -1,4 +1,4 @@
-import { Agent, createServer, type ClientRequest } from "node:http";
+import { Agent, createServer, ServerResponse, type ClientRequest } from "node:http";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -338,6 +338,56 @@ describe("Zalo local provider server", () => {
       ok: true,
       result: { message: { text: "queued first" } },
     });
+  });
+
+  it("restores concurrently failed poll responses in FIFO order", async () => {
+    const server = await startZaloServer({ botToken: "sample" });
+    servers.push(server);
+    for (const text of ["first", "second"]) {
+      const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({ chatId: "chat-1", senderId: "user-1", text }),
+        headers: adminHeaders(server),
+        method: "POST",
+      });
+      expect(inbound.status).toBe(200);
+    }
+
+    const responsePrototype = ServerResponse.prototype as unknown as {
+      end: (...args: unknown[]) => ServerResponse;
+    };
+    const originalEnd = responsePrototype.end;
+    let failedResponses = 0;
+    responsePrototype.end = function (this: ServerResponse, ...args: unknown[]) {
+      if (this.req?.url?.includes("/getUpdates") && failedResponses < 2) {
+        const delayMs = 10 + failedResponses++ * 10;
+        setTimeout(() => this.destroy(new Error("simulated response failure")), delayMs);
+        return this;
+      }
+      return Reflect.apply(originalEnd, this, args) as ServerResponse;
+    };
+
+    try {
+      await Promise.allSettled([
+        requestHttp({
+          method: "GET",
+          url: `${server.manifest.baseUrl}/botsample/getUpdates?timeout=0`,
+        }),
+        requestHttp({
+          method: "GET",
+          url: `${server.manifest.baseUrl}/botsample/getUpdates?timeout=0`,
+        }),
+      ]);
+    } finally {
+      responsePrototype.end = originalEnd;
+    }
+
+    for (const text of ["first", "second"]) {
+      const update = await fetch(`${server.manifest.baseUrl}/botsample/getUpdates?timeout=0`);
+      await expect(update.json()).resolves.toMatchObject({
+        ok: true,
+        result: { message: { text } },
+      });
+    }
   });
 
   it("supersedes concurrent long polls and delivers to the current request", async () => {


### PR DESCRIPTION
## Summary
- canonicalize WhatsApp identities and preserve accepted, atomic delivery records
- harden WebSocket limits, wire values, lifecycle cleanup, and timestamps
- make Zalo polling disconnect-safe, ownership-safe, and protocol-native
- redact webhook credentials and document canonical bridge targets

## Validation
- focused Vitest: 94 tests after review fixes
- typecheck and format checks pass
- Crabbox and clean autoreview pending before merge

## Release notes
- includes `CHANGELOG.md` entry