### PR TITLE
fix(openclaw): harden final bridge contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Harden autoreview launchers and release automation, document trusted script manifests, and canonicalize WhatsApp Cloud targets.
 - Reject unauthenticated public provider webhooks and tighten Discord, Feishu, Google Chat, Matrix, and Teams inbound protocol validation.
 - Enforce native Matrix, Mattermost, Signal, and Slack outcomes, pagination, retries, state, JSON-RPC, WebSocket, HTTP response, and recorder privacy contracts.
+- Harden OpenClaw artifact publication identity and cleanup, and align Mattermost, Matrix, Signal, Slack, Telegram, and WhatsApp bridge contracts.
 - Bound signed-JWT key refreshes and authenticate, decode, or suppress Google Chat, Teams, Feishu, and Discord webhook ingress according to provider contracts.
 - Bound recorder tail memory, harden shared provider cleanup and inbound matching, and reject non-global webhook targets.
 - Recover backpressured Signal events without recording rejected RPC calls.

--- a/src/openclaw/artifact-generation.ts
+++ b/src/openclaw/artifact-generation.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { CrablineServerManifest } from "../servers/index.js";
 import {
+  captureDirectoryIdentity,
   publishPrivateFileAtomically,
   removeSecuredPrivateDirectory,
   securePrivateDirectory,
@@ -213,6 +214,8 @@ export async function publishOpenClawCrablineArtifactGeneration(
   const providerReadinessArtifactPath = resolveProviderReadinessArtifactPath(params.selection);
   const outputDir = path.resolve(params.outputDir);
   await fs.mkdir(outputDir, { recursive: true });
+  const output = await captureDirectoryIdentity(outputDir);
+  await output.assertIdentityAt();
   const storePath = path.join(outputDir, OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY);
   const directoryOptions = {
     ...(dependencies.platform ? { platform: dependencies.platform } : {}),
@@ -221,10 +224,16 @@ export async function publishOpenClawCrablineArtifactGeneration(
       : {}),
   };
   const store = await securePrivateDirectory(storePath, directoryOptions);
+  await output.assertIdentityAt();
+  await store.assertIdentityAt();
   await params.lock.assertOwned();
   const currentPointer = await readOpenClawCrablineArtifactPointer(outputDir);
+  await output.assertIdentityAt();
+  await store.assertIdentityAt();
   if (currentPointer) {
     await assertCurrentGenerationExists(outputDir, currentPointer);
+    await output.assertIdentityAt();
+    await store.assertIdentityAt();
   }
   await pruneArtifactStore({
     directoryOptions,
@@ -232,6 +241,8 @@ export async function publishOpenClawCrablineArtifactGeneration(
     pointer: currentPointer,
     store,
   });
+  await output.assertIdentityAt();
+  await store.assertIdentityAt();
 
   const generationId = dependencies.createGenerationId?.() ?? randomUUID();
   const generation = `generation-${generationId}`;
@@ -241,6 +252,9 @@ export async function publishOpenClawCrablineArtifactGeneration(
   const stagingPath = path.join(storePath, `.staging-${generationId}`);
   const generationPath = path.join(storePath, generation);
   const staging = await securePrivateDirectory(stagingPath, directoryOptions);
+  await output.assertIdentityAt();
+  await store.assertIdentityAt();
+  await staging.assertIdentityAt();
   const publishPrivateFile = dependencies.publishPrivateFile ?? publishPrivateFileAtomically;
   const fileOptions = {
     ...(dependencies.platform ? { platform: dependencies.platform } : {}),
@@ -313,30 +327,44 @@ export async function publishOpenClawCrablineArtifactGeneration(
 
     await params.lock.assertOwned();
     for (const artifact of artifactContents) {
+      await output.assertIdentityAt();
+      await store.assertIdentityAt();
       await staging.assertIdentityAt();
       await publishPrivateFile(
         path.join(stagingPath, artifact.fileName),
         artifact.contents,
         fileOptions,
       );
+      await output.assertIdentityAt();
+      await store.assertIdentityAt();
       await staging.assertIdentityAt();
     }
     await params.lock.assertOwned();
+    await output.assertIdentityAt();
+    await store.assertIdentityAt();
     await fs.rename(stagingPath, generationPath);
     installed = true;
     await (dependencies.syncParent ?? syncParentDirectory)(generationPath, dependencies.platform);
+    await output.assertIdentityAt();
     await staging.assertIdentityAt(generationPath);
     await store.assertIdentityAt();
 
     await dependencies.beforePointerSwitch?.(pointer);
+    await output.assertIdentityAt();
+    await store.assertIdentityAt();
+    await staging.assertIdentityAt(generationPath);
     await params.lock.commitFileAtomically({
       contents: `${JSON.stringify(pointer, null, 2)}\n`,
       destinationPath: path.join(outputDir, OPENCLAW_CRABLINE_ARTIFACT_POINTER_PATH),
       stageDirectory: store.directoryPath,
       stageFile: async (filePath, contents) => {
+        await output.assertIdentityAt();
         await store.assertIdentityAt();
+        await staging.assertIdentityAt(generationPath);
         await publishPrivateFile(filePath, contents, fileOptions);
+        await output.assertIdentityAt();
         await store.assertIdentityAt();
+        await staging.assertIdentityAt(generationPath);
       },
     });
     committed = true;

--- a/src/openclaw/bridges/matrix.ts
+++ b/src/openclaw/bridges/matrix.ts
@@ -26,9 +26,12 @@ function eventThreadId(content: Record<string, unknown>): string | undefined {
   return relation?.rel_type === "m.thread" ? readString(relation.event_id) : undefined;
 }
 
+const MAX_DELIVERED_MATRIX_TRANSACTIONS = 1_000;
+
 export const MATRIX_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablineProviderBridge({
   provider: "matrix",
   createAdapter(matrix) {
+    const deliveredTransactions = new Set<string>();
     return {
       async probe(signal) {
         const response = await fetch(`${matrix.endpoints.clientApiRoot}/account/whoami`, {
@@ -38,7 +41,11 @@ export const MATRIX_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablinePr
         if (!response.ok) {
           throw new Error(`Crabline Matrix probe failed with HTTP ${response.status}.`);
         }
-        return await response.json();
+        const payload: unknown = await response.json();
+        if (!isRecord(payload) || readString(payload.user_id) !== matrix.botUserId) {
+          throw new Error("Crabline Matrix whoami probe returned an unexpected user.");
+        }
+        return payload;
       },
       createBinding() {
         return {
@@ -118,21 +125,25 @@ export const MATRIX_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablinePr
           !isRecord(event) ||
           event.type !== "api" ||
           event.method !== "PUT" ||
+          event.replayed === true ||
           !isRecord(event.body)
         ) {
           return null;
         }
-        const match = /^\/_matrix\/client\/(?:v3|r0)\/rooms\/([^/]+)\/send\/([^/]+)\/[^/]+$/u.exec(
-          readString(event.path) ?? "",
-        );
+        const match =
+          /^\/_matrix\/client\/(?:v3|r0)\/rooms\/([^/]+)\/send\/([^/]+)\/([^/]+)$/u.exec(
+            readString(event.path) ?? "",
+          );
         if (!match) {
           return null;
         }
         let roomId: string;
         let eventType: string;
+        let transactionId: string;
         try {
           roomId = decodeURIComponent(match[1]!);
           eventType = decodeURIComponent(match[2]!);
+          transactionId = decodeURIComponent(match[3]!);
         } catch {
           return null;
         }
@@ -143,7 +154,15 @@ export const MATRIX_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablinePr
         if (!text) {
           return null;
         }
+        const transactionKey = JSON.stringify([roomId, eventType, transactionId]);
+        if (deliveredTransactions.has(transactionKey)) {
+          return null;
+        }
         const threadId = eventThreadId(event.body);
+        deliveredTransactions.add(transactionKey);
+        if (deliveredTransactions.size > MAX_DELIVERED_MATRIX_TRANSACTIONS) {
+          deliveredTransactions.delete(deliveredTransactions.values().next().value!);
+        }
         return {
           accountId: DEFAULT_ACCOUNT_ID,
           senderId: matrix.botUserId,

--- a/src/openclaw/bridges/mattermost.ts
+++ b/src/openclaw/bridges/mattermost.ts
@@ -26,6 +26,11 @@ function targetKey(channelId: string, rootId?: string): string {
   return rootId ? `${channelId}:thread:${rootId}` : channelId;
 }
 
+function threadRootId(channelId: string, value: string): string {
+  const trimmed = value.trim();
+  return /^[a-z0-9]{26}$/u.test(trimmed) ? trimmed : mattermostId(`thread:${channelId}:${trimmed}`);
+}
+
 export const MATTERMOST_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablineProviderBridge({
   provider: "mattermost",
   createAdapter(mattermost) {
@@ -90,7 +95,7 @@ export const MATTERMOST_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabli
           kind === "direct"
             ? directChannelId(mattermost.botUserId, senderId)
             : nativeId(conversationId);
-        const rootId = input.threadId ? nativeId(input.threadId) : undefined;
+        const rootId = input.threadId ? threadRootId(channelId, input.threadId) : undefined;
         return {
           ...createAdminInboundRequest(mattermost),
           providerBody: {
@@ -123,12 +128,16 @@ export const MATTERMOST_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabli
         if (!channelId || !text) {
           return null;
         }
+        const target = targetByProviderTarget.get(targetKey(channelId, rootId));
+        if (!target) {
+          return null;
+        }
         return {
           accountId: DEFAULT_ACCOUNT_ID,
           senderId: mattermost.botUserId,
           senderName: "OpenClaw QA",
           text,
-          to: targetByProviderTarget.get(targetKey(channelId, rootId)) ?? channelId,
+          to: target,
         };
       },
     };

--- a/src/openclaw/bridges/signal.ts
+++ b/src/openclaw/bridges/signal.ts
@@ -9,13 +9,52 @@ import {
   readString,
 } from "../shared.js";
 
-function signalDirectId(id: string): string {
+const SIGNAL_UUID_RE =
+  /^(?:uuid:)?([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/iu;
+
+type SignalDirectIdentity =
+  | { recipient: string; sourceNumber: string }
+  | { recipient: string; sourceUuid: string };
+
+function deterministicSignalUuid(value: string): string {
+  const bytes = createHash("sha256")
+    .update("crabline:signal:direct\0")
+    .update(value)
+    .digest()
+    .subarray(0, 16);
+  bytes[6] = (bytes[6]! & 0x0f) | 0x80;
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+  const hex = bytes.toString("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+function signalDirectIdentity(id: string): SignalDirectIdentity {
   const value = id.trim();
-  if (/^\+?\d{3,}$/u.test(value)) {
-    return value.startsWith("+") ? value : `+${value}`;
+  if (/^\+?[1-9]\d{2,14}$/u.test(value)) {
+    const sourceNumber = value.startsWith("+") ? value : `+${value}`;
+    return { recipient: sourceNumber, sourceNumber };
   }
-  const suffix = createHash("sha256").update(value).digest().readUInt32BE() % 10_000_000;
-  return `+1555${String(suffix).padStart(7, "0")}`;
+  const sourceUuid =
+    SIGNAL_UUID_RE.exec(value)?.[1]?.toLowerCase() ?? deterministicSignalUuid(value);
+  return { recipient: sourceUuid, sourceUuid };
+}
+
+function signalRecipientValues(value: unknown): string[] {
+  const values = Array.isArray(value) ? value : [value];
+  return values.map(readString).filter((entry): entry is string => entry !== undefined);
+}
+
+function signalOutboundTargets(params: Record<string, unknown>, account: string): string[] {
+  const targets = [
+    ...signalRecipientValues(params.groupId).map((id) => `group:${id}`),
+    ...signalRecipientValues(params.groupIds).map((id) => `group:${id}`),
+    ...signalRecipientValues(params.recipient),
+    ...signalRecipientValues(params.recipients),
+    ...signalRecipientValues(params.username),
+    ...signalRecipientValues(params.usernames),
+    ...(params.noteToSelf === true ? [account] : []),
+  ];
+  return [...new Set(targets)];
 }
 
 function signalTarget(kind: "direct" | "group", id: string): string {
@@ -23,7 +62,7 @@ function signalTarget(kind: "direct" | "group", id: string): string {
   if (!value) {
     throw new Error("Signal target is required.");
   }
-  return kind === "group" ? `group:${value}` : signalDirectId(value);
+  return kind === "group" ? `group:${value}` : signalDirectIdentity(value).recipient;
 }
 
 export const SIGNAL_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablineProviderBridge({
@@ -86,16 +125,19 @@ export const SIGNAL_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablinePr
         if (!conversationId || !senderId) {
           throw new Error("Signal conversation and sender are required.");
         }
-        const sourceNumber = signalDirectId(senderId);
+        const senderIdentity = signalDirectIdentity(senderId);
         return {
           ...createAdminInboundRequest(signal),
           providerBody: {
             ...(kind === "group" ? { groupId: conversationId } : {}),
             ...(input.senderName ? { sourceName: input.senderName } : {}),
-            sourceNumber,
+            ...("sourceNumber" in senderIdentity
+              ? { sourceNumber: senderIdentity.sourceNumber }
+              : { sourceUuid: senderIdentity.sourceUuid }),
             text: input.text,
           },
-          providerTargetKey: kind === "group" ? `group:${conversationId}` : sourceNumber,
+          providerTargetKey:
+            kind === "group" ? `group:${conversationId}` : senderIdentity.recipient,
           qaTarget: qaTargetForInbound(input),
           stateConversation: { id: conversationId, kind },
         };
@@ -112,13 +154,11 @@ export const SIGNAL_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablinePr
           return null;
         }
         const text = readNonBlankString(event.body.params.message);
-        const groupId = readString(event.body.params.groupId);
-        const recipients = event.body.params.recipient;
-        const recipient = Array.isArray(recipients) ? readString(recipients[0]) : undefined;
-        const target = groupId ? `group:${groupId}` : recipient;
-        if (!text || !target) {
+        const targets = signalOutboundTargets(event.body.params, signal.account);
+        if (!text || targets.length !== 1) {
           return null;
         }
+        const target = targets[0]!;
         return {
           accountId: DEFAULT_ACCOUNT_ID,
           senderId: "openclaw",

--- a/src/openclaw/bridges/slack.ts
+++ b/src/openclaw/bridges/slack.ts
@@ -24,10 +24,10 @@ function requireSlackSendTargetId(value: string, label: string): string {
 }
 
 function requireSlackTargetKind(
-  parsed: { kind: "direct" | "group"; native: boolean },
+  parsed: { kind: "direct" | "group"; native: boolean; threadId?: string },
   targetId: string,
 ): void {
-  if (parsed.native) {
+  if (parsed.native || parsed.threadId !== undefined) {
     return;
   }
   const nativeKind = /^[DUW]/u.test(targetId) ? "direct" : "group";
@@ -61,6 +61,64 @@ function requireSlackThreadTs(value: string | undefined, label: string): string 
     throw new Error(`${label} must be a native Slack timestamp.`);
   }
   return trimmed;
+}
+
+function slackConversationKind(channel: string): "direct" | "group" {
+  return channel.startsWith("D") ? "direct" : "group";
+}
+
+function structuredSlackValues(value: unknown): unknown[] {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (typeof value !== "string") {
+    return [];
+  }
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function collectSlackFallbackText(value: unknown, output: string[]): void {
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      collectSlackFallbackText(entry, output);
+    }
+    return;
+  }
+  if (!isRecord(value)) {
+    return;
+  }
+  for (const key of ["fallback", "title", "alt_text"] as const) {
+    const text = readNonBlankString(value[key]);
+    if (text) {
+      output.push(text);
+    }
+  }
+  const text = value.text;
+  if (typeof text === "string" && text.trim()) {
+    output.push(text);
+  } else if (isRecord(text)) {
+    collectSlackFallbackText(text, output);
+  }
+  for (const key of ["blocks", "elements", "fields"] as const) {
+    collectSlackFallbackText(value[key], output);
+  }
+}
+
+function slackOutboundText(body: Record<string, unknown>): string | undefined {
+  if (typeof body.text === "string") {
+    // Explicit whitespace is invalid; structured fallback is only for text-less sends.
+    return body.text.trim() ? body.text : undefined;
+  }
+  const fallback: string[] = [];
+  collectSlackFallbackText(structuredSlackValues(body.blocks), fallback);
+  collectSlackFallbackText(structuredSlackValues(body.attachments), fallback);
+  const unique = [...new Set(fallback)];
+  return unique.length > 0 ? unique.join("\n") : undefined;
 }
 
 export const SLACK_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablineProviderBridge({
@@ -140,6 +198,10 @@ export const SLACK_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablinePro
       },
       createInbound(input) {
         const channel = requireSlackChannelId(input.conversation.id, "Slack conversation");
+        const kind = slackConversationKind(channel);
+        if (input.conversation.kind !== kind) {
+          throw new Error("Slack inbound conversation kind does not match the native channel id.");
+        }
         const user = requireSlackUserId(input.senderId, "Slack sender");
         const threadTs = requireSlackThreadTs(input.threadId, "Slack thread");
         return {
@@ -155,7 +217,7 @@ export const SLACK_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablinePro
           qaTarget: qaTargetForInbound(input),
           stateConversation: {
             id: channel,
-            kind: channel.startsWith("D") ? "direct" : "group",
+            kind,
           },
           ...(threadTs ? { threadId: threadTs } : {}),
         };
@@ -168,7 +230,7 @@ export const SLACK_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablinePro
           return null;
         }
         const channel = readString(event.body.channel);
-        const text = readNonBlankString(event.body.text);
+        const text = slackOutboundText(event.body);
         if (!channel || !text) {
           return null;
         }

--- a/src/openclaw/bridges/telegram.ts
+++ b/src/openclaw/bridges/telegram.ts
@@ -15,6 +15,7 @@ const TELEGRAM_SYMBOLIC_GROUP_ID_BASE = 1_000_000_000_000n;
 const TELEGRAM_SYMBOLIC_GROUP_ID_RANGE = 10_000_000_000n;
 const TELEGRAM_OUTBOUND_METHOD_RE =
   /\/(sendAnimation|sendAudio|sendDocument|sendMessage|sendPhoto|sendVideo)$/u;
+const TELEGRAM_USERNAME_RE = /^@[A-Za-z][A-Za-z0-9_]{3,31}$/u;
 
 function normalizeTelegramChatId(kind: "direct" | "group", id: string): string {
   const value = id.trim();
@@ -32,10 +33,13 @@ function normalizeTelegramChatId(kind: "direct" | "group", id: string): string {
     ) {
       throw new Error("Telegram numeric target must be a safe integer.");
     }
+    return numericId.toString();
+  }
+  if (kind === "group" && TELEGRAM_USERNAME_RE.test(value)) {
     return value;
   }
-  if (kind === "group" && /^@[A-Za-z][A-Za-z0-9_]{4,31}$/u.test(value)) {
-    return value;
+  if (value.startsWith("@")) {
+    throw new Error("Telegram usernames must contain 4-32 letters, digits, or underscores.");
   }
   const hash = createHash("sha256").update(`${kind}:${value}`).digest().readBigUInt64BE();
   if (kind === "group") {
@@ -46,6 +50,25 @@ function normalizeTelegramChatId(kind: "direct" | "group", id: string): string {
 
 function telegramTargetKey(chatId: string, threadId?: number) {
   return threadId === undefined ? chatId : `${chatId}:topic:${threadId}`;
+}
+
+function canonicalTelegramRecorderChatId(value: unknown): string | undefined {
+  const chatId = readString(value);
+  if (!chatId) {
+    return undefined;
+  }
+  if (/^-?\d+$/u.test(chatId)) {
+    const numericId = BigInt(chatId);
+    if (
+      numericId === 0n ||
+      numericId < BigInt(Number.MIN_SAFE_INTEGER) ||
+      numericId > BigInt(Number.MAX_SAFE_INTEGER)
+    ) {
+      return undefined;
+    }
+    return numericId.toString();
+  }
+  return TELEGRAM_USERNAME_RE.test(chatId) ? chatId : undefined;
 }
 
 function telegramBotCommandEntity(text: string, commandName: string) {
@@ -97,7 +120,7 @@ export const TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
         if (!response.ok) {
           throw new Error(`Crabline Telegram getMe probe failed with HTTP ${response.status}.`);
         }
-        const payload = await response.json();
+        const payload: unknown = await response.json();
         if (!isRecord(payload) || payload.ok !== true) {
           const errorCode = readString(isRecord(payload) ? payload.error_code : undefined);
           const description = readNonBlankString(
@@ -105,6 +128,20 @@ export const TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
           );
           const detail = description ?? (errorCode ? `error ${errorCode}` : "invalid response");
           throw new Error(`Crabline Telegram getMe probe failed: ${detail}.`);
+        }
+        const result = payload.result;
+        if (
+          !isRecord(result) ||
+          typeof result.id !== "number" ||
+          !Number.isSafeInteger(result.id) ||
+          result.id <= 0 ||
+          result.is_bot !== true ||
+          !readNonBlankString(result.first_name) ||
+          (result.username !== undefined &&
+            (typeof result.username !== "string" ||
+              !TELEGRAM_USERNAME_RE.test(`@${result.username}`)))
+        ) {
+          throw new Error("Crabline Telegram getMe probe failed: invalid response.");
         }
         return payload;
       },
@@ -162,8 +199,7 @@ export const TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
       createAgentDelivery(parsed) {
         const kind =
           parsed.native &&
-          (/^-\d+$/u.test(parsed.id.trim()) ||
-            /^@[A-Za-z][A-Za-z0-9_]{4,31}$/u.test(parsed.id.trim()))
+          (/^-\d+$/u.test(parsed.id.trim()) || TELEGRAM_USERNAME_RE.test(parsed.id.trim()))
             ? "group"
             : parsed.kind;
         const chatId = normalizeTelegramChatId(kind, parsed.id);
@@ -211,7 +247,7 @@ export const TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
         if (!method || !isRecord(event.body)) {
           return null;
         }
-        const chatId = readString(event.body.chat_id);
+        const chatId = canonicalTelegramRecorderChatId(event.body.chat_id);
         const text =
           method === "sendMessage"
             ? readNonBlankString(event.body.text)

--- a/src/openclaw/bridges/whatsapp.ts
+++ b/src/openclaw/bridges/whatsapp.ts
@@ -35,6 +35,13 @@ function requireWhatsAppTargetKind(
   }
 }
 
+function requireWhatsAppConversationKind(kind: "direct" | "group", targetId: string): void {
+  const nativeKind = targetId.endsWith("@g.us") ? "group" : "direct";
+  if (kind !== nativeKind) {
+    throw new Error("WhatsApp inbound conversation kind does not match the native JID.");
+  }
+}
+
 export const WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablineProviderBridge({
   provider: "whatsapp",
   createAdapter(whatsapp) {
@@ -112,6 +119,7 @@ export const WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
           throw new Error("WhatsApp does not support thread targets.");
         }
         const chatJid = requireWhatsAppJid(input.conversation.id, "WhatsApp conversation");
+        requireWhatsAppConversationKind(input.conversation.kind, chatJid);
         const senderJid = requireWhatsAppJid(input.senderId, "WhatsApp sender", true);
         return {
           ...createAdminInboundRequest(whatsapp),

--- a/src/openclaw/private-file.ts
+++ b/src/openclaw/private-file.ts
@@ -285,6 +285,25 @@ export type SecuredPrivateDirectory = {
   directoryPath: string;
 };
 
+export async function captureDirectoryIdentity(
+  directoryPath: string,
+): Promise<SecuredPrivateDirectory> {
+  const handle = await fs.open(directoryPath, "r");
+  try {
+    const identity = await readDirectoryHandleIdentity(handle);
+    const secured: SecuredPrivateDirectory = {
+      async assertIdentityAt(currentPath = directoryPath) {
+        await assertDirectoryPathIdentity(currentPath, identity);
+      },
+      directoryPath,
+    };
+    await secured.assertIdentityAt();
+    return secured;
+  } finally {
+    await handle.close();
+  }
+}
+
 export async function syncParentDirectory(
   filePath: string,
   platform: NodeJS.Platform = process.platform,
@@ -411,7 +430,9 @@ export async function publishPrivateFileAtomically(
   contents: string,
   options: {
     afterRename?: (filePath: string) => Promise<void>;
+    beforeRename?: (temporaryPath: string) => Promise<void>;
     platform?: NodeJS.Platform;
+    removeTemporaryFile?: (temporaryPath: string) => Promise<void>;
     secureWindowsFile?: (temporaryPath: string) => Promise<void>;
     syncParent?: (filePath: string, platform?: NodeJS.Platform) => Promise<void>;
   } = {},
@@ -422,6 +443,8 @@ export async function publishPrivateFileAtomically(
   );
   await fs.mkdir(path.dirname(filePath), { recursive: true });
   let handle: FileHandle | undefined;
+  let publicationFailed = false;
+  let primaryError: unknown;
   try {
     handle = await fs.open(temporaryPath, "wx+", 0o600);
     const identity = await readHandleIdentity(handle);
@@ -435,15 +458,56 @@ export async function publishPrivateFileAtomically(
     await handle.writeFile(contents, "utf8");
     await handle.sync();
     await assertPathIdentity(temporaryPath, identity);
+    await options.beforeRename?.(temporaryPath);
+    await assertPathIdentity(temporaryPath, identity);
     await fs.rename(temporaryPath, filePath);
     await (options.syncParent ?? syncParentDirectory)(filePath, options.platform);
     await options.afterRename?.(filePath);
     await assertPathIdentity(filePath, identity);
-  } finally {
-    try {
-      await handle?.close();
-    } finally {
-      await fs.rm(temporaryPath, { force: true }).catch(() => undefined);
+  } catch (error) {
+    publicationFailed = true;
+    primaryError = error;
+  }
+
+  const cleanupErrors: unknown[] = [];
+  try {
+    await handle?.close();
+  } catch (error) {
+    cleanupErrors.push(error);
+  }
+  try {
+    await (
+      options.removeTemporaryFile ??
+      ((candidatePath: string) => fs.rm(candidatePath, { force: true }))
+    )(temporaryPath);
+  } catch (error) {
+    cleanupErrors.push(error);
+  }
+
+  if (publicationFailed) {
+    if (cleanupErrors.length > 0) {
+      const primaryMessage =
+        primaryError instanceof Error ? primaryError.message : String(primaryError);
+      const aggregateError = new AggregateError(
+        [primaryError, ...cleanupErrors],
+        `${primaryMessage} Private temporary file cleanup also failed.`,
+      );
+      aggregateError.cause = primaryError;
+      const primaryCode =
+        typeof primaryError === "object" && primaryError !== null
+          ? (primaryError as NodeJS.ErrnoException).code
+          : undefined;
+      if (primaryCode) {
+        Object.assign(aggregateError, { code: primaryCode });
+      }
+      throw aggregateError;
     }
+    throw primaryError;
+  }
+  if (cleanupErrors.length === 1) {
+    throw cleanupErrors[0];
+  }
+  if (cleanupErrors.length > 1) {
+    throw new AggregateError(cleanupErrors, "Private temporary file publication cleanup failed.");
   }
 }

--- a/test/openclaw-artifact-generation.test.ts
+++ b/test/openclaw-artifact-generation.test.ts
@@ -580,6 +580,39 @@ describe("OpenClaw artifact generation publication", () => {
     }
   });
 
+  it.skipIf(process.platform === "win32")(
+    "rejects output directory replacement before publishing secret artifacts",
+    async () => {
+      const outputDir = await createTempDir();
+      const displacedOutputDir = `${outputDir}.displaced`;
+      const storePath = path.join(outputDir, OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY);
+      try {
+        await expect(
+          publishOpenClawCrablineArtifactGeneration(publishParams(outputDir), {
+            createGenerationId: () => "11111111-1111-4111-8111-111111111111",
+            platform: "win32",
+            secureWindowsDirectory: async (directoryPath) => {
+              if (directoryPath !== storePath) {
+                return;
+              }
+              await fs.rename(outputDir, displacedOutputDir);
+              await fs.symlink(displacedOutputDir, outputDir, "dir");
+            },
+            secureWindowsFile: async () => undefined,
+          }),
+        ).rejects.toThrow("Private directory path identity changed during publication.");
+
+        await expect(
+          fs.readdir(path.join(displacedOutputDir, OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY)),
+        ).resolves.toEqual([]);
+      } finally {
+        await fs.rm(outputDir, { force: true });
+        await fs.rename(displacedOutputDir, outputDir).catch(() => undefined);
+        await disposeTempDir(outputDir);
+      }
+    },
+  );
+
   it("removes failed staging and retains only the current and previous generations", async () => {
     const outputDir = await createTempDir();
     const storePath = path.join(outputDir, OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY);

--- a/test/openclaw-private-file.test.ts
+++ b/test/openclaw-private-file.test.ts
@@ -237,6 +237,85 @@ describe("OpenClaw private file publication", () => {
     }
   });
 
+  it("surfaces credential-bearing temporary file cleanup failures", async () => {
+    const directory = await createTempDir();
+    const publicationError = new Error("publication failed");
+    const cleanupError = new Error("temporary cleanup failed");
+    let temporaryPath: string | undefined;
+    try {
+      const failure = await publishPrivateFileAtomically(
+        path.join(directory, "manifest.json"),
+        "private credential\n",
+        {
+          beforeRename: async (candidatePath) => {
+            temporaryPath = candidatePath;
+            throw publicationError;
+          },
+          removeTemporaryFile: async () => {
+            throw cleanupError;
+          },
+        },
+      ).catch((error: unknown) => error);
+
+      expect(failure).toBeInstanceOf(AggregateError);
+      expect((failure as AggregateError).errors).toEqual([publicationError, cleanupError]);
+      expect((failure as Error).message).toContain("Private temporary file cleanup also failed.");
+      expect(temporaryPath).toBeDefined();
+      await expect(fs.readFile(temporaryPath!, "utf8")).resolves.toBe("private credential\n");
+    } finally {
+      if (temporaryPath) {
+        await fs.rm(temporaryPath, { force: true });
+      }
+      await disposeTempDir(directory);
+    }
+  });
+
+  it("preserves undefined and null publication rejection reasons", async () => {
+    const directory = await createTempDir();
+    try {
+      for (const rejectionReason of [undefined, null]) {
+        let rejected = false;
+        let receivedReason: unknown = Symbol("unrejected");
+        await publishPrivateFileAtomically(
+          path.join(directory, `manifest-${String(rejectionReason)}.json`),
+          "private credential\n",
+          {
+            beforeRename: async () => {
+              throw rejectionReason;
+            },
+          },
+        ).then(
+          () => undefined,
+          (error: unknown) => {
+            rejected = true;
+            receivedReason = error;
+          },
+        );
+        expect(rejected).toBe(true);
+        expect(receivedReason).toBe(rejectionReason);
+      }
+
+      const cleanupError = new Error("temporary cleanup failed");
+      const failure = await publishPrivateFileAtomically(
+        path.join(directory, "manifest-null-cleanup.json"),
+        "private credential\n",
+        {
+          beforeRename: async () => {
+            throw null;
+          },
+          removeTemporaryFile: async (temporaryPath) => {
+            await fs.rm(temporaryPath, { force: true });
+            throw cleanupError;
+          },
+        },
+      ).catch((error: unknown) => error);
+      expect(failure).toBeInstanceOf(AggregateError);
+      expect((failure as AggregateError).errors).toEqual([null, cleanupError]);
+    } finally {
+      await disposeTempDir(directory);
+    }
+  });
+
   it("preserves a replacement installed after the atomic rename", async () => {
     const directory = await createTempDir();
     try {

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -38,6 +38,8 @@ import {
   publishOpenClawCrablineArtifactGeneration,
   readOpenClawCrablineArtifactPointer,
 } from "../src/openclaw/artifact-generation.js";
+import { MATRIX_OPENCLAW_CRABLINE_PROVIDER_BRIDGE } from "../src/openclaw/bridges/matrix.js";
+import { SIGNAL_OPENCLAW_CRABLINE_PROVIDER_BRIDGE } from "../src/openclaw/bridges/signal.js";
 import { isRecord, parseQaTarget } from "../src/openclaw/shared.js";
 
 type ProviderReadinessTestDependencies = {
@@ -321,6 +323,46 @@ describe("OpenClaw local provider bridge", () => {
     try {
       await expect(probeOpenClawCrablineProvider(manifest)).rejects.toThrow(
         "Crabline Telegram getMe probe failed: Unauthorized.",
+      );
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  it.each([
+    { ok: true },
+    { ok: true, result: null },
+    { ok: true, result: { first_name: "Crabline", id: 424_242, is_bot: false } },
+    {
+      ok: true,
+      result: { first_name: "Crabline", id: 424_242, is_bot: true, username: "abc" },
+    },
+  ])("rejects malformed Telegram getMe success payloads: %j", async (payload) => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(payload), {
+        headers: { "content-type": "application/json" },
+        status: 200,
+      }),
+    );
+    try {
+      await expect(probeOpenClawCrablineProvider(manifest)).rejects.toThrow(
+        "Crabline Telegram getMe probe failed: invalid response.",
+      );
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  it("requires Matrix whoami to identify the configured bot user", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ user_id: "@other:matrix.test" }), {
+        headers: { "content-type": "application/json" },
+        status: 200,
+      }),
+    );
+    try {
+      await expect(probeOpenClawCrablineProvider(matrixManifest)).rejects.toThrow(
+        "Crabline Matrix whoami probe returned an unexpected user.",
       );
     } finally {
       fetchMock.mockRestore();
@@ -749,7 +791,7 @@ describe("OpenClaw local provider bridge", () => {
 
   it("closes a started server when adapter construction fails", async () => {
     const startupError = new Error("adapter construction failed");
-    const close = vi.fn(async () => undefined);
+    const close = vi.fn<() => Promise<void>>(async () => undefined);
 
     await expect(
       startOpenClawCrablineAdapter(
@@ -798,7 +840,13 @@ describe("OpenClaw local provider bridge", () => {
     expect(createOpenClawCrablineAgentDelivery({ manifest, target: "dm:42424242" }).to).toBe(
       "42424242",
     );
+    expect(createOpenClawCrablineAgentDelivery({ manifest, target: "dm:00042424242" }).to).toBe(
+      "42424242",
+    );
     expect(createOpenClawCrablineAgentDelivery({ manifest, target: "group:-100123" }).to).toBe(
+      "-100123",
+    );
+    expect(createOpenClawCrablineAgentDelivery({ manifest, target: "group:-000100123" }).to).toBe(
       "-100123",
     );
     expect(
@@ -810,6 +858,12 @@ describe("OpenClaw local provider bridge", () => {
     expect(createOpenClawCrablineAgentDelivery({ manifest, target: "-100123" }).to).toBe("-100123");
     expect(createOpenClawCrablineAgentDelivery({ manifest, target: "thread:-100123/42" }).to).toBe(
       "-100123:topic:42",
+    );
+    expect(createOpenClawCrablineAgentDelivery({ manifest, target: "channel:@tiny" }).to).toBe(
+      "@tiny",
+    );
+    expect(() => createOpenClawCrablineAgentDelivery({ manifest, target: "channel:@abc" })).toThrow(
+      "Telegram usernames must contain 4-32 letters, digits, or underscores.",
     );
 
     const inbound = createOpenClawCrablineInbound({
@@ -841,6 +895,20 @@ describe("OpenClaw local provider bridge", () => {
         id: symbolicDelivery.to,
         kind: "direct",
       },
+    });
+    expect(
+      createOpenClawCrablineInbound({
+        manifest,
+        input: {
+          conversation: { id: "00042424242", kind: "direct" },
+          senderId: "00042424242",
+          text: "canonical numeric ids",
+        },
+      }),
+    ).toMatchObject({
+      providerBody: { chatId: "42424242", fromId: 42_424_242 },
+      providerTargetKey: "42424242",
+      stateConversation: { id: "42424242", kind: "direct" },
     });
 
     expect(
@@ -978,6 +1046,21 @@ describe("OpenClaw local provider bridge", () => {
       text: "  hello\n",
       to: "dm:alice",
     });
+    expect(
+      createOpenClawCrablineOutboundFromRecorderEvent({
+        manifest,
+        targetByProviderTarget: new Map([["42424242", "dm:canonical"]]),
+        event: {
+          type: "api",
+          method: "POST",
+          path: "/bot<redacted>/sendMessage",
+          body: {
+            chat_id: "00042424242",
+            text: "canonical outbound id",
+          },
+        },
+      }),
+    ).toMatchObject({ to: "dm:canonical" });
 
     expect(
       createOpenClawCrablineOutboundFromRecorderEvent({
@@ -1206,6 +1289,26 @@ describe("OpenClaw local provider bridge", () => {
         },
       }),
     ).toThrow("WhatsApp does not support thread targets.");
+    expect(() =>
+      createOpenClawCrablineInbound({
+        manifest: whatsappManifest,
+        input: {
+          conversation: { id: "120363001234567890@g.us", kind: "direct" },
+          senderId: "15551234567@s.whatsapp.net",
+          text: "mismatched kind",
+        },
+      }),
+    ).toThrow("WhatsApp inbound conversation kind does not match the native JID.");
+    expect(() =>
+      createOpenClawCrablineInbound({
+        manifest: whatsappManifest,
+        input: {
+          conversation: { id: "15551234567@s.whatsapp.net", kind: "group" },
+          senderId: "15557654321@s.whatsapp.net",
+          text: "mismatched kind",
+        },
+      }),
+    ).toThrow("WhatsApp inbound conversation kind does not match the native JID.");
 
     const inbound = createOpenClawCrablineInbound({
       manifest: whatsappManifest,
@@ -1331,12 +1434,43 @@ describe("OpenClaw local provider bridge", () => {
       replyChannel: "slack",
       replyTo: "C1234567890:thread:1700000000.000100",
     });
+    expect(
+      createOpenClawCrablineAgentDelivery({
+        manifest: slackManifest,
+        target: "thread:D1234567890/1700000000.000100",
+      }),
+    ).toEqual({
+      channel: "slack",
+      to: "D1234567890",
+      replyChannel: "slack",
+      replyTo: "D1234567890:thread:1700000000.000100",
+    });
     expect(() =>
       createOpenClawCrablineAgentDelivery({
         manifest: slackManifest,
         target: "dm:C1234567890",
       }),
     ).toThrow("Slack target kind does not match the native conversation id.");
+    expect(() =>
+      createOpenClawCrablineInbound({
+        manifest: slackManifest,
+        input: {
+          conversation: { id: "D1234567890", kind: "group" },
+          senderId: "U1234567890",
+          text: "mismatched kind",
+        },
+      }),
+    ).toThrow("Slack inbound conversation kind does not match the native channel id.");
+    expect(() =>
+      createOpenClawCrablineInbound({
+        manifest: slackManifest,
+        input: {
+          conversation: { id: "C1234567890", kind: "direct" },
+          senderId: "U1234567890",
+          text: "mismatched kind",
+        },
+      }),
+    ).toThrow("Slack inbound conversation kind does not match the native channel id.");
     expect(() =>
       createOpenClawCrablineAgentDelivery({
         manifest: slackManifest,
@@ -1400,6 +1534,52 @@ describe("OpenClaw local provider bridge", () => {
       text: "hello from openclaw",
       to: "thread:qa/parent",
     });
+    expect(
+      createOpenClawCrablineOutboundFromRecorderEvent({
+        manifest: slackManifest,
+        targetByProviderTarget: new Map([["C1234567890", "group:qa"]]),
+        event: {
+          type: "api",
+          method: "POST",
+          path: "/api/chat.postMessage",
+          body: {
+            blocks: [{ text: { text: "block fallback", type: "mrkdwn" }, type: "section" }],
+            channel: "C1234567890",
+          },
+        },
+      }),
+    ).toMatchObject({ text: "block fallback", to: "group:qa" });
+    expect(
+      createOpenClawCrablineOutboundFromRecorderEvent({
+        manifest: slackManifest,
+        targetByProviderTarget: new Map([["C1234567890", "group:qa"]]),
+        event: {
+          type: "api",
+          method: "POST",
+          path: "/api/chat.postMessage",
+          body: {
+            attachments: JSON.stringify([{ fallback: "attachment fallback" }]),
+            channel: "C1234567890",
+          },
+        },
+      }),
+    ).toMatchObject({ text: "attachment fallback", to: "group:qa" });
+    expect(
+      createOpenClawCrablineOutboundFromRecorderEvent({
+        manifest: slackManifest,
+        targetByProviderTarget: new Map(),
+        event: {
+          type: "api",
+          method: "POST",
+          path: "/api/chat.postMessage",
+          body: {
+            blocks: [{ text: { text: "must not replace whitespace", type: "plain_text" } }],
+            channel: "C1234567890",
+            text: " \n\t",
+          },
+        },
+      }),
+    ).toBeNull();
   });
 
   it("maps Signal QA targets, inbound messages, and recorder events", () => {
@@ -1433,7 +1613,35 @@ describe("OpenClaw local provider bridge", () => {
       manifest: signalManifest,
       target: "dm:qa-operator",
     });
-    expect(directDelivery.to).toMatch(/^\+1555\d{7}$/u);
+    expect(directDelivery.to).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-8[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u,
+    );
+    expect(
+      createOpenClawCrablineAgentDelivery({
+        manifest: signalManifest,
+        target: "dm:+15551234567",
+      }).to,
+    ).toBe("+15551234567");
+    const firstSignalAdapter =
+      SIGNAL_OPENCLAW_CRABLINE_PROVIDER_BRIDGE.createAdapterFromManifest(signalManifest);
+    const firstRecipient = firstSignalAdapter.createAgentDelivery(
+      parseQaTarget("dm:recipient-1719"),
+    ).to;
+    const secondRecipient = firstSignalAdapter.createAgentDelivery(
+      parseQaTarget("dm:recipient-5529"),
+    ).to;
+    const secondSignalAdapter =
+      SIGNAL_OPENCLAW_CRABLINE_PROVIDER_BRIDGE.createAdapterFromManifest(signalManifest);
+    expect(secondSignalAdapter.createAgentDelivery(parseQaTarget("dm:recipient-5529")).to).toBe(
+      secondRecipient,
+    );
+    expect(secondSignalAdapter.createAgentDelivery(parseQaTarget("dm:recipient-1719")).to).toBe(
+      firstRecipient,
+    );
+    expect(firstRecipient).not.toBe(secondRecipient);
+    expect(firstRecipient).not.toBe(
+      firstSignalAdapter.createAgentDelivery(parseQaTarget("dm:+15551234567")).to,
+    );
 
     const directInbound = createOpenClawCrablineInbound({
       manifest: signalManifest,
@@ -1443,7 +1651,7 @@ describe("OpenClaw local provider bridge", () => {
         text: "hello",
       },
     });
-    expect(directInbound.providerBody).toMatchObject({ sourceNumber: directDelivery.to });
+    expect(directInbound.providerBody).toMatchObject({ sourceUuid: directDelivery.to });
     expect(directInbound.providerTargetKey).toBe(directDelivery.to);
 
     expect(
@@ -1461,6 +1669,52 @@ describe("OpenClaw local provider bridge", () => {
         },
       }),
     ).toMatchObject({ text: "direct reply", to: "dm:qa-operator" });
+
+    for (const testCase of [
+      { params: { recipient: directDelivery.to }, providerTarget: directDelivery.to },
+      { params: { recipients: [directDelivery.to] }, providerTarget: directDelivery.to },
+      { params: { groupIds: ["group-1"] }, providerTarget: "group:group-1" },
+      { params: { username: "alice.01" }, providerTarget: "alice.01" },
+      { params: { usernames: ["alice.01"] }, providerTarget: "alice.01" },
+      { params: { noteToSelf: true }, providerTarget: signalManifest.account },
+    ]) {
+      expect(
+        createOpenClawCrablineOutboundFromRecorderEvent({
+          manifest: signalManifest,
+          targetByProviderTarget: new Map([[testCase.providerTarget, "dm:mapped"]]),
+          event: {
+            body: {
+              method: "send",
+              params: { message: "recipient form", ...testCase.params },
+            },
+            method: "POST",
+            path: "/api/v1/rpc",
+            type: "api",
+          },
+        }),
+      ).toMatchObject({ text: "recipient form", to: "dm:mapped" });
+    }
+    expect(
+      createOpenClawCrablineOutboundFromRecorderEvent({
+        manifest: signalManifest,
+        targetByProviderTarget: new Map([
+          [directDelivery.to, "dm:first"],
+          ["+15557654321", "dm:second"],
+        ]),
+        event: {
+          body: {
+            method: "send",
+            params: {
+              message: "fan-out cannot be represented",
+              recipients: [directDelivery.to, "+15557654321"],
+            },
+          },
+          method: "POST",
+          path: "/api/v1/rpc",
+          type: "api",
+        },
+      }),
+    ).toBeNull();
 
     expect(
       createOpenClawCrablineInbound({
@@ -1591,18 +1845,22 @@ describe("OpenClaw local provider bridge", () => {
 
     for (const testCase of cases) {
       const text = `  ${testCase.name} reply\n`;
+      const targetByProviderTarget =
+        testCase.manifest.provider === "mattermost"
+          ? new Map([["aaaaaaaaaaaaaaaaaaaaaaaaaa", "group:qa"]])
+          : new Map<string, string>();
       expect(
         createOpenClawCrablineOutboundFromRecorderEvent({
           event: testCase.event(text),
           manifest: testCase.manifest,
-          targetByProviderTarget: new Map(),
+          targetByProviderTarget,
         }),
       ).toMatchObject({ text });
       expect(
         createOpenClawCrablineOutboundFromRecorderEvent({
           event: testCase.event(" \n\t"),
           manifest: testCase.manifest,
-          targetByProviderTarget: new Map(),
+          targetByProviderTarget,
         }),
       ).toBeNull();
     }
@@ -1682,11 +1940,15 @@ describe("OpenClaw local provider bridge", () => {
     ];
 
     for (const testCase of cases) {
+      const targetByProviderTarget =
+        testCase.manifest.provider === "mattermost"
+          ? new Map([["aaaaaaaaaaaaaaaaaaaaaaaaaa", "group:qa"]])
+          : new Map<string, string>();
       const translate = (event: unknown) =>
         translateOpenClawCrablineOutbound({
           event,
           manifest: testCase.manifest,
-          targetByProviderTarget: new Map(),
+          targetByProviderTarget,
         });
 
       expect(translate({ ...testCase.event, accepted: true })).not.toBeNull();
@@ -1783,6 +2045,18 @@ describe("OpenClaw local provider bridge", () => {
       text: "hello from openclaw",
       to: "dm:alice",
     });
+    expect(
+      createOpenClawCrablineOutboundFromRecorderEvent({
+        manifest: mattermostManifest,
+        targetByProviderTarget: new Map(),
+        event: {
+          body: { channel_id: inbound.providerTargetKey, message: "unmapped reply" },
+          method: "POST",
+          path: "/api/v4/posts",
+          type: "api",
+        },
+      }),
+    ).toBeNull();
 
     const binding = createOpenClawCrablineProviderBinding(mattermostManifest);
     expect(binding).toMatchObject({
@@ -1804,6 +2078,28 @@ describe("OpenClaw local provider bridge", () => {
     });
     expect(threadInbound.providerTargetKey).toMatch(/:thread:[a-z0-9]{26}$/u);
     expect(threadInbound.threadId).toBe(threadInbound.providerBody.rootId);
+    const otherThreadInbound = createOpenClawCrablineInbound({
+      manifest: mattermostManifest,
+      input: {
+        conversation: { id: "random", kind: "group" },
+        senderId: "alice",
+        text: "same symbolic thread in another channel",
+        threadId: "parent",
+      },
+    });
+    expect(otherThreadInbound.providerBody.rootId).not.toBe(threadInbound.providerBody.rootId);
+    const nativeRootId = "bbbbbbbbbbbbbbbbbbbbbbbbbb";
+    expect(
+      createOpenClawCrablineInbound({
+        manifest: mattermostManifest,
+        input: {
+          conversation: { id: "general", kind: "group" },
+          senderId: "alice",
+          text: "real root",
+          threadId: nativeRootId,
+        },
+      }).providerBody.rootId,
+    ).toBe(nativeRootId);
     expect(
       createOpenClawCrablineOutboundFromRecorderEvent({
         manifest: mattermostManifest,
@@ -1887,6 +2183,40 @@ describe("OpenClaw local provider bridge", () => {
       text: "hello from OpenClaw",
       to: `group:${roomId}`,
     });
+    const matrixAdapter =
+      MATRIX_OPENCLAW_CRABLINE_PROVIDER_BRIDGE.createAdapterFromManifest(matrixManifest);
+    const transactionEvent = {
+      accepted: true,
+      body: { body: "first delivery", msgtype: "m.text" },
+      method: "PUT",
+      path: `/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/send/m.room.message/stable-transaction`,
+      type: "api",
+    };
+    expect(
+      matrixAdapter.createOutboundFromRecorderEvent({
+        event: transactionEvent,
+        targetByProviderTarget: new Map([[roomId, `group:${roomId}`]]),
+      }),
+    ).toMatchObject({ text: "first delivery", to: `group:${roomId}` });
+    expect(
+      matrixAdapter.createOutboundFromRecorderEvent({
+        event: {
+          ...transactionEvent,
+          body: { body: "replayed body must not deliver", msgtype: "m.text" },
+        },
+        targetByProviderTarget: new Map([[roomId, `group:${roomId}`]]),
+      }),
+    ).toBeNull();
+    expect(
+      matrixAdapter.createOutboundFromRecorderEvent({
+        event: {
+          ...transactionEvent,
+          path: `/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/send/m.room.message/replayed-marker`,
+          replayed: true,
+        },
+        targetByProviderTarget: new Map([[roomId, `group:${roomId}`]]),
+      }),
+    ).toBeNull();
 
     for (const malformedPath of [
       "/_matrix/client/v3/rooms/%ZZ/send/m.room.message/txn-1",
@@ -2242,7 +2572,7 @@ describe("OpenClaw local provider bridge", () => {
     const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
     const cleanupFailure = new Error("lock release retries exhausted");
     let pointerAtCleanup: Awaited<ReturnType<typeof readOpenClawCrablineArtifactPointer>> = null;
-    const releaseLock = vi.fn(async () => {
+    const releaseLock = vi.fn<() => Promise<void>>(async () => {
       pointerAtCleanup = await readOpenClawCrablineArtifactPointer(outputDir);
       throw cleanupFailure;
     });
@@ -2487,7 +2817,7 @@ describe("OpenClaw local provider bridge", () => {
     const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-openclaw-heartbeat-"));
     const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
     const failure = new Error("heartbeat renewal failed");
-    const release = vi.fn(async () => undefined);
+    const release = vi.fn<() => Promise<void>>(async () => undefined);
     try {
       const prior = await runOpenClawCrablineProviderReadiness({ outputDir, selection });
       const priorGeneration = await readPublishedArtifactGeneration(outputDir, prior);


### PR DESCRIPTION
## Summary
- harden OpenClaw artifact publication identity, rollback, and private-file cleanup
- align Mattermost, Matrix, Signal, Slack, Telegram, and WhatsApp bridge contracts
- use deterministic UUIDv8 identities for symbolic Signal senders while preserving native numbers and UUIDs

## Validation
- focused OpenClaw suites (3 files, 90 tests)
- local `pnpm verify` (56 files, 819 tests)
- GitHub CI `verify` on `4d7e336bd8603d63b0f0e0ff6cec229490fdfae2`
- Crabbox `run_de55f12e8870` (56 files, 819 tests)
- exact-head autoreview with `gpt-5.6-sol` / high: clean

## Audit
- final10 clawpatch remediation
- changelog entry included