### PR TITLE
fix(runtime): harden final audit boundaries

### DIFF
--- a/.agents/skills/autoreview/scripts/autoreview_test.py
+++ b/.agents/skills/autoreview/scripts/autoreview_test.py
@@ -131,6 +131,40 @@ class AutoreviewCompatibilityTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             namespace["parse_args"](["--engine", "cursor"])
 
+    def test_harness_ignores_hostile_git_environment_and_hooks(self) -> None:
+        harness_path = SCRIPT_PATH.with_name("test-review-harness.py")
+        namespace = runpy.run_path(str(harness_path))
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            repo = root / "repo"
+            repo.mkdir()
+            hostile_hooks = root / "hooks"
+            hostile_hooks.mkdir()
+            marker = root / "hook-ran"
+            hook = hostile_hooks / "pre-commit"
+            hook.write_text(
+                f"#!/bin/sh\nprintf owned > {marker}\n",
+                encoding="utf-8",
+            )
+            hook.chmod(0o755)
+            foreign_git_dir = root / "foreign.git"
+            subprocess.run(["git", "init", "--bare", "--quiet", str(foreign_git_dir)], check=True)
+
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "GIT_CONFIG_COUNT": "1",
+                    "GIT_CONFIG_KEY_0": "core.hooksPath",
+                    "GIT_CONFIG_VALUE_0": str(hostile_hooks),
+                    "GIT_DIR": str(foreign_git_dir),
+                },
+                clear=False,
+            ):
+                namespace["create_fixture_repo"](repo, "malicious")
+
+            self.assertTrue((repo / ".git").is_dir())
+            self.assertFalse(marker.exists())
+
     def test_cursor_agent_bin_cli_alias(self) -> None:
         with mock.patch.object(
             sys,

--- a/.agents/skills/autoreview/scripts/test-review-harness.py
+++ b/.agents/skills/autoreview/scripts/test-review-harness.py
@@ -132,13 +132,23 @@ def write_fixture_file(repo: Path, content: str) -> None:
 
 
 def run(command: list[str], cwd: Path) -> None:
-    env = os.environ.copy()
+    env = {name: value for name, value in os.environ.items() if not name.startswith("GIT_")}
     env["GIT_CONFIG_GLOBAL"] = os.devnull
+    env["GIT_CONFIG_SYSTEM"] = os.devnull
     env["GIT_CONFIG_NOSYSTEM"] = "1"
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    if command and command[0] == "git":
+        command = [
+            "git",
+            "-c",
+            f"core.hooksPath={cwd / '.git-safe-hooks'}",
+            *command[1:],
+        ]
     subprocess.run(command, cwd=cwd, check=True, env=env)
 
 
 def create_fixture_repo(repo: Path, fixture: str) -> None:
+    (repo / ".git-safe-hooks").mkdir()
     run(["git", "-c", "init.templateDir=", "init", "--quiet"], repo)
     run(["git", "config", "user.name", "Review Fixture"], repo)
     run(["git", "config", "user.email", "review-fixture@example.com"], repo)

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,7 +3,11 @@ name: Dependency Review
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    paths: [package.json, pnpm-lock.yaml, .github/workflows/dependency-review.yml]
+    paths:
+      - package.json
+      - pnpm-lock.yaml
+      - ".github/actions/**"
+      - ".github/workflows/**"
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Harden CLI secret ingress and numeric parsing, provider cancellation and script thread propagation, timer bounds, review fixtures, and dependency review coverage.
 - Harden secondary provider adapters with stable pagination, scoped native IDs, immutable diagnostics redaction, Slack edit normalization, and bounded WhatsApp ingress.
 - Harden provider-core webhook hooks, recorder durability and cursor semantics, lazy adapter lifecycle and target parity, and signed-JWT key caching.
 - Harden autoreview launchers and release automation, document trusted script manifests, and canonicalize WhatsApp Cloud targets.

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -418,10 +418,16 @@ export function createProgram(
     .description("Start a local provider server that OpenClaw live adapters can target")
     .option("--host <host>", "Bind host", "127.0.0.1")
     .option("--port <port>", "Bind port", "0")
-    .option("--admin-token <token>", "Admin token for inbound test messages")
+    .option(
+      "--admin-token <token>",
+      "Admin token for inbound test messages (or CRABLINE_ADMIN_TOKEN)",
+    )
     .option("--account <number>", "Signal account number")
-    .option("--access-token <token>", "Matrix or WhatsApp access token")
-    .option("--bot-token <token>", "Mattermost, Slack, Telegram, or Zalo bot token")
+    .option("--access-token <token>", "Matrix or WhatsApp access token (or CRABLINE_ACCESS_TOKEN)")
+    .option(
+      "--bot-token <token>",
+      "Mattermost, Slack, Telegram, or Zalo bot token (or CRABLINE_BOT_TOKEN)",
+    )
     .option(
       "--bot-username <username>",
       "Mattermost, Telegram, or Zalo bot username",
@@ -431,12 +437,21 @@ export function createProgram(
     .option("--ready-file <path>", "Write the server runtime manifest to this path")
     .option("--self-jid <jid>", "WhatsApp self JID")
     .option("--show-secrets", "Print provider credentials in text output", false)
-    .option("--signing-secret <secret>", "Slack signing secret")
+    .option("--signing-secret <secret>", "Slack signing secret (or CRABLINE_SIGNING_SECRET)")
     .option("--once", "Start, print the runtime manifest, and stop immediately", false)
     .action(async (provider, commandOptions: ServeCommandOptions) => {
       const options = program.opts() as GlobalOptions;
       if (!isCrablineServerChannel(provider)) {
         throw new CrablineError(`Unsupported server channel: ${provider}`, {
+          kind: "config",
+        });
+      }
+      commandOptions.accessToken ??= process.env.CRABLINE_ACCESS_TOKEN;
+      commandOptions.adminToken ??= process.env.CRABLINE_ADMIN_TOKEN;
+      commandOptions.botToken ??= process.env.CRABLINE_BOT_TOKEN;
+      commandOptions.signingSecret ??= process.env.CRABLINE_SIGNING_SECRET;
+      if (!/^[0-9]+$/u.test(commandOptions.port)) {
+        throw new CrablineError(`Invalid local server port: ${commandOptions.port}`, {
           kind: "config",
         });
       }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -130,7 +130,7 @@ const ScriptCommandsSchema = z.strictObject({
 });
 
 const LoopbackConfigSchema = z.strictObject({
-  delayMs: z.number().int().min(0).default(25),
+  delayMs: z.number().int().min(0).max(MAX_TIMER_MS).default(25),
 });
 
 const ScriptConfigSchema = z.strictObject({

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -31,7 +31,9 @@ export class CrablineError extends Error {
     this.name = "CrablineError";
     this.kind = options?.kind;
     this.exitCode =
-      options?.exitCode ?? (options?.kind ? KIND_TO_EXIT[options.kind] : EXIT_CODES.FAILURE);
+      options?.exitCode === EXIT_CODES.SUCCESS
+        ? EXIT_CODES.FAILURE
+        : (options?.exitCode ?? (options?.kind ? KIND_TO_EXIT[options.kind] : EXIT_CODES.FAILURE));
   }
 }
 
@@ -40,5 +42,9 @@ export function ensureErrorMessage(error: unknown): string {
     return error.message;
   }
 
-  return String(error);
+  try {
+    return String(error);
+  } catch {
+    return "Unknown error";
+  }
 }

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -28,6 +28,8 @@ const INBOUND_ABORT_GRACE_MS = 250;
 const MAX_EXCLUDED_INBOUND_IDS = 1_024;
 const MAX_SCRIPT_STDIN_BYTES = 1024 * 1024;
 
+class UnsettledProviderOperationError extends CrablineError {}
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -70,7 +72,7 @@ async function withFixtureDeadline<T>(
       () => true,
     );
     if ((await raceInboundDeadline(settled, INBOUND_ABORT_GRACE_MS)) === INBOUND_DEADLINE_REACHED) {
-      throw new CrablineError(
+      throw new UnsettledProviderOperationError(
         `Provider ${operationName} did not settle within ${INBOUND_ABORT_GRACE_MS}ms after abort.`,
         {
           cause: timeoutError,
@@ -305,6 +307,9 @@ export async function runFixtureCommand(params: {
           providerId: fixture.provider,
         });
       } catch (error) {
+        if (error instanceof UnsettledProviderOperationError) {
+          abortDrainFailed = true;
+        }
         return (result = toFailure(fixture.id, fixture.provider, mode, error, "connectivity"));
       }
     } else {
@@ -366,6 +371,10 @@ export async function runFixtureCommand(params: {
             );
           } catch (error) {
             lastFailure = toFailure(fixture.id, fixture.provider, mode, error, "outbound", nonce);
+            if (error instanceof UnsettledProviderOperationError) {
+              abortDrainFailed = true;
+              break;
+            }
             continue;
           }
           if (!accepted.accepted) {
@@ -420,6 +429,7 @@ export async function runFixtureCommand(params: {
                     nonce,
                     since,
                     target: fixture.target,
+                    threadId: accepted.threadId,
                     timeoutMs,
                   },
                 });
@@ -429,7 +439,7 @@ export async function runFixtureCommand(params: {
               if (candidate === INBOUND_DEADLINE_REACHED) {
                 if (!(await abortAndDrainInboundWait(wait, controller))) {
                   abortDrainFailed = true;
-                  throw new CrablineError(
+                  throw new UnsettledProviderOperationError(
                     `Provider inbound wait did not settle within ${INBOUND_ABORT_GRACE_MS}ms after abort.`,
                     { kind: "inbound" },
                   );
@@ -481,7 +491,9 @@ export async function runFixtureCommand(params: {
               ok: false,
               providerId: fixture.provider,
             };
-            await sleep(50);
+            if (attempts < maxAttempts) {
+              await sleep(50);
+            }
             continue;
           }
 
@@ -523,7 +535,7 @@ export async function runFixtureCommand(params: {
         ) {
           cleanupErrors.push(
             new Error(
-              `Provider cleanup did not settle within ${INBOUND_ABORT_GRACE_MS}ms after an aborted inbound wait.`,
+              `Provider cleanup did not settle within ${INBOUND_ABORT_GRACE_MS}ms after an aborted operation.`,
             ),
           );
         }

--- a/src/providers/builtin/script.ts
+++ b/src/providers/builtin/script.ts
@@ -817,6 +817,7 @@ export class ScriptProviderAdapter implements ProviderAdapter {
           nonce: context.nonce,
           since: context.since,
           target: this.normalizeTarget(context.fixture.target),
+          threadId: context.threadId,
           timeoutMs: context.timeoutMs,
         },
       },

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -9,7 +9,7 @@ import {
   runCli,
   waitForShutdown,
 } from "../src/cli/program.js";
-import type { StartedCrablineServer } from "../src/servers/index.js";
+import type { StartCrablineServerParams, StartedCrablineServer } from "../src/servers/index.js";
 import { captureWrites, createTempDir, disposeTempDir, writeText } from "./test-helpers.js";
 
 const lockState = vi.hoisted(() => ({
@@ -41,6 +41,7 @@ const stripAnsi = (value: string): string => value.replace(ansiPattern, "");
 
 afterEach(async () => {
   process.exitCode = 0;
+  vi.unstubAllEnvs();
   lockState.options.length = 0;
   lockState.releaseError = undefined;
   await Promise.all(directories.splice(0).map(disposeTempDir));
@@ -376,6 +377,75 @@ describe("cli", () => {
 
     expect(probe?.usage()).toBe("[options] <fixtureId>");
     expect(probe?.description()).toBe("Probe provider readiness using a fixture");
+  });
+
+  it("rejects non-decimal serve ports before startup", async () => {
+    const startServer = vi.fn();
+    const program = createProgram(() => undefined, { startServer });
+
+    for (const port of ["1e3", "0x10", " 80"]) {
+      await expect(
+        program.parseAsync(["node", "crabline", "serve", "slack", "--port", port, "--once"]),
+      ).rejects.toThrow(`Invalid local server port: ${port}`);
+    }
+    expect(startServer).not.toHaveBeenCalled();
+  });
+
+  it("loads serve secrets from env while keeping flags authoritative", async () => {
+    vi.stubEnv("CRABLINE_ACCESS_TOKEN", "example");
+    vi.stubEnv("CRABLINE_ADMIN_TOKEN", "fake");
+    vi.stubEnv("CRABLINE_BOT_TOKEN", "sample");
+    vi.stubEnv("CRABLINE_SIGNING_SECRET", "test-token-placeholder");
+    const startServer = vi.fn(
+      async (_params: StartCrablineServerParams): Promise<StartedCrablineServer> => ({
+        async close() {},
+        manifest: {
+          adminToken: "fake",
+          baseUrl: "http://127.0.0.1:12345",
+          botToken: "placeholder",
+          endpoints: {
+            adminInboundUrl: "http://127.0.0.1:12345/crabline/slack/inbound",
+            apiRoot: "http://127.0.0.1:12345/api/",
+            eventsUrl: "http://127.0.0.1:12345/slack/events",
+          },
+          env: {
+            SLACK_API_URL: "http://127.0.0.1:12345/api/",
+            SLACK_BOT_TOKEN: "placeholder",
+            SLACK_SIGNING_SECRET: "test-token-placeholder",
+          },
+          provider: "slack" as const,
+          recorderPath: "/tmp/slack.jsonl",
+          signingSecret: "test-token-placeholder",
+          version: 1 as const,
+        },
+      }),
+    );
+    const program = createProgram(() => undefined, { startServer });
+    const captured = captureWrites();
+
+    try {
+      await program.parseAsync([
+        "node",
+        "crabline",
+        "--json",
+        "serve",
+        "slack",
+        "--bot-token",
+        "placeholder",
+        "--once",
+      ]);
+    } finally {
+      captured.restore();
+    }
+
+    expect(startServer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        adminToken: "fake",
+        botToken: "placeholder",
+        channel: "slack",
+        signingSecret: "test-token-placeholder",
+      }),
+    );
   });
 
   it("isolates exit codes across repeated invocations", async () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -112,6 +112,21 @@ describe("manifest schema", () => {
     ).not.toThrow();
   });
 
+  it("rejects loopback delays beyond the Node timer ceiling", () => {
+    expect(() =>
+      ManifestSchema.parse({
+        configVersion: 1,
+        fixtures: [],
+        providers: {
+          local: {
+            adapter: "loopback",
+            loopback: { delayMs: 2_147_483_648 },
+          },
+        },
+      }),
+    ).toThrow(/2147483647/u);
+  });
+
   it("rejects fixture ids that cannot be embedded in nonces", () => {
     for (const id of ["foo_bar", "foo.bar", "foo bar"]) {
       expect(() =>

--- a/test/release-workflow.test.ts
+++ b/test/release-workflow.test.ts
@@ -184,6 +184,8 @@ describe("release workflow", () => {
     expect(contents).not.toContain(
       "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6",
     );
+    expect(contents).toContain('      - ".github/actions/**"');
+    expect(contents).toContain('      - ".github/workflows/**"');
   });
 
   it("isolates package verification, OIDC publication, and GitHub release authority", async () => {

--- a/test/reporters-errors.test.ts
+++ b/test/reporters-errors.test.ts
@@ -13,6 +13,10 @@ describe("errors and reporters", () => {
     expect(error.exitCode).toBe(EXIT_CODES.AUTH);
     expect(ensureErrorMessage(error)).toBe("boom");
     expect(ensureErrorMessage("plain")).toBe("plain");
+    expect(new CrablineError("failed", { exitCode: EXIT_CODES.SUCCESS }).exitCode).toBe(
+      EXIT_CODES.FAILURE,
+    );
+    expect(ensureErrorMessage(Object.create(null))).toBe("Unknown error");
   });
 
   it("formats single and suite results", () => {

--- a/test/run.retry-timeout.test.ts
+++ b/test/run.retry-timeout.test.ts
@@ -212,6 +212,56 @@ describe("runFixtureCommand retries", () => {
     expect(cleanupCalls).toBe(1);
   });
 
+  it("does not retry an outbound send that ignores cancellation", async () => {
+    let cleanupCalls = 0;
+    let releaseSend: (() => void) | undefined;
+    let sendCalls = 0;
+    const provider: ProviderAdapter = {
+      id: "mock",
+      platform: "loopback",
+      status: "ready",
+      supports: ["probe", "send", "roundtrip", "agent"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      async probe() {
+        return { details: [], healthy: true };
+      },
+      async send() {
+        sendCalls += 1;
+        return await new Promise((resolve) => {
+          releaseSend = () =>
+            resolve({ accepted: true, messageId: "sent-late", threadId: "thread-1" });
+        });
+      },
+      async waitForInbound() {
+        throw new Error("wait must not run");
+      },
+      async cleanup() {
+        cleanupCalls += 1;
+        releaseSend?.();
+      },
+    };
+    const registry: Registry = {
+      catalog: OPENCLAW_SUPPORT_CATALOG,
+      resolve() {
+        return provider;
+      },
+    };
+
+    const result = await runFixtureCommand({
+      fixtureId: "fixture",
+      manifest,
+      manifestPath: "/tmp/crabline.yaml",
+      registry,
+    });
+
+    expect(result).toMatchObject({ failureKind: "timeout", ok: false });
+    expect(result.diagnostics).toContain("Provider send did not settle within 250ms after abort.");
+    expect(sendCalls).toBe(1);
+    expect(cleanupCalls).toBe(1);
+  });
+
   it("bounds cleanup after an inbound wait ignores cancellation", async () => {
     let releaseWait: (() => void) | undefined;
     const provider: ProviderAdapter = {
@@ -254,7 +304,7 @@ describe("runFixtureCommand retries", () => {
 
       expect(result).toMatchObject({ failureKind: "inbound", ok: false });
       expect(result.diagnostics).toContain(
-        "cleanup failed: Provider cleanup did not settle within 250ms after an aborted inbound wait.",
+        "cleanup failed: Provider cleanup did not settle within 250ms after an aborted operation.",
       );
     } finally {
       releaseWait?.();

--- a/test/script-provider.test.ts
+++ b/test/script-provider.test.ts
@@ -372,6 +372,27 @@ describe("script provider", () => {
     ).resolves.toMatchObject({ text: '["seen-1","seen-2"]' });
   });
 
+  it("passes the accepted outbound thread ID to wait commands", async () => {
+    const context = await createContext();
+    const waitScript = path.join(path.dirname(context.manifestPath), "wait-thread.mjs");
+    await writeText(
+      waitScript,
+      'let raw="";process.stdin.on("data",(chunk)=>raw+=chunk);process.stdin.on("end",()=>{const input=JSON.parse(raw);process.stdout.write(JSON.stringify({message:{author:"assistant",id:"inbound-thread",sentAt:new Date().toISOString(),text:input.wait.threadId,threadId:input.wait.threadId}}));});',
+    );
+    context.config.script!.commands.waitForInbound = `node ${waitScript}`;
+    const provider = new ScriptProviderAdapter(context);
+
+    await expect(
+      provider.waitForInbound({
+        ...context,
+        nonce: "nonce",
+        since: new Date().toISOString(),
+        threadId: "accepted-thread",
+        timeoutMs: 1000,
+      }),
+    ).resolves.toMatchObject({ text: "accepted-thread", threadId: "accepted-thread" });
+  });
+
   it("rejects inbound messages returned during the wait exit grace", async () => {
     const context = await createContext();
     const waitScript = path.join(path.dirname(context.manifestPath), "wait-late-message.mjs");


### PR DESCRIPTION
## Summary

- prevent duplicate sends when providers ignore timeout cancellation
- harden CLI secret ingress, decimal port parsing, error handling, script thread propagation, and timer bounds
- isolate autoreview fixtures from hostile Git state and cover workflow action dependency changes

## Validation

- `pnpm lint`
- `pnpm test` (56 files, 849 tests)
- `python3 .agents/skills/autoreview/scripts/autoreview_test.py`
- privacy scan clean