### PR TITLE
fix(automation): harden release and review launchers

### DIFF
--- a/.agents/skills/autoreview/SKILL.md
+++ b/.agents/skills/autoreview/SKILL.md
@@ -121,26 +121,26 @@ On native Windows, choose the matching pair:
 
 ```powershell
 # Project-local skill in the current repo for Codex and other agents:
-$AUTOREVIEW = ".agents\skills\autoreview\scripts\autoreview"
+$AUTOREVIEW = ".agents\skills\autoreview\scripts\autoreview.ps1"
 $AUTOREVIEW_HARNESS = ".agents\skills\autoreview\scripts\test-review-harness.ps1"
 ```
 
 ```powershell
 # Claude Code project-local skill in the current repo:
-$AUTOREVIEW = ".claude\skills\autoreview\scripts\autoreview"
+$AUTOREVIEW = ".claude\skills\autoreview\scripts\autoreview.ps1"
 $AUTOREVIEW_HARNESS = ".claude\skills\autoreview\scripts\test-review-harness.ps1"
 ```
 
 ```powershell
 # Source checkout of openclaw/agent-skills:
-$AUTOREVIEW = "skills\autoreview\scripts\autoreview"
+$AUTOREVIEW = "skills\autoreview\scripts\autoreview.ps1"
 $AUTOREVIEW_HARNESS = "skills\autoreview\scripts\test-review-harness.ps1"
 ```
 
 ```powershell
 # Global skill:
 $AgentsHome = if ($env:AGENTS_HOME) { $env:AGENTS_HOME } else { Join-Path $HOME ".agents" }
-$AUTOREVIEW = Join-Path $AgentsHome "skills\autoreview\scripts\autoreview"
+$AUTOREVIEW = Join-Path $AgentsHome "skills\autoreview\scripts\autoreview.ps1"
 $AUTOREVIEW_HARNESS = Join-Path $AgentsHome "skills\autoreview\scripts\test-review-harness.ps1"
 ```
 
@@ -364,10 +364,10 @@ The smoke harness has thin shell wrappers over a shared Python implementation:
 "$AUTOREVIEW_HARNESS" --fixture benign --engine codex
 ```
 
-On native Windows, invoke the extensionless Python helper through Python:
+On native Windows, invoke the PowerShell wrapper:
 
 ```powershell
-python $AUTOREVIEW --help
+& $AUTOREVIEW --help
 ```
 
 and the smoke harness:

--- a/.agents/skills/autoreview/scripts/autoreview.ps1
+++ b/.agents/skills/autoreview/scripts/autoreview.ps1
@@ -1,0 +1,34 @@
+$ErrorActionPreference = 'Stop'
+
+$Helper = Join-Path $PSScriptRoot 'autoreview'
+$ForwardedArgs = $args
+$Candidates = @(
+    @{ Name = 'py'; Arguments = @('-3') },
+    @{ Name = 'python3'; Arguments = @() },
+    @{ Name = 'python'; Arguments = @() }
+)
+
+foreach ($Candidate in $Candidates) {
+    $Command = Get-Command $Candidate.Name -CommandType Application -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if ($null -eq $Command) {
+        continue
+    }
+
+    $LauncherArgs = $Candidate.Arguments
+    try {
+        & $Command.Source @LauncherArgs -c 'import sys; raise SystemExit(0 if sys.version_info.major == 3 else 1)' *> $null
+    }
+    catch {
+        continue
+    }
+    if ($LASTEXITCODE -ne 0) {
+        continue
+    }
+
+    & $Command.Source @LauncherArgs $Helper @ForwardedArgs
+    exit $LASTEXITCODE
+}
+
+[Console]::Error.WriteLine('Python 3 is required to run autoreview.')
+exit 127

--- a/.agents/skills/autoreview/scripts/test-review-harness
+++ b/.agents/skills/autoreview/scripts/test-review-harness
@@ -4,11 +4,13 @@ set -euo pipefail
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 harness="$script_dir/test-review-harness.py"
 
-if command -v python3 >/dev/null 2>&1; then
+if command -v python3 >/dev/null 2>&1 &&
+  python3 -c 'import sys; raise SystemExit(0 if sys.version_info.major == 3 else 1)' >/dev/null 2>&1; then
   exec python3 "$harness" "$@"
 fi
 
-if command -v python >/dev/null 2>&1; then
+if command -v python >/dev/null 2>&1 &&
+  python -c 'import sys; raise SystemExit(0 if sys.version_info.major == 3 else 1)' >/dev/null 2>&1; then
   exec python "$harness" "$@"
 fi
 

--- a/.agents/skills/autoreview/scripts/test-review-harness.ps1
+++ b/.agents/skills/autoreview/scripts/test-review-harness.ps1
@@ -14,6 +14,11 @@ $ErrorActionPreference = 'Stop'
 
 $Harness = Join-Path $PSScriptRoot 'test-review-harness.py'
 $ForwardedArgs = @()
+$Candidates = @(
+    @{ Name = 'py'; Arguments = @('-3') },
+    @{ Name = 'python3'; Arguments = @() },
+    @{ Name = 'python'; Arguments = @() }
+)
 
 if ($Help) {
     $ForwardedArgs += '--help'
@@ -29,15 +34,25 @@ if ($PSBoundParameters.ContainsKey('Engine')) {
     }
 }
 
-$PyLauncher = Get-Command py -ErrorAction SilentlyContinue
-if ($null -ne $PyLauncher) {
-    & $PyLauncher.Source -3 $Harness @ForwardedArgs
-    exit $LASTEXITCODE
-}
+foreach ($Candidate in $Candidates) {
+    $Command = Get-Command $Candidate.Name -CommandType Application -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if ($null -eq $Command) {
+        continue
+    }
 
-$Python = Get-Command python -ErrorAction SilentlyContinue
-if ($null -ne $Python) {
-    & $Python.Source $Harness @ForwardedArgs
+    $LauncherArgs = $Candidate.Arguments
+    try {
+        & $Command.Source @LauncherArgs -c 'import sys; raise SystemExit(0 if sys.version_info.major == 3 else 1)' *> $null
+    }
+    catch {
+        continue
+    }
+    if ($LASTEXITCODE -ne 0) {
+        continue
+    }
+
+    & $Command.Source @LauncherArgs $Harness @ForwardedArgs
     exit $LASTEXITCODE
 }
 

--- a/.agents/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/.agents/skills/autoreview/tests/test_autoreview_hardening.py
@@ -73,6 +73,69 @@ class AutoreviewHardeningTests(unittest.TestCase):
         for disabled_engine in ("droid", "copilot", "opencode", "cursor"):
             self.assertNotIn(f"'{disabled_engine}'", harness)
 
+    def test_powershell_wrappers_launch_only_verified_python3(self) -> None:
+        scripts = SCRIPT.parent
+        wrappers = {
+            "autoreview.ps1": "autoreview",
+            "test-review-harness.ps1": "test-review-harness.py",
+        }
+
+        for filename, helper in wrappers.items():
+            with self.subTest(filename=filename):
+                wrapper = (scripts / filename).read_text(encoding="utf-8")
+                self.assertIn("@{ Name = 'py'; Arguments = @('-3') }", wrapper)
+                self.assertIn("@{ Name = 'python3'; Arguments = @() }", wrapper)
+                self.assertIn("@{ Name = 'python'; Arguments = @() }", wrapper)
+                self.assertIn("-CommandType Application", wrapper)
+                self.assertIn("sys.version_info.major == 3", wrapper)
+                self.assertIn(f"Join-Path $PSScriptRoot '{helper}'", wrapper)
+
+    @unittest.skipIf(os.name == "nt", "POSIX harness wrapper test")
+    def test_posix_harness_skips_non_python3_fallbacks(self) -> None:
+        harness = SCRIPT.with_name("test-review-harness")
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            bin_dir = root / "bin"
+            bin_dir.mkdir()
+            log_path = root / "launch.log"
+            fake_python3 = bin_dir / "python3"
+            fake_python = bin_dir / "python"
+            fake_python3.write_text(
+                "#!/usr/bin/env bash\n"
+                "if [[ \"$1\" == \"-c\" ]]; then exit 1; fi\n"
+                'printf "python3:%s\\n" "$*" >> "$HARNESS_LOG"\n'
+                "exit 91\n",
+                encoding="utf-8",
+            )
+            fake_python.write_text(
+                "#!/usr/bin/env bash\n"
+                "if [[ \"$1\" == \"-c\" ]]; then exit 0; fi\n"
+                'printf "python:%s\\n" "$*" >> "$HARNESS_LOG"\n'
+                "exit 23\n",
+                encoding="utf-8",
+            )
+            fake_python3.chmod(0o755)
+            fake_python.chmod(0o755)
+
+            result = subprocess.run(
+                [str(harness), "--help"],
+                check=False,
+                env={
+                    **os.environ,
+                    "HARNESS_LOG": str(log_path),
+                    "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+                },
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 23)
+            self.assertEqual(
+                log_path.read_text(encoding="utf-8").splitlines(),
+                [f"python:{harness.with_name('test-review-harness.py')} --help"],
+            )
+
     def test_local_bundle_blocks_sensitive_untracked_file(self) -> None:
         for rel in (".env", "tokens/session.dat", "secrets/local.py"):
             with self.subTest(rel=rel), tempfile.TemporaryDirectory() as tempdir:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Validate workflows
-        run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7
+        # actionlint 1.7.7 predates GitHub's concurrency.queue schema.
+        run: >-
+          go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7
+          -ignore 'unexpected key "queue" for "concurrency" section'
 
       - name: Verify
         run: pnpm verify

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,7 +14,7 @@ jobs:
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: high

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ permissions: {}
 concurrency:
   group: release
   cancel-in-progress: false
+  queue: max
 
 jobs:
   verify:
@@ -92,6 +93,7 @@ jobs:
           registry-url: https://registry.npmjs.org
       - run: npm install -g npm@12.0.1
       - run: pnpm install --frozen-lockfile
+      - run: pnpm build
       - run: pnpm verify
       - name: Pack and verify release artifact
         id: package
@@ -100,7 +102,7 @@ jobs:
         run: |
           set -euo pipefail
           metadata_path="$RUNNER_TEMP/npm-pack.json"
-          npm pack --json --pack-destination "$RUNNER_TEMP" > "$metadata_path"
+          npm pack --ignore-scripts --json --pack-destination "$RUNNER_TEMP" > "$metadata_path"
           node --input-type=module <<'NODE'
           import { execFileSync } from "node:child_process";
           import fs from "node:fs";

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Harden secondary provider adapters with stable pagination, scoped native IDs, immutable diagnostics redaction, Slack edit normalization, and bounded WhatsApp ingress.
 - Harden provider-core webhook hooks, recorder durability and cursor semantics, lazy adapter lifecycle and target parity, and signed-JWT key caching.
+- Harden autoreview launchers and release automation, document trusted script manifests, and canonicalize WhatsApp Cloud targets.
 - Bound signed-JWT key refreshes and authenticate, decode, or suppress Google Chat, Teams, Feishu, and Discord webhook ingress according to provider contracts.
 - Bound recorder tail memory, harden shared provider cleanup and inbound matching, and reject non-global webhook targets.
 - Recover backpressured Signal events without recording rejected RPC calls.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ The `script` adapter can bridge any OpenClaw channel represented by the
 configured `platform` enum by running local commands for `probe`, `send`,
 `waitForInbound`, or `watch`.
 
+Treat manifests that configure `adapter: script` as executable, trusted code:
+Crabline runs their declared commands with the configured environment. Load
+them only from sources you trust and review changes before use.
+
 ## Local Provider Servers
 
 `serve` starts provider-shaped HTTP APIs for OpenClaw live adapters. This is the
@@ -361,7 +365,7 @@ Examples:
 - Slack threads: `1700000000.000100`
 - Telegram chats: `-1001234567890` or `@channelusername`
 - Telegram topics: `42`
-- WhatsApp users: `+15551234567`
+- WhatsApp Cloud API users: digits-only `wa_id` values such as `15551234567`
 - WhatsApp groups: `120363001234567890@g.us`
 - Discord channels and threads: Discord snowflake ids such as
   `123456789012345678`

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -90,6 +90,8 @@ header before JSON parsing or recorder writes:
   tokens, including the activity channel and exact `serviceUrl`. An `appId` is
   required when the webhook host is non-loopback or `publicUrl` is set; an
   unauthenticated webhook remains available only on loopback.
+- Matrix webhook ingress currently has no provider-native authentication mode,
+  so it is restricted to loopback hosts and cannot set `publicUrl`.
 - Feishu `verificationToken` or `FEISHU_VERIFICATION_TOKEN` verifies plaintext
   callback tokens. `encryptKey` or `FEISHU_ENCRYPT_KEY` verifies
   `X-Lark-Signature` and decrypts encrypted event envelopes before challenge
@@ -112,6 +114,10 @@ Script providers use only the `script:` config block. Their required `platform`
 labels the OpenClaw channel represented by the bridge; it does not allow the
 matching built-in block such as `slack:` or `telegram:`. Move any behavior from
 those blocks into the commands or command environment when migrating:
+
+Treat manifests containing script providers as executable, trusted code.
+Crabline runs their declared commands with the configured environment, so load
+them only from sources you trust and review changes before use.
 
 ```yaml
 providers:

--- a/test/ci-workflow.test.ts
+++ b/test/ci-workflow.test.ts
@@ -23,7 +23,10 @@ describe("CI workflow hardening", () => {
       (job) => job.steps?.map((step) => step.run).filter(Boolean) ?? [],
     );
 
-    expect(commands).toContain("go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7");
+    expect(commands).toContain(
+      "go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 " +
+        '-ignore \'unexpected key "queue" for "concurrency" section\'',
+    );
   });
 
   it("pins CodeQL actions to immutable revisions", async () => {

--- a/test/package-production.test.ts
+++ b/test/package-production.test.ts
@@ -389,6 +389,26 @@ describe("production package", () => {
     }
   });
 
+  it("documents trusted script manifests and canonical WhatsApp Cloud targets", async () => {
+    const root = process.cwd();
+    const [readme, channelSetup] = await Promise.all([
+      fs.readFile(path.join(root, "README.md"), "utf8"),
+      fs.readFile(path.join(root, "docs/channel-setup.md"), "utf8"),
+    ]);
+
+    for (const document of [readme, channelSetup]) {
+      expect(document).toContain("executable, trusted code");
+      expect(document).toContain("only from sources you trust");
+    }
+    expect(channelSetup).toContain(
+      "Matrix webhook ingress currently has no provider-native authentication mode",
+    );
+    expect(readme).toContain(
+      "WhatsApp Cloud API users: digits-only `wa_id` values such as `15551234567`",
+    );
+    expect(readme).not.toContain("WhatsApp users: `+15551234567`");
+  });
+
   it("extracts pack metadata around lifecycle output", () => {
     const pack: NpmPackMetadata = {
       filename: "openclaw-crabline-0.1.9.tgz",

--- a/test/release-workflow.test.ts
+++ b/test/release-workflow.test.ts
@@ -22,6 +22,7 @@ type ReleaseWorkflow = {
   concurrency?: {
     "cancel-in-progress"?: boolean;
     group?: string;
+    queue?: string;
   };
   jobs?: Record<
     string,
@@ -86,6 +87,9 @@ describe("release workflow", () => {
     const steps = [...verifySteps, ...publishSteps, ...releaseSteps];
     const commands = steps.map((step) => step.run).filter((run): run is string => Boolean(run));
     const packageStep = verifySteps.find((step) => step.id === "package")?.run;
+    const uploadStep = verifySteps.find((step) =>
+      step.uses?.startsWith("actions/upload-artifact@"),
+    );
     const publishStep = publishSteps.find(
       (step) => step.name === "Publish package with npm provenance",
     )?.run;
@@ -94,6 +98,7 @@ describe("release workflow", () => {
     expect(workflow.concurrency).toEqual({
       "cancel-in-progress": false,
       group: "release",
+      queue: "max",
     });
     expect(
       verifySteps.find((step) => step.uses?.startsWith("actions/setup-node@"))?.with?.[
@@ -108,9 +113,18 @@ describe("release workflow", () => {
       expect(jobCommands).toContain("npm install -g npm@12.0.1");
     }
     expect(commands.some((command) => command.includes("npm@latest"))).toBe(false);
-    expect(packageStep).toContain('npm pack --json --pack-destination "$RUNNER_TEMP"');
+    const verifyCommands = verifySteps
+      .map((step) => step.run)
+      .filter((run): run is string => Boolean(run));
+    expect(verifyCommands.indexOf("pnpm build")).toBeLessThan(
+      verifyCommands.indexOf("pnpm verify"),
+    );
+    expect(packageStep).toContain(
+      'npm pack --ignore-scripts --json --pack-destination "$RUNNER_TEMP"',
+    );
     expect(packageStep).toContain("Packed artifact is missing the crabline CLI");
     expect(packageStep).toContain('execFileSync("tar", ["-xzf", tarballPath');
+    expect(uploadStep?.with?.path).toBe("${{ steps.package.outputs.tarball }}");
     expect(publishStep).toContain('npm view "$PACKAGE_NAME@$RELEASE_VERSION" dist.integrity');
     expect(publishStep).toContain('npm view "$PACKAGE_NAME@latest" version');
     expect(publishStep).toContain('"Refusing to publish " +');
@@ -156,6 +170,20 @@ describe("release workflow", () => {
     for (const actionRef of actionRefs) {
       expect(actionRef).toMatch(/^[^@]+@[0-9a-f]{40}$/u);
     }
+  });
+
+  it("identifies the dependency-review checkout pin as v7", async () => {
+    const contents = await fs.readFile(
+      path.join(process.cwd(), ".github/workflows/dependency-review.yml"),
+      "utf8",
+    );
+
+    expect(contents).toContain(
+      "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0",
+    );
+    expect(contents).not.toContain(
+      "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6",
+    );
   });
 
   it("isolates package verification, OIDC publication, and GitHub release authority", async () => {


### PR DESCRIPTION
## Summary
- harden cross-platform autoreview launchers and release concurrency
- build and verify the exact package tarball before publishing
- document script trust boundaries and Matrix webhook exposure limits

## Verification
- 14 targeted release/package tests
- 29 autoreview harness tests
- format, typecheck, and lint

## Changelog
- updated `CHANGELOG.md`