### PR TITLE
fix(openclaw): harden artifact persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Recover interrupted artifact and recorder writes, publish immutable readiness evidence, and harden private-directory and smoke-lock durability.
+
 ## 0.1.10 - 2026-07-13
 
 - Emit nested OpenClaw streaming config from the Matrix and Mattermost provider bridges.

--- a/src/openclaw.ts
+++ b/src/openclaw.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+import type { BigIntStats } from "node:fs";
 import {
   CRABLINE_SERVER_CHANNELS,
   isCrablineServerChannel,
@@ -39,6 +41,7 @@ import {
 } from "./openclaw/shared.js";
 import { publishOpenClawCrablineArtifactGeneration } from "./openclaw/artifact-generation.js";
 import { isAcceptedOpenClawCrablineOutbound } from "./openclaw/outbound-contract.js";
+import { syncParentDirectory } from "./openclaw/private-file.js";
 import {
   acquireOpenClawCrablineSmokeRunLock,
   releaseOpenClawCrablineSmokeRunLock,
@@ -82,6 +85,108 @@ const OPENCLAW_CRABLINE_PROVIDER_BRIDGES = {
 const OPENCLAW_CRABLINE_PROVIDER_BRIDGE_LIST = Object.values(
   OPENCLAW_CRABLINE_PROVIDER_BRIDGES,
 ) as readonly OpenClawCrablineProviderBridge[];
+const RECORDER_TEMP_NAME_PATTERN =
+  /^\.([a-z]+)-fake-provider\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl\.tmp$/iu;
+const RECORDER_LOCK_REMOVAL_TOMBSTONE_PATTERN =
+  /^\.(.+)\.\d+\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.remove$/iu;
+
+function isOpenClawCrablineRecorderTemporary(name: string): boolean {
+  const channel = RECORDER_TEMP_NAME_PATTERN.exec(name)?.[1]?.toLowerCase();
+  return channel !== undefined && isCrablineServerChannel(channel);
+}
+
+function isOpenClawCrablineRecorderTemporaryLock(name: string): boolean {
+  return name.endsWith(".lock") && isOpenClawCrablineRecorderTemporary(name.slice(0, -5));
+}
+
+function openClawCrablineRecorderLockTombstoneBaseName(name: string): string | null {
+  const originalName = RECORDER_LOCK_REMOVAL_TOMBSTONE_PATTERN.exec(name)?.[1];
+  return originalName !== undefined && isOpenClawCrablineRecorderTemporaryLock(originalName)
+    ? originalName
+    : null;
+}
+
+async function reclaimOpenClawCrablineRecorderTemporaryLock(
+  directoryPath: string,
+  name: string,
+  lock: Awaited<ReturnType<typeof acquireOpenClawCrablineSmokeRunLock>>,
+  quarantineBaseName = name,
+): Promise<void> {
+  const lockPath = path.join(directoryPath, name);
+  let identity: BigIntStats;
+  try {
+    identity = await fs.lstat(lockPath, { bigint: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+  if (!identity.isDirectory()) {
+    return;
+  }
+  const currentUserId = process.geteuid?.();
+  if (currentUserId !== undefined && identity.uid !== BigInt(currentUserId)) {
+    return;
+  }
+
+  const quarantinePath = path.join(
+    directoryPath,
+    `.${quarantineBaseName}.${process.pid}.${randomUUID()}.remove`,
+  );
+  await lock.assertOwned();
+  try {
+    await fs.rename(lockPath, quarantinePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
+  const quarantined = await fs.lstat(quarantinePath, { bigint: true });
+  if (
+    !quarantined.isDirectory() ||
+    quarantined.dev !== identity.dev ||
+    quarantined.ino !== identity.ino
+  ) {
+    throw new Error("OpenClaw Crabline recorder lock identity changed during recovery.");
+  }
+  await syncParentDirectory(quarantinePath);
+  await fs.rm(quarantinePath, { force: true, recursive: true });
+  await syncParentDirectory(quarantinePath);
+}
+
+async function reclaimOpenClawCrablineRecorderTemporaries(
+  directoryPath: string,
+  lock: Awaited<ReturnType<typeof acquireOpenClawCrablineSmokeRunLock>>,
+): Promise<void> {
+  for (const entry of await fs.readdir(directoryPath, { withFileTypes: true })) {
+    const tombstoneBaseName = entry.isDirectory()
+      ? openClawCrablineRecorderLockTombstoneBaseName(entry.name)
+      : null;
+    if (isOpenClawCrablineRecorderTemporaryLock(entry.name) || tombstoneBaseName !== null) {
+      if (entry.isDirectory()) {
+        await reclaimOpenClawCrablineRecorderTemporaryLock(
+          directoryPath,
+          entry.name,
+          lock,
+          tombstoneBaseName ?? entry.name,
+        );
+      }
+      continue;
+    }
+    if (
+      !isOpenClawCrablineRecorderTemporary(entry.name) ||
+      (!entry.isFile() && !entry.isSymbolicLink())
+    ) {
+      continue;
+    }
+    await lock.assertOwned();
+    const temporaryPath = path.join(directoryPath, entry.name);
+    await fs.rm(temporaryPath, { force: true });
+    await syncParentDirectory(temporaryPath);
+  }
+}
 
 function createOpenClawCrablineProviderAdapter(
   manifest: CrablineServerManifest,
@@ -248,15 +353,16 @@ export async function runOpenClawCrablineProviderReadiness(
   let outcome:
     | { committed: false; error: unknown }
     | { committed: true; result: OpenClawCrablineProviderReadinessResult };
+  let recorderPath: string | undefined;
 
   try {
-    const recorderPath = path.join(
-      outputDir,
-      "artifacts",
-      "crabline",
-      `${params.selection.channel}-fake-provider.jsonl`,
+    const recorderDirectory = path.join(outputDir, "artifacts", "crabline");
+    await fs.mkdir(recorderDirectory, { recursive: true });
+    await reclaimOpenClawCrablineRecorderTemporaries(recorderDirectory, smokeLock);
+    recorderPath = path.join(
+      recorderDirectory,
+      `.${params.selection.channel}-fake-provider.${randomUUID()}.jsonl.tmp`,
     );
-    await fs.mkdir(path.dirname(recorderPath), { recursive: true });
     const adapter = await (dependencies.startAdapter ?? startOpenClawCrablineAdapter)({
       channel: params.selection.channel,
       openclawConfig: {},
@@ -306,6 +412,14 @@ export async function runOpenClawCrablineProviderReadiness(
     if (probeFailed) {
       throw probeFailure;
     }
+    let recorderSnapshotContents = "";
+    try {
+      recorderSnapshotContents = await fs.readFile(recorderPath, "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    }
 
     const capabilityReport = {
       result: {
@@ -332,9 +446,21 @@ export async function runOpenClawCrablineProviderReadiness(
       lock: smokeLock,
       manifest: adapter.manifest,
       outputDir,
+      recorderSnapshot: {
+        contents: recorderSnapshotContents,
+        fileName: `${params.selection.channel}-fake-provider.jsonl`,
+      },
       selection: params.selection,
       providerReadiness,
     });
+    let recorderCleanupWarning: string | undefined;
+    try {
+      await fs.rm(recorderPath, { force: true });
+      recorderPath = undefined;
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      recorderCleanupWarning = `OpenClaw Crabline recorder snapshot committed but temporary cleanup failed: ${detail}`;
+    }
     outcome = {
       committed: true,
       result: {
@@ -347,11 +473,52 @@ export async function runOpenClawCrablineProviderReadiness(
         providerReadinessArtifactPath: generation.providerReadinessArtifactPath,
         smoke: generation.providerReadiness,
         smokeArtifactPath: generation.providerReadinessArtifactPath,
-        ...(generation.warnings ? { warnings: generation.warnings } : {}),
+        ...(generation.warnings || recorderCleanupWarning
+          ? {
+              warnings: [
+                ...(generation.warnings ?? []),
+                ...(recorderCleanupWarning ? [recorderCleanupWarning] : []),
+              ],
+            }
+          : {}),
       },
     };
   } catch (error) {
-    outcome = { committed: false, error };
+    let primaryError = error;
+    if (recorderPath) {
+      try {
+        await fs.rm(recorderPath, { force: true });
+        recorderPath = undefined;
+      } catch (cleanupError) {
+        if (primaryError instanceof Error) {
+          const existingCause = primaryError.cause;
+          try {
+            Object.defineProperty(primaryError, "cause", {
+              configurable: true,
+              value:
+                existingCause === undefined
+                  ? cleanupError
+                  : new AggregateError(
+                      [existingCause, cleanupError],
+                      "OpenClaw Crabline readiness failure cleanup also failed.",
+                    ),
+            });
+          } catch {
+            // Frozen failures remain authoritative even if temporary cleanup also fails.
+          }
+        } else {
+          const combinedError = new Error(
+            "OpenClaw Crabline readiness and temporary cleanup both failed.",
+            { cause: cleanupError },
+          );
+          Object.defineProperty(combinedError, "errors", {
+            value: [primaryError, cleanupError],
+          });
+          primaryError = combinedError;
+        }
+      }
+    }
+    outcome = { committed: false, error: primaryError };
   }
 
   try {

--- a/src/openclaw/artifact-generation.ts
+++ b/src/openclaw/artifact-generation.ts
@@ -22,6 +22,10 @@ import type { OpenClawCrablineSmokeRunLock } from "./smoke-lock.js";
 
 const GENERATION_NAME_PATTERN =
   /^generation-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
+const STAGING_NAME_PATTERN =
+  /^\.staging-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
+const REMOVAL_TOMBSTONE_PATTERN =
+  /^\.(.+)\.\d+\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.remove$/iu;
 export type OpenClawCrablineArtifactPointer = {
   capabilityMatrixPath: string;
   generation: string;
@@ -49,6 +53,11 @@ type PublishGenerationDependencies = {
   syncParent?: typeof syncParentDirectory;
 };
 
+type RecorderSnapshot = {
+  contents: string;
+  fileName: string;
+};
+
 function resolveProviderReadinessArtifactPath(
   selection: OpenClawCrablineChannelDriverSelection,
 ): typeof OPENCLAW_CRABLINE_PROVIDER_READINESS_PATH {
@@ -74,6 +83,31 @@ function assertGenerationName(value: unknown, field: string): asserts value is s
 
 function generationArtifactPath(generation: string, fileName: string): string {
   return path.join(OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY, generation, fileName);
+}
+
+function artifactRemovalTombstoneBaseName(name: string): string | null {
+  const originalName = REMOVAL_TOMBSTONE_PATTERN.exec(name)?.[1];
+  return originalName !== undefined &&
+    (GENERATION_NAME_PATTERN.test(originalName) || STAGING_NAME_PATTERN.test(originalName))
+    ? originalName
+    : null;
+}
+
+function withRecorderSnapshotPath(
+  providerReadiness: Record<string, unknown>,
+  recorderPath: string,
+): Record<string, unknown> {
+  const result = providerReadiness.result;
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    throw new Error("OpenClaw Crabline provider readiness result is malformed.");
+  }
+  return {
+    ...providerReadiness,
+    result: {
+      ...result,
+      recorderPath,
+    },
+  };
 }
 
 function parseArtifactPointer(contents: string): OpenClawCrablineArtifactPointer {
@@ -181,12 +215,16 @@ async function pruneArtifactStore(params: {
       : [],
   );
   for (const entry of await fs.readdir(params.store.directoryPath, { withFileTypes: true })) {
-    const isAbandonedStaging = entry.isDirectory() && entry.name.startsWith(".staging-");
+    const isAbandonedStaging = entry.isDirectory() && STAGING_NAME_PATTERN.test(entry.name);
     const isObsoleteGeneration =
       entry.isDirectory() &&
       GENERATION_NAME_PATTERN.test(entry.name) &&
       !retainedGenerations.has(entry.name);
-    if (!isAbandonedStaging && !isObsoleteGeneration) {
+    const removalTombstoneBaseName = entry.isDirectory()
+      ? artifactRemovalTombstoneBaseName(entry.name)
+      : null;
+    const isRemovalTombstone = removalTombstoneBaseName !== null;
+    if (!isAbandonedStaging && !isObsoleteGeneration && !isRemovalTombstone) {
       continue;
     }
     await params.lock.assertOwned();
@@ -195,7 +233,11 @@ async function pruneArtifactStore(params: {
       path.join(params.store.directoryPath, entry.name),
       params.directoryOptions,
     );
-    await removeSecuredPrivateDirectory(obsolete);
+    await removeSecuredPrivateDirectory(
+      obsolete,
+      undefined,
+      removalTombstoneBaseName ?? entry.name,
+    );
     await params.store.assertIdentityAt();
   }
 }
@@ -206,6 +248,7 @@ export async function publishOpenClawCrablineArtifactGeneration(
     lock: OpenClawCrablineSmokeRunLock;
     manifest: CrablineServerManifest;
     outputDir: string;
+    recorderSnapshot?: RecorderSnapshot;
     selection: OpenClawCrablineChannelDriverSelection;
     providerReadiness: Record<string, unknown>;
   },
@@ -222,6 +265,7 @@ export async function publishOpenClawCrablineArtifactGeneration(
     ...(dependencies.secureWindowsDirectory
       ? { secureWindowsDirectory: dependencies.secureWindowsDirectory }
       : {}),
+    ...(dependencies.syncParent ? { syncParent: dependencies.syncParent } : {}),
   };
   const store = await securePrivateDirectory(storePath, directoryOptions);
   await output.assertIdentityAt();
@@ -283,13 +327,29 @@ export async function publishOpenClawCrablineArtifactGeneration(
       smokeArtifactPath: generationArtifactPath(generation, providerReadinessArtifactPath),
       version: 1,
     };
+    if (
+      params.recorderSnapshot &&
+      (path.basename(params.recorderSnapshot.fileName) !== params.recorderSnapshot.fileName ||
+        !params.recorderSnapshot.fileName.endsWith(".jsonl"))
+    ) {
+      throw new Error("OpenClaw Crabline recorder snapshot filename is malformed.");
+    }
+    const recorderSnapshotPath = params.recorderSnapshot
+      ? generationArtifactPath(generation, params.recorderSnapshot.fileName)
+      : undefined;
+    const publishedManifest = recorderSnapshotPath
+      ? { ...params.manifest, recorderPath: recorderSnapshotPath }
+      : params.manifest;
+    const providerReadinessBase = recorderSnapshotPath
+      ? withRecorderSnapshotPath(params.providerReadiness, recorderSnapshotPath)
+      : params.providerReadiness;
     const providerReadiness = {
-      ...params.providerReadiness,
+      ...providerReadinessBase,
       manifestPath: pointer.manifestPath,
     };
-    const artifactContents = [
+    const artifactContents: { contents: string; fileName: string }[] = [
       {
-        contents: `${JSON.stringify(params.manifest, null, 2)}\n`,
+        contents: `${JSON.stringify(publishedManifest, null, 2)}\n`,
         fileName: OPENCLAW_CRABLINE_MANIFEST_PATH,
       },
       {
@@ -323,7 +383,15 @@ export async function publishOpenClawCrablineArtifactGeneration(
         )}\n`,
         fileName: providerReadinessArtifactPath,
       },
-    ] as const;
+      ...(params.recorderSnapshot
+        ? [
+            {
+              contents: params.recorderSnapshot.contents,
+              fileName: params.recorderSnapshot.fileName,
+            },
+          ]
+        : []),
+    ];
 
     await params.lock.assertOwned();
     for (const artifact of artifactContents) {

--- a/src/openclaw/private-file.ts
+++ b/src/openclaw/private-file.ts
@@ -250,6 +250,7 @@ async function assertPathIdentity(filePath: string, expected: FileIdentity): Pro
 type DirectoryIdentity = {
   device: bigint;
   inode: bigint;
+  userId: bigint;
 };
 
 async function readDirectoryHandleIdentity(handle: FileHandle): Promise<DirectoryIdentity> {
@@ -260,6 +261,7 @@ async function readDirectoryHandleIdentity(handle: FileHandle): Promise<Director
   return {
     device: stats.dev,
     inode: stats.ino,
+    userId: stats.uid,
   };
 }
 
@@ -319,13 +321,62 @@ export async function syncParentDirectory(
   }
 }
 
+async function syncParentAtAccessibleBoundary(
+  filePath: string,
+  syncParent: (filePath: string, platform?: NodeJS.Platform) => Promise<void>,
+  platform?: NodeJS.Platform,
+): Promise<boolean> {
+  try {
+    await syncParent(filePath, platform);
+    return true;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "EACCES" || code === "EPERM") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function syncPathAncestry(
+  filePath: string,
+  syncParent: (filePath: string, platform?: NodeJS.Platform) => Promise<void>,
+  platform?: NodeJS.Platform,
+  firstCreatedDirectory?: string,
+): Promise<void> {
+  const resolvedFilePath = path.resolve(filePath);
+  let currentPath = resolvedFilePath;
+  const syncThroughPath =
+    firstCreatedDirectory === undefined ? undefined : path.resolve(firstCreatedDirectory);
+  for (;;) {
+    const mandatory = syncThroughPath !== undefined || currentPath === resolvedFilePath;
+    if (mandatory) {
+      await syncParent(currentPath, platform);
+    } else if (!(await syncParentAtAccessibleBoundary(currentPath, syncParent, platform))) {
+      return;
+    }
+    if (currentPath === syncThroughPath) {
+      return;
+    }
+    const parentPath = path.dirname(currentPath);
+    if (path.dirname(parentPath) === parentPath) {
+      return;
+    }
+    currentPath = parentPath;
+  }
+}
+
 export async function removeSecuredPrivateDirectory(
   secured: SecuredPrivateDirectory,
   currentPath = secured.directoryPath,
+  quarantineBaseName = path.basename(currentPath),
 ): Promise<void> {
+  if (path.basename(quarantineBaseName) !== quarantineBaseName || quarantineBaseName.length === 0) {
+    throw new Error("Private directory quarantine basename is malformed.");
+  }
   const quarantinePath = path.join(
     path.dirname(currentPath),
-    `.${path.basename(currentPath)}.${process.pid}.${randomUUID()}.remove`,
+    `.${quarantineBaseName}.${process.pid}.${randomUUID()}.remove`,
   );
   await secured.assertIdentityAt(currentPath);
   await fs.rename(currentPath, quarantinePath);
@@ -338,8 +389,10 @@ export async function removeSecuredPrivateDirectory(
 export async function securePrivateDirectory(
   directoryPath: string,
   options: {
+    currentUserId?: number;
     platform?: NodeJS.Platform;
     secureWindowsDirectory?: (directoryPath: string) => Promise<void>;
+    syncParent?: (filePath: string, platform?: NodeJS.Platform) => Promise<void>;
   } = {},
 ): Promise<SecuredPrivateDirectory> {
   let created = false;
@@ -388,9 +441,24 @@ export async function securePrivateDirectory(
     if ((options.platform ?? process.platform) === "win32") {
       await (options.secureWindowsDirectory ?? applyOwnerOnlyWindowsDirectoryAcl)(directoryPath);
     } else {
+      const currentUserId = options.currentUserId ?? process.geteuid?.();
+      if (
+        currentUserId === undefined ||
+        !Number.isSafeInteger(currentUserId) ||
+        currentUserId < 0 ||
+        identity.userId !== BigInt(currentUserId)
+      ) {
+        throw new Error("Private directory must be owned by the current POSIX user.");
+      }
       await handle.chmod(0o700);
     }
     await secured.assertIdentityAt();
+    const syncParent = options.syncParent ?? syncParentDirectory;
+    if (created) {
+      await syncParent(directoryPath, options.platform);
+    } else {
+      await syncParentAtAccessibleBoundary(directoryPath, syncParent, options.platform);
+    }
   } catch (error) {
     let primaryError = error;
     try {
@@ -441,7 +509,8 @@ export async function publishPrivateFileAtomically(
     path.dirname(filePath),
     `.${path.basename(filePath)}.${process.pid}.${randomUUID()}.tmp`,
   );
-  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  const parentDirectory = path.resolve(path.dirname(filePath));
+  const firstCreatedDirectory = await fs.mkdir(parentDirectory, { recursive: true });
   let handle: FileHandle | undefined;
   let publicationFailed = false;
   let primaryError: unknown;
@@ -461,7 +530,12 @@ export async function publishPrivateFileAtomically(
     await options.beforeRename?.(temporaryPath);
     await assertPathIdentity(temporaryPath, identity);
     await fs.rename(temporaryPath, filePath);
-    await (options.syncParent ?? syncParentDirectory)(filePath, options.platform);
+    await syncPathAncestry(
+      filePath,
+      options.syncParent ?? syncParentDirectory,
+      options.platform,
+      firstCreatedDirectory,
+    );
     await options.afterRename?.(filePath);
     await assertPathIdentity(filePath, identity);
   } catch (error) {

--- a/src/openclaw/smoke-lock.ts
+++ b/src/openclaw/smoke-lock.ts
@@ -539,22 +539,28 @@ function needsLiveOwnerConfirmation(record: SmokeLockRecord, runtime: SmokeLockR
   );
 }
 
-async function observedOwnerChangedDuringConfirmation(
+type OwnerConfirmation = "changed" | "renewed" | "unchanged";
+
+async function confirmObservedOwner(
   lockDirectory: string,
   observed: SmokeLockRecord,
   runtime: SmokeLockRuntime,
-): Promise<boolean> {
+): Promise<OwnerConfirmation> {
   if (!needsLiveOwnerConfirmation(observed, runtime)) {
-    return false;
+    return "unchanged";
   }
   await runtime.sleep(runtime.leaseMs);
   const revalidated = await readLockRecord(lockDirectory);
-  return (
-    revalidated.kind === "record" &&
-    (revalidated.record.owner.token !== observed.owner.token ||
-      revalidated.record.renewedAtMs !== observed.renewedAtMs ||
-      isLockOwnerActive(revalidated.record, runtime))
-  );
+  if (revalidated.kind !== "record") {
+    return "unchanged";
+  }
+  if (revalidated.record.owner.token !== observed.owner.token) {
+    return "changed";
+  }
+  return revalidated.record.renewedAtMs !== observed.renewedAtMs ||
+    isLockOwnerActive(revalidated.record, runtime)
+    ? "renewed"
+    : "unchanged";
 }
 
 function activeRunError(params: {
@@ -785,13 +791,28 @@ async function resolveLockClaim(params: {
       requestedChannel: params.requestedChannel,
     });
   }
-  if (
-    await observedOwnerChangedDuringConfirmation(
-      params.claim.directoryPath,
-      observed.record,
-      params.runtime,
-    )
-  ) {
+  const confirmation = await confirmObservedOwner(
+    params.claim.directoryPath,
+    observed.record,
+    params.runtime,
+  );
+  if (confirmation === "renewed") {
+    if (params.claim.kind === "recovering") {
+      try {
+        await fs.rename(params.claim.directoryPath, params.lockDirectory);
+      } catch (error) {
+        if (!(await pathExists(params.lockDirectory))) {
+          throw error;
+        }
+      }
+    }
+    throw activeRunError({
+      channel: observed.record.owner.channel,
+      outputDir: params.outputDir,
+      requestedChannel: params.requestedChannel,
+    });
+  }
+  if (confirmation === "changed") {
     await resolveLockClaim(params);
     return;
   }
@@ -855,16 +876,23 @@ async function resolveLockContention(params: {
       requestedChannel: params.requestedChannel,
     });
   }
-  if (
-    observed.kind === "record" &&
-    (await observedOwnerChangedDuringConfirmation(
+  if (observed.kind === "record") {
+    const confirmation = await confirmObservedOwner(
       params.lockDirectory,
       observed.record,
       params.runtime,
-    ))
-  ) {
-    await resolveLockContention(params);
-    return;
+    );
+    if (confirmation === "renewed") {
+      throw activeRunError({
+        channel: observed.record.owner.channel,
+        outputDir: params.outputDir,
+        requestedChannel: params.requestedChannel,
+      });
+    }
+    if (confirmation === "changed") {
+      await resolveLockContention(params);
+      return;
+    }
   }
 
   await params.beforeRecoveryClaim();
@@ -1078,13 +1106,34 @@ export async function acquireOpenClawCrablineSmokeRunLock(
     }
 
     let ownedDirectory = lockDirectory;
+    let clockRegressed = false;
+    let lastObservedNowMs = createdAtMs;
+    let lastRenewedAtMs = createdAtMs;
+    let pendingRenewal = Promise.resolve();
     let commitFenceConsumed = false;
     let heartbeat: HeartbeatController;
     const renew = async () => {
-      const renewedAtMs = runtime.now();
-      if (!(await renewOwnedLock(ownedDirectory, token, renewedAtMs))) {
-        throw new Error("OpenClaw Crabline smoke lock ownership was lost.");
-      }
+      const renewal = pendingRenewal
+        .catch(() => undefined)
+        .then(async () => {
+          const nowMs = runtime.now();
+          if (nowMs < lastObservedNowMs) {
+            clockRegressed = true;
+          } else if (clockRegressed && nowMs >= lastRenewedAtMs) {
+            clockRegressed = false;
+          }
+          lastObservedNowMs = nowMs;
+          const renewedAtMs = clockRegressed ? lastRenewedAtMs + 1 : nowMs;
+          if (!Number.isSafeInteger(renewedAtMs)) {
+            throw new Error("OpenClaw Crabline smoke lock renewal timestamp overflowed.");
+          }
+          if (!(await renewOwnedLock(ownedDirectory, token, renewedAtMs))) {
+            throw new Error("OpenClaw Crabline smoke lock ownership was lost.");
+          }
+          lastRenewedAtMs = renewedAtMs;
+        });
+      pendingRenewal = renewal;
+      await renewal;
     };
     try {
       heartbeat = (dependencies.startHeartbeat ?? startHeartbeat)(

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -274,9 +274,18 @@ function consumeRecordedChunk(
 }
 
 async function appendJsonLine(filePath: string, line: string): Promise<void> {
-  await serializeAppend(filePath, async (publicationPath, logicalPath) => {
-    await appendCommittedLine(publicationPath, logicalPath, line, true);
-  });
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await serializeAppend(filePath, async (publicationPath, logicalPath) => {
+        await appendCommittedLine(publicationPath, logicalPath, line, true);
+      });
+      return;
+    } catch (error) {
+      if (!(error instanceof RecorderRotatedError) || attempt + 1 >= RECORDER_ROTATION_ATTEMPTS) {
+        throw error;
+      }
+    }
+  }
 }
 
 async function readRecorderFileIdentity(

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -1,10 +1,19 @@
 import { chmod, mkdir, open } from "node:fs/promises";
 import path from "node:path";
+import { lock } from "proper-lockfile";
 import type { ServerRequestEvent } from "./http.js";
 
 export type ServerEventObserver = (event: ServerRequestEvent) => void | Promise<void>;
 
 const pendingAppends = new Map<string, Promise<void>>();
+const durableRecorderIdentities = new Map<string, string>();
+const MAX_DURABLE_RECORDER_IDENTITIES = 128;
+const MAX_RECOVERY_VALIDATION_BYTES = 64 * 1024 * 1024;
+const MAX_RECOVERY_SCAN_BYTES = MAX_RECOVERY_VALIDATION_BYTES + 1;
+const RECORDER_LOCK_RETRY_MS = 100;
+const RECORDER_LOCK_STALE_MS = 30_000;
+const RECORDER_LOCK_UPDATE_MS = 10_000;
+const TAIL_SCAN_CHUNK_BYTES = 64 * 1024;
 
 function isManagedRecorderDirectory(directory: string): boolean {
   return (
@@ -13,7 +22,203 @@ function isManagedRecorderDirectory(directory: string): boolean {
   );
 }
 
-async function appendJsonLine(filePath: string, line: string): Promise<void> {
+async function readBufferAt(
+  file: Awaited<ReturnType<typeof open>>,
+  length: number,
+  position: number,
+): Promise<Buffer> {
+  const buffer = Buffer.alloc(length);
+  let bytesRead = 0;
+  while (bytesRead < length) {
+    const result = await file.read(buffer, bytesRead, length - bytesRead, position + bytesRead);
+    if (result.bytesRead === 0) {
+      break;
+    }
+    bytesRead += result.bytesRead;
+  }
+  return buffer.subarray(0, bytesRead);
+}
+
+async function findIncompleteTailStart(
+  file: Awaited<ReturnType<typeof open>>,
+  fileSize: number,
+): Promise<number> {
+  let position = fileSize;
+  while (position > 0) {
+    const scannedBytes = fileSize - position;
+    const remainingScanBytes = MAX_RECOVERY_SCAN_BYTES - scannedBytes;
+    if (remainingScanBytes <= 0) {
+      throw recoveryValidationLimitError();
+    }
+    const chunkStart = Math.max(0, position - Math.min(TAIL_SCAN_CHUNK_BYTES, remainingScanBytes));
+    const chunk = await readBufferAt(file, position - chunkStart, chunkStart);
+    const lastNewline = chunk.lastIndexOf(0x0a);
+    if (lastNewline >= 0) {
+      return chunkStart + lastNewline + 1;
+    }
+    if (chunk.length === 0) {
+      break;
+    }
+    position = chunkStart;
+  }
+  return 0;
+}
+
+function recoveryValidationLimitError(): Error {
+  return new Error(
+    "Server recorder final record is too large to validate safely; refusing to modify it.",
+  );
+}
+
+async function openRecorderFile(
+  filePath: string,
+): Promise<{ created: boolean; file: Awaited<ReturnType<typeof open>> }> {
+  try {
+    return {
+      created: true,
+      file: await open(filePath, "ax+", 0o600),
+    };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+      throw error;
+    }
+    return {
+      created: false,
+      file: await open(filePath, "a+", 0o600),
+    };
+  }
+}
+
+async function syncDirectory(directoryPath: string): Promise<void> {
+  if (process.platform === "win32") {
+    return;
+  }
+  const directory = await open(directoryPath, "r");
+  try {
+    await directory.sync();
+  } finally {
+    await directory.close();
+  }
+}
+
+async function syncRecorderPathAncestry(
+  filePath: string,
+  firstCreatedDirectory?: string,
+): Promise<void> {
+  if (process.platform === "win32") {
+    return;
+  }
+  const resolvedFilePath = path.resolve(filePath);
+  let currentPath = resolvedFilePath;
+  const syncThroughPath =
+    firstCreatedDirectory === undefined ? undefined : path.resolve(firstCreatedDirectory);
+  for (;;) {
+    const directoryPath = path.dirname(currentPath);
+    const mandatory = syncThroughPath !== undefined || currentPath === resolvedFilePath;
+    try {
+      await syncDirectory(directoryPath);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (!mandatory && (code === "EACCES" || code === "EPERM")) {
+        return;
+      }
+      throw error;
+    }
+    if (currentPath === syncThroughPath) {
+      return;
+    }
+    if (path.dirname(directoryPath) === directoryPath) {
+      return;
+    }
+    currentPath = directoryPath;
+  }
+}
+
+function recorderIdentity(stats: {
+  dev?: bigint | number;
+  ino?: bigint | number;
+}): string | undefined {
+  if (stats.dev === undefined || stats.ino === undefined) {
+    return undefined;
+  }
+  return `${stats.dev}:${stats.ino}`;
+}
+
+function rememberDurableRecorderIdentity(filePath: string, identity: string): void {
+  durableRecorderIdentities.delete(filePath);
+  durableRecorderIdentities.set(filePath, identity);
+  if (durableRecorderIdentities.size > MAX_DURABLE_RECORDER_IDENTITIES) {
+    const oldestPath = durableRecorderIdentities.keys().next().value;
+    if (oldestPath !== undefined) {
+      durableRecorderIdentities.delete(oldestPath);
+    }
+  }
+}
+
+function recorderLockReleaseError(
+  filePath: string,
+  operationError: unknown,
+  releaseError: unknown,
+): AggregateError {
+  return new AggregateError(
+    [operationError, releaseError],
+    `Server recorder append and lock release both failed for "${filePath}".`,
+    { cause: operationError },
+  );
+}
+
+function isRecorderLockContention(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as NodeJS.ErrnoException).code === "ELOCKED"
+  );
+}
+
+async function acquireRecorderLock(filePath: string): Promise<() => Promise<void>> {
+  while (true) {
+    try {
+      return await lock(filePath, {
+        realpath: false,
+        retries: 0,
+        stale: RECORDER_LOCK_STALE_MS,
+        update: RECORDER_LOCK_UPDATE_MS,
+      });
+    } catch (error) {
+      if (!isRecorderLockContention(error)) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, RECORDER_LOCK_RETRY_MS));
+    }
+  }
+}
+
+async function withRecorderLock<T>(filePath: string, operation: () => Promise<T>): Promise<T> {
+  const release = await acquireRecorderLock(filePath);
+  let operationFailed = false;
+  let operationError: unknown;
+  let result: T | undefined;
+  try {
+    result = await operation();
+  } catch (error) {
+    operationFailed = true;
+    operationError = error;
+  }
+  try {
+    await release();
+  } catch (releaseError) {
+    if (operationFailed) {
+      throw recorderLockReleaseError(filePath, operationError, releaseError);
+    }
+    throw releaseError;
+  }
+  if (operationFailed) {
+    throw operationError;
+  }
+  return result as T;
+}
+
+async function appendJsonLine(filePath: string, line: string, durable: boolean): Promise<void> {
   const key = path.resolve(filePath);
   const previous = pendingAppends.get(key) ?? Promise.resolve();
   const current = previous
@@ -24,13 +229,58 @@ async function appendJsonLine(filePath: string, line: string): Promise<void> {
       if (createdDirectory !== undefined || isManagedRecorderDirectory(path.resolve(directory))) {
         await chmod(directory, 0o700);
       }
-      const file = await open(filePath, "a", 0o600);
-      try {
-        await file.chmod(0o600);
-        await file.appendFile(line, { encoding: "utf8" });
-      } finally {
-        await file.close();
-      }
+      await withRecorderLock(key, async () => {
+        const opened = await openRecorderFile(filePath);
+        const { file } = opened;
+        try {
+          await file.chmod(0o600);
+          const stats = await file.stat();
+          const identity = recorderIdentity(stats);
+          const needsPathDurability =
+            opened.created ||
+            identity === undefined ||
+            durableRecorderIdentities.get(key) !== identity;
+          if (stats.size > 0) {
+            const finalByte = await readBufferAt(file, 1, stats.size - 1);
+            if (finalByte[0] !== 0x0a) {
+              const tailStart = await findIncompleteTailStart(file, stats.size);
+              const tailLength = stats.size - tailStart;
+              if (tailLength > MAX_RECOVERY_VALIDATION_BYTES) {
+                throw recoveryValidationLimitError();
+              }
+              const tail = await readBufferAt(file, tailLength, tailStart);
+              if (tail.length !== tailLength) {
+                throw new Error("Server recorder changed while repairing its final record.");
+              }
+              try {
+                JSON.parse(tail.toString("utf8"));
+                await file.appendFile("\n", { encoding: "utf8" });
+              } catch (error) {
+                if (!(error instanceof SyntaxError)) {
+                  throw error;
+                }
+                await file.truncate(tailStart);
+              }
+            }
+          }
+          await file.appendFile(line, { encoding: "utf8" });
+          if (durable || needsPathDurability) {
+            await file.sync();
+          }
+          if (needsPathDurability) {
+            const firstCreatedPath =
+              createdDirectory ?? (opened.created ? path.resolve(filePath) : undefined);
+            await syncRecorderPathAncestry(filePath, firstCreatedPath);
+            if (identity === undefined) {
+              durableRecorderIdentities.delete(key);
+            } else {
+              rememberDurableRecorderIdentity(key, identity);
+            }
+          }
+        } finally {
+          await file.close();
+        }
+      });
     });
   pendingAppends.set(key, current);
 
@@ -49,7 +299,11 @@ export async function recordServerEvent(params: {
   recorderPath: string;
 }): Promise<void> {
   // Observers only see events after the recorder append is durable.
-  await appendJsonLine(params.recorderPath, `${JSON.stringify(params.event)}\n`);
+  await appendJsonLine(
+    params.recorderPath,
+    `${JSON.stringify(params.event)}\n`,
+    params.onEvent !== undefined,
+  );
   await params.onEvent?.(params.event);
 }
 

--- a/test/openclaw-artifact-generation.test.ts
+++ b/test/openclaw-artifact-generation.test.ts
@@ -664,6 +664,80 @@ describe("OpenClaw artifact generation publication", () => {
     }
   });
 
+  it("reclaims interrupted artifact removal tombstones", async () => {
+    const outputDir = await createTempDir();
+    const storePath = path.join(outputDir, OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY);
+    const tombstoneName =
+      ".generation-22222222-2222-4222-8222-222222222222.4242.33333333-3333-4333-8333-333333333333.remove";
+    try {
+      await publishOpenClawCrablineArtifactGeneration(publishParams(outputDir), {
+        createGenerationId: () => "11111111-1111-4111-8111-111111111111",
+      });
+      await fs.mkdir(path.join(storePath, tombstoneName), { mode: 0o700 });
+      await fs.writeFile(path.join(storePath, tombstoneName, "stale.json"), "{}\n");
+
+      await publishOpenClawCrablineArtifactGeneration(publishParams(outputDir), {
+        createGenerationId: () => "44444444-4444-4444-8444-444444444444",
+      });
+
+      await expect(fs.stat(path.join(storePath, tombstoneName))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      expect((await fs.readdir(storePath)).some((entry) => entry.endsWith(".remove"))).toBe(false);
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
+  it("keeps removal tombstones recognizable when reclamation is interrupted", async () => {
+    const outputDir = await createTempDir();
+    const storePath = path.join(outputDir, OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY);
+    const tombstoneBaseName = "generation-22222222-2222-4222-8222-222222222222";
+    const tombstoneName = `.${tombstoneBaseName}.4242.33333333-3333-4333-8333-333333333333.remove`;
+    const removalFailure = new Error("simulated interrupted tombstone removal");
+    let rmSpy: ReturnType<typeof vi.spyOn> | undefined;
+    try {
+      await publishOpenClawCrablineArtifactGeneration(publishParams(outputDir), {
+        createGenerationId: () => "11111111-1111-4111-8111-111111111111",
+      });
+      await fs.mkdir(path.join(storePath, tombstoneName), { mode: 0o700 });
+      await fs.writeFile(path.join(storePath, tombstoneName, "stale.json"), "{}\n");
+
+      const originalRm = fs.rm.bind(fs);
+      let interruptRemoval = true;
+      rmSpy = vi.spyOn(fs, "rm").mockImplementation(async (candidatePath, options) => {
+        if (interruptRemoval && String(candidatePath).endsWith(".remove")) {
+          interruptRemoval = false;
+          throw removalFailure;
+        }
+        await originalRm(candidatePath, options);
+      });
+      await expect(
+        publishOpenClawCrablineArtifactGeneration(publishParams(outputDir), {
+          createGenerationId: () => "44444444-4444-4444-8444-444444444444",
+        }),
+      ).rejects.toBe(removalFailure);
+      rmSpy.mockRestore();
+      rmSpy = undefined;
+
+      const retainedTombstones = (await fs.readdir(storePath)).filter((entry) =>
+        entry.endsWith(".remove"),
+      );
+      expect(retainedTombstones).toHaveLength(1);
+      expect(retainedTombstones[0]).toMatch(
+        new RegExp(`^\\.${tombstoneBaseName}\\.\\d+\\.[0-9a-f-]{36}\\.remove$`, "u"),
+      );
+
+      await publishOpenClawCrablineArtifactGeneration(publishParams(outputDir), {
+        createGenerationId: () => "55555555-5555-4555-8555-555555555555",
+      });
+      expect((await fs.readdir(storePath)).some((entry) => entry.endsWith(".remove"))).toBe(false);
+    } finally {
+      rmSpy?.mockRestore();
+      await disposeTempDir(outputDir);
+    }
+  });
+
   it("removes staging when artifact serialization fails", async () => {
     const outputDir = await createTempDir();
     const storePath = path.join(outputDir, OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY);

--- a/test/openclaw-private-file.test.ts
+++ b/test/openclaw-private-file.test.ts
@@ -10,6 +10,24 @@ import {
 } from "../src/openclaw/private-file.js";
 import { createTempDir, disposeTempDir } from "./test-helpers.js";
 
+function expectedAncestrySyncPaths(filePath: string, syncThroughPath?: string): string[] {
+  const paths: string[] = [];
+  let currentPath = path.resolve(filePath);
+  const resolvedSyncThroughPath =
+    syncThroughPath === undefined ? undefined : path.resolve(syncThroughPath);
+  for (;;) {
+    paths.push(currentPath);
+    if (currentPath === resolvedSyncThroughPath) {
+      return paths;
+    }
+    const parentPath = path.dirname(currentPath);
+    if (path.dirname(parentPath) === parentPath) {
+      return paths;
+    }
+    currentPath = parentPath;
+  }
+}
+
 describe("OpenClaw private file publication", () => {
   it("replaces permissive POSIX files with mode 0600", async () => {
     const directory = await createTempDir();
@@ -42,6 +60,113 @@ describe("OpenClaw private file publication", () => {
       await disposeTempDir(directory);
     }
   });
+
+  it("resyncs an existing private directory after an interrupted creation", async () => {
+    const directory = await createTempDir();
+    try {
+      const generationPath = path.join(directory, "generation");
+      const syncFailure = new Error("simulated parent sync interruption");
+      const syncParent = vi
+        .fn<(filePath: string, platform?: NodeJS.Platform) => Promise<void>>()
+        .mockRejectedValueOnce(syncFailure)
+        .mockResolvedValueOnce();
+      await fs.mkdir(generationPath, { mode: 0o700 });
+
+      await expect(
+        securePrivateDirectory(generationPath, { platform: "linux", syncParent }),
+      ).rejects.toBe(syncFailure);
+      await expect(fs.stat(generationPath)).resolves.toBeDefined();
+
+      const secured = await securePrivateDirectory(generationPath, {
+        platform: "linux",
+        syncParent,
+      });
+
+      await secured.assertIdentityAt();
+      expect(syncParent.mock.calls).toEqual([
+        [generationPath, "linux"],
+        [generationPath, "linux"],
+      ]);
+    } finally {
+      await disposeTempDir(directory);
+    }
+  });
+
+  it.each(["EACCES", "EPERM"] as const)(
+    "accepts an existing private directory below a parent that rejects fsync with %s",
+    async (code) => {
+      const directory = await createTempDir();
+      try {
+        const generationPath = path.join(directory, "generation");
+        const syncParent = vi.fn(async () => {
+          throw Object.assign(new Error("inaccessible parent"), { code });
+        });
+        await fs.mkdir(generationPath, { mode: 0o700 });
+
+        const secured = await securePrivateDirectory(generationPath, {
+          platform: "linux",
+          syncParent,
+        });
+
+        await secured.assertIdentityAt();
+        expect(syncParent).toHaveBeenCalledWith(generationPath, "linux");
+      } finally {
+        await disposeTempDir(directory);
+      }
+    },
+  );
+
+  it.each(["EACCES", "EPERM"] as const)(
+    "rolls back a newly created private directory when parent fsync fails with %s",
+    async (code) => {
+      const directory = await createTempDir();
+      try {
+        const generationPath = path.join(directory, "generation");
+        const syncFailure = Object.assign(new Error("parent sync denied"), { code });
+
+        await expect(
+          securePrivateDirectory(generationPath, {
+            platform: "linux",
+            syncParent: async () => {
+              throw syncFailure;
+            },
+          }),
+        ).rejects.toBe(syncFailure);
+
+        await expect(fs.stat(generationPath)).rejects.toMatchObject({ code: "ENOENT" });
+        await expect(fs.readdir(directory)).resolves.toEqual([]);
+      } finally {
+        await disposeTempDir(directory);
+      }
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "rejects POSIX private directories not owned by the current user",
+    async () => {
+      const directory = await createTempDir();
+      try {
+        const generationPath = path.join(directory, "generation");
+        await fs.mkdir(generationPath, { mode: 0o777 });
+        await fs.chmod(generationPath, 0o777);
+        const currentUserId = process.geteuid?.();
+        if (currentUserId === undefined) {
+          throw new Error("POSIX effective user id is unavailable.");
+        }
+
+        await expect(
+          securePrivateDirectory(generationPath, {
+            currentUserId: currentUserId + 1,
+            platform: "linux",
+          }),
+        ).rejects.toThrow("Private directory must be owned by the current POSIX user.");
+
+        expect((await fs.stat(generationPath)).mode & 0o777).toBe(0o777);
+      } finally {
+        await disposeTempDir(directory);
+      }
+    },
+  );
 
   it.skipIf(process.platform === "win32")(
     "rejects a symlinked POSIX directory before changing target permissions",
@@ -338,7 +463,7 @@ describe("OpenClaw private file publication", () => {
     }
   });
 
-  it("syncs the parent directory after atomic publication", async () => {
+  it("stops safely at an inaccessible pre-existing ancestor after publication", async () => {
     const directory = await createTempDir();
     try {
       const filePath = path.join(directory, "manifest.json");
@@ -349,12 +474,149 @@ describe("OpenClaw private file publication", () => {
           events.push("afterRename");
         },
         syncParent: async (publishedPath) => {
-          expect(publishedPath).toBe(filePath);
-          events.push("syncParent");
+          events.push(`sync:${publishedPath}`);
+          if (publishedPath === directory) {
+            throw Object.assign(new Error("execute-only ancestor"), { code: "EACCES" });
+          }
         },
       });
 
-      expect(events).toEqual(["syncParent", "afterRename"]);
+      expect(events).toEqual([`sync:${filePath}`, `sync:${directory}`, "afterRename"]);
+      await expect(fs.readFile(filePath, "utf8")).resolves.toBe("private\n");
+    } finally {
+      await disposeTempDir(directory);
+    }
+  });
+
+  it("fails publication when the immediate parent directory cannot be synced", async () => {
+    const directory = await createTempDir();
+    try {
+      const filePath = path.join(directory, "manifest.json");
+      const syncFailure = Object.assign(new Error("publication directory denied"), {
+        code: "EACCES",
+      });
+      const afterRename = vi.fn<() => Promise<void>>();
+
+      await expect(
+        publishPrivateFileAtomically(filePath, "private\n", {
+          afterRename,
+          syncParent: async (publishedPath) => {
+            expect(publishedPath).toBe(filePath);
+            throw syncFailure;
+          },
+        }),
+      ).rejects.toBe(syncFailure);
+
+      expect(afterRename).not.toHaveBeenCalled();
+      await expect(fs.readFile(filePath, "utf8")).resolves.toBe("private\n");
+    } finally {
+      await disposeTempDir(directory);
+    }
+  });
+
+  it("fails publication when known newly created ancestry cannot be synced", async () => {
+    const directory = await createTempDir();
+    try {
+      const firstParent = path.join(directory, "first");
+      const finalParent = path.join(firstParent, "nested");
+      const filePath = path.join(finalParent, "manifest.json");
+      const syncFailure = Object.assign(new Error("created ancestry denied"), { code: "EPERM" });
+      const syncedPaths: string[] = [];
+
+      await expect(
+        publishPrivateFileAtomically(filePath, "private\n", {
+          syncParent: async (publishedPath) => {
+            syncedPaths.push(publishedPath);
+            if (publishedPath === firstParent) {
+              throw syncFailure;
+            }
+          },
+        }),
+      ).rejects.toBe(syncFailure);
+
+      expect(syncedPaths).toEqual([filePath, finalParent, firstParent]);
+      await expect(fs.readFile(filePath, "utf8")).resolves.toBe("private\n");
+    } finally {
+      await disposeTempDir(directory);
+    }
+  });
+
+  it("syncs newly created ancestry through its existing parent", async () => {
+    const directory = await createTempDir();
+    try {
+      const firstParent = path.join(directory, "first");
+      const secondParent = path.join(firstParent, "second");
+      const filePath = path.join(secondParent, "manifest.json");
+      const syncedPaths: string[] = [];
+
+      await publishPrivateFileAtomically(filePath, "private\n", {
+        syncParent: async (publishedPath) => {
+          syncedPaths.push(publishedPath);
+        },
+      });
+
+      expect(syncedPaths).toEqual(expectedAncestrySyncPaths(filePath, firstParent));
+    } finally {
+      await disposeTempDir(directory);
+    }
+  });
+
+  it("publishes through a newly created descendant beginning with two dots", async () => {
+    const directory = await createTempDir();
+    try {
+      const firstParent = path.join(directory, "first");
+      const dottedParent = path.join(firstParent, "..cache");
+      const finalParent = path.join(dottedParent, "nested");
+      const filePath = path.join(finalParent, "manifest.json");
+      const syncedPaths: string[] = [];
+
+      await publishPrivateFileAtomically(filePath, "private\n", {
+        syncParent: async (publishedPath) => {
+          syncedPaths.push(publishedPath);
+        },
+      });
+
+      await expect(fs.readFile(filePath, "utf8")).resolves.toBe("private\n");
+      await expect(fs.readdir(finalParent)).resolves.toEqual(["manifest.json"]);
+      expect(syncedPaths).toEqual(expectedAncestrySyncPaths(filePath, firstParent));
+    } finally {
+      await disposeTempDir(directory);
+    }
+  });
+
+  it("resyncs pre-existing ancestry after an interrupted publication attempt", async () => {
+    const directory = await createTempDir();
+    const ancestrySyncFailure = new Error("simulated ancestry sync interruption");
+    try {
+      const filePath = path.join(directory, "first", "second", "manifest.json");
+      const syncAttempts: string[][] = [[], []];
+      let attempt = 0;
+      const syncParent = async (publishedPath: string) => {
+        syncAttempts[attempt]!.push(publishedPath);
+        if (attempt === 0) {
+          throw ancestrySyncFailure;
+        }
+        if (publishedPath === directory) {
+          throw Object.assign(new Error("execute-only ancestor"), { code: "EACCES" });
+        }
+      };
+
+      await expect(publishPrivateFileAtomically(filePath, "first\n", { syncParent })).rejects.toBe(
+        ancestrySyncFailure,
+      );
+      await expect(fs.readFile(filePath, "utf8")).resolves.toBe("first\n");
+
+      attempt = 1;
+      await publishPrivateFileAtomically(filePath, "second\n", { syncParent });
+
+      expect(syncAttempts[0]).toEqual([filePath]);
+      expect(syncAttempts[1]).toEqual([
+        filePath,
+        path.dirname(filePath),
+        path.dirname(path.dirname(filePath)),
+        directory,
+      ]);
+      await expect(fs.readFile(filePath, "utf8")).resolves.toBe("second\n");
     } finally {
       await disposeTempDir(directory);
     }

--- a/test/openclaw-smoke-lock.test.ts
+++ b/test/openclaw-smoke-lock.test.ts
@@ -1162,6 +1162,46 @@ describe("OpenClaw smoke lock cleanup", () => {
     }
   });
 
+  it("does not reclaim a live owner after a backward clock jump when its heartbeat advances", async () => {
+    const outputDir = await createTempDir();
+    const params = { channel: "telegram" as const, outputDir };
+    let now = 100_000;
+    let renew: (() => Promise<void>) | undefined;
+    try {
+      const firstLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+        isProcessAlive: () => true,
+        leaseMs: 1_000,
+        now: () => now,
+        pid: 4_242,
+        processStartedAtMs: 100,
+        startHeartbeat: (heartbeat) => {
+          renew = heartbeat;
+          return disableHeartbeat(heartbeat, 333);
+        },
+      });
+
+      now = 1_000;
+      await renew!();
+      await expect(
+        acquireOpenClawCrablineSmokeRunLock(params, {
+          isProcessAlive: () => true,
+          leaseMs: 1_000,
+          now: () => now,
+          pid: 5_252,
+          processStartedAtMs: 200,
+          sleep: async () => {
+            await renew!();
+          },
+          startHeartbeat: disableHeartbeat,
+        }),
+      ).rejects.toThrow("OpenClaw Crabline smoke is already running");
+
+      await firstLock.release();
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
   it("retries strict owner parsing failures during release", async () => {
     const outputDir = await createTempDir();
     const params = { channel: "telegram" as const, outputDir };

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -2516,13 +2516,16 @@ describe("OpenClaw local provider bridge", () => {
                 ...manifest,
                 recorderPath: params.recorderPath!,
               },
-              probe: async () => ({
-                ok: true,
-                result: {
-                  is_bot: true,
-                  username: "crabline_bot",
-                },
-              }),
+              probe: async () => {
+                await fs.writeFile(params.recorderPath!, '{"event":"probe"}\n');
+                return {
+                  ok: true,
+                  result: {
+                    is_bot: true,
+                    username: "crabline_bot",
+                  },
+                };
+              },
             }) as Awaited<ReturnType<typeof startOpenClawCrablineAdapter>>,
         },
       );
@@ -2613,7 +2616,11 @@ describe("OpenClaw local provider bridge", () => {
             proof: "provider-api-probe",
             provider: "telegram",
             ready: true,
-            recorderPath: "artifacts/crabline/telegram-fake-provider.jsonl",
+            recorderPath: path.join(
+              OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY,
+              result.generation,
+              "telegram-fake-provider.jsonl",
+            ),
             probe: {
               ok: true,
               result: {
@@ -2632,8 +2639,23 @@ describe("OpenClaw local provider bridge", () => {
       });
       const writtenManifest = JSON.parse(
         await fs.readFile(path.join(outputDir, result.manifestPath), "utf8"),
-      ) as { provider?: string };
+      ) as { provider?: string; recorderPath?: string };
       expect(writtenManifest.provider).toBe("telegram");
+      expect(writtenManifest.recorderPath).toBe(
+        path.join(
+          OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY,
+          result.generation,
+          "telegram-fake-provider.jsonl",
+        ),
+      );
+      await expect(
+        fs.readFile(path.join(outputDir, writtenManifest.recorderPath!), "utf8"),
+      ).resolves.toBe('{"event":"probe"}\n');
+      expect(
+        (await fs.readdir(path.join(outputDir, "artifacts", "crabline"))).filter((entry) =>
+          entry.endsWith(".tmp"),
+        ),
+      ).toEqual([]);
       expect(await fs.readFile(legacyManifestPath, "utf8")).toBe("permissive stale manifest\n");
       const manifestMode = (await fs.stat(path.join(outputDir, result.manifestPath))).mode & 0o777;
       const expectedMode = process.platform === "win32" ? manifestMode : 0o600;
@@ -2653,6 +2675,217 @@ describe("OpenClaw local provider bridge", () => {
       await fs.rm(outputDir, { recursive: true, force: true });
     }
   });
+
+  it("keeps readiness recorder snapshots immutable across later generations", async () => {
+    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-recorder-snapshots-"));
+    const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
+    let run = 0;
+    const startAdapter = async (params: Parameters<typeof startOpenClawCrablineAdapter>[0]) => {
+      const currentRun = ++run;
+      await fs.writeFile(params.recorderPath!, `run-${currentRun}\n`);
+      return {
+        close: async () => undefined,
+        manifest: {
+          ...manifest,
+          recorderPath: params.recorderPath!,
+        },
+        probe: async () => ({ currentRun }),
+      } as Awaited<ReturnType<typeof startOpenClawCrablineAdapter>>;
+    };
+    try {
+      const first = await runProviderReadinessWithDependencies(
+        { outputDir, selection },
+        { startAdapter },
+      );
+      const firstRecorderPath = (first.providerReadiness as { result: { recorderPath: string } })
+        .result.recorderPath;
+      await expect(fs.readFile(path.join(outputDir, firstRecorderPath), "utf8")).resolves.toBe(
+        "run-1\n",
+      );
+
+      const second = await runProviderReadinessWithDependencies(
+        { outputDir, selection },
+        { startAdapter },
+      );
+      const secondRecorderPath = (second.providerReadiness as { result: { recorderPath: string } })
+        .result.recorderPath;
+
+      expect(secondRecorderPath).not.toBe(firstRecorderPath);
+      await expect(fs.readFile(path.join(outputDir, firstRecorderPath), "utf8")).resolves.toBe(
+        "run-1\n",
+      );
+      await expect(fs.readFile(path.join(outputDir, secondRecorderPath), "utf8")).resolves.toBe(
+        "run-2\n",
+      );
+    } finally {
+      await fs.rm(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it("reclaims only exact stale readiness recorder temporaries", async () => {
+    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-recorder-recovery-"));
+    const recorderDirectory = path.join(outputDir, "artifacts", "crabline");
+    const staleTelegram = ".telegram-fake-provider.11111111-1111-4111-8111-111111111111.jsonl.tmp";
+    const staleSlack = ".slack-fake-provider.22222222-2222-4222-8222-222222222222.jsonl.tmp";
+    const staleTelegramLock = `${staleTelegram}.lock`;
+    const lookalike = ".telegram-fake-provider.not-a-uuid.jsonl.tmp";
+    const lookalikeLock = `${staleTelegram}.lock.extra`;
+    const unrelatedLock = "unrelated.lock";
+    const lookalikeTombstone = `.${staleTelegramLock}.1234.not-a-uuid.remove`;
+    const matchingDirectory =
+      ".telegram-fake-provider.33333333-3333-4333-8333-333333333333.jsonl.tmp";
+    const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
+    try {
+      await fs.mkdir(path.join(recorderDirectory, matchingDirectory), { recursive: true });
+      await fs.mkdir(path.join(recorderDirectory, staleTelegramLock), { recursive: true });
+      await fs.mkdir(path.join(recorderDirectory, lookalikeLock), { recursive: true });
+      await fs.mkdir(path.join(recorderDirectory, unrelatedLock), { recursive: true });
+      await fs.mkdir(path.join(recorderDirectory, lookalikeTombstone), { recursive: true });
+      await Promise.all([
+        fs.writeFile(path.join(recorderDirectory, staleTelegram), "stale telegram\n"),
+        fs.writeFile(path.join(recorderDirectory, staleSlack), "stale slack\n"),
+        fs.writeFile(path.join(recorderDirectory, lookalike), "preserve\n"),
+      ]);
+
+      await runProviderReadinessWithDependencies(
+        { outputDir, selection },
+        {
+          startAdapter: async (params) =>
+            ({
+              close: async () => undefined,
+              manifest: { ...manifest, recorderPath: params.recorderPath! },
+              probe: async () => ({ ok: true }),
+            }) as Awaited<ReturnType<typeof startOpenClawCrablineAdapter>>,
+        },
+      );
+
+      await expect(fs.stat(path.join(recorderDirectory, staleTelegram))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      await expect(fs.stat(path.join(recorderDirectory, staleSlack))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      await expect(fs.stat(path.join(recorderDirectory, staleTelegramLock))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      await expect(fs.readFile(path.join(recorderDirectory, lookalike), "utf8")).resolves.toBe(
+        "preserve\n",
+      );
+      await expect(fs.stat(path.join(recorderDirectory, lookalikeLock))).resolves.toMatchObject({
+        isDirectory: expect.any(Function),
+      });
+      await expect(fs.stat(path.join(recorderDirectory, unrelatedLock))).resolves.toMatchObject({
+        isDirectory: expect.any(Function),
+      });
+      await expect(
+        fs.stat(path.join(recorderDirectory, lookalikeTombstone)),
+      ).resolves.toMatchObject({
+        isDirectory: expect.any(Function),
+      });
+      await expect(fs.stat(path.join(recorderDirectory, matchingDirectory))).resolves.toMatchObject(
+        {
+          isDirectory: expect.any(Function),
+        },
+      );
+    } finally {
+      await fs.rm(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it("reclaims recorder lock tombstones after interrupted removal", async () => {
+    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-recorder-lock-retry-"));
+    const recorderDirectory = path.join(outputDir, "artifacts", "crabline");
+    const lockName = ".telegram-fake-provider.55555555-5555-4555-8555-555555555555.jsonl.tmp.lock";
+    const removalFailure = new Error("simulated recorder lock tombstone removal interruption");
+    const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
+    let rmSpy: ReturnType<typeof vi.spyOn> | undefined;
+    const startAdapter = async (params: Parameters<typeof startOpenClawCrablineAdapter>[0]) =>
+      ({
+        close: async () => undefined,
+        manifest: { ...manifest, recorderPath: params.recorderPath! },
+        probe: async () => ({ ok: true }),
+      }) as Awaited<ReturnType<typeof startOpenClawCrablineAdapter>>;
+    try {
+      await fs.mkdir(path.join(recorderDirectory, lockName), { recursive: true });
+      const originalRm = fs.rm.bind(fs);
+      let interruptRemoval = true;
+      rmSpy = vi.spyOn(fs, "rm").mockImplementation(async (candidatePath, options) => {
+        if (
+          interruptRemoval &&
+          path.basename(String(candidatePath)).includes(".jsonl.tmp.lock.") &&
+          String(candidatePath).endsWith(".remove")
+        ) {
+          interruptRemoval = false;
+          throw removalFailure;
+        }
+        await originalRm(candidatePath, options);
+      });
+
+      await expect(
+        runProviderReadinessWithDependencies({ outputDir, selection }, { startAdapter }),
+      ).rejects.toBe(removalFailure);
+      rmSpy.mockRestore();
+      rmSpy = undefined;
+
+      const retainedTombstones = (await fs.readdir(recorderDirectory)).filter((entry) =>
+        entry.endsWith(".remove"),
+      );
+      expect(retainedTombstones).toHaveLength(1);
+      expect(retainedTombstones[0]).toMatch(
+        /^\.\.telegram-fake-provider\.55555555-5555-4555-8555-555555555555\.jsonl\.tmp\.lock\.\d+\.[0-9a-f-]{36}\.remove$/u,
+      );
+
+      await runProviderReadinessWithDependencies({ outputDir, selection }, { startAdapter });
+
+      expect((await fs.readdir(recorderDirectory)).some((entry) => entry.endsWith(".remove"))).toBe(
+        false,
+      );
+    } finally {
+      rmSpy?.mockRestore();
+      await fs.rm(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "preserves exact recorder temporary lock symlinks without following them",
+    async () => {
+      const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-recorder-lock-symlink-"));
+      const recorderDirectory = path.join(outputDir, "artifacts", "crabline");
+      const targetDirectory = path.join(outputDir, "external-lock-target");
+      const lockName =
+        ".telegram-fake-provider.44444444-4444-4444-8444-444444444444.jsonl.tmp.lock";
+      const lockPath = path.join(recorderDirectory, lockName);
+      const tombstoneName = `.${lockName}.1234.66666666-6666-4666-8666-666666666666.remove`;
+      const tombstonePath = path.join(recorderDirectory, tombstoneName);
+      const markerPath = path.join(targetDirectory, "preserve.txt");
+      const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
+      try {
+        await fs.mkdir(recorderDirectory, { recursive: true });
+        await fs.mkdir(targetDirectory);
+        await fs.writeFile(markerPath, "preserve\n");
+        await fs.symlink(targetDirectory, lockPath);
+        await fs.symlink(targetDirectory, tombstonePath);
+
+        await runProviderReadinessWithDependencies(
+          { outputDir, selection },
+          {
+            startAdapter: async (params) =>
+              ({
+                close: async () => undefined,
+                manifest: { ...manifest, recorderPath: params.recorderPath! },
+                probe: async () => ({ ok: true }),
+              }) as Awaited<ReturnType<typeof startOpenClawCrablineAdapter>>,
+          },
+        );
+
+        expect((await fs.lstat(lockPath)).isSymbolicLink()).toBe(true);
+        expect((await fs.lstat(tombstonePath)).isSymbolicLink()).toBe(true);
+        await expect(fs.readFile(markerPath, "utf8")).resolves.toBe("preserve\n");
+      } finally {
+        await fs.rm(outputDir, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("owns complete artifact publication and releases only after the generation is installed", async () => {
     const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-openclaw-artifacts-"));

--- a/test/recorder-concurrency.test.ts
+++ b/test/recorder-concurrency.test.ts
@@ -5,22 +5,55 @@ import { appendRecordedInbound } from "../src/providers/recorder.js";
 import { recordServerEvent } from "../src/servers/recorder.js";
 
 const fsMocks = vi.hoisted(() => ({
+  lock: vi.fn<() => Promise<() => Promise<void>>>(),
+  lockRelease: vi.fn<() => Promise<void>>(),
   providerSync: vi.fn<(filePath: string) => Promise<void>>(),
   providerWrite: vi.fn<(filePath: string, data: string) => Promise<void>>(),
+  serverDirectory: "",
+  serverDirectorySync: vi.fn<(directoryPath: string) => Promise<void>>(),
+  serverFileExists: false,
+  serverOpen: vi.fn<(filePath: string, flags: string) => void>(),
+  serverSync: vi.fn<(filePath: string) => Promise<void>>(),
   serverWrite: vi.fn<(filePath: string, data: string) => Promise<void>>(),
 }));
+
+vi.mock("proper-lockfile", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("proper-lockfile")>();
+  return {
+    ...actual,
+    lock: fsMocks.lock,
+  };
+});
 
 vi.mock("node:fs/promises", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs/promises")>();
   return {
     ...actual,
     open: async (...args: Parameters<typeof actual.open>) => {
-      if (args[1] === "a" && String(args[0]).includes("crabline-server-recorder")) {
-        const filePath = String(args[0]);
+      const filePath = String(args[0]);
+      if (args[1] === "r" && filePath === fsMocks.serverDirectory) {
+        return {
+          close: async () => {},
+          sync: async () => await fsMocks.serverDirectorySync(filePath),
+        } as unknown as Awaited<ReturnType<typeof actual.open>>;
+      }
+      if (
+        (args[1] === "a+" || args[1] === "ax+") &&
+        filePath.includes("crabline-server-recorder")
+      ) {
+        fsMocks.serverOpen(filePath, args[1]);
+        if (args[1] === "ax+" && fsMocks.serverFileExists) {
+          throw Object.assign(new Error("Recorder already exists"), { code: "EEXIST" });
+        }
+        fsMocks.serverFileExists = true;
         return {
           appendFile: async (data: string) => await fsMocks.serverWrite(filePath, data),
           chmod: async () => {},
           close: async () => {},
+          read: async (buffer: Buffer) => ({ buffer, bytesRead: 0 }),
+          stat: async () => ({ dev: 1, ino: 1, size: 0 }),
+          sync: async () => await fsMocks.serverSync(filePath),
+          truncate: async () => {},
         } as unknown as Awaited<ReturnType<typeof actual.open>>;
       }
       const handle = await actual.open(...args);
@@ -43,23 +76,54 @@ type PendingWrite = {
 };
 
 let pendingWrites: PendingWrite[] = [];
+let pendingWriteWaiters: Array<{ count: number; resolve: () => void }> = [];
+
+function addPendingWrite(data: string, resolve: () => void): void {
+  pendingWrites.push({ data, resolve });
+  const readyWaiters = pendingWriteWaiters.filter((waiter) => pendingWrites.length >= waiter.count);
+  pendingWriteWaiters = pendingWriteWaiters.filter((waiter) => pendingWrites.length < waiter.count);
+  for (const waiter of readyWaiters) {
+    waiter.resolve();
+  }
+}
+
+async function waitForPendingWrites(count: number): Promise<void> {
+  if (pendingWrites.length >= count) {
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    pendingWriteWaiters.push({ count, resolve });
+  });
+}
 
 beforeEach(() => {
   pendingWrites = [];
+  pendingWriteWaiters = [];
+  fsMocks.lockRelease.mockReset();
+  fsMocks.lockRelease.mockResolvedValue();
+  fsMocks.lock.mockReset();
+  fsMocks.lock.mockResolvedValue(fsMocks.lockRelease);
   fsMocks.providerSync.mockReset();
   fsMocks.providerSync.mockResolvedValue(undefined);
   fsMocks.providerWrite.mockReset();
+  fsMocks.serverDirectory = "";
+  fsMocks.serverDirectorySync.mockReset();
+  fsMocks.serverDirectorySync.mockResolvedValue(undefined);
+  fsMocks.serverFileExists = false;
+  fsMocks.serverOpen.mockReset();
+  fsMocks.serverSync.mockReset();
+  fsMocks.serverSync.mockResolvedValue(undefined);
   fsMocks.serverWrite.mockReset();
   fsMocks.serverWrite.mockImplementation(
     async (_filePath, data) =>
       await new Promise<void>((resolve) => {
-        pendingWrites.push({ data, resolve });
+        addPendingWrite(data, resolve);
       }),
   );
   fsMocks.providerWrite.mockImplementation(
     async (_filePath, data) =>
       await new Promise<void>((resolve) => {
-        pendingWrites.push({ data, resolve });
+        addPendingWrite(data, resolve);
       }),
   );
 });
@@ -69,11 +133,13 @@ async function expectSerializedWrites(
   first: Promise<unknown>,
   second: Promise<unknown>,
 ) {
-  await vi.waitFor(() => expect(write.mock.calls).toHaveLength(1));
+  await waitForPendingWrites(1);
+  expect(write.mock.calls).toHaveLength(1);
   expect(pendingWrites).toHaveLength(1);
 
   pendingWrites[0]!.resolve();
-  await vi.waitFor(() => expect(write.mock.calls).toHaveLength(2));
+  await waitForPendingWrites(2);
+  expect(write.mock.calls).toHaveLength(2);
   expect(pendingWrites).toHaveLength(2);
 
   pendingWrites[1]!.resolve();
@@ -83,6 +149,7 @@ async function expectSerializedWrites(
 describe("recorder append serialization", () => {
   it("serializes server event appends to the same JSONL file", async () => {
     const recorderPath = path.join("/tmp", "crabline-server-recorder.jsonl");
+    fsMocks.serverDirectory = path.dirname(recorderPath);
     const firstEvent = {
       at: "2026-07-12T10:00:00.000Z",
       method: "GET",
@@ -97,13 +164,14 @@ describe("recorder append serialization", () => {
 
     const first = recordServerEvent({
       event: firstEvent,
-      onEvent: undefined,
+      onEvent: () => undefined,
       recorderPath,
     });
-    await vi.waitFor(() => expect(fsMocks.serverWrite).toHaveBeenCalledTimes(1));
+    await waitForPendingWrites(1);
+    expect(fsMocks.serverWrite).toHaveBeenCalledTimes(1);
     const second = recordServerEvent({
       event: secondEvent,
-      onEvent: undefined,
+      onEvent: () => undefined,
       recorderPath,
     });
 
@@ -112,6 +180,10 @@ describe("recorder append serialization", () => {
       `${JSON.stringify(firstEvent)}\n`,
       `${JSON.stringify(secondEvent)}\n`,
     ]);
+    expect(fsMocks.serverSync).toHaveBeenCalledTimes(2);
+    expect(fsMocks.serverDirectorySync).toHaveBeenCalledOnce();
+    expect(fsMocks.lock).toHaveBeenCalledTimes(2);
+    expect(fsMocks.serverOpen.mock.calls.map(([, flags]) => flags)).toEqual(["ax+", "ax+", "a+"]);
   });
 
   it("serializes provider inbound appends to the same JSONL file", async () => {

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -416,6 +416,66 @@ describe("recorder", () => {
     ]);
   });
 
+  it("retries a single append against a recorder rotated during append", async () => {
+    const filePath = await createRecorderPath();
+    const rotatedPath = `${filePath}.rotated`;
+    const event = {
+      author: "assistant" as const,
+      id: "rotated-single",
+      provider: "slack",
+      sentAt: new Date().toISOString(),
+      text: "preserve both generations",
+      threadId: "slack:C123",
+    };
+
+    const probeHandle = await open(filePath, "a+");
+    const fileHandlePrototype = Object.getPrototypeOf(probeHandle) as {
+      writeFile(data: string, encoding: BufferEncoding): Promise<void>;
+    };
+    await probeHandle.close();
+    const originalWriteFile = fileHandlePrototype.writeFile;
+    let releaseWrite!: () => void;
+    let reportWrite!: () => void;
+    const writeReported = new Promise<void>((resolve) => {
+      reportWrite = resolve;
+    });
+    const writeReleased = new Promise<void>((resolve) => {
+      releaseWrite = resolve;
+    });
+    let interceptAppend = true;
+    fileHandlePrototype.writeFile = async function (
+      this: FileHandle,
+      data: string,
+      encoding: BufferEncoding,
+    ) {
+      await originalWriteFile.call(this, data, encoding);
+      if (interceptAppend && data.includes('"id":"rotated-single"')) {
+        interceptAppend = false;
+        reportWrite();
+        await writeReleased;
+      }
+    };
+
+    const append = appendRecordedInbound(filePath, event);
+    try {
+      await writeReported;
+      await rename(filePath, rotatedPath);
+      await writeFile(filePath, "", "utf8");
+      releaseWrite();
+      await expect(append).resolves.toMatchObject({ id: event.id });
+    } finally {
+      releaseWrite();
+      fileHandlePrototype.writeFile = originalWriteFile;
+    }
+
+    await expect(readRecordedInbound(filePath)).resolves.toEqual([
+      expect.objectContaining({ id: event.id }),
+    ]);
+    await expect(readRecordedInbound(rotatedPath)).resolves.toEqual([
+      expect.objectContaining({ id: event.id }),
+    ]);
+  });
+
   it("retries against a symlinked recorder retargeted during append", async () => {
     const filePath = await createRecorderPath();
     const firstTarget = path.join(path.dirname(filePath), "first-target.jsonl");

--- a/test/server-recorder.test.ts
+++ b/test/server-recorder.test.ts
@@ -1,16 +1,45 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { once } from "node:events";
+import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ServerRequestEvent } from "../src/servers/http.js";
 import { recordCommittedServerEvent, recordServerEvent } from "../src/servers/recorder.js";
 
+const lockMocks = vi.hoisted(() => {
+  const release = vi.fn<() => Promise<void>>();
+  return {
+    lock: vi.fn<
+      (filePath: string, options: Record<string, unknown>) => Promise<() => Promise<void>>
+    >(),
+    release,
+  };
+});
+
 const fsMocks = vi.hoisted(() => {
+  const directory = {
+    close: vi.fn<() => Promise<void>>(),
+    sync: vi.fn<() => Promise<void>>(),
+  };
   const file = {
     appendFile: vi.fn<(data: string, options: { encoding: "utf8" }) => Promise<void>>(),
     chmod: vi.fn<(mode: number) => Promise<void>>(),
     close: vi.fn<() => Promise<void>>(),
+    read: vi.fn<
+      (
+        buffer: Buffer,
+        offset: number,
+        length: number,
+        position: number,
+      ) => Promise<{ bytesRead: number; buffer: Buffer }>
+    >(),
+    stat: vi.fn<() => Promise<{ dev?: number; ino?: number; size: number }>>(),
+    sync: vi.fn<() => Promise<void>>(),
+    truncate: vi.fn<(length: number) => Promise<void>>(),
   };
   return {
     chmod: vi.fn<(filePath: string, mode: number) => Promise<void>>(),
+    directory,
     file,
     mkdir:
       vi.fn<
@@ -19,7 +48,17 @@ const fsMocks = vi.hoisted(() => {
           options: { mode: number; recursive: true },
         ) => Promise<string | undefined>
       >(),
-    open: vi.fn<(filePath: string, flags: string, mode: number) => Promise<typeof file>>(),
+    open: vi.fn<
+      (filePath: string, flags: string, mode?: number) => Promise<typeof directory | typeof file>
+    >(),
+  };
+});
+
+vi.mock("proper-lockfile", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("proper-lockfile")>();
+  return {
+    ...actual,
+    lock: lockMocks.lock,
   };
 });
 
@@ -33,6 +72,60 @@ vi.mock("node:fs/promises", async (importOriginal) => {
   };
 });
 
+type RecorderProcess = {
+  child: ChildProcessWithoutNullStreams;
+  exited: Promise<number | null>;
+  stderr: () => string;
+  stdout: () => string;
+};
+
+function startRecorderProcess(recorderPath: string, pathname: string): RecorderProcess {
+  const recorderModuleUrl = new URL("../src/servers/recorder.ts", import.meta.url).href;
+  const script = `
+    import { recordServerEvent } from ${JSON.stringify(recorderModuleUrl)};
+    process.stdout.write("ready\\n");
+    process.stdin.once("data", async () => {
+      process.stdin.destroy();
+      try {
+        await recordServerEvent({
+          event: {
+            at: "2026-07-12T12:00:00.000Z",
+            method: "POST",
+            path: process.argv[2],
+            query: {},
+            type: "api",
+          },
+          onEvent: undefined,
+          recorderPath: process.argv[1],
+        });
+        process.stdout.write("done\\n");
+      } catch (error) {
+        console.error(error);
+        process.exitCode = 1;
+      }
+    });
+  `;
+  const child = spawn(
+    process.execPath,
+    ["--import", "tsx", "--input-type=module", "--eval", script, recorderPath, pathname],
+    { stdio: ["pipe", "pipe", "pipe"] },
+  );
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (chunk: Buffer) => {
+    stdout += chunk.toString();
+  });
+  child.stderr.on("data", (chunk: Buffer) => {
+    stderr += chunk.toString();
+  });
+  return {
+    child,
+    exited: once(child, "exit").then(([code]) => code as number | null),
+    stderr: () => stderr,
+    stdout: () => stdout,
+  };
+}
+
 function serverEvent(pathname: string): ServerRequestEvent {
   return {
     at: "2026-07-12T12:00:00.000Z",
@@ -44,44 +137,263 @@ function serverEvent(pathname: string): ServerRequestEvent {
 }
 
 beforeEach(() => {
+  lockMocks.release.mockReset();
+  lockMocks.release.mockResolvedValue();
+  lockMocks.lock.mockReset();
+  lockMocks.lock.mockResolvedValue(lockMocks.release);
   fsMocks.chmod.mockReset();
   fsMocks.chmod.mockResolvedValue();
+  fsMocks.directory.close.mockReset();
+  fsMocks.directory.close.mockResolvedValue();
+  fsMocks.directory.sync.mockReset();
+  fsMocks.directory.sync.mockResolvedValue();
   fsMocks.file.appendFile.mockReset();
   fsMocks.file.appendFile.mockResolvedValue();
   fsMocks.file.chmod.mockReset();
   fsMocks.file.chmod.mockResolvedValue();
   fsMocks.file.close.mockReset();
   fsMocks.file.close.mockResolvedValue();
+  fsMocks.file.read.mockReset();
+  fsMocks.file.read.mockResolvedValue({ buffer: Buffer.alloc(0), bytesRead: 0 });
+  fsMocks.file.stat.mockReset();
+  fsMocks.file.stat.mockResolvedValue({ dev: 1, ino: 1, size: 0 });
+  fsMocks.file.sync.mockReset();
+  fsMocks.file.sync.mockResolvedValue();
+  fsMocks.file.truncate.mockReset();
+  fsMocks.file.truncate.mockResolvedValue();
   fsMocks.mkdir.mockReset();
   fsMocks.mkdir.mockResolvedValue(undefined);
   fsMocks.open.mockReset();
-  fsMocks.open.mockResolvedValue(fsMocks.file);
+  fsMocks.open.mockImplementation(async (_filePath, flags) => {
+    if (flags === "ax+") {
+      throw Object.assign(new Error("Recorder already exists"), { code: "EEXIST" });
+    }
+    return flags === "r" ? fsMocks.directory : fsMocks.file;
+  });
 });
 
 describe("server recorder", () => {
-  it("creates recorder artifacts with owner-only permissions before append", async () => {
-    const recorderPath = path.join("/tmp", "private", "events.jsonl");
-    fsMocks.mkdir.mockResolvedValueOnce(path.join("/tmp", "private"));
+  it("makes a recursively created recorder path durable before observing its first append", async () => {
+    const firstParent = path.join("/tmp", "private");
+    const finalParent = path.join(firstParent, "nested");
+    const recorderPath = path.join(finalParent, "events.jsonl");
+    const observer = vi.fn<(event: ServerRequestEvent) => void>();
+    fsMocks.mkdir.mockResolvedValueOnce(firstParent);
+    fsMocks.open.mockImplementation(async (_filePath, flags) =>
+      flags === "r" ? fsMocks.directory : fsMocks.file,
+    );
     await recordServerEvent({
       event: serverEvent("/private"),
-      onEvent: undefined,
+      onEvent: observer,
       recorderPath,
     });
 
-    expect(fsMocks.mkdir).toHaveBeenCalledWith(path.join("/tmp", "private"), {
+    expect(fsMocks.mkdir).toHaveBeenCalledWith(finalParent, {
       mode: 0o700,
       recursive: true,
     });
-    expect(fsMocks.chmod).toHaveBeenCalledWith(path.join("/tmp", "private"), 0o700);
-    expect(fsMocks.open).toHaveBeenCalledWith(recorderPath, "a", 0o600);
+    expect(fsMocks.chmod).toHaveBeenCalledWith(finalParent, 0o700);
+    expect(fsMocks.open.mock.calls).toEqual([
+      [recorderPath, "ax+", 0o600],
+      [finalParent, "r"],
+      [firstParent, "r"],
+      [path.dirname(firstParent), "r"],
+    ]);
     expect(fsMocks.file.chmod).toHaveBeenCalledWith(0o600);
     expect(fsMocks.file.appendFile).toHaveBeenCalledWith(expect.any(String), {
       encoding: "utf8",
     });
+    expect(fsMocks.file.sync).toHaveBeenCalledOnce();
+    expect(fsMocks.directory.sync).toHaveBeenCalledTimes(3);
+    expect(fsMocks.file.sync.mock.invocationCallOrder[0]).toBeLessThan(
+      fsMocks.directory.sync.mock.invocationCallOrder[0]!,
+    );
+    expect(fsMocks.directory.sync.mock.invocationCallOrder.at(-1)).toBeLessThan(
+      observer.mock.invocationCallOrder[0]!,
+    );
+    expect(lockMocks.lock).toHaveBeenCalledWith(path.resolve(recorderPath), {
+      realpath: false,
+      retries: 0,
+      stale: 30_000,
+      update: 10_000,
+    });
+    expect(lockMocks.release).toHaveBeenCalledOnce();
     expect(fsMocks.file.chmod.mock.invocationCallOrder[0]).toBeLessThan(
       fsMocks.file.appendFile.mock.invocationCallOrder[0]!,
     );
     expect(fsMocks.file.close).toHaveBeenCalledOnce();
+    expect(fsMocks.directory.close).toHaveBeenCalledTimes(3);
+  });
+
+  it("resyncs recorder ancestry after an interrupted first-append attempt", async () => {
+    const firstParent = path.join("/tmp", "retry-private");
+    const finalParent = path.join(firstParent, "nested");
+    const recorderPath = path.join(finalParent, "events.jsonl");
+    const ancestrySyncFailure = new Error("simulated recorder ancestry sync interruption");
+    const observer = vi.fn<(event: ServerRequestEvent) => void>();
+    let recorderExists = false;
+    fsMocks.mkdir.mockResolvedValueOnce(firstParent).mockResolvedValueOnce(undefined);
+    fsMocks.file.stat.mockResolvedValue({ dev: 42, ino: 84, size: 0 });
+    fsMocks.directory.sync.mockRejectedValueOnce(ancestrySyncFailure).mockResolvedValue(undefined);
+    fsMocks.open.mockImplementation(async (openedPath, flags) => {
+      if (flags === "r") {
+        if (openedPath === path.dirname(firstParent)) {
+          throw Object.assign(new Error("execute-only ancestor"), { code: "EACCES" });
+        }
+        return fsMocks.directory;
+      }
+      if (flags === "ax+") {
+        if (recorderExists) {
+          throw Object.assign(new Error("Recorder already exists"), { code: "EEXIST" });
+        }
+        recorderExists = true;
+      }
+      return fsMocks.file;
+    });
+
+    await expect(
+      recordServerEvent({
+        event: serverEvent("/interrupted"),
+        onEvent: observer,
+        recorderPath,
+      }),
+    ).rejects.toBe(ancestrySyncFailure);
+    expect(observer).not.toHaveBeenCalled();
+
+    const retryEvent = serverEvent("/retry");
+    await recordServerEvent({
+      event: retryEvent,
+      onEvent: observer,
+      recorderPath,
+    });
+
+    expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(2);
+    expect(fsMocks.file.sync).toHaveBeenCalledTimes(2);
+    expect(fsMocks.directory.sync).toHaveBeenCalledTimes(3);
+    expect(fsMocks.open).not.toHaveBeenCalledWith(path.parse(recorderPath).root, "r");
+    expect(observer).toHaveBeenCalledOnce();
+    expect(observer).toHaveBeenCalledWith(retryEvent);
+    expect(fsMocks.directory.sync.mock.invocationCallOrder.at(-1)).toBeLessThan(
+      observer.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("fails an immediate parent sync without caching durability or notifying observers", async () => {
+    const finalParent = path.join("/tmp", "recorder-immediate-denied");
+    const recorderPath = path.join(finalParent, "events.jsonl");
+    const syncFailure = Object.assign(new Error("recorder parent denied"), { code: "EACCES" });
+    const observer = vi.fn<(event: ServerRequestEvent) => void>();
+    let immediateAttempts = 0;
+    fsMocks.file.stat.mockResolvedValue({ dev: 61, ino: 62, size: 0 });
+    fsMocks.open.mockImplementation(async (openedPath, flags) => {
+      if (flags === "ax+") {
+        throw Object.assign(new Error("Recorder already exists"), { code: "EEXIST" });
+      }
+      if (flags === "r") {
+        if (openedPath === finalParent && immediateAttempts++ === 0) {
+          throw syncFailure;
+        }
+        if (openedPath === path.dirname(finalParent)) {
+          throw Object.assign(new Error("execute-only ancestor"), { code: "EACCES" });
+        }
+        return fsMocks.directory;
+      }
+      return fsMocks.file;
+    });
+
+    await expect(
+      recordServerEvent({
+        event: serverEvent("/denied"),
+        onEvent: observer,
+        recorderPath,
+      }),
+    ).rejects.toBe(syncFailure);
+    expect(observer).not.toHaveBeenCalled();
+
+    const retryEvent = serverEvent("/retry-after-denial");
+    await recordServerEvent({
+      event: retryEvent,
+      onEvent: observer,
+      recorderPath,
+    });
+
+    expect(immediateAttempts).toBe(2);
+    expect(fsMocks.file.sync).toHaveBeenCalledTimes(2);
+    expect(fsMocks.directory.sync).toHaveBeenCalledOnce();
+    expect(observer).toHaveBeenCalledOnce();
+    expect(observer).toHaveBeenCalledWith(retryEvent);
+  });
+
+  it("fails newly created recorder ancestry sync and retries the uncached inode", async () => {
+    const firstParent = path.join("/tmp", "recorder-created-denied");
+    const finalParent = path.join(firstParent, "nested");
+    const recorderPath = path.join(finalParent, "events.jsonl");
+    const syncFailure = Object.assign(new Error("created recorder ancestry denied"), {
+      code: "EPERM",
+    });
+    const observer = vi.fn<(event: ServerRequestEvent) => void>();
+    let recorderExists = false;
+    let denyCreatedBoundary = true;
+    fsMocks.mkdir.mockResolvedValueOnce(firstParent).mockResolvedValueOnce(undefined);
+    fsMocks.file.stat.mockResolvedValue({ dev: 71, ino: 72, size: 0 });
+    fsMocks.open.mockImplementation(async (openedPath, flags) => {
+      if (flags === "ax+") {
+        if (recorderExists) {
+          throw Object.assign(new Error("Recorder already exists"), { code: "EEXIST" });
+        }
+        recorderExists = true;
+        return fsMocks.file;
+      }
+      if (flags === "r") {
+        if (openedPath === path.dirname(firstParent)) {
+          if (denyCreatedBoundary) {
+            denyCreatedBoundary = false;
+            throw syncFailure;
+          }
+          throw Object.assign(new Error("execute-only ancestor"), { code: "EACCES" });
+        }
+        return fsMocks.directory;
+      }
+      return fsMocks.file;
+    });
+
+    await expect(
+      recordServerEvent({
+        event: serverEvent("/created-denied"),
+        onEvent: observer,
+        recorderPath,
+      }),
+    ).rejects.toBe(syncFailure);
+    expect(observer).not.toHaveBeenCalled();
+
+    const retryEvent = serverEvent("/retry-created-denial");
+    await recordServerEvent({
+      event: retryEvent,
+      onEvent: observer,
+      recorderPath,
+    });
+
+    expect(fsMocks.file.sync).toHaveBeenCalledTimes(2);
+    expect(fsMocks.directory.sync).toHaveBeenCalledTimes(4);
+    expect(observer).toHaveBeenCalledOnce();
+    expect(observer).toHaveBeenCalledWith(retryEvent);
+  });
+
+  it("keeps retrying while another recorder owner remains live", async () => {
+    const contention = Object.assign(new Error("Lock file is already being held"), {
+      code: "ELOCKED",
+    });
+    lockMocks.lock.mockRejectedValueOnce(contention).mockResolvedValueOnce(lockMocks.release);
+
+    await recordServerEvent({
+      event: serverEvent("/after-contention"),
+      onEvent: undefined,
+      recorderPath: path.join("/tmp", "crabline-server-recorder-contention.jsonl"),
+    });
+
+    expect(lockMocks.lock).toHaveBeenCalledTimes(2);
+    expect(fsMocks.file.appendFile).toHaveBeenCalledOnce();
+    expect(lockMocks.release).toHaveBeenCalledOnce();
   });
 
   it("repairs managed recorder directories without chmodding caller-owned parents", async () => {
@@ -164,12 +476,337 @@ describe("server recorder", () => {
     expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(2);
   });
 
-  it("invokes observers only after the event is durable", async () => {
-    let releaseAppend: (() => void) | undefined;
-    const appendBlocked = new Promise<void>((resolve) => {
-      releaseAppend = resolve;
+  it("fills short tail reads before repairing a torn final append", async () => {
+    const recorderPath = path.join("/tmp", "crabline-server-recorder-torn.jsonl");
+    const completed = `${JSON.stringify(serverEvent("/completed"))}\n`;
+    const torn = '{"type":"api","path":"/torn"';
+    const contents = Buffer.from(completed + torn);
+    fsMocks.file.stat.mockResolvedValueOnce({ dev: 1, ino: 1, size: contents.length });
+    fsMocks.file.read.mockImplementation(async (buffer, offset, length, position) => {
+      const source = contents.subarray(position, position + Math.min(length, 3));
+      source.copy(buffer, offset);
+      return { buffer, bytesRead: source.length };
     });
-    fsMocks.file.appendFile.mockReturnValueOnce(appendBlocked);
+
+    await recordServerEvent({
+      event: serverEvent("/after-recovery"),
+      onEvent: () => undefined,
+      recorderPath,
+    });
+
+    expect(fsMocks.file.truncate).toHaveBeenCalledWith(Buffer.byteLength(completed));
+    expect(fsMocks.file.read.mock.calls.length).toBeGreaterThan(3);
+    expect(fsMocks.file.appendFile).toHaveBeenLastCalledWith(
+      `${JSON.stringify(serverEvent("/after-recovery"))}\n`,
+      { encoding: "utf8" },
+    );
+    expect(fsMocks.file.sync).toHaveBeenCalledOnce();
+  });
+
+  it("appends server records larger than four MiB", async () => {
+    const event = {
+      ...serverEvent("/oversized"),
+      query: { payload: "x".repeat(4 * 1024 * 1024) },
+    };
+
+    await expect(
+      recordServerEvent({
+        event,
+        onEvent: undefined,
+        recorderPath: path.join("/tmp", "crabline-server-recorder-oversized.jsonl"),
+      }),
+    ).resolves.toBeUndefined();
+
+    const recordedLine = fsMocks.file.appendFile.mock.calls[0]?.[0];
+    expect(recordedLine).toBeDefined();
+    expect(Buffer.byteLength(recordedLine!)).toBeGreaterThan(4 * 1024 * 1024);
+    expect(JSON.parse(recordedLine!).query.payload).toHaveLength(4 * 1024 * 1024);
+  });
+
+  it("preserves a valid oversized legacy tail and restores its missing newline", async () => {
+    const recorderPath = path.join("/tmp", "crabline-server-recorder-valid-oversized-tail.jsonl");
+    const completed = `${JSON.stringify(serverEvent("/completed"))}\n`;
+    const legacyEvent = JSON.stringify({
+      ...serverEvent("/legacy-oversized"),
+      query: { payload: "x".repeat(4 * 1024 * 1024) },
+    });
+    const contents = Buffer.from(completed + legacyEvent);
+    fsMocks.file.stat.mockResolvedValueOnce({ dev: 1, ino: 1, size: contents.length });
+    fsMocks.file.read.mockImplementation(async (buffer, offset, length, position) => {
+      const source = contents.subarray(position, position + length);
+      source.copy(buffer, offset);
+      return { buffer, bytesRead: source.length };
+    });
+
+    await expect(
+      recordServerEvent({
+        event: serverEvent("/after-valid-oversized-tail"),
+        onEvent: undefined,
+        recorderPath,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(fsMocks.file.truncate).not.toHaveBeenCalled();
+    expect(fsMocks.file.appendFile.mock.calls).toEqual([
+      ["\n", { encoding: "utf8" }],
+      [`${JSON.stringify(serverEvent("/after-valid-oversized-tail"))}\n`, { encoding: "utf8" }],
+    ]);
+  });
+
+  it("repairs an exact 64 MiB valid tail after scanning its preceding delimiter", async () => {
+    const recorderPath = path.join("/tmp", "crabline-server-recorder-valid-boundary-tail.jsonl");
+    const completed = `${JSON.stringify(serverEvent("/completed"))}\n`;
+    const completedBuffer = Buffer.from(completed);
+    const validationBudget = 64 * 1024 * 1024;
+    const tailStart = completedBuffer.length;
+    const fileSize = tailStart + validationBudget;
+    fsMocks.file.stat.mockResolvedValueOnce({ dev: 1, ino: 1, size: fileSize });
+    fsMocks.file.read.mockImplementation(async (buffer, offset, length, position) => {
+      const bytesRead = Math.max(0, Math.min(length, fileSize - position));
+      if (bytesRead === 0) {
+        return { buffer, bytesRead };
+      }
+      buffer.fill(0x78, offset, offset + bytesRead);
+      const completedStart = Math.max(0, position);
+      const completedEnd = Math.min(position + bytesRead, tailStart);
+      if (completedStart < completedEnd) {
+        completedBuffer
+          .subarray(completedStart, completedEnd)
+          .copy(buffer, offset + completedStart - position);
+      }
+      if (position <= tailStart && tailStart < position + bytesRead) {
+        buffer[offset + tailStart - position] = 0x22;
+      }
+      const tailEnd = fileSize - 1;
+      if (position <= tailEnd && tailEnd < position + bytesRead) {
+        buffer[offset + tailEnd - position] = 0x22;
+      }
+      return { buffer, bytesRead };
+    });
+
+    await expect(
+      recordServerEvent({
+        event: serverEvent("/after-valid-boundary-tail"),
+        onEvent: undefined,
+        recorderPath,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(fsMocks.file.read).toHaveBeenCalledWith(expect.any(Buffer), 0, 1, tailStart - 1);
+    expect(fsMocks.file.read).toHaveBeenCalledWith(
+      expect.any(Buffer),
+      0,
+      validationBudget,
+      tailStart,
+    );
+    expect(fsMocks.file.truncate).not.toHaveBeenCalled();
+    expect(fsMocks.file.appendFile.mock.calls).toEqual([
+      ["\n", { encoding: "utf8" }],
+      [`${JSON.stringify(serverEvent("/after-valid-boundary-tail"))}\n`, { encoding: "utf8" }],
+    ]);
+  });
+
+  it("truncates an invalid oversized torn tail without wedging later appends", async () => {
+    const recorderPath = path.join("/tmp", "crabline-server-recorder-oversized-tail.jsonl");
+    const completed = `${JSON.stringify(serverEvent("/completed"))}\n`;
+    const contents = Buffer.from(`${completed}{"payload":"${"x".repeat(4 * 1024 * 1024)}"`);
+    fsMocks.file.stat.mockResolvedValueOnce({ dev: 1, ino: 1, size: contents.length });
+    fsMocks.file.read.mockImplementation(async (buffer, offset, length, position) => {
+      const source = contents.subarray(position, position + length);
+      source.copy(buffer, offset);
+      return { buffer, bytesRead: source.length };
+    });
+
+    await expect(
+      recordServerEvent({
+        event: serverEvent("/after-oversized-tail"),
+        onEvent: undefined,
+        recorderPath,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(fsMocks.file.truncate).toHaveBeenCalledWith(Buffer.byteLength(completed));
+    expect(fsMocks.file.appendFile).toHaveBeenLastCalledWith(
+      `${JSON.stringify(serverEvent("/after-oversized-tail"))}\n`,
+      { encoding: "utf8" },
+    );
+  });
+
+  it("stops scanning a sparse no-newline tail at the validation budget without modifying it", async () => {
+    const recorderPath = path.join("/tmp", "crabline-server-recorder-unvalidated-tail.jsonl");
+    const fileSize = 8 * 1024 * 1024 * 1024;
+    const validationBudget = 64 * 1024 * 1024;
+    fsMocks.file.stat.mockResolvedValueOnce({ dev: 1, ino: 1, size: fileSize });
+    fsMocks.file.read.mockImplementation(async (buffer, offset, length, position) => {
+      if (length === 1 && position === fileSize - 1) {
+        buffer[offset] = 0x7d;
+        return { buffer, bytesRead: 1 };
+      }
+      buffer.fill(0, offset, offset + length);
+      return { buffer, bytesRead: length };
+    });
+
+    await expect(
+      recordServerEvent({
+        event: serverEvent("/after-unvalidated-tail"),
+        onEvent: undefined,
+        recorderPath,
+      }),
+    ).rejects.toThrow(
+      "Server recorder final record is too large to validate safely; refusing to modify it.",
+    );
+
+    const scanCalls = fsMocks.file.read.mock.calls.filter(([, , length]) => length !== 1);
+    expect(scanCalls).toHaveLength(1024);
+    expect(scanCalls.reduce((total, [, , length]) => total + length, 0)).toBe(validationBudget);
+    expect(Math.min(...scanCalls.map(([, , , position]) => position))).toBe(
+      fileSize - validationBudget,
+    );
+    expect(fsMocks.file.read).toHaveBeenCalledWith(
+      expect.any(Buffer),
+      0,
+      1,
+      fileSize - validationBudget - 1,
+    );
+    expect(fsMocks.file.truncate).not.toHaveBeenCalled();
+    expect(fsMocks.file.appendFile).not.toHaveBeenCalled();
+  });
+
+  it("serializes torn-tail recovery and append across recorder processes", async () => {
+    const actualFs = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+    const actualLockfile =
+      await vi.importActual<typeof import("proper-lockfile")>("proper-lockfile");
+    const directory = await actualFs.mkdtemp(
+      path.join(os.tmpdir(), "crabline-server-recorder-process-"),
+    );
+    const recorderPath = path.join(directory, "events.jsonl");
+    const completed = `${JSON.stringify(serverEvent("/completed"))}\n`;
+    const initialContents = `${completed}{"type":"api","path":"/torn"`;
+    let releaseGate: (() => Promise<void>) | undefined;
+    const processes: RecorderProcess[] = [];
+    try {
+      await actualFs.writeFile(recorderPath, initialContents, { mode: 0o600 });
+      releaseGate = await actualLockfile.lock(recorderPath, {
+        realpath: false,
+        stale: 30_000,
+        update: 10_000,
+      });
+      const first = startRecorderProcess(recorderPath, "/process-a");
+      const second = startRecorderProcess(recorderPath, "/process-b");
+      processes.push(first, second);
+
+      await vi.waitFor(
+        () => {
+          expect(first.stdout()).toContain("ready\n");
+          expect(second.stdout()).toContain("ready\n");
+        },
+        { timeout: 5_000 },
+      );
+      first.child.stdin.end("go\n");
+      second.child.stdin.end("go\n");
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(first.stdout()).not.toContain("done\n");
+      expect(second.stdout()).not.toContain("done\n");
+      await expect(actualFs.readFile(recorderPath, "utf8")).resolves.toBe(initialContents);
+
+      await releaseGate();
+      releaseGate = undefined;
+      await vi.waitFor(
+        () => {
+          expect(first.stdout()).toContain("done\n");
+          expect(second.stdout()).toContain("done\n");
+        },
+        { timeout: 5_000 },
+      );
+      await expect(Promise.all(processes.map((process) => process.exited))).resolves.toEqual([
+        0, 0,
+      ]);
+
+      const recordedPaths = (await actualFs.readFile(recorderPath, "utf8"))
+        .trimEnd()
+        .split("\n")
+        .map((line) => (JSON.parse(line) as ServerRequestEvent).path)
+        .sort();
+      expect(recordedPaths).toEqual(["/completed", "/process-a", "/process-b"]);
+    } finally {
+      await releaseGate?.();
+      for (const process of processes) {
+        if (process.child.exitCode === null) {
+          process.child.kill();
+        }
+      }
+      await Promise.all(processes.map((process) => process.exited));
+      await actualFs.rm(directory, { force: true, recursive: true });
+    }
+  });
+
+  it("waits beyond five seconds for a live recorder owner", async () => {
+    const actualFs = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+    const actualLockfile =
+      await vi.importActual<typeof import("proper-lockfile")>("proper-lockfile");
+    const directory = await actualFs.mkdtemp(
+      path.join(os.tmpdir(), "crabline-server-recorder-long-lock-"),
+    );
+    const recorderPath = path.join(directory, "events.jsonl");
+    const initialContents = `${JSON.stringify(serverEvent("/completed"))}\n`;
+    let releaseGate: (() => Promise<void>) | undefined;
+    let recorderProcess: RecorderProcess | undefined;
+    try {
+      await actualFs.writeFile(recorderPath, initialContents, { mode: 0o600 });
+      releaseGate = await actualLockfile.lock(recorderPath, {
+        realpath: false,
+        stale: 30_000,
+        update: 10_000,
+      });
+      recorderProcess = startRecorderProcess(recorderPath, "/after-long-lock");
+
+      await vi.waitFor(
+        () => {
+          expect(recorderProcess?.stdout()).toContain("ready\n");
+        },
+        { timeout: 5_000 },
+      );
+      recorderProcess.child.stdin.end("go\n");
+      await new Promise((resolve) => setTimeout(resolve, 5_500));
+
+      expect(recorderProcess.stdout()).not.toContain("done\n");
+      expect(recorderProcess.child.exitCode).toBeNull();
+      await expect(actualFs.readFile(recorderPath, "utf8")).resolves.toBe(initialContents);
+
+      await releaseGate();
+      releaseGate = undefined;
+      await vi.waitFor(
+        () => {
+          expect(recorderProcess?.stdout()).toContain("done\n");
+        },
+        { timeout: 5_000 },
+      );
+      await expect(recorderProcess.exited).resolves.toBe(0);
+
+      const recordedPaths = (await actualFs.readFile(recorderPath, "utf8"))
+        .trimEnd()
+        .split("\n")
+        .map((line) => (JSON.parse(line) as ServerRequestEvent).path);
+      expect(recordedPaths).toEqual(["/completed", "/after-long-lock"]);
+    } finally {
+      await releaseGate?.();
+      if (recorderProcess?.child.exitCode === null) {
+        recorderProcess.child.kill();
+      }
+      if (recorderProcess) {
+        await recorderProcess.exited;
+      }
+      await actualFs.rm(directory, { force: true, recursive: true });
+    }
+  }, 15_000);
+
+  it("invokes observers only after the event is durable", async () => {
+    let releaseSync: (() => void) | undefined;
+    const syncBlocked = new Promise<void>((resolve) => {
+      releaseSync = resolve;
+    });
+    fsMocks.file.sync.mockReturnValueOnce(syncBlocked);
     const observer = vi.fn<(event: ServerRequestEvent) => void>();
     const event = serverEvent("/ordered");
 
@@ -178,10 +815,10 @@ describe("server recorder", () => {
       onEvent: observer,
       recorderPath: path.join("/tmp", "crabline-server-recorder-order.jsonl"),
     });
-    await vi.waitFor(() => expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(fsMocks.file.sync).toHaveBeenCalledTimes(1));
     expect(observer).not.toHaveBeenCalled();
 
-    releaseAppend?.();
+    releaseSync?.();
     await recording;
     expect(observer).toHaveBeenCalledWith(event);
   });


### PR DESCRIPTION
## Summary

- recover interrupted artifact removals and preserve immutable recorder snapshots
- enforce POSIX ownership and durable ancestor creation for private artifacts
- harden recorder rotation, torn-tail repair, observer durability, and smoke-lock renewal under clock regression

## Validation

- focused persistence tests (182 passed)
- `pnpm verify` (856 passed)
- privacy scan clean