### PR TITLE
fix(runtime): bound CLI and fixture execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Reject unauthenticated public provider webhooks and tighten Discord, Feishu, Google Chat, Matrix, and Teams inbound protocol validation.
 - Enforce native Matrix, Mattermost, Signal, and Slack outcomes, pagination, retries, state, JSON-RPC, WebSocket, HTTP response, and recorder privacy contracts.
 - Harden OpenClaw artifact publication identity and cleanup, and align Mattermost, Matrix, Signal, Slack, Telegram, and WhatsApp bridge contracts.
+- Bound fixture execution and script input, harden CLI pipe output and manifest parsing, and preserve watch cleanup and stateless inbound progress.
 - Bound signed-JWT key refreshes and authenticate, decode, or suppress Google Chat, Teams, Feishu, and Discord webhook ingress according to provider contracts.
 - Bound recorder tail memory, harden shared provider cleanup and inbound matching, and reject non-global webhook targets.
 - Recover backpressured Signal events without recording rejected RPC calls.

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -145,9 +145,11 @@ The complete multi-channel script fixture is available in
 Each command receives one JSON document on stdin. Every payload contains the
 parsed `fixture` plus `provider.config`, `provider.id`, and
 `provider.manifestPath`. `send` adds `outbound` with `mode`, `nonce`, normalized
-`target`, and `text`; `waitForInbound` adds `wait` with `nonce`, `since`,
-normalized `target`, and `timeoutMs`; `watch` adds `watch` with optional `since`
-and normalized `target`.
+`target`, and `text`; `waitForInbound` adds `wait` with `excludeIds`, `nonce`,
+`since`, normalized `target`, and `timeoutMs`. A stateless wait bridge must
+exclude messages whose IDs are listed in `excludeIds` while retaining later
+messages with the same timestamp. Crabline retains at most 1024 unmatched IDs
+per wait. `watch` adds `watch` with optional `since` and normalized `target`.
 
 Non-watch commands must write exactly one JSON value to stdout:
 

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -7,7 +7,12 @@ import { lock } from "proper-lockfile";
 import { loadManifest } from "../config/load.js";
 import { createRegistry } from "../providers/registry.js";
 import { formatJson, formatRunResultText, sanitizeTerminalText } from "../core/reporters.js";
-import { computeExitCode, runFixtureCommand, runSuite } from "../core/run.js";
+import {
+  assertScriptStdinPayloadSize,
+  computeExitCode,
+  runFixtureCommand,
+  runSuite,
+} from "../core/run.js";
 import { CrablineError, ensureErrorMessage } from "../core/errors.js";
 import {
   isCrablineServerChannel,
@@ -125,18 +130,19 @@ const SERVE_PARAM_FACTORIES = {
   }),
 } satisfies Record<CrablineServerChannel, ServeParamFactory>;
 
-function print(value: string): void {
-  process.stdout.write(`${value}\n`);
+function isClosedPipeError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === "EPIPE" || code === "ERR_STREAM_DESTROYED";
 }
 
-async function printWatchLine(value: string): Promise<boolean> {
+async function writeOutput(stream: NodeJS.WriteStream, value: string): Promise<boolean> {
   try {
     await new Promise<void>((resolve, reject) => {
       let drained = false;
       let written = false;
       const cleanup = () => {
-        process.stdout.off("drain", onDrain);
-        process.stdout.off("error", onError);
+        stream.off("drain", onDrain);
+        stream.off("error", onError);
       };
       const finish = () => {
         if (drained && written) {
@@ -152,31 +158,41 @@ async function printWatchLine(value: string): Promise<boolean> {
         cleanup();
         reject(error);
       };
-      process.stdout.once("error", onError);
-      const hasCapacity = process.stdout.write(`${value}\n`, (error) => {
-        if (error) {
-          process.stdout.once("error", () => undefined);
-          onError(error);
-          return;
-        }
-        written = true;
-        finish();
-      });
+      stream.once("error", onError);
+      let hasCapacity: boolean;
+      try {
+        hasCapacity = stream.write(value, (error) => {
+          if (error) {
+            stream.once("error", () => undefined);
+            onError(error);
+            return;
+          }
+          written = true;
+          finish();
+        });
+      } catch (error) {
+        cleanup();
+        reject(error);
+        return;
+      }
       if (hasCapacity) {
         drained = true;
         finish();
       } else {
-        process.stdout.once("drain", onDrain);
+        stream.once("drain", onDrain);
       }
     });
     return true;
   } catch (error) {
-    const code = (error as NodeJS.ErrnoException).code;
-    if (code === "EPIPE" || code === "ERR_STREAM_DESTROYED") {
+    if (isClosedPipeError(error)) {
       return false;
     }
     throw error;
   }
+}
+
+async function print(value: string): Promise<boolean> {
+  return await writeOutput(process.stdout, `${value}\n`);
 }
 
 async function withManifest<T>(
@@ -224,7 +240,7 @@ export function createProgram(
         })),
         support: registry.catalog,
       };
-      print(options.json ? formatJson(payload) : renderProvidersText(payload));
+      await print(options.json ? formatJson(payload) : renderProvidersText(payload));
     });
 
   program
@@ -233,13 +249,13 @@ export function createProgram(
     .action(async () => {
       const options = program.opts() as GlobalOptions;
       const { manifest } = await loadManifest(options.config);
-      print(
+      await print(
         options.json
           ? formatJson(manifest.fixtures)
           : manifest.fixtures
               .map(
                 (fixture) =>
-                  `${fixture.id} ${fixture.mode} provider=${fixture.provider} target=${fixture.target.id}`,
+                  `${sanitizeTerminalText(fixture.id, true)} ${sanitizeTerminalText(fixture.mode, true)} provider=${sanitizeTerminalText(fixture.provider, true)} target=${sanitizeTerminalText(fixture.target.id, true)}`,
               )
               .join("\n"),
       );
@@ -263,7 +279,7 @@ export function createProgram(
         modeOverride: "probe",
         registry,
       });
-      print(options.json ? formatJson(result) : formatRunResultText(result));
+      await print(options.json ? formatJson(result) : formatRunResultText(result));
       setExitCode(computeExitCode(result));
     });
 
@@ -282,7 +298,7 @@ export function createProgram(
           modeOverride: mode,
           registry,
         });
-        print(options.json ? formatJson(result) : formatRunResultText(result));
+        await print(options.json ? formatJson(result) : formatRunResultText(result));
         setExitCode(computeExitCode(result));
       });
   }
@@ -300,7 +316,7 @@ export function createProgram(
         manifestPath: path,
         registry,
       });
-      print(options.json ? formatJson(result) : formatRunResultText(result));
+      await print(options.json ? formatJson(result) : formatRunResultText(result));
       setExitCode(computeExitCode(result));
     });
 
@@ -324,29 +340,46 @@ export function createProgram(
         }
 
         const controller = new AbortController();
-        const watch = provider.watch({
-          config: manifest.providers[fixture.provider]!,
-          fixture,
-          manifestPath: path,
-          providerId: fixture.provider,
-          signal: controller.signal,
-          userName: manifest.userName,
-        });
-        const iterator = watch[Symbol.asyncIterator]();
+        let iterator:
+          | AsyncIterator<NonNullable<Awaited<ReturnType<typeof provider.waitForInbound>>>>
+          | undefined;
         const stopWatch = onceAsync(async () => {
           controller.abort();
-          await iterator.return?.();
+          await iterator?.return?.();
         });
         const shutdown = installShutdownHandler(stopWatch);
         const lifecycleErrors: unknown[] = [];
         try {
+          const watchContext = {
+            config: manifest.providers[fixture.provider]!,
+            fixture,
+            manifestPath: path,
+            providerId: fixture.provider,
+            signal: controller.signal,
+            userName: manifest.userName,
+          };
+          if (watchContext.config.adapter === "script") {
+            assertScriptStdinPayloadSize({
+              fixture,
+              provider: {
+                config: watchContext.config,
+                id: fixture.provider,
+                manifestPath: path,
+              },
+              watch: {
+                target: fixture.target,
+              },
+            });
+          }
+          const watch = provider.watch(watchContext);
+          iterator = watch[Symbol.asyncIterator]();
           while (true) {
             const result = await iterator.next();
             if (result.done) {
               break;
             }
             const message = result.value;
-            const written = await printWatchLine(
+            const written = await print(
               options.json
                 ? formatJson(message)
                 : `${sanitizeTerminalText(message.sentAt, true)} ${sanitizeTerminalText(message.author, true)} ${sanitizeTerminalText(message.text, true)}`,
@@ -488,7 +521,7 @@ export function createProgram(
                   identity: await publish(commandOptions.readyFile, readyContents),
                 };
               }
-              print(
+              await print(
                 options.json
                   ? payload
                   : renderServeText(server.manifest, commandOptions.showSecrets === true),
@@ -549,7 +582,7 @@ export function createProgram(
       const findings = diagnose(manifest);
       const ok = findings.length === 0;
       const payload = { findings, ok };
-      print(options.json ? formatJson(payload) : ok ? "doctor ok" : findings.join("\n"));
+      await print(options.json ? formatJson(payload) : ok ? "doctor ok" : findings.join("\n"));
       setExitCode(ok ? 0 : 10);
     });
 
@@ -1016,8 +1049,12 @@ export async function runCli(argv: string[]): Promise<number> {
     exitCode = code;
   });
   const parserErrors: string[] = [];
+  const parserOutput: string[] = [];
   const bufferParserErrors = (command: Command): void => {
-    command.configureOutput({ writeErr: (message) => parserErrors.push(message) });
+    command.configureOutput({
+      writeErr: (message) => parserErrors.push(message),
+      writeOut: (message) => parserOutput.push(message),
+    });
     for (const child of command.commands) {
       bufferParserErrors(child);
     }
@@ -1025,6 +1062,7 @@ export async function runCli(argv: string[]): Promise<number> {
   bufferParserErrors(program);
   try {
     await program.parseAsync(argv);
+    await writeOutput(process.stdout, parserOutput.join(""));
     return exitCode;
   } catch (error) {
     const errorExitCode =
@@ -1036,11 +1074,13 @@ export async function runCli(argv: string[]): Promise<number> {
           ? error.exitCode
           : 1;
     if (error instanceof CommanderError && errorExitCode === 0) {
+      await writeOutput(process.stdout, parserOutput.join(""));
       return 0;
     }
     const json = program.opts().json === true;
     if (json) {
-      process.stderr.write(
+      await writeOutput(
+        process.stderr,
         `${formatJson({
           error: {
             ...(error instanceof CommanderError ? { code: error.code } : {}),
@@ -1055,9 +1095,9 @@ export async function runCli(argv: string[]): Promise<number> {
         })}\n`,
       );
     } else if (error instanceof CommanderError) {
-      process.stderr.write(parserErrors.join(""));
+      await writeOutput(process.stderr, parserErrors.join(""));
     } else {
-      process.stderr.write(`${ensureErrorMessage(error)}\n`);
+      await writeOutput(process.stderr, `${ensureErrorMessage(error)}\n`);
     }
     return errorExitCode;
   }

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -6,6 +6,8 @@ import { type ManifestDefinition, ManifestSchema } from "./schema.js";
 
 const DEFAULT_CONFIG_CANDIDATES = ["crabline.yaml", "crabline.yml", "crabline.json"] as const;
 
+class DuplicateJsonKeyError extends SyntaxError {}
+
 function configLoadError(resolvedPath: string, error: unknown, detail: string): CrablineError {
   return new CrablineError(`Unable to load config file "${resolvedPath}": ${detail}`, {
     cause: error,
@@ -31,11 +33,23 @@ function formatYamlParseError(error: unknown): string {
 }
 
 function formatJsonParseError(error: unknown): string {
+  if (error instanceof DuplicateJsonKeyError) {
+    return "JSON parse error: duplicate object key.";
+  }
   if (!(error instanceof SyntaxError)) {
     return "JSON parse failed.";
   }
   const position = /\bposition (\d+)\b/u.exec(error.message)?.[1];
   return position ? `JSON parse error at position ${position}.` : "JSON parse error.";
+}
+
+function parseJson(raw: string): unknown {
+  const parsed: unknown = JSON.parse(raw);
+  const document = YAML.parseDocument(raw, { schema: "json", uniqueKeys: true });
+  if (document.errors.some((error) => error.code === "DUPLICATE_KEY")) {
+    throw new DuplicateJsonKeyError("JSON contains a duplicate object key.");
+  }
+  return parsed;
 }
 
 export async function resolveConfigPath(explicitPath?: string): Promise<string> {
@@ -82,7 +96,7 @@ export async function loadManifest(
   const isJson = path.extname(resolvedPath).toLowerCase() === ".json";
   let parsed: unknown;
   try {
-    parsed = isJson ? JSON.parse(raw) : YAML.parse(raw, { merge: true });
+    parsed = isJson ? parseJson(raw) : YAML.parse(raw, { merge: true });
   } catch (error) {
     const detail = isJson ? formatJsonParseError(error) : formatYamlParseError(error);
     throw configLoadError(resolvedPath, new Error(detail), detail);

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -3,6 +3,7 @@ import { inboundRegexSafetyError } from "../core/safe-regex.js";
 
 export const FIXTURE_MODES = ["probe", "send", "roundtrip", "agent"] as const;
 const FIXTURE_ID_PATTERN = /^[a-z0-9-]+$/i;
+const MAX_TIMER_MS = 2_147_483_647;
 export const INBOUND_AUTHORS = ["assistant", "user", "system", "any"] as const;
 export const INBOUND_STRATEGIES = ["contains", "exact", "regex"] as const;
 export const INBOUND_NONCE_MODES = ["contains", "exact", "ignore"] as const;
@@ -647,7 +648,7 @@ export const FixtureSchema = z.strictObject({
   retries: z.number().int().min(0).default(0),
   tags: z.array(z.string().min(1)).default([]),
   target: TargetSchema,
-  timeoutMs: z.number().int().min(100).default(30_000),
+  timeoutMs: z.number().int().min(100).max(MAX_TIMER_MS).default(30_000),
 });
 
 const MANIFEST_EXTENSION_KEY_PATTERN = /^x-[a-z0-9][a-z0-9._-]*$/u;

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -25,6 +25,8 @@ export type SuiteRunResult = {
 
 const INBOUND_DEADLINE_REACHED = Symbol("inbound deadline reached");
 const INBOUND_ABORT_GRACE_MS = 250;
+const MAX_EXCLUDED_INBOUND_IDS = 1_024;
+const MAX_SCRIPT_STDIN_BYTES = 1024 * 1024;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -45,6 +47,170 @@ async function raceInboundDeadline<T>(
       clearTimeout(timer);
     }
   }
+}
+
+async function withFixtureDeadline<T>(
+  operation: (signal: AbortSignal) => Promise<T>,
+  timeoutMs: number,
+  operationName: string,
+): Promise<T> {
+  const controller = new AbortController();
+  const pending = Promise.resolve().then(async () => await operation(controller.signal));
+  const result = await raceInboundDeadline(pending, timeoutMs);
+  if (result === INBOUND_DEADLINE_REACHED) {
+    const timeoutError = new CrablineError(
+      `Provider ${operationName} timed out after ${timeoutMs}ms.`,
+      {
+        kind: "timeout",
+      },
+    );
+    controller.abort(timeoutError);
+    const settled = pending.then(
+      () => true,
+      () => true,
+    );
+    if ((await raceInboundDeadline(settled, INBOUND_ABORT_GRACE_MS)) === INBOUND_DEADLINE_REACHED) {
+      throw new CrablineError(
+        `Provider ${operationName} did not settle within ${INBOUND_ABORT_GRACE_MS}ms after abort.`,
+        {
+          cause: timeoutError,
+          kind: "timeout",
+        },
+      );
+    }
+    throw timeoutError;
+  }
+  return result;
+}
+
+async function withCleanupDeadline<T>(
+  operation: Promise<T>,
+  timeoutMs: number,
+  operationName: string,
+): Promise<T> {
+  const result = await raceInboundDeadline(operation, timeoutMs);
+  if (result === INBOUND_DEADLINE_REACHED) {
+    throw new CrablineError(`Provider ${operationName} timed out after ${timeoutMs}ms.`, {
+      kind: "timeout",
+    });
+  }
+  return result;
+}
+
+function jsonStringByteLength(value: string, limit: number): number {
+  let bytes = 2;
+  for (let index = 0; index < value.length && bytes <= limit; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code === 0x22 || code === 0x5c || code === 0x08 || code === 0x09 || code === 0x0a) {
+      bytes += 2;
+    } else if (code === 0x0c || code === 0x0d) {
+      bytes += 2;
+    } else if (code <= 0x1f) {
+      bytes += 6;
+    } else if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        bytes += 4;
+        index += 1;
+      } else {
+        bytes += 6;
+      }
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      bytes += 6;
+    } else if (code <= 0x7f) {
+      bytes += 1;
+    } else if (code <= 0x7ff) {
+      bytes += 2;
+    } else {
+      bytes += 3;
+    }
+  }
+  return bytes;
+}
+
+function boundedJsonByteLength(
+  value: unknown,
+  limit: number,
+  ancestors = new Set<object>(),
+  arrayEntry = false,
+): number {
+  if (value === null || value === undefined || typeof value === "function") {
+    return value === undefined && !arrayEntry ? 0 : 4;
+  }
+  if (typeof value === "string") {
+    return jsonStringByteLength(value, limit);
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? String(value).length : 4;
+  }
+  if (typeof value === "boolean") {
+    return value ? 4 : 5;
+  }
+  if (typeof value !== "object") {
+    return 0;
+  }
+  if (ancestors.has(value)) {
+    throw new CrablineError("Script command input must not contain circular values.", {
+      kind: "config",
+    });
+  }
+
+  ancestors.add(value);
+  let bytes = 2;
+  let entries = 0;
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      if (entries > 0) {
+        bytes += 1;
+      }
+      bytes += boundedJsonByteLength(entry, limit - bytes, ancestors, true);
+      entries += 1;
+      if (bytes > limit) {
+        break;
+      }
+    }
+  } else {
+    for (const [key, entry] of Object.entries(value)) {
+      if (entry === undefined || typeof entry === "function") {
+        continue;
+      }
+      if (entries > 0) {
+        bytes += 1;
+      }
+      bytes += jsonStringByteLength(key, limit - bytes) + 1;
+      bytes += boundedJsonByteLength(entry, limit - bytes, ancestors);
+      entries += 1;
+      if (bytes > limit) {
+        break;
+      }
+    }
+  }
+  ancestors.delete(value);
+  return bytes;
+}
+
+export function assertScriptStdinPayloadSize(payload: unknown): void {
+  if (boundedJsonByteLength(payload, MAX_SCRIPT_STDIN_BYTES) > MAX_SCRIPT_STDIN_BYTES) {
+    throw new CrablineError(`Script command input exceeded ${MAX_SCRIPT_STDIN_BYTES} bytes.`, {
+      kind: "config",
+    });
+  }
+}
+
+function scriptPayloadBase(context: {
+  config: ManifestDefinition["providers"][string];
+  fixture: ManifestDefinition["fixtures"][number];
+  manifestPath: string;
+  providerId: string;
+}): object {
+  return {
+    fixture: context.fixture,
+    provider: {
+      config: context.config,
+      id: context.providerId,
+      manifestPath: context.manifestPath,
+    },
+  };
 }
 
 async function abortAndDrainInboundWait(
@@ -122,7 +288,14 @@ export async function runFixtureCommand(params: {
       // Preflight failures still flow through provider cleanup before returning.
     } else if (mode === "probe") {
       try {
-        const probeResult = await provider.probe(contextBase);
+        if (contextBase.config.adapter === "script") {
+          assertScriptStdinPayloadSize(scriptPayloadBase(contextBase));
+        }
+        const probeResult = await withFixtureDeadline(
+          async (signal) => await provider.probe({ ...contextBase, signal }),
+          fixture.timeoutMs,
+          "probe",
+        );
         return (result = {
           diagnostics: probeResult.details,
           failureKind: probeResult.healthy ? undefined : "connectivity",
@@ -169,12 +342,28 @@ export async function runFixtureCommand(params: {
           const since = new Date().toISOString();
           let accepted;
           try {
-            accepted = await provider.send({
+            const sendContext = {
               ...contextBase,
               mode,
               nonce,
               text: outboundText,
-            });
+            };
+            if (contextBase.config.adapter === "script") {
+              assertScriptStdinPayloadSize({
+                ...scriptPayloadBase(contextBase),
+                outbound: {
+                  mode,
+                  nonce,
+                  target: fixture.target,
+                  text: outboundText,
+                },
+              });
+            }
+            accepted = await withFixtureDeadline(
+              async (signal) => await provider.send({ ...sendContext, signal }),
+              fixture.timeoutMs,
+              "send",
+            );
           } catch (error) {
             lastFailure = toFailure(fixture.id, fixture.provider, mode, error, "outbound", nonce);
             continue;
@@ -207,19 +396,35 @@ export async function runFixtureCommand(params: {
 
           const inboundDeadline = Date.now() + fixture.timeoutMs;
           const seenInbound = new Set<string>();
+          const excludedInboundIds = new Set<string>();
           let inbound;
           try {
             while (Date.now() < inboundDeadline) {
               const timeoutMs = inboundDeadline - Date.now();
               const controller = new AbortController();
-              const wait = provider.waitForInbound({
+              const excludeIds = [...excludedInboundIds];
+              const waitContext = {
                 ...contextBase,
+                excludeIds,
                 nonce,
                 signal: controller.signal,
                 since,
                 threadId: accepted.threadId,
                 timeoutMs,
-              });
+              };
+              if (contextBase.config.adapter === "script") {
+                assertScriptStdinPayloadSize({
+                  ...scriptPayloadBase(contextBase),
+                  wait: {
+                    excludeIds,
+                    nonce,
+                    since,
+                    target: fixture.target,
+                    timeoutMs,
+                  },
+                });
+              }
+              const wait = provider.waitForInbound(waitContext);
               const candidate = await raceInboundDeadline(wait, timeoutMs);
               if (candidate === INBOUND_DEADLINE_REACHED) {
                 if (!(await abortAndDrainInboundWait(wait, controller))) {
@@ -245,6 +450,15 @@ export async function runFixtureCommand(params: {
               if (matchesInbound(candidate, fixture.inboundMatch, nonce)) {
                 inbound = candidate;
                 break;
+              }
+              if (!excludedInboundIds.has(candidate.id)) {
+                if (excludedInboundIds.size >= MAX_EXCLUDED_INBOUND_IDS) {
+                  throw new CrablineError(
+                    `Provider returned more than ${MAX_EXCLUDED_INBOUND_IDS} unmatched inbound message IDs.`,
+                    { kind: "inbound" },
+                  );
+                }
+                excludedInboundIds.add(candidate.id);
               }
             }
           } catch (error) {
@@ -314,7 +528,7 @@ export async function runFixtureCommand(params: {
           );
         }
         if (!abortDrainFailed) {
-          await cleanup;
+          await withCleanupDeadline(cleanup, fixture.timeoutMs, "cleanup");
         }
       }
     } catch (error) {

--- a/src/providers/builtin/script.ts
+++ b/src/providers/builtin/script.ts
@@ -764,6 +764,7 @@ export class ScriptProviderAdapter implements ProviderAdapter {
       payload: createPayload(context),
       schema: ScriptProbeResultSchema,
       shell: this.#config.shell,
+      signal: context.signal,
       timeoutMs: context.fixture.timeoutMs,
     });
     return {
@@ -794,6 +795,7 @@ export class ScriptProviderAdapter implements ProviderAdapter {
       },
       schema: ScriptSendResultSchema,
       shell: this.#config.shell,
+      signal: context.signal,
       timeoutMs: context.fixture.timeoutMs,
     });
   }
@@ -811,6 +813,7 @@ export class ScriptProviderAdapter implements ProviderAdapter {
       payload: {
         ...createPayload(context),
         wait: {
+          excludeIds: context.excludeIds ?? [],
           nonce: context.nonce,
           since: context.since,
           target: this.normalizeTarget(context.fixture.target),

--- a/src/providers/builtin/whatsapp.ts
+++ b/src/providers/builtin/whatsapp.ts
@@ -218,7 +218,9 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
   }
 
   override async probe(context: ProviderContext): Promise<ProbeResult> {
+    context.signal?.throwIfAborted();
     const server = await this.#ensureWebhookServer();
+    context.signal?.throwIfAborted();
     const target = this.normalizeTarget(context.fixture.target);
     const details = [
       "whatsapp local mock ready",

--- a/src/providers/local-mock.ts
+++ b/src/providers/local-mock.ts
@@ -114,8 +114,27 @@ type MockWebhookPayload = {
   threadId?: string;
 };
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const cleanup = () => signal?.removeEventListener("abort", abort);
+    const abort = () => {
+      if (timer) {
+        clearTimeout(timer);
+      }
+      cleanup();
+      reject(signal?.reason ?? new Error("Provider operation aborted."));
+    };
+    timer = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, ms);
+    if (signal?.aborted) {
+      abort();
+      return;
+    }
+    signal?.addEventListener("abort", abort, { once: true });
+  });
 }
 
 function isAddressInChannel(threadId: string, channelId?: string): boolean {
@@ -237,7 +256,9 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
   }
 
   async probe(context: ProviderContext): Promise<ProbeResult> {
+    context.signal?.throwIfAborted();
     const server = await this.#ensureWebhookServer();
+    context.signal?.throwIfAborted();
     const target = this.normalizeTarget(context.fixture.target);
     const details = [
       `${this.platform} local mock ready`,
@@ -273,9 +294,10 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
   }
 
   async #send(context: SendContext): Promise<SendResult> {
+    const { signal } = context;
     const threadId = this.#codec.resolveThreadId(context.fixture.target);
     const messageId = createMessageId(this.platform);
-    this.#assertActive();
+    signal?.throwIfAborted();
     await appendRecordedInbound(this.#recorderPath, {
       author: "user",
       id: messageId,
@@ -292,7 +314,8 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
     });
 
     if (context.mode !== "send" && context.fixture.target.behavior !== "sink") {
-      await sleep(this.#config.loopback?.delayMs ?? 25);
+      await sleep(this.#config.loopback?.delayMs ?? 25, signal);
+      signal?.throwIfAborted();
       await appendRecordedInbound(this.#recorderPath, {
         author: "assistant",
         id: `${messageId}-reply`,

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -170,11 +170,11 @@ export class LazyProviderAdapter implements ProviderAdapter {
   }
 
   probe(context: ProviderContext): Promise<ProbeResult> {
-    return this.#runOperation((provider) => provider.probe(context));
+    return this.#runOperation((provider) => provider.probe(context), context.signal);
   }
 
   send(context: SendContext): Promise<SendResult> {
-    return this.#runOperation((provider) => provider.send(context));
+    return this.#runOperation((provider) => provider.send(context), context.signal);
   }
 
   waitForInbound(context: WaitContext): Promise<InboundEnvelope | null> {

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -48,6 +48,7 @@ export type ProviderContext = {
   fixture: FixtureDefinition;
   manifestPath: string;
   providerId: string;
+  signal?: AbortSignal | undefined;
   userName: string;
 };
 
@@ -58,8 +59,8 @@ export type SendContext = ProviderContext & {
 };
 
 export type WaitContext = ProviderContext & {
+  excludeIds?: readonly string[] | undefined;
   nonce: string;
-  signal?: AbortSignal | undefined;
   since: string;
   threadId?: string | undefined;
   timeoutMs: number;

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -94,6 +94,42 @@ describe("cli", () => {
     expect(captured.stdout.join("")).toContain("roundtrip-fixture");
   });
 
+  it("sanitizes user-controlled fixture fields in text output", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const configPath = path.join(directory, "crabline.json");
+    await writeText(
+      configPath,
+      JSON.stringify({
+        configVersion: 1,
+        fixtures: [
+          {
+            id: "fixture",
+            mode: "send",
+            provider: "local\u001b[2J",
+            target: { id: "sink\u0007\nnext" },
+          },
+        ],
+        providers: {
+          "local\u001b[2J": { adapter: "loopback", platform: "loopback" },
+        },
+      }),
+    );
+    const captured = captureWrites();
+
+    try {
+      expect(await runCli(["node", "crabline", "--config", configPath, "fixtures"])).toBe(0);
+    } finally {
+      captured.restore();
+    }
+
+    const output = captured.stdout.join("");
+    expect(output).toContain(String.raw`provider=local\x1b[2J`);
+    expect(output).toContain(String.raw`target=sink\x07\nnext`);
+    expect(output).not.toContain("\u001b");
+    expect(output).not.toContain("\u0007");
+  });
+
   it("runs doctor, probe, send, roundtrip, and suite commands", async () => {
     const configPath = await createConfig();
     const captured = captureWrites();
@@ -150,6 +186,32 @@ describe("cli", () => {
 
     expect(exitCode!).toBe(10);
     expect(captured.stderr.join("")).toContain("Unknown fixture");
+  });
+
+  it("treats closed ordinary stdout and stderr pipes as graceful", async () => {
+    const configPath = await createConfig();
+    const stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation((() => {
+      throw Object.assign(new Error("closed stdout"), { code: "EPIPE" });
+    }) as typeof process.stdout.write);
+
+    try {
+      await expect(runCli(["node", "crabline", "--config", configPath, "fixtures"])).resolves.toBe(
+        0,
+      );
+    } finally {
+      stdoutWrite.mockRestore();
+    }
+
+    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation((() => {
+      throw Object.assign(new Error("closed stderr"), { code: "ERR_STREAM_DESTROYED" });
+    }) as typeof process.stderr.write);
+    try {
+      await expect(
+        runCli(["node", "crabline", "--config", configPath, "probe", "missing"]),
+      ).resolves.toBe(10);
+    } finally {
+      stderrWrite.mockRestore();
+    }
   });
 
   it("reports JSON failures as one machine-readable document", async () => {
@@ -866,6 +928,46 @@ describe("cli", () => {
     expect(failure).toBeInstanceOf(AggregateError);
     expect((failure as AggregateError).errors).toEqual([watchError, cleanupError]);
     expect((failure as AggregateError).cause).toBe(watchError);
+  });
+
+  it("cleans up when watch setup throws synchronously", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const configPath = path.join(directory, "crabline.yaml");
+    await writeText(
+      configPath,
+      [
+        "configVersion: 1",
+        "providers:",
+        "  local:",
+        "    adapter: loopback",
+        "fixtures:",
+        "  - id: watched",
+        "    provider: local",
+        "    mode: agent",
+        "    target:",
+        "      id: echo-bot",
+      ].join("\n"),
+    );
+    const setupError = new Error("watch setup exploded");
+    const cleanup = vi.fn(async () => undefined);
+    const provider = {
+      cleanup,
+      watch() {
+        throw setupError;
+      },
+    };
+    const program = createProgram(() => undefined, {
+      createRegistry: () =>
+        ({
+          resolve: () => provider,
+        }) as never,
+    });
+
+    await expect(
+      program.parseAsync(["node", "crabline", "--config", configPath, "watch", "watched"]),
+    ).rejects.toBe(setupError);
+    expect(cleanup).toHaveBeenCalledTimes(1);
   });
 
   it("preserves an undefined watch failure", async () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -238,6 +238,24 @@ describe("manifest schema", () => {
     expect(manifest.fixtures[0]?.inboundMatch.author).toBe("assistant");
   });
 
+  it("rejects fixture timeouts above Node's timer ceiling", () => {
+    expect(() =>
+      ManifestSchema.parse({
+        configVersion: 1,
+        fixtures: [
+          {
+            id: "oversized-timeout",
+            mode: "send",
+            provider: "local",
+            target: { id: "sink-bot" },
+            timeoutMs: 2_147_483_648,
+          },
+        ],
+        providers: { local: { adapter: "loopback" } },
+      }),
+    ).toThrow(/2147483647/u);
+  });
+
   it("rejects unknown keys throughout user-authored config", () => {
     const base = {
       configVersion: 1,

--- a/test/load.test.ts
+++ b/test/load.test.ts
@@ -55,6 +55,20 @@ describe("config load", () => {
     expect(loaded.path).toBe(configPath);
   });
 
+  it("rejects duplicate keys in JSON manifests", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const configPath = path.join(directory, "crabline.json");
+    await writeText(
+      configPath,
+      '{"configVersion":1,"providers":{"local":{"adapter":"loopback","adapter":"script"}},"fixtures":[]}',
+    );
+
+    await expect(loadManifest(configPath)).rejects.toThrow(
+      /JSON parse error: duplicate object key/u,
+    );
+  });
+
   it("parses explicit JSON paths case-insensitively", async () => {
     const directory = await createTempDir();
     directories.push(directory);

--- a/test/run.behavior.test.ts
+++ b/test/run.behavior.test.ts
@@ -313,6 +313,62 @@ describe("run behavior", () => {
     expect(roundtrip.failureKind).toBe("outbound");
   });
 
+  it("bounds hung probe and send operations by the fixture timeout", async () => {
+    let abortedOperations = 0;
+    const waitForAbort = async (signal: AbortSignal | undefined): Promise<never> =>
+      await new Promise((_, reject) => {
+        if (!signal) {
+          reject(new Error("missing provider cancellation signal"));
+          return;
+        }
+        signal.addEventListener(
+          "abort",
+          () => {
+            abortedOperations += 1;
+            reject(signal.reason);
+          },
+          { once: true },
+        );
+      });
+    const provider: ProviderAdapter = {
+      id: "mock",
+      platform: "loopback",
+      status: "ready",
+      supports: ["probe", "send", "roundtrip", "agent"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      probe: async (context) => await waitForAbort(context.signal),
+      send: async (context) => await waitForAbort(context.signal),
+      waitForInbound: async () => null,
+    };
+    const boundedManifest = withAllCapabilities({
+      ...manifest,
+      fixtures: [{ ...manifest.fixtures[0]!, timeoutMs: 10 }],
+    });
+
+    const probe = await runFixtureCommand({
+      fixtureId: "fixture",
+      manifest: boundedManifest,
+      manifestPath: "/tmp/crabline.yaml",
+      modeOverride: "probe",
+      registry: buildRegistry(provider),
+    });
+    const send = await runFixtureCommand({
+      fixtureId: "fixture",
+      manifest: boundedManifest,
+      manifestPath: "/tmp/crabline.yaml",
+      modeOverride: "send",
+      registry: buildRegistry(provider),
+    });
+
+    expect(probe).toMatchObject({ failureKind: "timeout", ok: false });
+    expect(probe.diagnostics).toContain("Provider probe timed out after 10ms.");
+    expect(send).toMatchObject({ failureKind: "timeout", ok: false });
+    expect(send.diagnostics).toContain("Provider send timed out after 10ms.");
+    expect(abortedOperations).toBe(2);
+  });
+
   it("classifies plain provider failures by execution stage", async () => {
     let stage: "probe" | "send" | "wait" = "probe";
     const provider: ProviderAdapter = {
@@ -509,9 +565,130 @@ describe("run behavior", () => {
     expect(waitCalls).toBe(3);
   });
 
+  it("advances stateless inbound waits past unmatched envelopes", async () => {
+    let sendCalls = 0;
+    let unrelatedSentAt = "";
+    let matchedSentAt = "";
+    const provider: ProviderAdapter = {
+      id: "mock",
+      platform: "loopback",
+      status: "ready",
+      supports: ["probe", "send", "roundtrip", "agent"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      probe: async () => ({ details: [], healthy: true }),
+      send: async () => {
+        sendCalls += 1;
+        const base = Date.now() + 100;
+        unrelatedSentAt = new Date(base).toISOString();
+        matchedSentAt = new Date(base + 100).toISOString();
+        return { accepted: true, messageId: "sent", threadId: "thread" };
+      },
+      waitForInbound: async (context) => {
+        if (
+          Date.parse(context.since) <= Date.parse(unrelatedSentAt) &&
+          !context.excludeIds?.includes("unrelated")
+        ) {
+          return {
+            author: "assistant",
+            id: "unrelated",
+            provider: "mock",
+            sentAt: unrelatedSentAt,
+            text: "not the requested nonce",
+            threadId: "thread",
+          };
+        }
+        return {
+          author: "assistant",
+          id: "matched",
+          provider: "mock",
+          sentAt: matchedSentAt,
+          text: `ACK ${context.nonce}`,
+          threadId: "thread",
+        };
+      },
+    };
+    const boundedManifest = withAllCapabilities({
+      ...manifest,
+      fixtures: [{ ...manifest.fixtures[0]!, timeoutMs: 100 }],
+    });
+
+    const result = await runFixtureCommand({
+      fixtureId: "fixture",
+      manifest: boundedManifest,
+      manifestPath: "/tmp/crabline.yaml",
+      registry: buildRegistry(provider),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.diagnostics).toContain("matched inbound matched");
+    expect(sendCalls).toBe(1);
+  });
+
+  it("preserves a later match that shares an unmatched envelope timestamp", async () => {
+    let waitCalls = 0;
+    let sharedSentAt = "";
+    const provider: ProviderAdapter = {
+      id: "mock",
+      platform: "loopback",
+      status: "ready",
+      supports: ["probe", "send", "roundtrip", "agent"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      probe: async () => ({ details: [], healthy: true }),
+      send: async () => {
+        sharedSentAt = new Date(Date.now() + 100).toISOString();
+        return { accepted: true, messageId: "sent", threadId: "thread" };
+      },
+      waitForInbound: async (context) => {
+        waitCalls += 1;
+        if (Date.parse(context.since) > Date.parse(sharedSentAt)) {
+          return null;
+        }
+        const messages = [
+          {
+            author: "assistant" as const,
+            id: "unrelated",
+            provider: "mock",
+            sentAt: sharedSentAt,
+            text: "not the requested nonce",
+            threadId: "thread",
+          },
+          {
+            author: "assistant" as const,
+            id: "matched",
+            provider: "mock",
+            sentAt: sharedSentAt,
+            text: `ACK ${context.nonce}`,
+            threadId: "thread",
+          },
+        ];
+        return messages.find((message) => !context.excludeIds?.includes(message.id)) ?? null;
+      },
+    };
+    const boundedManifest = withAllCapabilities({
+      ...manifest,
+      fixtures: [{ ...manifest.fixtures[0]!, timeoutMs: 100 }],
+    });
+
+    const result = await runFixtureCommand({
+      fixtureId: "fixture",
+      manifest: boundedManifest,
+      manifestPath: "/tmp/crabline.yaml",
+      registry: buildRegistry(provider),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.diagnostics).toContain("matched inbound matched");
+    expect(waitCalls).toBe(2);
+  });
+
   it("bounds repeated inbound envelopes by the fixture deadline", async () => {
     let sendCalls = 0;
     let waitCalls = 0;
+    let maxExcludedIds = 0;
     const repeated = {
       author: "assistant" as const,
       id: "repeated",
@@ -533,8 +710,9 @@ describe("run behavior", () => {
         sendCalls += 1;
         return { accepted: true, messageId: "sent", threadId: "thread" };
       },
-      waitForInbound: async () => {
+      waitForInbound: async (context) => {
         waitCalls += 1;
+        maxExcludedIds = Math.max(maxExcludedIds, context.excludeIds?.length ?? 0);
         return repeated;
       },
     };
@@ -554,6 +732,50 @@ describe("run behavior", () => {
     expect(sendCalls).toBe(1);
     expect(waitCalls).toBeGreaterThan(1);
     expect(waitCalls).toBeLessThan(10);
+    expect(maxExcludedIds).toBe(1);
+  });
+
+  it("bounds unique unmatched inbound IDs", async () => {
+    let waitCalls = 0;
+    const provider: ProviderAdapter = {
+      id: "mock",
+      platform: "loopback",
+      status: "ready",
+      supports: ["probe", "send", "roundtrip", "agent"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      probe: async () => ({ details: [], healthy: true }),
+      send: async () => ({ accepted: true, messageId: "sent", threadId: "thread" }),
+      waitForInbound: async () => {
+        waitCalls += 1;
+        return {
+          author: "assistant",
+          id: `unmatched-${waitCalls}`,
+          provider: "mock",
+          sentAt: new Date().toISOString(),
+          text: "not the requested nonce",
+          threadId: "thread",
+        };
+      },
+    };
+    const boundedManifest = withAllCapabilities({
+      ...manifest,
+      fixtures: [{ ...manifest.fixtures[0]!, timeoutMs: 5_000 }],
+    });
+
+    const result = await runFixtureCommand({
+      fixtureId: "fixture",
+      manifest: boundedManifest,
+      manifestPath: "/tmp/crabline.yaml",
+      registry: buildRegistry(provider),
+    });
+
+    expect(result.failureKind).toBe("inbound");
+    expect(result.diagnostics).toContain(
+      "Provider returned more than 1024 unmatched inbound message IDs.",
+    );
+    expect(waitCalls).toBe(1025);
   });
 
   it("bounds a hung inbound provider by the core deadline", async () => {
@@ -626,6 +848,82 @@ describe("run behavior", () => {
     expect(result.failureKind).toBe("assertion");
     expect(result.diagnostics).toContain("cleanup failed: cleanup exploded");
     expect(computeExitCode(result)).toBe(EXIT_CODES.ASSERTION);
+  });
+
+  it("bounds ordinary provider cleanup by the fixture timeout", async () => {
+    const provider: ProviderAdapter = {
+      id: "mock",
+      platform: "loopback",
+      status: "ready",
+      supports: ["probe", "send", "roundtrip", "agent"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      probe: async () => ({ details: [], healthy: true }),
+      send: async () => ({ accepted: true, messageId: "sent", threadId: "thread" }),
+      waitForInbound: async () => null,
+      cleanup: async () => await new Promise(() => undefined),
+    };
+    const boundedManifest = withAllCapabilities({
+      ...manifest,
+      fixtures: [{ ...manifest.fixtures[0]!, timeoutMs: 10 }],
+    });
+
+    const result = await runFixtureCommand({
+      fixtureId: "fixture",
+      manifest: boundedManifest,
+      manifestPath: "/tmp/crabline.yaml",
+      modeOverride: "send",
+      registry: buildRegistry(provider),
+    });
+
+    expect(result).toMatchObject({ failureKind: "assertion", ok: false });
+    expect(result.diagnostics).toContain("cleanup failed: Provider cleanup timed out after 10ms.");
+  });
+
+  it("rejects oversized script stdin payloads before provider dispatch", async () => {
+    let sendCalls = 0;
+    const provider: ProviderAdapter = {
+      id: "mock",
+      platform: "slack",
+      status: "bridge",
+      supports: ["send"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      probe: async () => ({ details: [], healthy: true }),
+      send: async () => {
+        sendCalls += 1;
+        return { accepted: true, messageId: "sent", threadId: "thread" };
+      },
+      waitForInbound: async () => null,
+    };
+    const scriptManifest: ManifestDefinition = {
+      ...manifest,
+      fixtures: [{ ...manifest.fixtures[0]!, mode: "send", provider: "mock" }],
+      providers: {
+        mock: {
+          adapter: "script",
+          capabilities: ["send"],
+          env: [],
+          notes: "x".repeat(1024 * 1024),
+          platform: "slack",
+          script: { commands: { send: "send" } },
+          status: "active",
+        },
+      },
+    };
+
+    const result = await runFixtureCommand({
+      fixtureId: "fixture",
+      manifest: scriptManifest,
+      manifestPath: "/tmp/crabline.yaml",
+      registry: buildRegistry(provider),
+    });
+
+    expect(result).toMatchObject({ failureKind: "config", ok: false });
+    expect(result.diagnostics).toContain("Script command input exceeded 1048576 bytes.");
+    expect(sendCalls).toBe(0);
   });
 
   it("preserves captured failures when cleanup fails", async () => {

--- a/test/script-provider.test.ts
+++ b/test/script-provider.test.ts
@@ -351,6 +351,27 @@ describe("script provider", () => {
     ).resolves.toBeNull();
   });
 
+  it("passes excluded inbound IDs to stateless wait commands", async () => {
+    const context = await createContext();
+    const waitScript = path.join(path.dirname(context.manifestPath), "wait-exclusions.mjs");
+    await writeText(
+      waitScript,
+      'let raw="";process.stdin.on("data",(chunk)=>raw+=chunk);process.stdin.on("end",()=>{const input=JSON.parse(raw);process.stdout.write(JSON.stringify({message:{author:"assistant",id:"inbound-after-exclusions",sentAt:new Date().toISOString(),text:JSON.stringify(input.wait.excludeIds),threadId:"thread-1"}}));});',
+    );
+    context.config.script!.commands.waitForInbound = `node ${waitScript}`;
+    const provider = new ScriptProviderAdapter(context);
+
+    await expect(
+      provider.waitForInbound({
+        ...context,
+        excludeIds: ["seen-1", "seen-2"],
+        nonce: "nonce",
+        since: new Date().toISOString(),
+        timeoutMs: 1000,
+      }),
+    ).resolves.toMatchObject({ text: '["seen-1","seen-2"]' });
+  });
+
   it("rejects inbound messages returned during the wait exit grace", async () => {
     const context = await createContext();
     const waitScript = path.join(path.dirname(context.manifestPath), "wait-late-message.mjs");


### PR DESCRIPTION
## Summary
- bound fixture lifecycle operations and script-adapter input
- harden CLI output under pipe closure and terminal-controlled manifest data
- reject duplicate JSON keys and unsafe timer ranges
- preserve stateless inbound progress and watch cleanup

## Verification
- focused runtime coverage: 9 files, 215 tests
- focused lifecycle/script adjudication: 3 files, 73 tests
- local `pnpm verify`: 56 files, 831 tests
- Crabbox `run_d5912c396f7a`: 56 files, 831 tests
- exact-head `gpt-5.6-sol` high autoreview: clean
- GitHub CI: green

## Changelog
- updated `CHANGELOG.md`