### PR TITLE
fix(servers): harden final transport semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Enforce native Matrix, Mattermost, Signal, and Slack outcomes, pagination, retries, state, JSON-RPC, WebSocket, HTTP response, and recorder privacy contracts.
 - Harden OpenClaw artifact publication identity and cleanup, and align Mattermost, Matrix, Signal, Slack, Telegram, and WhatsApp bridge contracts.
 - Bound fixture execution and script input, harden CLI pipe output and manifest parsing, and preserve watch cleanup and stateless inbound progress.
+- Harden Telegram, WhatsApp, and Zalo webhook validation, delivery acknowledgement, identity correlation, media metadata, and accepted-send evidence.
 - Bound signed-JWT key refreshes and authenticate, decode, or suppress Google Chat, Teams, Feishu, and Discord webhook ingress according to provider contracts.
 - Bound recorder tail memory, harden shared provider cleanup and inbound matching, and reject non-global webhook targets.
 - Recover backpressured Signal events without recording rejected RPC calls.

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -29,7 +29,16 @@ const TELEGRAM_MAX_REQUEST_BODY_BYTES = 50 * 1024 * 1024;
 const TELEGRAM_WEBHOOK_MAX_BACKOFF_EXPONENT = 5;
 const TELEGRAM_WEBHOOK_RETRY_BASE_MS = 100;
 const TELEGRAM_WEBHOOK_DELIVERY_TIMEOUT_MS = 3_000;
+const MAX_ACTIVE_TELEGRAM_WEBHOOK_VALIDATIONS = 8;
 const TELEGRAM_CHAT_USERNAME_PATTERN = /^@[A-Za-z][A-Za-z0-9_]{3,31}$/u;
+const TELEGRAM_SEND_METHODS = new Set([
+  "sendanimation",
+  "sendaudio",
+  "senddocument",
+  "sendmessage",
+  "sendphoto",
+  "sendvideo",
+]);
 const TELEGRAM_MEDIA_FIELDS = [
   "animation",
   "audio",
@@ -70,6 +79,7 @@ const TELEGRAM_UNSUPPORTED_UPDATE_FIELDS = [
 ] as const;
 
 type TelegramServerEvent = {
+  accepted?: boolean | undefined;
   at: string;
   body?: unknown;
   method: string;
@@ -129,10 +139,13 @@ type TelegramMessage = {
     type: "group" | "private" | "supergroup";
   };
   animation?: {
+    duration: number;
     file_id: string;
     file_name?: string;
     file_unique_id: string;
+    height: number;
     mime_type?: string;
+    width: number;
   };
   caption?: string;
   date: number;
@@ -170,10 +183,13 @@ type TelegramMessage = {
   }>;
   text?: string;
   video?: {
+    duration: number;
     file_id: string;
     file_name?: string;
     file_unique_id: string;
+    height: number;
     mime_type?: string;
+    width: number;
   };
 };
 
@@ -389,6 +405,8 @@ function createOutboundMediaMessage(
   }
   const caption = toStringValue(body.caption);
   const duration = Math.max(0, toIntegerValue(body.duration) ?? 0);
+  const height = Math.max(1, toIntegerValue(body.height) ?? 1);
+  const width = Math.max(1, toIntegerValue(body.width) ?? 1);
   const media = {
     file_id: `crabline-${mediaKind}-${state.nextMessageId}`,
     file_name: fileName,
@@ -404,7 +422,11 @@ function createOutboundMediaMessage(
         ? [{ ...media, height: 1, width: 1 }]
         : {
             ...media,
-            ...(mediaKind === "audio" ? { duration } : {}),
+            ...(mediaKind === "audio"
+              ? { duration }
+              : mediaKind === "animation" || mediaKind === "video"
+                ? { duration, height, width }
+                : {}),
             mime_type: "application/octet-stream",
           },
     message_id: state.nextMessageId++,
@@ -462,16 +484,10 @@ function createInboundUpdate(
   ) {
     return undefined;
   }
-  const entities = Array.isArray(body.entities)
-    ? body.entities.filter(
-        (entry): entry is { length: number; offset: number; type: string } =>
-          typeof entry === "object" &&
-          entry !== null &&
-          typeof (entry as { length?: unknown }).length === "number" &&
-          typeof (entry as { offset?: unknown }).offset === "number" &&
-          typeof (entry as { type?: unknown }).type === "string",
-      )
-    : undefined;
+  const entities = parseTelegramEntities(body.entities, text);
+  if (body.entities !== undefined && !entities) {
+    return undefined;
+  }
   return {
     message: {
       chat: createChat(chatId),
@@ -489,6 +505,39 @@ function createInboundUpdate(
     },
     update_id: updateId ?? state.nextUpdateId,
   };
+}
+
+function parseTelegramEntities(
+  value: unknown,
+  text: string,
+): Array<{ length: number; offset: number; type: string }> | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const entities: Array<{ length: number; offset: number; type: string }> = [];
+  for (const entry of value) {
+    if (!isJsonObject(entry)) {
+      return undefined;
+    }
+    const length = toIntegerValue(entry.length);
+    const offset = toIntegerValue(entry.offset);
+    const type = toStringValue(entry.type);
+    if (
+      length === undefined ||
+      length < 1 ||
+      offset === undefined ||
+      offset < 0 ||
+      offset + length > text.length ||
+      !type
+    ) {
+      return undefined;
+    }
+    entities.push({ length, offset, type });
+  }
+  return entities;
 }
 
 function hasTelegramMedia(value: Record<string, unknown>): boolean {
@@ -609,8 +658,8 @@ async function handleTelegramAdminInbound(params: {
     params.state.updates.push(update);
     params.state.updates.sort((left, right) => left.update_id - right.update_id);
     if (params.state.webhook) {
-      const deliveryError = await deliverTelegramWebhookUpdates(params.state);
-      return deliveryError ?? jsonResponse({ ok: true, update });
+      scheduleTelegramWebhookDelivery(params.state, 0);
+      return jsonResponse({ ok: true, update });
     }
     finishTelegramUpdatePoll(params.state, "update");
     return jsonResponse({ ok: true, update });
@@ -674,19 +723,28 @@ async function validateTelegramWebhookUrl(
   deadlineAt: number,
   signal: AbortSignal,
 ): Promise<Response | { addresses: WebhookAddress[] | undefined }> {
+  const remainingMs = deadlineAt - Date.now();
+  if (remainingMs <= 0) {
+    return telegramError("Bad Request: webhook host could not be resolved");
+  }
+  const deadline = new AbortController();
+  const timer = setTimeout(
+    () => deadline.abort(new DOMException("Webhook delivery timed out", "TimeoutError")),
+    remainingMs,
+  );
+  timer.unref();
   let target;
   try {
-    target = await withTelegramWebhookDeadline(
-      validateWebhookTarget({
-        allowLoopbackHttp: state.allowLoopbackHttpWebhook,
-        restrictPrivateAddresses: state.restrictWebhookTargets,
-        url,
-      }),
-      deadlineAt,
-      signal,
-    );
+    target = await validateWebhookTarget({
+      allowLoopbackHttp: state.allowLoopbackHttpWebhook,
+      restrictPrivateAddresses: state.restrictWebhookTargets,
+      signal: AbortSignal.any([signal, deadline.signal]),
+      url,
+    });
   } catch {
     return telegramError("Bad Request: webhook host could not be resolved");
+  } finally {
+    clearTimeout(timer);
   }
   if (!("error" in target)) {
     return target;
@@ -951,6 +1009,9 @@ async function handleTelegramApi(params: {
       if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
         return telegramError("Bad Request: bad webhook URL");
       }
+      if (params.state.activeWebhookValidations.size >= MAX_ACTIVE_TELEGRAM_WEBHOOK_VALIDATIONS) {
+        return telegramError("Too Many Requests: too many webhook validations", 429);
+      }
       const validation = new AbortController();
       params.state.activeWebhookValidations.add(validation);
       const target = await validateTelegramWebhookUrl(
@@ -1211,15 +1272,33 @@ async function handleRequest(params: { request: IncomingMessage; state: Telegram
   if (!isJsonObject(body)) {
     return telegramError("Bad Request: can't parse JSON object");
   }
-  await appendEvent(params.state, {
+  const event: TelegramServerEvent = {
     at: new Date().toISOString(),
     body: redactTelegramSecrets(body),
     method: requestMethod,
     path: `/bot<redacted>/${botPath.method}`,
     query: redactTelegramSecrets(queryRecord(url)),
     type: "api",
-  });
-  return handleTelegramApi({
+  };
+  if (TELEGRAM_SEND_METHODS.has(botPath.method.toLowerCase())) {
+    const response = await handleTelegramApi({
+      body,
+      method: botPath.method,
+      request: params.request,
+      state: params.state,
+    });
+    event.accepted = response.ok;
+    try {
+      await appendEvent(params.state, event);
+    } catch (error) {
+      if (!event.accepted) {
+        throw error;
+      }
+    }
+    return response;
+  }
+  await appendEvent(params.state, event);
+  return await handleTelegramApi({
     body,
     method: botPath.method,
     request: params.request,
@@ -1254,7 +1333,7 @@ export async function startTelegramServer(
     nextUpdateId: 1,
     onEvent: params.onEvent,
     recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "telegram.jsonl"),
-    restrictWebhookTargets: !isLoopbackHost(host),
+    restrictWebhookTargets: true,
     closing: false,
     updates: [],
     webhook: undefined,

--- a/src/servers/webhook-target.ts
+++ b/src/servers/webhook-target.ts
@@ -15,11 +15,118 @@ export type ValidatedWebhookTarget =
   | { addresses: WebhookAddress[] | undefined }
   | { error: WebhookTargetError };
 
+export const MAX_CONCURRENT_WEBHOOK_DNS_LOOKUPS = 8;
+
 const BLOCKED_IPV4_ADDRESSES = createBlockedIpv4Addresses();
 const BLOCKED_IPV6_ADDRESSES = createBlockedIpv6Addresses();
 const GLOBAL_IPV4_EXCEPTIONS = createGlobalIpv4Exceptions();
 const GLOBAL_IPV6_EXCEPTIONS = createGlobalIpv6Exceptions();
 const ALLOCATED_GLOBAL_IPV6_RANGES = createAllocatedGlobalIpv6Ranges();
+
+type WebhookDnsLookupResult = ReadonlyArray<{ address: string; family: number }>;
+type WebhookDnsLookup = (hostname: string) => Promise<WebhookDnsLookupResult>;
+
+type PendingWebhookDnsLookup = {
+  hostname: string;
+  onAbort: () => void;
+  reject(error: unknown): void;
+  resolve(addresses: WebhookDnsLookupResult): void;
+  settled: boolean;
+  signal: AbortSignal | undefined;
+  started: boolean;
+};
+
+export class WebhookDnsLookupPool {
+  readonly #pending: PendingWebhookDnsLookup[] = [];
+  #active = 0;
+
+  constructor(
+    private readonly maxConcurrent: number,
+    private readonly lookupHostname: WebhookDnsLookup = async (hostname) =>
+      await lookup(hostname, { all: true, verbatim: true }),
+  ) {
+    if (!Number.isSafeInteger(maxConcurrent) || maxConcurrent < 1) {
+      throw new Error("Webhook DNS lookup concurrency must be a positive safe integer.");
+    }
+  }
+
+  resolve(hostname: string, signal?: AbortSignal): Promise<WebhookDnsLookupResult> {
+    return new Promise<WebhookDnsLookupResult>((resolve, reject) => {
+      const pending: PendingWebhookDnsLookup = {
+        hostname,
+        onAbort: () => {
+          if (pending.settled) {
+            return;
+          }
+          pending.settled = true;
+          if (!pending.started) {
+            const index = this.#pending.indexOf(pending);
+            if (index >= 0) {
+              this.#pending.splice(index, 1);
+            }
+          }
+          signal?.removeEventListener("abort", pending.onAbort);
+          reject(abortSignalError(signal));
+          this.#pump();
+        },
+        reject,
+        resolve,
+        settled: false,
+        signal,
+        started: false,
+      };
+      if (signal?.aborted) {
+        pending.onAbort();
+        return;
+      }
+      signal?.addEventListener("abort", pending.onAbort, { once: true });
+      this.#pending.push(pending);
+      this.#pump();
+    });
+  }
+
+  #pump(): void {
+    while (this.#active < this.maxConcurrent) {
+      const pending = this.#pending.shift();
+      if (!pending) {
+        return;
+      }
+      if (pending.settled) {
+        continue;
+      }
+      pending.started = true;
+      this.#active += 1;
+      void this.lookupHostname(pending.hostname)
+        .then(
+          (addresses) => {
+            if (!pending.settled) {
+              pending.settled = true;
+              pending.resolve(addresses);
+            }
+          },
+          (error: unknown) => {
+            if (!pending.settled) {
+              pending.settled = true;
+              pending.reject(error);
+            }
+          },
+        )
+        .finally(() => {
+          pending.signal?.removeEventListener("abort", pending.onAbort);
+          this.#active -= 1;
+          this.#pump();
+        });
+    }
+  }
+}
+
+const webhookDnsLookupPool = new WebhookDnsLookupPool(MAX_CONCURRENT_WEBHOOK_DNS_LOOKUPS);
+
+function abortSignalError(signal: AbortSignal | undefined): Error {
+  return signal?.reason instanceof Error
+    ? signal.reason
+    : new DOMException("Webhook DNS lookup aborted", "AbortError");
+}
 
 function createBlockedIpv4Addresses(): BlockList {
   const blockList = new BlockList();
@@ -202,13 +309,16 @@ function isBlockedWebhookAddress(address: string): boolean {
   return false;
 }
 
-async function resolveWebhookAddresses(hostname: string): Promise<WebhookAddress[]> {
+async function resolveWebhookAddresses(
+  hostname: string,
+  signal?: AbortSignal,
+): Promise<WebhookAddress[]> {
   const normalized = normalizeHostname(hostname);
   const family = isIP(normalized);
   if (family === 4 || family === 6) {
     return [{ address: normalized, family }];
   }
-  return (await lookup(normalized, { all: true, verbatim: true })).flatMap((entry) =>
+  return (await webhookDnsLookupPool.resolve(normalized, signal)).flatMap((entry) =>
     entry.family === 4 || entry.family === 6
       ? [{ address: entry.address, family: entry.family }]
       : [],
@@ -218,16 +328,18 @@ async function resolveWebhookAddresses(hostname: string): Promise<WebhookAddress
 export async function validateWebhookTarget(params: {
   allowLoopbackHttp: boolean;
   restrictPrivateAddresses: boolean;
+  signal?: AbortSignal | undefined;
   url: URL;
 }): Promise<ValidatedWebhookTarget> {
-  if (
+  const allowThisLoopbackHttp =
     params.url.protocol === "http:" &&
-    (!params.allowLoopbackHttp || !isLoopbackHost(params.url.hostname))
-  ) {
+    params.allowLoopbackHttp &&
+    isLoopbackHost(params.url.hostname);
+  if (params.url.protocol !== "https:" && !allowThisLoopbackHttp) {
     return { error: "https-required" };
   }
-  if (params.url.protocol !== "http:" && params.url.protocol !== "https:") {
-    return { error: "https-required" };
+  if (allowThisLoopbackHttp) {
+    return { addresses: undefined };
   }
   if (!params.restrictPrivateAddresses) {
     return { addresses: undefined };
@@ -235,8 +347,11 @@ export async function validateWebhookTarget(params: {
 
   let addresses: WebhookAddress[];
   try {
-    addresses = await resolveWebhookAddresses(params.url.hostname);
-  } catch {
+    addresses = await resolveWebhookAddresses(params.url.hostname, params.signal);
+  } catch (error) {
+    if (params.signal?.aborted) {
+      throw error;
+    }
     return { error: "unresolvable" };
   }
   if (addresses.length === 0) {
@@ -275,6 +390,7 @@ export async function postWebhookRequest(params: {
     const request = send(
       params.url,
       {
+        agent: false,
         ...(address ? { family: address.family } : {}),
         headers: {
           "content-length": String(Buffer.byteLength(params.body)),

--- a/src/servers/whatsapp-baileys-websocket.ts
+++ b/src/servers/whatsapp-baileys-websocket.ts
@@ -25,7 +25,7 @@ import { KEY_BUNDLE_TYPE, xmppPreKey, xmppSignedPreKey } from "./whatsapp-wire/s
 import { WebSocket, WebSocketServer, type ServerOptions } from "ws";
 import type { ServerRequestEvent } from "./http.js";
 import { closeWebSocketServer } from "./websocket.js";
-import { canonicalizeWhatsAppUserJid } from "./whatsapp-jid.js";
+import { canonicalizeWhatsAppUserCorrelationJid } from "./whatsapp-jid.js";
 
 // Keep the local server independent from Baileys at runtime. Tests use Baileys
 // as a black-box client to verify this narrow WhatsApp Web wire subset.
@@ -124,7 +124,7 @@ export class WhatsAppSignalBundleStore {
     const uniqueNewJids = new Set<string>();
     const canonicalJids: string[] = [];
     for (const jid of jids) {
-      const canonical = canonicalizeWhatsAppUserJid(jid);
+      const canonical = canonicalizeWhatsAppUserCorrelationJid(jid);
       if (!canonical) {
         throw new Error(`Invalid WhatsApp signal bundle JID: ${jid}.`);
       }
@@ -644,6 +644,18 @@ class WhatsAppBaileysWebSocketSession {
       };
     }
     if (node.attrs.xmlns === "w:g2") {
+      if (node.attrs.type !== "get" || child?.tag !== "query") {
+        return {
+          attrs: { ...attrs, type: "error" },
+          content: [
+            {
+              attrs: { code: "501", text: "unsupported group operation", type: "cancel" },
+              tag: "error",
+            },
+          ],
+          tag: "iq",
+        };
+      }
       return {
         attrs,
         content: [

--- a/src/servers/whatsapp-jid.ts
+++ b/src/servers/whatsapp-jid.ts
@@ -13,6 +13,15 @@ export function canonicalizeWhatsAppUserJid(value: string): string | undefined {
   return `${user}${device === undefined ? "" : `:${device}`}@${server}`;
 }
 
+export function canonicalizeWhatsAppUserCorrelationJid(value: string): string | undefined {
+  const jid = canonicalizeWhatsAppUserJid(value);
+  if (!jid) {
+    return undefined;
+  }
+  const separator = jid.lastIndexOf("@");
+  return `${jid.slice(0, separator).split(":", 1)[0]}@${jid.slice(separator + 1)}`;
+}
+
 export function canonicalizeWhatsAppGroupJid(value: string): string | undefined {
   const match = WHATSAPP_GROUP_JID_RE.exec(value.trim());
   return match ? `${match[1]}@g.us` : undefined;

--- a/src/servers/whatsapp.ts
+++ b/src/servers/whatsapp.ts
@@ -3,6 +3,7 @@ import { randomBytes } from "node:crypto";
 import path from "node:path";
 import {
   adminAuthError,
+  drainRequestBody,
   hasAdminToken,
   InvalidJsonBodyError,
   isJsonObject,
@@ -24,6 +25,7 @@ import {
 } from "./whatsapp-baileys-websocket.js";
 import {
   canonicalizeWhatsAppChatJid,
+  canonicalizeWhatsAppUserCorrelationJid,
   canonicalizeWhatsAppUserJid,
   isWhatsAppGroupJid,
 } from "./whatsapp-jid.js";
@@ -206,9 +208,7 @@ function waIdFromJid(jid: string): string {
 }
 
 function directPeerIdentity(jid: string): string {
-  const separator = jid.lastIndexOf("@");
-  const user = jid.slice(0, separator).split(":", 1)[0] ?? jid;
-  return `${user}@${jid.slice(separator + 1).toLowerCase()}`;
+  return canonicalizeWhatsAppUserCorrelationJid(jid) ?? jid;
 }
 
 function requireMessagingProduct(body: Record<string, unknown>): Response | undefined {
@@ -424,6 +424,7 @@ async function handleRequest(params: { request: IncomingMessage; state: WhatsApp
 
   if (url.pathname === "/_crabline/admin/whatsapp/inbound") {
     if (params.request.method !== "POST") {
+      drainRequestBody(params.request);
       return new Response("not found", { status: 404 });
     }
     if (!hasAdminToken(params.request, params.state.adminToken)) {
@@ -502,6 +503,7 @@ async function handleRequest(params: { request: IncomingMessage; state: WhatsApp
   }
   if (url.pathname === messagesPath) {
     if (params.request.method !== "POST") {
+      drainRequestBody(params.request);
       return new Response("not found", { status: 404 });
     }
     const body = await parseUnknownRequestBody(params.request);
@@ -535,6 +537,7 @@ async function handleRequest(params: { request: IncomingMessage; state: WhatsApp
     await appendEvent(params.state, event);
     return response;
   }
+  drainRequestBody(params.request);
   return new Response("not found", { status: 404 });
 }
 
@@ -542,11 +545,17 @@ export async function startWhatsAppServer(
   params: StartWhatsAppServerParams = {},
 ): Promise<StartedWhatsAppServer> {
   const host = params.host ?? "127.0.0.1";
-  if (params.accessToken !== undefined && !params.accessToken.trim()) {
-    throw new Error("WhatsApp accessToken must not be empty.");
+  if (
+    params.accessToken !== undefined &&
+    (!params.accessToken.trim() || params.accessToken !== params.accessToken.trim())
+  ) {
+    throw new Error("WhatsApp accessToken must not be empty or whitespace-padded.");
   }
-  if (params.adminToken !== undefined && !params.adminToken.trim()) {
-    throw new Error("WhatsApp adminToken must not be empty.");
+  if (
+    params.adminToken !== undefined &&
+    (!params.adminToken.trim() || params.adminToken !== params.adminToken.trim())
+  ) {
+    throw new Error("WhatsApp adminToken must not be empty or whitespace-padded.");
   }
   const graphVersion = params.graphVersion ?? DEFAULT_GRAPH_VERSION;
   if (!WHATSAPP_GRAPH_VERSION_RE.test(graphVersion)) {

--- a/src/servers/zalo.ts
+++ b/src/servers/zalo.ts
@@ -1,5 +1,10 @@
 import { randomBytes } from "node:crypto";
-import type { ClientRequest, IncomingMessage, ServerResponse } from "node:http";
+import {
+  validateHeaderValue,
+  type ClientRequest,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
 import path from "node:path";
 import {
   adminAuthError,
@@ -28,7 +33,13 @@ import {
 type ZaloChatType = "GROUP" | "PRIVATE";
 
 const DEFAULT_WEBHOOK_DELIVERY_TIMEOUT_MS = 5_000;
+const MAX_ACTIVE_ZALO_WEBHOOK_VALIDATIONS = 8;
 const MAX_WEBHOOK_DELIVERY_TIMEOUT_MS = 30_000;
+const MAX_ZALO_WEBHOOK_SECRET_BYTES = 256;
+
+type ZaloServerEvent = ServerRequestEvent & {
+  accepted?: boolean | undefined;
+};
 
 type ZaloMessage = {
   chat: { chat_type: ZaloChatType; id: string };
@@ -63,6 +74,7 @@ type ZaloValidatedWebhookTarget = {
 
 type ZaloServerState = {
   activeWebhookRequests: Set<ClientRequest>;
+  activeWebhookValidations: Set<AbortController>;
   adminToken: string;
   allowLoopbackHttpWebhook: boolean;
   botId: string;
@@ -121,7 +133,7 @@ export type StartZaloServerParams = {
   webhookDeliveryTimeoutMs?: number | undefined;
 };
 
-async function appendEvent(state: ZaloServerState, event: ServerRequestEvent): Promise<void> {
+async function appendEvent(state: ZaloServerState, event: ZaloServerEvent): Promise<void> {
   await recordServerEvent({ event, onEvent: state.onEvent, recorderPath: state.recorderPath });
 }
 
@@ -189,10 +201,12 @@ function webhookDeliveryTimeoutMs(value: number | undefined): number {
 async function validateWebhookUrl(
   url: URL,
   state: Pick<ZaloServerState, "allowLoopbackHttpWebhook" | "restrictWebhookTargets">,
+  signal?: AbortSignal,
 ): Promise<Response | ZaloValidatedWebhookTarget> {
   const target = await validateWebhookTarget({
     allowLoopbackHttp: state.allowLoopbackHttpWebhook,
     restrictPrivateAddresses: state.restrictWebhookTargets,
+    signal,
     url,
   });
   if ("error" in target) {
@@ -205,33 +219,44 @@ async function validateWebhookUrl(
   return target;
 }
 
-function webhookTimeoutError(timeoutMs: number): DOMException {
-  return new DOMException(`Webhook delivery timed out after ${timeoutMs}ms`, "TimeoutError");
+function validateZaloWebhookSecret(secretToken: string): Response | undefined {
+  if (Buffer.byteLength(secretToken) > MAX_ZALO_WEBHOOK_SECRET_BYTES) {
+    return zaloError(`secret_token must not exceed ${MAX_ZALO_WEBHOOK_SECRET_BYTES} bytes`, 400);
+  }
+  try {
+    validateHeaderValue("x-bot-api-secret-token", secretToken);
+  } catch {
+    return zaloError("secret_token contains invalid HTTP header characters", 400);
+  }
+  return undefined;
 }
 
-async function withWebhookDeadline<T>(
-  promise: Promise<T>,
+async function validateWebhookUrlWithDeadline(
+  url: URL,
+  state: ZaloServerState,
   deadlineAt: number,
-  timeoutMs: number,
-): Promise<T> {
+): Promise<Response | ZaloValidatedWebhookTarget> {
   const remainingMs = deadlineAt - Date.now();
   if (remainingMs <= 0) {
-    throw webhookTimeoutError(timeoutMs);
+    throw webhookTimeoutError(state.webhookDeliveryTimeoutMs);
   }
-  return await new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(() => reject(webhookTimeoutError(timeoutMs)), remainingMs);
-    timer.unref();
-    promise.then(
-      (value) => {
-        clearTimeout(timer);
-        resolve(value);
-      },
-      (error: unknown) => {
-        clearTimeout(timer);
-        reject(error);
-      },
-    );
-  });
+  const validation = new AbortController();
+  state.activeWebhookValidations.add(validation);
+  const timer = setTimeout(
+    () => validation.abort(webhookTimeoutError(state.webhookDeliveryTimeoutMs)),
+    remainingMs,
+  );
+  timer.unref();
+  try {
+    return await validateWebhookUrl(url, state, validation.signal);
+  } finally {
+    clearTimeout(timer);
+    state.activeWebhookValidations.delete(validation);
+  }
+}
+
+function webhookTimeoutError(timeoutMs: number): DOMException {
+  return new DOMException(`Webhook delivery timed out after ${timeoutMs}ms`, "TimeoutError");
 }
 
 /** @internal */
@@ -507,11 +532,7 @@ async function deliverWebhookUpdate(
   const url = new URL(webhook.url);
   let target: Response | ZaloValidatedWebhookTarget;
   try {
-    target = await withWebhookDeadline(
-      validateWebhookUrl(url, state),
-      deadlineAt,
-      state.webhookDeliveryTimeoutMs,
-    );
+    target = await validateWebhookUrlWithDeadline(url, state, deadlineAt);
   } catch (error) {
     if (error instanceof DOMException && error.name === "TimeoutError") {
       return zaloError(`Webhook delivery timed out after ${state.webhookDeliveryTimeoutMs}ms`, 502);
@@ -637,14 +658,32 @@ async function handleZaloMethod(
     return zaloError("Bad Request: can't parse JSON object", 400);
   }
   const body = requestParams(url, parsedBody);
-  await appendEvent(state, {
+  const event: ZaloServerEvent = {
     at: new Date().toISOString(),
     ...(Object.keys(body).length > 0 ? { body: redactParams(body) } : {}),
     method: request.method ?? "GET",
     path: `/bot<redacted>/${method}`,
     query: redactParams(queryRecord(url)) as Record<string, string>,
     type: "api",
-  });
+  };
+
+  if (method === "sendMessage" || method === "sendPhoto") {
+    const chatId = requireParam(body, "chat_id");
+    const content = requireParam(body, method === "sendMessage" ? "text" : "photo");
+    const error = firstError(chatId, content);
+    const sendResponse = error ?? zaloOk({ date: Date.now(), message_id: messageId(state) });
+    event.accepted = sendResponse.ok;
+    try {
+      await appendEvent(state, event);
+    } catch (appendError) {
+      if (!event.accepted) {
+        throw appendError;
+      }
+    }
+    return sendResponse;
+  }
+
+  await appendEvent(state, event);
 
   if (method === "getMe") {
     return zaloOk({
@@ -661,15 +700,6 @@ async function handleZaloMethod(
     const parsedTimeout = Number(readTrimmedString(body.timeout) ?? "30");
     const timeout = Number.isFinite(parsedTimeout) ? Math.max(0, Math.min(parsedTimeout, 50)) : 30;
     return await waitForUpdate(request, response, state, timeout);
-  }
-  if (method === "sendMessage" || method === "sendPhoto") {
-    const chatId = requireParam(body, "chat_id");
-    const content = requireParam(body, method === "sendMessage" ? "text" : "photo");
-    const error = firstError(chatId, content);
-    if (error) {
-      return error;
-    }
-    return zaloOk({ date: Date.now(), message_id: messageId(state) });
   }
   if (method === "sendChatAction") {
     const chatId = requireParam(body, "chat_id");
@@ -693,13 +723,29 @@ async function handleZaloMethod(
     if (typeof webhookUrl !== "string" || typeof secretToken !== "string") {
       return zaloError("Invalid webhook parameters", 400);
     }
+    const secretError = validateZaloWebhookSecret(secretToken);
+    if (secretError) {
+      return secretError;
+    }
     let parsedUrl: URL;
     try {
       parsedUrl = new URL(webhookUrl);
     } catch {
       return zaloError("url must be a valid HTTPS URL", 400);
     }
-    const target = await validateWebhookUrl(parsedUrl, state);
+    if (state.activeWebhookValidations.size >= MAX_ACTIVE_ZALO_WEBHOOK_VALIDATIONS) {
+      return zaloError("Too many webhook validations", 429);
+    }
+    let target: Response | ZaloValidatedWebhookTarget;
+    try {
+      target = await validateWebhookUrlWithDeadline(
+        parsedUrl,
+        state,
+        Date.now() + state.webhookDeliveryTimeoutMs,
+      );
+    } catch {
+      return zaloError("url host could not be resolved", 400);
+    }
     if (target instanceof Response) {
       return target;
     }
@@ -732,6 +778,7 @@ export async function startZaloServer(
   const host = params.host ?? "127.0.0.1";
   const state: ZaloServerState = {
     activeWebhookRequests: new Set(),
+    activeWebhookValidations: new Set(),
     adminToken: params.adminToken ?? randomBytes(24).toString("hex"),
     allowLoopbackHttpWebhook: isLoopbackHost(host),
     botId: params.botId ?? "1459232241454765289",
@@ -749,7 +796,7 @@ export async function startZaloServer(
     pendingRequest: undefined,
     recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "zalo.jsonl"),
     reservedUpdateOrders: new Set(),
-    restrictWebhookTargets: !isLoopbackHost(host),
+    restrictWebhookTargets: true,
     updateOrders: new WeakMap(),
     updates: [],
     webhook: undefined,
@@ -806,6 +853,9 @@ export async function startZaloServer(
       state.closing = true;
       for (const request of state.activeWebhookRequests) {
         request.destroy(new Error("Zalo server is shutting down."));
+      }
+      for (const validation of state.activeWebhookValidations) {
+        validation.abort(new Error("Zalo server is shutting down."));
       }
       if (state.pendingRequest) {
         settlePendingUpdate(state, state.pendingRequest, { kind: "shutdown" });

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -135,7 +135,7 @@ describe("telegram local provider server", () => {
       },
     });
 
-    const collectibleUsername = await fetch(
+    const shortUsername = await fetch(
       `${server.manifest.baseUrl}/bot123456:fake-token/sendMessage`,
       {
         body: JSON.stringify({
@@ -146,13 +146,12 @@ describe("telegram local provider server", () => {
         method: "POST",
       },
     );
-    await expect(collectibleUsername.json()).resolves.toMatchObject({
-      result: {
-        chat: { id: "@tiny", type: "supergroup" },
-      },
+    expect(shortUsername.status).toBe(200);
+    await expect(shortUsername.json()).resolves.toMatchObject({
+      result: { chat: { id: "@tiny", type: "supergroup" } },
     });
 
-    const shortUsername = await fetch(
+    const shorterUsername = await fetch(
       `${server.manifest.baseUrl}/bot123456:fake-token/sendMessage`,
       {
         body: JSON.stringify({
@@ -163,7 +162,7 @@ describe("telegram local provider server", () => {
         method: "POST",
       },
     );
-    expect(shortUsername.status).toBe(400);
+    expect(shorterUsername.status).toBe(400);
   });
 
   it("serves Telegram Bot API calls and queues injected inbound updates", async () => {
@@ -354,6 +353,29 @@ describe("telegram local provider server", () => {
       },
     });
 
+    for (const [method, field] of [
+      ["sendAnimation", "animation"],
+      ["sendVideo", "video"],
+    ] as const) {
+      const response = await fetch(`${server.manifest.baseUrl}/bot123456:fake-token/${method}`, {
+        body: JSON.stringify({
+          [field]: `fixture-${field}.mp4`,
+          chat_id: "-1001234567890",
+          duration: 7,
+          height: 360,
+          width: 640,
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      await expect(response.json()).resolves.toMatchObject({
+        ok: true,
+        result: {
+          [field]: { duration: 7, height: 360, width: 640 },
+        },
+      });
+    }
+
     const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
       body: JSON.stringify({
         chatId: "-1001234567890",
@@ -393,6 +415,37 @@ describe("telegram local provider server", () => {
           update_id: 1,
         },
       ],
+    });
+  });
+
+  it("validates inbound entity integers and UTF-16 bounds", async () => {
+    const server = await startTelegramServer();
+    servers.push(server);
+
+    for (const entities of [
+      [{ length: 1.5, offset: 0, type: "bold" }],
+      [{ length: 1, offset: -1, type: "bold" }],
+      [{ length: 2, offset: 2, type: "bold" }],
+    ]) {
+      const invalidEntity = await injectUpdate(server, {
+        chatId: 42,
+        entities,
+        text: "😀",
+      });
+      expect(invalidEntity.status).toBe(400);
+    }
+    const utf16Entity = await injectUpdate(server, {
+      chatId: 42,
+      entities: [{ length: 2, offset: 0, type: "custom_emoji" }],
+      text: "😀",
+    });
+    await expect(utf16Entity.json()).resolves.toMatchObject({
+      ok: true,
+      update: {
+        message: {
+          entities: [{ length: 2, offset: 0, type: "custom_emoji" }],
+        },
+      },
     });
   });
 
@@ -639,6 +692,7 @@ describe("telegram local provider server", () => {
 
       const inbound = await injectUpdate(server, { chatId: 42, text: "webhook update" });
       expect(inbound.status).toBe(200);
+      await expect.poll(() => delivered.length).toBe(2);
       expect(delivered).toEqual([
         {
           body: expect.objectContaining({
@@ -754,7 +808,7 @@ describe("telegram local provider server", () => {
         },
       );
       expect(replaced.status).toBe(200);
-      expect((await inbound).status).toBe(502);
+      expect((await inbound).status).toBe(200);
       await expect.poll(() => delivered).toEqual([1]);
     } finally {
       oldWebhook.closeAllConnections();
@@ -803,7 +857,7 @@ describe("telegram local provider server", () => {
         },
       );
       expect(deleted.status).toBe(200);
-      expect((await inbound).status).toBe(502);
+      expect((await inbound).status).toBe(200);
       await expect((await getUpdates(server, {})).json()).resolves.toMatchObject({
         result: [{ message: { text: "delete delivery" }, update_id: 1 }],
       });
@@ -875,7 +929,7 @@ describe("telegram local provider server", () => {
       releaseFirst();
 
       expect((await lowerUpdate).status).toBe(200);
-      expect(delivered).toEqual([10, 5]);
+      await expect.poll(() => delivered).toEqual([10, 5]);
     } finally {
       releaseFirst();
       await new Promise<void>((resolve, reject) =>
@@ -943,7 +997,7 @@ describe("telegram local provider server", () => {
       await new Promise((resolve) => setTimeout(resolve, 25));
       releaseFinal();
 
-      expect((await lowerUpdate).status).toBe(502);
+      expect((await lowerUpdate).status).toBe(200);
       await expect
         .poll(() => attemptedUpdateIds.filter((updateId) => updateId === 5).length, {
           timeout: 5_000,
@@ -978,10 +1032,10 @@ describe("telegram local provider server", () => {
         headers: { "content-type": "application/json" },
         method: "POST",
       });
-      expect((await injectUpdate(server, { chatId: 42, text: "retry me" })).status).toBe(502);
+      expect((await injectUpdate(server, { chatId: 42, text: "retry me" })).status).toBe(200);
       await expect.poll(() => attempts, { timeout: 8_000 }).toBe(7);
       expect((await injectUpdate(server, { chatId: 42, text: "after recovery" })).status).toBe(200);
-      expect(attempts).toBe(8);
+      await expect.poll(() => attempts).toBe(8);
       const info = await fetch(
         `${server.manifest.baseUrl}/bottest-token-placeholder/getWebhookInfo`,
       );
@@ -1034,7 +1088,7 @@ describe("telegram local provider server", () => {
         headers: { "content-type": "application/json" },
         method: "POST",
       });
-      expect((await injectUpdate(server, { chatId: 42, text: "recover me" })).status).toBe(502);
+      expect((await injectUpdate(server, { chatId: 42, text: "recover me" })).status).toBe(200);
       await expect.poll(() => attempts).toBe(2);
 
       const info = await fetch(
@@ -1085,18 +1139,22 @@ describe("telegram local provider server", () => {
         method: "POST",
       });
       expect((await injectUpdate(server, { chatId: 42, text: "do not redirect" })).status).toBe(
-        502,
+        200,
       );
+      await expect
+        .poll(async () => {
+          const info = await fetch(
+            `${server.manifest.baseUrl}/bottest-token-placeholder/getWebhookInfo`,
+          );
+          return (await info.json()) as unknown;
+        })
+        .toMatchObject({
+          result: {
+            last_error_message: "Wrong response from the webhook: 302",
+            pending_update_count: 1,
+          },
+        });
       expect(redirectedRequests).toBe(0);
-      const info = await fetch(
-        `${server.manifest.baseUrl}/bottest-token-placeholder/getWebhookInfo`,
-      );
-      await expect(info.json()).resolves.toMatchObject({
-        result: {
-          last_error_message: "Wrong response from the webhook: 302",
-          pending_update_count: 1,
-        },
-      });
     } finally {
       await Promise.all([
         new Promise<void>((resolve, reject) =>
@@ -1125,6 +1183,107 @@ describe("telegram local provider server", () => {
     await expect(rejected.json()).resolves.toEqual({
       description: "Bad Request: webhook URL must use HTTPS",
       error_code: 400,
+      ok: false,
+    });
+
+    const privateHttps = await fetch(
+      `${server.manifest.baseUrl}/bottest-token-placeholder/setWebhook`,
+      {
+        body: JSON.stringify({ url: "https://10.0.0.1/telegram" }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      },
+    );
+    expect(privateHttps.status).toBe(400);
+    await expect(privateHttps.json()).resolves.toMatchObject({
+      description: "Bad Request: webhook URL must not target a private or link-local address",
+    });
+  });
+
+  it("records producer-owned acceptance for Telegram sends", async () => {
+    const observed: Array<{ accepted?: boolean; path?: string }> = [];
+    const server = await startTelegramServer({
+      botToken: "test-token-placeholder",
+      onEvent(event) {
+        observed.push(event);
+      },
+    });
+    servers.push(server);
+
+    const accepted = await fetch(
+      `${server.manifest.baseUrl}/bottest-token-placeholder/sendMessage`,
+      {
+        body: JSON.stringify({ chat_id: 42, text: "accepted" }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      },
+    );
+    const rejected = await fetch(
+      `${server.manifest.baseUrl}/bottest-token-placeholder/sendMessage`,
+      {
+        body: JSON.stringify({ chat_id: 42 }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      },
+    );
+
+    expect(accepted.status).toBe(200);
+    expect(rejected.status).toBe(400);
+    expect(observed).toEqual([
+      expect.objectContaining({ accepted: true, path: "/bot<redacted>/sendMessage" }),
+      expect.objectContaining({ accepted: false, path: "/bot<redacted>/sendMessage" }),
+    ]);
+  });
+
+  it("preserves committed sends but surfaces rejected-send evidence failures", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    let failAcceptedEvent = true;
+    const server = await startTelegramServer({
+      botToken: "test-token-placeholder",
+      onEvent(event) {
+        if (event.path !== "/bot<redacted>/sendMessage") {
+          return;
+        }
+        const accepted = (event as { accepted?: boolean }).accepted;
+        if (accepted && failAcceptedEvent) {
+          failAcceptedEvent = false;
+          throw new Error("accepted Telegram evidence failed");
+        }
+        if (accepted === false) {
+          throw new Error("rejected Telegram evidence failed");
+        }
+      },
+      recorderPath: path.join(directory, "telegram-send-evidence.jsonl"),
+    });
+    servers.push(server);
+
+    const first = await fetch(`${server.manifest.baseUrl}/bottest-token-placeholder/sendMessage`, {
+      body: JSON.stringify({ chat_id: 42, text: "committed" }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    expect(first.status).toBe(200);
+    await expect(first.json()).resolves.toMatchObject({ result: { message_id: 1 } });
+
+    const second = await fetch(`${server.manifest.baseUrl}/bottest-token-placeholder/sendMessage`, {
+      body: JSON.stringify({ chat_id: 42, text: "next" }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    await expect(second.json()).resolves.toMatchObject({ result: { message_id: 2 } });
+
+    const rejected = await fetch(
+      `${server.manifest.baseUrl}/bottest-token-placeholder/sendMessage`,
+      {
+        body: JSON.stringify({ chat_id: 42 }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      },
+    );
+    expect(rejected.status).toBe(500);
+    await expect(rejected.json()).resolves.toEqual({
+      error: "internal server error",
       ok: false,
     });
   });
@@ -1625,7 +1784,7 @@ describe("telegram local provider server", () => {
     await expect(response.json()).resolves.toMatchObject({ ok: true });
     const webhookSecret = "test-auth-token";
     const webhookUrl = new URL(`${server.manifest.baseUrl}/bot${botToken}/setWebhook`);
-    webhookUrl.searchParams.set("url", "https://example.invalid/telegram");
+    webhookUrl.searchParams.set("url", "https://93.184.216.34/telegram");
     webhookUrl.searchParams.set("secret_token", webhookSecret);
     const webhook = await fetch(webhookUrl);
     await expect(webhook.json()).resolves.toMatchObject({ ok: true });

--- a/test/webhook-target.test.ts
+++ b/test/webhook-target.test.ts
@@ -1,5 +1,10 @@
+import { createServer } from "node:http";
 import { describe, expect, it } from "vitest";
-import { validateWebhookTarget } from "../src/servers/webhook-target.js";
+import {
+  postWebhookRequest,
+  validateWebhookTarget,
+  WebhookDnsLookupPool,
+} from "../src/servers/webhook-target.js";
 
 async function validate(address: string) {
   return await validateWebhookTarget({
@@ -75,5 +80,91 @@ describe("webhook target validation", () => {
     await expect(validate(host)).resolves.toEqual({
       addresses: [{ address, family }],
     });
+  });
+
+  it("only exempts loopback HTTP from private-address blocking", async () => {
+    await expect(
+      validateWebhookTarget({
+        allowLoopbackHttp: true,
+        restrictPrivateAddresses: true,
+        url: new URL("http://127.0.0.1/webhook"),
+      }),
+    ).resolves.toEqual({ addresses: undefined });
+    await expect(
+      validateWebhookTarget({
+        allowLoopbackHttp: true,
+        restrictPrivateAddresses: true,
+        url: new URL("https://10.0.0.1/webhook"),
+      }),
+    ).resolves.toEqual({ error: "private-address" });
+  });
+
+  it.each(["ftp://93.184.216.34/webhook", "ws://93.184.216.34/webhook"])(
+    "rejects unsupported webhook protocol %s",
+    async (url) => {
+      await expect(
+        validateWebhookTarget({
+          allowLoopbackHttp: true,
+          restrictPrivateAddresses: true,
+          url: new URL(url),
+        }),
+      ).resolves.toEqual({ error: "https-required" });
+    },
+  );
+
+  it("bounds DNS lookup concurrency and cancels queued registrations", async () => {
+    const started: string[] = [];
+    const releases = new Map<
+      string,
+      (addresses: Array<{ address: string; family: number }>) => void
+    >();
+    const pool = new WebhookDnsLookupPool(
+      2,
+      async (hostname) =>
+        await new Promise((resolve) => {
+          started.push(hostname);
+          releases.set(hostname, resolve);
+        }),
+    );
+    const first = pool.resolve("first.test");
+    const second = pool.resolve("second.test");
+    const controller = new AbortController();
+    const third = pool.resolve("third.test", controller.signal);
+
+    expect(started).toEqual(["first.test", "second.test"]);
+    controller.abort();
+    await expect(third).rejects.toMatchObject({ name: "AbortError" });
+    expect(started).toEqual(["first.test", "second.test"]);
+
+    releases.get("first.test")?.([{ address: "93.184.216.34", family: 4 }]);
+    releases.get("second.test")?.([{ address: "93.184.216.35", family: 4 }]);
+    await expect(first).resolves.toEqual([{ address: "93.184.216.34", family: 4 }]);
+    await expect(second).resolves.toEqual([{ address: "93.184.216.35", family: 4 }]);
+  });
+
+  it("does not reuse sockets for DNS-pinned webhook delivery", async () => {
+    const remotePorts: number[] = [];
+    const receiver = createServer((request, response) => {
+      remotePorts.push(request.socket.remotePort ?? 0);
+      request.resume();
+      response.end("ok");
+    });
+    await new Promise<void>((resolve) => receiver.listen(0, "127.0.0.1", resolve));
+    const address = receiver.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Unable to resolve webhook receiver.");
+    }
+    const url = new URL(`http://127.0.0.1:${address.port}/webhook`);
+
+    try {
+      await postWebhookRequest({ body: "{}", timeoutMs: 1_000, url });
+      await postWebhookRequest({ body: "{}", timeoutMs: 1_000, url });
+      expect(remotePorts).toHaveLength(2);
+      expect(new Set(remotePorts).size).toBe(2);
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        receiver.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
   });
 });

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import { Agent } from "node:http";
 import { createServer as createNetServer } from "node:net";
 import path from "node:path";
 import {
@@ -13,7 +14,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocket } from "ws";
 import { startWhatsAppServer, type StartedWhatsAppServer } from "../src/index.js";
 import { ADMIN_TOKEN_HEADER } from "../src/servers/http.js";
-import { MAX_WHATSAPP_WEBSOCKET_FRAGMENTS } from "../src/servers/whatsapp-baileys-websocket.js";
+import {
+  MAX_WHATSAPP_WEBSOCKET_FRAGMENTS,
+  WhatsAppSignalBundleStore,
+} from "../src/servers/whatsapp-baileys-websocket.js";
 import { createTempDir, disposeTempDir, requestHttp } from "./test-helpers.js";
 
 const servers: StartedWhatsAppServer[] = [];
@@ -183,6 +187,12 @@ describe("whatsapp local provider server", () => {
     );
     await expect(startWhatsAppServer({ adminToken: " \n\t" })).rejects.toThrow(
       "adminToken must not be empty",
+    );
+    await expect(startWhatsAppServer({ accessToken: " padded" })).rejects.toThrow(
+      "accessToken must not be empty or whitespace-padded",
+    );
+    await expect(startWhatsAppServer({ adminToken: "padded " })).rejects.toThrow(
+      "adminToken must not be empty or whitespace-padded",
     );
     await expect(startWhatsAppServer({ selfJid: "not-a-whatsapp-jid" })).rejects.toThrow(
       "selfJid must be a WhatsApp user JID",
@@ -520,6 +530,14 @@ describe("whatsapp local provider server", () => {
     expect(directBody.message.key).not.toHaveProperty("participant");
   });
 
+  it("correlates bare and device user JIDs to one signal identity", () => {
+    const store = new WhatsAppSignalBundleStore(1);
+    const bare = store.resolveMany(["15551234567@s.whatsapp.net"])[0];
+    expect(store.resolveMany(["15551234567:2@s.whatsapp.net"])[0]).toBe(bare);
+    expect(store.resolveMany(["15551234567:0@c.us"])[0]).toBe(bare);
+    expect(store.size).toBe(1);
+  });
+
   it("authenticates Graph requests before reading or recording their bodies", async () => {
     const directory = await createTempDir();
     directories.push(directory);
@@ -593,6 +611,48 @@ describe("whatsapp local provider server", () => {
         type: "api",
       }),
     ]);
+  });
+
+  it("drains request bodies on early 404 routes", async () => {
+    const server = await startWhatsAppServer({
+      accessToken: "fake",
+      adminToken: "admin",
+    });
+    servers.push(server);
+    const body = JSON.stringify({ text: "discard this body" });
+    const routes = [
+      { method: "PUT", url: server.manifest.endpoints.adminInboundUrl },
+      { method: "GET", url: server.manifest.endpoints.messagesUrl },
+      { method: "POST", url: `${server.manifest.baseUrl}/v25.0/unknown` },
+    ];
+
+    for (const route of routes) {
+      const agent = new Agent({ keepAlive: true, maxSockets: 1 });
+      try {
+        const rejected = await requestHttp({
+          agent,
+          body,
+          headers: {
+            authorization: "Bearer fake",
+            "content-length": String(Buffer.byteLength(body)),
+            "content-type": "application/json",
+            [ADMIN_TOKEN_HEADER]: "admin",
+          },
+          method: route.method,
+          url: route.url,
+        });
+        expect(rejected.status).toBe(404);
+        const accepted = await requestHttp({
+          agent,
+          headers: { authorization: "Bearer fake" },
+          method: "GET",
+          url: server.manifest.endpoints.phoneNumberUrl,
+        });
+        expect(accepted.status).toBe(200);
+      } finally {
+        agent.destroy();
+      }
+    }
   });
 
   it("commits accepted sends before publishing their evidence", async () => {
@@ -833,6 +893,17 @@ describe("whatsapp local provider server", () => {
           ),
         "Baileys connection open",
       );
+      await expect(
+        socket.query({
+          attrs: {
+            to: "120363001234567890@g.us",
+            type: "set",
+            xmlns: "w:g2",
+          },
+          content: [{ attrs: {}, content: Buffer.from("unsupported mutation"), tag: "subject" }],
+          tag: "iq",
+        }),
+      ).rejects.toThrow("unsupported group operation");
       const liveInbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
         body: JSON.stringify({
           chatJid: "120363001234567890@g.us",

--- a/test/zalo-server.test.ts
+++ b/test/zalo-server.test.ts
@@ -262,6 +262,115 @@ describe("Zalo local provider server", () => {
     }
   });
 
+  it("rejects oversized or header-unsafe webhook secrets", async () => {
+    const server = await startZaloServer({ botToken: "test-token-placeholder" });
+    servers.push(server);
+
+    for (const secretToken of ["a".repeat(257), "safe\r\nunsafe"]) {
+      const response = await fetch(
+        `${server.manifest.baseUrl}/bottest-token-placeholder/setWebhook`,
+        {
+          body: JSON.stringify({
+            secret_token: secretToken,
+            url: "https://93.184.216.34/zalo",
+          }),
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        },
+      );
+      expect(response.status).toBe(400);
+    }
+  });
+
+  it("records producer-owned acceptance for Zalo sends", async () => {
+    const observed: Array<{ accepted?: boolean; path?: string }> = [];
+    const server = await startZaloServer({
+      botToken: "test-token-placeholder",
+      onEvent(event) {
+        observed.push(event);
+      },
+    });
+    servers.push(server);
+
+    const accepted = await fetch(
+      `${server.manifest.baseUrl}/bottest-token-placeholder/sendMessage`,
+      {
+        body: JSON.stringify({ chat_id: "chat-1", text: "accepted" }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      },
+    );
+    const rejected = await fetch(
+      `${server.manifest.baseUrl}/bottest-token-placeholder/sendMessage`,
+      {
+        body: JSON.stringify({ chat_id: "chat-1" }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      },
+    );
+
+    expect(accepted.status).toBe(200);
+    expect(rejected.status).toBe(400);
+    expect(observed).toEqual([
+      expect.objectContaining({ accepted: true, path: "/bot<redacted>/sendMessage" }),
+      expect.objectContaining({ accepted: false, path: "/bot<redacted>/sendMessage" }),
+    ]);
+  });
+
+  it("preserves committed sends but surfaces rejected-send evidence failures", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    let failAcceptedEvent = true;
+    const server = await startZaloServer({
+      botToken: "test-token-placeholder",
+      onEvent(event) {
+        if (event.path !== "/bot<redacted>/sendMessage") {
+          return;
+        }
+        const accepted = (event as { accepted?: boolean }).accepted;
+        if (accepted && failAcceptedEvent) {
+          failAcceptedEvent = false;
+          throw new Error("accepted Zalo evidence failed");
+        }
+        if (accepted === false) {
+          throw new Error("rejected Zalo evidence failed");
+        }
+      },
+      recorderPath: path.join(directory, "zalo-send-evidence.jsonl"),
+    });
+    servers.push(server);
+
+    const first = await fetch(`${server.manifest.baseUrl}/bottest-token-placeholder/sendMessage`, {
+      body: JSON.stringify({ chat_id: "chat-1", text: "committed" }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    expect(first.status).toBe(200);
+    const firstBody = (await first.json()) as { result: { message_id: string } };
+
+    const second = await fetch(`${server.manifest.baseUrl}/bottest-token-placeholder/sendMessage`, {
+      body: JSON.stringify({ chat_id: "chat-1", text: "next" }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    const secondBody = (await second.json()) as { result: { message_id: string } };
+    expect(secondBody.result.message_id).not.toBe(firstBody.result.message_id);
+
+    const rejected = await fetch(
+      `${server.manifest.baseUrl}/bottest-token-placeholder/sendMessage`,
+      {
+        body: JSON.stringify({ chat_id: "chat-1" }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      },
+    );
+    expect(rejected.status).toBe(500);
+    await expect(rejected.json()).resolves.toEqual({
+      error: "internal server error",
+      ok: false,
+    });
+  });
+
   it("keeps queued updates when webhook delivery is enabled", async () => {
     const webhook = createServer((_request, response) => {
       response.statusCode = 200;
@@ -813,6 +922,19 @@ describe("Zalo local provider server", () => {
       description: "url must use HTTPS",
       error_code: 400,
       ok: false,
+    });
+
+    const privateHttps = await fetch(`${server.manifest.baseUrl}/bottest-auth-token/setWebhook`, {
+      body: JSON.stringify({
+        secret_token: "secret-token",
+        url: "https://10.0.0.1/zalo",
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    expect(privateHttps.status).toBe(400);
+    await expect(privateHttps.json()).resolves.toMatchObject({
+      description: "url must not target a private or link-local address",
     });
   });
 


### PR DESCRIPTION
## Summary
- harden Telegram webhook validation and preserve valid collectible usernames
- require explicit HTTP(S) webhook targets and drain rejected request bodies
- strengthen WhatsApp identity correlation, media metadata, and accepted-send evidence
- preserve Zalo delivery acknowledgement and update semantics

## Verification
- focused transport coverage: 4 files, 129 tests
- local `pnpm verify`: 56 files, 844 tests
- Crabbox `run_e8220152af93`: 56 files, 844 tests
- exact-head `gpt-5.6-sol` high autoreview: clean
- GitHub CI: green

## Changelog
- updated `CHANGELOG.md`