### PR TITLE
fix(servers): enforce native delivery contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Harden provider-core webhook hooks, recorder durability and cursor semantics, lazy adapter lifecycle and target parity, and signed-JWT key caching.
 - Harden autoreview launchers and release automation, document trusted script manifests, and canonicalize WhatsApp Cloud targets.
 - Reject unauthenticated public provider webhooks and tighten Discord, Feishu, Google Chat, Matrix, and Teams inbound protocol validation.
+- Enforce native Matrix, Mattermost, Signal, and Slack outcomes, pagination, retries, state, JSON-RPC, WebSocket, HTTP response, and recorder privacy contracts.
 - Bound signed-JWT key refreshes and authenticate, decode, or suppress Google Chat, Teams, Feishu, and Discord webhook ingress according to provider contracts.
 - Bound recorder tail memory, harden shared provider cleanup and inbound matching, and reject non-global webhook targets.
 - Recover backpressured Signal events without recording rejected RPC calls.

--- a/src/servers/http.ts
+++ b/src/servers/http.ts
@@ -183,7 +183,14 @@ export async function writeResponse(
 ): Promise<void> {
   response.statusCode = fetchResponse.status;
   for (const [name, value] of fetchResponse.headers) {
+    if (name.toLowerCase() === "set-cookie") {
+      continue;
+    }
     response.setHeader(name, value);
+  }
+  const setCookies = fetchResponse.headers.getSetCookie();
+  if (setCookies.length > 0) {
+    response.setHeader("set-cookie", setCookies);
   }
   const body = Buffer.from(await fetchResponse.arrayBuffer());
   await new Promise<void>((resolve, reject) => {
@@ -271,7 +278,11 @@ export async function startHttpJsonServer(params: {
         await handled.onWriteFailure?.();
         throw error;
       }
-      await handled.onWriteSuccess?.();
+      try {
+        await handled.onWriteSuccess?.();
+      } catch {
+        // Delivery is already committed; lifecycle failures must not trigger another response.
+      }
     } catch (error) {
       let handled: Response | undefined;
       try {

--- a/src/servers/index.ts
+++ b/src/servers/index.ts
@@ -114,26 +114,25 @@ export function startCrablineServer(
 export async function startCrablineServer(
   params: StartCrablineServerParams,
 ): Promise<StartedCrablineServer> {
-  if (params.channel === "mattermost") {
-    return await startMattermostServer(params);
+  switch (params.channel) {
+    case "mattermost":
+      return await startMattermostServer(params);
+    case "matrix":
+      return await startMatrixServer(params);
+    case "signal":
+      return await startSignalServer(params);
+    case "slack":
+      return await startSlackServer(params);
+    case "telegram":
+      return await startTelegramServer(params);
+    case "whatsapp":
+      return await startWhatsAppServer(params);
+    case "zalo":
+      return await startZaloServer(params);
+    default: {
+      const unsupported: never = params;
+      void unsupported;
+      throw new CrablineError("Unsupported server channel.", { kind: "config" });
+    }
   }
-  if (params.channel === "matrix") {
-    return await startMatrixServer(params);
-  }
-  if (params.channel === "signal") {
-    return await startSignalServer(params);
-  }
-  if (params.channel === "slack") {
-    return await startSlackServer(params);
-  }
-  if (params.channel === "telegram") {
-    return await startTelegramServer(params);
-  }
-  if (params.channel === "whatsapp") {
-    return await startWhatsAppServer(params);
-  }
-  if (params.channel === "zalo") {
-    return await startZaloServer(params);
-  }
-  throw new CrablineError("Unsupported server channel.", { kind: "config" });
 }

--- a/src/servers/matrix.ts
+++ b/src/servers/matrix.ts
@@ -1,5 +1,6 @@
 import { createHash, randomBytes } from "node:crypto";
 import type { IncomingMessage } from "node:http";
+import { isIP } from "node:net";
 import path from "node:path";
 import {
   adminAuthError,
@@ -15,7 +16,11 @@ import {
   startHttpJsonServer,
   type ServerRequestEvent,
 } from "./http.js";
-import { recordServerEvent, type ServerEventObserver } from "./recorder.js";
+import {
+  recordCommittedServerEvent,
+  recordServerEvent,
+  type ServerEventObserver,
+} from "./recorder.js";
 
 type MatrixEvent = {
   content: Record<string, unknown>;
@@ -56,7 +61,8 @@ type MatrixServerState = {
   adminToken: string;
   botUserId: string;
   deviceId: string;
-  filters: Map<string, Record<string, unknown>>;
+  filterBytes: number;
+  filters: Map<string, { body: Record<string, unknown>; bytes: number }>;
   nextEvent: number;
   nextFilter: number;
   nextSequence: number;
@@ -68,6 +74,13 @@ type MatrixServerState = {
   transactions: Map<string, MatrixTransactionResponse>;
 };
 
+type MatrixRecorderEvent = ServerRequestEvent & {
+  accepted?: boolean | undefined;
+};
+
+const MAX_MATRIX_FILTER_BYTES = 1024 * 1024;
+const MAX_MATRIX_FILTERS = 100;
+const MAX_MATRIX_IDENTIFIER_BYTES = 255;
 const MAX_MATRIX_TIMELINE_EVENTS = 1_000;
 const MAX_MATRIX_TRANSACTION_RESPONSES = 1_000;
 const MATRIX_TRANSACTION_RETENTION_MS = 10 * 60_000;
@@ -124,8 +137,102 @@ function matrixId(prefix: "$" | "!", value: string, serverName: string): string 
   return `${prefix}${createHash("sha256").update(value).digest("hex").slice(0, 16)}:${serverName}`;
 }
 
-async function appendEvent(state: MatrixServerState, event: ServerRequestEvent): Promise<void> {
-  await recordServerEvent({ event, onEvent: state.onEvent, recorderPath: state.recorderPath });
+function isMatrixIpv4Address(value: string): boolean {
+  const octets = value.split(".");
+  return (
+    octets.length === 4 && octets.every((octet) => /^\d{1,3}$/u.test(octet) && Number(octet) <= 255)
+  );
+}
+
+function isMatrixServerName(value: string): boolean {
+  const ipv6 = /^\[([^\]]+)\](?::(\d{1,5}))?$/u.exec(value);
+  if (ipv6) {
+    return isIP(ipv6[1]!) === 6;
+  }
+  const hostAndPort = /^([^:]+?)(?::(\d{1,5}))?$/u.exec(value);
+  if (!hostAndPort) {
+    return false;
+  }
+  const hostname = hostAndPort[1]!;
+  if (isMatrixIpv4Address(hostname)) {
+    return true;
+  }
+  if (/^\d+\.\d+\.\d+\.\d+$/u.test(hostname)) {
+    return false;
+  }
+  return hostname.length <= 255 && /^[A-Za-z0-9.-]+$/u.test(hostname);
+}
+
+function hasLoneSurrogate(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (next < 0xdc00 || next > 0xdfff) {
+        return true;
+      }
+      index += 1;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isMatrixScopedIdentifier(value: string, sigil: "!" | "$" | "@"): boolean {
+  const separator = value.indexOf(":");
+  const localpart = value.slice(1, separator);
+  return (
+    value.startsWith(sigil) &&
+    Buffer.byteLength(value, "utf8") <= MAX_MATRIX_IDENTIFIER_BYTES &&
+    separator >= (sigil === "@" ? 1 : 2) &&
+    !localpart.includes("\0") &&
+    !hasLoneSurrogate(localpart) &&
+    isMatrixServerName(value.slice(separator + 1))
+  );
+}
+
+function isMatrixHashIdentifier(
+  value: string,
+  sigil: "!" | "$",
+  allowLegacyBase64: boolean,
+): boolean {
+  if (!value.startsWith(sigil) || Buffer.byteLength(value, "utf8") > MAX_MATRIX_IDENTIFIER_BYTES) {
+    return false;
+  }
+  const opaqueId = value.slice(1);
+  const encoding =
+    allowLegacyBase64 && /^[A-Za-z0-9+/]{43}$/u.test(opaqueId)
+      ? "base64"
+      : /^[A-Za-z0-9_-]{43}$/u.test(opaqueId)
+        ? "base64url"
+        : undefined;
+  if (!encoding) {
+    return false;
+  }
+  const decoded = Buffer.from(opaqueId, encoding);
+  return decoded.length === 32 && decoded.toString(encoding).replace(/=+$/u, "") === opaqueId;
+}
+
+function isMatrixRoomId(value: string): boolean {
+  return isMatrixScopedIdentifier(value, "!") || isMatrixHashIdentifier(value, "!", false);
+}
+
+function isMatrixEventId(value: string): boolean {
+  return isMatrixScopedIdentifier(value, "$") || isMatrixHashIdentifier(value, "$", true);
+}
+
+function isMatrixUserId(value: string): boolean {
+  return isMatrixScopedIdentifier(value, "@");
+}
+
+async function appendEvent(
+  state: MatrixServerState,
+  event: ServerRequestEvent,
+  committed = false,
+): Promise<void> {
+  const params = { event, onEvent: state.onEvent, recorderPath: state.recorderPath };
+  await (committed ? recordCommittedServerEvent(params) : recordServerEvent(params));
 }
 
 function authorized(request: IncomingMessage, token: string): boolean {
@@ -135,6 +242,17 @@ function authorized(request: IncomingMessage, token: string): boolean {
 
 function matrixError(errcode: string, error: string, status: number): Response {
   return jsonResponse({ errcode, error }, status);
+}
+
+function matrixResourceLimitError(error: string): Response {
+  return jsonResponse(
+    {
+      admin_contact: "mailto:admin@localhost",
+      errcode: "M_RESOURCE_LIMIT_EXCEEDED",
+      error,
+    },
+    503,
+  );
 }
 
 function decodeMatrixPathSegment(value: string): string {
@@ -340,7 +458,7 @@ function resolveSyncFilter(
   }
   const stored = state.filters.get(value);
   if (stored) {
-    return stored;
+    return stored.body;
   }
   try {
     const parsed = JSON.parse(value) as unknown;
@@ -363,7 +481,7 @@ function syncRoom(room: MatrixRoom, since: number | undefined, timelineLimit: nu
   const limited = historyWasTrimmed || timeline.length < available.length;
   const omittedTimeline = available.slice(0, available.length - timeline.length);
   const omittedState = new Map<string, MatrixEvent>();
-  if (historyWasTrimmed) {
+  if (since === undefined || room.createdSequence > since || historyWasTrimmed) {
     for (const [key, event] of room.stateBeforeTimeline) {
       omittedState.set(key, event);
     }
@@ -381,12 +499,9 @@ function syncRoom(room: MatrixRoom, since: number | undefined, timelineLimit: nu
         .map((entry) => entry.event),
     },
     state: {
-      events:
-        since === undefined || room.createdSequence > since
-          ? room.state
-          : limited
-            ? [...omittedState.values()]
-            : [],
+      events: [...omittedState.values()].filter(
+        (event) => !timeline.some((entry) => entry.event.event_id === event.event_id),
+      ),
     },
     timeline: {
       events: timeline.map((entry) => entry.event),
@@ -456,6 +571,14 @@ async function handleAdminInbound(params: {
   if (!roomId || !sender || !text) {
     return jsonResponse({ error: "roomId, senderId, and text are required", ok: false }, 400);
   }
+  const threadId = readTrimmedString(params.body.threadId);
+  if (
+    !isMatrixRoomId(roomId) ||
+    !isMatrixUserId(sender) ||
+    (threadId !== undefined && !isMatrixEventId(threadId))
+  ) {
+    return jsonResponse({ error: "Invalid Matrix identifier", ok: false }, 400);
+  }
   const direct = params.body.direct === true;
   const room =
     params.state.rooms.get(roomId) ??
@@ -510,7 +633,6 @@ async function handleAdminInbound(params: {
     });
   }
   const content: Record<string, unknown> = { body: text, msgtype: "m.text" };
-  const threadId = readTrimmedString(params.body.threadId);
   if (threadId) {
     content["m.relates_to"] = {
       event_id: threadId,
@@ -535,6 +657,7 @@ async function handleMatrixApi(params: {
   body: Record<string, unknown>;
   method: string;
   path: string;
+  recorderEvent: MatrixRecorderEvent;
   state: MatrixServerState;
   url: URL;
 }): Promise<Response> {
@@ -579,8 +702,16 @@ async function handleMatrixApi(params: {
     if (userId !== params.state.botUserId) {
       return matrixError("M_FORBIDDEN", "Cannot create a filter for another user", 403);
     }
+    const bytes = Buffer.byteLength(JSON.stringify(params.body), "utf8");
+    if (
+      params.state.filters.size >= MAX_MATRIX_FILTERS ||
+      params.state.filterBytes + bytes > MAX_MATRIX_FILTER_BYTES
+    ) {
+      return matrixResourceLimitError("Too many stored filters");
+    }
     const filterId = String(params.state.nextFilter++);
-    params.state.filters.set(filterId, params.body);
+    params.state.filters.set(filterId, { body: params.body, bytes });
+    params.state.filterBytes += bytes;
     return jsonResponse({ filter_id: filterId });
   }
 
@@ -591,7 +722,7 @@ async function handleMatrixApi(params: {
       return matrixError("M_FORBIDDEN", "Cannot get filters for another user", 403);
     }
     const filter = params.state.filters.get(decodeMatrixPathSegment(match[2]!));
-    return filter ? jsonResponse(filter) : matrixError("M_NOT_FOUND", "Unknown filter", 404);
+    return filter ? jsonResponse(filter.body) : matrixError("M_NOT_FOUND", "Unknown filter", 404);
   }
 
   match = /^\/rooms\/([^/]+)\/joined_members$/u.exec(relativePath);
@@ -640,13 +771,17 @@ async function handleMatrixApi(params: {
     ]);
     const existingResponse = transactionResponse(params.state, transactionKey);
     if (existingResponse) {
+      params.recorderEvent.accepted =
+        existingResponse.status >= 200 && existingResponse.status < 300;
       return jsonResponse(existingResponse.body, existingResponse.status);
     }
     if (params.state.transactions.size >= MAX_MATRIX_TRANSACTION_RESPONSES) {
-      return matrixError("M_LIMIT_EXCEEDED", "Too many retained transaction responses", 429);
+      params.recorderEvent.accepted = false;
+      return matrixResourceLimitError("Too many retained transaction responses");
     }
     const room = params.state.rooms.get(roomId);
     if (!room) {
+      params.recorderEvent.accepted = false;
       const body = { errcode: "M_NOT_FOUND", error: "Unknown room" };
       rememberTransaction(params.state, transactionKey, {
         body,
@@ -671,6 +806,7 @@ async function handleMatrixApi(params: {
       status: 200,
     });
     notifySyncWaiters(params.state);
+    params.recorderEvent.accepted = true;
     return jsonResponse(body);
   }
 
@@ -766,6 +902,7 @@ export async function startMatrixServer(
     adminToken: params.adminToken ?? randomBytes(24).toString("hex"),
     botUserId: params.botUserId ?? `@openclaw:${serverName}`,
     deviceId: params.deviceId ?? "CRABLINE",
+    filterBytes: 0,
     filters: new Map(),
     nextEvent: 1,
     nextFilter: 1,
@@ -855,15 +992,24 @@ export async function startMatrixServer(
       if (!isJsonObject(parsedBody)) {
         return matrixError("M_BAD_JSON", "Request body must be a JSON object", 400);
       }
-      await appendEvent(state, {
+      const event: MatrixRecorderEvent = {
         at: new Date().toISOString(),
         ...(Object.keys(parsedBody).length > 0 ? { body: parsedBody } : {}),
         method,
         path: url.pathname,
         query: queryRecord(url),
         type,
+      };
+      const response = await handleMatrixApi({
+        body: parsedBody,
+        method,
+        path: url.pathname,
+        recorderEvent: event,
+        state,
+        url,
       });
-      return await handleMatrixApi({ body: parsedBody, method, path: url.pathname, state, url });
+      await appendEvent(state, event, response.ok && ["DELETE", "POST", "PUT"].includes(method));
+      return response;
     },
   });
 

--- a/src/servers/mattermost.ts
+++ b/src/servers/mattermost.ts
@@ -17,7 +17,11 @@ import {
   startHttpJsonServer,
   type ServerRequestEvent,
 } from "./http.js";
-import { recordServerEvent, type ServerEventObserver } from "./recorder.js";
+import {
+  recordCommittedServerEvent,
+  recordServerEvent,
+  type ServerEventObserver,
+} from "./recorder.js";
 import { resolveMaxPendingInboundEvents } from "./pending-events.js";
 import { closeWebSocketServer } from "./websocket.js";
 
@@ -55,6 +59,9 @@ type MattermostWebSocketEvent = {
   };
   data: Record<string, unknown>;
   event: string;
+};
+type MattermostRecorderEvent = ServerRequestEvent & {
+  accepted?: boolean | undefined;
 };
 
 type MattermostServerState = {
@@ -118,8 +125,13 @@ export function mattermostId(value: string): string {
   return createHash("sha256").update(value).digest("hex").slice(0, 26);
 }
 
-async function appendEvent(state: MattermostServerState, event: ServerRequestEvent): Promise<void> {
-  await recordServerEvent({ event, onEvent: state.onEvent, recorderPath: state.recorderPath });
+async function appendEvent(
+  state: MattermostServerState,
+  event: ServerRequestEvent,
+  committed = false,
+): Promise<void> {
+  const params = { event, onEvent: state.onEvent, recorderPath: state.recorderPath };
+  await (committed ? recordCommittedServerEvent(params) : recordServerEvent(params));
 }
 
 function authorized(request: IncomingMessage, token: string): boolean {
@@ -210,6 +222,34 @@ function sendEvent(
   return true;
 }
 
+function sendControlMessage(
+  state: MattermostServerState,
+  client: WebSocket,
+  value: Record<string, unknown>,
+): boolean {
+  if (client.readyState !== WebSocket.OPEN) {
+    state.websocketClients.delete(client);
+    return false;
+  }
+  const payload = JSON.stringify(value);
+  if (
+    client.bufferedAmount + Buffer.byteLength(payload, "utf8") >
+    state.maxWebSocketBufferedBytes
+  ) {
+    state.websocketClients.delete(client);
+    client.close(1013, "client too slow");
+    return false;
+  }
+  try {
+    client.send(payload);
+    return true;
+  } catch {
+    state.websocketClients.delete(client);
+    client.terminate();
+    return false;
+  }
+}
+
 function broadcast(
   state: MattermostServerState,
   event: MattermostWebSocketEvent,
@@ -292,16 +332,17 @@ function handleAdminInbound(params: {
   ) {
     return pendingQueueFullResponse(params.state);
   }
-  const senderName = readTrimmedString(params.body.senderName) ?? senderId;
-  const channelType = readTrimmedString(params.body.channelType) ?? "D";
   const previousUser = params.state.users.get(senderId);
   const previousChannel = params.state.channels.get(channelId);
+  const senderName =
+    readTrimmedString(params.body.senderName) ?? previousUser?.username ?? senderId;
+  const channelType = readTrimmedString(params.body.channelType) ?? previousChannel?.type ?? "D";
   const previousNextPost = params.state.nextPost;
   params.state.users.set(senderId, { id: senderId, update_at: Date.now(), username: senderName });
   params.state.channels.set(channelId, {
-    display_name: channelId,
+    display_name: previousChannel?.display_name ?? channelId,
     id: channelId,
-    name: channelId,
+    name: previousChannel?.name ?? channelId,
     type: channelType,
   });
   const post = createPost({
@@ -407,7 +448,7 @@ async function handleApi(params: {
       },
       false,
     );
-    return jsonResponse({});
+    return jsonResponse({ status: "OK" });
   }
   if (method === "POST" && apiPath === "/posts") {
     const channelId = readTrimmedString(body.channel_id);
@@ -481,7 +522,7 @@ async function handleApi(params: {
       ),
       false,
     );
-    return new Response(null, { status: 204 });
+    return jsonResponse({ status: "OK" });
   }
   return mattermostError("Not found", 404);
 }
@@ -517,15 +558,25 @@ async function handleRequest(request: IncomingMessage, state: MattermostServerSt
   }
   const body =
     method === "GET" || method === "DELETE" ? {} : await parseUnknownRequestBody(request);
-  await appendEvent(state, {
+  const event: MattermostRecorderEvent = {
     at: new Date().toISOString(),
     ...(typeof body === "object" && body !== null && Object.keys(body).length > 0 ? { body } : {}),
     method,
     path: url.pathname,
     query: queryRecord(url),
     type: "api",
+  };
+  const response = await handleApi({
+    body,
+    method,
+    path: url.pathname.slice("/api/v4".length),
+    state,
   });
-  return await handleApi({ body, method, path: url.pathname.slice("/api/v4".length), state });
+  if (method === "POST" && url.pathname === "/api/v4/posts") {
+    event.accepted = response.status === 201;
+  }
+  await appendEvent(state, event, response.ok && method !== "GET");
+  return response;
 }
 
 function attachWebSocketServer(params: {
@@ -595,13 +646,11 @@ function attachWebSocketServer(params: {
           message.action !== "authentication_challenge" ||
           message.data?.token !== params.state.botToken
         ) {
-          client.send(
-            JSON.stringify({
-              error: { id: "api.context.unauthorized", message: "Authentication failed" },
-              seq_reply: seq,
-              status: "FAIL",
-            }),
-          );
+          sendControlMessage(params.state, client, {
+            error: { id: "api.context.unauthorized", message: "Authentication failed" },
+            seq_reply: seq,
+            status: "FAIL",
+          });
           authenticationOpen = false;
           client.close(4001, "authentication failed");
           return;
@@ -610,7 +659,7 @@ function attachWebSocketServer(params: {
         authenticationOpen = false;
         unauthenticatedClients.delete(client);
         params.state.websocketClients.set(client, 0);
-        client.send(JSON.stringify({ seq_reply: seq, status: "OK" }));
+        sendControlMessage(params.state, client, { seq_reply: seq, status: "OK" });
         sendEvent(params.state, client, {
           broadcast: eventBroadcast({ userId: params.state.botUserId }),
           data: {
@@ -631,16 +680,14 @@ function attachWebSocketServer(params: {
       if (message.action === "user_typing") {
         const channelId = readTrimmedString(message.data?.channel_id);
         if (!channelId || !params.state.channels.has(channelId)) {
-          client.send(
-            JSON.stringify({
-              error: {
-                id: "api.channel.get.find.app_error",
-                message: "Channel not found",
-              },
-              seq_reply: seq,
-              status: "FAIL",
-            }),
-          );
+          sendControlMessage(params.state, client, {
+            error: {
+              id: "api.channel.get.find.app_error",
+              message: "Channel not found",
+            },
+            seq_reply: seq,
+            status: "FAIL",
+          });
           return;
         }
         broadcast(
@@ -659,20 +706,22 @@ function attachWebSocketServer(params: {
           },
           false,
         );
-        client.send(JSON.stringify({ seq_reply: seq, status: "OK" }));
+        sendControlMessage(params.state, client, { seq_reply: seq, status: "OK" });
         return;
       }
       if (message.action === "ping") {
-        client.send(JSON.stringify({ data: { text: "pong" }, seq_reply: seq, status: "OK" }));
+        sendControlMessage(params.state, client, {
+          data: { text: "pong" },
+          seq_reply: seq,
+          status: "OK",
+        });
         return;
       }
-      client.send(
-        JSON.stringify({
-          error: { id: "api.websocket.invalid_action", message: "Unsupported action" },
-          seq_reply: seq,
-          status: "FAIL",
-        }),
-      );
+      sendControlMessage(params.state, client, {
+        error: { id: "api.websocket.invalid_action", message: "Unsupported action" },
+        seq_reply: seq,
+        status: "FAIL",
+      });
     });
     client.once("close", () => {
       authenticationOpen = false;

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -1,4 +1,4 @@
-import { appendFile, mkdir } from "node:fs/promises";
+import { chmod, mkdir, open } from "node:fs/promises";
 import path from "node:path";
 import type { ServerRequestEvent } from "./http.js";
 
@@ -6,14 +6,31 @@ export type ServerEventObserver = (event: ServerRequestEvent) => void | Promise<
 
 const pendingAppends = new Map<string, Promise<void>>();
 
+function isManagedRecorderDirectory(directory: string): boolean {
+  return (
+    directory === path.resolve(".crabline", "servers") ||
+    directory === path.resolve("artifacts", "crabline")
+  );
+}
+
 async function appendJsonLine(filePath: string, line: string): Promise<void> {
   const key = path.resolve(filePath);
   const previous = pendingAppends.get(key) ?? Promise.resolve();
   const current = previous
     .catch(() => {})
     .then(async () => {
-      await mkdir(path.dirname(filePath), { recursive: true });
-      await appendFile(filePath, line, "utf8");
+      const directory = path.dirname(filePath);
+      const createdDirectory = await mkdir(directory, { mode: 0o700, recursive: true });
+      if (createdDirectory !== undefined || isManagedRecorderDirectory(path.resolve(directory))) {
+        await chmod(directory, 0o700);
+      }
+      const file = await open(filePath, "a", 0o600);
+      try {
+        await file.chmod(0o600);
+        await file.appendFile(line, { encoding: "utf8" });
+      } finally {
+        await file.close();
+      }
     });
   pendingAppends.set(key, current);
 
@@ -31,6 +48,19 @@ export async function recordServerEvent(params: {
   onEvent: ServerEventObserver | undefined;
   recorderPath: string;
 }): Promise<void> {
+  // Observers only see events after the recorder append is durable.
   await appendJsonLine(params.recorderPath, `${JSON.stringify(params.event)}\n`);
   await params.onEvent?.(params.event);
+}
+
+export async function recordCommittedServerEvent(params: {
+  event: ServerRequestEvent;
+  onEvent: ServerEventObserver | undefined;
+  recorderPath: string;
+}): Promise<void> {
+  try {
+    await recordServerEvent(params);
+  } catch {
+    // The provider mutation already committed, so telemetry failure cannot change its response.
+  }
 }

--- a/src/servers/signal.ts
+++ b/src/servers/signal.ts
@@ -17,7 +17,11 @@ import {
   type ServerRequestEvent,
   writeResponse,
 } from "./http.js";
-import { recordServerEvent, type ServerEventObserver } from "./recorder.js";
+import {
+  recordCommittedServerEvent,
+  recordServerEvent,
+  type ServerEventObserver,
+} from "./recorder.js";
 import { resolveMaxPendingInboundEvents } from "./pending-events.js";
 
 type SignalServerState = {
@@ -52,8 +56,12 @@ const DEFAULT_MAX_SIGNAL_SSE_CLIENTS = 32;
 const MAX_SIGNAL_SSE_BUFFER_BYTES = 2 * 1024 * 1024;
 type SignalSseWriteResult = "accepted" | "queued" | "rejected";
 type SignalRpcResult = {
+  accepted: boolean;
   record: boolean;
   response: Response;
+};
+type SignalRecorderEvent = ServerRequestEvent & {
+  accepted?: boolean | undefined;
 };
 
 export type SignalServerManifest = {
@@ -88,8 +96,13 @@ export type StartSignalServerParams = {
   maxSseClients?: number | undefined;
 };
 
-async function appendEvent(state: SignalServerState, event: ServerRequestEvent): Promise<void> {
-  await recordServerEvent({ event, onEvent: state.onEvent, recorderPath: state.recorderPath });
+async function appendEvent(
+  state: SignalServerState,
+  event: ServerRequestEvent,
+  committed = false,
+): Promise<void> {
+  const params = { event, onEvent: state.onEvent, recorderPath: state.recorderPath };
+  await (committed ? recordCommittedServerEvent(params) : recordServerEvent(params));
 }
 
 function rpcResponse(id: unknown, result: unknown): Response {
@@ -354,17 +367,22 @@ async function handleAdminInbound(params: {
   body: Record<string, unknown>;
   state: SignalServerState;
 }): Promise<Response> {
-  const text = readTrimmedString(params.body.text);
+  const text = typeof params.body.text === "string" ? params.body.text : undefined;
   const sourceNumber = readTrimmedString(params.body.sourceNumber ?? params.body.senderId);
-  if (!text || !sourceNumber) {
-    return jsonResponse({ error: "sourceNumber and text are required", ok: false }, 400);
+  const sourceUuid = readTrimmedString(params.body.sourceUuid);
+  if (!text || text.trim().length === 0 || (!sourceNumber && !sourceUuid)) {
+    return jsonResponse(
+      { error: "text and at least one source identity are required", ok: false },
+      400,
+    );
   }
   const timestamp = readInteger(params.body.timestamp) ?? params.state.nextTimestamp++;
   const groupId = readTrimmedString(params.body.groupId);
   const payload = {
     envelope: {
       sourceName: readTrimmedString(params.body.sourceName ?? params.body.senderName),
-      sourceNumber,
+      ...(sourceNumber ? { sourceNumber } : {}),
+      ...(sourceUuid ? { sourceUuid } : {}),
       timestamp,
       dataMessage: {
         message: text,
@@ -389,45 +407,78 @@ async function handleRpc(params: {
   body: Record<string, unknown>;
   state: SignalServerState;
 }): Promise<SignalRpcResult> {
-  const method = readTrimmedString(params.body.method);
-  if (!method) {
+  const hasId = Object.hasOwn(params.body, "id");
+  const id = params.body.id;
+  const validId =
+    !hasId ||
+    id === null ||
+    typeof id === "string" ||
+    (typeof id === "number" && Number.isFinite(id));
+  const method = params.body.method;
+  if (typeof method !== "string" || !validId) {
     return {
+      accepted: false,
       record: false,
-      response: rpcError(-32600, "Invalid Request", params.body.id),
+      response: rpcError(-32600, "Invalid Request", validId ? id : null),
     };
   }
   if (params.body.jsonrpc !== "2.0") {
     return {
+      accepted: false,
       record: false,
-      response: rpcError(-32600, "Invalid Request", params.body.id),
+      response: rpcError(-32600, "Invalid Request", id),
+    };
+  }
+  const notification = !hasId;
+  if (
+    params.body.params !== undefined &&
+    !Array.isArray(params.body.params) &&
+    !isJsonObject(params.body.params)
+  ) {
+    return {
+      accepted: false,
+      record: false,
+      response: rpcError(-32600, "Invalid Request", id),
     };
   }
   if (method === "version") {
     return {
+      accepted: false,
       record: true,
-      response: rpcResponse(params.body.id, { version: "crabline-signal-1" }),
+      response: notification
+        ? new Response(null, { status: 204 })
+        : rpcResponse(id, { version: "crabline-signal-1" }),
     };
   }
   if (["send", "sendReaction", "sendReceipt", "sendTyping"].includes(method)) {
     if (!validSignalRpcParams(method, params.body.params)) {
       return {
+        accepted: false,
         record: false,
-        response: rpcError(-32602, "Invalid params", params.body.id),
+        response: notification
+          ? new Response(null, { status: 204 })
+          : rpcError(-32602, "Invalid params", id),
       };
     }
     const timestamp = params.state.nextTimestamp++;
     return {
+      accepted: true,
       record: true,
-      response: rpcResponse(params.body.id, method === "sendTyping" ? {} : { timestamp }),
+      response: notification
+        ? new Response(null, { status: 204 })
+        : rpcResponse(id, method === "sendTyping" ? {} : { timestamp }),
     };
   }
   return {
+    accepted: false,
     record: false,
-    response: jsonResponse({
-      error: { code: -32601, message: `Method not found: ${method}` },
-      id: params.body.id ?? null,
-      jsonrpc: "2.0",
-    }),
+    response: notification
+      ? new Response(null, { status: 204 })
+      : jsonResponse({
+          error: { code: -32601, message: `Method not found: ${method}` },
+          id: id ?? null,
+          jsonrpc: "2.0",
+        }),
   };
 }
 
@@ -611,14 +662,16 @@ async function handleRequest(params: {
     }
     const rpc = await handleRpc({ body, state: params.state });
     if (rpc.record) {
-      await appendEvent(params.state, {
+      const event: SignalRecorderEvent = {
+        accepted: rpc.accepted,
         at: new Date().toISOString(),
         body,
         method: "POST",
         path: url.pathname,
         query: queryRecord(url),
         type: "api",
-      });
+      };
+      await appendEvent(params.state, event, rpc.accepted || rpc.response.status === 204);
     }
     fetchResponse = rpc.response;
   } else {
@@ -666,7 +719,13 @@ export async function startSignalServer(
         } else {
           errorResponse = jsonResponse({ error: "internal server error", ok: false }, 500);
         }
-        await writeResponse(response, errorResponse);
+        try {
+          await writeResponse(response, errorResponse);
+        } catch (writeError) {
+          response.destroy(
+            writeError instanceof Error ? writeError : new Error(String(writeError)),
+          );
+        }
       } else {
         response.destroy(error instanceof Error ? error : new Error(String(error)));
       }

--- a/src/servers/slack.ts
+++ b/src/servers/slack.ts
@@ -23,9 +23,16 @@ import {
   SLACK_TS_RULE,
   SLACK_USER_ID_RULE,
 } from "../providers/slack-ids.js";
-import { recordServerEvent, type ServerEventObserver } from "./recorder.js";
+import {
+  recordCommittedServerEvent,
+  recordServerEvent,
+  type ServerEventObserver,
+} from "./recorder.js";
 
 const SLACK_SIGNATURE_TOLERANCE_SECONDS = 5 * 60;
+const SLACK_EVENT_MAX_RETRIES = 3;
+const SLACK_EVENT_MAX_REDIRECTS = 2;
+const SLACK_EVENT_RETRY_DELAYS_MS = [0, 60_000, 5 * 60_000] as const;
 
 type SlackMessage = {
   attachments?: unknown;
@@ -44,6 +51,7 @@ type SlackMessage = {
 };
 
 type SlackServerState = {
+  activeEventDeliveries: Set<Promise<void>>;
   adminToken: string;
   botId: string;
   botToken: string;
@@ -54,6 +62,8 @@ type SlackServerState = {
         retryAfterSeconds: number;
       }
     | undefined;
+  closing: boolean;
+  deliveryAbortController: AbortController;
   eventsRequestUrl: string | undefined;
   nextDmIndex: number;
   nextMpimIndex: number;
@@ -65,6 +75,19 @@ type SlackServerState = {
   userMpimChannels: Map<string, { id: string; users: string[] }>;
   messagesByChannel: Map<string, SlackMessage[]>;
 };
+type SlackRecorderEvent = ServerRequestEvent & {
+  accepted?: boolean | undefined;
+};
+
+type SlackRetryReason =
+  | "connection_failed"
+  | "http_error"
+  | "http_timeout"
+  | "ssl_error"
+  | "too_many_redirects"
+  | "unknown_error";
+
+type SlackCursorKind = "history" | "replies";
 
 export type SlackServerManifest = {
   adminToken: string;
@@ -347,6 +370,33 @@ function requireSlackLimit(value: unknown): number | Response {
   return limit;
 }
 
+function decodeSlackCursor(value: unknown, kind: SlackCursorKind): string | Response | undefined {
+  if (value === undefined || value === "") {
+    return undefined;
+  }
+  if (typeof value !== "string" || !/^[A-Za-z0-9_-]+$/u.test(value)) {
+    return slackError("invalid_cursor");
+  }
+  const cursor = value;
+  try {
+    const decoded = Buffer.from(cursor, "base64url").toString("utf8");
+    const prefix = `${kind}:`;
+    if (!decoded.startsWith(prefix)) {
+      return slackError("invalid_cursor");
+    }
+    const boundary = decoded.slice(prefix.length);
+    return SLACK_TS_RULE.pattern.test(boundary) && encodeSlackCursor(kind, boundary) === cursor
+      ? boundary
+      : slackError("invalid_cursor");
+  } catch {
+    return slackError("invalid_cursor");
+  }
+}
+
+function encodeSlackCursor(kind: SlackCursorKind, boundary: string): string {
+  return Buffer.from(`${kind}:${boundary}`, "utf8").toString("base64url");
+}
+
 function appendMessage(state: SlackServerState, message: SlackMessage): SlackMessage {
   const messages = state.messagesByChannel.get(message.channel) ?? [];
   messages.push(message);
@@ -354,8 +404,9 @@ function appendMessage(state: SlackServerState, message: SlackMessage): SlackMes
   return message;
 }
 
-async function appendEvent(state: SlackServerState, event: ServerRequestEvent) {
-  await recordServerEvent({ event, onEvent: state.onEvent, recorderPath: state.recorderPath });
+async function appendEvent(state: SlackServerState, event: ServerRequestEvent, committed = false) {
+  const params = { event, onEvent: state.onEvent, recorderPath: state.recorderPath };
+  await (committed ? recordCommittedServerEvent(params) : recordServerEvent(params));
 }
 
 function redactSlackAuthFields(value: Record<string, unknown>): Record<string, unknown> {
@@ -457,34 +508,175 @@ function authenticateSlackEventsRequest(
   return undefined;
 }
 
+function errorChain(error: unknown): Array<Record<string, unknown>> {
+  const chain: Array<Record<string, unknown>> = [];
+  let current = error;
+  while (current && typeof current === "object" && chain.length < 4) {
+    const entry = current as Record<string, unknown>;
+    chain.push(entry);
+    current = entry.cause;
+  }
+  return chain;
+}
+
+function classifySlackRetryReason(error: unknown): SlackRetryReason {
+  const chain = errorChain(error);
+  const names = chain.map((entry) => String(entry.name ?? ""));
+  const codes = chain.map((entry) => String(entry.code ?? "").toUpperCase());
+  const messages = chain.map((entry) => String(entry.message ?? "").toLowerCase());
+  if (
+    codes.includes("UND_ERR_REDIRECT") ||
+    messages.some((message) => message.includes("redirect count exceeded"))
+  ) {
+    return "too_many_redirects";
+  }
+  if (
+    names.some((name) => name === "AbortError" || name === "TimeoutError") ||
+    codes.some((code) =>
+      ["ETIMEDOUT", "UND_ERR_BODY_TIMEOUT", "UND_ERR_HEADERS_TIMEOUT"].includes(code),
+    )
+  ) {
+    return "http_timeout";
+  }
+  if (
+    codes.some(
+      (code) =>
+        code.includes("CERT") ||
+        code.includes("SSL") ||
+        code.includes("TLS") ||
+        code === "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+    )
+  ) {
+    return "ssl_error";
+  }
+  if (
+    codes.some((code) =>
+      [
+        "EAI_AGAIN",
+        "ECONNREFUSED",
+        "ECONNRESET",
+        "EHOSTUNREACH",
+        "ENETUNREACH",
+        "ENOTFOUND",
+        "UND_ERR_CONNECT_TIMEOUT",
+        "UND_ERR_SOCKET",
+      ].includes(code),
+    )
+  ) {
+    return "connection_failed";
+  }
+  return "unknown_error";
+}
+
+async function waitForSlackRetry(delayMs: number, signal: AbortSignal): Promise<boolean> {
+  if (signal.aborted) {
+    return false;
+  }
+  return await new Promise<boolean>((resolve) => {
+    let settled = false;
+    const finish = (completed: boolean) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+      resolve(completed);
+    };
+    const onAbort = () => finish(false);
+    const timer = setTimeout(() => finish(true), delayMs);
+    timer.unref();
+    signal.addEventListener("abort", onAbort, { once: true });
+    if (signal.aborted) {
+      onAbort();
+    }
+  });
+}
+
 async function deliverSlackEvent(
   state: SlackServerState,
   event: ReturnType<typeof asSlackEventCallback>,
-): Promise<Response | undefined> {
+  lifecycleSignal: AbortSignal,
+): Promise<void> {
   if (!state.eventsRequestUrl) {
     return undefined;
   }
   const body = JSON.stringify(event);
-  const timestamp = Math.floor(Date.now() / 1000).toString();
-  try {
-    const response = await fetch(state.eventsRequestUrl, {
-      body,
-      headers: {
+  let retryReason: SlackRetryReason | undefined;
+  for (let attempt = 0; attempt <= SLACK_EVENT_MAX_RETRIES; attempt += 1) {
+    if (lifecycleSignal.aborted) {
+      return;
+    }
+    try {
+      const timestamp = Math.floor(Date.now() / 1000).toString();
+      const headers = {
         "content-type": "application/json",
+        ...(attempt > 0
+          ? {
+              "x-slack-retry-num": String(attempt),
+              "x-slack-retry-reason": retryReason ?? "unknown_error",
+            }
+          : {}),
         "x-slack-request-timestamp": timestamp,
         "x-slack-signature": slackRequestSignature(state.signingSecret, timestamp, body),
-      },
-      method: "POST",
-      signal: AbortSignal.timeout(3_000),
-    });
-    await response.body?.cancel();
-    if (!response.ok) {
-      return slackError("event_delivery_failed", 502);
+      };
+      const signal = AbortSignal.any([lifecycleSignal, AbortSignal.timeout(3_000)]);
+      let requestUrl = state.eventsRequestUrl;
+      let response: Response | undefined;
+      for (let redirectCount = 0; ; redirectCount += 1) {
+        response = await fetch(requestUrl, {
+          body,
+          headers,
+          method: "POST",
+          redirect: "manual",
+          signal,
+        });
+        const location = response.headers.get("location");
+        if (![301, 302].includes(response.status) || !location) {
+          break;
+        }
+        await response.body?.cancel();
+        if (redirectCount >= SLACK_EVENT_MAX_REDIRECTS) {
+          response = undefined;
+          retryReason = "too_many_redirects";
+          break;
+        }
+        requestUrl = new URL(location, requestUrl).toString();
+      }
+      if (response) {
+        const noRetry = response.headers.get("x-slack-no-retry") === "1";
+        await response.body?.cancel();
+        if (response.ok || noRetry) {
+          return;
+        }
+        retryReason = "http_error";
+      }
+    } catch (error) {
+      if (lifecycleSignal.aborted) {
+        return;
+      }
+      retryReason = classifySlackRetryReason(error);
     }
-  } catch {
-    return slackError("event_delivery_failed", 502);
+    const retryDelay = SLACK_EVENT_RETRY_DELAYS_MS[attempt];
+    if (retryDelay !== undefined && !(await waitForSlackRetry(retryDelay, lifecycleSignal))) {
+      return;
+    }
   }
-  return undefined;
+}
+
+function scheduleSlackEventDelivery(
+  state: SlackServerState,
+  event: ReturnType<typeof asSlackEventCallback>,
+): void {
+  if (!state.eventsRequestUrl || state.closing) {
+    return;
+  }
+  const delivery = deliverSlackEvent(state, event, state.deliveryAbortController.signal).finally(
+    () => {
+      state.activeEventDeliveries.delete(delivery);
+    },
+  );
+  state.activeEventDeliveries.add(delivery);
 }
 
 async function handleSlackApi(params: {
@@ -579,6 +771,7 @@ async function handleSlackApi(params: {
             id: channel.id,
             is_group: false,
             is_mpim: true,
+            is_private: true,
             members: [params.state.botUserId, ...channel.users],
           },
         });
@@ -606,7 +799,13 @@ async function handleSlackApi(params: {
           is_channel: channel.startsWith("C"),
           is_group: mpim ? false : channel.startsWith("G"),
           is_im: channel.startsWith("D"),
-          ...(mpim ? { is_mpim: true, members: [params.state.botUserId, ...mpim.users] } : {}),
+          ...(mpim
+            ? {
+                is_mpim: true,
+                is_private: true,
+                members: [params.state.botUserId, ...mpim.users],
+              }
+            : {}),
           name: "crabline",
         },
       });
@@ -628,6 +827,10 @@ async function handleSlackApi(params: {
       if (limit instanceof Response) {
         return limit;
       }
+      const boundary = decodeSlackCursor(params.body.cursor, "history");
+      if (boundary instanceof Response) {
+        return boundary;
+      }
       const messages = messagesForChannel(params.state, channel).filter((message) => {
         if (message.thread_ts !== undefined && message.reply_broadcast !== true) {
           return false;
@@ -640,9 +843,18 @@ async function handleSlackApi(params: {
         }
         return true;
       });
+      const ordered = [...messages]
+        .reverse()
+        .filter((message) => boundary === undefined || message.ts < boundary);
+      const page = ordered.slice(0, limit);
+      const hasMore = page.length < ordered.length;
+      const nextBoundary = page.at(-1)?.ts;
       return slackOk({
-        has_more: messages.length > limit,
-        messages: [...messages].reverse().slice(0, limit),
+        has_more: hasMore,
+        messages: page,
+        response_metadata: {
+          next_cursor: hasMore && nextBoundary ? encodeSlackCursor("history", nextBoundary) : "",
+        },
       });
     }
     case "conversations.replies": {
@@ -665,10 +877,25 @@ async function handleSlackApi(params: {
       if (limit instanceof Response) {
         return limit;
       }
+      const boundary = decodeSlackCursor(params.body.cursor, "replies");
+      if (boundary instanceof Response) {
+        return boundary;
+      }
       const messages = messagesForChannel(params.state, channel).filter(
-        (message) => message.ts === threadTs || message.thread_ts === threadTs,
+        (message) =>
+          (message.ts === threadTs || message.thread_ts === threadTs) &&
+          (boundary === undefined || message.ts > boundary),
       );
-      return slackOk({ has_more: messages.length > limit, messages: messages.slice(0, limit) });
+      const page = messages.slice(0, limit);
+      const hasMore = page.length < messages.length;
+      const nextBoundary = page.at(-1)?.ts;
+      return slackOk({
+        has_more: hasMore,
+        messages: page,
+        response_metadata: {
+          next_cursor: hasMore && nextBoundary ? encodeSlackCursor("replies", nextBoundary) : "",
+        },
+      });
     }
     default:
       return slackError("unknown_method", 404);
@@ -723,10 +950,7 @@ async function handleAdminInbound(params: {
     }),
   );
   const event = asSlackEventCallback(message);
-  const deliveryError = await deliverSlackEvent(params.state, event);
-  if (deliveryError) {
-    return deliveryError;
-  }
+  scheduleSlackEventDelivery(params.state, event);
   return slackOk({ event, message });
 }
 
@@ -822,19 +1046,32 @@ async function handleRequest(params: { request: IncomingMessage; state: SlackSer
   if (authError) {
     return authError;
   }
-  await appendEvent(params.state, {
+  const event: SlackRecorderEvent = {
     at: new Date().toISOString(),
     body: redactSlackAuthFields(body),
     method: params.request.method ?? "GET",
     path: url.pathname,
     query: redactSlackAuthQuery(query),
     type: "api",
-  });
-  return await handleSlackApi({
+  };
+  const response = await handleSlackApi({
     body,
     method: methodMatch[1],
     state: params.state,
   });
+  const mutation = ["chat.postMessage", "conversations.open"].includes(methodMatch[1]);
+  const payload = mutation
+    ? ((await response
+        .clone()
+        .json()
+        .catch(() => undefined)) as unknown)
+    : undefined;
+  const committed = isJsonObject(payload) && payload.ok === true;
+  if (methodMatch[1] === "chat.postMessage") {
+    event.accepted = committed;
+  }
+  await appendEvent(params.state, event, committed);
+  return response;
 }
 
 export async function startSlackServer(
@@ -843,11 +1080,14 @@ export async function startSlackServer(
   const host = params.host ?? "127.0.0.1";
   const externallyBound = !isLoopbackHost(host);
   const state: SlackServerState = {
+    activeEventDeliveries: new Set(),
     adminToken: params.adminToken ?? randomBytes(24).toString("base64url"),
     botId: params.botId ?? "BCRABLINE",
     botToken: params.botToken ?? "xoxb-crabline-slack-token",
     botUserId: params.botUserId ?? "UCRABBOT",
     chatPostMessageRateLimit: resolveChatPostMessageRateLimit(params.chatPostMessageRateLimit),
+    closing: false,
+    deliveryAbortController: new AbortController(),
     eventsRequestUrl: params.eventsRequestUrl,
     nextDmIndex: 1,
     nextMpimIndex: 1,
@@ -886,6 +1126,9 @@ export async function startSlackServer(
   const apiRoot = `${baseUrl}/api/`;
   return {
     async close() {
+      state.closing = true;
+      state.deliveryAbortController.abort();
+      await Promise.allSettled(state.activeEventDeliveries);
       await httpServer.close();
     },
     manifest: {

--- a/test/http-server.test.ts
+++ b/test/http-server.test.ts
@@ -107,6 +107,60 @@ describe("server HTTP body reader", () => {
     }
   });
 
+  it("preserves repeated Set-Cookie response headers", async () => {
+    const server = await startHttpJsonServer({
+      async handle() {
+        const headers = new Headers();
+        headers.append("set-cookie", "first=1; Path=/");
+        headers.append("set-cookie", "second=2; Path=/");
+        return new Response(null, { headers });
+      },
+      host: "127.0.0.1",
+      port: 0,
+      serverName: "test",
+    });
+
+    try {
+      const response = await fetch(server.baseUrl);
+      expect(response.headers.getSetCookie()).toEqual(["first=1; Path=/", "second=2; Path=/"]);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("does not write a second response when a post-delivery callback fails", async () => {
+    let errorHandlerCalls = 0;
+    const server = await startHttpJsonServer({
+      async handle() {
+        return {
+          onWriteSuccess() {
+            throw new Error("post-commit failure");
+          },
+          response: Response.json({ ok: true }),
+        };
+      },
+      handleError() {
+        errorHandlerCalls++;
+        return Response.json({ ok: false }, { status: 500 });
+      },
+      host: "127.0.0.1",
+      port: 0,
+      serverName: "test",
+    });
+
+    try {
+      const first = await fetch(server.baseUrl);
+      expect(first.status).toBe(200);
+      await expect(first.json()).resolves.toEqual({ ok: true });
+      const second = await fetch(server.baseUrl);
+      expect(second.status).toBe(200);
+      await expect(second.json()).resolves.toEqual({ ok: true });
+      expect(errorHandlerCalls).toBe(0);
+    } finally {
+      await server.close();
+    }
+  });
+
   it("reports response delivery failure to transactional handlers", async () => {
     let releaseHandler: (() => void) | undefined;
     let observeHandler: (() => void) | undefined;

--- a/test/matrix-server.test.ts
+++ b/test/matrix-server.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { ClientEvent, createClient, RoomEvent, SyncState, type MatrixEvent } from "matrix-js-sdk";
 import { afterEach, describe, expect, it } from "vitest";
 import { startMatrixServer, type StartedMatrixServer } from "../src/index.js";
+import { ADMIN_TOKEN_HEADER } from "../src/servers/http.js";
 import { createTempDir, disposeTempDir, requestHttp } from "./test-helpers.js";
 
 const servers: StartedMatrixServer[] = [];
@@ -89,6 +90,7 @@ describe("Matrix local provider server", () => {
       .map((line) => JSON.parse(line) as Record<string, unknown>);
     expect(records).toContainEqual(
       expect.objectContaining({
+        accepted: true,
         body: { body: "hello Matrix", msgtype: "m.text" },
         method: "PUT",
         path: "/_matrix/client/v3/rooms/!qa%3Amatrix.test/send/m.room.message/txn-1",
@@ -240,6 +242,238 @@ describe("Matrix local provider server", () => {
     });
   });
 
+  it("bounds retained filters by count and aggregate bytes", async () => {
+    const server = await startMatrixServer({ accessToken: "test-token-placeholder" });
+    servers.push(server);
+    const filtersUrl = `${server.manifest.endpoints.clientApiRoot}/user/${encodeURIComponent(server.manifest.botUserId)}/filter`;
+    const createFilter = (body: Record<string, unknown>) =>
+      fetch(filtersUrl, {
+        body: JSON.stringify(body),
+        headers: { ...auth("test-token-placeholder"), "content-type": "application/json" },
+        method: "POST",
+      });
+
+    expect((await createFilter({ value: "x".repeat(700_000) })).status).toBe(200);
+    const oversizedAggregate = await createFilter({ value: "y".repeat(400_000) });
+    expect(oversizedAggregate.status).toBe(503);
+    await expect(oversizedAggregate.json()).resolves.toEqual({
+      admin_contact: "mailto:admin@localhost",
+      errcode: "M_RESOURCE_LIMIT_EXCEEDED",
+      error: "Too many stored filters",
+    });
+
+    const countServer = await startMatrixServer();
+    servers.push(countServer);
+    const countUrl = `${countServer.manifest.endpoints.clientApiRoot}/user/${encodeURIComponent(countServer.manifest.botUserId)}/filter`;
+    for (let index = 0; index < 100; index += 1) {
+      const response = await fetch(countUrl, {
+        body: JSON.stringify({ index }),
+        headers: {
+          ...auth(countServer.manifest.accessToken),
+          "content-type": "application/json",
+        },
+        method: "POST",
+      });
+      expect(response.status).toBe(200);
+    }
+    const overCount = await fetch(countUrl, {
+      body: "{}",
+      headers: {
+        ...auth(countServer.manifest.accessToken),
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+    expect(overCount.status).toBe(503);
+  });
+
+  it("rejects malformed native identifiers before mutating room state", async () => {
+    const server = await startMatrixServer();
+    servers.push(server);
+    for (const body of [
+      { roomId: "room", senderId: "@alice:matrix.test", text: "bad room" },
+      { roomId: "!short", senderId: "@alice:matrix.test", text: "bad room hash" },
+      { roomId: "!room:matrix.test", senderId: "alice", text: "bad sender" },
+      { roomId: "!room:bad/name", senderId: "@alice:matrix.test", text: "bad room host" },
+      { roomId: "!room:matrix.test", senderId: "@alice:bad?host", text: "bad sender host" },
+      { roomId: "!room:256.2.3.4", senderId: "@alice:matrix.test", text: "bad IPv4" },
+      {
+        roomId: "!room:matrix.test",
+        senderId: "@alice:matrix.test",
+        text: "bad thread",
+        threadId: "event",
+      },
+      {
+        roomId: "!room:matrix.test",
+        senderId: "@alice:matrix.test",
+        text: "bad event hash",
+        threadId: "$short",
+      },
+    ]) {
+      const response = await fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify(body),
+        headers: {
+          "content-type": "application/json",
+          [ADMIN_TOKEN_HEADER]: server.manifest.adminToken,
+        },
+        method: "POST",
+      });
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({
+        error: "Invalid Matrix identifier",
+        ok: false,
+      });
+    }
+    const rooms = await fetch(`${server.manifest.endpoints.clientApiRoot}/joined_rooms`, {
+      headers: auth(server.manifest.accessToken),
+    });
+    const body = (await rooms.json()) as { joined_rooms: string[] };
+    expect(body.joined_rooms).not.toContain("!room:matrix.test");
+  });
+
+  it("accepts version-specific domainless room and event identifiers", async () => {
+    const server = await startMatrixServer();
+    servers.push(server);
+    const roomId = `!${Buffer.alloc(32, 0xab).toString("base64url")}`;
+    const threadId = `$${Buffer.alloc(32, 0xff).toString("base64").replace(/=+$/u, "")}`;
+
+    const response = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({
+        roomId,
+        senderId: "@alice:matrix.test",
+        text: "domainless identifiers",
+        threadId,
+      }),
+      headers: {
+        "content-type": "application/json",
+        [ADMIN_TOKEN_HEADER]: server.manifest.adminToken,
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      event: {
+        content: {
+          "m.relates_to": {
+            event_id: threadId,
+            "m.in_reply_to": { event_id: threadId },
+          },
+        },
+        room_id: roomId,
+      },
+      ok: true,
+    });
+  });
+
+  it("accepts whitespace in domain-scoped identifier localparts", async () => {
+    const server = await startMatrixServer();
+    servers.push(server);
+    const roomId = "!room name:matrix.test";
+    const threadId = "$event root:matrix.test";
+
+    const response = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({
+        roomId,
+        senderId: "@Alice Smith:matrix.test",
+        text: "scoped identifiers",
+        threadId,
+      }),
+      headers: {
+        "content-type": "application/json",
+        [ADMIN_TOKEN_HEADER]: server.manifest.adminToken,
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      event: {
+        content: {
+          "m.relates_to": {
+            event_id: threadId,
+            "m.in_reply_to": { event_id: threadId },
+          },
+        },
+        room_id: roomId,
+        sender: "@Alice Smith:matrix.test",
+      },
+      ok: true,
+    });
+
+    const emptyLocalpart = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({
+        roomId,
+        senderId: "@:matrix.test",
+        text: "historical empty localpart",
+      }),
+      headers: {
+        "content-type": "application/json",
+        [ADMIN_TOKEN_HEADER]: server.manifest.adminToken,
+      },
+      method: "POST",
+    });
+    expect(emptyLocalpart.status).toBe(200);
+    await expect(emptyLocalpart.json()).resolves.toMatchObject({
+      event: { sender: "@:matrix.test" },
+      ok: true,
+    });
+  });
+
+  it("accepts numeric DNS-form Matrix server names", async () => {
+    const server = await startMatrixServer();
+    servers.push(server);
+
+    const response = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({
+        roomId: "!room:123",
+        senderId: "@alice:123",
+        text: "numeric server name",
+      }),
+      headers: {
+        "content-type": "application/json",
+        [ADMIN_TOKEN_HEADER]: server.manifest.adminToken,
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      event: {
+        room_id: "!room:123",
+        sender: "@alice:123",
+      },
+      ok: true,
+    });
+  });
+
+  it("accepts Matrix IPv4 server names with leading-zero octets", async () => {
+    const server = await startMatrixServer();
+    servers.push(server);
+
+    const response = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({
+        roomId: "!room:01.2.003.4",
+        senderId: "@alice:01.2.003.4",
+        text: "Matrix IPv4 grammar",
+      }),
+      headers: {
+        "content-type": "application/json",
+        [ADMIN_TOKEN_HEADER]: server.manifest.adminToken,
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      event: {
+        room_id: "!room:01.2.003.4",
+        sender: "@alice:01.2.003.4",
+      },
+      ok: true,
+    });
+  });
+
   it("returns M_UNKNOWN_POS for malformed sync tokens instead of initial sync", async () => {
     const directory = await createTempDir();
     directories.push(directory);
@@ -293,6 +527,44 @@ describe("Matrix local provider server", () => {
       errcode: "M_UNKNOWN",
       error: "Internal server error",
     });
+  });
+
+  it("preserves committed transaction success when recording callbacks fail", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const recorderPath = path.join(directory, "matrix-committed.jsonl");
+    const server = await startMatrixServer({
+      accessToken: "test-token-placeholder",
+      onEvent() {
+        throw new Error("observer failed");
+      },
+      recorderPath,
+      roomId: "!committed:matrix.test",
+    });
+    servers.push(server);
+    const transactionUrl = `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!committed:matrix.test")}/send/m.room.message/stable-transaction`;
+    const request = () =>
+      fetch(transactionUrl, {
+        body: JSON.stringify({ body: "committed once", msgtype: "m.text" }),
+        headers: { ...auth("test-token-placeholder"), "content-type": "application/json" },
+        method: "PUT",
+      });
+
+    const first = await request();
+    const firstBody = (await first.json()) as { event_id: string };
+    expect(first.status).toBe(200);
+    const replay = await request();
+    expect(replay.status).toBe(200);
+    await expect(replay.json()).resolves.toEqual(firstBody);
+
+    const records = (await fs.readFile(recorderPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { accepted?: boolean; path: string });
+    expect(records.filter((record) => record.path === new URL(transactionUrl).pathname)).toEqual([
+      expect.objectContaining({ accepted: true }),
+      expect.objectContaining({ accepted: true }),
+    ]);
   });
 
   it("works with matrix-js-sdk sync and delivers admin inbound as a room event", async () => {
@@ -717,6 +989,20 @@ describe("Matrix local provider server", () => {
       displayname: "Alicia",
       membership: "join",
     });
+
+    const freshSync = (await (
+      await fetch(server.manifest.endpoints.syncUrl, {
+        headers: auth("test-token-placeholder"),
+      })
+    ).json()) as {
+      rooms: { join: Record<string, { state: { events: MatrixEvent[] } }> };
+    };
+    expect(freshSync.rooms.join[roomId]?.state.events).not.toContainEqual(
+      expect.objectContaining({
+        content: { displayname: "Alicia", membership: "join" },
+        state_key: "@alice:matrix.test",
+      }),
+    );
   });
 
   it("includes omitted state changes when an incremental timeline is limited", async () => {
@@ -840,9 +1126,10 @@ describe("Matrix local provider server", () => {
         method: "PUT",
       },
     );
-    expect(admitted.status).toBe(429);
+    expect(admitted.status).toBe(503);
     await expect(admitted.json()).resolves.toEqual({
-      errcode: "M_LIMIT_EXCEEDED",
+      admin_contact: "mailto:admin@localhost",
+      errcode: "M_RESOURCE_LIMIT_EXCEEDED",
       error: "Too many retained transaction responses",
     });
     for (const text of ["advance the bounded timeline", "overflow the bounded timeline"]) {

--- a/test/mattermost-server.test.ts
+++ b/test/mattermost-server.test.ts
@@ -272,13 +272,78 @@ describe("Mattermost local provider server", () => {
       headers: { authorization: "Bearer fake" },
       method: "DELETE",
     });
-    expect(deleted.status).toBe(204);
+    expect(deleted.status).toBe(200);
+    await expect(deleted.json()).resolves.toEqual({ status: "OK" });
     await expect(deletedEvent).resolves.toMatchObject({ event: "post_deleted", seq: 4 });
     socket.close();
 
     const recorded = await fs.readFile(recorderPath, "utf8");
     expect(recorded).toContain('"path":"/crabline/mattermost/inbound"');
     expect(recorded).toContain('"path":"/api/v4/posts"');
+    expect(recorded).toContain('"accepted":true');
+  });
+
+  it("preserves committed REST mutation success when recording callbacks fail", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const recorderPath = path.join(directory, "mattermost-committed.jsonl");
+    const server = await startMattermostServer({
+      adminToken: "admin",
+      botToken: "fake",
+      onEvent(event) {
+        if (event.type === "api") {
+          throw new Error("observer failed");
+        }
+      },
+      recorderPath,
+    });
+    servers.push(server);
+    const registered = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({
+        channelId: "seed-channel",
+        senderId: "bbbbbbbbbbbbbbbbbbbbbbbbbb",
+        text: "register user",
+      }),
+      headers: {
+        "content-type": "application/json",
+        "x-crabline-admin-token": "admin",
+      },
+      method: "POST",
+    });
+    expect(registered.status).toBe(200);
+
+    const direct = await fetch(`${server.manifest.endpoints.apiRoot}/channels/direct`, {
+      body: JSON.stringify([server.manifest.botUserId, "bbbbbbbbbbbbbbbbbbbbbbbbbb"]),
+      headers: {
+        authorization: "Bearer fake",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+    expect(direct.status).toBe(201);
+    const channel = (await direct.json()) as { id: string };
+
+    const post = await fetch(`${server.manifest.endpoints.apiRoot}/posts`, {
+      body: JSON.stringify({ channel_id: channel.id, message: "committed once" }),
+      headers: {
+        authorization: "Bearer fake",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+    expect(post.status).toBe(201);
+    await expect(post.json()).resolves.toMatchObject({
+      channel_id: channel.id,
+      message: "committed once",
+    });
+
+    const records = (await fs.readFile(recorderPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { accepted?: boolean; path: string });
+    expect(records).toContainEqual(
+      expect.objectContaining({ accepted: true, path: "/api/v4/posts" }),
+    );
   });
 
   it("expires silent and invalid WebSocket authentication", async () => {
@@ -559,6 +624,7 @@ describe("Mattermost local provider server", () => {
       method: "POST",
     });
     expect(restTyping.status).toBe(200);
+    await expect(restTyping.json()).resolves.toEqual({ status: "OK" });
     await noRestTypingEvent;
 
     const typingAck = nextMessage(socket);
@@ -601,6 +667,40 @@ describe("Mattermost local provider server", () => {
     await reauthenticated;
     await expectNoSocketMessage(reconnected);
     reconnected.close();
+  });
+
+  it("preserves known user and channel metadata when later ingress omits it", async () => {
+    const server = await startMattermostServer({ adminToken: "admin", botToken: "fake" });
+    servers.push(server);
+    for (const body of [
+      {
+        channelId: "channel-1",
+        channelType: "O",
+        senderId: "user-1",
+        senderName: "Alice",
+        text: "first",
+      },
+      { channelId: "channel-1", senderId: "user-1", text: "second" },
+    ]) {
+      const response = await fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify(body),
+        headers: {
+          "content-type": "application/json",
+          "x-crabline-admin-token": "admin",
+        },
+        method: "POST",
+      });
+      expect(response.status).toBe(200);
+    }
+
+    const user = await fetch(`${server.manifest.endpoints.apiRoot}/users/user-1`, {
+      headers: { authorization: "Bearer fake" },
+    });
+    await expect(user.json()).resolves.toMatchObject({ username: "Alice" });
+    const channel = await fetch(`${server.manifest.endpoints.apiRoot}/channels/channel-1`, {
+      headers: { authorization: "Bearer fake" },
+    });
+    await expect(channel.json()).resolves.toMatchObject({ type: "O" });
   });
 
   it("returns a native client error for malformed escaped path segments", async () => {

--- a/test/recorder-concurrency.test.ts
+++ b/test/recorder-concurrency.test.ts
@@ -5,17 +5,24 @@ import { appendRecordedInbound } from "../src/providers/recorder.js";
 import { recordServerEvent } from "../src/servers/recorder.js";
 
 const fsMocks = vi.hoisted(() => ({
-  appendFile: vi.fn<(filePath: string, data: string, encoding: string) => Promise<void>>(),
   providerSync: vi.fn<(filePath: string) => Promise<void>>(),
   providerWrite: vi.fn<(filePath: string, data: string) => Promise<void>>(),
+  serverWrite: vi.fn<(filePath: string, data: string) => Promise<void>>(),
 }));
 
 vi.mock("node:fs/promises", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs/promises")>();
   return {
     ...actual,
-    appendFile: fsMocks.appendFile,
     open: async (...args: Parameters<typeof actual.open>) => {
+      if (args[1] === "a" && String(args[0]).includes("crabline-server-recorder")) {
+        const filePath = String(args[0]);
+        return {
+          appendFile: async (data: string) => await fsMocks.serverWrite(filePath, data),
+          chmod: async () => {},
+          close: async () => {},
+        } as unknown as Awaited<ReturnType<typeof actual.open>>;
+      }
       const handle = await actual.open(...args);
       if (args[1] === "a+" && String(args[0]).includes("crabline-provider-recorder")) {
         handle.sync = async () => {
@@ -39,11 +46,11 @@ let pendingWrites: PendingWrite[] = [];
 
 beforeEach(() => {
   pendingWrites = [];
-  fsMocks.appendFile.mockReset();
   fsMocks.providerSync.mockReset();
   fsMocks.providerSync.mockResolvedValue(undefined);
   fsMocks.providerWrite.mockReset();
-  fsMocks.appendFile.mockImplementation(
+  fsMocks.serverWrite.mockReset();
+  fsMocks.serverWrite.mockImplementation(
     async (_filePath, data) =>
       await new Promise<void>((resolve) => {
         pendingWrites.push({ data, resolve });
@@ -93,14 +100,14 @@ describe("recorder append serialization", () => {
       onEvent: undefined,
       recorderPath,
     });
-    await vi.waitFor(() => expect(fsMocks.appendFile).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(fsMocks.serverWrite).toHaveBeenCalledTimes(1));
     const second = recordServerEvent({
       event: secondEvent,
       onEvent: undefined,
       recorderPath,
     });
 
-    await expectSerializedWrites(fsMocks.appendFile, first, second);
+    await expectSerializedWrites(fsMocks.serverWrite, first, second);
     expect(pendingWrites.map((write) => write.data)).toEqual([
       `${JSON.stringify(firstEvent)}\n`,
       `${JSON.stringify(secondEvent)}\n`,

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -32,6 +32,14 @@ async function createRecorderPath(): Promise<string> {
   return path.join(directory, "inbound.jsonl");
 }
 
+function runAfterDelay<T>(operation: () => Promise<T>, delayMs = 25): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    setTimeout(() => {
+      void operation().then(resolve, reject);
+    }, delayMs);
+  });
+}
+
 describe("recorder", () => {
   it("returns an empty list for a missing recorder file", async () => {
     const filePath = await createRecorderPath();
@@ -760,21 +768,22 @@ describe("recorder", () => {
       timeoutMs: 500,
     });
 
-    setTimeout(() => {
-      void appendRecordedInbound(filePath, {
+    const append = runAfterDelay(() =>
+      appendRecordedInbound(filePath, {
         author: "assistant",
         id: "evt-2",
         provider: "slack",
         sentAt: new Date().toISOString(),
         text: "match me",
         threadId: "slack:C123",
-      });
-    }, 25);
+      }),
+    );
 
     await expect(waitPromise).resolves.toMatchObject({
       id: "evt-2",
       text: "match me",
     });
+    await append;
   });
 
   it("retains unread events when a cursor returns an earlier match", async () => {
@@ -998,14 +1007,13 @@ describe("recorder", () => {
         timeoutMs: 500,
       });
 
-      setTimeout(() => {
-        void appendFile(filePath, `${tail.slice(splitAt)}\n`, "utf8");
-      }, 25);
+      const append = runAfterDelay(() => appendFile(filePath, `${tail.slice(splitAt)}\n`, "utf8"));
 
       await expect(waitPromise).resolves.toMatchObject({
         id: "evt-tail",
         text: "completed tail",
       });
+      await append;
       const fileSize = Buffer.byteLength(`${history}${tail}\n`);
       expect(bytesRead).toBeGreaterThanOrEqual(fileSize);
       expect(bytesRead).toBeLessThan(fileSize * 2);
@@ -1101,9 +1109,9 @@ describe("recorder", () => {
       timeoutMs: 500,
     });
 
-    setTimeout(() => {
+    const replace = runAfterDelay(async () => {
       const replacementPath = `${filePath}.replacement`;
-      void writeFile(
+      await writeFile(
         replacementPath,
         `${JSON.stringify({
           author: "assistant",
@@ -1115,13 +1123,15 @@ describe("recorder", () => {
           threadId: "slack:C123",
         })}\n`,
         "utf8",
-      ).then(() => rename(replacementPath, filePath));
-    }, 25);
+      );
+      await rename(replacementPath, filePath);
+    });
 
     await expect(waitPromise).resolves.toMatchObject({
       id: "after-replacement",
       threadId: "slack:C123",
     });
+    await replace;
   });
 
   it("preserves the offset when atomic replacement retains recorder history", async () => {
@@ -1197,8 +1207,8 @@ describe("recorder", () => {
       timeoutMs: 500,
     });
 
-    setTimeout(() => {
-      void writeFile(
+    const truncate = runAfterDelay(() =>
+      writeFile(
         filePath,
         `${JSON.stringify({
           author: "assistant",
@@ -1210,13 +1220,14 @@ describe("recorder", () => {
           threadId: "slack:C123",
         })}\n`,
         "utf8",
-      );
-    }, 25);
+      ),
+    );
 
     await expect(waitPromise).resolves.toMatchObject({
       id: "after-truncate",
       threadId: "slack:C123",
     });
+    await truncate;
   });
 
   it("streams new inbound events", async () => {
@@ -1227,20 +1238,21 @@ describe("recorder", () => {
       pollMs: 10,
     })[Symbol.asyncIterator]();
 
-    setTimeout(() => {
-      void appendRecordedInbound(filePath, {
+    const append = runAfterDelay(() =>
+      appendRecordedInbound(filePath, {
         author: "user",
         id: "evt-3",
         provider: "slack",
         sentAt: new Date().toISOString(),
         text: "tail me",
         threadId: "slack:C999",
-      });
-    }, 25);
+      }),
+    );
 
     const next = await iterator.next();
     expect(next.done).toBe(false);
     expect(next.value?.id).toBe("evt-3");
+    await append;
   });
 
   it("stops before yielding buffered events after abort", async () => {
@@ -1318,19 +1330,20 @@ describe("recorder", () => {
         pollMs: 10,
       })[Symbol.asyncIterator]();
 
-      setTimeout(() => {
-        void appendRecordedInbound(filePath, {
+      const append = runAfterDelay(() =>
+        appendRecordedInbound(filePath, {
           author: "user",
           id: "evt-tail",
           provider: "slack",
           sentAt: new Date().toISOString(),
           text: "tail me",
           threadId: "slack:C999",
-        });
-      }, 25);
+        }),
+      );
 
       const next = await iterator.next();
       expect(next.value?.id).toBe("evt-tail");
+      await append;
       expect(bytesRead).toBeGreaterThanOrEqual(Buffer.byteLength(history));
       expect(bytesRead).toBeLessThan(Buffer.byteLength(history) * 2);
     } finally {

--- a/test/server-dispatcher.test.ts
+++ b/test/server-dispatcher.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  CRABLINE_SERVER_CHANNELS,
+  startCrablineServer,
+  type StartedCrablineServer,
+  type StartCrablineServerParams,
+} from "../src/servers/index.js";
+
+const servers: StartedCrablineServer[] = [];
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => server.close()));
+});
+
+describe("provider server dispatcher", () => {
+  it("routes every declared server channel", async () => {
+    for (const channel of CRABLINE_SERVER_CHANNELS) {
+      const server = await startCrablineServer({ channel } as StartCrablineServerParams);
+      servers.push(server);
+      expect(server.manifest.provider).toBe(channel);
+    }
+  });
+
+  it("rejects unknown channels", async () => {
+    await expect(
+      startCrablineServer({ channel: "unknown" } as unknown as StartCrablineServerParams),
+    ).rejects.toThrow("Unsupported server channel");
+  });
+});

--- a/test/server-recorder.test.ts
+++ b/test/server-recorder.test.ts
@@ -1,16 +1,36 @@
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ServerRequestEvent } from "../src/servers/http.js";
-import { recordServerEvent } from "../src/servers/recorder.js";
+import { recordCommittedServerEvent, recordServerEvent } from "../src/servers/recorder.js";
 
-const fsMocks = vi.hoisted(() => ({
-  appendFile: vi.fn<(filePath: string, data: string, encoding: string) => Promise<void>>(),
-  mkdir: vi.fn<(filePath: string, options: { recursive: true }) => Promise<string | undefined>>(),
-}));
+const fsMocks = vi.hoisted(() => {
+  const file = {
+    appendFile: vi.fn<(data: string, options: { encoding: "utf8" }) => Promise<void>>(),
+    chmod: vi.fn<(mode: number) => Promise<void>>(),
+    close: vi.fn<() => Promise<void>>(),
+  };
+  return {
+    chmod: vi.fn<(filePath: string, mode: number) => Promise<void>>(),
+    file,
+    mkdir:
+      vi.fn<
+        (
+          filePath: string,
+          options: { mode: number; recursive: true },
+        ) => Promise<string | undefined>
+      >(),
+    open: vi.fn<(filePath: string, flags: string, mode: number) => Promise<typeof file>>(),
+  };
+});
 
 vi.mock("node:fs/promises", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs/promises")>();
-  return { ...actual, appendFile: fsMocks.appendFile, mkdir: fsMocks.mkdir };
+  return {
+    ...actual,
+    chmod: fsMocks.chmod,
+    mkdir: fsMocks.mkdir,
+    open: fsMocks.open,
+  };
 });
 
 function serverEvent(pathname: string): ServerRequestEvent {
@@ -24,13 +44,65 @@ function serverEvent(pathname: string): ServerRequestEvent {
 }
 
 beforeEach(() => {
-  fsMocks.appendFile.mockReset();
-  fsMocks.appendFile.mockResolvedValue();
+  fsMocks.chmod.mockReset();
+  fsMocks.chmod.mockResolvedValue();
+  fsMocks.file.appendFile.mockReset();
+  fsMocks.file.appendFile.mockResolvedValue();
+  fsMocks.file.chmod.mockReset();
+  fsMocks.file.chmod.mockResolvedValue();
+  fsMocks.file.close.mockReset();
+  fsMocks.file.close.mockResolvedValue();
   fsMocks.mkdir.mockReset();
   fsMocks.mkdir.mockResolvedValue(undefined);
+  fsMocks.open.mockReset();
+  fsMocks.open.mockResolvedValue(fsMocks.file);
 });
 
 describe("server recorder", () => {
+  it("creates recorder artifacts with owner-only permissions before append", async () => {
+    const recorderPath = path.join("/tmp", "private", "events.jsonl");
+    fsMocks.mkdir.mockResolvedValueOnce(path.join("/tmp", "private"));
+    await recordServerEvent({
+      event: serverEvent("/private"),
+      onEvent: undefined,
+      recorderPath,
+    });
+
+    expect(fsMocks.mkdir).toHaveBeenCalledWith(path.join("/tmp", "private"), {
+      mode: 0o700,
+      recursive: true,
+    });
+    expect(fsMocks.chmod).toHaveBeenCalledWith(path.join("/tmp", "private"), 0o700);
+    expect(fsMocks.open).toHaveBeenCalledWith(recorderPath, "a", 0o600);
+    expect(fsMocks.file.chmod).toHaveBeenCalledWith(0o600);
+    expect(fsMocks.file.appendFile).toHaveBeenCalledWith(expect.any(String), {
+      encoding: "utf8",
+    });
+    expect(fsMocks.file.chmod.mock.invocationCallOrder[0]).toBeLessThan(
+      fsMocks.file.appendFile.mock.invocationCallOrder[0]!,
+    );
+    expect(fsMocks.file.close).toHaveBeenCalledOnce();
+  });
+
+  it("repairs managed recorder directories without chmodding caller-owned parents", async () => {
+    const callerOwnedPath = path.join("/tmp", "events.jsonl");
+    await recordServerEvent({
+      event: serverEvent("/caller-owned"),
+      onEvent: undefined,
+      recorderPath: callerOwnedPath,
+    });
+    expect(fsMocks.chmod).not.toHaveBeenCalled();
+    expect(fsMocks.file.chmod).toHaveBeenCalledWith(0o600);
+
+    const managedPath = path.resolve(".crabline", "servers", "events.jsonl");
+    await recordServerEvent({
+      event: serverEvent("/managed"),
+      onEvent: undefined,
+      recorderPath: managedPath,
+    });
+    expect(fsMocks.chmod).toHaveBeenCalledWith(path.dirname(managedPath), 0o700);
+  });
+
   it("admits directory creation and append into one serialized queue", async () => {
     let releaseFirstMkdir: (() => void) | undefined;
     fsMocks.mkdir
@@ -54,25 +126,25 @@ describe("server recorder", () => {
     });
 
     await vi.waitFor(() => expect(fsMocks.mkdir).toHaveBeenCalledTimes(1));
-    expect(fsMocks.appendFile).not.toHaveBeenCalled();
+    expect(fsMocks.file.appendFile).not.toHaveBeenCalled();
 
     releaseFirstMkdir?.();
     await Promise.all([first, second]);
 
     expect(fsMocks.mkdir).toHaveBeenCalledTimes(2);
-    expect(fsMocks.appendFile.mock.calls.map(([, line]) => JSON.parse(line).path)).toEqual([
+    expect(fsMocks.file.appendFile.mock.calls.map(([line]) => JSON.parse(line).path)).toEqual([
       "/first",
       "/second",
     ]);
     expect(fsMocks.mkdir.mock.invocationCallOrder[1]).toBeGreaterThan(
-      fsMocks.appendFile.mock.invocationCallOrder[0]!,
+      fsMocks.file.appendFile.mock.invocationCallOrder[0]!,
     );
   });
 
   it("recovers serialization after an append failure", async () => {
     const recorderPath = path.join("/tmp", "crabline-server-recorder-recovery.jsonl");
     const appendFailure = new Error("disk unavailable");
-    fsMocks.appendFile.mockRejectedValueOnce(appendFailure).mockResolvedValueOnce();
+    fsMocks.file.appendFile.mockRejectedValueOnce(appendFailure).mockResolvedValueOnce();
 
     await expect(
       recordServerEvent({
@@ -89,7 +161,7 @@ describe("server recorder", () => {
       }),
     ).resolves.toBeUndefined();
 
-    expect(fsMocks.appendFile).toHaveBeenCalledTimes(2);
+    expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(2);
   });
 
   it("invokes observers only after the event is durable", async () => {
@@ -97,7 +169,7 @@ describe("server recorder", () => {
     const appendBlocked = new Promise<void>((resolve) => {
       releaseAppend = resolve;
     });
-    fsMocks.appendFile.mockReturnValueOnce(appendBlocked);
+    fsMocks.file.appendFile.mockReturnValueOnce(appendBlocked);
     const observer = vi.fn<(event: ServerRequestEvent) => void>();
     const event = serverEvent("/ordered");
 
@@ -106,7 +178,7 @@ describe("server recorder", () => {
       onEvent: observer,
       recorderPath: path.join("/tmp", "crabline-server-recorder-order.jsonl"),
     });
-    await vi.waitFor(() => expect(fsMocks.appendFile).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(1));
     expect(observer).not.toHaveBeenCalled();
 
     releaseAppend?.();
@@ -135,6 +207,20 @@ describe("server recorder", () => {
       }),
     ).resolves.toBeUndefined();
 
-    expect(fsMocks.appendFile).toHaveBeenCalledTimes(2);
+    expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not surface telemetry failure after a committed mutation", async () => {
+    const observerFailure = new Error("observer failed");
+
+    await expect(
+      recordCommittedServerEvent({
+        event: serverEvent("/committed"),
+        onEvent: async () => {
+          throw observerFailure;
+        },
+        recorderPath: path.join("/tmp", "crabline-server-recorder-committed.jsonl"),
+      }),
+    ).resolves.toBeUndefined();
   });
 });

--- a/test/signal-server.test.ts
+++ b/test/signal-server.test.ts
@@ -154,7 +154,6 @@ describe("signal local provider server", () => {
       ["send", {}],
       ["sendReaction", { emoji: "👍", recipient: ["+15551234567"] }],
       ["sendReceipt", { recipient: "+15551234567", targetTimestamp: [] }],
-      ["sendTyping", null],
       ["sendTyping", { username: ["alice"] }],
       ["sendTyping", { noteToSelf: true }],
       ["sendTyping", { recipient: ["+15551234567"], stop: "yes" }],
@@ -220,9 +219,188 @@ describe("signal local provider server", () => {
 
     const recorded = await fs.readFile(recorderPath, "utf8");
     expect(recorded).toContain('"method":"send"');
+    expect(recorded).toContain('"accepted":true');
     expect(recorded).not.toContain("invalid-jsonrpc-send");
     expect(recorded).not.toContain("must not be recorded");
     expect(recorded).toContain('"path":"/crabline/signal/inbound"');
+  });
+
+  it("enforces JSON-RPC envelopes and does not respond to notifications", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const recorderPath = path.join(directory, "signal-notifications.jsonl");
+    const server = await startSignalServer({ recorderPath });
+    servers.push(server);
+
+    for (const body of [
+      { id: true, jsonrpc: "2.0", method: "version" },
+      { id: {}, jsonrpc: "2.0", method: "version" },
+      { id: 1, jsonrpc: "2.0", method: 42 },
+      { id: 1, method: "version" },
+      { id: 1, jsonrpc: "2.0", method: "sendTyping", params: null },
+      { id: 1, jsonrpc: "2.0", method: "version", params: 42 },
+    ]) {
+      const invalid = await fetch(server.manifest.endpoints.rpcUrl, {
+        body: JSON.stringify(body),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      expect(invalid.status).toBe(400);
+      await expect(invalid.json()).resolves.toMatchObject({
+        error: { code: -32600, message: "Invalid Request" },
+        jsonrpc: "2.0",
+      });
+    }
+
+    const malformedNotification = await fetch(server.manifest.endpoints.rpcUrl, {
+      body: JSON.stringify({ jsonrpc: "2.0", method: "version", params: 42 }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    expect(malformedNotification.status).toBe(400);
+    await expect(malformedNotification.json()).resolves.toEqual({
+      error: { code: -32600, message: "Invalid Request" },
+      id: null,
+      jsonrpc: "2.0",
+    });
+
+    const padded = await fetch(server.manifest.endpoints.rpcUrl, {
+      body: JSON.stringify({ id: 1, jsonrpc: "2.0", method: " send ", params: {} }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    await expect(padded.json()).resolves.toEqual({
+      error: { code: -32601, message: "Method not found:  send " },
+      id: 1,
+      jsonrpc: "2.0",
+    });
+
+    for (const body of [
+      { jsonrpc: "2.0", method: "version" },
+      {
+        jsonrpc: "2.0",
+        method: "send",
+        params: { message: "notification", recipient: "+15551234567" },
+      },
+      { jsonrpc: "2.0", method: "missing" },
+    ]) {
+      const notification = await fetch(server.manifest.endpoints.rpcUrl, {
+        body: JSON.stringify(body),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      expect(notification.status).toBe(204);
+      await expect(notification.text()).resolves.toBe("");
+    }
+
+    const recorded = await fs.readFile(recorderPath, "utf8");
+    expect(recorded).toContain('"message":"notification"');
+    expect(recorded).toContain('"accepted":true');
+  });
+
+  it("accepts UUID-only admin inbound and preserves dual source identities", async () => {
+    const server = await startSignalServer({ adminToken: "admin" });
+    servers.push(server);
+    const sourceUuid = "11111111-2222-4333-8444-555555555555";
+
+    const uuidOnly = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({
+        sourceName: "Alice",
+        sourceUuid,
+        text: "uuid-only inbound",
+        timestamp: 1_700_000_000_000,
+      }),
+      headers: {
+        "content-type": "application/json",
+        "x-crabline-admin-token": "admin",
+      },
+      method: "POST",
+    });
+    expect(uuidOnly.status).toBe(200);
+    await expect(uuidOnly.json()).resolves.toMatchObject({
+      event: {
+        envelope: {
+          dataMessage: { message: "uuid-only inbound" },
+          sourceName: "Alice",
+          sourceUuid,
+          timestamp: 1_700_000_000_000,
+        },
+      },
+      ok: true,
+    });
+
+    const dualIdentity = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({
+        senderId: "+15557654321",
+        sourceUuid,
+        text: "dual identity inbound",
+      }),
+      headers: {
+        "content-type": "application/json",
+        "x-crabline-admin-token": "admin",
+      },
+      method: "POST",
+    });
+    await expect(dualIdentity.json()).resolves.toMatchObject({
+      event: {
+        envelope: {
+          sourceNumber: "+15557654321",
+          sourceUuid,
+        },
+      },
+      ok: true,
+    });
+
+    const missingIdentity = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({ text: "missing identity" }),
+      headers: {
+        "content-type": "application/json",
+        "x-crabline-admin-token": "admin",
+      },
+      method: "POST",
+    });
+    expect(missingIdentity.status).toBe(400);
+    await expect(missingIdentity.json()).resolves.toEqual({
+      error: "text and at least one source identity are required",
+      ok: false,
+    });
+  });
+
+  it("preserves padded admin text and rejects non-string text", async () => {
+    const server = await startSignalServer({ adminToken: "admin" });
+    servers.push(server);
+    const controller = new AbortController();
+    const events = await fetch(server.manifest.endpoints.eventsUrl, {
+      signal: controller.signal,
+    });
+    try {
+      const padded = await fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({ sourceNumber: "+15557654321", text: "  hello  " }),
+        headers: {
+          "content-type": "application/json",
+          "x-crabline-admin-token": "admin",
+        },
+        method: "POST",
+      });
+      expect(padded.status).toBe(200);
+      const reader = events.body!.getReader();
+      const chunk = await reader.read();
+      expect(new TextDecoder().decode(chunk.value)).toContain('"message":"  hello  "');
+
+      for (const text of [42, {}, "   "]) {
+        const invalid = await fetch(server.manifest.endpoints.adminInboundUrl, {
+          body: JSON.stringify({ sourceNumber: "+15557654321", text }),
+          headers: {
+            "content-type": "application/json",
+            "x-crabline-admin-token": "admin",
+          },
+          method: "POST",
+        });
+        expect(invalid.status).toBe(400);
+      }
+    } finally {
+      controller.abort();
+    }
   });
 
   it("rejects admin inbound when the disconnected event queue is full", async () => {
@@ -743,6 +921,52 @@ describe("signal local provider server", () => {
       error: "internal server error",
       ok: false,
     });
+  });
+
+  it("preserves accepted RPC success when recording callbacks fail", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const recorderPath = path.join(directory, "signal-committed.jsonl");
+    const server = await startSignalServer({
+      onEvent() {
+        throw new Error("observer failed");
+      },
+      recorderPath,
+    });
+    servers.push(server);
+
+    for (const [method, params] of [
+      ["send", { message: "committed once", recipient: "+15551234567" }],
+      ["sendTyping", { recipient: "+15551234567" }],
+    ] as const) {
+      const response = await fetch(server.manifest.endpoints.rpcUrl, {
+        body: JSON.stringify({ id: method, jsonrpc: "2.0", method, params }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        id: method,
+        jsonrpc: "2.0",
+        result: expect.anything(),
+      });
+    }
+    const notification = await fetch(server.manifest.endpoints.rpcUrl, {
+      body: JSON.stringify({ jsonrpc: "2.0", method: "version" }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    expect(notification.status).toBe(204);
+
+    const records = (await fs.readFile(recorderPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { accepted?: boolean });
+    expect(records).toEqual([
+      expect.objectContaining({ accepted: true }),
+      expect.objectContaining({ accepted: true }),
+      expect.objectContaining({ accepted: false }),
+    ]);
   });
 
   it("drains unauthenticated admin request bodies", async () => {

--- a/test/slack-server.test.ts
+++ b/test/slack-server.test.ts
@@ -2,7 +2,7 @@ import { createHmac } from "node:crypto";
 import fs from "node:fs/promises";
 import { createServer } from "node:http";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   startSlackServer,
   type StartedSlackServer,
@@ -17,6 +17,7 @@ const directories: string[] = [];
 afterEach(async () => {
   await Promise.all(servers.splice(0).map((server) => server.close()));
   await Promise.all(directories.splice(0).map(disposeTempDir));
+  vi.restoreAllMocks();
 });
 
 async function startTestSlackServer(
@@ -77,6 +78,26 @@ async function postSignedSlackEvent(
     },
     method: "POST",
   });
+}
+
+function runRetryTimersImmediately(): number[] {
+  const delays: number[] = [];
+  const originalSetTimeout = globalThis.setTimeout.bind(globalThis);
+  vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+    callback: (...args: unknown[]) => void,
+    delay?: number,
+    ...args: unknown[]
+  ) => {
+    const requestedDelay = delay ?? 0;
+    if ([0, 60_000, 5 * 60_000].includes(requestedDelay)) {
+      if (requestedDelay > 0) {
+        delays.push(requestedDelay);
+      }
+      return originalSetTimeout(callback, 0, ...args);
+    }
+    return originalSetTimeout(callback, requestedDelay, ...args);
+  }) as typeof setTimeout);
+  return delays;
 }
 
 describe("slack local provider server", () => {
@@ -155,6 +176,7 @@ describe("slack local provider server", () => {
         id: "G000000001",
         is_group: false,
         is_mpim: true,
+        is_private: true,
         members: ["UCRABBOT", ...users],
       },
       ok: true,
@@ -184,6 +206,7 @@ describe("slack local provider server", () => {
         is_group: false,
         is_im: false,
         is_mpim: true,
+        is_private: true,
         members: ["UCRABBOT", ...users],
         name: "crabline",
       },
@@ -399,6 +422,115 @@ describe("slack local provider server", () => {
         ok: false,
       });
     }
+  });
+
+  it("paginates history and replies with cursors", async () => {
+    const server = await startTestSlackServer();
+    const parent = await postMessage(server, {
+      channel: "C1234567890",
+      text: "parent",
+    });
+    for (const text of ["reply one", "reply two", "reply three"]) {
+      await postMessage(server, {
+        channel: "C1234567890",
+        text,
+        thread_ts: parent.ts,
+      });
+    }
+
+    const collect = async (method: string, body: Record<string, unknown>) => {
+      const texts: string[] = [];
+      let cursor = "";
+      do {
+        const response = await slackApi(server, method, { ...body, cursor, limit: 2 });
+        const payload = (await response.json()) as {
+          messages: Array<{ text: string }>;
+          response_metadata: { next_cursor: string };
+        };
+        texts.push(...payload.messages.map((message) => message.text));
+        cursor = payload.response_metadata.next_cursor;
+      } while (cursor);
+      return texts;
+    };
+
+    await postMessage(server, { channel: "C1234567890", text: "newer root" });
+    expect(await collect("conversations.history", { channel: "C1234567890" })).toEqual([
+      "newer root",
+      "parent",
+    ]);
+    expect(
+      await collect("conversations.replies", { channel: "C1234567890", ts: parent.ts }),
+    ).toEqual(["parent", "reply one", "reply two", "reply three"]);
+
+    const invalid = await slackApi(server, "conversations.history", {
+      channel: "C1234567890",
+      cursor: "not-a-cursor",
+    });
+    await expect(invalid.json()).resolves.toEqual({ error: "invalid_cursor", ok: false });
+    for (const cursor of ["MQ=", "M Q", "MQ!", "MDE", " MQ"]) {
+      const malformed = await slackApi(server, "conversations.history", {
+        channel: "C1234567890",
+        cursor,
+      });
+      await expect(malformed.json()).resolves.toEqual({ error: "invalid_cursor", ok: false });
+    }
+  });
+
+  it("keeps history pagination stable when newer messages arrive", async () => {
+    const server = await startTestSlackServer();
+    for (const text of ["oldest", "middle", "newest"]) {
+      await postMessage(server, { channel: "C1234567890", text });
+    }
+
+    const first = await slackApi(server, "conversations.history", {
+      channel: "C1234567890",
+      limit: 2,
+    });
+    const firstBody = (await first.json()) as {
+      messages: Array<{ text: string }>;
+      response_metadata: { next_cursor: string };
+    };
+    expect(firstBody.messages.map((message) => message.text)).toEqual(["newest", "middle"]);
+
+    await postMessage(server, { channel: "C1234567890", text: "inserted later" });
+    const second = await slackApi(server, "conversations.history", {
+      channel: "C1234567890",
+      cursor: firstBody.response_metadata.next_cursor,
+      limit: 2,
+    });
+    const secondBody = (await second.json()) as { messages: Array<{ text: string }> };
+    expect(secondBody.messages.map((message) => message.text)).toEqual(["oldest"]);
+  });
+
+  it("preserves committed Web API mutation success when recording callbacks fail", async () => {
+    const server = await startTestSlackServer({
+      onEvent() {
+        throw new Error("observer failed");
+      },
+    });
+
+    const opened = await slackApi(server, "conversations.open", {
+      users: "U1234567890",
+    });
+    const openedBody = (await opened.json()) as { channel: { id: string }; ok: boolean };
+    expect(openedBody.ok).toBe(true);
+
+    const posted = await slackApi(server, "chat.postMessage", {
+      channel: openedBody.channel.id,
+      text: "committed once",
+    });
+    await expect(posted.json()).resolves.toMatchObject({
+      message: { text: "committed once" },
+      ok: true,
+    });
+
+    const records = (await fs.readFile(server.manifest.recorderPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { accepted?: boolean; path: string });
+    expect(records).toContainEqual(
+      expect.objectContaining({ accepted: true, path: "/api/chat.postMessage" }),
+    );
   });
 
   it("preserves message whitespace and accepts blocks-only admin events", async () => {
@@ -645,8 +777,19 @@ describe("slack local provider server", () => {
     }
   });
 
-  it("retains inbound message state when Events API delivery is rejected", async () => {
-    const eventsReceiver = createServer((_request, response) => {
+  it("preserves committed inbound success when Events API delivery is rejected", async () => {
+    const deliveries: Array<{ reason: string | undefined; retry: string | undefined }> = [];
+    const eventsReceiver = createServer((request, response) => {
+      deliveries.push({
+        reason:
+          typeof request.headers["x-slack-retry-reason"] === "string"
+            ? request.headers["x-slack-retry-reason"]
+            : undefined,
+        retry:
+          typeof request.headers["x-slack-retry-num"] === "string"
+            ? request.headers["x-slack-retry-num"]
+            : undefined,
+      });
       response.statusCode = 503;
       response.end();
     });
@@ -659,6 +802,7 @@ describe("slack local provider server", () => {
       eventsRequestUrl: `http://127.0.0.1:${address.port}/slack/events`,
       signingSecret: "test-signing-secret",
     });
+    const retryDelays = runRetryTimersImmediately();
 
     try {
       const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
@@ -673,11 +817,19 @@ describe("slack local provider server", () => {
         },
         method: "POST",
       });
-      expect(inbound.status).toBe(502);
-      await expect(inbound.json()).resolves.toEqual({
-        error: "event_delivery_failed",
-        ok: false,
+      expect(inbound.status).toBe(200);
+      await expect(inbound.json()).resolves.toMatchObject({
+        message: { text: "retained after callback failure" },
+        ok: true,
       });
+      await vi.waitFor(() => expect(deliveries).toHaveLength(4));
+      expect(deliveries).toEqual([
+        { reason: undefined, retry: undefined },
+        { reason: "http_error", retry: "1" },
+        { reason: "http_error", retry: "2" },
+        { reason: "http_error", retry: "3" },
+      ]);
+      expect(retryDelays).toEqual([60_000, 5 * 60_000]);
 
       await expect(
         (
@@ -693,6 +845,311 @@ describe("slack local provider server", () => {
       await new Promise<void>((resolve, reject) =>
         eventsReceiver.close((error) => (error ? reject(error) : resolve())),
       );
+    }
+  });
+
+  it("returns committed inbound while Events API retries wait in the background", async () => {
+    const originalFetch = globalThis.fetch.bind(globalThis);
+    let deliveryAttempts = 0;
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      if (String(input) !== "https://events.invalid/slack/events") {
+        return await originalFetch(input, init);
+      }
+      deliveryAttempts += 1;
+      return new Response(null, { status: 503 });
+    });
+    const server = await startTestSlackServer({
+      eventsRequestUrl: "https://events.invalid/slack/events",
+    });
+
+    try {
+      const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({
+          channel: "C1234567890",
+          text: "background retries",
+          user: "U1234567890",
+        }),
+        headers: {
+          "content-type": "application/json",
+          [ADMIN_TOKEN_HEADER]: server.manifest.adminToken,
+        },
+        method: "POST",
+      });
+
+      expect(inbound.status).toBe(200);
+      await vi.waitFor(() => expect(deliveryAttempts).toBe(2));
+      await server.close();
+      servers.splice(servers.indexOf(server), 1);
+      expect(deliveryAttempts).toBe(2);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("retries a failed Events API delivery without duplicating message state", async () => {
+    const deliveries: Array<{
+      body: string;
+      reason: string | undefined;
+      retry: string | undefined;
+      signature: string | undefined;
+      timestamp: string | undefined;
+    }> = [];
+    const eventsReceiver = createServer(async (request, response) => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of request) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+      deliveries.push({
+        body: Buffer.concat(chunks).toString("utf8"),
+        reason:
+          typeof request.headers["x-slack-retry-reason"] === "string"
+            ? request.headers["x-slack-retry-reason"]
+            : undefined,
+        retry:
+          typeof request.headers["x-slack-retry-num"] === "string"
+            ? request.headers["x-slack-retry-num"]
+            : undefined,
+        signature:
+          typeof request.headers["x-slack-signature"] === "string"
+            ? request.headers["x-slack-signature"]
+            : undefined,
+        timestamp:
+          typeof request.headers["x-slack-request-timestamp"] === "string"
+            ? request.headers["x-slack-request-timestamp"]
+            : undefined,
+      });
+      response.statusCode = deliveries.length === 1 ? 503 : 200;
+      response.end();
+    });
+    await new Promise<void>((resolve) => eventsReceiver.listen(0, "127.0.0.1", resolve));
+    const address = eventsReceiver.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Unable to resolve Slack Events API receiver address.");
+    }
+    const server = await startTestSlackServer({
+      eventsRequestUrl: `http://127.0.0.1:${address.port}/slack/events`,
+    });
+    runRetryTimersImmediately();
+    let now = 1_700_000_000_000;
+    vi.spyOn(Date, "now").mockImplementation(() => {
+      now += 301_000;
+      return now;
+    });
+
+    try {
+      const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({
+          channel: "C1234567890",
+          text: "retry once",
+          user: "U1234567890",
+        }),
+        headers: {
+          "content-type": "application/json",
+          [ADMIN_TOKEN_HEADER]: server.manifest.adminToken,
+        },
+        method: "POST",
+      });
+      expect(inbound.status).toBe(200);
+      await vi.waitFor(() => expect(deliveries).toHaveLength(2));
+      expect(deliveries).toHaveLength(2);
+      expect(deliveries[0]?.body).toBe(deliveries[1]?.body);
+      expect(deliveries.map((delivery) => delivery.retry)).toEqual([undefined, "1"]);
+      expect(deliveries.map((delivery) => delivery.reason)).toEqual([undefined, "http_error"]);
+      expect(new Set(deliveries.map((delivery) => delivery.timestamp)).size).toBe(2);
+      for (const delivery of deliveries) {
+        expect(delivery.signature).toBe(
+          `v0=${createHmac("sha256", server.manifest.signingSecret)
+            .update(`v0:${delivery.timestamp}:${delivery.body}`)
+            .digest("hex")}`,
+        );
+      }
+
+      const history = await slackApi(server, "conversations.history", {
+        channel: "C1234567890",
+      });
+      await expect(history.json()).resolves.toMatchObject({
+        messages: [{ text: "retry once" }],
+      });
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        eventsReceiver.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+
+  it("honors the Events API no-retry response header", async () => {
+    let deliveries = 0;
+    const eventsReceiver = createServer((_request, response) => {
+      deliveries += 1;
+      response.writeHead(503, { "x-slack-no-retry": "1" });
+      response.end();
+    });
+    await new Promise<void>((resolve) => eventsReceiver.listen(0, "127.0.0.1", resolve));
+    const address = eventsReceiver.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Unable to resolve Slack Events API receiver address.");
+    }
+    const server = await startTestSlackServer({
+      eventsRequestUrl: `http://127.0.0.1:${address.port}/slack/events`,
+    });
+
+    try {
+      const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({
+          channel: "C1234567890",
+          text: "do not retry",
+          user: "U1234567890",
+        }),
+        headers: {
+          "content-type": "application/json",
+          [ADMIN_TOKEN_HEADER]: server.manifest.adminToken,
+        },
+        method: "POST",
+      });
+      expect(inbound.status).toBe(200);
+      await vi.waitFor(() => expect(deliveries).toBe(1));
+      expect(deliveries).toBe(1);
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        eventsReceiver.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+
+  it("follows at most two Events API redirects before retrying", async () => {
+    const originalFetch = globalThis.fetch.bind(globalThis);
+    const deliveries: Array<{
+      path: string;
+      reason: string | null;
+      retry: string | null;
+    }> = [];
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = new URL(String(input));
+      if (url.hostname !== "events.invalid") {
+        return await originalFetch(input, init);
+      }
+      deliveries.push({
+        path: url.pathname,
+        reason: new Headers(init?.headers).get("x-slack-retry-reason"),
+        retry: new Headers(init?.headers).get("x-slack-retry-num"),
+      });
+      const step = Number(url.pathname.slice(1));
+      return new Response(null, {
+        headers: { location: `/${step + 1}` },
+        status: step % 2 === 0 ? 301 : 302,
+      });
+    });
+    const server = await startTestSlackServer({
+      eventsRequestUrl: "https://events.invalid/0",
+    });
+    runRetryTimersImmediately();
+
+    const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({
+        channel: "C1234567890",
+        text: "redirect limit",
+        user: "U1234567890",
+      }),
+      headers: {
+        "content-type": "application/json",
+        [ADMIN_TOKEN_HEADER]: server.manifest.adminToken,
+      },
+      method: "POST",
+    });
+
+    expect(inbound.status).toBe(200);
+    await vi.waitFor(() => expect(deliveries).toHaveLength(12));
+    expect(deliveries.map((delivery) => delivery.path)).toEqual([
+      "/0",
+      "/1",
+      "/2",
+      "/0",
+      "/1",
+      "/2",
+      "/0",
+      "/1",
+      "/2",
+      "/0",
+      "/1",
+      "/2",
+    ]);
+    expect(deliveries.filter((delivery) => delivery.path === "/0")).toEqual([
+      { path: "/0", reason: null, retry: null },
+      { path: "/0", reason: "too_many_redirects", retry: "1" },
+      { path: "/0", reason: "too_many_redirects", retry: "2" },
+      { path: "/0", reason: "too_many_redirects", retry: "3" },
+    ]);
+    fetchSpy.mockRestore();
+  });
+
+  it("classifies Slack retry reasons from the preceding delivery failure", async () => {
+    const originalFetch = globalThis.fetch.bind(globalThis);
+    runRetryTimersImmediately();
+    const failures: Array<{
+      expected: string;
+      failure: Error | Response;
+    }> = [
+      {
+        expected: "http_timeout",
+        failure: new DOMException("timed out", "TimeoutError"),
+      },
+      {
+        expected: "connection_failed",
+        failure: Object.assign(new TypeError("fetch failed"), {
+          cause: Object.assign(new Error("connection refused"), { code: "ECONNREFUSED" }),
+        }),
+      },
+      {
+        expected: "ssl_error",
+        failure: Object.assign(new TypeError("fetch failed"), {
+          cause: Object.assign(new Error("certificate rejected"), {
+            code: "DEPTH_ZERO_SELF_SIGNED_CERT",
+          }),
+        }),
+      },
+      {
+        expected: "http_error",
+        failure: new Response(null, { status: 503 }),
+      },
+    ];
+
+    for (const { expected, failure } of failures) {
+      const retryReasons: string[] = [];
+      let deliveryAttempt = 0;
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+        if (String(input) !== "https://events.invalid/slack/events") {
+          return await originalFetch(input, init);
+        }
+        deliveryAttempt += 1;
+        if (deliveryAttempt === 1) {
+          if (failure instanceof Response) {
+            return failure.clone();
+          }
+          throw failure;
+        }
+        retryReasons.push(new Headers(init?.headers).get("x-slack-retry-reason") ?? "");
+        return new Response(null, { status: 200 });
+      });
+      const server = await startTestSlackServer({
+        eventsRequestUrl: "https://events.invalid/slack/events",
+      });
+
+      const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({
+          channel: "C1234567890",
+          text: `retry because ${expected}`,
+          user: "U1234567890",
+        }),
+        headers: {
+          "content-type": "application/json",
+          [ADMIN_TOKEN_HEADER]: server.manifest.adminToken,
+        },
+        method: "POST",
+      });
+      expect(inbound.status).toBe(200);
+      await vi.waitFor(() => expect(retryReasons).toEqual([expected]));
+      expect(retryReasons).toEqual([expected]);
+      fetchSpy.mockRestore();
     }
   });
 


### PR DESCRIPTION
## Summary
- enforce provider-native Matrix filter, sync-state, identifier, and accepted-send semantics
- harden Mattermost WebSocket/control responses and Signal JSON-RPC behavior
- add Slack callback retries, cursor pagination, HTTP header fidelity, recorder privacy, background delivery lifecycle, and exhaustive dispatcher coverage

## Validation
- local `pnpm verify` (56 files, 811 tests)
- GitHub CI `verify` on `559ba5b898e29b46d75df43f8f5bcd6110e8c979`
- Crabbox `run_61a7eab3b6d4` (56 files, 811 tests)
- exact-head autoreview with `gpt-5.6-sol` / high: clean

## Audit
- final10 clawpatch remediation
- changelog entry included