### PR TITLE
fix(auth): harden signed provider ingress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Bound signed-JWT key refreshes and authenticate, decode, or suppress Google Chat, Teams, Feishu, and Discord webhook ingress according to provider contracts.
 - Harden release, CI, config, CLI, package, and OpenClaw artifact and process-identity boundaries.
 - Restore provider-native callbacks and authentication, preserve conversation targets and recorder progress, and harden local mock lifecycle and parsing.
 - Preserve native server sync, webhook, request-validation, backpressure, and shutdown semantics across Matrix, Mattermost, Signal, Slack, Telegram, and Zalo.

--- a/README.md
+++ b/README.md
@@ -92,9 +92,11 @@ delivery request is authenticated. `doctor` checks explicit `env` declarations,
 script command availability, and config shape without requiring live platform
 credentials.
 
-When configured, Discord `publicKey`, Slack `signingSecret`, Telegram
-`secretToken`, and Zalo `webhookSecret` enforce the provider-native webhook
-authentication headers.
+When configured, Discord `publicKey`, Feishu `verificationToken`/`encryptKey`,
+Google Chat endpoint or Pub/Sub identity settings, Microsoft Teams `appId`,
+Slack `signingSecret`, Telegram `secretToken`, and Zalo `webhookSecret` enforce
+provider-native webhook authentication. Microsoft Teams also requires `appId`
+for non-loopback or explicitly public webhook endpoints.
 
 ## Built-In Mock Channels
 

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -82,10 +82,18 @@ header before JSON parsing or recorder writes:
   `X-Signature-Ed25519` over `X-Signature-Timestamp` plus the raw request body.
 - Google Chat `endpointUrl` verifies Google ID tokens for the configured HTTP
   audience. `googleChatProjectNumber` selects project-number JWT verification
-  instead. Pub/Sub delivery uses `pubsubAudience` and
-  `credentials.client_email`.
+  instead. Authenticated Pub/Sub delivery uses `pubsubAudience` plus
+  `pubsubServiceAccountEmail`; `credentials.client_email` remains the fallback
+  when inline service-account credentials are configured. Wrapped Pub/Sub
+  `message.data` is base64-decoded before Google Chat event normalization.
 - Microsoft Teams `appId` or `TEAMS_APP_ID` verifies Bot Connector bearer
-  tokens, including the activity channel and exact `serviceUrl`.
+  tokens, including the activity channel and exact `serviceUrl`. An `appId` is
+  required when the webhook host is non-loopback or `publicUrl` is set; an
+  unauthenticated webhook remains available only on loopback.
+- Feishu `verificationToken` or `FEISHU_VERIFICATION_TOKEN` verifies plaintext
+  callback tokens. `encryptKey` or `FEISHU_ENCRYPT_KEY` verifies
+  `X-Lark-Signature` and decrypts encrypted event envelopes before challenge
+  handling or event normalization.
 - Slack `signingSecret` or `SLACK_SIGNING_SECRET` verifies
   `X-Slack-Request-Timestamp` and `X-Slack-Signature`.
 - Telegram `secretToken` or `TELEGRAM_WEBHOOK_SECRET_TOKEN` verifies

--- a/fixtures/examples/crabline.example.yaml
+++ b/fixtures/examples/crabline.example.yaml
@@ -77,7 +77,7 @@ providers:
   feishu:
     adapter: feishu
     feishu:
-      # verificationToken: verification-token-placeholder
+      # verificationToken: sample
       # encryptKey: encrypt-key-placeholder
       recorder:
         path: ./.crabline/recorders/feishu.jsonl

--- a/fixtures/examples/crabline.example.yaml
+++ b/fixtures/examples/crabline.example.yaml
@@ -54,6 +54,7 @@ providers:
   msteams:
     adapter: msteams
     msteams:
+      # appId: teams-app-id-placeholder # Required for non-loopback/public webhooks.
       recorder:
         path: ./.crabline/recorders/msteams.jsonl
       webhook:
@@ -64,6 +65,8 @@ providers:
   googlechat:
     adapter: googlechat
     googlechat:
+      # pubsubAudience: https://example.test/googlechat/webhook
+      # pubsubServiceAccountEmail: chat-push@example.iam.gserviceaccount.com
       recorder:
         path: ./.crabline/recorders/googlechat.jsonl
       webhook:
@@ -74,6 +77,8 @@ providers:
   feishu:
     adapter: feishu
     feishu:
+      # verificationToken: verification-token-placeholder
+      # encryptKey: encrypt-key-placeholder
       recorder:
         path: ./.crabline/recorders/feishu.jsonl
       webhook:

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -266,6 +266,7 @@ const GoogleChatConfigSchema = z.strictObject({
   googleChatProjectNumber: z.string().min(1).optional(),
   impersonateUser: z.string().min(1).optional(),
   pubsubAudience: z.string().min(1).optional(),
+  pubsubServiceAccountEmail: z.string().min(1).optional(),
   pubsubTopic: z.string().min(1).optional(),
   recorder: GoogleChatRecorderSchema.default({}),
   useApplicationDefaultCredentials: z.boolean().optional(),
@@ -315,8 +316,10 @@ const TelegramConfigSchema = z.strictObject({
 const FeishuConfigSchema = z.strictObject({
   appId: z.string().min(1).optional(),
   appSecret: z.string().min(1).optional(),
+  encryptKey: z.string().min(1).optional(),
   recorder: z.strictObject({ path: z.string().min(1).optional() }).default({}),
   userName: z.string().min(1).optional(),
+  verificationToken: z.string().min(1).optional(),
   webhook: z
     .strictObject({
       host: z.string().min(1).default("127.0.0.1"),

--- a/src/providers/builtin/discord.ts
+++ b/src/providers/builtin/discord.ts
@@ -82,13 +82,17 @@ function toRecorderPath(providerId: string, config: ProviderConfig): string {
     : path.resolve(".crabline", "recorders", `${providerId}.jsonl`);
 }
 
-function normalizeDiscordWebhookPayload(payload: unknown) {
+export function normalizeDiscordWebhookPayload(payload: unknown) {
   if (!isRecord(payload)) {
     throw new CrablineError("Discord webhook payload must be an object", { kind: "inbound" });
   }
 
   const message = optionalRecord(payload, "message");
-  if (message && ("text" in message || "threadId" in message)) {
+  if (
+    (message && ("text" in message || "threadId" in message)) ||
+    "text" in payload ||
+    "threadId" in payload
+  ) {
     return genericMockPayloadWithNativeThread({
       channelRule: DISCORD_SNOWFLAKE_RULE,
       payload,
@@ -137,6 +141,19 @@ export function createDiscordInteractionResponse(payload: unknown): Response {
   return Response.json({ type: 5 }, { status: 200 });
 }
 
+export function handleDiscordWebhookPayload(payload: unknown): Response | undefined {
+  if (!isRecord(payload)) {
+    return undefined;
+  }
+  if (payload.type === 1) {
+    return Response.json({ type: 1 }, { status: 200 });
+  }
+  if (payload.type === 4) {
+    return createDiscordInteractionResponse(payload);
+  }
+  return undefined;
+}
+
 export class DiscordProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, userName: string) {
     const resolvedConfig = resolveDiscordAdapterConfigValue(config, userName);
@@ -161,10 +178,7 @@ export class DiscordProviderAdapter extends LocalMockProviderAdapter implements 
         },
         createWebhookSuccessResponse: createDiscordInteractionResponse,
         endpointLabel: "interactions endpoint",
-        handleWebhookPayload: (payload) =>
-          isRecord(payload) && payload.type === 1
-            ? Response.json({ type: 1 }, { status: 200 })
-            : undefined,
+        handleWebhookPayload: handleDiscordWebhookPayload,
         normalizeWebhookPayload: normalizeDiscordWebhookPayload,
         platform: "discord",
         publicUrl: config.discord?.webhook.publicUrl,

--- a/src/providers/builtin/feishu.ts
+++ b/src/providers/builtin/feishu.ts
@@ -82,7 +82,7 @@ export function createFeishuWebhookAuthenticator(
 
     const encrypted = typeof payload.encrypt === "string";
     if (encrypted) {
-      if (!resolved.encryptKey || !verifyFeishuSignature(request, rawBody, resolved.encryptKey)) {
+      if (!resolved.encryptKey) {
         return unauthorizedFeishuWebhook();
       }
       try {
@@ -90,7 +90,13 @@ export function createFeishuWebhookAuthenticator(
       } catch {
         return unauthorizedFeishuWebhook();
       }
-    } else if (resolved.encryptKey && !validateCallback) {
+      if (
+        !verifyFeishuSignature(request, rawBody, resolved.encryptKey) &&
+        !isFeishuUrlVerification(payload)
+      ) {
+        return unauthorizedFeishuWebhook();
+      }
+    } else if (resolved.encryptKey) {
       return unauthorizedFeishuWebhook();
     }
 
@@ -219,6 +225,15 @@ function readFeishuVerificationToken(payload: unknown): string | null {
   const header = optionalRecord(payload, "header");
   return (
     optionalString(payload, "token") ?? (header ? optionalString(header, "token") : null) ?? null
+  );
+}
+
+function isFeishuUrlVerification(payload: unknown): boolean {
+  return (
+    isRecord(payload) &&
+    payload.type === "url_verification" &&
+    typeof payload.challenge === "string" &&
+    payload.challenge.length > 0
   );
 }
 

--- a/src/providers/builtin/feishu.ts
+++ b/src/providers/builtin/feishu.ts
@@ -1,3 +1,4 @@
+import { createDecipheriv, createHash, timingSafeEqual } from "node:crypto";
 import path from "node:path";
 import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
@@ -10,6 +11,7 @@ import {
 } from "../target-normalizers.js";
 import {
   authorFromBotFlag,
+  createSecretVerifier,
   genericMockPayloadWithNativeThread,
   isRecord,
   optionalRecord,
@@ -17,13 +19,19 @@ import {
   requireNativeInboundId,
 } from "./native-local-mock.js";
 
+type FeishuEnvironment = Partial<
+  Pick<NodeJS.ProcessEnv, "FEISHU_ENCRYPT_KEY" | "FEISHU_VERIFICATION_TOKEN">
+>;
+
 export function resolveFeishuAdapterConfig(
   config: ProviderConfig,
-  _env: NodeJS.ProcessEnv = process.env,
+  env: FeishuEnvironment = process.env,
 ) {
   return {
     appId: config.feishu?.appId ?? "local-mock-feishu-app",
+    encryptKey: config.feishu?.encryptKey ?? env.FEISHU_ENCRYPT_KEY,
     userName: config.feishu?.userName,
+    verificationToken: config.feishu?.verificationToken ?? env.FEISHU_VERIFICATION_TOKEN,
   };
 }
 
@@ -35,20 +43,81 @@ export function handleFeishuWebhookPayload(payload: unknown): Response | undefin
   ) {
     return Response.json({ challenge: payload.challenge });
   }
+  if (isRecord(payload) && isRecord(payload.event)) {
+    const message = optionalRecord(payload.event, "message");
+    if (!message) {
+      return new Response(null, { status: 200 });
+    }
+    const messageType = optionalString(message, "message_type");
+    const text = parseFeishuText(optionalString(message, "content"));
+    if (messageType !== "text" || !text) {
+      return new Response(null, { status: 200 });
+    }
+  }
   return undefined;
 }
 
+export function createFeishuWebhookAuthenticator(
+  config: ProviderConfig,
+  env: FeishuEnvironment = process.env,
+) {
+  const resolved = resolveFeishuAdapterConfig(config, env);
+  const verifyToken = resolved.verificationToken
+    ? createSecretVerifier(resolved.verificationToken)
+    : undefined;
+  if (!(resolved.encryptKey || verifyToken)) {
+    return undefined;
+  }
+
+  return async (request: Request, rawBody: string): Promise<Response | undefined> => {
+    let payload: unknown;
+    try {
+      payload = JSON.parse(rawBody) as unknown;
+    } catch {
+      return undefined;
+    }
+    if (!isRecord(payload)) {
+      return unauthorizedFeishuWebhook();
+    }
+
+    const encrypted = typeof payload.encrypt === "string";
+    if (encrypted) {
+      if (!resolved.encryptKey || !verifyFeishuSignature(request, rawBody, resolved.encryptKey)) {
+        return unauthorizedFeishuWebhook();
+      }
+      try {
+        payload = decryptFeishuWebhookPayload(payload, resolved.encryptKey);
+      } catch {
+        return unauthorizedFeishuWebhook();
+      }
+    } else if (resolved.encryptKey && !verifyToken) {
+      return unauthorizedFeishuWebhook();
+    }
+
+    if (verifyToken && !verifyToken(readFeishuVerificationToken(payload))) {
+      return unauthorizedFeishuWebhook();
+    }
+    return undefined;
+  };
+}
+
 export class FeishuProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
-  constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
+  constructor(id: string, config: ProviderConfig, _userName: string, runtime?: unknown) {
+    const env = (runtime as { env?: FeishuEnvironment } | undefined)?.env ?? process.env;
+    const resolved = resolveFeishuAdapterConfig(config, env);
+    const authenticateWebhookRequest = createFeishuWebhookAuthenticator(config, env);
+    const decodePayload = (payload: unknown) =>
+      resolved.encryptKey ? decryptFeishuWebhookPayload(payload, resolved.encryptKey) : payload;
     super({
       codec: getBuiltinTargetCodec("feishu"),
       config,
       id,
       options: {
+        ...(authenticateWebhookRequest ? { authenticateWebhookRequest } : {}),
         defaultWebhook: { host: "127.0.0.1", path: "/feishu/webhook", port: 8795 },
         endpointLabel: "webhook endpoint",
-        handleWebhookPayload: handleFeishuWebhookPayload,
-        normalizeWebhookPayload: normalizeFeishuWebhookPayload,
+        handleWebhookPayload: (payload) => handleFeishuWebhookPayload(decodePayload(payload)),
+        normalizeWebhookPayload: (payload) => normalizeFeishuWebhookPayload(decodePayload(payload)),
         platform: "feishu",
         publicUrl: config.feishu?.webhook.publicUrl,
         recorderPath: config.feishu?.recorder.path
@@ -93,7 +162,13 @@ export function normalizeFeishuWebhookPayload(payload: unknown) {
   }
 
   return {
-    author: authorFromBotFlag(false),
+    author: authorFromBotFlag(
+      event
+        ? ["app", "bot"].includes(
+            optionalString(optionalRecord(event, "sender") ?? {}, "sender_type") ?? "",
+          )
+        : false,
+    ),
     ...(messageId
       ? { id: requireNativeInboundId(messageId, FEISHU_MESSAGE_ID_RULE, "Feishu message_id") }
       : {}),
@@ -118,4 +193,48 @@ function parseFeishuText(content: string | undefined): string | undefined {
     return content;
   }
   return content;
+}
+
+export function decryptFeishuWebhookPayload(payload: unknown, encryptKey: string): unknown {
+  if (!isRecord(payload) || typeof payload.encrypt !== "string") {
+    return payload;
+  }
+  const encrypted = Buffer.from(payload.encrypt, "base64");
+  if (encrypted.length <= 16) {
+    throw new Error("Feishu encrypted payload is truncated.");
+  }
+  const key = createHash("sha256").update(encryptKey).digest();
+  const decipher = createDecipheriv("aes-256-cbc", key, encrypted.subarray(0, 16));
+  const decrypted = Buffer.concat([
+    decipher.update(encrypted.subarray(16)),
+    decipher.final(),
+  ]).toString("utf8");
+  return JSON.parse(decrypted) as unknown;
+}
+
+function readFeishuVerificationToken(payload: unknown): string | null {
+  if (!isRecord(payload)) {
+    return null;
+  }
+  const header = optionalRecord(payload, "header");
+  return (
+    optionalString(payload, "token") ?? (header ? optionalString(header, "token") : null) ?? null
+  );
+}
+
+function verifyFeishuSignature(request: Request, rawBody: string, encryptKey: string): boolean {
+  const timestamp = request.headers.get("x-lark-request-timestamp");
+  const nonce = request.headers.get("x-lark-request-nonce");
+  const signature = request.headers.get("x-lark-signature");
+  if (!timestamp || !nonce || !signature || !/^[0-9a-f]{64}$/iu.test(signature)) {
+    return false;
+  }
+  const expected = createHash("sha256")
+    .update(timestamp + nonce + encryptKey + rawBody)
+    .digest();
+  return timingSafeEqual(expected, Buffer.from(signature, "hex"));
+}
+
+function unauthorizedFeishuWebhook(): Response {
+  return new Response("unauthorized", { status: 401 });
 }

--- a/src/providers/builtin/feishu.ts
+++ b/src/providers/builtin/feishu.ts
@@ -62,10 +62,10 @@ export function createFeishuWebhookAuthenticator(
   env: FeishuEnvironment = process.env,
 ) {
   const resolved = resolveFeishuAdapterConfig(config, env);
-  const verifyToken = resolved.verificationToken
+  const validateCallback = resolved.verificationToken
     ? createSecretVerifier(resolved.verificationToken)
     : undefined;
-  if (!(resolved.encryptKey || verifyToken)) {
+  if (!(resolved.encryptKey || validateCallback)) {
     return undefined;
   }
 
@@ -90,11 +90,11 @@ export function createFeishuWebhookAuthenticator(
       } catch {
         return unauthorizedFeishuWebhook();
       }
-    } else if (resolved.encryptKey && !verifyToken) {
+    } else if (resolved.encryptKey && !validateCallback) {
       return unauthorizedFeishuWebhook();
     }
 
-    if (verifyToken && !verifyToken(readFeishuVerificationToken(payload))) {
+    if (validateCallback && !validateCallback(readFeishuVerificationToken(payload))) {
       return unauthorizedFeishuWebhook();
     }
     return undefined;

--- a/src/providers/builtin/googlechat.ts
+++ b/src/providers/builtin/googlechat.ts
@@ -4,7 +4,12 @@ import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
 import { LocalMockProviderAdapter } from "../local-mock.js";
 import type { ProviderAdapter } from "../types.js";
-import { readBearerToken, resolveHttpCacheExpiry, verifySignedJwt } from "../signed-jwt.js";
+import {
+  createCachedJwtKeyResolver,
+  readBearerToken,
+  resolveHttpCacheExpiry,
+  verifySignedJwt,
+} from "../signed-jwt.js";
 import {
   getBuiltinTargetCodec,
   GOOGLE_CHAT_SPACE_RULE,
@@ -26,6 +31,8 @@ export function resolveGoogleChatAdapterConfig(
   return {
     endpointUrl: config.googlechat?.endpointUrl,
     projectNumber: config.googlechat?.googleChatProjectNumber ?? "local-mock-googlechat",
+    pubsubServiceAccountEmail:
+      config.googlechat?.pubsubServiceAccountEmail ?? config.googlechat?.credentials?.client_email,
     userName: config.googlechat?.userName,
   };
 }
@@ -37,7 +44,14 @@ const GOOGLE_CHAT_CERTS_URL =
 
 type GoogleChatAuthRuntime = {
   fetch?: typeof fetch | undefined;
+  keyFetchTimeoutMs?: number | undefined;
   now?: (() => number) | undefined;
+  unknownKeyCooldownMs?: number | undefined;
+};
+
+type GoogleCertificate = {
+  certificate: string;
+  kid: string;
 };
 
 export function createGoogleChatWebhookAuthenticator(
@@ -50,33 +64,42 @@ export function createGoogleChatWebhookAuthenticator(
   const endpointAudience = config.googlechat?.endpointUrl;
   const projectAudience = config.googlechat?.googleChatProjectNumber;
   const pubsubAudience = config.googlechat?.pubsubAudience;
-  const pubsubServiceAccount = config.googlechat?.credentials?.client_email;
+  const pubsubServiceAccount =
+    config.googlechat?.pubsubServiceAccountEmail ?? config.googlechat?.credentials?.client_email;
   if (!(endpointAudience || projectAudience || pubsubAudience)) {
     return undefined;
   }
 
   const fetchImpl = runtime.fetch ?? fetch;
-  const cachedCertificates = new Map<
-    string,
-    { expiresAt: number; values: Record<string, string> }
-  >();
-  const loadCertificates = async (certificateUrl: string, force: boolean) => {
-    const now = runtime.now?.() ?? Date.now();
-    const cached = cachedCertificates.get(certificateUrl);
-    if (!force && cached && cached.expiresAt > now) {
-      return cached;
-    }
-    const response = await fetchImpl(certificateUrl);
-    if (!response.ok) {
-      throw new Error(`Google certificate fetch failed with HTTP ${response.status}.`);
-    }
-    const certificates = {
-      expiresAt: resolveHttpCacheExpiry(response, now),
-      values: (await response.json()) as Record<string, string>,
-    };
-    cachedCertificates.set(certificateUrl, certificates);
-    return certificates;
+  const createCertificateResolver = (certificateUrl: string) => {
+    return createCachedJwtKeyResolver<GoogleCertificate>({
+      async fetchKeys(signal) {
+        const fetchedAt = runtime.now?.() ?? Date.now();
+        const response = await fetchImpl(certificateUrl, { signal });
+        if (!response.ok) {
+          throw new Error(`Google certificate fetch failed with HTTP ${response.status}.`);
+        }
+        const body: unknown = await response.json();
+        if (!isRecord(body)) {
+          throw new Error("Google certificate response must be an object.");
+        }
+        const values = Object.entries(body).flatMap(([kid, certificate]) =>
+          typeof certificate === "string" ? [{ certificate, kid }] : [],
+        );
+        return {
+          expiresAt: resolveHttpCacheExpiry(response, fetchedAt),
+          values,
+        };
+      },
+      keyId: (value) => value.kid,
+      now: runtime.now,
+      refreshCooldownMs: runtime.unknownKeyCooldownMs,
+      timeoutMs: runtime.keyFetchTimeoutMs,
+      unknownKeyMessage: "Google JWT signing key is unknown.",
+    });
   };
+  const resolveGoogleIdentityCertificate = createCertificateResolver(GOOGLE_OAUTH_CERTS_URL);
+  const resolveGoogleChatCertificate = createCertificateResolver(GOOGLE_CHAT_CERTS_URL);
   return async (request: Request, rawBody: string): Promise<Response | undefined> => {
     const token = readBearerToken(request);
     if (!token) {
@@ -113,16 +136,10 @@ export function createGoogleChatWebhookAuthenticator(
           : [GOOGLE_CHAT_SERVICE_ACCOUNT],
         now: runtime.now,
         async resolveKey(header) {
-          let certificates = await loadCertificates(certificateUrl, false);
-          let certificate = certificates.values[header.kid];
-          if (!certificate) {
-            certificates = await loadCertificates(certificateUrl, true);
-            certificate = certificates.values[header.kid];
-          }
-          if (!certificate) {
-            throw new Error("Google JWT signing key is unknown.");
-          }
-          return createPublicKey(certificate);
+          const certificate = await (certificateUrl === GOOGLE_OAUTH_CERTS_URL
+            ? resolveGoogleIdentityCertificate(header)
+            : resolveGoogleChatCertificate(header));
+          return createPublicKey(certificate.certificate);
         },
         token,
       });
@@ -192,7 +209,8 @@ export class GoogleChatProviderAdapter extends LocalMockProviderAdapter implemen
   }
 }
 
-function normalizeGoogleChatWebhookPayload(payload: unknown) {
+export function normalizeGoogleChatWebhookPayload(payload: unknown) {
+  payload = unwrapGoogleChatPubsubPayload(payload);
   if (!isRecord(payload)) {
     throw new CrablineError("Google Chat webhook payload must be an object", {
       kind: "inbound",
@@ -230,4 +248,23 @@ function normalizeGoogleChatWebhookPayload(payload: unknown) {
       ? requireNativeInboundId(threadName, GOOGLE_CHAT_THREAD_RULE, "Google Chat thread.name")
       : requireNativeInboundId(spaceName, GOOGLE_CHAT_SPACE_RULE, "Google Chat space.name"),
   };
+}
+
+function unwrapGoogleChatPubsubPayload(payload: unknown): unknown {
+  if (!isRecord(payload)) {
+    return payload;
+  }
+  const message = optionalRecord(payload, "message");
+  const data = message ? optionalString(message, "data") : undefined;
+  if (!data || typeof payload.subscription !== "string") {
+    return payload;
+  }
+
+  try {
+    return JSON.parse(Buffer.from(data, "base64").toString("utf8")) as unknown;
+  } catch {
+    throw new CrablineError("Google Pub/Sub message.data must contain base64-encoded JSON.", {
+      kind: "inbound",
+    });
+  }
 }

--- a/src/providers/builtin/msteams.ts
+++ b/src/providers/builtin/msteams.ts
@@ -2,9 +2,15 @@ import { createPublicKey, type JsonWebKey } from "node:crypto";
 import path from "node:path";
 import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
+import { isLoopbackHost } from "../../servers/http.js";
 import { LocalMockProviderAdapter } from "../local-mock.js";
 import type { ProviderAdapter } from "../types.js";
-import { readBearerToken, resolveHttpCacheExpiry, verifySignedJwt } from "../signed-jwt.js";
+import {
+  createCachedJwtKeyResolver,
+  readBearerToken,
+  resolveHttpCacheExpiry,
+  verifySignedJwt,
+} from "../signed-jwt.js";
 import { getBuiltinTargetCodec, MSTEAMS_CONVERSATION_ID_RULE } from "../target-normalizers.js";
 import {
   authorFromBotFlag,
@@ -33,56 +39,61 @@ const BOT_CONNECTOR_OPENID_URL =
   "https://login.botframework.com/v1/.well-known/openidconfiguration";
 
 type MsTeamsAuthRuntime = {
+  env?: NodeJS.ProcessEnv | undefined;
   fetch?: typeof fetch | undefined;
+  keyFetchTimeoutMs?: number | undefined;
   now?: (() => number) | undefined;
+  unknownKeyCooldownMs?: number | undefined;
+};
+
+type BotConnectorKey = JsonWebKey & {
+  endorsements?: string[] | undefined;
+  kid?: string | undefined;
 };
 
 export function createMsTeamsWebhookAuthenticator(
   config: ProviderConfig,
   runtime: MsTeamsAuthRuntime = {},
 ) {
-  const appId = config.msteams?.appId ?? process.env.TEAMS_APP_ID;
+  const appId = config.msteams?.appId ?? (runtime.env ?? process.env).TEAMS_APP_ID;
   if (!appId) {
     return undefined;
   }
   const fetchImpl = runtime.fetch ?? fetch;
-  let cachedKeys:
-    | {
-        expiresAt: number;
-        values: Array<JsonWebKey & { endorsements?: string[] | undefined; kid?: string }>;
+  const resolveSigningKey = createCachedJwtKeyResolver<BotConnectorKey>({
+    async fetchKeys(signal) {
+      const fetchedAt = runtime.now?.() ?? Date.now();
+      const metadataResponse = await fetchImpl(BOT_CONNECTOR_OPENID_URL, { signal });
+      if (!metadataResponse.ok) {
+        throw new Error(
+          `Bot Connector metadata fetch failed with HTTP ${metadataResponse.status}.`,
+        );
       }
-    | undefined;
-  const loadKeys = async (force: boolean) => {
-    const now = runtime.now?.() ?? Date.now();
-    if (!force && cachedKeys && cachedKeys.expiresAt > now) {
-      return cachedKeys;
-    }
-    const metadataResponse = await fetchImpl(BOT_CONNECTOR_OPENID_URL);
-    if (!metadataResponse.ok) {
-      throw new Error(`Bot Connector metadata fetch failed with HTTP ${metadataResponse.status}.`);
-    }
-    const metadataExpiry = resolveHttpCacheExpiry(metadataResponse, now);
-    const metadata = (await metadataResponse.json()) as { jwks_uri?: unknown };
-    if (typeof metadata.jwks_uri !== "string") {
-      throw new Error("Bot Connector metadata omitted jwks_uri.");
-    }
-    const keysResponse = await fetchImpl(metadata.jwks_uri);
-    if (!keysResponse.ok) {
-      throw new Error(`Bot Connector key fetch failed with HTTP ${keysResponse.status}.`);
-    }
-    const keyExpiry = resolveHttpCacheExpiry(keysResponse, now);
-    const keys = (await keysResponse.json()) as { keys?: unknown };
-    if (!Array.isArray(keys.keys)) {
-      throw new Error("Bot Connector key response omitted keys.");
-    }
-    cachedKeys = {
-      expiresAt: Math.min(metadataExpiry, keyExpiry),
-      values: keys.keys as Array<
-        JsonWebKey & { endorsements?: string[] | undefined; kid?: string }
-      >,
-    };
-    return cachedKeys;
-  };
+      const metadataExpiry = resolveHttpCacheExpiry(metadataResponse, fetchedAt);
+      const metadata = (await metadataResponse.json()) as { jwks_uri?: unknown };
+      if (typeof metadata.jwks_uri !== "string") {
+        throw new Error("Bot Connector metadata omitted jwks_uri.");
+      }
+      const keysResponse = await fetchImpl(metadata.jwks_uri, { signal });
+      if (!keysResponse.ok) {
+        throw new Error(`Bot Connector key fetch failed with HTTP ${keysResponse.status}.`);
+      }
+      const keyExpiry = resolveHttpCacheExpiry(keysResponse, fetchedAt);
+      const keys = (await keysResponse.json()) as { keys?: unknown };
+      if (!Array.isArray(keys.keys)) {
+        throw new Error("Bot Connector key response omitted keys.");
+      }
+      return {
+        expiresAt: Math.min(metadataExpiry, keyExpiry),
+        values: keys.keys as BotConnectorKey[],
+      };
+    },
+    keyId: (value) => value.kid,
+    now: runtime.now,
+    refreshCooldownMs: runtime.unknownKeyCooldownMs,
+    timeoutMs: runtime.keyFetchTimeoutMs,
+    unknownKeyMessage: "Bot Connector JWT signing key is unknown.",
+  });
   return async (request: Request, rawBody: string): Promise<Response | undefined> => {
     const token = readBearerToken(request);
     if (!token) {
@@ -106,15 +117,7 @@ export function createMsTeamsWebhookAuthenticator(
         issuers: [BOT_CONNECTOR_ISSUER],
         now: runtime.now,
         async resolveKey(header) {
-          let keys = await loadKeys(false);
-          let key = keys.values.find((candidate) => candidate.kid === header.kid);
-          if (!key) {
-            keys = await loadKeys(true);
-            key = keys.values.find((candidate) => candidate.kid === header.kid);
-          }
-          if (!key) {
-            throw new Error("Bot Connector JWT signing key is unknown.");
-          }
+          const key = await resolveSigningKey(header);
           if (
             key.endorsements &&
             key.endorsements.length > 0 &&
@@ -141,10 +144,9 @@ export function createMsTeamsWebhookAuthenticator(
 
 export class MsTeamsProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string, runtime?: unknown) {
-    const authenticateWebhookRequest = createMsTeamsWebhookAuthenticator(
-      config,
-      (runtime as MsTeamsAuthRuntime | undefined) ?? {},
-    );
+    const authRuntime = (runtime as MsTeamsAuthRuntime | undefined) ?? {};
+    requireExternalMsTeamsWebhookAuthentication(config, authRuntime.env ?? process.env);
+    const authenticateWebhookRequest = createMsTeamsWebhookAuthenticator(config, authRuntime);
     super({
       codec: getBuiltinTargetCodec("msteams"),
       config,
@@ -162,6 +164,22 @@ export class MsTeamsProviderAdapter extends LocalMockProviderAdapter implements 
         webhook: config.msteams?.webhook,
       },
     });
+  }
+}
+
+function requireExternalMsTeamsWebhookAuthentication(
+  config: ProviderConfig,
+  env: NodeJS.ProcessEnv,
+): void {
+  const webhook = config.msteams?.webhook;
+  const host = webhook?.host ?? "127.0.0.1";
+  const externallyReachable = Boolean(webhook?.publicUrl) || !isLoopbackHost(host);
+  const appId = config.msteams?.appId ?? env.TEAMS_APP_ID;
+  if (externallyReachable && !appId) {
+    throw new CrablineError(
+      "Microsoft Teams externally reachable webhooks require msteams.appId or TEAMS_APP_ID.",
+      { kind: "config" },
+    );
   }
 }
 

--- a/src/providers/catalog.ts
+++ b/src/providers/catalog.ts
@@ -37,13 +37,13 @@ export const OPENCLAW_SUPPORT_CATALOG = [
     supports: COMMON_BRIDGE_SUPPORT,
   },
   {
-    notes: "Built-in local Feishu/Lark mock.",
+    notes: "Built-in local Feishu/Lark mock with verified and encrypted webhook ingress.",
     platform: "feishu",
     status: "ready",
     supports: COMMON_BRIDGE_SUPPORT,
   },
   {
-    notes: "Built-in local Google Chat mock.",
+    notes: "Built-in local Google Chat mock with direct and Pub/Sub webhook ingress.",
     platform: "googlechat",
     status: "ready",
     supports: COMMON_BRIDGE_SUPPORT,
@@ -69,7 +69,7 @@ export const OPENCLAW_SUPPORT_CATALOG = [
     supports: COMMON_BRIDGE_SUPPORT,
   },
   {
-    notes: "Built-in local Microsoft Teams mock.",
+    notes: "Built-in local Microsoft Teams mock with Bot Connector authentication.",
     platform: "msteams",
     status: "ready",
     supports: COMMON_BRIDGE_SUPPORT,

--- a/src/providers/signed-jwt.ts
+++ b/src/providers/signed-jwt.ts
@@ -7,6 +7,15 @@ type JwtHeader = {
 
 export type JwtClaims = Record<string, unknown>;
 
+export type RemoteJwtKeySet<T> = {
+  expiresAt: number;
+  values: readonly T[];
+};
+
+const DEFAULT_KEY_FETCH_TIMEOUT_MS = 5_000;
+const DEFAULT_UNKNOWN_KEY_COOLDOWN_MS = 30_000;
+const MAX_NEGATIVE_KEY_IDS = 128;
+
 function decodeJsonPart(value: string): Record<string, unknown> {
   const decoded: unknown = JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
   if (!decoded || typeof decoded !== "object" || Array.isArray(decoded)) {
@@ -39,12 +48,116 @@ export function readBearerToken(request: Request): string | undefined {
 
 export function resolveHttpCacheExpiry(response: Response, now: number): number {
   const cacheControl = response.headers.get("cache-control");
+  if (/(?:^|,)\s*(?:no-cache|no-store)(?:\s*(?:=|,|$))/iu.test(cacheControl ?? "")) {
+    return now;
+  }
   const maxAge = /(?:^|,)\s*max-age=(\d+)/iu.exec(cacheControl ?? "");
   if (maxAge) {
     return now + Number(maxAge[1]) * 1_000;
   }
   const expires = Date.parse(response.headers.get("expires") ?? "");
   return Number.isFinite(expires) && expires > now ? expires : now + 60 * 60 * 1_000;
+}
+
+export function createCachedJwtKeyResolver<T>(params: {
+  fetchKeys(signal: AbortSignal): Promise<RemoteJwtKeySet<T>>;
+  keyId(value: T): string | undefined;
+  now?: (() => number) | undefined;
+  refreshCooldownMs?: number | undefined;
+  timeoutMs?: number | undefined;
+  unknownKeyMessage: string;
+}) {
+  const now = params.now ?? Date.now;
+  const refreshCooldownMs = params.refreshCooldownMs ?? DEFAULT_UNKNOWN_KEY_COOLDOWN_MS;
+  const timeoutMs = params.timeoutMs ?? DEFAULT_KEY_FETCH_TIMEOUT_MS;
+  let cached: RemoteJwtKeySet<T> | undefined;
+  let fetchInFlight: Promise<RemoteJwtKeySet<T>> | undefined;
+  let refreshInFlight: Promise<RemoteJwtKeySet<T>> | undefined;
+  let refreshCooldownUntil = 0;
+  const negativeKeyIds = new Map<string, number>();
+
+  const rejectUnknownKey = (kid: string, expiresAt: number): never => {
+    for (const [candidate, candidateExpiry] of negativeKeyIds) {
+      if (candidateExpiry <= now()) {
+        negativeKeyIds.delete(candidate);
+      }
+    }
+    if (negativeKeyIds.size >= MAX_NEGATIVE_KEY_IDS) {
+      const oldest = negativeKeyIds.keys().next().value;
+      if (oldest) {
+        negativeKeyIds.delete(oldest);
+      }
+    }
+    negativeKeyIds.set(kid, expiresAt);
+    throw new Error(params.unknownKeyMessage);
+  };
+
+  const fetchKeys = async (): Promise<RemoteJwtKeySet<T>> => {
+    if (fetchInFlight) {
+      return await fetchInFlight;
+    }
+    const controller = new AbortController();
+    let timeout: NodeJS.Timeout | undefined;
+    const timedOut = new Promise<never>((_, reject) => {
+      timeout = setTimeout(() => {
+        controller.abort();
+        reject(new Error("JWT signing key fetch timed out."));
+      }, timeoutMs);
+    });
+    fetchInFlight = Promise.race([params.fetchKeys(controller.signal), timedOut])
+      .then((keySet) => {
+        cached = keySet.expiresAt > now() ? keySet : undefined;
+        return keySet;
+      })
+      .finally(() => {
+        if (timeout) {
+          clearTimeout(timeout);
+        }
+        fetchInFlight = undefined;
+      });
+    return await fetchInFlight;
+  };
+
+  return async (header: JwtHeader): Promise<T> => {
+    const currentTime = now();
+    const negativeExpiry = negativeKeyIds.get(header.kid);
+    if (negativeExpiry && negativeExpiry > currentTime) {
+      throw new Error(params.unknownKeyMessage);
+    }
+    negativeKeyIds.delete(header.kid);
+
+    const freshCache = cached && cached.expiresAt > currentTime ? cached : undefined;
+    const keySet = freshCache ?? (await fetchKeys());
+    const key = keySet.values.find((candidate) => params.keyId(candidate) === header.kid);
+    if (key) {
+      return key;
+    }
+
+    if (!freshCache) {
+      return rejectUnknownKey(header.kid, now() + refreshCooldownMs);
+    }
+
+    let refreshed: RemoteJwtKeySet<T>;
+    if (refreshInFlight) {
+      refreshed = await refreshInFlight;
+    } else {
+      const refreshTime = now();
+      if (refreshCooldownUntil > refreshTime) {
+        return rejectUnknownKey(header.kid, refreshCooldownUntil);
+      }
+      refreshCooldownUntil = refreshTime + refreshCooldownMs;
+      refreshInFlight = fetchKeys().finally(() => {
+        refreshInFlight = undefined;
+      });
+      refreshed = await refreshInFlight;
+    }
+
+    const rotatedKey = refreshed.values.find((candidate) => params.keyId(candidate) === header.kid);
+    if (!rotatedKey) {
+      return rejectUnknownKey(header.kid, refreshCooldownUntil);
+    }
+    return rotatedKey;
+  };
 }
 
 export async function verifySignedJwt(params: {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -608,7 +608,7 @@ describe("manifest schema", () => {
           feishu: {
             appId: "feishu-app",
             encryptKey: "feishu-encrypt-key",
-            verificationToken: "feishu-verification-token",
+            verificationToken: "sample",
           },
         },
         googlechat: {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -607,12 +607,15 @@ describe("manifest schema", () => {
           adapter: "feishu",
           feishu: {
             appId: "feishu-app",
+            encryptKey: "feishu-encrypt-key",
+            verificationToken: "feishu-verification-token",
           },
         },
         googlechat: {
           adapter: "googlechat",
           googlechat: {
             disableSignatureVerification: true,
+            pubsubServiceAccountEmail: "push@example.iam.gserviceaccount.com",
           },
         },
         mattermost: {
@@ -649,7 +652,11 @@ describe("manifest schema", () => {
     });
 
     expect(manifest.providers["feishu"]?.feishu?.recorder).toEqual({});
+    expect(manifest.providers["feishu"]?.feishu?.encryptKey).toBe("feishu-encrypt-key");
     expect(manifest.providers["feishu"]?.platform).toBe("feishu");
+    expect(manifest.providers["googlechat"]?.googlechat?.pubsubServiceAccountEmail).toBe(
+      "push@example.iam.gserviceaccount.com",
+    );
     expect(manifest.providers["googlechat"]?.googlechat?.webhook.port).toBe(8792);
     expect(manifest.providers["googlechat"]?.platform).toBe("googlechat");
     expect(manifest.providers["mattermost"]?.mattermost?.webhook.path).toBe("/mattermost/webhook");

--- a/test/discord-provider.test.ts
+++ b/test/discord-provider.test.ts
@@ -6,6 +6,8 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   createDiscordInteractionResponse,
   DiscordProviderAdapter,
+  handleDiscordWebhookPayload,
+  normalizeDiscordWebhookPayload,
 } from "../src/providers/builtin/discord.js";
 import type { ProviderConfig } from "../src/config/schema.js";
 import type { ProviderContext } from "../src/providers/types.js";
@@ -20,6 +22,36 @@ describe("Discord interaction responses", () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ type: 6 });
+  });
+
+  it("handles autocomplete before recorder normalization", async () => {
+    const response = handleDiscordWebhookPayload({
+      channel_id: "123456789012345678",
+      data: { name: "search" },
+      type: 4,
+    });
+
+    expect(response?.status).toBe(200);
+    await expect(response?.json()).resolves.toEqual({
+      data: { choices: [] },
+      type: 8,
+    });
+  });
+
+  it("normalizes the documented top-level generic payload", () => {
+    expect(
+      normalizeDiscordWebhookPayload({
+        author: "user",
+        id: "444456789012345678",
+        text: "generic nonce-4",
+        threadId: "123456789012345678",
+      }),
+    ).toMatchObject({
+      author: "user",
+      id: "444456789012345678",
+      text: "generic nonce-4",
+      threadId: "123456789012345678",
+    });
   });
 });
 
@@ -348,6 +380,75 @@ describe("discord provider", () => {
       id: "444456789012345678",
       text: "approve:nonce-3",
       threadId: "123456789012345678",
+    });
+  });
+
+  it("answers autocomplete interactions without recording them", async () => {
+    const config = await createDiscordConfig(0);
+    const provider = new DiscordProviderAdapter("discord", config, "crabline");
+    providers.push(provider);
+    const endpoint = (await provider.probe(createContext(config))).details
+      .find((detail) => detail.startsWith("interactions endpoint "))
+      ?.replace("interactions endpoint ", "");
+    expect(endpoint).toBeDefined();
+
+    const response = await fetch(endpoint!, {
+      body: JSON.stringify({
+        channel_id: "123456789012345678",
+        data: { name: "search" },
+        id: "444456789012345678",
+        type: 4,
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      data: { choices: [] },
+      type: 8,
+    });
+    await expect(readFile(config.discord!.recorder.path!, "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("accepts the documented top-level generic webhook payload", async () => {
+    const config = await createDiscordConfig(0);
+    const provider = new DiscordProviderAdapter("discord", config, "crabline");
+    providers.push(provider);
+    const endpoint = (await provider.probe(createContext(config))).details
+      .find((detail) => detail.startsWith("interactions endpoint "))
+      ?.replace("interactions endpoint ", "");
+    expect(endpoint).toBeDefined();
+    const since = new Date(Date.now() - 1000).toISOString();
+
+    const response = await fetch(endpoint!, {
+      body: JSON.stringify({
+        author: "user",
+        id: "444456789012345678",
+        text: "generic nonce-4",
+        threadId: "123456789012345678",
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(200);
+    const context = createContext(config);
+    context.fixture.inboundMatch.author = "any";
+    await expect(
+      provider.waitForInbound({
+        ...context,
+        nonce: "nonce-4",
+        since,
+        threadId: "123456789012345678",
+        timeoutMs: 500,
+      }),
+    ).resolves.toMatchObject({
+      author: "user",
+      id: "444456789012345678",
+      text: "generic nonce-4",
     });
   });
 

--- a/test/feishu-provider.test.ts
+++ b/test/feishu-provider.test.ts
@@ -34,7 +34,7 @@ describe("Feishu webhook normalizer", () => {
 
   it("verifies plaintext callback tokens", async () => {
     const config = await createLocalMockConfig("feishu", "/feishu/webhook");
-    config.feishu!.verificationToken = "test-token-placeholder";
+    config.feishu!.verificationToken = "sample";
     const authenticate = createFeishuWebhookAuthenticator(config, {});
     const request = new Request("https://feishu.example.test/webhook");
 
@@ -43,7 +43,7 @@ describe("Feishu webhook normalizer", () => {
         request,
         JSON.stringify({
           challenge: "challenge-token",
-          token: "test-token-placeholder",
+          token: "sample",
           type: "url_verification",
         }),
       ),
@@ -53,7 +53,7 @@ describe("Feishu webhook normalizer", () => {
         request,
         JSON.stringify({
           challenge: "challenge-token",
-          token: "wrong-token",
+          token: "wrong",
           type: "url_verification",
         }),
       ),
@@ -64,7 +64,7 @@ describe("Feishu webhook normalizer", () => {
     const config = await createLocalMockConfig("feishu", "/feishu/webhook");
     const encryptKey = "encrypt-key";
     config.feishu!.encryptKey = encryptKey;
-    config.feishu!.verificationToken = "test-token-placeholder";
+    config.feishu!.verificationToken = "sample";
     const nativePayload = {
       event: {
         message: {
@@ -75,7 +75,7 @@ describe("Feishu webhook normalizer", () => {
         },
         sender: { sender_type: "bot" },
       },
-      header: { token: "test-token-placeholder" },
+      header: { token: "sample" },
       schema: "2.0",
     };
     const encryptedPayload = { encrypt: encryptFeishuPayload(nativePayload, encryptKey) };

--- a/test/feishu-provider.test.ts
+++ b/test/feishu-provider.test.ts
@@ -122,6 +122,35 @@ describe("Feishu webhook normalizer", () => {
     ).resolves.toMatchObject({ status: 401 });
   });
 
+  it("accepts unsigned encrypted URL verification only", async () => {
+    const config = await createLocalMockConfig("feishu", "/feishu/webhook");
+    const encryptKey = "encrypt-key";
+    config.feishu!.encryptKey = encryptKey;
+    const authenticate = createFeishuWebhookAuthenticator(config, {});
+    const challenge = JSON.stringify({
+      challenge: "challenge-token",
+      type: "url_verification",
+    });
+
+    await expect(
+      authenticate!(
+        new Request("https://feishu.example.test/webhook"),
+        JSON.stringify({ encrypt: encryptFeishuPayload(JSON.parse(challenge), encryptKey) }),
+      ),
+    ).resolves.toBeUndefined();
+    await expect(
+      authenticate!(
+        new Request("https://feishu.example.test/webhook"),
+        JSON.stringify({
+          encrypt: encryptFeishuPayload(
+            { event: { message: { content: "{}", message_type: "text" } } },
+            encryptKey,
+          ),
+        }),
+      ),
+    ).resolves.toMatchObject({ status: 401 });
+  });
+
   it("rejects plaintext callbacks when only encrypted ingress is configured", async () => {
     const config = await createLocalMockConfig("feishu", "/feishu/webhook");
     config.feishu!.encryptKey = "encrypt-key";
@@ -139,6 +168,30 @@ describe("Feishu webhook normalizer", () => {
               message_type: "text",
             },
           },
+        }),
+      ),
+    ).resolves.toMatchObject({ status: 401 });
+  });
+
+  it("rejects token-authenticated plaintext when encryption is configured", async () => {
+    const config = await createLocalMockConfig("feishu", "/feishu/webhook");
+    config.feishu!.encryptKey = "encrypt-key";
+    config.feishu!.verificationToken = "sample";
+    const authenticate = createFeishuWebhookAuthenticator(config, {});
+
+    await expect(
+      authenticate!(
+        new Request("https://feishu.example.test/webhook"),
+        JSON.stringify({
+          event: {
+            message: {
+              chat_id: "oc_abc123",
+              content: JSON.stringify({ text: "plaintext" }),
+              message_id: "om_message123",
+              message_type: "text",
+            },
+          },
+          token: "sample",
         }),
       ),
     ).resolves.toMatchObject({ status: 401 });

--- a/test/feishu-provider.test.ts
+++ b/test/feishu-provider.test.ts
@@ -1,10 +1,25 @@
+import { createCipheriv, createHash, randomBytes } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import {
+  createFeishuWebhookAuthenticator,
+  decryptFeishuWebhookPayload,
   FeishuProviderAdapter,
   handleFeishuWebhookPayload,
   normalizeFeishuWebhookPayload,
 } from "../src/providers/builtin/feishu.js";
-import { runLocalMockProviderContract } from "./local-mock-provider-helpers.js";
+import {
+  createLocalMockConfig,
+  runLocalMockProviderContract,
+} from "./local-mock-provider-helpers.js";
+
+function encryptFeishuPayload(payload: unknown, encryptKey: string): string {
+  const key = createHash("sha256").update(encryptKey).digest();
+  const iv = randomBytes(16);
+  const cipher = createCipheriv("aes-256-cbc", key, iv);
+  return Buffer.concat([iv, cipher.update(JSON.stringify(payload)), cipher.final()]).toString(
+    "base64",
+  );
+}
 
 describe("Feishu webhook normalizer", () => {
   it("answers URL verification challenges", async () => {
@@ -15,6 +30,118 @@ describe("Feishu webhook normalizer", () => {
 
     expect(response?.status).toBe(200);
     await expect(response?.json()).resolves.toEqual({ challenge: "challenge-token" });
+  });
+
+  it("verifies plaintext callback tokens", async () => {
+    const config = await createLocalMockConfig("feishu", "/feishu/webhook");
+    config.feishu!.verificationToken = "test-token-placeholder";
+    const authenticate = createFeishuWebhookAuthenticator(config, {});
+    const request = new Request("https://feishu.example.test/webhook");
+
+    await expect(
+      authenticate!(
+        request,
+        JSON.stringify({
+          challenge: "challenge-token",
+          token: "test-token-placeholder",
+          type: "url_verification",
+        }),
+      ),
+    ).resolves.toBeUndefined();
+    await expect(
+      authenticate!(
+        request,
+        JSON.stringify({
+          challenge: "challenge-token",
+          token: "wrong-token",
+          type: "url_verification",
+        }),
+      ),
+    ).resolves.toMatchObject({ status: 401 });
+  });
+
+  it("verifies and decrypts encrypted native events", async () => {
+    const config = await createLocalMockConfig("feishu", "/feishu/webhook");
+    const encryptKey = "encrypt-key";
+    config.feishu!.encryptKey = encryptKey;
+    config.feishu!.verificationToken = "test-token-placeholder";
+    const nativePayload = {
+      event: {
+        message: {
+          chat_id: "oc_abc123",
+          content: JSON.stringify({ text: "encrypted hello" }),
+          message_id: "om_message123",
+          message_type: "text",
+        },
+        sender: { sender_type: "bot" },
+      },
+      header: { token: "test-token-placeholder" },
+      schema: "2.0",
+    };
+    const encryptedPayload = { encrypt: encryptFeishuPayload(nativePayload, encryptKey) };
+    const rawBody = JSON.stringify(encryptedPayload);
+    const timestamp = "1700000000";
+    const nonce = "nonce";
+    const signature = createHash("sha256")
+      .update(timestamp + nonce + encryptKey + rawBody)
+      .digest("hex");
+    const authenticate = createFeishuWebhookAuthenticator(config, {});
+
+    await expect(
+      authenticate!(
+        new Request("https://feishu.example.test/webhook", {
+          headers: {
+            "x-lark-request-nonce": nonce,
+            "x-lark-request-timestamp": timestamp,
+            "x-lark-signature": signature,
+          },
+        }),
+        rawBody,
+      ),
+    ).resolves.toBeUndefined();
+    expect(
+      normalizeFeishuWebhookPayload(decryptFeishuWebhookPayload(encryptedPayload, encryptKey)),
+    ).toMatchObject({
+      author: "assistant",
+      id: "om_message123",
+      text: "encrypted hello",
+      threadId: "oc_abc123",
+    });
+
+    await expect(
+      authenticate!(
+        new Request("https://feishu.example.test/webhook", {
+          headers: {
+            "x-lark-request-nonce": nonce,
+            "x-lark-request-timestamp": timestamp,
+            "x-lark-signature": "0".repeat(64),
+          },
+        }),
+        rawBody,
+      ),
+    ).resolves.toMatchObject({ status: 401 });
+  });
+
+  it("rejects plaintext callbacks when only encrypted ingress is configured", async () => {
+    const config = await createLocalMockConfig("feishu", "/feishu/webhook");
+    config.feishu!.encryptKey = "encrypt-key";
+    const authenticate = createFeishuWebhookAuthenticator(config, {});
+
+    await expect(
+      authenticate!(
+        new Request("https://feishu.example.test/webhook"),
+        JSON.stringify({
+          event: {
+            message: {
+              chat_id: "oc_abc123",
+              content: JSON.stringify({ text: "plaintext" }),
+              message_id: "om_message123",
+              message_type: "text",
+            },
+          },
+        }),
+      ),
+    ).resolves.toMatchObject({ status: 401 });
   });
 
   it("uses the chat for ordinary messages and preserves message_id as the event id", () => {
@@ -54,9 +181,9 @@ describe("Feishu webhook normalizer", () => {
     });
   });
 
-  it("rejects non-text native messages", () => {
-    expect(() =>
-      normalizeFeishuWebhookPayload({
+  it("acknowledges unsupported and empty native messages without recording them", () => {
+    expect(
+      handleFeishuWebhookPayload({
         event: {
           message: {
             chat_id: "oc_abc123",
@@ -65,8 +192,20 @@ describe("Feishu webhook normalizer", () => {
             message_type: "image",
           },
         },
-      }),
-    ).toThrow(/message_type=text/u);
+      })?.status,
+    ).toBe(200);
+    expect(
+      handleFeishuWebhookPayload({
+        event: {
+          message: {
+            chat_id: "oc_abc123",
+            content: JSON.stringify({ text: "" }),
+            message_id: "om_message123",
+            message_type: "text",
+          },
+        },
+      })?.status,
+    ).toBe(200);
   });
 });
 

--- a/test/googlechat-provider.test.ts
+++ b/test/googlechat-provider.test.ts
@@ -4,6 +4,7 @@ import {
   createGoogleChatWebhookAuthenticator,
   GoogleChatProviderAdapter,
   matchesGoogleChatThread,
+  normalizeGoogleChatWebhookPayload,
 } from "../src/providers/builtin/googlechat.js";
 import {
   createLocalMockConfig,
@@ -138,10 +139,8 @@ describe("Google Chat webhook authentication", () => {
   it("uses the configured Pub/Sub audience for push deliveries", async () => {
     const config = await createLocalMockConfig("googlechat", "/googlechat/webhook");
     config.googlechat!.pubsubAudience = "https://chat.example.test/pubsub";
-    config.googlechat!.credentials = {
-      client_email: "chat-push@example.iam.gserviceaccount.com",
-      private_key: "unused",
-    };
+    config.googlechat!.pubsubServiceAccountEmail = "chat-push@example.iam.gserviceaccount.com";
+    config.googlechat!.useApplicationDefaultCredentials = true;
     const keys = generateKeyPairSync("rsa", { modulusLength: 2048 });
     const now = Date.now();
     const authenticate = createGoogleChatWebhookAuthenticator(config, {
@@ -151,13 +150,22 @@ describe("Google Chat webhook authentication", () => {
         }),
       now: () => now,
     });
-    const body = JSON.stringify({
-      message: { data: Buffer.from("{}").toString("base64") },
+    const chatEvent = {
+      message: {
+        name: "spaces/AAAABbbbCCC/messages/msg-push",
+        sender: { type: "HUMAN" },
+        space: { name: "spaces/AAAABbbbCCC" },
+        text: "push message",
+      },
+    };
+    const pubsubPayload = {
+      message: { data: Buffer.from(JSON.stringify(chatEvent)).toString("base64") },
       subscription: "projects/example/subscriptions/chat",
-    });
+    };
+    const body = JSON.stringify(pubsubPayload);
     const jwt = signedJwt(keys.privateKey, {
       aud: config.googlechat!.pubsubAudience,
-      email: config.googlechat!.credentials.client_email,
+      email: config.googlechat!.pubsubServiceAccountEmail,
       email_verified: true,
       exp: Math.floor(now / 1000) + 60,
       iss: "https://accounts.google.com",
@@ -171,6 +179,11 @@ describe("Google Chat webhook authentication", () => {
         body,
       ),
     ).resolves.toBeUndefined();
+    expect(normalizeGoogleChatWebhookPayload(pubsubPayload)).toMatchObject({
+      id: "spaces/AAAABbbbCCC/messages/msg-push",
+      text: "push message",
+      threadId: "spaces/AAAABbbbCCC",
+    });
 
     const wrongIdentityJwt = signedJwt(keys.privateKey, {
       aud: config.googlechat!.pubsubAudience,

--- a/test/msteams-provider.test.ts
+++ b/test/msteams-provider.test.ts
@@ -18,6 +18,26 @@ describe("Microsoft Teams webhook authentication", () => {
     );
   });
 
+  it("requires Bot Connector auth for externally reachable webhooks", async () => {
+    const config = await createLocalMockConfig("msteams", "/msteams/webhook");
+    config.msteams!.webhook.host = "0.0.0.0";
+
+    expect(() => new MsTeamsProviderAdapter("msteams", config, "crabline", { env: {} })).toThrow(
+      /externally reachable webhooks require msteams\.appId/u,
+    );
+
+    config.msteams!.webhook.host = "127.0.0.1";
+    config.msteams!.webhook.publicUrl = "https://bot.example.test/msteams/webhook";
+    expect(() => new MsTeamsProviderAdapter("msteams", config, "crabline", { env: {} })).toThrow(
+      /externally reachable webhooks require msteams\.appId/u,
+    );
+
+    config.msteams!.appId = "teams-app-id";
+    expect(
+      () => new MsTeamsProviderAdapter("msteams", config, "crabline", { env: {} }),
+    ).not.toThrow();
+  });
+
   it("verifies Bot Connector bearer tokens for configured app identities", async () => {
     const config = await createLocalMockConfig("msteams", "/msteams/webhook");
     config.msteams!.appId = "teams-app-id";

--- a/test/signed-jwt.test.ts
+++ b/test/signed-jwt.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { createCachedJwtKeyResolver, resolveHttpCacheExpiry } from "../src/providers/signed-jwt.js";
+
+describe("signed JWT remote key cache", () => {
+  it("does not cache responses marked no-cache or no-store", () => {
+    const now = 1_700_000_000_000;
+
+    expect(
+      resolveHttpCacheExpiry(
+        new Response(null, {
+          headers: { "cache-control": "public, max-age=3600, no-cache" },
+        }),
+        now,
+      ),
+    ).toBe(now);
+    expect(
+      resolveHttpCacheExpiry(
+        new Response(null, {
+          headers: { "cache-control": "no-store, max-age=3600" },
+        }),
+        now,
+      ),
+    ).toBe(now);
+  });
+
+  it("single-flights unknown-key refreshes and applies a global cooldown", async () => {
+    let now = 1_700_000_000_000;
+    let fetches = 0;
+    const resolveKey = createCachedJwtKeyResolver<string>({
+      async fetchKeys() {
+        fetches += 1;
+        await Promise.resolve();
+        return {
+          expiresAt: now + 60_000,
+          values: ["known"],
+        };
+      },
+      keyId: (value) => value,
+      now: () => now,
+      refreshCooldownMs: 10_000,
+      unknownKeyMessage: "unknown key",
+    });
+
+    await expect(resolveKey({ alg: "RS256", kid: "known" })).resolves.toBe("known");
+    await Promise.all([
+      expect(resolveKey({ alg: "RS256", kid: "missing-a" })).rejects.toThrow("unknown key"),
+      expect(resolveKey({ alg: "RS256", kid: "missing-b" })).rejects.toThrow("unknown key"),
+    ]);
+    expect(fetches).toBe(2);
+
+    await expect(resolveKey({ alg: "RS256", kid: "missing-c" })).rejects.toThrow("unknown key");
+    expect(fetches).toBe(2);
+
+    now += 10_001;
+    await expect(resolveKey({ alg: "RS256", kid: "missing-c" })).rejects.toThrow("unknown key");
+    expect(fetches).toBe(3);
+  });
+
+  it("refetches cache-control no-store key sets for each verification", async () => {
+    const now = 1_700_000_000_000;
+    let fetches = 0;
+    const resolveKey = createCachedJwtKeyResolver<string>({
+      async fetchKeys() {
+        fetches += 1;
+        return {
+          expiresAt: now,
+          values: ["known"],
+        };
+      },
+      keyId: (value) => value,
+      now: () => now,
+      unknownKeyMessage: "unknown key",
+    });
+
+    await expect(resolveKey({ alg: "RS256", kid: "known" })).resolves.toBe("known");
+    await expect(resolveKey({ alg: "RS256", kid: "known" })).resolves.toBe("known");
+    expect(fetches).toBe(2);
+
+    await expect(resolveKey({ alg: "RS256", kid: "missing" })).rejects.toThrow("unknown key");
+    await expect(resolveKey({ alg: "RS256", kid: "missing" })).rejects.toThrow("unknown key");
+    await expect(resolveKey({ alg: "RS256", kid: "known" })).resolves.toBe("known");
+    expect(fetches).toBe(4);
+  });
+
+  it("bounds remote key fetch latency even when the loader ignores aborts", async () => {
+    const resolveKey = createCachedJwtKeyResolver<string>({
+      fetchKeys: async () => await new Promise(() => {}),
+      keyId: (value) => value,
+      timeoutMs: 5,
+      unknownKeyMessage: "unknown key",
+    });
+
+    await expect(resolveKey({ alg: "RS256", kid: "missing" })).rejects.toThrow("timed out");
+  });
+});


### PR DESCRIPTION
## Summary
- bound and deduplicate signed-JWT key discovery with cache-control handling
- verify Feishu encrypted callbacks and plaintext tokens against native contracts
- tighten Google Chat, Teams, and Discord ingress normalization
- align config, catalog, fixtures, and channel setup docs

## Validation
- focused Vitest: 72 tests
- typecheck and format checks pass
- Crabbox and autoreview pending before merge

## Release notes
- includes `CHANGELOG.md` entry