### PR TITLE
fix(providers): harden provider core behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Harden secondary provider adapters with stable pagination, scoped native IDs, immutable diagnostics redaction, Slack edit normalization, and bounded WhatsApp ingress.
+- Harden provider-core webhook hooks, recorder durability and cursor semantics, lazy adapter lifecycle and target parity, and signed-JWT key caching.
 - Bound signed-JWT key refreshes and authenticate, decode, or suppress Google Chat, Teams, Feishu, and Discord webhook ingress according to provider contracts.
 - Bound recorder tail memory, harden shared provider cleanup and inbound matching, and reject non-global webhook targets.
 - Recover backpressured Signal events without recording rejected RPC calls.

--- a/src/providers/local-mock.ts
+++ b/src/providers/local-mock.ts
@@ -7,7 +7,6 @@ import {
   createRecordedInboundCursor,
   waitForRecordedInbound,
   watchRecordedInbound,
-  type RecordedInboundEnvelope,
   type RecordedInboundCursor,
 } from "./recorder.js";
 import type {
@@ -46,7 +45,11 @@ export type LocalMockAdapterOptions = {
     target: NormalizedTarget,
     raw?: unknown,
   ) => boolean;
-  handleWebhookPayload?: (payload: unknown) => Promise<Response | undefined> | Response | undefined;
+  handleWebhookPayload?: (
+    payload: unknown,
+    request: Request,
+    rawBody: string,
+  ) => Promise<Response | undefined> | Response | undefined;
   normalizeWebhookPayload?: (payload: unknown) => unknown;
   platform: ProviderPlatform;
   publicUrl?: string | undefined;
@@ -60,6 +63,22 @@ type WaitCursorState = {
   active: number;
   cursor?: RecordedInboundCursor | undefined;
 };
+
+function cursorHasAdvanced(
+  candidate: RecordedInboundCursor,
+  current: RecordedInboundCursor | undefined,
+): boolean {
+  if (!current) {
+    return true;
+  }
+  if (candidate.readState.generation !== current.readState.generation) {
+    return candidate.readState.generation > current.readState.generation;
+  }
+  if (candidate.readState.offset !== current.readState.offset) {
+    return candidate.readState.offset > current.readState.offset;
+  }
+  return candidate.buffered.length < current.buffered.length;
+}
 
 function pruneInactiveWaitCursors(cursors: Map<string, WaitCursorState>): void {
   for (const [key, state] of cursors) {
@@ -174,18 +193,6 @@ function normalizeWebhookPayload(payload: unknown): MockWebhookPayload {
 
 function mockReplyText(params: { platform: ProviderPlatform; text: string }) {
   return `[${params.platform} mock] ${params.text}`;
-}
-
-function isOutboundRecord(event: RecordedInboundEnvelope): boolean {
-  if (event.recordedDirection !== undefined) {
-    return event.recordedDirection === "outbound";
-  }
-  return (
-    event.raw !== null &&
-    typeof event.raw === "object" &&
-    "direction" in event.raw &&
-    event.raw.direction === "outbound"
-  );
 }
 
 export class LocalMockProviderAdapter implements ProviderAdapter {
@@ -331,7 +338,6 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
         filePath: this.#recorderPath,
         matches: (candidate) =>
           candidate.provider === this.id &&
-          !isOutboundRecord(candidate) &&
           (expectedAuthor === "any" || candidate.author === expectedAuthor) &&
           (this.#options.matchesThread ?? isAddressInChannel)(
             candidate.threadId,
@@ -339,11 +345,15 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
             target,
             candidate.raw,
           ),
+        recordedDirection: "inbound",
         since: context.since,
         signal,
         timeoutMs: context.timeoutMs,
       });
-      if (event && this.#waitCursors.get(cursorKey) === cursorState) {
+      if (
+        this.#waitCursors.get(cursorKey) === cursorState &&
+        cursorHasAdvanced(cursor, cursorState.cursor)
+      ) {
         cursorState.cursor = cursor;
       }
       return event;
@@ -368,13 +378,13 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
       filePath: this.#recorderPath,
       matches: (entry) =>
         entry.provider === this.id &&
-        !isOutboundRecord(entry) &&
         (this.#options.matchesThread ?? isAddressInChannel)(
           entry.threadId,
           target.threadId ?? target.channelId,
           target,
           entry.raw,
         ),
+      recordedDirection: "inbound",
       signal,
       since: context.since,
     })) {
@@ -407,10 +417,6 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
     if (this.#cleanupBegun) {
       return new Response("provider is shutting down", { status: 503 });
     }
-    const mediaType = request.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase();
-    if (mediaType !== "application/json") {
-      return new Response("expected application/json", { status: 415 });
-    }
     const rawBody = await request.text();
     const authenticationFailure = await this.#options.authenticateWebhookRequest?.(
       request,
@@ -419,15 +425,23 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
     if (authenticationFailure) {
       return authenticationFailure;
     }
+    const mediaType = request.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase();
     let rawPayload: unknown;
-    try {
-      rawPayload = JSON.parse(rawBody) as unknown;
-    } catch {
-      return new Response("invalid JSON", { status: 400 });
+    if (mediaType === "application/json") {
+      try {
+        rawPayload = JSON.parse(rawBody) as unknown;
+      } catch {
+        return new Response("invalid JSON", { status: 400 });
+      }
+    } else {
+      rawPayload = rawBody;
     }
-    const directResponse = await this.#options.handleWebhookPayload?.(rawPayload);
+    const directResponse = await this.#options.handleWebhookPayload?.(rawPayload, request, rawBody);
     if (directResponse) {
       return directResponse;
+    }
+    if (mediaType !== "application/json") {
+      return new Response("expected application/json", { status: 415 });
     }
     let payload: MockWebhookPayload;
     try {

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -112,7 +112,12 @@ export function cloneRecordedInboundCursor(cursor: RecordedInboundCursor): Recor
 }
 
 function rememberRecentRecord(seen: Set<string>, event: InboundEnvelope): boolean {
-  const key = JSON.stringify([event.provider, event.threadId, event.id]);
+  const key = JSON.stringify([
+    event.provider,
+    event.threadId,
+    event.id,
+    recordedDirectionOf(event),
+  ]);
   if (seen.has(key)) {
     return false;
   }
@@ -121,6 +126,64 @@ function rememberRecentRecord(seen: Set<string>, event: InboundEnvelope): boolea
     seen.delete(seen.values().next().value!);
   }
   return true;
+}
+
+function recordedDirectionOf(
+  event: Pick<RecordableInboundEnvelope, "raw" | "recordedDirection">,
+): "inbound" | "outbound" {
+  if (event.recordedDirection) {
+    return event.recordedDirection;
+  }
+  return event.raw !== null &&
+    typeof event.raw === "object" &&
+    "direction" in event.raw &&
+    event.raw.direction === "outbound"
+    ? "outbound"
+    : "inbound";
+}
+
+function requireNonEmptyString(value: unknown, field: keyof RecordedInboundEnvelope): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`Recorded inbound envelope ${field} must be a non-empty string.`);
+  }
+  return value;
+}
+
+function requireString(value: unknown, field: keyof RecordedInboundEnvelope): string {
+  if (typeof value !== "string") {
+    throw new Error(`Recorded inbound envelope ${field} must be a string.`);
+  }
+  return value;
+}
+
+function parseRecordedEnvelope(value: unknown): RecordedInboundEnvelope {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Recorded inbound envelope must be an object.");
+  }
+  const record = value as Record<string, unknown>;
+  if (record.author !== "assistant" && record.author !== "system" && record.author !== "user") {
+    throw new Error("Recorded inbound envelope author must be assistant, system, or user.");
+  }
+  if (
+    record.recordedDirection !== undefined &&
+    record.recordedDirection !== "inbound" &&
+    record.recordedDirection !== "outbound"
+  ) {
+    throw new Error("Recorded inbound envelope recordedDirection must be inbound or outbound.");
+  }
+  return {
+    author: record.author,
+    id: requireNonEmptyString(record.id, "id"),
+    provider: requireNonEmptyString(record.provider, "provider"),
+    ...(record.raw !== undefined ? { raw: record.raw } : {}),
+    recordedAt: requireNonEmptyString(record.recordedAt, "recordedAt"),
+    ...(record.recordedDirection !== undefined
+      ? { recordedDirection: record.recordedDirection }
+      : {}),
+    sentAt: requireNonEmptyString(record.sentAt, "sentAt"),
+    text: requireString(record.text, "text"),
+    threadId: requireNonEmptyString(record.threadId, "threadId"),
+  };
 }
 
 function parseRecordedLine(line: string): RecordedInboundEnvelope[] {
@@ -136,9 +199,9 @@ function parseRecordedLine(line: string): RecordedInboundEnvelope[] {
     "events" in parsed &&
     Array.isArray(parsed.events)
   ) {
-    return parsed.events as RecordedInboundEnvelope[];
+    return parsed.events.map(parseRecordedEnvelope);
   }
-  return [parsed as RecordedInboundEnvelope];
+  return [parseRecordedEnvelope(parsed)];
 }
 
 function resetIncrementalReadState(state: IncrementalReadState): void {
@@ -212,7 +275,7 @@ function consumeRecordedChunk(
 
 async function appendJsonLine(filePath: string, line: string): Promise<void> {
   await serializeAppend(filePath, async (publicationPath, logicalPath) => {
-    await appendCommittedLine(publicationPath, logicalPath, line, false);
+    await appendCommittedLine(publicationPath, logicalPath, line, true);
   });
 }
 
@@ -461,6 +524,7 @@ async function readRecordedInboundAppend(
     const stats = await handle.stat();
     const identity = { dev: stats.dev, ino: stats.ino };
     const sameFile = state.identity?.dev === identity.dev && state.identity.ino === identity.ino;
+    const rotated = state.identity !== undefined && !sameFile;
     let hasContinuity = stats.size >= state.offset;
 
     if (hasContinuity && state.offset > 0 && state.continuity.length === 0) {
@@ -476,6 +540,8 @@ async function readRecordedInboundAppend(
 
     if (!hasContinuity) {
       resetIncrementalReadState(state);
+    } else if (rotated) {
+      state.generation += 1;
     }
     state.identity = identity;
 
@@ -513,7 +579,13 @@ export async function appendRecordedInbound(
     recordedAt: new Date().toISOString(),
   } satisfies RecordedInboundEnvelope;
 
-  await appendJsonLine(filePath, `${JSON.stringify(recorded)}\n`);
+  const line = `${JSON.stringify(recorded)}\n`;
+  if (Buffer.byteLength(line) > MAX_PENDING_RECORD_BYTES) {
+    throw new Error(
+      `Recorder record exceeded ${MAX_PENDING_RECORD_BYTES} bytes without a newline.`,
+    );
+  }
+  await appendJsonLine(filePath, line);
   return recorded;
 }
 
@@ -575,8 +647,8 @@ export async function appendRecordedInboundBatch(
   }
 }
 
-function recordIdentity(event: Pick<InboundEnvelope, "id" | "provider" | "threadId">): string {
-  return JSON.stringify([event.provider, event.threadId, event.id]);
+function recordIdentity(event: RecordableInboundEnvelope): string {
+  return JSON.stringify([event.provider, event.threadId, event.id, recordedDirectionOf(event)]);
 }
 
 async function syncRecordIdentityIndex(filePath: string): Promise<Set<string>> {
@@ -633,8 +705,11 @@ export async function readRecordedInbound(filePath: string): Promise<RecordedInb
   if (tail.trim()) {
     try {
       events.push(...parseRecordedLine(tail));
-    } catch {
-      // Ignore a partial final append; completed lines remain strict.
+    } catch (error) {
+      if (!(error instanceof SyntaxError)) {
+        throw error;
+      }
+      // Ignore a syntactically partial final append; completed lines remain strict.
     }
   }
 
@@ -646,6 +721,7 @@ export async function waitForRecordedInbound(params: {
   filePath: string;
   matches: (event: RecordedInboundEnvelope) => boolean;
   pollMs?: number;
+  recordedDirection?: "inbound" | "outbound" | undefined;
   signal?: AbortSignal | undefined;
   since?: string | undefined;
   timeoutMs: number;
@@ -654,11 +730,18 @@ export async function waitForRecordedInbound(params: {
   const cursor = params.cursor ?? createRecordedInboundCursor();
 
   while (!params.signal?.aborted && Date.now() <= deadline) {
+    const generation = cursor.readState.generation;
     const events =
       cursor.buffered.length > 0
         ? cursor.buffered.splice(0)
         : await readRecordedInboundAppend(params.filePath, cursor.readState);
+    if (cursor.readState.generation !== generation) {
+      cursor.seen.clear();
+    }
     for (const [index, event] of events.entries()) {
+      if (params.recordedDirection && recordedDirectionOf(event) !== params.recordedDirection) {
+        continue;
+      }
       // Incremental read state owns progress; this bounded window only filters appended retries.
       if (!rememberRecentRecord(cursor.seen, event)) {
         continue;
@@ -693,6 +776,7 @@ export async function* watchRecordedInbound(params: {
   filePath: string;
   matches: (event: RecordedInboundEnvelope) => boolean;
   pollMs?: number;
+  recordedDirection?: "inbound" | "outbound" | undefined;
   signal?: AbortSignal | undefined;
   since?: string | undefined;
 }): AsyncIterable<RecordedInboundEnvelope> {
@@ -700,7 +784,11 @@ export async function* watchRecordedInbound(params: {
   const seen = new Set<string>();
 
   while (!params.signal?.aborted) {
+    const generation = state.generation;
     const events = await readRecordedInboundAppend(params.filePath, state);
+    if (state.generation !== generation) {
+      seen.clear();
+    }
     if (params.signal?.aborted) {
       return;
     }
@@ -709,6 +797,9 @@ export async function* watchRecordedInbound(params: {
         return;
       }
       if (!rememberRecentRecord(seen, event)) {
+        continue;
+      }
+      if (params.recordedDirection && recordedDirectionOf(event) !== params.recordedDirection) {
         continue;
       }
       if (params.since && new Date(event.sentAt).getTime() < new Date(params.since).getTime()) {

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -138,7 +138,6 @@ export class LazyProviderAdapter implements ProviderAdapter {
   readonly status;
   readonly supports;
 
-  readonly #adapterName: string;
   readonly #factory: ProviderFactory;
   readonly #normalizeTarget: ProviderAdapter["normalizeTarget"];
   readonly #activeWatches = new Set<ActiveWatch>();
@@ -157,7 +156,6 @@ export class LazyProviderAdapter implements ProviderAdapter {
     status: ProviderSupportStatus;
     supports: ProviderAdapter["supports"];
   }) {
-    this.#adapterName = params.adapterName;
     this.#factory = params.factory;
     this.#normalizeTarget = params.normalizeTarget;
     this.id = params.id;
@@ -215,18 +213,40 @@ export class LazyProviderAdapter implements ProviderAdapter {
       this.#activeWatches.delete(activeWatch);
     };
     const close = () => {
+      if (closed) {
+        return Promise.resolve({ done: true as const, value: undefined as never });
+      }
       closePromise ??= (async () => {
         controller.abort();
         try {
-          return source.return
+          const result = source.return
             ? await source.return()
             : { done: true as const, value: undefined as never };
+          if (result.done) {
+            finish();
+          }
+          return result;
+        } catch (error) {
+          finish();
+          throw error;
         } finally {
           dispatch.reach();
-          finish();
         }
       })();
-      return closePromise;
+      const closing = closePromise;
+      void closing.then(
+        () => {
+          if (closePromise === closing) {
+            closePromise = null;
+          }
+        },
+        () => {
+          if (closePromise === closing) {
+            closePromise = null;
+          }
+        },
+      );
+      return closing;
     };
     const iterator: AsyncIterableIterator<InboundEnvelope> = {
       async next() {
@@ -260,7 +280,9 @@ export class LazyProviderAdapter implements ProviderAdapter {
     activeWatch = {
       abort: () => controller.abort(),
       close: async () => {
-        await close();
+        while (!(await close()).done) {
+          // Async iterators may yield final values before acknowledging return.
+        }
       },
       dispatch,
     };
@@ -315,10 +337,7 @@ export class LazyProviderAdapter implements ProviderAdapter {
       })
       .catch((error: unknown) => {
         this.#providerPromise = null;
-        throw new CrablineError(
-          `Provider adapter "${this.#adapterName}" could not load. Install its optional peer dependencies before using this adapter.`,
-          { cause: error, kind: "config" },
-        );
+        throw error;
       });
     return await this.#providerPromise;
   }

--- a/src/providers/signed-jwt.ts
+++ b/src/providers/signed-jwt.ts
@@ -51,12 +51,16 @@ export function resolveHttpCacheExpiry(response: Response, now: number): number 
   if (/(?:^|,)\s*(?:no-cache|no-store)(?:\s*(?:=|,|$))/iu.test(cacheControl ?? "")) {
     return now;
   }
+  const ageHeader = response.headers.get("age");
+  const ageSeconds = ageHeader && /^\d+$/u.test(ageHeader) ? Number.parseInt(ageHeader, 10) : 0;
   const maxAge = /(?:^|,)\s*max-age=(\d+)/iu.exec(cacheControl ?? "");
   if (maxAge) {
-    return now + Number(maxAge[1]) * 1_000;
+    return now + Math.max(0, Number(maxAge[1]) - ageSeconds) * 1_000;
   }
   const expires = Date.parse(response.headers.get("expires") ?? "");
-  return Number.isFinite(expires) && expires > now ? expires : now + 60 * 60 * 1_000;
+  return Number.isFinite(expires) && expires > now
+    ? expires
+    : now + Math.max(0, 60 * 60 - ageSeconds) * 1_000;
 }
 
 export function createCachedJwtKeyResolver<T>(params: {
@@ -74,6 +78,8 @@ export function createCachedJwtKeyResolver<T>(params: {
   let fetchInFlight: Promise<RemoteJwtKeySet<T>> | undefined;
   let refreshInFlight: Promise<RemoteJwtKeySet<T>> | undefined;
   let refreshCooldownUntil = 0;
+  let fetchFailureCooldownUntil = 0;
+  let fetchFailureError: unknown;
   const negativeKeyIds = new Map<string, number>();
 
   const rejectUnknownKey = (kid: string, expiresAt: number): never => {
@@ -96,6 +102,9 @@ export function createCachedJwtKeyResolver<T>(params: {
     if (fetchInFlight) {
       return await fetchInFlight;
     }
+    if (fetchFailureCooldownUntil > now()) {
+      throw fetchFailureError;
+    }
     const controller = new AbortController();
     let timeout: NodeJS.Timeout | undefined;
     const timedOut = new Promise<never>((_, reject) => {
@@ -107,7 +116,20 @@ export function createCachedJwtKeyResolver<T>(params: {
     fetchInFlight = Promise.race([params.fetchKeys(controller.signal), timedOut])
       .then((keySet) => {
         cached = keySet.expiresAt > now() ? keySet : undefined;
+        fetchFailureCooldownUntil = 0;
+        fetchFailureError = undefined;
+        for (const value of keySet.values) {
+          const keyId = params.keyId(value);
+          if (keyId) {
+            negativeKeyIds.delete(keyId);
+          }
+        }
         return keySet;
+      })
+      .catch((error: unknown) => {
+        fetchFailureCooldownUntil = now() + refreshCooldownMs;
+        fetchFailureError = error;
+        throw error;
       })
       .finally(() => {
         if (timeout) {

--- a/src/providers/target-normalizers.ts
+++ b/src/providers/target-normalizers.ts
@@ -153,6 +153,15 @@ export function createGenericLocalMockTargetCodec(
       }
       if (target.threadId) {
         normalized.channelId ??= encode(target.id);
+        if (
+          target.threadId.startsWith(prefix) &&
+          !target.threadId.startsWith(`${normalized.channelId}:`)
+        ) {
+          throw new CrablineError(
+            `${platform} canonical thread parent must match the target channel.`,
+            { kind: "config" },
+          );
+        }
         normalized.threadId = target.threadId.startsWith(prefix)
           ? target.threadId
           : `${normalized.channelId}:${target.threadId}`;

--- a/test/local-mock-provider.test.ts
+++ b/test/local-mock-provider.test.ts
@@ -1,4 +1,4 @@
-import { appendFile, readFile } from "node:fs/promises";
+import { appendFile, open, readFile, writeFile, type FileHandle } from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ManifestDefinition, ProviderConfig } from "../src/config/schema.js";
@@ -315,6 +315,80 @@ describe("local mock provider", () => {
       ).rejects.toThrow(/sensitive/u);
     },
   );
+
+  it.each([
+    {
+      body: undefined,
+      contentType: undefined,
+      expectedPayload: "",
+      method: "GET",
+    },
+    {
+      body: "provider challenge",
+      contentType: "text/plain",
+      expectedPayload: "provider challenge",
+      method: "POST",
+    },
+  ])("lets provider hooks intercept $method non-JSON requests", async (requestCase) => {
+    let handleRequest: ((request: Request) => Promise<Response>) | undefined;
+    webhookMocks.startWebhookServer.mockImplementationOnce(async (params) => {
+      handleRequest = params.handle;
+      return {
+        async close() {},
+        endpointUrl: "http://127.0.0.1:43210/slack/events",
+      };
+    });
+    const authenticate = vi.fn(() => undefined);
+    const handlePayload = vi.fn(
+      (payload: unknown, request: Request, rawBody: string) =>
+        new Response(
+          JSON.stringify({
+            method: request.method,
+            payload,
+            rawBody,
+          }),
+          { status: 202 },
+        ),
+    );
+    const config = createConfig();
+    const provider = new LocalMockProviderAdapter({
+      codec: createGenericLocalMockTargetCodec("slack"),
+      config,
+      id: "provider-a",
+      options: {
+        authenticateWebhookRequest: authenticate,
+        defaultWebhook: { host: "127.0.0.1", path: "/slack/events", port: 0 },
+        endpointLabel: "events endpoint",
+        handleWebhookPayload: handlePayload,
+        platform: "slack",
+      },
+    });
+    providers.push(provider);
+    await provider.probe(createContext(config));
+
+    const response = await handleRequest!(
+      new Request("http://127.0.0.1:43210/slack/events?challenge=1", {
+        ...(requestCase.body === undefined ? {} : { body: requestCase.body }),
+        ...(requestCase.contentType
+          ? { headers: { "content-type": requestCase.contentType } }
+          : {}),
+        method: requestCase.method,
+      }),
+    );
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toEqual({
+      method: requestCase.method,
+      payload: requestCase.expectedPayload,
+      rawBody: requestCase.expectedPayload,
+    });
+    expect(authenticate).toHaveBeenCalledWith(expect.any(Request), requestCase.expectedPayload);
+    expect(handlePayload).toHaveBeenCalledWith(
+      requestCase.expectedPayload,
+      expect.any(Request),
+      requestCase.expectedPayload,
+    );
+  });
 
   it("rejects malformed normalized webhook envelopes", async () => {
     let handleRequest: ((request: Request) => Promise<Response>) | undefined;
@@ -666,6 +740,139 @@ describe("local mock provider", () => {
       },
     });
     await iterator.return?.();
+  });
+
+  it("keeps inbound and outbound records with the same provider id distinct", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const recorderPath = path.join(directory, "same-id-directions.jsonl");
+    const config = createConfig();
+    const provider = new LocalMockProviderAdapter({
+      codec: createGenericLocalMockTargetCodec("slack"),
+      config,
+      id: "provider-a",
+      options: {
+        defaultWebhook: { host: "127.0.0.1", path: "/slack/events", port: 0 },
+        endpointLabel: "events endpoint",
+        platform: "slack",
+        recorderPath,
+      },
+    });
+    providers.push(provider);
+    const context = createContext(config);
+    context.fixture.inboundMatch.author = "any";
+    const sentAt = new Date().toISOString();
+    for (const recordedDirection of ["outbound", "inbound"] as const) {
+      await appendRecordedInbound(recorderPath, {
+        author: recordedDirection === "outbound" ? "user" : "assistant",
+        id: "shared-id",
+        provider: "provider-a",
+        recordedDirection,
+        sentAt,
+        text: recordedDirection,
+        threadId: "slack:C1234567890",
+      });
+    }
+
+    await expect(
+      provider.waitForInbound({
+        ...context,
+        nonce: "direction",
+        since: new Date(0).toISOString(),
+        threadId: "slack:C1234567890",
+        timeoutMs: 100,
+      }),
+    ).resolves.toMatchObject({
+      id: "shared-id",
+      recordedDirection: "inbound",
+      text: "inbound",
+    });
+  });
+
+  it("persists incremental cursor progress after a timeout", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const recorderPath = path.join(directory, "timeout-progress.jsonl");
+    const now = new Date().toISOString();
+    await writeFile(
+      recorderPath,
+      Array.from(
+        { length: 10_000 },
+        (_, index) =>
+          `${JSON.stringify({
+            author: "user",
+            id: `history-${index}`,
+            provider: "provider-a",
+            recordedAt: now,
+            sentAt: now,
+            text: "history",
+            threadId: "slack:C1234567890",
+          })}\n`,
+      ).join(""),
+      "utf8",
+    );
+    const config = createConfig();
+    const provider = new LocalMockProviderAdapter({
+      codec: createGenericLocalMockTargetCodec("slack"),
+      config,
+      id: "provider-a",
+      options: {
+        defaultWebhook: { host: "127.0.0.1", path: "/slack/events", port: 0 },
+        endpointLabel: "events endpoint",
+        platform: "slack",
+        recorderPath,
+      },
+    });
+    providers.push(provider);
+    const context = {
+      ...createContext(config),
+      nonce: "timeout-progress",
+      since: new Date(0).toISOString(),
+      threadId: "slack:C1234567890",
+      timeoutMs: 5,
+    };
+
+    const probeHandle = await open(recorderPath, "r");
+    const fileHandlePrototype = Object.getPrototypeOf(probeHandle);
+    await probeHandle.close();
+    const originalRead = fileHandlePrototype.read;
+    let phase = 0;
+    const positions: number[][] = [[], []];
+    fileHandlePrototype.read = async function (
+      this: FileHandle,
+      buffer: Uint8Array,
+      offset?: number | null,
+      length?: number | null,
+      position?: number | null,
+    ) {
+      positions[phase]!.push(position ?? -1);
+      const result = await originalRead.call(this, buffer, offset, length, position);
+      await sleep(2);
+      return result;
+    };
+
+    try {
+      await expect(provider.waitForInbound(context)).resolves.toBeNull();
+      phase = 1;
+      await expect(provider.waitForInbound(context)).resolves.toBeNull();
+      expect(positions[0]?.[0]).toBe(0);
+      expect(positions[1]?.[0]).toBeGreaterThan(0);
+    } finally {
+      fileHandlePrototype.read = originalRead;
+    }
+  });
+
+  it("rejects canonical generic threads whose parent differs from the target channel", () => {
+    const codec = createGenericLocalMockTargetCodec("loopback");
+
+    expect(() =>
+      codec.normalize({
+        channelId: "room-a",
+        id: "room-a",
+        metadata: {},
+        threadId: "loopback:room-b:topic",
+      }),
+    ).toThrow(/thread parent must match the target channel/u);
   });
 
   it("bounds successful wait cursors while retaining recent progress", async () => {

--- a/test/recorder-concurrency.test.ts
+++ b/test/recorder-concurrency.test.ts
@@ -6,6 +6,7 @@ import { recordServerEvent } from "../src/servers/recorder.js";
 
 const fsMocks = vi.hoisted(() => ({
   appendFile: vi.fn<(filePath: string, data: string, encoding: string) => Promise<void>>(),
+  providerSync: vi.fn<(filePath: string) => Promise<void>>(),
   providerWrite: vi.fn<(filePath: string, data: string) => Promise<void>>(),
 }));
 
@@ -17,6 +18,9 @@ vi.mock("node:fs/promises", async (importOriginal) => {
     open: async (...args: Parameters<typeof actual.open>) => {
       const handle = await actual.open(...args);
       if (args[1] === "a+" && String(args[0]).includes("crabline-provider-recorder")) {
+        handle.sync = async () => {
+          await fsMocks.providerSync(String(args[0]));
+        };
         handle.writeFile = async (data) => {
           await fsMocks.providerWrite(String(args[0]), String(data));
         };
@@ -36,6 +40,8 @@ let pendingWrites: PendingWrite[] = [];
 beforeEach(() => {
   pendingWrites = [];
   fsMocks.appendFile.mockReset();
+  fsMocks.providerSync.mockReset();
+  fsMocks.providerSync.mockResolvedValue(undefined);
   fsMocks.providerWrite.mockReset();
   fsMocks.appendFile.mockImplementation(
     async (_filePath, data) =>
@@ -130,6 +136,7 @@ describe("recorder append serialization", () => {
         expect.objectContaining({ id: "first" }),
         expect.objectContaining({ id: "second" }),
       ]);
+      expect(fsMocks.providerSync).toHaveBeenCalledTimes(2);
     } finally {
       await rm(recorderPath, { force: true });
     }

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -62,6 +62,131 @@ describe("recorder", () => {
     expect(events[0]?.text).toBe("hello");
   });
 
+  it("round-trips empty message text", async () => {
+    const filePath = await createRecorderPath();
+    const recorded = await appendRecordedInbound(filePath, {
+      author: "assistant",
+      id: "empty-text",
+      provider: "slack",
+      sentAt: new Date().toISOString(),
+      text: "",
+      threadId: "slack:C123",
+    });
+
+    await expect(readRecordedInbound(filePath)).resolves.toEqual([recorded]);
+  });
+
+  it("rejects an oversized single append before it reaches the recorder", async () => {
+    const filePath = await createRecorderPath();
+    const event = {
+      author: "assistant" as const,
+      id: "oversized-single",
+      provider: "slack",
+      sentAt: new Date().toISOString(),
+      text: "x".repeat(4 * 1024 * 1024),
+      threadId: "slack:C123",
+    };
+
+    await expect(appendRecordedInbound(filePath, event)).rejects.toThrow(
+      "Recorder record exceeded",
+    );
+    await expect(
+      appendRecordedInbound(filePath, { ...event, id: "after-oversized", text: "small" }),
+    ).resolves.toMatchObject({ id: "after-oversized" });
+    await expect(readRecordedInbound(filePath)).resolves.toEqual([
+      expect.objectContaining({ id: "after-oversized" }),
+    ]);
+  });
+
+  it("deduplicates inbound and outbound directions independently", async () => {
+    const filePath = await createRecorderPath();
+    const cursor = createRecordedInboundCursor();
+    const sentAt = new Date().toISOString();
+    const base = {
+      id: "same-id",
+      provider: "slack",
+      sentAt,
+      threadId: "slack:C123",
+    };
+    const outbound = await appendRecordedInbound(filePath, {
+      ...base,
+      author: "user",
+      recordedDirection: "outbound",
+      text: "outbound",
+    });
+    const inbound = await appendRecordedInbound(filePath, {
+      ...base,
+      author: "assistant",
+      recordedDirection: "inbound",
+      text: "inbound",
+    });
+
+    await expect(
+      waitForRecordedInbound({ cursor, filePath, matches: () => true, timeoutMs: 30 }),
+    ).resolves.toEqual(outbound);
+    await expect(
+      waitForRecordedInbound({ cursor, filePath, matches: () => true, timeoutMs: 30 }),
+    ).resolves.toEqual(inbound);
+    await expect(
+      waitForRecordedInbound({
+        filePath,
+        matches: () => true,
+        recordedDirection: "inbound",
+        timeoutMs: 30,
+      }),
+    ).resolves.toEqual(inbound);
+  });
+
+  it("clears cursor deduplication when the recorder generation changes", async () => {
+    const filePath = await createRecorderPath();
+    const cursor = createRecordedInboundCursor();
+    const event = {
+      author: "assistant" as const,
+      id: "reused-after-rotation",
+      provider: "slack",
+      sentAt: new Date().toISOString(),
+      text: "first generation",
+      threadId: "slack:C123",
+    };
+    await appendRecordedInbound(filePath, event);
+    await expect(
+      waitForRecordedInbound({ cursor, filePath, matches: () => true, timeoutMs: 30 }),
+    ).resolves.toMatchObject({ text: "first generation" });
+
+    await rename(filePath, `${filePath}.old`);
+    await appendRecordedInbound(filePath, { ...event, text: "second generation" });
+
+    await expect(
+      waitForRecordedInbound({ cursor, filePath, matches: () => true, timeoutMs: 30 }),
+    ).resolves.toMatchObject({ text: "second generation" });
+  });
+
+  it("runtime-validates parsed recorder envelopes", async () => {
+    const filePath = await createRecorderPath();
+    await writeFile(
+      filePath,
+      `${JSON.stringify({
+        author: "assistant",
+        id: "invalid-envelope",
+        provider: "slack",
+        recordedAt: new Date().toISOString(),
+        sentAt: new Date().toISOString(),
+        text: 42,
+        threadId: "slack:C123",
+      })}\n`,
+      "utf8",
+    );
+
+    await expect(readRecordedInbound(filePath)).rejects.toThrow(/envelope text must be a string/u);
+    await expect(
+      waitForRecordedInbound({
+        filePath,
+        matches: () => true,
+        timeoutMs: 30,
+      }),
+    ).rejects.toThrow(/envelope text must be a string/u);
+  });
+
   it("appends retry-idempotent batches without partial duplicates", async () => {
     const filePath = await createRecorderPath();
     const sentAt = new Date().toISOString();

--- a/test/registry-lifecycle.test.ts
+++ b/test/registry-lifecycle.test.ts
@@ -878,4 +878,95 @@ describe("lazy provider lifecycle", () => {
     });
     expect(cleanup).toHaveBeenCalledOnce();
   });
+
+  it("keeps a lazy watch active when the source return reports done false", async () => {
+    const { context } = createTelegramManifest("/tmp/unused.jsonl");
+    const event = (id: string) => ({
+      author: "assistant" as const,
+      id,
+      provider: "test",
+      sentAt: new Date().toISOString(),
+      text: id,
+      threadId: "thread",
+    });
+    let returnCalls = 0;
+    const concrete: ProviderAdapter = {
+      id: "test",
+      platform: "loopback",
+      status: "ready",
+      supports: ["agent"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      async probe() {
+        return { details: [], healthy: true };
+      },
+      async send() {
+        return { accepted: true, messageId: "sent", threadId: "thread" };
+      },
+      async waitForInbound() {
+        return null;
+      },
+      watch() {
+        return {
+          [Symbol.asyncIterator]() {
+            return {
+              async next() {
+                return { done: false as const, value: event("watch-event") };
+              },
+              async return() {
+                returnCalls += 1;
+                return returnCalls === 1
+                  ? { done: false as const, value: event("return-value") }
+                  : { done: true as const, value: undefined };
+              },
+            };
+          },
+        };
+      },
+    };
+    const provider = new LazyProviderAdapter({
+      adapterName: "test",
+      factory: async () => concrete,
+      id: "test",
+      normalizeTarget: concrete.normalizeTarget.bind(concrete),
+      platform: "loopback",
+      status: "ready",
+      supports: ["agent"],
+    });
+    const iterator = provider.watch(context)[Symbol.asyncIterator]();
+
+    await expect(iterator.next()).resolves.toMatchObject({
+      done: false,
+      value: { id: "watch-event" },
+    });
+    await expect(iterator.return!()).resolves.toMatchObject({
+      done: false,
+      value: { id: "return-value" },
+    });
+    await expect(iterator.return!()).resolves.toEqual({ done: true, value: undefined });
+    expect(returnCalls).toBe(2);
+    await provider.cleanup();
+  });
+
+  it("preserves lazy factory errors", async () => {
+    const factoryError = new Error("constructor rejected provider configuration");
+    const provider = new LazyProviderAdapter({
+      adapterName: "test",
+      factory: async () => {
+        throw factoryError;
+      },
+      id: "test",
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      platform: "loopback",
+      status: "ready",
+      supports: ["probe"],
+    });
+    const { context } = createTelegramManifest("/tmp/unused.jsonl");
+
+    await expect(provider.probe(context)).rejects.toBe(factoryError);
+    await provider.cleanup();
+  });
 });

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -1,9 +1,17 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import type { ManifestDefinition, ProviderConfig } from "../src/config/schema.js";
+import {
+  BUILTIN_ADAPTERS,
+  type ManifestDefinition,
+  type ProviderConfig,
+} from "../src/config/schema.js";
 import { TelegramProviderAdapter } from "../src/providers/builtin/telegram.js";
 import { createRegistry } from "../src/providers/registry.js";
+import {
+  normalizeBuiltinTarget,
+  type BuiltinProviderAdapterId,
+} from "../src/providers/target-normalizers.js";
 import type { ProviderContext, SendContext, WaitContext } from "../src/providers/types.js";
 import { createTempDir, disposeTempDir } from "./test-helpers.js";
 
@@ -107,6 +115,138 @@ describe("registry", () => {
       channelId: "-1001234567890",
       threadId: "-1001234567890:42",
     });
+  });
+
+  it.each([
+    [
+      "discord",
+      {
+        channelId: "123456789012345678",
+        id: "123456789012345678",
+        metadata: {},
+        threadId: "223456789012345678",
+      },
+    ],
+    ["feishu", { channelId: "oc_abc123", id: "oc_abc123", metadata: {}, threadId: "om_abc123" }],
+    [
+      "googlechat",
+      {
+        channelId: "spaces/AAAABbbbCCC",
+        id: "spaces/AAAABbbbCCC",
+        metadata: {},
+        threadId: "spaces/AAAABbbbCCC/threads/BBBBccccDDD",
+      },
+    ],
+    [
+      "imessage",
+      {
+        channelId: "+15551234567",
+        id: "+15551234567",
+        metadata: {},
+        threadId: "iMessage;-;chat-guid",
+      },
+    ],
+    [
+      "loopback",
+      {
+        channelId: "room-a",
+        id: "room-a",
+        metadata: {},
+        threadId: "loopback:room-a:topic",
+      },
+    ],
+    [
+      "matrix",
+      {
+        channelId: "!abcdef:matrix.org",
+        id: "!abcdef:matrix.org",
+        metadata: {},
+        threadId: "$eventid:matrix.org",
+      },
+    ],
+    [
+      "mattermost",
+      {
+        channelId: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+        id: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+        metadata: {},
+        threadId: "bbbbbbbbbbbbbbbbbbbbbbbbbb",
+      },
+    ],
+    [
+      "msteams",
+      {
+        channelId: "19:conversation@thread.v2",
+        id: "19:conversation@thread.v2",
+        metadata: {},
+        threadId: "reply-chain",
+      },
+    ],
+    [
+      "slack",
+      {
+        channelId: "C1234567890",
+        id: "C1234567890",
+        metadata: {},
+        threadId: "1700000000.000100",
+      },
+    ],
+    [
+      "telegram",
+      {
+        channelId: "-1001234567890",
+        id: "-1001234567890",
+        metadata: {},
+        threadId: "-1001234567890:42",
+      },
+    ],
+    [
+      "whatsapp",
+      {
+        channelId: "15551234567",
+        id: "15551234567",
+        metadata: {},
+        threadId: "15551234567",
+      },
+    ],
+    [
+      "zalo",
+      {
+        channelId: "123456789012",
+        id: "123456789012",
+        metadata: {},
+        threadId: "987654321012",
+      },
+    ],
+  ] satisfies Array<
+    readonly [BuiltinProviderAdapterId, ManifestDefinition["fixtures"][number]["target"]]
+  >)("keeps the %s lazy adapter in parity with its target codec", (adapter, target) => {
+    expect(BUILTIN_ADAPTERS).toContain(adapter);
+    const fixture = {
+      ...manifest.fixtures[0]!,
+      id: `${adapter}-parity`,
+      provider: adapter,
+      target,
+    };
+    const config = {
+      adapter,
+      capabilities: ["probe"],
+      env: [],
+      platform: adapter,
+      status: "active",
+    } as ProviderConfig;
+    const registry = createRegistry(
+      {
+        ...manifest,
+        fixtures: [fixture],
+        providers: { [adapter]: config },
+      },
+      "/tmp/crabline.yaml",
+    );
+
+    expect(registry.resolve(adapter, fixture.id).normalizeTarget(target)).toEqual(
+      normalizeBuiltinTarget(adapter, target),
+    );
   });
 
   it("applies provider-specific validation through lazy adapters", () => {

--- a/test/signed-jwt.test.ts
+++ b/test/signed-jwt.test.ts
@@ -23,6 +23,27 @@ describe("signed JWT remote key cache", () => {
     ).toBe(now);
   });
 
+  it("subtracts response Age from cache freshness", () => {
+    const now = 1_700_000_000_000;
+
+    expect(
+      resolveHttpCacheExpiry(
+        new Response(null, {
+          headers: { age: "120", "cache-control": "public, max-age=3600" },
+        }),
+        now,
+      ),
+    ).toBe(now + 3_480_000);
+    expect(
+      resolveHttpCacheExpiry(
+        new Response(null, {
+          headers: { age: "7200", "cache-control": "public, max-age=3600" },
+        }),
+        now,
+      ),
+    ).toBe(now);
+  });
+
   it("single-flights unknown-key refreshes and applies a global cooldown", async () => {
     let now = 1_700_000_000_000;
     let fetches = 0;
@@ -91,5 +112,56 @@ describe("signed JWT remote key cache", () => {
     });
 
     await expect(resolveKey({ alg: "RS256", kid: "missing" })).rejects.toThrow("timed out");
+  });
+
+  it("backs off failed key fetches", async () => {
+    let now = 1_700_000_000_000;
+    let fetches = 0;
+    const fetchError = new Error("JWKS unavailable");
+    const resolveKey = createCachedJwtKeyResolver<string>({
+      async fetchKeys() {
+        fetches += 1;
+        throw fetchError;
+      },
+      keyId: (value) => value,
+      now: () => now,
+      refreshCooldownMs: 10_000,
+      unknownKeyMessage: "unknown key",
+    });
+
+    await expect(resolveKey({ alg: "RS256", kid: "missing" })).rejects.toBe(fetchError);
+    await expect(resolveKey({ alg: "RS256", kid: "missing" })).rejects.toBe(fetchError);
+    expect(fetches).toBe(1);
+
+    now += 10_001;
+    await expect(resolveKey({ alg: "RS256", kid: "missing" })).rejects.toBe(fetchError);
+    expect(fetches).toBe(2);
+  });
+
+  it("invalidates negative entries when a refreshed key set contains them", async () => {
+    let now = 1_700_000_000_000;
+    let fetches = 0;
+    const resolveKey = createCachedJwtKeyResolver<string>({
+      async fetchKeys() {
+        fetches += 1;
+        return {
+          expiresAt: now + (fetches < 3 ? 1_000 : 60_000),
+          values: fetches < 3 ? ["known"] : ["known", "rotated"],
+        };
+      },
+      keyId: (value) => value,
+      now: () => now,
+      refreshCooldownMs: 10_000,
+      unknownKeyMessage: "unknown key",
+    });
+
+    await expect(resolveKey({ alg: "RS256", kid: "known" })).resolves.toBe("known");
+    await expect(resolveKey({ alg: "RS256", kid: "rotated" })).rejects.toThrow("unknown key");
+    expect(fetches).toBe(2);
+
+    now += 2_000;
+    await expect(resolveKey({ alg: "RS256", kid: "known" })).resolves.toBe("known");
+    await expect(resolveKey({ alg: "RS256", kid: "rotated" })).resolves.toBe("rotated");
+    expect(fetches).toBe(3);
   });
 });


### PR DESCRIPTION
## Summary
- harden webhook hook inputs and recorder durability/cursor semantics
- make lazy adapter lifecycle deterministic and preserve native load failures
- improve target parity and signed-JWT cache behavior

## Verification
- 109 focused tests
- 762 full-suite tests
- format, typecheck, and lint
- exact branch autoreview

## Changelog
- updated `CHANGELOG.md`