### PR TITLE
fix(openclaw): harden final bridge delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Harden CLI secret ingress and numeric parsing, provider cancellation and script thread propagation, timer bounds, review fixtures, and dependency review coverage.
 - Complete final provider remediation across authenticated webhook exposure, native callback decoding, interaction values, target identities, JWT boundaries, and bounded ingress shutdown.
 - Fan out queued Signal events, tighten Matrix, Slack, Mattermost, Telegram, and Zalo protocol fidelity, and exercise DNS-pinned webhook delivery.
+- Harden OpenClaw Matrix, Slack, Telegram, WhatsApp, Mattermost, and Zalo bridge identity and accepted-send contracts, make WhatsApp transport lifecycle cleanup failure-atomic, and declare the direct-only Baileys outbound subset.
 - Harden secondary provider adapters with stable pagination, scoped native IDs, immutable diagnostics redaction, Slack edit normalization, and bounded WhatsApp ingress.
 - Harden provider-core webhook hooks, recorder durability and cursor semantics, lazy adapter lifecycle and target parity, and signed-JWT key caching.
 - Harden autoreview launchers and release automation, document trusted script manifests, and canonicalize WhatsApp Cloud targets.

--- a/README.md
+++ b/README.md
@@ -295,7 +295,11 @@ runtime needs to connect through the local provider. Cloud API-compatible
 clients can send text messages through
 `POST /v25.0/<phone-number-id>/messages` with a bearer token. The local server completes
 the Baileys Noise handshake, serves bootstrap/device/prekey queries, and records
-encrypted outbound WebSocket stanzas. The WebSocket endpoint rejects clients
+encrypted outbound WebSocket stanzas. Direct `msg` and `pkmsg` text sends are
+also recorded as normalized accepted-send evidence for the OpenClaw bridge.
+Group outbound uses sender-key `skmsg` encryption and is outside this supported
+subset, so OpenClaw Crabline outbound targets are direct users only. Group
+inbound injection remains supported. The WebSocket endpoint rejects clients
 that do not present the access token embedded in the manifest URL. The admin
 token is generated randomly unless `--admin-token <token>` is provided.
 

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -372,7 +372,11 @@ runtime needs to connect through the local provider. Cloud API-compatible
 clients can send text messages through
 `POST /v25.0/<phone-number-id>/messages` with a bearer token. The local server completes
 the Baileys Noise handshake, serves bootstrap/device/prekey queries, and records
-encrypted outbound WebSocket stanzas. The WebSocket endpoint rejects clients
+encrypted outbound WebSocket stanzas. Direct `msg` and `pkmsg` text sends are
+also recorded as normalized accepted-send evidence for the OpenClaw bridge.
+Group outbound uses sender-key `skmsg` encryption and is outside this supported
+subset, so OpenClaw Crabline outbound targets are direct users only. Group
+inbound injection remains supported. The WebSocket endpoint rejects clients
 that do not present the access token embedded in the manifest URL. The admin
 token is generated randomly unless `--admin-token <token>` is provided.
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@types/node": "^22.20.1",
     "commander": "^15.0.0",
     "curve25519-js": "^0.0.4",
+    "libsignal": "6.0.0",
     "picocolors": "^1.1.1",
     "proper-lockfile": "4.1.2",
     "re2js": "2.8.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       curve25519-js:
         specifier: ^0.0.4
         version: 0.0.4
+      libsignal:
+        specifier: 6.0.0
+        version: 6.0.0
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1

--- a/src/openclaw/bridges/matrix.ts
+++ b/src/openclaw/bridges/matrix.ts
@@ -1,3 +1,4 @@
+import { isIP } from "node:net";
 import {
   canonicalConversationIdForInbound,
   createAdminInboundRequest,
@@ -9,9 +10,74 @@ import {
   readString,
 } from "../shared.js";
 
+const MAX_MATRIX_IDENTIFIER_BYTES = 255;
+
+function isMatrixIpv4Address(value: string): boolean {
+  const octets = value.split(".");
+  return (
+    octets.length === 4 && octets.every((octet) => /^\d{1,3}$/u.test(octet) && Number(octet) <= 255)
+  );
+}
+
+function isMatrixServerName(value: string): boolean {
+  const ipv6 = /^\[([^\]]+)\](?::(\d{1,5}))?$/u.exec(value);
+  if (ipv6) {
+    return isIP(ipv6[1]!) === 6;
+  }
+  const hostAndPort = /^([^:]+?)(?::(\d{1,5}))?$/u.exec(value);
+  if (!hostAndPort) {
+    return false;
+  }
+  const hostname = hostAndPort[1]!;
+  if (isMatrixIpv4Address(hostname)) {
+    return true;
+  }
+  if (/^\d+\.\d+\.\d+\.\d+$/u.test(hostname)) {
+    return false;
+  }
+  return hostname.length <= 255 && /^[A-Za-z0-9.-]+$/u.test(hostname);
+}
+
+function hasLoneSurrogate(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (next < 0xdc00 || next > 0xdfff) {
+        return true;
+      }
+      index += 1;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isMatrixRoomId(value: string): boolean {
+  if (!value.startsWith("!") || Buffer.byteLength(value, "utf8") > MAX_MATRIX_IDENTIFIER_BYTES) {
+    return false;
+  }
+  const separator = value.indexOf(":");
+  if (separator >= 2) {
+    const localpart = value.slice(1, separator);
+    return (
+      !localpart.includes("\0") &&
+      !hasLoneSurrogate(localpart) &&
+      isMatrixServerName(value.slice(separator + 1))
+    );
+  }
+  const opaqueId = value.slice(1);
+  if (!/^[A-Za-z0-9_-]{43}$/u.test(opaqueId)) {
+    return false;
+  }
+  const decoded = Buffer.from(opaqueId, "base64url");
+  return decoded.length === 32 && decoded.toString("base64url") === opaqueId;
+}
+
 function matrixRoomId(value: string): string {
   const trimmed = value.trim();
-  if (!trimmed.startsWith("!") || !trimmed.includes(":")) {
+  if (!isMatrixRoomId(trimmed)) {
     throw new Error("Matrix targets must be native room IDs.");
   }
   return trimmed;

--- a/src/openclaw/bridges/mattermost.ts
+++ b/src/openclaw/bridges/mattermost.ts
@@ -43,7 +43,18 @@ export const MATTERMOST_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabli
         if (!response.ok) {
           throw new Error(`Crabline Mattermost probe failed with HTTP ${response.status}.`);
         }
-        return await response.json();
+        const payload: unknown = await response.json();
+        if (
+          !isRecord(payload) ||
+          readString(payload.id) !== mattermost.botUserId ||
+          !readNonBlankString(payload.username) ||
+          typeof payload.update_at !== "number" ||
+          !Number.isSafeInteger(payload.update_at) ||
+          payload.update_at < 0
+        ) {
+          throw new Error("Crabline Mattermost users/me probe returned an unexpected user.");
+        }
+        return payload;
       },
       createBinding() {
         return {

--- a/src/openclaw/bridges/slack.ts
+++ b/src/openclaw/bridges/slack.ts
@@ -111,8 +111,12 @@ function collectSlackFallbackText(value: unknown, output: string[]): void {
 
 function slackOutboundText(body: Record<string, unknown>): string | undefined {
   if (typeof body.text === "string") {
-    // Explicit whitespace is invalid; structured fallback is only for text-less sends.
-    return body.text.trim() ? body.text : undefined;
+    if (body.text.trim()) {
+      return body.text;
+    }
+    if (body.text.length > 0) {
+      return undefined;
+    }
   }
   const fallback: string[] = [];
   collectSlackFallbackText(structuredSlackValues(body.blocks), fallback);

--- a/src/openclaw/bridges/telegram.ts
+++ b/src/openclaw/bridges/telegram.ts
@@ -14,7 +14,7 @@ const TELEGRAM_SYMBOLIC_DIRECT_ID_MASK = TELEGRAM_SYMBOLIC_DIRECT_ID_BASE - 1n;
 const TELEGRAM_SYMBOLIC_GROUP_ID_BASE = 1_000_000_000_000n;
 const TELEGRAM_SYMBOLIC_GROUP_ID_RANGE = 10_000_000_000n;
 const TELEGRAM_OUTBOUND_METHOD_RE =
-  /\/(sendAnimation|sendAudio|sendDocument|sendMessage|sendPhoto|sendVideo)$/u;
+  /\/(sendAnimation|sendAudio|sendDocument|sendMessage|sendPhoto|sendVideo)$/iu;
 const TELEGRAM_USERNAME_RE = /^@[A-Za-z][A-Za-z0-9_]{3,31}$/u;
 
 function normalizeTelegramChatId(kind: "direct" | "group", id: string): string {
@@ -243,13 +243,13 @@ export const TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
         if (!isRecord(event) || event.type !== "api" || typeof event.path !== "string") {
           return null;
         }
-        const method = TELEGRAM_OUTBOUND_METHOD_RE.exec(event.path)?.[1];
+        const method = TELEGRAM_OUTBOUND_METHOD_RE.exec(event.path)?.[1]?.toLowerCase();
         if (!method || !isRecord(event.body)) {
           return null;
         }
         const chatId = canonicalTelegramRecorderChatId(event.body.chat_id);
         const text =
-          method === "sendMessage"
+          method === "sendmessage"
             ? readNonBlankString(event.body.text)
             : readNonBlankString(event.body.caption);
         if (!chatId || !text) {

--- a/src/openclaw/bridges/whatsapp.ts
+++ b/src/openclaw/bridges/whatsapp.ts
@@ -9,6 +9,7 @@ import {
 } from "../shared.js";
 import {
   canonicalizeWhatsAppChatJid,
+  canonicalizeWhatsAppUserCorrelationJid,
   canonicalizeWhatsAppUserJid,
 } from "../../servers/whatsapp-jid.js";
 
@@ -57,7 +58,11 @@ export const WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
         if (!response.ok) {
           throw new Error(`Crabline WhatsApp probe failed with HTTP ${response.status}.`);
         }
-        return await response.json();
+        const payload: unknown = await response.json();
+        if (!isRecord(payload) || readString(payload.id) !== whatsapp.phoneNumberId) {
+          throw new Error("Crabline WhatsApp probe returned an unexpected phone number.");
+        }
+        return payload;
       },
       createBinding() {
         return {
@@ -107,6 +112,9 @@ export const WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
         }
         const to = requireWhatsAppJid(parsed.id, "WhatsApp target");
         requireWhatsAppTargetKind(parsed, to);
+        if (to.endsWith("@g.us")) {
+          throw new Error("WhatsApp Crabline WebSocket outbound supports direct targets only.");
+        }
         return {
           channel: "whatsapp",
           to,
@@ -149,16 +157,32 @@ export const WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
         ) {
           return null;
         }
-        if (event.path !== messagesPath || !isRecord(event.body)) {
+        if (!isRecord(event.body)) {
           return null;
         }
-        const to = readString(event.body.to);
+        const baileysKey = isRecord(event.body.key) ? event.body.key : undefined;
+        const baileysMessage = isRecord(event.body.message) ? event.body.message : undefined;
+        const isBaileysSend = event.method === "WEBSOCKET" && event.path === "/ws/chat";
+        if (!isBaileysSend && event.path !== messagesPath) {
+          return null;
+        }
+        const to = isBaileysSend ? readString(baileysKey?.remoteJid) : readString(event.body.to);
         const textPayload = event.body.text;
-        const text = isRecord(textPayload) ? readNonBlankString(textPayload.body) : undefined;
+        const text = isBaileysSend
+          ? readNonBlankString(baileysMessage?.conversation)
+          : isRecord(textPayload)
+            ? readNonBlankString(textPayload.body)
+            : undefined;
         if (!to || !text) {
           return null;
         }
-        const providerTarget = /^\d{7,15}$/u.test(to) ? `${to}@s.whatsapp.net` : to;
+        const providerTarget = isBaileysSend
+          ? canonicalizeWhatsAppUserCorrelationJid(to)
+          : (canonicalizeWhatsAppChatJid(to) ??
+            (/^\d{7,15}$/u.test(to) ? `${to}@s.whatsapp.net` : to));
+        if (!providerTarget) {
+          return null;
+        }
         return {
           accountId: DEFAULT_ACCOUNT_ID,
           senderId: "openclaw",

--- a/src/openclaw/bridges/zalo.ts
+++ b/src/openclaw/bridges/zalo.ts
@@ -30,7 +30,7 @@ export const ZALO_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablineProv
         }
         const result = await response.json();
         const bot = isRecord(result) && isRecord(result.result) ? result.result : undefined;
-        if (!isRecord(result) || result.ok !== true || !readNonBlankString(bot?.id)) {
+        if (!isRecord(result) || result.ok !== true || readNonBlankString(bot?.id) !== zalo.botId) {
           const detail =
             (isRecord(result) ? readNonBlankString(result.description) : undefined) ??
             (isRecord(result) ? readNonBlankString(result.error) : undefined) ??

--- a/src/openclaw/outbound-contract.ts
+++ b/src/openclaw/outbound-contract.ts
@@ -1,10 +1,11 @@
 import type { CrablineServerManifest } from "../servers/index.js";
+import { canonicalizeWhatsAppUserCorrelationJid } from "../servers/whatsapp-jid.js";
 import { isRecord, readNonBlankString } from "./shared.js";
 
 const MATRIX_SEND_PATH_RE =
   /^\/_matrix\/client\/(?:v3|r0)\/rooms\/[^/]+\/send\/m\.room\.message\/[^/]+$/u;
 const TELEGRAM_SEND_PATH_RE =
-  /^\/bot<redacted>\/(?:sendAnimation|sendAudio|sendDocument|sendMessage|sendPhoto|sendVideo)$/u;
+  /^\/bot<redacted>\/(?:sendAnimation|sendAudio|sendDocument|sendMessage|sendPhoto|sendVideo)$/iu;
 const ZALO_SEND_PATH_RE = /^\/bot<redacted>\/(?:sendMessage|sendPhoto)$/u;
 
 export function isAcceptedOpenClawCrablineOutbound(params: {
@@ -33,7 +34,17 @@ export function isAcceptedOpenClawCrablineOutbound(params: {
       return (method === "GET" || method === "POST") && TELEGRAM_SEND_PATH_RE.test(requestPath);
     case "whatsapp": {
       const messagesPath = new URL(params.manifest.endpoints.messagesUrl).pathname;
-      return method === "POST" && requestPath === messagesPath;
+      const body = isRecord(params.event.body) ? params.event.body : undefined;
+      const key = isRecord(body?.key) ? body.key : undefined;
+      const directWebSocketTarget = canonicalizeWhatsAppUserCorrelationJid(
+        readNonBlankString(key?.remoteJid) ?? "",
+      );
+      return (
+        (method === "POST" && requestPath === messagesPath) ||
+        (method === "WEBSOCKET" &&
+          requestPath === "/ws/chat" &&
+          directWebSocketTarget !== undefined)
+      );
     }
     case "zalo":
       return (method === "GET" || method === "POST") && ZALO_SEND_PATH_RE.test(requestPath);

--- a/src/servers/whatsapp-baileys-websocket.ts
+++ b/src/servers/whatsapp-baileys-websocket.ts
@@ -1,6 +1,7 @@
 import { Buffer } from "node:buffer";
 import type { IncomingMessage, Server } from "node:http";
 import type { Duplex } from "node:stream";
+import { ProtocolAddress, SessionCipher, SessionRecord, type SignalStorage } from "libsignal";
 import {
   aesDecryptGCM,
   aesEncryptGCM,
@@ -109,6 +110,8 @@ export type MockSignalBundle = {
 
 export class WhatsAppSignalBundleStore {
   readonly #bundles = new Map<string, MockSignalBundle>();
+  readonly #lidByPhoneNumber = new Map<string, string>();
+  readonly #sessions = new Map<string, Map<string, SessionRecord>>();
 
   constructor(private readonly maxBundles = MAX_WHATSAPP_SIGNAL_BUNDLES) {
     if (!Number.isSafeInteger(maxBundles) || maxBundles < 1) {
@@ -120,27 +123,97 @@ export class WhatsAppSignalBundleStore {
     return this.#bundles.size;
   }
 
+  associateLid(phoneNumberJid: string, lidJid: string): void {
+    const phoneNumber = canonicalizeWhatsAppUserCorrelationJid(phoneNumberJid);
+    const lid = canonicalizeWhatsAppUserCorrelationJid(lidJid);
+    if (!phoneNumber?.endsWith("@s.whatsapp.net") || !lid?.endsWith("@lid")) {
+      throw new Error("Invalid WhatsApp PN/LID signal mapping.");
+    }
+    this.#lidByPhoneNumber.set(signalBundleIdentityKey(phoneNumber), signalBundleIdentityKey(lid));
+  }
+
   resolveMany(jids: string[]): MockSignalBundle[] {
-    const uniqueNewJids = new Set<string>();
-    const canonicalJids: string[] = [];
+    const uniqueNewIdentities = new Set<string>();
+    const identityKeys: string[] = [];
     for (const jid of jids) {
       const canonical = canonicalizeWhatsAppUserCorrelationJid(jid);
       if (!canonical) {
         throw new Error(`Invalid WhatsApp signal bundle JID: ${jid}.`);
       }
-      canonicalJids.push(canonical);
-      if (!this.#bundles.has(canonical)) {
-        uniqueNewJids.add(canonical);
+      const identityKey = signalBundleIdentityKey(canonical);
+      identityKeys.push(identityKey);
+      if (!this.#bundles.has(identityKey)) {
+        uniqueNewIdentities.add(identityKey);
       }
     }
-    if (this.#bundles.size + uniqueNewJids.size > this.maxBundles) {
+    if (this.#bundles.size + uniqueNewIdentities.size > this.maxBundles) {
       throw new Error(`WhatsApp signal bundle limit exceeded (${this.maxBundles}).`);
     }
-    return canonicalJids.map((jid) => this.#resolve(jid));
+    return identityKeys.map((identityKey) => this.#resolve(identityKey));
   }
 
-  #resolve(jid: string): MockSignalBundle {
-    const existing = this.#bundles.get(jid);
+  async decryptDirectMessage(params: {
+    ciphertext: Uint8Array;
+    recipientJid: string;
+    remoteJid: string;
+    type: "msg" | "pkmsg";
+  }): Promise<Buffer | undefined> {
+    const recipientJid = canonicalizeWhatsAppUserCorrelationJid(params.recipientJid);
+    const recipientIdentityKey = recipientJid ? signalBundleIdentityKey(recipientJid) : undefined;
+    const mappedLidIdentityKey = recipientIdentityKey
+      ? this.#lidByPhoneNumber.get(recipientIdentityKey)
+      : undefined;
+    const identityKey =
+      mappedLidIdentityKey && this.#bundles.has(mappedLidIdentityKey)
+        ? mappedLidIdentityKey
+        : recipientIdentityKey;
+    const bundle = identityKey ? this.#bundles.get(identityKey) : undefined;
+    if (!identityKey || !bundle) {
+      return undefined;
+    }
+    const remoteAddress = signalProtocolAddress(params.remoteJid);
+    if (!remoteAddress) {
+      return undefined;
+    }
+    const sessions = this.#sessions.get(identityKey) ?? new Map<string, SessionRecord>();
+    this.#sessions.set(identityKey, sessions);
+    const stagedSessions = new Map<string, SessionRecord>();
+    const storage: SignalStorage = {
+      async loadSession(id) {
+        const session = stagedSessions.get(id) ?? sessions.get(id);
+        return session ? cloneSignalSession(session) : undefined;
+      },
+      async storeSession(id, session) {
+        stagedSessions.set(id, cloneSignalSession(session));
+      },
+      isTrustedIdentity: () => true,
+      async loadPreKey(id) {
+        if (String(id) !== String(bundle.preKeyId)) {
+          return undefined;
+        }
+        return signalKeyPair(bundle.preKey);
+      },
+      removePreKey: () => undefined,
+      loadSignedPreKey: () => signalKeyPair(bundle.signedPreKey.keyPair),
+      getOurRegistrationId: () => bundle.registrationId,
+      getOurIdentity: () => signalKeyPair(bundle.identityKey),
+    };
+    const cipher = new SessionCipher(
+      storage,
+      new ProtocolAddress(remoteAddress.name, remoteAddress.deviceId),
+    );
+    const plaintext =
+      params.type === "pkmsg"
+        ? await cipher.decryptPreKeyWhisperMessage(params.ciphertext)
+        : await cipher.decryptWhisperMessage(params.ciphertext);
+    for (const [id, session] of stagedSessions) {
+      sessions.set(id, session);
+    }
+    return plaintext;
+  }
+
+  #resolve(bundleKey: string): MockSignalBundle {
+    const existing = this.#bundles.get(bundleKey);
     if (existing) {
       return existing;
     }
@@ -152,7 +225,7 @@ export class WhatsAppSignalBundleStore {
       registrationId: 1,
       signedPreKey: signedKeyPair(identityKey, 1),
     };
-    this.#bundles.set(jid, bundle);
+    this.#bundles.set(bundleKey, bundle);
     return bundle;
   }
 }
@@ -535,6 +608,11 @@ class WhatsAppBaileysWebSocketSession {
     }
     if (node.tag === "message") {
       const peer = requireAttr(node, "to");
+      const normalizedMessage = await normalizeAcceptedBaileysMessage({
+        node,
+        remoteJid: this.params.selfJid,
+        signalBundles: this.params.signalBundles,
+      });
       await this.#sendNode({
         attrs: {
           class: "message",
@@ -545,6 +623,17 @@ class WhatsAppBaileysWebSocketSession {
         },
         tag: "ack",
       });
+      if (normalizedMessage) {
+        await this.params.appendEvent({
+          accepted: true,
+          at: new Date().toISOString(),
+          body: normalizedMessage,
+          method: "WEBSOCKET",
+          path: this.params.path,
+          query: {},
+          type: "api",
+        } as ServerRequestEvent & { accepted: true });
+      }
     }
   }
 
@@ -724,6 +813,10 @@ class WhatsAppBaileysWebSocketSession {
   }
 
   #createUSyncUser(jid: string): BinaryNode {
+    const lid = lidForJid(jid);
+    if (canonicalizeWhatsAppUserCorrelationJid(jid)?.endsWith("@s.whatsapp.net")) {
+      this.params.signalBundles.associateLid(jid, lid);
+    }
     return {
       attrs: { jid },
       content: [
@@ -738,7 +831,7 @@ class WhatsAppBaileysWebSocketSession {
           ],
           tag: "devices",
         },
-        { attrs: { val: lidForJid(jid) }, tag: "lid" },
+        { attrs: { val: lid }, tag: "lid" },
       ],
       tag: "user",
     };
@@ -1006,6 +1099,218 @@ function removeNoiseIntroHeader(chunk: NodeBuffer): NodeBuffer {
 
 function children(node: BinaryNode): BinaryNode[] {
   return Array.isArray(node.content) ? node.content : [];
+}
+
+async function normalizeAcceptedBaileysMessage(params: {
+  node: BinaryNode;
+  remoteJid: string;
+  signalBundles: WhatsAppSignalBundleStore;
+}): Promise<WhatsAppBaileysInboundMessage | undefined> {
+  const peer = canonicalizeWhatsAppUserCorrelationJid(params.node.attrs.to ?? "");
+  const messageId = params.node.attrs.id;
+  if (!peer || !messageId) {
+    return undefined;
+  }
+  const candidates = encryptedMessageCandidates(params.node);
+  const remoteCorrelationJid = canonicalizeWhatsAppUserCorrelationJid(params.remoteJid);
+  candidates.sort((left, right) => {
+    const leftIsSelf =
+      canonicalizeWhatsAppUserCorrelationJid(left.recipientJid) === remoteCorrelationJid;
+    const rightIsSelf =
+      canonicalizeWhatsAppUserCorrelationJid(right.recipientJid) === remoteCorrelationJid;
+    return Number(leftIsSelf) - Number(rightIsSelf);
+  });
+  for (const candidate of candidates) {
+    try {
+      const decrypted = await params.signalBundles.decryptDirectMessage({
+        ciphertext: candidate.ciphertext,
+        recipientJid: candidate.recipientJid,
+        remoteJid: params.remoteJid,
+        type: candidate.type,
+      });
+      const text = decrypted ? readWhatsAppConversation(unpadRandomMax16(decrypted)) : undefined;
+      if (text) {
+        return {
+          key: {
+            fromMe: true,
+            id: messageId,
+            remoteJid: peer,
+          },
+          message: { conversation: text },
+          messageTimestamp: Math.floor(Date.now() / 1000),
+        };
+      }
+    } catch {
+      // Other participant envelopes may not belong to this mock server identity.
+    }
+  }
+  return undefined;
+}
+
+function encryptedMessageCandidates(node: BinaryNode): Array<{
+  ciphertext: Uint8Array;
+  recipientJid: string;
+  type: "msg" | "pkmsg";
+}> {
+  const result: Array<{
+    ciphertext: Uint8Array;
+    recipientJid: string;
+    type: "msg" | "pkmsg";
+  }> = [];
+  const visit = (current: BinaryNode, recipientJid?: string) => {
+    const nextRecipient = current.tag === "to" ? current.attrs.jid : recipientJid;
+    if (
+      current.tag === "enc" &&
+      nextRecipient &&
+      (current.attrs.type === "msg" || current.attrs.type === "pkmsg") &&
+      current.content instanceof Uint8Array
+    ) {
+      result.push({
+        ciphertext: current.content,
+        recipientJid: nextRecipient,
+        type: current.attrs.type,
+      });
+    }
+    for (const child of children(current)) {
+      visit(child, nextRecipient);
+    }
+  };
+  visit(node);
+  return result;
+}
+
+function signalKeyPair(pair: KeyPair): { privKey: Buffer; pubKey: Buffer } {
+  return {
+    privKey: Buffer.from(pair.private),
+    pubKey:
+      pair.public.length === 33
+        ? Buffer.from(pair.public)
+        : Buffer.concat([KEY_BUNDLE_TYPE, pair.public]),
+  };
+}
+
+function cloneSignalSession(session: SessionRecord): SessionRecord {
+  return SessionRecord.deserialize(session.serialize());
+}
+
+export function signalBundleIdentityKey(jid: string): string {
+  return jid.replace(/:\d+(?=@)/u, "");
+}
+
+function signalProtocolAddress(jid: string): { deviceId: number; name: string } | undefined {
+  const match = /^(\d{7,15})(?::(\d+))?@(s\.whatsapp\.net|lid)$/iu.exec(jid);
+  if (!match) {
+    return undefined;
+  }
+  const deviceId = Number(match[2] ?? "0");
+  if (!Number.isSafeInteger(deviceId) || deviceId < 0) {
+    return undefined;
+  }
+  return {
+    deviceId,
+    name: match[3]!.toLowerCase() === "lid" ? `${match[1]}_1` : match[1]!,
+  };
+}
+
+function unpadRandomMax16(value: Uint8Array): Buffer {
+  const buffer = Buffer.from(value);
+  const padding = buffer.at(-1);
+  if (!padding || padding > 16 || padding > buffer.length) {
+    throw new Error("Invalid WhatsApp message padding.");
+  }
+  for (let index = buffer.length - padding; index < buffer.length; index += 1) {
+    if (buffer[index] !== padding) {
+      throw new Error("Invalid WhatsApp message padding.");
+    }
+  }
+  return buffer.subarray(0, buffer.length - padding);
+}
+
+function readWhatsAppConversation(message: Uint8Array): string | undefined {
+  const fields = readProtobufLengthDelimitedFields(message);
+  const conversation = readUtf8(fields.get(1)?.[0]);
+  if (conversation?.trim()) {
+    return conversation;
+  }
+  const extendedText = fields.get(6)?.[0];
+  const extendedConversation = extendedText
+    ? readUtf8(readProtobufLengthDelimitedFields(extendedText).get(1)?.[0])
+    : undefined;
+  if (extendedConversation?.trim()) {
+    return extendedConversation;
+  }
+  const deviceSentMessage = fields.get(31)?.[0];
+  const nestedMessage = deviceSentMessage
+    ? readProtobufLengthDelimitedFields(deviceSentMessage).get(2)?.[0]
+    : undefined;
+  return nestedMessage ? readWhatsAppConversation(nestedMessage) : undefined;
+}
+
+function readProtobufLengthDelimitedFields(value: Uint8Array): Map<number, Uint8Array[]> {
+  const fields = new Map<number, Uint8Array[]>();
+  let offset = 0;
+  while (offset < value.length) {
+    const tag = readProtobufVarint(value, offset);
+    offset = tag.offset;
+    const fieldNumber = tag.value >>> 3;
+    const wireType = tag.value & 7;
+    if (fieldNumber < 1) {
+      throw new Error("Invalid WhatsApp protobuf field.");
+    }
+    if (wireType === 2) {
+      const length = readProtobufVarint(value, offset);
+      offset = length.offset;
+      const end = offset + length.value;
+      if (end > value.length) {
+        throw new Error("Invalid WhatsApp protobuf length.");
+      }
+      const entries = fields.get(fieldNumber) ?? [];
+      entries.push(value.subarray(offset, end));
+      fields.set(fieldNumber, entries);
+      offset = end;
+      continue;
+    }
+    if (wireType === 0) {
+      offset = readProtobufVarint(value, offset).offset;
+      continue;
+    }
+    if (wireType === 1) {
+      offset += 8;
+      continue;
+    }
+    if (wireType === 5) {
+      offset += 4;
+      continue;
+    }
+    throw new Error(`Unsupported WhatsApp protobuf wire type: ${wireType}.`);
+  }
+  return fields;
+}
+
+function readProtobufVarint(value: Uint8Array, start: number): { offset: number; value: number } {
+  let result = 0;
+  let shift = 0;
+  let offset = start;
+  while (offset < value.length && shift <= 28) {
+    const byte = value[offset++]!;
+    result += (byte & 0x7f) * 2 ** shift;
+    if ((byte & 0x80) === 0) {
+      if (!Number.isSafeInteger(result)) {
+        break;
+      }
+      return { offset, value: result };
+    }
+    shift += 7;
+  }
+  throw new Error("Invalid WhatsApp protobuf varint.");
+}
+
+function readUtf8(value: Uint8Array | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const text = Buffer.from(value).toString("utf8");
+  return Buffer.from(text, "utf8").equals(Buffer.from(value)) ? text : undefined;
 }
 
 function createInboundMessageNode(message: WhatsAppBaileysInboundMessage): BinaryNode {

--- a/src/servers/whatsapp.ts
+++ b/src/servers/whatsapp.ts
@@ -619,19 +619,46 @@ export async function startWhatsAppServer(
     /^http/u,
     "ws",
   )}/ws/chat?access_token=${encodeURIComponent(state.accessToken)}`;
-  const baileysWebSocketServer = attachWhatsAppBaileysWebSocketServer({
+  const baileysWebSocketOptions = {
     accessToken: state.accessToken,
-    appendEvent: (event) => appendEvent(state, event),
+    appendEvent: (event: ServerRequestEvent) => appendEvent(state, event),
     httpServer: httpServer.server,
     maxPendingInboundMessages,
     path: "/ws/chat",
     selfJid: state.selfJid,
-  });
+  };
+  let baileysWebSocketServer;
+  try {
+    baileysWebSocketServer = attachWhatsAppBaileysWebSocketServer(baileysWebSocketOptions);
+  } catch (error) {
+    try {
+      await httpServer.close();
+    } catch (closeError) {
+      const aggregateError = new AggregateError(
+        [error, closeError],
+        "WhatsApp WebSocket startup failed and HTTP rollback also failed.",
+      );
+      aggregateError.cause = error;
+      throw aggregateError;
+    }
+    throw error;
+  }
   state.prepareInboundMessage = (message) => baileysWebSocketServer.prepareInboundMessage(message);
   return {
     async close() {
-      await baileysWebSocketServer.close();
-      await httpServer.close();
+      const results = await Promise.allSettled([
+        baileysWebSocketServer.close(),
+        httpServer.close(),
+      ]);
+      const errors = results.flatMap((result) =>
+        result.status === "rejected" ? [result.reason] : [],
+      );
+      if (errors.length === 1) {
+        throw errors[0];
+      }
+      if (errors.length > 1) {
+        throw new AggregateError(errors, "WhatsApp server shutdown failed.");
+      }
     },
     manifest: {
       accessToken: state.accessToken,

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -369,6 +369,47 @@ describe("OpenClaw local provider bridge", () => {
     }
   });
 
+  it.each([null, {}, { id: "999999999999999" }])(
+    "requires WhatsApp to return the configured phone resource: %j",
+    async (payload) => {
+      const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify(payload), {
+          headers: { "content-type": "application/json" },
+          status: 200,
+        }),
+      );
+      try {
+        await expect(probeOpenClawCrablineProvider(whatsappManifest)).rejects.toThrow(
+          "Crabline WhatsApp probe returned an unexpected phone number.",
+        );
+      } finally {
+        fetchMock.mockRestore();
+      }
+    },
+  );
+
+  it.each([
+    null,
+    {},
+    { id: "bbbbbbbbbbbbbbbbbbbbbbbbbb", update_at: 0, username: "openclaw" },
+    { id: mattermostManifest.botUserId, update_at: 0, username: " \n\t" },
+    { id: mattermostManifest.botUserId, update_at: -1, username: "openclaw" },
+  ])("requires Mattermost users/me to identify the configured bot: %j", async (payload) => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(payload), {
+        headers: { "content-type": "application/json" },
+        status: 200,
+      }),
+    );
+    try {
+      await expect(probeOpenClawCrablineProvider(mattermostManifest)).rejects.toThrow(
+        "Crabline Mattermost users/me probe returned an unexpected user.",
+      );
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
   it("rejects Zalo application errors returned with HTTP 200", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ description: "Unauthorized", error_code: 401, ok: false }), {
@@ -385,24 +426,26 @@ describe("OpenClaw local provider bridge", () => {
     }
   });
 
-  it.each([{ ok: true }, { ok: true, result: null }, { ok: true, result: {} }])(
-    "rejects malformed Zalo success payloads: %j",
-    async (payload) => {
-      const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-        new Response(JSON.stringify(payload), {
-          headers: { "content-type": "application/json" },
-          status: 200,
-        }),
+  it.each([
+    { ok: true },
+    { ok: true, result: null },
+    { ok: true, result: {} },
+    { ok: true, result: { id: "different-bot" } },
+  ])("rejects malformed Zalo success payloads: %j", async (payload) => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(payload), {
+        headers: { "content-type": "application/json" },
+        status: 200,
+      }),
+    );
+    try {
+      await expect(probeOpenClawCrablineProvider(zaloManifest)).rejects.toThrow(
+        "Crabline Zalo getMe probe failed: invalid response.",
       );
-      try {
-        await expect(probeOpenClawCrablineProvider(zaloManifest)).rejects.toThrow(
-          "Crabline Zalo getMe probe failed: invalid response.",
-        );
-      } finally {
-        fetchMock.mockRestore();
-      }
-    },
-  );
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
 
   it.each([
     { label: "Mattermost users.me", manifest: mattermostManifest },
@@ -1032,7 +1075,7 @@ describe("OpenClaw local provider bridge", () => {
         event: {
           type: "api",
           method: "POST",
-          path: "/bot<redacted>/sendMessage",
+          path: "/bot<redacted>/SeNdMeSsAgE",
           body: {
             chat_id: "100001",
             text: "  hello\n",
@@ -1251,15 +1294,12 @@ describe("OpenClaw local provider bridge", () => {
       replyChannel: "whatsapp",
       replyTo: "15551234567@s.whatsapp.net",
     });
-    expect(
+    expect(() =>
       createOpenClawCrablineAgentDelivery({
         manifest: whatsappManifest,
         target: "group:15551234567-1234567890@g.us",
       }),
-    ).toMatchObject({
-      to: "15551234567-1234567890@g.us",
-      replyTo: "15551234567-1234567890@g.us",
-    });
+    ).toThrow("WhatsApp Crabline WebSocket outbound supports direct targets only.");
     expect(() =>
       createOpenClawCrablineAgentDelivery({
         manifest: whatsappManifest,
@@ -1386,6 +1426,54 @@ describe("OpenClaw local provider bridge", () => {
       senderId: "openclaw",
       senderName: "OpenClaw QA",
       text: "hello from openclaw",
+      to: "dm:alice",
+    });
+    expect(
+      createOpenClawCrablineOutboundFromRecorderEvent({
+        manifest: whatsappManifest,
+        targetByProviderTarget: new Map([
+          ["120363001234567890@g.us", "group:120363001234567890@g.us"],
+        ]),
+        event: {
+          accepted: true,
+          type: "api",
+          method: "WEBSOCKET",
+          path: "/ws/chat",
+          body: {
+            key: {
+              fromMe: true,
+              id: "3EB0AABBCCDDEEFF0022",
+              remoteJid: "120363001234567890@g.us",
+            },
+            message: { conversation: "unsupported group send" },
+          },
+        },
+      }),
+    ).toBeNull();
+    expect(
+      createOpenClawCrablineOutboundFromRecorderEvent({
+        manifest: whatsappManifest,
+        targetByProviderTarget: new Map([["15551234567@s.whatsapp.net", "dm:alice"]]),
+        event: {
+          accepted: true,
+          type: "api",
+          method: "WEBSOCKET",
+          path: "/ws/chat",
+          body: {
+            key: {
+              fromMe: true,
+              id: "3EB0AABBCCDDEEFF0011",
+              remoteJid: "15551234567:0@s.whatsapp.net",
+            },
+            message: { conversation: "hello through Baileys" },
+          },
+        },
+      }),
+    ).toEqual({
+      accountId: "default",
+      senderId: "openclaw",
+      senderName: "OpenClaw QA",
+      text: "hello through Baileys",
       to: "dm:alice",
     });
     expect(
@@ -1545,6 +1633,7 @@ describe("OpenClaw local provider bridge", () => {
           body: {
             blocks: [{ text: { text: "block fallback", type: "mrkdwn" }, type: "section" }],
             channel: "C1234567890",
+            text: "",
           },
         },
       }),
@@ -1560,6 +1649,7 @@ describe("OpenClaw local provider bridge", () => {
           body: {
             attachments: JSON.stringify([{ fallback: "attachment fallback" }]),
             channel: "C1234567890",
+            text: "",
           },
         },
       }),
@@ -1971,6 +2061,36 @@ describe("OpenClaw local provider bridge", () => {
         targetByProviderTarget: new Map(),
       }),
     ).toBeNull();
+    const whatsappWebSocketEvent = {
+      accepted: true,
+      body: {
+        key: { remoteJid: "15551234567@s.whatsapp.net" },
+        message: { conversation: "reply" },
+      },
+      method: "WEBSOCKET",
+      path: "/ws/chat",
+      type: "api",
+    };
+    expect(
+      translateOpenClawCrablineOutbound({
+        event: whatsappWebSocketEvent,
+        manifest: whatsappManifest,
+        targetByProviderTarget: new Map(),
+      }),
+    ).not.toBeNull();
+    expect(
+      translateOpenClawCrablineOutbound({
+        event: {
+          ...whatsappWebSocketEvent,
+          body: {
+            key: { remoteJid: "120363001234567890@g.us" },
+            message: { conversation: "unsupported group reply" },
+          },
+        },
+        manifest: whatsappManifest,
+        targetByProviderTarget: new Map(),
+      }),
+    ).toBeNull();
   });
 
   it("maps Mattermost QA targets, inbound messages, and recorder events", () => {
@@ -2122,6 +2242,7 @@ describe("OpenClaw local provider bridge", () => {
 
   it("maps Matrix native rooms, inbound messages, and recorder events", () => {
     const roomId = "!qa:matrix.test";
+    const domainlessRoomId = `!${Buffer.alloc(32, 0xab).toString("base64url")}`;
     expect(
       createOpenClawCrablineAgentDelivery({
         manifest: matrixManifest,
@@ -2133,8 +2254,23 @@ describe("OpenClaw local provider bridge", () => {
       replyTo: `room:${roomId}`,
       to: `room:${roomId}`,
     });
+    expect(
+      createOpenClawCrablineAgentDelivery({
+        manifest: matrixManifest,
+        target: `channel:${domainlessRoomId}`,
+      }),
+    ).toMatchObject({
+      replyTo: `room:${domainlessRoomId}`,
+      to: `room:${domainlessRoomId}`,
+    });
     expect(() =>
       createOpenClawCrablineAgentDelivery({ manifest: matrixManifest, target: "channel:general" }),
+    ).toThrow("Matrix targets must be native room IDs.");
+    expect(() =>
+      createOpenClawCrablineAgentDelivery({
+        manifest: matrixManifest,
+        target: "channel:!qa:bad/server",
+      }),
     ).toThrow("Matrix targets must be native room IDs.");
     expect(() =>
       createOpenClawCrablineAgentDelivery({
@@ -2255,24 +2391,17 @@ describe("OpenClaw local provider bridge", () => {
       threadId: "$root:matrix.test",
     });
 
-    const slashThreadInbound = createOpenClawCrablineInbound({
-      manifest: matrixManifest,
-      input: {
-        conversation: { id: `${roomId}/archive`, kind: "group" },
-        senderId: "@alice:matrix.test",
-        text: "threaded Matrix message",
-        threadId: "$root/child:matrix.test",
-      },
-    });
-    expect(slashThreadInbound.qaTarget).toBe(
-      `thread:/v1/${roomId}%2Farchive/$root%2Fchild:matrix.test`,
-    );
-    expect(parseQaTarget(slashThreadInbound.qaTarget)).toEqual({
-      id: `${roomId}/archive`,
-      kind: "group",
-      native: false,
-      threadId: "$root/child:matrix.test",
-    });
+    expect(() =>
+      createOpenClawCrablineInbound({
+        manifest: matrixManifest,
+        input: {
+          conversation: { id: `${roomId}/archive`, kind: "group" },
+          senderId: "@alice:matrix.test",
+          text: "threaded Matrix message",
+          threadId: "$root/child:matrix.test",
+        },
+      }),
+    ).toThrow("Matrix targets must be native room IDs.");
     expect(parseQaTarget("thread:room/foo%2Fbar")).toEqual({
       id: "room",
       kind: "group",

--- a/test/package-production.test.ts
+++ b/test/package-production.test.ts
@@ -156,6 +156,7 @@ describe("production package", () => {
     };
 
     expect(pkg.dependencies?.["@types/node"]).toBeDefined();
+    expect(pkg.dependencies?.libsignal).toBe("6.0.0");
     expect(pkg.devDependencies?.["@types/node"]).toBeUndefined();
     expect(pkg.exports).toEqual({
       ".": {

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -10,14 +10,27 @@ import {
   type SignalDataSet,
   type SignalDataTypeMap,
 } from "baileys";
+import {
+  ProtocolAddress,
+  SessionBuilder,
+  SessionCipher,
+  SessionRecord,
+  type SignalStorage,
+} from "libsignal";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { WebSocket } from "ws";
-import { startWhatsAppServer, type StartedWhatsAppServer } from "../src/index.js";
+import { WebSocket, WebSocketServer } from "ws";
+import {
+  createOpenClawCrablineOutboundFromRecorderEvent,
+  startWhatsAppServer,
+  type StartedWhatsAppServer,
+} from "../src/index.js";
 import { ADMIN_TOKEN_HEADER } from "../src/servers/http.js";
 import {
   MAX_WHATSAPP_WEBSOCKET_FRAGMENTS,
+  signalBundleIdentityKey,
   WhatsAppSignalBundleStore,
 } from "../src/servers/whatsapp-baileys-websocket.js";
+import { Curve, KEY_BUNDLE_TYPE, type KeyPair } from "../src/servers/whatsapp-wire/crypto.js";
 import { createTempDir, disposeTempDir, requestHttp } from "./test-helpers.js";
 
 const servers: StartedWhatsAppServer[] = [];
@@ -87,6 +100,33 @@ function createMemorySignalStore(): MemorySignalStore {
       }
     },
   };
+}
+
+function signalTestKeyPair(pair: KeyPair): { privKey: Buffer; pubKey: Buffer } {
+  return {
+    privKey: Buffer.from(pair.private),
+    pubKey: Buffer.concat([KEY_BUNDLE_TYPE, pair.public]),
+  };
+}
+
+function createSignalTestStorage(identityKey: KeyPair, registrationId: number): SignalStorage {
+  const sessions = new Map<string, SessionRecord>();
+  return {
+    getOurIdentity: () => signalTestKeyPair(identityKey),
+    getOurRegistrationId: () => registrationId,
+    isTrustedIdentity: () => true,
+    loadPreKey: async () => undefined,
+    loadSession: async (id) => sessions.get(id),
+    loadSignedPreKey: () => signalTestKeyPair(identityKey),
+    removePreKey: () => undefined,
+    storeSession: async (id, session) => {
+      sessions.set(id, session);
+    },
+  };
+}
+
+function signalCiphertext(body: string): Buffer {
+  return Buffer.isBuffer(body) ? Buffer.from(body) : Buffer.from(body, "binary");
 }
 
 function createBaileysTestSocket(server: StartedWhatsAppServer) {
@@ -205,6 +245,45 @@ describe("whatsapp local provider server", () => {
     const server = await startWhatsAppServer({ port });
     servers.push(server);
     expect(new URL(server.manifest.baseUrl).port).toBe(String(port));
+  });
+
+  it("releases the HTTP listener when WebSocket attachment fails", async () => {
+    const port = await resolveFreePort();
+    const originalOn = WebSocketServer.prototype.on;
+    let rejectedConnectionHandler = false;
+    const onSpy = vi
+      .spyOn(WebSocketServer.prototype, "on")
+      .mockImplementation(function (this: WebSocketServer, event, listener) {
+        if (!rejectedConnectionHandler && event === "connection") {
+          rejectedConnectionHandler = true;
+          throw new Error("injected WebSocket attachment failure");
+        }
+        return Reflect.apply(originalOn, this, [event, listener]);
+      });
+
+    await expect(startWhatsAppServer({ port })).rejects.toThrow(
+      "injected WebSocket attachment failure",
+    );
+    onSpy.mockRestore();
+
+    const replacement = await startWhatsAppServer({ port });
+    servers.push(replacement);
+    expect(new URL(replacement.manifest.baseUrl).port).toBe(String(port));
+  });
+
+  it("releases the HTTP listener when WebSocket shutdown fails", async () => {
+    const port = await resolveFreePort();
+    const server = await startWhatsAppServer({ port });
+    const closeSpy = vi
+      .spyOn(WebSocketServer.prototype, "close")
+      .mockImplementation((callback) => callback?.(new Error("injected WebSocket close failure")));
+
+    await expect(server.close()).rejects.toThrow("injected WebSocket close failure");
+    closeSpy.mockRestore();
+
+    const replacement = await startWhatsAppServer({ port });
+    servers.push(replacement);
+    expect(new URL(replacement.manifest.baseUrl).port).toBe(String(port));
   });
 
   it("serves Cloud API sends and injected inbound webhook payloads", async () => {
@@ -530,12 +609,76 @@ describe("whatsapp local provider server", () => {
     expect(directBody.message.key).not.toHaveProperty("participant");
   });
 
-  it("correlates bare and device user JIDs to one signal identity", () => {
-    const store = new WhatsAppSignalBundleStore(1);
-    const bare = store.resolveMany(["15551234567@s.whatsapp.net"])[0];
-    expect(store.resolveMany(["15551234567:2@s.whatsapp.net"])[0]).toBe(bare);
-    expect(store.resolveMany(["15551234567:0@c.us"])[0]).toBe(bare);
-    expect(store.size).toBe(1);
+  it("separates PN and LID signal bundle/session keys while normalizing devices", () => {
+    const phoneNumberKey = signalBundleIdentityKey("15551234567:2@s.whatsapp.net");
+    const lidKey = signalBundleIdentityKey("15551234567:3@lid");
+    expect(phoneNumberKey).toBe("15551234567@s.whatsapp.net");
+    expect(lidKey).toBe("15551234567@lid");
+    expect(phoneNumberKey).not.toBe(lidKey);
+
+    const store = new WhatsAppSignalBundleStore(2);
+    const [phoneNumber, lid] = store.resolveMany(["15551234567@s.whatsapp.net", "15551234567@lid"]);
+    expect(phoneNumber).not.toBe(lid);
+    expect(store.resolveMany(["15551234567:2@s.whatsapp.net"])[0]).toBe(phoneNumber);
+    expect(store.resolveMany(["15551234567:0@c.us"])[0]).toBe(phoneNumber);
+    expect(store.resolveMany(["15551234567:3@lid"])[0]).toBe(lid);
+    expect(store.size).toBe(2);
+  });
+
+  it("does not commit failed Signal candidate ratchet mutations", async () => {
+    const recipientJid = "15551234567@s.whatsapp.net";
+    const senderJid = "15550000001@s.whatsapp.net";
+    const receiver = new WhatsAppSignalBundleStore(1);
+    const bundle = receiver.resolveMany([recipientJid])[0]!;
+    const senderIdentity = Curve.generateKeyPair();
+    const senderStorage = createSignalTestStorage(senderIdentity, 2);
+    const senderAddress = new ProtocolAddress("15551234567", 0);
+    await new SessionBuilder(senderStorage, senderAddress).initOutgoing({
+      identityKey: signalTestKeyPair(bundle.identityKey).pubKey,
+      preKey: {
+        keyId: bundle.preKeyId,
+        publicKey: signalTestKeyPair(bundle.preKey).pubKey,
+      },
+      registrationId: bundle.registrationId,
+      signedPreKey: {
+        keyId: bundle.signedPreKey.keyId,
+        publicKey: signalTestKeyPair(bundle.signedPreKey.keyPair).pubKey,
+        signature: bundle.signedPreKey.signature,
+      },
+    });
+    const sender = new SessionCipher(senderStorage, senderAddress);
+    const first = await sender.encrypt(Buffer.from("first direct message"));
+    expect(first.type).toBe(3);
+    await expect(
+      receiver.decryptDirectMessage({
+        ciphertext: signalCiphertext(first.body),
+        recipientJid,
+        remoteJid: senderJid,
+        type: "pkmsg",
+      }),
+    ).resolves.toEqual(Buffer.from("first direct message"));
+
+    const second = await sender.encrypt(Buffer.from("second direct message"));
+    expect(second.type).toBe(3);
+    const validCiphertext = signalCiphertext(second.body);
+    const invalidCiphertext = Buffer.from(validCiphertext);
+    invalidCiphertext[invalidCiphertext.length - 1] = invalidCiphertext.at(-1)! ^ 0xff;
+    await expect(
+      receiver.decryptDirectMessage({
+        ciphertext: invalidCiphertext,
+        recipientJid,
+        remoteJid: senderJid,
+        type: "pkmsg",
+      }),
+    ).rejects.toThrow(/.+/u);
+    await expect(
+      receiver.decryptDirectMessage({
+        ciphertext: validCiphertext,
+        recipientJid,
+        remoteJid: senderJid,
+        type: "pkmsg",
+      }),
+    ).resolves.toEqual(Buffer.from("second direct message"));
   });
 
   it("authenticates Graph requests before reading or recording their bodies", async () => {
@@ -926,17 +1069,76 @@ describe("whatsapp local provider server", () => {
       });
       await waitForCondition(
         () =>
-          fs.readFile(server.manifest.recorderPath, "utf8").then(
-            (recorder) => recorder.includes('"tag":"message"'),
-            () => false,
-          ),
-        "WhatsApp message recorder event",
+          fs
+            .readFile(server.manifest.recorderPath, "utf8")
+            .then((recorder) =>
+              recorder
+                .trim()
+                .split("\n")
+                .some((line) => {
+                  const event: unknown = JSON.parse(line);
+                  return (
+                    !!event &&
+                    typeof event === "object" &&
+                    "accepted" in event &&
+                    event.accepted === true &&
+                    "body" in event &&
+                    !!event.body &&
+                    typeof event.body === "object" &&
+                    "message" in event.body &&
+                    !!event.body.message &&
+                    typeof event.body.message === "object" &&
+                    "conversation" in event.body.message &&
+                    event.body.message.conversation === "hello through real baileys"
+                  );
+                }),
+            )
+            .catch(() => false),
+        "accepted WhatsApp Baileys recorder event",
       );
       const recorder = await fs.readFile(server.manifest.recorderPath, "utf8");
       expect(recorder).toContain('"method":"WEBSOCKET"');
       expect(recorder).toContain('"tag":"message"');
       expect(recorder).toContain('"to":"15551234567@s.whatsapp.net"');
-
+      const recorderEvents = recorder
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as unknown);
+      const acceptedEvent = recorderEvents.find(
+        (event) =>
+          !!event &&
+          typeof event === "object" &&
+          "accepted" in event &&
+          event.accepted === true &&
+          "method" in event &&
+          event.method === "WEBSOCKET",
+      );
+      expect(acceptedEvent).toMatchObject({
+        accepted: true,
+        body: {
+          key: {
+            fromMe: true,
+            remoteJid: "15551234567@s.whatsapp.net",
+          },
+          message: { conversation: "hello through real baileys" },
+        },
+        method: "WEBSOCKET",
+        path: "/ws/chat",
+        type: "api",
+      });
+      expect(
+        createOpenClawCrablineOutboundFromRecorderEvent({
+          event: acceptedEvent,
+          manifest: server.manifest,
+          targetByProviderTarget: new Map([["15551234567@s.whatsapp.net", "dm:alice"]]),
+        }),
+      ).toEqual({
+        accountId: "default",
+        senderId: "openclaw",
+        senderName: "OpenClaw QA",
+        text: "hello through real baileys",
+        to: "dm:alice",
+      });
       await waitForCondition(
         () =>
           messageUpserts


### PR DESCRIPTION
## Summary

- normalize provider-native bridge targets and probe identities across Matrix, Mattermost, Slack, Telegram, WhatsApp, and Zalo
- record accepted Baileys direct-message sends through the normal WhatsApp observable path
- make WhatsApp WebSocket startup rollback and shutdown failure handling atomic

## Validation

- focused bridge and WhatsApp tests (82 passed)
- `pnpm verify` (860 passed)
- privacy scan clean

## Supported subset

Baileys normalization covers direct `msg` and `pkmsg` text sends. Group `skmsg` decryption remains unsupported.