### PR TITLE
fix(providers): harden external webhook authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Harden secondary provider adapters with stable pagination, scoped native IDs, immutable diagnostics redaction, Slack edit normalization, and bounded WhatsApp ingress.
 - Harden provider-core webhook hooks, recorder durability and cursor semantics, lazy adapter lifecycle and target parity, and signed-JWT key caching.
 - Harden autoreview launchers and release automation, document trusted script manifests, and canonicalize WhatsApp Cloud targets.
+- Reject unauthenticated public provider webhooks and tighten Discord, Feishu, Google Chat, Matrix, and Teams inbound protocol validation.
 - Bound signed-JWT key refreshes and authenticate, decode, or suppress Google Chat, Teams, Feishu, and Discord webhook ingress according to provider contracts.
 - Bound recorder tail memory, harden shared provider cleanup and inbound matching, and reject non-global webhook targets.
 - Recover backpressured Signal events without recording rejected RPC calls.

--- a/README.md
+++ b/README.md
@@ -92,11 +92,12 @@ delivery request is authenticated. `doctor` checks explicit `env` declarations,
 script command availability, and config shape without requiring live platform
 credentials.
 
-When configured, Discord `publicKey`, Feishu `verificationToken`/`encryptKey`,
-Google Chat endpoint or Pub/Sub identity settings, Microsoft Teams `appId`,
-Slack `signingSecret`, Telegram `secretToken`, and Zalo `webhookSecret` enforce
-provider-native webhook authentication. Microsoft Teams also requires `appId`
-for non-loopback or explicitly public webhook endpoints.
+When configured, Discord `publicKey`, Feishu `encryptKey`, Google Chat endpoint
+or Pub/Sub identity settings, Microsoft Teams `appId`, Slack `signingSecret`,
+Telegram `secretToken`, and Zalo `webhookSecret` enforce provider-native
+webhook authentication. Feishu `verificationToken` remains an additional or
+loopback-only callback check. Microsoft Teams also requires `appId` for
+non-loopback or explicitly public webhook endpoints.
 
 ## Built-In Mock Channels
 

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -86,6 +86,9 @@ header before JSON parsing or recorder writes:
   `pubsubServiceAccountEmail`; `credentials.client_email` remains the fallback
   when inline service-account credentials are configured. Wrapped Pub/Sub
   `message.data` is base64-decoded before Google Chat event normalization.
+  Google Workspace add-on `chat.messagePayload` events are rejected until the
+  adapter can bind the verified request to a configured add-on deployment
+  identity.
 - Microsoft Teams `appId` or `TEAMS_APP_ID` verifies Bot Connector bearer
   tokens, including the activity channel and exact `serviceUrl`. An `appId` is
   required when the webhook host is non-loopback or `publicUrl` is set; an
@@ -93,9 +96,10 @@ header before JSON parsing or recorder writes:
 - Matrix webhook ingress currently has no provider-native authentication mode,
   so it is restricted to loopback hosts and cannot set `publicUrl`.
 - Feishu `verificationToken` or `FEISHU_VERIFICATION_TOKEN` verifies plaintext
-  callback tokens. `encryptKey` or `FEISHU_ENCRYPT_KEY` verifies
-  `X-Lark-Signature` and decrypts encrypted event envelopes before challenge
-  handling or event normalization.
+  callback tokens on loopback and remains an additional check when configured
+  with encryption. Externally reachable webhooks require `encryptKey` or
+  `FEISHU_ENCRYPT_KEY` to verify `X-Lark-Signature` and decrypt encrypted event
+  envelopes before challenge handling or event normalization.
 - Slack `signingSecret` or `SLACK_SIGNING_SECRET` verifies
   `X-Slack-Request-Timestamp` and `X-Slack-Signature`.
 - Telegram `secretToken` or `TELEGRAM_WEBHOOK_SECRET_TOKEN` verifies

--- a/src/providers/builtin/discord.ts
+++ b/src/providers/builtin/discord.ts
@@ -13,10 +13,15 @@ import {
   optionalString,
   requireNativeInboundId,
 } from "./native-local-mock.js";
+import { requireExternalWebhookAuthentication } from "./external-webhook-auth.js";
 
 type DiscordEnvironment = Partial<
   Pick<NodeJS.ProcessEnv, "DISCORD_APPLICATION_ID" | "DISCORD_BOT_TOKEN" | "DISCORD_PUBLIC_KEY">
 >;
+
+type DiscordRuntime = {
+  env?: DiscordEnvironment | undefined;
+};
 
 function resolveDiscordAdapterConfigValue(
   config: ProviderConfig,
@@ -75,6 +80,32 @@ function authenticateDiscordWebhook(publicKey: KeyObject, request: Request, rawB
   return undefined;
 }
 
+function discordApplicationCommandText(data: Record<string, unknown>): string | undefined {
+  const name = optionalString(data, "name");
+  if (!name) {
+    return undefined;
+  }
+
+  const values: string[] = [];
+  const collectValues = (options: unknown): void => {
+    if (!Array.isArray(options)) {
+      return;
+    }
+    for (const option of options) {
+      if (!isRecord(option)) {
+        continue;
+      }
+      const value = option.value;
+      if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+        values.push(String(value));
+      }
+      collectValues(option.options);
+    }
+  };
+  collectValues(data.options);
+  return [name, ...values].join(" ");
+}
+
 function toRecorderPath(providerId: string, config: ProviderConfig): string {
   const configuredPath = config.discord?.recorder.path;
   return configuredPath
@@ -107,7 +138,7 @@ export function normalizeDiscordWebhookPayload(payload: unknown) {
     optionalString(payload, "content") ??
     (data
       ? (optionalString(data, "content") ??
-        optionalString(data, "name") ??
+        discordApplicationCommandText(data) ??
         optionalString(data, "custom_id"))
       : undefined) ??
     (message ? optionalString(message, "content") : undefined);
@@ -155,11 +186,18 @@ export function handleDiscordWebhookPayload(payload: unknown): Response | undefi
 }
 
 export class DiscordProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
-  constructor(id: string, config: ProviderConfig, userName: string) {
-    const resolvedConfig = resolveDiscordAdapterConfigValue(config, userName);
+  constructor(id: string, config: ProviderConfig, userName: string, runtime?: unknown) {
+    const env = (runtime as DiscordRuntime | undefined)?.env ?? process.env;
+    const resolvedConfig = resolveDiscordAdapterConfigValue(config, userName, env);
     const publicKey = resolvedConfig.publicKey
       ? discordPublicKey(resolvedConfig.publicKey)
       : undefined;
+    requireExternalWebhookAuthentication({
+      authenticated: Boolean(publicKey),
+      provider: "Discord",
+      requirement: "discord.publicKey or DISCORD_PUBLIC_KEY",
+      webhook: config.discord?.webhook,
+    });
     super({
       codec: getBuiltinTargetCodec("discord"),
       config,

--- a/src/providers/builtin/external-webhook-auth.ts
+++ b/src/providers/builtin/external-webhook-auth.ts
@@ -1,0 +1,23 @@
+import { CrablineError } from "../../core/errors.js";
+import { isLoopbackHost } from "../../servers/http.js";
+
+type WebhookConfig = {
+  host?: string | undefined;
+  publicUrl?: string | undefined;
+};
+
+export function requireExternalWebhookAuthentication(params: {
+  authenticated: boolean;
+  provider: string;
+  requirement: string;
+  webhook: WebhookConfig | undefined;
+}): void {
+  const host = params.webhook?.host ?? "127.0.0.1";
+  const externallyReachable = Boolean(params.webhook?.publicUrl) || !isLoopbackHost(host);
+  if (externallyReachable && !params.authenticated) {
+    throw new CrablineError(
+      `${params.provider} externally reachable webhooks require ${params.requirement}.`,
+      { kind: "config" },
+    );
+  }
+}

--- a/src/providers/builtin/feishu.ts
+++ b/src/providers/builtin/feishu.ts
@@ -18,10 +18,29 @@ import {
   optionalString,
   requireNativeInboundId,
 } from "./native-local-mock.js";
+import { requireExternalWebhookAuthentication } from "./external-webhook-auth.js";
 
 type FeishuEnvironment = Partial<
   Pick<NodeJS.ProcessEnv, "FEISHU_ENCRYPT_KEY" | "FEISHU_VERIFICATION_TOKEN">
 >;
+
+type FeishuAuthRuntime = {
+  now?: (() => number) | undefined;
+};
+
+type FeishuReplayReservation = {
+  keys: Set<string>;
+  promise: Promise<boolean>;
+  resolve: (accepted: boolean) => void;
+};
+
+type FeishuReplayState = {
+  accepted: Map<string, number>;
+  inFlight: Map<string, FeishuReplayReservation>;
+};
+
+const FEISHU_MAX_CALLBACK_AGE_MS = 5 * 60_000;
+const FEISHU_REPLAY_CACHE_LIMIT = 2_048;
 
 export function resolveFeishuAdapterConfig(
   config: ProviderConfig,
@@ -60,6 +79,16 @@ export function handleFeishuWebhookPayload(payload: unknown): Response | undefin
 export function createFeishuWebhookAuthenticator(
   config: ProviderConfig,
   env: FeishuEnvironment = process.env,
+  runtime: FeishuAuthRuntime = {},
+) {
+  return createFeishuWebhookAuthenticatorWithReplay(config, env, runtime);
+}
+
+function createFeishuWebhookAuthenticatorWithReplay(
+  config: ProviderConfig,
+  env: FeishuEnvironment,
+  runtime: FeishuAuthRuntime,
+  replayState?: FeishuReplayState,
 ) {
   const resolved = resolveFeishuAdapterConfig(config, env);
   const validateCallback = resolved.verificationToken
@@ -68,7 +97,6 @@ export function createFeishuWebhookAuthenticator(
   if (!(resolved.encryptKey || validateCallback)) {
     return undefined;
   }
-
   return async (request: Request, rawBody: string): Promise<Response | undefined> => {
     let payload: unknown;
     try {
@@ -79,8 +107,10 @@ export function createFeishuWebhookAuthenticator(
     if (!isRecord(payload)) {
       return unauthorizedFeishuWebhook();
     }
+    const encryptedEnvelope = payload;
 
     const encrypted = typeof payload.encrypt === "string";
+    let signedRequest = false;
     if (encrypted) {
       if (!resolved.encryptKey) {
         return unauthorizedFeishuWebhook();
@@ -96,6 +126,7 @@ export function createFeishuWebhookAuthenticator(
       ) {
         return unauthorizedFeishuWebhook();
       }
+      signedRequest = !isFeishuUrlVerification(payload);
     } else if (resolved.encryptKey) {
       return unauthorizedFeishuWebhook();
     }
@@ -103,15 +134,63 @@ export function createFeishuWebhookAuthenticator(
     if (validateCallback && !validateCallback(readFeishuVerificationToken(payload))) {
       return unauthorizedFeishuWebhook();
     }
+    const now = runtime.now?.() ?? Date.now();
+    const callbackTimestamp = readFeishuCallbackTimestamp(request, payload, signedRequest);
+    if (callbackTimestamp === null) {
+      return unauthorizedFeishuWebhook();
+    }
+    if (
+      callbackTimestamp !== undefined &&
+      Math.abs(now - callbackTimestamp) > FEISHU_MAX_CALLBACK_AGE_MS
+    ) {
+      return unauthorizedFeishuWebhook();
+    }
+    const callbackKeys = readFeishuCallbackKeys(payload, encryptedEnvelope);
+    if (!replayState) {
+      return undefined;
+    }
+    pruneFeishuReplayCache(replayState.accepted, now);
+    while (callbackKeys.length > 0) {
+      if (callbackKeys.some((key) => replayState.accepted.has(key))) {
+        return new Response(null, { status: 200 });
+      }
+      const reservation = callbackKeys
+        .map((key) => replayState.inFlight.get(key))
+        .find((candidate) => candidate !== undefined);
+      if (!reservation) {
+        reserveFeishuCallback(replayState, callbackKeys);
+        break;
+      }
+      if (await reservation.promise) {
+        return new Response(null, { status: 200 });
+      }
+    }
     return undefined;
   };
 }
 
 export class FeishuProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string, runtime?: unknown) {
-    const env = (runtime as { env?: FeishuEnvironment } | undefined)?.env ?? process.env;
+    const authRuntime =
+      (runtime as (FeishuAuthRuntime & { env?: FeishuEnvironment }) | undefined) ?? {};
+    const env = authRuntime.env ?? process.env;
     const resolved = resolveFeishuAdapterConfig(config, env);
-    const authenticateWebhookRequest = createFeishuWebhookAuthenticator(config, env);
+    requireExternalWebhookAuthentication({
+      authenticated: Boolean(resolved.encryptKey),
+      provider: "Feishu",
+      requirement: "feishu.encryptKey or FEISHU_ENCRYPT_KEY for X-Lark-Signature verification",
+      webhook: config.feishu?.webhook,
+    });
+    const replayState: FeishuReplayState = {
+      accepted: new Map(),
+      inFlight: new Map(),
+    };
+    const authenticateWebhookRequest = createFeishuWebhookAuthenticatorWithReplay(
+      config,
+      env,
+      authRuntime,
+      replayState,
+    );
     const decodePayload = (payload: unknown) =>
       resolved.encryptKey ? decryptFeishuWebhookPayload(payload, resolved.encryptKey) : payload;
     super({
@@ -120,6 +199,12 @@ export class FeishuProviderAdapter extends LocalMockProviderAdapter implements P
       id,
       options: {
         ...(authenticateWebhookRequest ? { authenticateWebhookRequest } : {}),
+        createWebhookSuccessResponse(payload, responseId) {
+          return new Response(JSON.stringify({ id: responseId, ok: true }), {
+            headers: { "content-type": "application/json" },
+            status: 200,
+          });
+        },
         defaultWebhook: { host: "127.0.0.1", path: "/feishu/webhook", port: 8795 },
         endpointLabel: "webhook endpoint",
         handleWebhookPayload: (payload) => handleFeishuWebhookPayload(decodePayload(payload)),
@@ -129,6 +214,20 @@ export class FeishuProviderAdapter extends LocalMockProviderAdapter implements P
         recorderPath: config.feishu?.recorder.path
           ? path.resolve(config.feishu.recorder.path)
           : undefined,
+        settleWebhookRequest({ accepted, payload, rawBody }) {
+          const encryptedEnvelope = readFeishuSettledEnvelope(payload, rawBody);
+          const decodedPayload = decodePayload(encryptedEnvelope);
+          if (accepted) {
+            acceptFeishuCallback(
+              replayState,
+              decodedPayload,
+              encryptedEnvelope,
+              authRuntime.now?.() ?? Date.now(),
+            );
+          } else {
+            rejectFeishuCallback(replayState, decodedPayload, encryptedEnvelope);
+          }
+        },
         webhook: config.feishu?.webhook,
       },
     });
@@ -195,10 +294,21 @@ function parseFeishuText(content: string | undefined): string | undefined {
     if (isRecord(parsed) && typeof parsed.text === "string") {
       return parsed.text;
     }
+    return undefined;
   } catch {
     return content;
   }
-  return content;
+}
+
+function readFeishuSettledEnvelope(payload: unknown, rawBody: string): unknown {
+  if (isRecord(payload)) {
+    return payload;
+  }
+  try {
+    return JSON.parse(rawBody) as unknown;
+  } catch {
+    return payload;
+  }
 }
 
 export function decryptFeishuWebhookPayload(payload: unknown, encryptKey: string): unknown {
@@ -206,7 +316,7 @@ export function decryptFeishuWebhookPayload(payload: unknown, encryptKey: string
     return payload;
   }
   const encrypted = Buffer.from(payload.encrypt, "base64");
-  if (encrypted.length <= 16) {
+  if (encrypted.length <= 16 || (encrypted.length - 16) % 16 !== 0) {
     throw new Error("Feishu encrypted payload is truncated.");
   }
   const key = createHash("sha256").update(encryptKey).digest();
@@ -248,6 +358,131 @@ function verifyFeishuSignature(request: Request, rawBody: string, encryptKey: st
     .update(timestamp + nonce + encryptKey + rawBody)
     .digest();
   return timingSafeEqual(expected, Buffer.from(signature, "hex"));
+}
+
+function readFeishuCallbackTimestamp(
+  request: Request,
+  payload: unknown,
+  signedRequest: boolean,
+): number | null | undefined {
+  const requestTimestamp = signedRequest
+    ? request.headers.get("x-lark-request-timestamp")
+    : undefined;
+  const header = isRecord(payload) ? optionalRecord(payload, "header") : undefined;
+  const headerTimestamp = header ? optionalString(header, "create_time") : undefined;
+  const value = requestTimestamp ?? headerTimestamp;
+  if (!value) {
+    return undefined;
+  }
+  if (!/^\d+$/u.test(value)) {
+    return null;
+  }
+  const timestamp = Number(value);
+  if (!Number.isSafeInteger(timestamp)) {
+    return null;
+  }
+  if (timestamp >= 100_000_000_000_000) {
+    return Math.floor(timestamp / 1_000);
+  }
+  if (timestamp >= 100_000_000_000) {
+    return timestamp;
+  }
+  return timestamp * 1_000;
+}
+
+function readFeishuCallbackKeys(payload: unknown, encryptedEnvelope: unknown): string[] {
+  if (!isRecord(payload) || isFeishuUrlVerification(payload)) {
+    return [];
+  }
+  const event = optionalRecord(payload, "event");
+  const message = event ? optionalRecord(event, "message") : undefined;
+  const header = optionalRecord(payload, "header");
+  const messageId = message ? optionalString(message, "message_id") : undefined;
+  const eventId = header ? optionalString(header, "event_id") : undefined;
+  const encrypted = isRecord(encryptedEnvelope)
+    ? optionalString(encryptedEnvelope, "encrypt")
+    : undefined;
+  return [
+    ...(messageId ? [`message:${messageId}`] : []),
+    ...(eventId ? [`event:${eventId}`] : []),
+    ...(encrypted ? [`encrypted:${createHash("sha256").update(encrypted).digest("hex")}`] : []),
+  ];
+}
+
+function reserveFeishuCallback(replayState: FeishuReplayState, callbackKeys: string[]): void {
+  let resolveReservation!: (accepted: boolean) => void;
+  const promise = new Promise<boolean>((resolve) => {
+    resolveReservation = resolve;
+  });
+  const reservation: FeishuReplayReservation = {
+    keys: new Set(callbackKeys),
+    promise,
+    resolve: resolveReservation,
+  };
+  for (const key of callbackKeys) {
+    replayState.inFlight.set(key, reservation);
+  }
+}
+
+function acceptFeishuCallback(
+  replayState: FeishuReplayState,
+  payload: unknown,
+  encryptedEnvelope: unknown,
+  now: number,
+): void {
+  const callbackKeys = readFeishuCallbackKeys(payload, encryptedEnvelope);
+  pruneFeishuReplayCache(replayState.accepted, now);
+  for (const key of callbackKeys) {
+    replayState.accepted.set(key, now);
+  }
+  const reservations = new Set(
+    callbackKeys
+      .map((key) => replayState.inFlight.get(key))
+      .filter((reservation) => reservation !== undefined),
+  );
+  for (const reservation of reservations) {
+    releaseFeishuReservation(replayState, reservation, true);
+  }
+}
+
+function rejectFeishuCallback(
+  replayState: FeishuReplayState,
+  payload: unknown,
+  encryptedEnvelope: unknown,
+): void {
+  const callbackKeys = readFeishuCallbackKeys(payload, encryptedEnvelope);
+  const reservations = new Set(
+    callbackKeys
+      .map((key) => replayState.inFlight.get(key))
+      .filter((reservation) => reservation !== undefined),
+  );
+  for (const reservation of reservations) {
+    releaseFeishuReservation(replayState, reservation, false);
+  }
+}
+
+function releaseFeishuReservation(
+  replayState: FeishuReplayState,
+  reservation: FeishuReplayReservation,
+  accepted: boolean,
+): void {
+  for (const key of reservation.keys) {
+    if (replayState.inFlight.get(key) === reservation) {
+      replayState.inFlight.delete(key);
+    }
+  }
+  reservation.resolve(accepted);
+}
+
+function pruneFeishuReplayCache(recentCallbacks: Map<string, number>, now: number): void {
+  for (const [key, acceptedAt] of recentCallbacks) {
+    if (
+      now - acceptedAt > FEISHU_MAX_CALLBACK_AGE_MS ||
+      recentCallbacks.size > FEISHU_REPLAY_CACHE_LIMIT
+    ) {
+      recentCallbacks.delete(key);
+    }
+  }
 }
 
 function unauthorizedFeishuWebhook(): Response {

--- a/src/providers/builtin/googlechat.ts
+++ b/src/providers/builtin/googlechat.ts
@@ -23,6 +23,7 @@ import {
   optionalString,
   requireNativeInboundId,
 } from "./native-local-mock.js";
+import { requireExternalWebhookAuthentication } from "./external-webhook-auth.js";
 
 export function resolveGoogleChatAdapterConfig(
   config: ProviderConfig,
@@ -61,9 +62,9 @@ export function createGoogleChatWebhookAuthenticator(
   if (config.googlechat?.disableSignatureVerification) {
     return undefined;
   }
-  const endpointAudience = config.googlechat?.endpointUrl;
+  const endpointAudience = config.googlechat?.endpointUrl ?? config.googlechat?.webhook.publicUrl;
   const projectAudience = config.googlechat?.googleChatProjectNumber;
-  const pubsubAudience = config.googlechat?.pubsubAudience;
+  const pubsubAudience = config.googlechat?.pubsubAudience ?? endpointAudience;
   const pubsubServiceAccount =
     config.googlechat?.pubsubServiceAccountEmail ?? config.googlechat?.credentials?.client_email;
   if (!(endpointAudience || projectAudience || pubsubAudience)) {
@@ -171,7 +172,14 @@ export function createGoogleChatWebhookAuthenticator(
 export function matchesGoogleChatThread(
   candidateThreadId: string,
   expectedThreadId: string | undefined,
+  target: { channelId?: string | undefined } = {},
 ): boolean {
+  const candidateSpace = GOOGLE_CHAT_THREAD_RULE.pattern.test(candidateThreadId)
+    ? candidateThreadId.slice(0, candidateThreadId.indexOf("/threads/"))
+    : candidateThreadId;
+  if (target.channelId && candidateSpace !== target.channelId) {
+    return false;
+  }
   if (!expectedThreadId) {
     return true;
   }
@@ -184,6 +192,23 @@ export function matchesGoogleChatThread(
 
 export class GoogleChatProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string, runtime?: unknown) {
+    const endpointAudience = config.googlechat?.endpointUrl ?? config.googlechat?.webhook.publicUrl;
+    const pubsubServiceAccount =
+      config.googlechat?.pubsubServiceAccountEmail ?? config.googlechat?.credentials?.client_email;
+    const authenticationConfigured =
+      !config.googlechat?.disableSignatureVerification &&
+      Boolean(
+        endpointAudience ||
+        config.googlechat?.googleChatProjectNumber ||
+        (config.googlechat?.pubsubAudience && pubsubServiceAccount),
+      );
+    requireExternalWebhookAuthentication({
+      authenticated: authenticationConfigured,
+      provider: "Google Chat",
+      requirement:
+        "googlechat.endpointUrl, googlechat.googleChatProjectNumber, or googlechat.pubsubAudience with a Pub/Sub service-account identity and signature verification enabled",
+      webhook: config.googlechat?.webhook,
+    });
     const authenticateWebhookRequest = createGoogleChatWebhookAuthenticator(
       config,
       (runtime as GoogleChatAuthRuntime | undefined) ?? {},
@@ -217,6 +242,13 @@ export function normalizeGoogleChatWebhookPayload(payload: unknown) {
     });
   }
 
+  const chat = optionalRecord(payload, "chat");
+  if (chat && "messagePayload" in chat) {
+    throw new CrablineError(
+      "Google Workspace add-on chat.messagePayload events are unsupported without a configured deployment identity",
+      { kind: "inbound" },
+    );
+  }
   const payloadMessage = optionalRecord(payload, "message");
   const message = payloadMessage ?? payload;
   if (payloadMessage && optionalString(payloadMessage, "threadId")) {
@@ -235,6 +267,11 @@ export function normalizeGoogleChatWebhookPayload(payload: unknown) {
   const text = optionalString(message, "text") ?? optionalString(message, "argumentText");
   if (!spaceName || !text) {
     throw new CrablineError("Google Chat message payload requires space.name and text", {
+      kind: "inbound",
+    });
+  }
+  if (threadName && !threadName.startsWith(`${spaceName}/threads/`)) {
+    throw new CrablineError("Google Chat thread.name must belong to message.space.name", {
       kind: "inbound",
     });
   }

--- a/src/providers/builtin/matrix.ts
+++ b/src/providers/builtin/matrix.ts
@@ -16,6 +16,7 @@ import {
   optionalString,
   requireNativeInboundId,
 } from "./native-local-mock.js";
+import { requireExternalWebhookAuthentication } from "./external-webhook-auth.js";
 
 export function resolveMatrixAdapterConfig(
   config: ProviderConfig,
@@ -38,6 +39,13 @@ export class MatrixProviderAdapter extends LocalMockProviderAdapter implements P
   constructor(id: string, config: ProviderConfig, userName: string, _runtime?: unknown) {
     const resolvedConfig = resolveMatrixAdapterConfig(config, userName);
     const botUserId = resolvedConfig.auth.userID;
+    requireExternalWebhookAuthentication({
+      authenticated: false,
+      provider: "Matrix",
+      requirement:
+        "a provider-native authenticated ingress mode, which this adapter does not support",
+      webhook: config.matrix?.webhook,
+    });
     super({
       codec: getBuiltinTargetCodec("matrix"),
       config,
@@ -98,25 +106,32 @@ export function normalizeMatrixWebhookPayload(payload: unknown, botUserId?: stri
   const content = optionalRecord(payload, "content");
   const roomId = optionalString(payload, "room_id");
   const eventId = optionalString(payload, "event_id");
+  const eventType = optionalString(payload, "type");
   const senderId = optionalString(payload, "sender");
   const text = content ? optionalString(content, "body") : undefined;
-  if (!roomId || !text) {
-    throw new CrablineError("Matrix event payload requires room_id and content.body", {
+  if (eventType !== "m.room.message") {
+    throw new CrablineError("Matrix event payload requires type=m.room.message", {
+      kind: "inbound",
+    });
+  }
+  if (!roomId || !eventId || !text) {
+    throw new CrablineError("Matrix event payload requires room_id, event_id, and content.body", {
       kind: "inbound",
     });
   }
 
   const relation = content ? optionalRecord(content, "m.relates_to") : undefined;
-  const threadRootId =
-    relation && optionalString(relation, "rel_type") === "m.thread"
-      ? optionalString(relation, "event_id")
-      : undefined;
+  const isThread = relation && optionalString(relation, "rel_type") === "m.thread";
+  const threadRootId = isThread ? optionalString(relation, "event_id") : undefined;
+  if (isThread && !threadRootId) {
+    throw new CrablineError("Matrix m.thread relation requires event_id", {
+      kind: "inbound",
+    });
+  }
 
   return {
     author: authorFromBotFlag(senderId !== undefined && senderId === botUserId),
-    ...(eventId
-      ? { id: requireNativeInboundId(eventId, MATRIX_EVENT_ID_RULE, "Matrix event_id") }
-      : {}),
+    id: requireNativeInboundId(eventId, MATRIX_EVENT_ID_RULE, "Matrix event_id"),
     raw: payload,
     text,
     threadId: threadRootId

--- a/src/providers/builtin/msteams.ts
+++ b/src/providers/builtin/msteams.ts
@@ -2,7 +2,6 @@ import { createPublicKey, type JsonWebKey } from "node:crypto";
 import path from "node:path";
 import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
-import { isLoopbackHost } from "../../servers/http.js";
 import { LocalMockProviderAdapter } from "../local-mock.js";
 import type { ProviderAdapter } from "../types.js";
 import {
@@ -20,6 +19,7 @@ import {
   optionalString,
   requireNativeInboundId,
 } from "./native-local-mock.js";
+import { requireExternalWebhookAuthentication } from "./external-webhook-auth.js";
 
 export function resolveMsTeamsAdapterConfig(
   config: ProviderConfig,
@@ -118,11 +118,7 @@ export function createMsTeamsWebhookAuthenticator(
         now: runtime.now,
         async resolveKey(header) {
           const key = await resolveSigningKey(header);
-          if (
-            key.endorsements &&
-            key.endorsements.length > 0 &&
-            !key.endorsements.includes(channelId)
-          ) {
+          if (key.endorsements && !key.endorsements.includes(channelId)) {
             throw new Error("Bot Connector JWT key does not endorse the activity channel.");
           }
           return createPublicKey({ format: "jwk", key });
@@ -171,16 +167,13 @@ function requireExternalMsTeamsWebhookAuthentication(
   config: ProviderConfig,
   env: NodeJS.ProcessEnv,
 ): void {
-  const webhook = config.msteams?.webhook;
-  const host = webhook?.host ?? "127.0.0.1";
-  const externallyReachable = Boolean(webhook?.publicUrl) || !isLoopbackHost(host);
   const appId = config.msteams?.appId ?? env.TEAMS_APP_ID;
-  if (externallyReachable && !appId) {
-    throw new CrablineError(
-      "Microsoft Teams externally reachable webhooks require msteams.appId or TEAMS_APP_ID.",
-      { kind: "config" },
-    );
-  }
+  requireExternalWebhookAuthentication({
+    authenticated: Boolean(appId),
+    provider: "Microsoft Teams",
+    requirement: "msteams.appId or TEAMS_APP_ID",
+    webhook: config.msteams?.webhook,
+  });
 }
 
 export function normalizeMsTeamsWebhookPayload(payload: unknown) {

--- a/src/providers/local-mock.ts
+++ b/src/providers/local-mock.ts
@@ -54,6 +54,7 @@ export type LocalMockAdapterOptions = {
   platform: ProviderPlatform;
   publicUrl?: string | undefined;
   recorderPath?: string | undefined;
+  settleWebhookRequest?: (params: { accepted: boolean; payload: unknown; rawBody: string }) => void;
   webhook?: LocalMockWebhookConfig | undefined;
 };
 
@@ -431,59 +432,87 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
       try {
         rawPayload = JSON.parse(rawBody) as unknown;
       } catch {
+        this.#options.settleWebhookRequest?.({
+          accepted: false,
+          payload: undefined,
+          rawBody,
+        });
         return new Response("invalid JSON", { status: 400 });
       }
     } else {
       rawPayload = rawBody;
     }
-    const directResponse = await this.#options.handleWebhookPayload?.(rawPayload, request, rawBody);
-    if (directResponse) {
-      return directResponse;
-    }
-    if (mediaType !== "application/json") {
-      return new Response("expected application/json", { status: 415 });
-    }
-    let payload: MockWebhookPayload;
+    let settled = false;
+    const settle = (accepted: boolean) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      this.#options.settleWebhookRequest?.({ accepted, payload: rawPayload, rawBody });
+    };
+    const respond = (response: Response) => {
+      settle(response.ok);
+      return response;
+    };
     try {
-      payload = normalizeWebhookPayload(
-        this.#options.normalizeWebhookPayload
-          ? this.#options.normalizeWebhookPayload(rawPayload)
-          : rawPayload,
+      const directResponse = await this.#options.handleWebhookPayload?.(
+        rawPayload,
+        request,
+        rawBody,
+      );
+      if (directResponse) {
+        return respond(directResponse);
+      }
+      if (mediaType !== "application/json") {
+        return respond(new Response("expected application/json", { status: 415 }));
+      }
+      let payload: MockWebhookPayload;
+      try {
+        payload = normalizeWebhookPayload(
+          this.#options.normalizeWebhookPayload
+            ? this.#options.normalizeWebhookPayload(rawPayload)
+            : rawPayload,
+        );
+      } catch (error) {
+        if (error instanceof CrablineError && error.kind === "inbound") {
+          return respond(new Response(ensureErrorMessage(error), { status: 400 }));
+        }
+        throw error;
+      }
+
+      const id = payload.message?.id ?? payload.id ?? createMessageId(this.platform);
+      const threadId = payload.message?.threadId ?? payload.threadId;
+      const text = payload.message?.text ?? payload.text;
+      if (!threadId || !text) {
+        return respond(
+          new Response("payload requires message.threadId and message.text", { status: 400 }),
+        );
+      }
+      if (this.#cleanupBegun) {
+        return respond(new Response("provider is shutting down", { status: 503 }));
+      }
+
+      await appendRecordedInbound(this.#recorderPath, {
+        author: authorFromPayload(payload),
+        id,
+        provider: this.id,
+        raw: payload.message?.raw ?? payload.raw ?? payload,
+        recordedDirection: "inbound",
+        sentAt: new Date().toISOString(),
+        text,
+        threadId,
+      });
+      return respond(
+        (await this.#options.createWebhookSuccessResponse?.(rawPayload, id)) ??
+          new Response(JSON.stringify({ ok: true, id }), {
+            headers: { "content-type": "application/json" },
+            status: 200,
+          }),
       );
     } catch (error) {
-      if (error instanceof CrablineError && error.kind === "inbound") {
-        return new Response(ensureErrorMessage(error), { status: 400 });
-      }
+      settle(false);
       throw error;
     }
-
-    const id = payload.message?.id ?? payload.id ?? createMessageId(this.platform);
-    const threadId = payload.message?.threadId ?? payload.threadId;
-    const text = payload.message?.text ?? payload.text;
-    if (!threadId || !text) {
-      return new Response("payload requires message.threadId and message.text", { status: 400 });
-    }
-    if (this.#cleanupBegun) {
-      return new Response("provider is shutting down", { status: 503 });
-    }
-
-    await appendRecordedInbound(this.#recorderPath, {
-      author: authorFromPayload(payload),
-      id,
-      provider: this.id,
-      raw: payload.message?.raw ?? payload.raw ?? payload,
-      recordedDirection: "inbound",
-      sentAt: new Date().toISOString(),
-      text,
-      threadId,
-    });
-    return (
-      (await this.#options.createWebhookSuccessResponse?.(rawPayload, id)) ??
-      new Response(JSON.stringify({ ok: true, id }), {
-        headers: { "content-type": "application/json" },
-        status: 200,
-      })
-    );
   }
 
   async #ensureWebhookServer(): Promise<StartedWebhookServer> {

--- a/test/discord-provider.test.ts
+++ b/test/discord-provider.test.ts
@@ -53,6 +53,34 @@ describe("Discord interaction responses", () => {
       threadId: "123456789012345678",
     });
   });
+
+  it("includes nested application-command option values", () => {
+    expect(
+      normalizeDiscordWebhookPayload({
+        channel_id: "123456789012345678",
+        data: {
+          name: "deploy",
+          options: [
+            {
+              name: "service",
+              options: [
+                {
+                  name: "environment",
+                  options: [{ name: "nonce", type: 3, value: "nonce-nested" }],
+                  type: 1,
+                },
+              ],
+              type: 2,
+            },
+          ],
+        },
+        id: "444456789012345678",
+        type: 2,
+      }),
+    ).toMatchObject({
+      text: "deploy nonce-nested",
+    });
+  });
 });
 
 afterEach(async () => {
@@ -128,6 +156,25 @@ function createContext(config: ProviderConfig): ProviderContext {
 }
 
 describe("discord provider", () => {
+  it("requires signatures for externally reachable interaction endpoints", async () => {
+    const config = await createDiscordConfig(0);
+    config.discord!.webhook.host = "0.0.0.0";
+    expect(() => new DiscordProviderAdapter("discord", config, "crabline", { env: {} })).toThrow(
+      /externally reachable webhooks require discord\.publicKey/u,
+    );
+
+    config.discord!.webhook.host = "127.0.0.1";
+    config.discord!.webhook.publicUrl = "https://discord.example.test/interactions";
+    expect(() => new DiscordProviderAdapter("discord", config, "crabline", { env: {} })).toThrow(
+      /externally reachable webhooks require discord\.publicKey/u,
+    );
+
+    config.discord!.publicKey = "a".repeat(64);
+    expect(
+      () => new DiscordProviderAdapter("discord", config, "crabline", { env: {} }),
+    ).not.toThrow();
+  });
+
   it("verifies configured signatures and answers PING without recording it", async () => {
     const { privateKey, publicKey } = generateKeyPairSync("ed25519");
     const config = await createDiscordConfig(0);
@@ -232,6 +279,7 @@ describe("discord provider", () => {
   it("probes built-in discord configuration and DM targets", async () => {
     const config = await createDiscordConfig(0);
     config.discord!.webhook.publicUrl = "https://example.ngrok.app/discord/interactions";
+    config.discord!.publicKey = "a".repeat(64);
     const provider = new DiscordProviderAdapter("discord", config, "crabline");
     providers.push(provider);
 
@@ -287,7 +335,6 @@ describe("discord provider", () => {
 
   it("records webhook inbound events and waits for them", async () => {
     const config = await createDiscordConfig(0);
-    config.discord!.webhook.publicUrl = "https://example.ngrok.app/discord/interactions";
     const provider = new DiscordProviderAdapter("discord", config, "crabline");
     providers.push(provider);
 

--- a/test/feishu-provider.test.ts
+++ b/test/feishu-provider.test.ts
@@ -1,4 +1,5 @@
-import { createCipheriv, createHash, randomBytes } from "node:crypto";
+import { createCipheriv, createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 import {
   createFeishuWebhookAuthenticator,
@@ -9,12 +10,13 @@ import {
 } from "../src/providers/builtin/feishu.js";
 import {
   createLocalMockConfig,
+  createProviderContext,
   runLocalMockProviderContract,
 } from "./local-mock-provider-helpers.js";
 
 function encryptFeishuPayload(payload: unknown, encryptKey: string): string {
   const key = createHash("sha256").update(encryptKey).digest();
-  const iv = randomBytes(16);
+  const iv = Buffer.alloc(16, 0x42);
   const cipher = createCipheriv("aes-256-cbc", key, iv);
   return Buffer.concat([iv, cipher.update(JSON.stringify(payload)), cipher.final()]).toString(
     "base64",
@@ -22,6 +24,24 @@ function encryptFeishuPayload(payload: unknown, encryptKey: string): string {
 }
 
 describe("Feishu webhook normalizer", () => {
+  it("requires native authentication for externally reachable webhooks", async () => {
+    const config = await createLocalMockConfig("feishu", "/feishu/webhook");
+    config.feishu!.webhook.host = "0.0.0.0";
+    expect(() => new FeishuProviderAdapter("feishu", config, "crabline", { env: {} })).toThrow(
+      /externally reachable webhooks require feishu\.encryptKey/u,
+    );
+
+    config.feishu!.verificationToken = "sample";
+    expect(() => new FeishuProviderAdapter("feishu", config, "crabline", { env: {} })).toThrow(
+      /X-Lark-Signature verification/u,
+    );
+
+    config.feishu!.encryptKey = "encrypt-key";
+    expect(
+      () => new FeishuProviderAdapter("feishu", config, "crabline", { env: {} }),
+    ).not.toThrow();
+  });
+
   it("answers URL verification challenges", async () => {
     const response = handleFeishuWebhookPayload({
       challenge: "challenge-token",
@@ -85,7 +105,13 @@ describe("Feishu webhook normalizer", () => {
     const signature = createHash("sha256")
       .update(timestamp + nonce + encryptKey + rawBody)
       .digest("hex");
-    const authenticate = createFeishuWebhookAuthenticator(config, {});
+    const authenticate = createFeishuWebhookAuthenticator(
+      config,
+      {},
+      {
+        now: () => Number(timestamp) * 1_000,
+      },
+    );
 
     await expect(
       authenticate!(
@@ -120,6 +146,12 @@ describe("Feishu webhook normalizer", () => {
         rawBody,
       ),
     ).resolves.toMatchObject({ status: 401 });
+  });
+
+  it("rejects encrypted payloads without ciphertext after the IV", () => {
+    expect(() =>
+      decryptFeishuWebhookPayload({ encrypt: Buffer.alloc(16).toString("base64") }, "encrypt-key"),
+    ).toThrow(/truncated/u);
   });
 
   it("accepts unsigned encrypted URL verification only", async () => {
@@ -259,6 +291,166 @@ describe("Feishu webhook normalizer", () => {
         },
       })?.status,
     ).toBe(200);
+    expect(
+      handleFeishuWebhookPayload({
+        event: {
+          message: {
+            chat_id: "oc_abc123",
+            content: JSON.stringify({ unexpected: "object" }),
+            message_id: "om_message123",
+            message_type: "text",
+          },
+        },
+      })?.status,
+    ).toBe(200);
+    expect(() =>
+      normalizeFeishuWebhookPayload({
+        event: {
+          message: {
+            chat_id: "oc_abc123",
+            content: JSON.stringify({ unexpected: "object" }),
+            message_id: "om_message123",
+            message_type: "text",
+          },
+        },
+      }),
+    ).toThrow(/message\.content/u);
+  });
+
+  it("rejects stale callbacks", async () => {
+    const config = await createLocalMockConfig("feishu", "/feishu/webhook");
+    const encryptKey = "encrypt-key";
+    const now = 1_700_000_000_000;
+    config.feishu!.encryptKey = encryptKey;
+    const nativePayload = {
+      event: {
+        message: {
+          chat_id: "oc_abc123",
+          content: JSON.stringify({ text: "hello" }),
+          message_id: "om_duplicate123",
+          message_type: "text",
+        },
+      },
+      header: { event_id: "event-duplicate", token: "sample" },
+      schema: "2.0",
+    };
+    const rawBody = JSON.stringify({
+      encrypt: encryptFeishuPayload(nativePayload, encryptKey),
+    });
+    const authenticate = createFeishuWebhookAuthenticator(config, {}, { now: () => now });
+    const createRequest = (timestamp: number) => {
+      const timestampText = String(timestamp);
+      const nonce = `nonce-${timestampText}`;
+      const signature = createHash("sha256")
+        .update(timestampText + nonce + encryptKey + rawBody)
+        .digest("hex");
+      return new Request("https://feishu.example.test/webhook", {
+        headers: {
+          "x-lark-request-nonce": nonce,
+          "x-lark-request-timestamp": timestampText,
+          "x-lark-signature": signature,
+        },
+      });
+    };
+
+    await expect(authenticate!(createRequest(now / 1_000), rawBody)).resolves.toBeUndefined();
+    await expect(authenticate!(createRequest(now / 1_000 - 301), rawBody)).resolves.toMatchObject({
+      status: 401,
+    });
+    const malformedTimestamp = "not-a-timestamp";
+    const nonce = "nonce-malformed";
+    const signature = createHash("sha256")
+      .update(malformedTimestamp + nonce + encryptKey + rawBody)
+      .digest("hex");
+    await expect(
+      authenticate!(
+        new Request("https://feishu.example.test/webhook", {
+          headers: {
+            "x-lark-request-nonce": nonce,
+            "x-lark-request-timestamp": malformedTimestamp,
+            "x-lark-signature": signature,
+          },
+        }),
+        rawBody,
+      ),
+    ).resolves.toMatchObject({ status: 401 });
+  });
+
+  it("suppresses retries only after successful recorder persistence", async () => {
+    const config = await createLocalMockConfig("feishu", "/feishu/webhook");
+    const encryptKey = "encrypt-key";
+    const now = 1_700_000_000_000;
+    config.feishu!.encryptKey = encryptKey;
+    const provider = new FeishuProviderAdapter("feishu", config, "crabline", {
+      env: {},
+      now: () => now,
+    });
+    const context = createProviderContext("feishu", config, {
+      id: "oc_abc123",
+      metadata: {},
+    });
+    const endpoint = (await provider.probe(context)).details
+      .find((detail) => detail.startsWith("webhook endpoint "))
+      ?.replace("webhook endpoint ", "");
+    expect(endpoint).toBeDefined();
+
+    const send = async (nativePayload: unknown) => {
+      const rawBody = JSON.stringify({
+        encrypt: encryptFeishuPayload(nativePayload, encryptKey),
+      });
+      const timestamp = String(now / 1_000);
+      const nonce = createHash("sha256").update(rawBody).digest("hex").slice(0, 16);
+      const signature = createHash("sha256")
+        .update(timestamp + nonce + encryptKey + rawBody)
+        .digest("hex");
+      return await fetch(endpoint!, {
+        body: rawBody,
+        headers: {
+          "content-type": "application/json",
+          "x-lark-request-nonce": nonce,
+          "x-lark-request-timestamp": timestamp,
+          "x-lark-signature": signature,
+        },
+        method: "POST",
+      });
+    };
+
+    try {
+      const validPayload = {
+        event: {
+          message: {
+            chat_id: "oc_abc123",
+            content: JSON.stringify({ text: "persist once" }),
+            message_id: "om_persist123",
+            message_type: "text",
+          },
+        },
+        header: { event_id: "event-persist" },
+        schema: "2.0",
+      };
+      const concurrentResponses = await Promise.all([send(validPayload), send(validPayload)]);
+      expect(concurrentResponses.map((response) => response.status)).toEqual([200, 200]);
+      expect((await send(validPayload)).status).toBe(200);
+      expect(
+        (await readFile(config.feishu!.recorder.path!, "utf8")).trim().split("\n"),
+      ).toHaveLength(1);
+
+      const rejectedPayload = {
+        event: {
+          message: {
+            content: JSON.stringify({ text: "missing chat" }),
+            message_id: "om_rejected123",
+            message_type: "text",
+          },
+        },
+        header: { event_id: "event-rejected" },
+        schema: "2.0",
+      };
+      expect((await send(rejectedPayload)).status).toBe(400);
+      expect((await send(rejectedPayload)).status).toBe(400);
+    } finally {
+      await provider.cleanup();
+    }
   });
 });
 

--- a/test/googlechat-provider.test.ts
+++ b/test/googlechat-provider.test.ts
@@ -25,6 +25,28 @@ function signedJwt(
 }
 
 describe("Google Chat webhook authentication", () => {
+  it("requires signed identity for externally reachable webhooks", async () => {
+    const config = await createLocalMockConfig("googlechat", "/googlechat/webhook");
+    config.googlechat!.webhook.host = "0.0.0.0";
+    expect(() => new GoogleChatProviderAdapter("googlechat", config, "crabline")).toThrow(
+      /externally reachable webhooks require googlechat\.endpointUrl/u,
+    );
+
+    config.googlechat!.pubsubAudience = "https://chat.example.test/googlechat/webhook";
+    expect(() => new GoogleChatProviderAdapter("googlechat", config, "crabline")).toThrow(
+      /Pub\/Sub service-account identity/u,
+    );
+
+    config.googlechat!.endpointUrl = "https://chat.example.test/googlechat/webhook";
+    config.googlechat!.disableSignatureVerification = true;
+    expect(() => new GoogleChatProviderAdapter("googlechat", config, "crabline")).toThrow(
+      /signature verification enabled/u,
+    );
+
+    config.googlechat!.disableSignatureVerification = false;
+    expect(() => new GoogleChatProviderAdapter("googlechat", config, "crabline")).not.toThrow();
+  });
+
   it("verifies HTTP endpoint audience ID tokens", async () => {
     const config = await createLocalMockConfig("googlechat", "/googlechat/webhook");
     config.googlechat!.endpointUrl = "https://chat.example.test/googlechat/webhook";
@@ -136,9 +158,9 @@ describe("Google Chat webhook authentication", () => {
     ).resolves.toBeUndefined();
   });
 
-  it("uses the configured Pub/Sub audience for push deliveries", async () => {
+  it("defaults the Pub/Sub audience to the endpoint URL", async () => {
     const config = await createLocalMockConfig("googlechat", "/googlechat/webhook");
-    config.googlechat!.pubsubAudience = "https://chat.example.test/pubsub";
+    config.googlechat!.endpointUrl = "https://chat.example.test/pubsub";
     config.googlechat!.pubsubServiceAccountEmail = "chat-push@example.iam.gserviceaccount.com";
     config.googlechat!.useApplicationDefaultCredentials = true;
     const keys = generateKeyPairSync("rsa", { modulusLength: 2048 });
@@ -164,7 +186,7 @@ describe("Google Chat webhook authentication", () => {
     };
     const body = JSON.stringify(pubsubPayload);
     const jwt = signedJwt(keys.privateKey, {
-      aud: config.googlechat!.pubsubAudience,
+      aud: config.googlechat!.endpointUrl,
       email: config.googlechat!.pubsubServiceAccountEmail,
       email_verified: true,
       exp: Math.floor(now / 1000) + 60,
@@ -186,7 +208,7 @@ describe("Google Chat webhook authentication", () => {
     });
 
     const wrongIdentityJwt = signedJwt(keys.privateKey, {
-      aud: config.googlechat!.pubsubAudience,
+      aud: config.googlechat!.endpointUrl,
       email: "other@example.iam.gserviceaccount.com",
       email_verified: true,
       exp: Math.floor(now / 1000) + 60,
@@ -206,6 +228,39 @@ describe("Google Chat webhook authentication", () => {
     expect(
       matchesGoogleChatThread("spaces/AAAABbbbCCC/threads/BBBBccccDDD", "spaces/AAAABbbbCCC"),
     ).toBe(true);
+    expect(
+      matchesGoogleChatThread("spaces/OtherSpace/threads/BBBBccccDDD", undefined, {
+        channelId: "spaces/AAAABbbbCCC",
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects unbound Workspace add-on payloads and cross-space threads", () => {
+    expect(() =>
+      normalizeGoogleChatWebhookPayload({
+        chat: {
+          messagePayload: {
+            message: {
+              name: "spaces/AAAABbbbCCC/messages/msg-native",
+              sender: { type: "HUMAN" },
+              space: { name: "spaces/AAAABbbbCCC" },
+              text: "native event",
+              thread: { name: "spaces/AAAABbbbCCC/threads/BBBBccccDDD" },
+            },
+          },
+        },
+      }),
+    ).toThrow(/unsupported without a configured deployment identity/u);
+
+    expect(() =>
+      normalizeGoogleChatWebhookPayload({
+        message: {
+          space: { name: "spaces/AAAABbbbCCC" },
+          text: "wrong parent",
+          thread: { name: "spaces/OtherSpace/threads/BBBBccccDDD" },
+        },
+      }),
+    ).toThrow(/must belong to message\.space\.name/u);
   });
 });
 

--- a/test/matrix-provider.test.ts
+++ b/test/matrix-provider.test.ts
@@ -4,9 +4,20 @@ import {
   matchesMatrixThread,
   normalizeMatrixWebhookPayload,
 } from "../src/providers/builtin/matrix.js";
-import { runLocalMockProviderContract } from "./local-mock-provider-helpers.js";
+import {
+  createLocalMockConfig,
+  runLocalMockProviderContract,
+} from "./local-mock-provider-helpers.js";
 
 describe("Matrix webhook normalizer", () => {
+  it("rejects externally reachable webhooks without native authentication", async () => {
+    const config = await createLocalMockConfig("matrix", "/matrix/webhook");
+    config.matrix!.webhook.host = "0.0.0.0";
+    expect(() => new MatrixProviderAdapter("matrix", config, "crabline")).toThrow(
+      /provider-native authenticated ingress mode/u,
+    );
+  });
+
   it("uses the room for main-timeline events", () => {
     const payload = {
       content: { body: "hello", msgtype: "m.text" },
@@ -64,6 +75,36 @@ describe("Matrix webhook normalizer", () => {
         channelId: "!abc123:matrix.org",
       }),
     ).toBe(true);
+  });
+
+  it("requires native event identity, type, and thread roots", () => {
+    expect(() =>
+      normalizeMatrixWebhookPayload({
+        content: { body: "missing id", msgtype: "m.text" },
+        room_id: "!abc123:matrix.org",
+        type: "m.room.message",
+      }),
+    ).toThrow(/event_id/u);
+    expect(() =>
+      normalizeMatrixWebhookPayload({
+        content: { body: "wrong type", msgtype: "m.text" },
+        event_id: "$event123:matrix.org",
+        room_id: "!abc123:matrix.org",
+        type: "m.reaction",
+      }),
+    ).toThrow(/type=m\.room\.message/u);
+    expect(() =>
+      normalizeMatrixWebhookPayload({
+        content: {
+          body: "missing root",
+          "m.relates_to": { rel_type: "m.thread" },
+          msgtype: "m.text",
+        },
+        event_id: "$event123:matrix.org",
+        room_id: "!abc123:matrix.org",
+        type: "m.room.message",
+      }),
+    ).toThrow(/m\.thread relation requires event_id/u);
   });
 });
 

--- a/test/msteams-provider.test.ts
+++ b/test/msteams-provider.test.ts
@@ -177,6 +177,24 @@ describe("Microsoft Teams webhook authentication", () => {
         missingChannelBody,
       ),
     ).resolves.toMatchObject({ status: 401 });
+
+    const emptyEndorsementsAuthenticator = createMsTeamsWebhookAuthenticator(config, {
+      fetch: async (input: string | URL | Request) =>
+        String(input).includes("openidconfiguration")
+          ? Response.json({ jwks_uri: "https://login.example.test/keys" })
+          : Response.json({
+              keys: [{ ...jwk, endorsements: [], kid: "test-key" }],
+            }),
+      now: () => now,
+    });
+    await expect(
+      emptyEndorsementsAuthenticator!(
+        new Request(url, {
+          headers: { authorization: `Bearer ${header}.${payload}.${signature}` },
+        }),
+        body,
+      ),
+    ).resolves.toMatchObject({ status: 401 });
   });
 });
 


### PR DESCRIPTION
## Summary
- reject unauthenticated public provider webhooks
- tighten Discord, Feishu, Google Chat, Matrix, and Teams inbound protocol validation
- make Feishu replay ownership persist until explicit request success or failure

## Verification
- local `pnpm verify`: 55 files, 783 tests
- exact-head autoreview: clean (`gpt-5.6-sol`, high)
- GitHub CI: green
- Crabbox `pnpm verify`: run `run_65a457873501`, 55 files, 783 tests

## Changelog
- updated `CHANGELOG.md`