### PR TITLE
fix(runtime): harden execution and release paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,6 +264,34 @@ jobs:
             return 0
           }
 
+          guard_latest_version() {
+            local latest_version
+            if ! latest_version="$(npm view "$PACKAGE_NAME@latest" version 2>/dev/null)"; then
+              echo "::error::Unable to resolve the current npm latest version for $PACKAGE_NAME."
+              return 1
+            fi
+            node --input-type=module -e '
+              const [release, latest] = process.argv.slice(1);
+              const parse = (value) => {
+                const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(value);
+                if (!match) {
+                  throw new Error(`Expected a stable semantic version, got ${value}.`);
+                }
+                return match.slice(1).map(BigInt);
+              };
+              const releaseParts = parse(release);
+              const latestParts = parse(latest);
+              for (let index = 0; index < releaseParts.length; index += 1) {
+                if (releaseParts[index] > latestParts[index]) process.exit(0);
+                if (releaseParts[index] < latestParts[index]) {
+                  throw new Error(
+                    `Refusing to publish ${release} because npm latest is newer at ${latest}.`,
+                  );
+                }
+              }
+            ' "$RELEASE_VERSION" "$latest_version"
+          }
+
           if check_existing_package; then
             echo "$PACKAGE_NAME@$RELEASE_VERSION is already published with the expected integrity."
             exit 0
@@ -274,6 +302,7 @@ jobs:
             fi
           fi
 
+          guard_latest_version
           if npm publish "$PACKAGE_TARBALL" --access public --provenance; then
             exit 0
           else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -275,7 +275,7 @@ jobs:
               const parse = (value) => {
                 const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(value);
                 if (!match) {
-                  throw new Error(`Expected a stable semantic version, got ${value}.`);
+                  throw new Error("Expected a stable semantic version, got " + value + ".");
                 }
                 return match.slice(1).map(BigInt);
               };
@@ -285,7 +285,11 @@ jobs:
                 if (releaseParts[index] > latestParts[index]) process.exit(0);
                 if (releaseParts[index] < latestParts[index]) {
                   throw new Error(
-                    `Refusing to publish ${release} because npm latest is newer at ${latest}.`,
+                    "Refusing to publish " +
+                      release +
+                      " because npm latest is newer at " +
+                      latest +
+                      ".",
                   );
                 }
               }

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,7 +23,7 @@ jobs:
           stale-issue-label: stale
           stale-pr-label: stale
           exempt-issue-labels: enhancement,maintainer,pinned,security,no-stale
-          exempt-pr-labels: maintainer,no-stale
+          exempt-pr-labels: maintainer,security,no-stale
           operations-per-run: 1000
           ascending: true
           exempt-all-assignees: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Enforce safe Telegram identities while acknowledging valid unsupported updates.
 - Align Slack callback, thread-history, and message-text behavior with its native protocol.
 - Canonicalize WhatsApp identities and accepted-send evidence, publish webhook batches atomically with bounded retry deduplication, and preserve Zalo updates across disconnects and concurrent polls.
+- Harden shared runtime cleanup, terminal and script diagnostics, smoke artifact rollback, test helpers, source maps, and stable release publication.
 - Harden release, CI, config, CLI, package, and OpenClaw artifact and process-identity boundaries.
 - Restore provider-native callbacks and authentication, preserve conversation targets and recorder progress, and harden local mock lifecycle and parsing.
 - Preserve native server sync, webhook, request-validation, backpressure, and shutdown semantics across Matrix, Mattermost, Signal, Slack, Telegram, and Zalo.

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -6,7 +6,7 @@ import nodePath from "node:path";
 import { lock } from "proper-lockfile";
 import { loadManifest } from "../config/load.js";
 import { createRegistry } from "../providers/registry.js";
-import { formatJson, formatRunResultText } from "../core/reporters.js";
+import { formatJson, formatRunResultText, sanitizeTerminalText } from "../core/reporters.js";
 import { computeExitCode, runFixtureCommand, runSuite } from "../core/run.js";
 import { CrablineError, ensureErrorMessage } from "../core/errors.js";
 import {
@@ -127,6 +127,56 @@ const SERVE_PARAM_FACTORIES = {
 
 function print(value: string): void {
   process.stdout.write(`${value}\n`);
+}
+
+async function printWatchLine(value: string): Promise<boolean> {
+  try {
+    await new Promise<void>((resolve, reject) => {
+      let drained = false;
+      let written = false;
+      const cleanup = () => {
+        process.stdout.off("drain", onDrain);
+        process.stdout.off("error", onError);
+      };
+      const finish = () => {
+        if (drained && written) {
+          cleanup();
+          resolve();
+        }
+      };
+      const onDrain = () => {
+        drained = true;
+        finish();
+      };
+      const onError = (error: Error) => {
+        cleanup();
+        reject(error);
+      };
+      process.stdout.once("error", onError);
+      const hasCapacity = process.stdout.write(`${value}\n`, (error) => {
+        if (error) {
+          process.stdout.once("error", () => undefined);
+          onError(error);
+          return;
+        }
+        written = true;
+        finish();
+      });
+      if (hasCapacity) {
+        drained = true;
+        finish();
+      } else {
+        process.stdout.once("drain", onDrain);
+      }
+    });
+    return true;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "EPIPE" || code === "ERR_STREAM_DESTROYED") {
+      return false;
+    }
+    throw error;
+  }
 }
 
 async function withManifest<T>(
@@ -296,11 +346,14 @@ export function createProgram(
               break;
             }
             const message = result.value;
-            print(
+            const written = await printWatchLine(
               options.json
                 ? formatJson(message)
-                : `${message.sentAt} ${message.author} ${message.text}`,
+                : `${sanitizeTerminalText(message.sentAt, true)} ${sanitizeTerminalText(message.author, true)} ${sanitizeTerminalText(message.text, true)}`,
             );
+            if (!written) {
+              break;
+            }
           }
         } catch (error) {
           lifecycleErrors.push(error);

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -116,11 +116,16 @@ const InboundMatchSchema = z
     }
   });
 
+const ScriptCommandSchema = z
+  .string()
+  .min(1)
+  .refine((value) => value.trim().length > 0, "script command must not be blank");
+
 const ScriptCommandsSchema = z.strictObject({
-  probe: z.string().min(1).optional(),
-  send: z.string().min(1).optional(),
-  waitForInbound: z.string().min(1).optional(),
-  watch: z.string().min(1).optional(),
+  probe: ScriptCommandSchema.optional(),
+  send: ScriptCommandSchema.optional(),
+  waitForInbound: ScriptCommandSchema.optional(),
+  watch: ScriptCommandSchema.optional(),
 });
 
 const LoopbackConfigSchema = z.strictObject({

--- a/src/core/reporters.ts
+++ b/src/core/reporters.ts
@@ -1,13 +1,42 @@
 import pc from "picocolors";
 import type { CommandRunResult, SuiteRunResult } from "./run.js";
 
+const BIDI_CONTROL_CODE_POINTS = new Set([
+  0x202a, 0x202b, 0x202c, 0x202d, 0x202e, 0x2066, 0x2067, 0x2068, 0x2069,
+]);
+
+export function sanitizeTerminalText(value: string, singleLine = false): string {
+  let sanitized = "";
+  for (const character of value) {
+    const codePoint = character.codePointAt(0)!;
+    if (character === "\n") {
+      sanitized += singleLine ? String.raw`\n` : "\n";
+    } else if (character === "\r") {
+      sanitized += String.raw`\r`;
+    } else if (character === "\t") {
+      sanitized += String.raw`\t`;
+    } else if (codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f)) {
+      sanitized += String.raw`\x${codePoint.toString(16).padStart(2, "0")}`;
+    } else if (
+      codePoint === 0x2028 ||
+      codePoint === 0x2029 ||
+      BIDI_CONTROL_CODE_POINTS.has(codePoint)
+    ) {
+      sanitized += String.raw`\u${codePoint.toString(16).padStart(4, "0")}`;
+    } else {
+      sanitized += character;
+    }
+  }
+  return sanitized;
+}
+
 export function formatRunResultText(result: CommandRunResult | SuiteRunResult): string {
   if ("results" in result) {
     const lines = [
       `${pc.bold("suite")} ${result.totalPassed}/${result.results.length} passed`,
       ...result.results.flatMap((entry) => [
         formatCaseLine(entry),
-        ...entry.diagnostics.map((diagnostic) => `  - ${diagnostic}`),
+        ...entry.diagnostics.flatMap(formatDiagnostic),
       ]),
     ];
     return lines.join("\n");
@@ -21,11 +50,17 @@ export function formatJson(result: unknown): string {
 }
 
 function formatSingleResult(result: CommandRunResult): string {
-  const lines = [formatCaseLine(result), ...result.diagnostics.map((entry) => `  - ${entry}`)];
+  const lines = [formatCaseLine(result), ...result.diagnostics.flatMap(formatDiagnostic)];
   return lines.join("\n");
+}
+
+function formatDiagnostic(diagnostic: string): string[] {
+  return sanitizeTerminalText(diagnostic)
+    .split("\n")
+    .map((line) => `  - ${line}`);
 }
 
 function formatCaseLine(result: CommandRunResult): string {
   const colorize = result.ok ? pc.green : result.failureKind === "timeout" ? pc.yellow : pc.red;
-  return `${colorize(result.ok ? "PASS" : "FAIL")} ${result.fixtureId} ${result.mode} ${result.providerId}`;
+  return `${colorize(result.ok ? "PASS" : "FAIL")} ${sanitizeTerminalText(result.fixtureId, true)} ${sanitizeTerminalText(result.mode, true)} ${sanitizeTerminalText(result.providerId, true)}`;
 }

--- a/src/core/reporters.ts
+++ b/src/core/reporters.ts
@@ -2,7 +2,7 @@ import pc from "picocolors";
 import type { CommandRunResult, SuiteRunResult } from "./run.js";
 
 const BIDI_CONTROL_CODE_POINTS = new Set([
-  0x202a, 0x202b, 0x202c, 0x202d, 0x202e, 0x2066, 0x2067, 0x2068, 0x2069,
+  0x061c, 0x200e, 0x200f, 0x202a, 0x202b, 0x202c, 0x202d, 0x202e, 0x2066, 0x2067, 0x2068, 0x2069,
 ]);
 
 export function sanitizeTerminalText(value: string, singleLine = false): string {

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -89,33 +89,38 @@ export async function runFixtureCommand(params: {
   let result: CommandRunResult | undefined;
   try {
     if (!provider.supports.includes(mode)) {
-      return (result = {
+      result = {
         diagnostics: [`provider ${fixture.provider} does not support mode ${mode}`],
         failureKind: "config",
         fixtureId: fixture.id,
         mode,
         ok: false,
         providerId: fixture.provider,
-      });
+      };
     }
 
-    for (const envName of [
-      ...fixture.env,
-      ...(params.manifest.providers[fixture.provider]?.env ?? []),
-    ]) {
-      if (!process.env[envName]) {
-        return (result = {
-          diagnostics: [`missing env: ${envName}`],
-          failureKind: "config",
-          fixtureId: fixture.id,
-          mode,
-          ok: false,
-          providerId: fixture.provider,
-        });
+    if (!result) {
+      for (const envName of [
+        ...fixture.env,
+        ...(params.manifest.providers[fixture.provider]?.env ?? []),
+      ]) {
+        if (!process.env[envName]) {
+          result = {
+            diagnostics: [`missing env: ${envName}`],
+            failureKind: "config",
+            fixtureId: fixture.id,
+            mode,
+            ok: false,
+            providerId: fixture.provider,
+          };
+          break;
+        }
       }
     }
 
-    if (mode === "probe") {
+    if (result) {
+      // Preflight failures still flow through provider cleanup before returning.
+    } else if (mode === "probe") {
       try {
         const probeResult = await provider.probe(contextBase);
         return (result = {
@@ -129,165 +134,165 @@ export async function runFixtureCommand(params: {
       } catch (error) {
         return (result = toFailure(fixture.id, fixture.provider, mode, error, "connectivity"));
       }
-    }
-
-    if (fixture.inboundMatch.strategy === "regex" && fixture.inboundMatch.pattern) {
-      try {
-        RegExp(fixture.inboundMatch.pattern, "u");
-        const safetyError = inboundRegexSafetyError(fixture.inboundMatch.pattern);
-        if (safetyError) {
-          throw new Error(safetyError);
-        }
-      } catch (error) {
-        return (result = toFailure(
-          fixture.id,
-          fixture.provider,
-          mode,
-          new CrablineError(`Invalid inbound regex: ${ensureErrorMessage(error)}`, {
-            cause: error,
-            kind: "config",
-          }),
-          "config",
-        ));
-      }
-    }
-
-    let attempts = 0;
-    const maxAttempts = fixture.retries + 1;
-    let lastFailure: CommandRunResult | null = null;
-
-    while (attempts < maxAttempts) {
-      attempts += 1;
-      const nonce = createNonce(fixture.id);
-
-      try {
-        const outboundText = createOutboundText({ ...fixture, mode }, nonce);
-        const since = new Date().toISOString();
-        let accepted;
+    } else {
+      if (fixture.inboundMatch.strategy === "regex" && fixture.inboundMatch.pattern) {
         try {
-          accepted = await provider.send({
-            ...contextBase,
-            mode,
-            nonce,
-            text: outboundText,
-          });
+          RegExp(fixture.inboundMatch.pattern, "u");
+          const safetyError = inboundRegexSafetyError(fixture.inboundMatch.pattern);
+          if (safetyError) {
+            throw new Error(safetyError);
+          }
         } catch (error) {
-          lastFailure = toFailure(fixture.id, fixture.provider, mode, error, "outbound", nonce);
-          continue;
-        }
-        if (!accepted.accepted) {
-          lastFailure = toFailure(
+          return (result = toFailure(
             fixture.id,
             fixture.provider,
             mode,
-            new CrablineError(`Provider rejected outbound message ${accepted.messageId}.`, {
-              kind: "outbound",
+            new CrablineError(`Invalid inbound regex: ${ensureErrorMessage(error)}`, {
+              cause: error,
+              kind: "config",
             }),
-            "outbound",
-            nonce,
-          );
-          continue;
+            "config",
+          ));
         }
-        diagnostics.push(`accepted message ${accepted.messageId}`);
+      }
 
-        if (mode === "send") {
+      let attempts = 0;
+      const maxAttempts = fixture.retries + 1;
+      let lastFailure: CommandRunResult | null = null;
+
+      while (attempts < maxAttempts) {
+        attempts += 1;
+        const nonce = createNonce(fixture.id);
+
+        try {
+          const outboundText = createOutboundText({ ...fixture, mode }, nonce);
+          const since = new Date().toISOString();
+          let accepted;
+          try {
+            accepted = await provider.send({
+              ...contextBase,
+              mode,
+              nonce,
+              text: outboundText,
+            });
+          } catch (error) {
+            lastFailure = toFailure(fixture.id, fixture.provider, mode, error, "outbound", nonce);
+            continue;
+          }
+          if (!accepted.accepted) {
+            lastFailure = toFailure(
+              fixture.id,
+              fixture.provider,
+              mode,
+              new CrablineError(`Provider rejected outbound message ${accepted.messageId}.`, {
+                kind: "outbound",
+              }),
+              "outbound",
+              nonce,
+            );
+            continue;
+          }
+          diagnostics.push(`accepted message ${accepted.messageId}`);
+
+          if (mode === "send") {
+            return (result = {
+              diagnostics,
+              fixtureId: fixture.id,
+              mode,
+              nonce,
+              ok: true,
+              providerId: fixture.provider,
+            });
+          }
+
+          const inboundDeadline = Date.now() + fixture.timeoutMs;
+          const seenInbound = new Set<string>();
+          let inbound;
+          try {
+            while (Date.now() < inboundDeadline) {
+              const timeoutMs = inboundDeadline - Date.now();
+              const controller = new AbortController();
+              const wait = provider.waitForInbound({
+                ...contextBase,
+                nonce,
+                signal: controller.signal,
+                since,
+                threadId: accepted.threadId,
+                timeoutMs,
+              });
+              const candidate = await raceInboundDeadline(wait, timeoutMs);
+              if (candidate === INBOUND_DEADLINE_REACHED) {
+                if (!(await abortAndDrainInboundWait(wait, controller))) {
+                  abortDrainFailed = true;
+                  throw new CrablineError(
+                    `Provider inbound wait did not settle within ${INBOUND_ABORT_GRACE_MS}ms after abort.`,
+                    { kind: "inbound" },
+                  );
+                }
+                break;
+              }
+              if (!candidate) {
+                break;
+              }
+
+              const key = JSON.stringify([candidate.provider, candidate.threadId, candidate.id]);
+              if (seenInbound.has(key)) {
+                await sleep(Math.min(10, Math.max(0, inboundDeadline - Date.now())));
+                continue;
+              }
+              seenInbound.add(key);
+
+              if (matchesInbound(candidate, fixture.inboundMatch, nonce)) {
+                inbound = candidate;
+                break;
+              }
+            }
+          } catch (error) {
+            lastFailure = toFailure(fixture.id, fixture.provider, mode, error, "inbound", nonce);
+            if (abortDrainFailed) {
+              break;
+            }
+            continue;
+          }
+          if (!inbound) {
+            lastFailure = {
+              diagnostics: [
+                ...diagnostics,
+                `timed out waiting for inbound after ${fixture.timeoutMs}ms`,
+              ],
+              failureKind: "timeout",
+              fixtureId: fixture.id,
+              mode,
+              nonce,
+              ok: false,
+              providerId: fixture.provider,
+            };
+            await sleep(50);
+            continue;
+          }
+
           return (result = {
-            diagnostics,
+            diagnostics: [...diagnostics, `matched inbound ${inbound.id}`],
             fixtureId: fixture.id,
             mode,
             nonce,
             ok: true,
             providerId: fixture.provider,
           });
-        }
-
-        const inboundDeadline = Date.now() + fixture.timeoutMs;
-        const seenInbound = new Set<string>();
-        let inbound;
-        try {
-          while (Date.now() < inboundDeadline) {
-            const timeoutMs = inboundDeadline - Date.now();
-            const controller = new AbortController();
-            const wait = provider.waitForInbound({
-              ...contextBase,
-              nonce,
-              signal: controller.signal,
-              since,
-              threadId: accepted.threadId,
-              timeoutMs,
-            });
-            const candidate = await raceInboundDeadline(wait, timeoutMs);
-            if (candidate === INBOUND_DEADLINE_REACHED) {
-              if (!(await abortAndDrainInboundWait(wait, controller))) {
-                abortDrainFailed = true;
-                throw new CrablineError(
-                  `Provider inbound wait did not settle within ${INBOUND_ABORT_GRACE_MS}ms after abort.`,
-                  { kind: "inbound" },
-                );
-              }
-              break;
-            }
-            if (!candidate) {
-              break;
-            }
-
-            const key = JSON.stringify([candidate.provider, candidate.threadId, candidate.id]);
-            if (seenInbound.has(key)) {
-              await sleep(Math.min(10, Math.max(0, inboundDeadline - Date.now())));
-              continue;
-            }
-            seenInbound.add(key);
-
-            if (matchesInbound(candidate, fixture.inboundMatch, nonce)) {
-              inbound = candidate;
-              break;
-            }
-          }
         } catch (error) {
-          lastFailure = toFailure(fixture.id, fixture.provider, mode, error, "inbound", nonce);
-          if (abortDrainFailed) {
-            break;
-          }
-          continue;
+          lastFailure = toFailure(fixture.id, fixture.provider, mode, error, "assertion", nonce);
         }
-        if (!inbound) {
-          lastFailure = {
-            diagnostics: [
-              ...diagnostics,
-              `timed out waiting for inbound after ${fixture.timeoutMs}ms`,
-            ],
-            failureKind: "timeout",
-            fixtureId: fixture.id,
-            mode,
-            nonce,
-            ok: false,
-            providerId: fixture.provider,
-          };
-          await sleep(50);
-          continue;
-        }
-
-        return (result = {
-          diagnostics: [...diagnostics, `matched inbound ${inbound.id}`],
-          fixtureId: fixture.id,
-          mode,
-          nonce,
-          ok: true,
-          providerId: fixture.provider,
-        });
-      } catch (error) {
-        lastFailure = toFailure(fixture.id, fixture.provider, mode, error, "assertion", nonce);
       }
-    }
 
-    return (result = lastFailure ?? {
-      diagnostics: ["unknown failure"],
-      failureKind: "assertion",
-      fixtureId: fixture.id,
-      mode,
-      ok: false,
-      providerId: fixture.provider,
-    });
+      return (result = lastFailure ?? {
+        diagnostics: ["unknown failure"],
+        failureKind: "assertion",
+        fixtureId: fixture.id,
+        mode,
+        ok: false,
+        providerId: fixture.provider,
+      });
+    }
   } finally {
     const cleanupErrors: unknown[] = [];
     try {

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -78,33 +78,6 @@ export async function runFixtureCommand(params: {
   const diagnostics: string[] = [];
   let abortDrainFailed = false;
 
-  if (!provider.supports.includes(mode)) {
-    return {
-      diagnostics: [`provider ${fixture.provider} does not support mode ${mode}`],
-      failureKind: "config",
-      fixtureId: fixture.id,
-      mode,
-      ok: false,
-      providerId: fixture.provider,
-    };
-  }
-
-  for (const envName of [
-    ...fixture.env,
-    ...(params.manifest.providers[fixture.provider]?.env ?? []),
-  ]) {
-    if (!process.env[envName]) {
-      return {
-        diagnostics: [`missing env: ${envName}`],
-        failureKind: "config",
-        fixtureId: fixture.id,
-        mode,
-        ok: false,
-        providerId: fixture.provider,
-      };
-    }
-  }
-
   const contextBase = {
     config: params.manifest.providers[fixture.provider]!,
     fixture,
@@ -115,6 +88,33 @@ export async function runFixtureCommand(params: {
 
   let result: CommandRunResult | undefined;
   try {
+    if (!provider.supports.includes(mode)) {
+      return (result = {
+        diagnostics: [`provider ${fixture.provider} does not support mode ${mode}`],
+        failureKind: "config",
+        fixtureId: fixture.id,
+        mode,
+        ok: false,
+        providerId: fixture.provider,
+      });
+    }
+
+    for (const envName of [
+      ...fixture.env,
+      ...(params.manifest.providers[fixture.provider]?.env ?? []),
+    ]) {
+      if (!process.env[envName]) {
+        return (result = {
+          diagnostics: [`missing env: ${envName}`],
+          failureKind: "config",
+          fixtureId: fixture.id,
+          mode,
+          ok: false,
+          providerId: fixture.provider,
+        });
+      }
+    }
+
     if (mode === "probe") {
       try {
         const probeResult = await provider.probe(contextBase);
@@ -173,6 +173,19 @@ export async function runFixtureCommand(params: {
           });
         } catch (error) {
           lastFailure = toFailure(fixture.id, fixture.provider, mode, error, "outbound", nonce);
+          continue;
+        }
+        if (!accepted.accepted) {
+          lastFailure = toFailure(
+            fixture.id,
+            fixture.provider,
+            mode,
+            new CrablineError(`Provider rejected outbound message ${accepted.messageId}.`, {
+              kind: "outbound",
+            }),
+            "outbound",
+            nonce,
+          );
           continue;
         }
         diagnostics.push(`accepted message ${accepted.messageId}`);
@@ -276,7 +289,12 @@ export async function runFixtureCommand(params: {
       providerId: fixture.provider,
     });
   } finally {
-    let cleanupError: unknown;
+    const cleanupErrors: unknown[] = [];
+    try {
+      provider.beginCleanup?.();
+    } catch (error) {
+      cleanupErrors.push(error);
+    }
     try {
       const cleanup = provider.cleanup?.();
       if (cleanup) {
@@ -284,8 +302,10 @@ export async function runFixtureCommand(params: {
           abortDrainFailed &&
           (await raceInboundDeadline(cleanup, INBOUND_ABORT_GRACE_MS)) === INBOUND_DEADLINE_REACHED
         ) {
-          cleanupError = new Error(
-            `Provider cleanup did not settle within ${INBOUND_ABORT_GRACE_MS}ms after an aborted inbound wait.`,
+          cleanupErrors.push(
+            new Error(
+              `Provider cleanup did not settle within ${INBOUND_ABORT_GRACE_MS}ms after an aborted inbound wait.`,
+            ),
           );
         }
         if (!abortDrainFailed) {
@@ -293,9 +313,16 @@ export async function runFixtureCommand(params: {
         }
       }
     } catch (error) {
-      cleanupError = error;
+      cleanupErrors.push(error);
     }
-    if (cleanupError !== undefined) {
+    if (cleanupErrors.length > 0) {
+      const cleanupError =
+        cleanupErrors.length === 1
+          ? cleanupErrors[0]
+          : new AggregateError(
+              cleanupErrors,
+              cleanupErrors.map((error) => ensureErrorMessage(error)).join("; "),
+            );
       const diagnostic = `cleanup failed: ${ensureErrorMessage(cleanupError)}`;
       if (result) {
         result.diagnostics.push(diagnostic);

--- a/src/openclaw/artifact-generation.ts
+++ b/src/openclaw/artifact-generation.ts
@@ -303,8 +303,8 @@ export async function publishOpenClawCrablineArtifactGeneration(
     }
     await params.lock.assertOwned();
     await fs.rename(stagingPath, generationPath);
-    await (dependencies.syncParent ?? syncParentDirectory)(generationPath, dependencies.platform);
     installed = true;
+    await (dependencies.syncParent ?? syncParentDirectory)(generationPath, dependencies.platform);
     await staging.assertIdentityAt(generationPath);
     await store.assertIdentityAt();
 

--- a/src/openclaw/smoke-lock.ts
+++ b/src/openclaw/smoke-lock.ts
@@ -3,6 +3,7 @@ import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import fs, { type FileHandle } from "node:fs/promises";
 import path from "node:path";
+import { performance } from "node:perf_hooks";
 import { isCrablineServerChannel, type CrablineServerChannel } from "../servers/index.js";
 import { resolveWindowsPowerShellPath, securePrivateDirectory } from "./private-file.js";
 import { OPENCLAW_CRABLINE_MANIFEST_PATH } from "./shared.js";
@@ -93,7 +94,18 @@ const LOCK_LEASE_MS = 10 * 60 * 1000;
 const RELEASE_ATTEMPTS = 3;
 const RELEASE_RETRY_DELAY_MS = 10;
 const MAX_PROCESS_ID = 2_147_483_647;
-const CURRENT_PROCESS_STARTED_AT_MS = Math.trunc(Date.now() - process.uptime() * 1000);
+const CURRENT_PROCESS_STARTED_AT_MS = processStartedAtMsFromTimeOrigin(performance.timeOrigin);
+
+export function processStartedAtMsFromTimeOrigin(timeOrigin: number): number {
+  if (
+    !Number.isFinite(timeOrigin) ||
+    timeOrigin <= 0 ||
+    !Number.isSafeInteger(Math.trunc(timeOrigin))
+  ) {
+    throw new Error("Process time origin is invalid.");
+  }
+  return Math.trunc(timeOrigin);
+}
 
 function parseCommitStagePath(contents: string, token: string): string {
   let value: { path?: unknown; token?: unknown };

--- a/src/providers/builtin/script.ts
+++ b/src/providers/builtin/script.ts
@@ -243,14 +243,14 @@ function formatScriptError(
   if (commandContainsSensitiveValue(command)) {
     return `${summary}\n[script diagnostics redacted]`;
   }
-  let withoutCommands = detail;
-  for (const configuredCommand of diagnostics.configuredCommands) {
-    withoutCommands = withoutCommands.split(configuredCommand).join("[configured script command]");
-  }
-  const redacted = redactSensitivePayloadValues(
-    redactSensitiveEnvironmentValues(withoutCommands, diagnostics.sensitiveEnvironmentValues),
+  let redacted = redactSensitivePayloadValues(
+    redactSensitiveEnvironmentValues(detail, diagnostics.sensitiveEnvironmentValues),
     payload,
-  ).trim();
+  );
+  for (const configuredCommand of diagnostics.configuredCommands) {
+    redacted = redacted.split(configuredCommand).join("[configured script command]");
+  }
+  redacted = redacted.trim();
   return redacted ? `${summary}\n${redacted}` : summary;
 }
 

--- a/src/providers/builtin/script.ts
+++ b/src/providers/builtin/script.ts
@@ -356,13 +356,13 @@ function runScript<T>(params: {
     let settled = false;
     let timeoutGrace: NodeJS.Timeout | undefined;
     const abort = () => {
-      finish(() => {
-        void terminateChild(child);
+      finish(async () => {
+        await terminateChild(child);
         reject(params.signal?.reason ?? new Error("Script command aborted."));
       });
     };
 
-    const finish = (callback: () => void) => {
+    const finish = (callback: () => Promise<void> | void) => {
       if (settled) {
         return;
       }
@@ -370,12 +370,12 @@ function runScript<T>(params: {
       clearTimeout(timeout);
       clearTimeout(timeoutGrace);
       params.signal?.removeEventListener("abort", abort);
-      callback();
+      void callback();
     };
 
     const failForOutputLimit = () => {
-      finish(() => {
-        void terminateChild(child);
+      finish(async () => {
+        await terminateChild(child);
         reject(
           new CrablineError(`Script command exceeded ${MAX_SCRIPT_OUTPUT_BYTES} bytes of output.`, {
             kind: "connectivity",
@@ -467,8 +467,8 @@ function runScript<T>(params: {
     });
 
     const failForTimeout = () => {
-      finish(() => {
-        void terminateChild(child);
+      finish(async () => {
+        await terminateChild(child);
         reject(
           new CrablineError(`Script command timed out after ${params.timeoutMs}ms.`, {
             kind: "timeout",

--- a/src/providers/builtin/script.ts
+++ b/src/providers/builtin/script.ts
@@ -1,5 +1,6 @@
-import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { spawn, type ChildProcess, type ChildProcessByStdio } from "node:child_process";
 import path from "node:path";
+import type { Readable, Writable } from "node:stream";
 import { z } from "zod";
 import { CrablineError, ensureErrorMessage } from "../../core/errors.js";
 import type {
@@ -13,6 +14,7 @@ import type {
 
 const MAX_SCRIPT_OUTPUT_BYTES = 1024 * 1024;
 const SCRIPT_WAIT_EXIT_GRACE_MS = 250;
+const WINDOWS_TERMINATION_TIMEOUT_MS = 5_000;
 
 type ScriptWatchIterator = AsyncIterableIterator<InboundEnvelope> & {
   [Symbol.asyncIterator](): ScriptWatchIterator;
@@ -28,6 +30,13 @@ type ScriptPayload = {
     manifestPath: string;
   };
 };
+
+type ScriptDiagnosticsSnapshot = {
+  configuredCommands: string[];
+  sensitiveEnvironmentValues: string[];
+};
+
+type SpawnedScriptChild = ChildProcessByStdio<Writable, Readable, Readable>;
 
 const ScriptMessageSchema = z.object({
   author: z.enum(["assistant", "system", "user"]),
@@ -61,12 +70,35 @@ const ScriptInboundResultSchema = z
     { message: "result must contain either a message or timeout: true" },
   );
 
-function terminateChild(child: ChildProcess): void {
+async function terminateChild(child: ChildProcess): Promise<void> {
   if (process.platform === "win32" && child.pid) {
-    spawnSync("taskkill.exe", ["/PID", String(child.pid), "/T", "/F"], {
-      stdio: "ignore",
-      timeout: 5000,
-      windowsHide: true,
+    await new Promise<void>((resolve) => {
+      let taskkill: ChildProcess;
+      try {
+        taskkill = spawn("taskkill.exe", ["/PID", String(child.pid), "/T", "/F"], {
+          stdio: "ignore",
+          windowsHide: true,
+        });
+      } catch {
+        resolve();
+        return;
+      }
+      let settled = false;
+      const finish = () => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timeout);
+        resolve();
+      };
+      const timeout = setTimeout(() => {
+        taskkill.kill("SIGKILL");
+        finish();
+      }, WINDOWS_TERMINATION_TIMEOUT_MS);
+      timeout.unref();
+      taskkill.once("close", finish);
+      taskkill.once("error", finish);
     });
   } else if (child.pid) {
     try {
@@ -114,8 +146,8 @@ function commandContainsSensitiveValue(command: string): boolean {
   );
 }
 
-function redactSensitiveEnvironmentValues(detail: string): string {
-  let redacted = detail;
+function snapshotSensitiveEnvironmentValues(): string[] {
+  const representations = new Set<string>();
   const values = Object.entries(process.env)
     .filter(
       ([name, value]) =>
@@ -123,15 +155,21 @@ function redactSensitiveEnvironmentValues(detail: string): string {
     )
     .map(([, value]) => value!)
     .sort((left, right) => right.length - left.length);
+  for (const value of values) {
+    representations.add(value);
+    representations.add(JSON.stringify(value));
+    representations.add(JSON.stringify(value).slice(1, -1));
+  }
+  return [...representations].sort((left, right) => right.length - left.length);
+}
 
-  for (const value of new Set(values)) {
-    for (const representation of [
-      value,
-      JSON.stringify(value),
-      JSON.stringify(value).slice(1, -1),
-    ]) {
-      redacted = redacted.split(representation).join("[redacted environment value]");
-    }
+function redactSensitiveEnvironmentValues(
+  detail: string,
+  sensitiveEnvironmentValues: string[],
+): string {
+  let redacted = detail;
+  for (const representation of sensitiveEnvironmentValues) {
+    redacted = redacted.split(representation).join("[redacted environment value]");
   }
   return redacted;
 }
@@ -196,6 +234,7 @@ function formatScriptError(
   summary: string,
   detail: string,
   command: string,
+  diagnostics: ScriptDiagnosticsSnapshot,
   payload?: unknown,
 ): string {
   if (!detail.trim()) {
@@ -204,16 +243,41 @@ function formatScriptError(
   if (commandContainsSensitiveValue(command)) {
     return `${summary}\n[script diagnostics redacted]`;
   }
-  const withoutCommand = detail.split(command).join("[configured script command]");
+  let withoutCommands = detail;
+  for (const configuredCommand of diagnostics.configuredCommands) {
+    withoutCommands = withoutCommands.split(configuredCommand).join("[configured script command]");
+  }
   const redacted = redactSensitivePayloadValues(
-    redactSensitiveEnvironmentValues(withoutCommand),
+    redactSensitiveEnvironmentValues(withoutCommands, diagnostics.sensitiveEnvironmentValues),
     payload,
   ).trim();
   return redacted ? `${summary}\n${redacted}` : summary;
 }
 
+function createScriptDiagnosticsSnapshot(
+  command: string,
+  payload: unknown,
+): ScriptDiagnosticsSnapshot {
+  const configuredCommands = new Set([command]);
+  const commands = (
+    payload as {
+      provider?: { config?: { script?: { commands?: Record<string, unknown> } } };
+    }
+  ).provider?.config?.script?.commands;
+  for (const configuredCommand of Object.values(commands ?? {})) {
+    if (typeof configuredCommand === "string" && configuredCommand.length > 0) {
+      configuredCommands.add(configuredCommand);
+    }
+  }
+  return {
+    configuredCommands: [...configuredCommands].sort((left, right) => right.length - left.length),
+    sensitiveEnvironmentValues: snapshotSensitiveEnvironmentValues(),
+  };
+}
+
 function parseScriptJson<T>(params: {
   command: string;
+  diagnostics: ScriptDiagnosticsSnapshot;
   output: string;
   payload?: unknown;
   schema: z.ZodType<T>;
@@ -227,6 +291,7 @@ function parseScriptJson<T>(params: {
         "Script command did not return valid JSON.",
         ensureErrorMessage(error),
         params.command,
+        params.diagnostics,
         params.payload,
       ),
       { kind: "config" },
@@ -257,14 +322,32 @@ function runScript<T>(params: {
   if (params.signal?.aborted) {
     return Promise.reject(params.signal.reason ?? new Error("Script command aborted."));
   }
+  const diagnostics = createScriptDiagnosticsSnapshot(params.command, params.payload);
   return new Promise((resolve, reject) => {
-    const child = spawn(params.command, {
-      cwd: params.cwd ? path.resolve(params.cwd) : process.cwd(),
-      env: process.env,
-      shell: params.shell ?? true,
-      detached: process.platform !== "win32",
-      stdio: ["pipe", "pipe", "pipe"],
-    });
+    let child: SpawnedScriptChild;
+    try {
+      child = spawn(params.command, {
+        cwd: params.cwd ? path.resolve(params.cwd) : process.cwd(),
+        env: process.env,
+        shell: params.shell ?? true,
+        detached: process.platform !== "win32",
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+    } catch (error) {
+      reject(
+        new CrablineError(
+          formatScriptError(
+            "Script command failed to start.",
+            ensureErrorMessage(error),
+            params.command,
+            diagnostics,
+            params.payload,
+          ),
+          { kind: "connectivity" },
+        ),
+      );
+      return;
+    }
 
     const stdout: Buffer[] = [];
     const stderr: Buffer[] = [];
@@ -274,7 +357,7 @@ function runScript<T>(params: {
     let timeoutGrace: NodeJS.Timeout | undefined;
     const abort = () => {
       finish(() => {
-        terminateChild(child);
+        void terminateChild(child);
         reject(params.signal?.reason ?? new Error("Script command aborted."));
       });
     };
@@ -292,7 +375,7 @@ function runScript<T>(params: {
 
     const failForOutputLimit = () => {
       finish(() => {
-        terminateChild(child);
+        void terminateChild(child);
         reject(
           new CrablineError(`Script command exceeded ${MAX_SCRIPT_OUTPUT_BYTES} bytes of output.`, {
             kind: "connectivity",
@@ -332,6 +415,7 @@ function runScript<T>(params: {
               "Script command failed to start.",
               ensureErrorMessage(error),
               params.command,
+              diagnostics,
               params.payload,
             ),
             { kind: "connectivity" },
@@ -350,6 +434,7 @@ function runScript<T>(params: {
                 `Script command failed${signal ? ` (${signal})` : ""}.`,
                 stderrText.trim() ? stderrText : stdoutText,
                 params.command,
+                diagnostics,
                 params.payload,
               ),
               { kind: "connectivity" },
@@ -361,6 +446,7 @@ function runScript<T>(params: {
         try {
           const result = parseScriptJson({
             command: params.command,
+            diagnostics,
             output: stdoutText,
             payload: params.payload,
             schema: params.schema,
@@ -382,7 +468,7 @@ function runScript<T>(params: {
 
     const failForTimeout = () => {
       finish(() => {
-        terminateChild(child);
+        void terminateChild(child);
         reject(
           new CrablineError(`Script command timed out after ${params.timeoutMs}ms.`, {
             kind: "timeout",
@@ -434,19 +520,36 @@ function watchScript(params: {
         target: params.normalizeTarget(params.context.fixture.target),
       },
     };
-    const child = spawn(params.command, {
-      cwd: params.cwd ? path.resolve(params.cwd) : process.cwd(),
-      env: process.env,
-      shell: params.shell ?? true,
-      detached: process.platform !== "win32",
-      stdio: ["pipe", "pipe", "pipe"],
-    });
+    const diagnostics = createScriptDiagnosticsSnapshot(params.command, payload);
+    let child: SpawnedScriptChild;
+    try {
+      child = spawn(params.command, {
+        cwd: params.cwd ? path.resolve(params.cwd) : process.cwd(),
+        env: process.env,
+        shell: params.shell ?? true,
+        detached: process.platform !== "win32",
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+    } catch (error) {
+      throw new CrablineError(
+        formatScriptError(
+          "Script watch command failed to start.",
+          ensureErrorMessage(error),
+          params.command,
+          diagnostics,
+          payload,
+        ),
+        { kind: "connectivity" },
+      );
+    }
 
     let buffer = "";
     let stderr = "";
     let childError: unknown;
     let outputLimitError: CrablineError | undefined;
-    const stopChild = () => terminateChild(child);
+    const stopChild = () => {
+      void terminateChild(child);
+    };
     params.cancelSignal.addEventListener("abort", stopChild, { once: true });
     params.context.signal?.addEventListener("abort", stopChild, { once: true });
     if (params.cancelSignal.aborted || params.context.signal?.aborted) {
@@ -467,7 +570,7 @@ function watchScript(params: {
           `Script watch command exceeded ${MAX_SCRIPT_OUTPUT_BYTES} bytes of stderr.`,
           { kind: "connectivity" },
         );
-        terminateChild(child);
+        void terminateChild(child);
       }
     });
     child.once("error", (error) => {
@@ -507,6 +610,7 @@ function watchScript(params: {
           }
           const parsed = parseScriptJson({
             command: params.command,
+            diagnostics,
             output: line,
             payload,
             schema: ScriptMessageSchema,
@@ -527,6 +631,7 @@ function watchScript(params: {
       if (buffer.trim()) {
         const parsed = parseScriptJson({
           command: params.command,
+          diagnostics,
           output: buffer,
           payload,
           schema: ScriptMessageSchema,
@@ -547,6 +652,7 @@ function watchScript(params: {
             "Script watch command failed to start.",
             ensureErrorMessage(childError),
             params.command,
+            diagnostics,
             payload,
           ),
           { kind: "connectivity" },
@@ -558,6 +664,7 @@ function watchScript(params: {
             `Script watch command failed${exit.signal ? ` (${exit.signal})` : ""}.`,
             stderr,
             params.command,
+            diagnostics,
             payload,
           ),
           { kind: "connectivity" },
@@ -576,6 +683,7 @@ function watchScript(params: {
             "Script watch command failed to start.",
             ensureErrorMessage(childError),
             params.command,
+            diagnostics,
             payload,
           ),
           { kind: "connectivity" },
@@ -587,7 +695,7 @@ function watchScript(params: {
       params.context.signal?.removeEventListener("abort", stopChild);
       child.stdin.destroy();
       if (!childCloseObserved) {
-        terminateChild(child);
+        await terminateChild(child);
       }
       await childClosed;
     }

--- a/test/ci-workflow.test.ts
+++ b/test/ci-workflow.test.ts
@@ -5,6 +5,7 @@ import { parse } from "yaml";
 type WorkflowStep = {
   run?: string;
   uses?: string;
+  with?: Record<string, unknown>;
 };
 
 type Workflow = {
@@ -35,5 +36,14 @@ describe("CI workflow hardening", () => {
     for (const actionRef of actionRefs) {
       expect(actionRef).toMatch(/^[^@]+@[0-9a-f]{40}$/u);
     }
+  });
+
+  it("exempts security pull requests from stale automation", async () => {
+    const workflow = await readWorkflow(".github/workflows/stale.yml");
+    const staleStep = Object.values(workflow.jobs ?? {})
+      .flatMap((job) => job.steps ?? [])
+      .find((step) => step.uses?.startsWith("actions/stale@"));
+
+    expect(String(staleStep?.with?.["exempt-pr-labels"]).split(",")).toContain("security");
   });
 });

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -966,6 +966,181 @@ describe("cli", () => {
     expect(process.listenerCount("SIGTERM")).toBe(baseline);
   });
 
+  it("waits for stdout backpressure while watching", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const configPath = path.join(directory, "crabline.yaml");
+    await writeText(
+      configPath,
+      [
+        "configVersion: 1",
+        "providers:",
+        "  local:",
+        "    adapter: loopback",
+        "fixtures:",
+        "  - id: watched",
+        "    provider: local",
+        "    mode: agent",
+        "    target:",
+        "      id: echo-bot",
+      ].join("\n"),
+    );
+    const cleanup = vi.fn(async () => undefined);
+    const provider = {
+      cleanup,
+      async *watch() {
+        yield {
+          author: "assistant",
+          id: "message",
+          provider: "local",
+          sentAt: new Date().toISOString(),
+          text: "payload",
+          threadId: "thread",
+        };
+      },
+    };
+    let completeWrite: ((error?: Error | null) => void) | undefined;
+    const write = vi.spyOn(process.stdout, "write").mockImplementation(((
+      _chunk: string | Uint8Array,
+      encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+      callback?: (error?: Error | null) => void,
+    ) => {
+      completeWrite = typeof encodingOrCallback === "function" ? encodingOrCallback : callback;
+      return false;
+    }) as typeof process.stdout.write);
+    const program = createProgram(() => undefined, {
+      createRegistry: () =>
+        ({
+          resolve: () => provider,
+        }) as never,
+    });
+    let settled = false;
+
+    try {
+      const running = program
+        .parseAsync(["node", "crabline", "--config", configPath, "watch", "watched"])
+        .finally(() => {
+          settled = true;
+        });
+      await vi.waitFor(() => expect(write).toHaveBeenCalledTimes(1));
+      completeWrite?.(null);
+      await Promise.resolve();
+      expect(settled).toBe(false);
+      process.stdout.emit("drain");
+      await running;
+    } finally {
+      write.mockRestore();
+    }
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats a closed watch stdout pipe as graceful shutdown", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const configPath = path.join(directory, "crabline.yaml");
+    await writeText(
+      configPath,
+      [
+        "configVersion: 1",
+        "providers:",
+        "  local:",
+        "    adapter: loopback",
+        "fixtures:",
+        "  - id: watched",
+        "    provider: local",
+        "    mode: agent",
+        "    target:",
+        "      id: echo-bot",
+      ].join("\n"),
+    );
+    const cleanup = vi.fn(async () => undefined);
+    const provider = {
+      cleanup,
+      async *watch() {
+        yield {
+          author: "assistant",
+          id: "message",
+          provider: "local",
+          sentAt: new Date().toISOString(),
+          text: "payload",
+          threadId: "thread",
+        };
+      },
+    };
+    const write = vi.spyOn(process.stdout, "write").mockImplementation((() => {
+      queueMicrotask(() => {
+        process.stdout.emit("error", Object.assign(new Error("broken pipe"), { code: "EPIPE" }));
+      });
+      return false;
+    }) as typeof process.stdout.write);
+    const program = createProgram(() => undefined, {
+      createRegistry: () =>
+        ({
+          resolve: () => provider,
+        }) as never,
+    });
+
+    try {
+      await expect(
+        program.parseAsync(["node", "crabline", "--config", configPath, "watch", "watched"]),
+      ).resolves.toBe(program);
+    } finally {
+      write.mockRestore();
+    }
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it("sanitizes terminal controls in watch text output", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const configPath = path.join(directory, "crabline.yaml");
+    await writeText(
+      configPath,
+      [
+        "configVersion: 1",
+        "providers:",
+        "  local:",
+        "    adapter: loopback",
+        "fixtures:",
+        "  - id: watched",
+        "    provider: local",
+        "    mode: agent",
+        "    target:",
+        "      id: echo-bot",
+      ].join("\n"),
+    );
+    const captured = captureWrites();
+    const provider = {
+      async *watch() {
+        yield {
+          author: "assistant",
+          id: "message",
+          provider: "local",
+          sentAt: "now",
+          text: "first\u001b[2J\nsecond",
+          threadId: "thread",
+        };
+      },
+    };
+    const program = createProgram(() => undefined, {
+      createRegistry: () =>
+        ({
+          resolve: () => provider,
+        }) as never,
+    });
+
+    try {
+      await program.parseAsync(["node", "crabline", "--config", configPath, "watch", "watched"]);
+    } finally {
+      captured.restore();
+    }
+
+    expect(captured.stdout.join("")).toContain(String.raw`first\x1b[2J\nsecond`);
+    expect(captured.stdout.join("")).not.toContain("\u001b");
+  });
+
   it("preserves shutdown and ready-file cleanup failures", async () => {
     const directory = await createTempDir();
     directories.push(directory);

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -371,6 +371,27 @@ describe("manifest schema", () => {
     expect(manifest.providers.slack?.script?.commands.waitForInbound).toBe("wait");
   });
 
+  it("rejects whitespace-only script commands", () => {
+    expect(() =>
+      ManifestSchema.parse({
+        configVersion: 1,
+        fixtures: [],
+        providers: {
+          slack: {
+            adapter: "script",
+            capabilities: ["send"],
+            platform: "slack",
+            script: {
+              commands: {
+                send: " \t\n ",
+              },
+            },
+          },
+        },
+      }),
+    ).toThrow(/script command must not be blank/u);
+  });
+
   it("rejects adapter config blocks for a different built-in adapter", () => {
     expect(() =>
       ManifestSchema.parse({

--- a/test/local-mock-provider-helpers.ts
+++ b/test/local-mock-provider-helpers.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import type { BuiltinAdapterId, ProviderConfig, ProviderPlatform } from "../src/config/schema.js";
 import type { ProviderAdapter, ProviderContext } from "../src/providers/types.js";
-import { createTempDir, disposeTempDir } from "./test-helpers.js";
+import { createTempDir, disposeTempDir, settleCleanup } from "./test-helpers.js";
 
 type ProviderCtor = new (
   id: string,
@@ -43,8 +43,10 @@ const directories: string[] = [];
 const providers: ProviderAdapter[] = [];
 
 afterEach(async () => {
-  await Promise.all(providers.splice(0).map((provider) => provider.cleanup?.()));
-  await Promise.all(directories.splice(0).map(disposeTempDir));
+  await settleCleanup([
+    ...providers.splice(0).map(async (provider) => provider.cleanup?.()),
+    ...directories.splice(0).map(disposeTempDir),
+  ]);
 });
 
 export async function createLocalMockConfig(

--- a/test/local-mock-provider.test.ts
+++ b/test/local-mock-provider.test.ts
@@ -14,7 +14,7 @@ import {
 import { appendRecordedInbound } from "../src/providers/recorder.js";
 import type { Registry } from "../src/providers/registry.js";
 import type { ProviderAdapter, ProviderContext } from "../src/providers/types.js";
-import { createTempDir, disposeTempDir } from "./test-helpers.js";
+import { createTempDir, disposeTempDir, settleCleanup } from "./test-helpers.js";
 
 const webhookMocks = vi.hoisted(() => ({
   startWebhookServer: vi.fn(),
@@ -36,8 +36,10 @@ beforeEach(() => {
 });
 
 afterEach(async () => {
-  await Promise.all(providers.splice(0).map((provider) => provider.cleanup?.()));
-  await Promise.all(directories.splice(0).map(disposeTempDir));
+  await settleCleanup([
+    ...providers.splice(0).map(async (provider) => provider.cleanup?.()),
+    ...directories.splice(0).map(disposeTempDir),
+  ]);
 });
 
 function sleep(ms: number): Promise<void> {

--- a/test/openclaw-artifact-generation.test.ts
+++ b/test/openclaw-artifact-generation.test.ts
@@ -164,6 +164,30 @@ describe("OpenClaw artifact generation publication", () => {
     }
   });
 
+  it("rolls back the installed generation when parent sync fails", async () => {
+    const outputDir = await createTempDir();
+    const storePath = path.join(outputDir, OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY);
+    const generationPath = path.join(storePath, "generation-11111111-1111-4111-8111-111111111111");
+    const syncFailure = new Error("directory sync failed");
+    try {
+      await expect(
+        publishOpenClawCrablineArtifactGeneration(publishParams(outputDir), {
+          createGenerationId: () => "11111111-1111-4111-8111-111111111111",
+          syncParent: async (filePath) => {
+            if (filePath === generationPath) {
+              throw syncFailure;
+            }
+          },
+        }),
+      ).rejects.toBe(syncFailure);
+
+      await expect(fs.stat(generationPath)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.readdir(storePath)).resolves.toEqual([]);
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
   it("preserves a generation retained as a successor pointer rollback", async () => {
     const outputDir = await createTempDir();
     const lock = createLock();

--- a/test/openclaw-smoke-lock.test.ts
+++ b/test/openclaw-smoke-lock.test.ts
@@ -7,6 +7,7 @@ import {
   isProcessAlive,
   processIdentityFromDarwin,
   processIdentityFromLinuxStat,
+  processStartedAtMsFromTimeOrigin,
   releaseOpenClawCrablineSmokeRunLock,
 } from "../src/openclaw/smoke-lock.js";
 import { OPENCLAW_CRABLINE_MANIFEST_PATH } from "../src/openclaw/shared.js";
@@ -37,6 +38,13 @@ describe("OpenClaw smoke lock cleanup", () => {
       ),
     ).toBe("darwin:1783864000.123456:Sun Jul 12 16:04:00 2026");
     expect(processIdentityFromDarwin("", "{ sec = 1, usec = 2 }")).toBeNull();
+  });
+
+  it("preserves sub-second process start identity from the runtime time origin", () => {
+    expect(processStartedAtMsFromTimeOrigin(1_783_864_000_123.875)).toBe(1_783_864_000_123);
+    expect(() => processStartedAtMsFromTimeOrigin(Number.NaN)).toThrow(
+      "Process time origin is invalid.",
+    );
   });
 
   it("uses a canonical environment for Darwin process start times", () => {

--- a/test/package-production.test.ts
+++ b/test/package-production.test.ts
@@ -84,7 +84,6 @@ describe("production package", () => {
         }
       }),
     );
-
     const installRoot = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-production-install-"));
     const packDirectory = path.join(installRoot, "pack");
     const consumerDirectory = path.join(installRoot, "consumer");
@@ -185,6 +184,28 @@ describe("production package", () => {
       await fs.rm(installRoot, { force: true, recursive: true });
     }
   }, 120_000);
+
+  it("embeds source contents in published JavaScript source maps", async () => {
+    const root = process.cwd();
+    const pack = await npmPackDryRun(root);
+    const sourceMaps = pack.files
+      .map((file) => file.path)
+      .filter((file) => file.startsWith("dist/") && file.endsWith(".js.map"));
+
+    expect(sourceMaps).not.toEqual([]);
+    await Promise.all(
+      sourceMaps.map(async (file) => {
+        const sourceMap = JSON.parse(await fs.readFile(path.join(root, file), "utf8")) as {
+          sources?: unknown[];
+          sourcesContent?: unknown[];
+        };
+        expect(sourceMap.sourcesContent, `${file} is missing inline source contents`).toHaveLength(
+          sourceMap.sources?.length ?? 0,
+        );
+        expect(sourceMap.sourcesContent?.every((source) => typeof source === "string")).toBe(true);
+      }),
+    );
+  });
 
   it("uses portable cleanup scripts", async () => {
     const root = process.cwd();

--- a/test/release-workflow.test.ts
+++ b/test/release-workflow.test.ts
@@ -113,7 +113,8 @@ describe("release workflow", () => {
     expect(packageStep).toContain('execFileSync("tar", ["-xzf", tarballPath');
     expect(publishStep).toContain('npm view "$PACKAGE_NAME@$RELEASE_VERSION" dist.integrity');
     expect(publishStep).toContain('npm view "$PACKAGE_NAME@latest" version');
-    expect(publishStep).toContain("Refusing to publish ${release} because npm latest is newer");
+    expect(publishStep).toContain('"Refusing to publish " +');
+    expect(publishStep).toContain('" because npm latest is newer at " +');
     expect(publishStep).toContain('npm publish "$PACKAGE_TARBALL" --access public --provenance');
     expect(releaseStep).toContain('gh release view "$RELEASE_TAG"');
     expect(releaseStep).toContain("--json isDraft,isPrerelease");

--- a/test/release-workflow.test.ts
+++ b/test/release-workflow.test.ts
@@ -112,6 +112,8 @@ describe("release workflow", () => {
     expect(packageStep).toContain("Packed artifact is missing the crabline CLI");
     expect(packageStep).toContain('execFileSync("tar", ["-xzf", tarballPath');
     expect(publishStep).toContain('npm view "$PACKAGE_NAME@$RELEASE_VERSION" dist.integrity');
+    expect(publishStep).toContain('npm view "$PACKAGE_NAME@latest" version');
+    expect(publishStep).toContain("Refusing to publish ${release} because npm latest is newer");
     expect(publishStep).toContain('npm publish "$PACKAGE_TARBALL" --access public --provenance');
     expect(releaseStep).toContain('gh release view "$RELEASE_TAG"');
     expect(releaseStep).toContain("--json isDraft,isPrerelease");
@@ -257,11 +259,25 @@ describe("release workflow", () => {
     });
     expect(racedCalls).toEqual([
       "view @openclaw/crabline@1.2.3 dist.integrity",
+      "view @openclaw/crabline@latest version",
       expect.stringMatching(
         /publish .*\/release\/crabline-1\.2\.3\.tgz --access public --provenance$/u,
       ),
       "view @openclaw/crabline@1.2.3 dist.integrity",
     ]);
+
+    await expect(
+      runPublishStep(publishStep, {
+        MOCK_LATEST_VERSION: "1.2.4",
+      }),
+    ).rejects.toThrow("Refusing to publish 1.2.3 because npm latest is newer at 1.2.4.");
+    await expect(
+      runPublishStep(publishStep, {
+        MOCK_LATEST_STATUS: "1",
+      }),
+    ).rejects.toThrow(
+      "::error::Unable to resolve the current npm latest version for @openclaw/crabline.",
+    );
   });
 });
 
@@ -452,6 +468,13 @@ set -euo pipefail
 echo "$*" >> "$MOCK_LOG"
 if [[ "$1" == "publish" ]]; then
   exit "\${MOCK_PUBLISH_STATUS:-0}"
+fi
+if [[ "$2" == "$PACKAGE_NAME@latest" ]]; then
+  if [[ "\${MOCK_LATEST_STATUS:-0}" -ne 0 ]]; then
+    exit "$MOCK_LATEST_STATUS"
+  fi
+  echo "\${MOCK_LATEST_VERSION:-1.2.2}"
+  exit 0
 fi
 count=0
 if [[ -f "$MOCK_VIEW_COUNT" ]]; then

--- a/test/reporters-errors.test.ts
+++ b/test/reporters-errors.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { CrablineError, ensureErrorMessage } from "../src/core/errors.js";
 import { EXIT_CODES } from "../src/core/exit-codes.js";
-import { formatJson, formatRunResultText } from "../src/core/reporters.js";
+import { formatJson, formatRunResultText, sanitizeTerminalText } from "../src/core/reporters.js";
 
 const ansiPattern = new RegExp(String.raw`\u001B\[[0-?]*[ -/]*[@-~]`, "g");
 
@@ -43,5 +43,23 @@ describe("errors and reporters", () => {
     expect(formatJson(undefined)).toBe("null");
     expect(formatJson(Symbol("value"))).toBe("null");
     expect(formatJson(() => undefined)).toBe("null");
+  });
+
+  it("neutralizes terminal controls in text output", () => {
+    const output = formatRunResultText({
+      diagnostics: ["first\u001b[2J\rsecond\nthird\u202e"],
+      fixtureId: "fixture\u001b]0;owned\u0007",
+      mode: "send",
+      ok: false,
+      providerId: "local",
+    });
+
+    expect(output).not.toContain("\u001b");
+    expect(output).not.toContain("\u0007");
+    expect(output).not.toContain("\r");
+    expect(stripAnsi(output)).toContain(String.raw`fixture\x1b]0;owned\x07`);
+    expect(output).toContain(String.raw`first\x1b[2J\rsecond`);
+    expect(output).toContain("  - third\\u202e");
+    expect(sanitizeTerminalText("line\nbreak", true)).toBe(String.raw`line\nbreak`);
   });
 });

--- a/test/reporters-errors.test.ts
+++ b/test/reporters-errors.test.ts
@@ -53,13 +53,14 @@ describe("errors and reporters", () => {
       ok: false,
       providerId: "local",
     });
+    const plainOutput = stripAnsi(output);
 
-    expect(output).not.toContain("\u001b");
-    expect(output).not.toContain("\u0007");
-    expect(output).not.toContain("\r");
-    expect(stripAnsi(output)).toContain(String.raw`fixture\x1b]0;owned\x07`);
-    expect(output).toContain(String.raw`first\x1b[2J\rsecond`);
-    expect(output).toContain("  - third\\u202e");
+    expect(plainOutput).not.toContain("\u001b");
+    expect(plainOutput).not.toContain("\u0007");
+    expect(plainOutput).not.toContain("\r");
+    expect(plainOutput).toContain(String.raw`fixture\x1b]0;owned\x07`);
+    expect(plainOutput).toContain(String.raw`first\x1b[2J\rsecond`);
+    expect(plainOutput).toContain("  - third\\u202e");
     expect(sanitizeTerminalText("line\nbreak", true)).toBe(String.raw`line\nbreak`);
     expect(sanitizeTerminalText("\u061c\u200e\u200f")).toBe(String.raw`\u061c\u200e\u200f`);
   });

--- a/test/reporters-errors.test.ts
+++ b/test/reporters-errors.test.ts
@@ -61,5 +61,6 @@ describe("errors and reporters", () => {
     expect(output).toContain(String.raw`first\x1b[2J\rsecond`);
     expect(output).toContain("  - third\\u202e");
     expect(sanitizeTerminalText("line\nbreak", true)).toBe(String.raw`line\nbreak`);
+    expect(sanitizeTerminalText("\u061c\u200e\u200f")).toBe(String.raw`\u061c\u200e\u200f`);
   });
 });

--- a/test/run.behavior.test.ts
+++ b/test/run.behavior.test.ts
@@ -343,6 +343,96 @@ describe("run behavior", () => {
     expect((await run()).failureKind).toBe("inbound");
   });
 
+  it("retries rejected outbound results and fails when rejection persists", async () => {
+    let sendCalls = 0;
+    const provider: ProviderAdapter = {
+      id: "mock",
+      platform: "loopback",
+      status: "ready",
+      supports: ["probe", "send", "roundtrip", "agent"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      probe: async () => ({ details: [], healthy: true }),
+      send: async () => {
+        sendCalls += 1;
+        return {
+          accepted: sendCalls > 1,
+          messageId: `sent-${sendCalls}`,
+          threadId: "thread",
+        };
+      },
+      waitForInbound: async (context) => ({
+        author: "assistant",
+        id: "inbound",
+        provider: "mock",
+        sentAt: new Date().toISOString(),
+        text: `ACK ${context.nonce}`,
+        threadId: "thread",
+      }),
+    };
+    const retryingManifest = withAllCapabilities({
+      ...manifest,
+      fixtures: [{ ...manifest.fixtures[0]!, retries: 1 }],
+    });
+
+    const recovered = await runFixtureCommand({
+      fixtureId: "fixture",
+      manifest: retryingManifest,
+      manifestPath: "/tmp/crabline.yaml",
+      registry: buildRegistry(provider),
+    });
+    expect(recovered.ok).toBe(true);
+    expect(sendCalls).toBe(2);
+
+    sendCalls = 0;
+    provider.send = async () => {
+      sendCalls += 1;
+      return { accepted: false, messageId: `rejected-${sendCalls}`, threadId: "thread" };
+    };
+    const rejected = await runFixtureCommand({
+      fixtureId: "fixture",
+      manifest: retryingManifest,
+      manifestPath: "/tmp/crabline.yaml",
+      registry: buildRegistry(provider),
+    });
+    expect(rejected).toMatchObject({ failureKind: "outbound", ok: false });
+    expect(rejected.diagnostics).toContain("Provider rejected outbound message rejected-2.");
+    expect(sendCalls).toBe(2);
+  });
+
+  it("begins cleanup before cleanup on preflight failures", async () => {
+    const events: string[] = [];
+    const provider: ProviderAdapter = {
+      id: "mock",
+      platform: "loopback",
+      status: "ready",
+      supports: ["probe"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      probe: async () => ({ details: [], healthy: true }),
+      send: async () => ({ accepted: true, messageId: "sent", threadId: "thread" }),
+      waitForInbound: async () => null,
+      beginCleanup() {
+        events.push("begin");
+      },
+      async cleanup() {
+        events.push("cleanup");
+      },
+    };
+
+    const result = await runFixtureCommand({
+      fixtureId: "fixture",
+      manifest: withAllCapabilities(manifest),
+      manifestPath: "/tmp/crabline.yaml",
+      registry: buildRegistry(provider),
+    });
+
+    expect(result).toMatchObject({ failureKind: "config", ok: false });
+    expect(events).toEqual(["begin", "cleanup"]);
+  });
+
   it("keeps waiting through unrelated inbound messages without resending", async () => {
     let sendCalls = 0;
     let waitCalls = 0;

--- a/test/run.behavior.test.ts
+++ b/test/run.behavior.test.ts
@@ -79,7 +79,7 @@ describe("run behavior", () => {
     ).rejects.toThrow(/Unknown fixture/);
   });
 
-  it("returns config failures for unsupported modes and missing env", async () => {
+  it("returns config failures for unsupported modes and missing env after cleanup", async () => {
     const provider: ProviderAdapter = {
       id: "mock",
       platform: "loopback",
@@ -91,6 +91,9 @@ describe("run behavior", () => {
       probe: async () => ({ details: [], healthy: true }),
       send: async () => ({ accepted: true, messageId: "1", threadId: "1" }),
       waitForInbound: async () => null,
+      cleanup: async () => {
+        throw new Error("preflight cleanup exploded");
+      },
     };
 
     const unsupported = await runFixtureCommand({
@@ -100,6 +103,7 @@ describe("run behavior", () => {
       registry: buildRegistry(provider),
     });
     expect(unsupported.failureKind).toBe("config");
+    expect(unsupported.diagnostics).toContain("cleanup failed: preflight cleanup exploded");
 
     const withEnv: ManifestDefinition = {
       ...manifest,
@@ -109,9 +113,14 @@ describe("run behavior", () => {
       fixtureId: "fixture",
       manifest: withEnv,
       manifestPath: "/tmp/crabline.yaml",
-      registry: buildRegistry(provider),
+      registry: buildRegistry({
+        ...provider,
+        supports: ["probe", "send", "roundtrip", "agent"],
+      }),
     });
     expect(missingEnv.failureKind).toBe("config");
+    expect(missingEnv.diagnostics).toContain("missing env: MISSING_ENV");
+    expect(missingEnv.diagnostics).toContain("cleanup failed: preflight cleanup exploded");
   });
 
   it("rejects an invalid inbound regex before sending", async () => {

--- a/test/script-provider.test.ts
+++ b/test/script-provider.test.ts
@@ -747,6 +747,45 @@ describe("script provider", () => {
     }
   });
 
+  it("redacts environment secrets before configured command substrings", async () => {
+    const context = await createContext();
+    const envName = ["SCRIPT", "TOKEN"].join("_");
+    const marker = "overlap-prefix-configured-fragment-overlap-suffix";
+    const originalValue = process.env[envName];
+    process.env[envName] = marker;
+
+    try {
+      const failingScript = path.join(path.dirname(context.manifestPath), "send-overlap.mjs");
+      await writeText(
+        failingScript,
+        `process.stderr.write(process.env[${JSON.stringify(envName)}]);process.exitCode=7;`,
+      );
+      context.config.script!.commands.send = `node ${JSON.stringify(failingScript)}`;
+      context.config.script!.commands.watch = "configured-fragment";
+      const provider = new ScriptProviderAdapter(context);
+
+      const failure = await provider
+        .send({
+          ...context,
+          mode: "send",
+          nonce: "nonce",
+          text: "payload",
+        })
+        .catch((error: unknown) => error);
+      const message = ensureErrorMessage(failure);
+
+      expect(message).toContain("[redacted environment value]");
+      expect(message).not.toContain("overlap-prefix");
+      expect(message).not.toContain("overlap-suffix");
+    } finally {
+      if (originalValue === undefined) {
+        delete process.env[envName];
+      } else {
+        process.env[envName] = originalValue;
+      }
+    }
+  });
+
   it("uses stdout diagnostics when stderr is only whitespace", async () => {
     const context = await createContext();
     const failingScript = path.join(path.dirname(context.manifestPath), "send-stdout-error.mjs");

--- a/test/script-provider.test.ts
+++ b/test/script-provider.test.ts
@@ -469,6 +469,87 @@ describe("script provider", () => {
     }
   });
 
+  it("redacts every configured command from diagnostics", async () => {
+    const context = await createContext();
+    const configuredWatchCommand = "node /private/watch-command.mjs --opaque-value";
+    const failingScript = path.join(path.dirname(context.manifestPath), "send-other-command.mjs");
+    await writeText(
+      failingScript,
+      `process.stderr.write(${JSON.stringify(configuredWatchCommand)});process.exitCode=7;`,
+    );
+    context.config.script!.commands.send = `node ${JSON.stringify(failingScript)}`;
+    context.config.script!.commands.watch = configuredWatchCommand;
+    const provider = new ScriptProviderAdapter(context);
+
+    const failure = await provider
+      .send({
+        ...context,
+        mode: "send",
+        nonce: "nonce",
+        text: "payload",
+      })
+      .catch((error: unknown) => error);
+
+    expect(ensureErrorMessage(failure)).toContain("[configured script command]");
+    expect(inspect(failure, { depth: null })).not.toContain(configuredWatchCommand);
+  });
+
+  it("redacts the sensitive environment snapshot used for a subprocess", async () => {
+    const context = await createContext();
+    const envName = ["CRABLINE", "ACCESS", "TOKEN"].join("_");
+    const originalValue = process.env[envName];
+    const inheritedValue = "inherited-before-spawn";
+    const replacementValue = "changed-after-spawn";
+    const failingScript = path.join(path.dirname(context.manifestPath), "send-delayed-env.mjs");
+    await writeText(
+      failingScript,
+      `setTimeout(()=>{process.stderr.write(process.env[${JSON.stringify(envName)}]);process.exitCode=7;},25);`,
+    );
+    context.config.script!.commands.send = `node ${JSON.stringify(failingScript)}`;
+    const provider = new ScriptProviderAdapter(context);
+    process.env[envName] = inheritedValue;
+
+    try {
+      const pending = provider.send({
+        ...context,
+        mode: "send",
+        nonce: "nonce",
+        text: "payload",
+      });
+      process.env[envName] = replacementValue;
+      const failure = await pending.catch((error: unknown) => error);
+
+      expect(ensureErrorMessage(failure)).toContain("[redacted environment value]");
+      expect(inspect(failure, { depth: null })).not.toContain(inheritedValue);
+    } finally {
+      if (originalValue === undefined) {
+        delete process.env[envName];
+      } else {
+        process.env[envName] = originalValue;
+      }
+    }
+  });
+
+  it("wraps synchronous spawn validation failures", async () => {
+    const context = await createContext();
+    const command = "node private-command.mjs";
+    context.config.script!.commands.send = command;
+    context.config.script!.shell = "invalid\u0000shell";
+    const provider = new ScriptProviderAdapter(context);
+
+    const failure = await provider
+      .send({
+        ...context,
+        mode: "send",
+        nonce: "nonce",
+        text: "payload",
+      })
+      .catch((error: unknown) => error);
+
+    expect(ensureErrorMessage(failure)).toContain("Script command failed to start");
+    expect(inspect(failure, { depth: null })).not.toContain(command);
+  });
+
   it("validates watched JSON message contracts", async () => {
     const context = await createContext();
     const watchScript = path.join(path.dirname(context.manifestPath), "watch-invalid.mjs");

--- a/test/test-helpers.test.ts
+++ b/test/test-helpers.test.ts
@@ -1,0 +1,73 @@
+import { EventEmitter } from "node:events";
+import type { ClientRequest, IncomingMessage, request as httpRequest } from "node:http";
+import { describe, expect, it, vi } from "vitest";
+import { captureWrites, requestHttp, settleCleanup } from "./test-helpers.js";
+
+describe("test helpers", () => {
+  it("rejects incomplete HTTP responses", async () => {
+    const response = Object.assign(new EventEmitter(), {
+      complete: false,
+      headers: {},
+      statusCode: 200,
+    });
+    const request = Object.assign(new EventEmitter(), {
+      destroy: vi.fn(),
+      end: vi.fn(),
+      setTimeout: vi.fn(),
+      write: vi.fn(),
+    });
+    const requestImpl = ((
+      _url: string,
+      _options: unknown,
+      receive: (response: IncomingMessage) => void,
+    ) => {
+      queueMicrotask(() => {
+        receive(response as IncomingMessage);
+        response.emit("data", Buffer.from("partial"));
+        response.emit("close");
+      });
+      return request as unknown as ClientRequest;
+    }) as typeof httpRequest;
+
+    await expect(
+      requestHttp({
+        method: "GET",
+        requestImpl,
+        url: "http://127.0.0.1/",
+      }),
+    ).rejects.toThrow("HTTP response closed before completion.");
+  });
+
+  it("preserves write overload callbacks while capturing output", async () => {
+    const captured = captureWrites();
+    const stdoutCallback = vi.fn();
+    const stderrCallback = vi.fn();
+
+    try {
+      process.stdout.write("text", "utf8", stdoutCallback);
+      process.stderr.write(Buffer.from("bytes"), stderrCallback);
+      await Promise.resolve();
+    } finally {
+      captured.restore();
+    }
+
+    expect(captured.stdout).toEqual(["text"]);
+    expect(captured.stderr).toEqual(["bytes"]);
+    expect(stdoutCallback).toHaveBeenCalledWith(null);
+    expect(stderrCallback).toHaveBeenCalledWith(null);
+  });
+
+  it("runs every cleanup operation before reporting failures", async () => {
+    const completed: string[] = [];
+
+    const failure = await settleCleanup([
+      Promise.reject(new Error("first cleanup failed")),
+      Promise.resolve().then(() => {
+        completed.push("second");
+      }),
+    ]).catch((error: unknown) => error);
+
+    expect(failure).toEqual(new Error("first cleanup failed"));
+    expect(completed).toEqual(["second"]);
+  });
+});

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -22,11 +22,19 @@ export async function requestHttp(params: {
   body?: Buffer | string;
   headers?: Record<string, string>;
   method: string;
+  requestImpl?: typeof httpRequest;
   timeoutMs?: number;
   url: string;
 }): Promise<{ body: string; headers: import("node:http").IncomingHttpHeaders; status: number }> {
   return await new Promise((resolve, reject) => {
-    const request = httpRequest(
+    let settled = false;
+    const fail = (error: Error) => {
+      if (!settled) {
+        settled = true;
+        reject(error);
+      }
+    };
+    const request = (params.requestImpl ?? httpRequest)(
       params.url,
       {
         agent: params.agent,
@@ -36,16 +44,29 @@ export async function requestHttp(params: {
       (response) => {
         const chunks: Buffer[] = [];
         response.on("data", (chunk: Buffer) => chunks.push(chunk));
-        response.once("end", () =>
+        response.once("aborted", () => {
+          fail(new Error("HTTP response was aborted before completion."));
+        });
+        response.once("error", fail);
+        response.once("end", () => {
+          if (settled) {
+            return;
+          }
+          settled = true;
           resolve({
             body: Buffer.concat(chunks).toString("utf8"),
             headers: response.headers,
             status: response.statusCode ?? 0,
-          }),
-        );
+          });
+        });
+        response.once("close", () => {
+          if (!response.complete) {
+            fail(new Error("HTTP response closed before completion."));
+          }
+        });
       },
     );
-    request.once("error", reject);
+    request.once("error", fail);
     request.setTimeout(params.timeoutMs ?? 2_000, () => {
       request.destroy(new Error(`HTTP request timed out after ${params.timeoutMs ?? 2_000} ms.`));
     });
@@ -56,6 +77,19 @@ export async function requestHttp(params: {
   });
 }
 
+export async function settleCleanup(operations: Promise<unknown>[]): Promise<void> {
+  const results = await Promise.allSettled(operations);
+  const errors = results
+    .filter((result): result is PromiseRejectedResult => result.status === "rejected")
+    .map((result) => result.reason);
+  if (errors.length === 1) {
+    throw errors[0];
+  }
+  if (errors.length > 1) {
+    throw new AggregateError(errors, "Multiple test cleanup operations failed.");
+  }
+}
+
 export const captureWrites = (): {
   restore: () => void;
   stderr: string[];
@@ -63,18 +97,29 @@ export const captureWrites = (): {
 } => {
   const stdout: string[] = [];
   const stderr: string[] = [];
-  const originalStdoutWrite = process.stdout.write.bind(process.stdout);
-  const originalStderrWrite = process.stderr.write.bind(process.stderr);
+  const originalStdoutWrite = process.stdout.write;
+  const originalStderrWrite = process.stderr.write;
 
-  process.stdout.write = ((chunk: string | Uint8Array) => {
-    stdout.push(String(chunk));
-    return true;
-  }) as typeof process.stdout.write;
+  const capture =
+    (target: string[]) =>
+    (
+      chunk: string | Uint8Array,
+      encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+      callback?: (error?: Error | null) => void,
+    ) => {
+      const encoding = typeof encodingOrCallback === "string" ? encodingOrCallback : undefined;
+      target.push(
+        typeof chunk === "string" ? chunk : Buffer.from(chunk).toString(encoding ?? "utf8"),
+      );
+      const completion = typeof encodingOrCallback === "function" ? encodingOrCallback : callback;
+      if (completion) {
+        queueMicrotask(() => completion(null));
+      }
+      return true;
+    };
 
-  process.stderr.write = ((chunk: string | Uint8Array) => {
-    stderr.push(String(chunk));
-    return true;
-  }) as typeof process.stderr.write;
+  process.stdout.write = capture(stdout) as typeof process.stdout.write;
+  process.stderr.write = capture(stderr) as typeof process.stderr.write;
 
   return {
     restore() {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,6 +15,7 @@
     "resolveJsonModule": true,
     "declaration": true,
     "sourceMap": true,
+    "inlineSources": true,
     "verbatimModuleSyntax": true,
     "types": ["node"]
   }


### PR DESCRIPTION
## Summary
- make CLI watch output backpressure-safe and terminal-safe
- preserve provider cleanup and rejected-send semantics
- harden script process termination and diagnostic redaction
- protect artifact publication, test helpers, source maps, and stable npm releases

## Validation
- focused Vitest: 179 tests before review fixes; 87 affected tests after
- typecheck and format checks pass
- Crabbox and clean autoreview pending before merge

## Release notes
- includes `CHANGELOG.md` entry