### PR TITLE
fix(providers): complete final protocol remediation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Harden CLI secret ingress and numeric parsing, provider cancellation and script thread propagation, timer bounds, review fixtures, and dependency review coverage.
+- Complete final provider remediation across authenticated webhook exposure, native callback decoding, interaction values, target identities, JWT boundaries, and bounded ingress shutdown.
 - Harden secondary provider adapters with stable pagination, scoped native IDs, immutable diagnostics redaction, Slack edit normalization, and bounded WhatsApp ingress.
 - Harden provider-core webhook hooks, recorder durability and cursor semantics, lazy adapter lifecycle and target parity, and signed-JWT key caching.
 - Harden autoreview launchers and release automation, document trusted script manifests, and canonicalize WhatsApp Cloud targets.

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -83,9 +83,11 @@ header before JSON parsing or recorder writes:
 - Google Chat `endpointUrl` verifies Google ID tokens for the configured HTTP
   audience. `googleChatProjectNumber` selects project-number JWT verification
   instead. Authenticated Pub/Sub delivery uses `pubsubAudience` plus
-  `pubsubServiceAccountEmail`; `credentials.client_email` remains the fallback
-  when inline service-account credentials are configured. Wrapped Pub/Sub
-  `message.data` is base64-decoded before Google Chat event normalization.
+  `pubsubServiceAccountEmail`; `pubsubAudience` falls back to `endpointUrl`
+  when omitted, and `credentials.client_email` remains the service-account
+  email fallback when inline credentials are configured. Wrapped Pub/Sub
+  `message.data` must be canonical base64 before Google Chat event
+  normalization.
   Google Workspace add-on `chat.messagePayload` events are rejected until the
   adapter can bind the verified request to a configured add-on deployment
   identity.
@@ -95,13 +97,18 @@ header before JSON parsing or recorder writes:
   unauthenticated webhook remains available only on loopback.
 - Matrix webhook ingress currently has no provider-native authentication mode,
   so it is restricted to loopback hosts and cannot set `publicUrl`.
+- Mattermost and iMessage webhook ingress currently have no provider-native
+  authentication mode, so those adapter webhooks are restricted to loopback
+  hosts and cannot set `publicUrl`. Their API credentials do not authenticate
+  inbound callbacks.
 - Feishu `verificationToken` or `FEISHU_VERIFICATION_TOKEN` verifies plaintext
   callback tokens on loopback and remains an additional check when configured
   with encryption. Externally reachable webhooks require `encryptKey` or
   `FEISHU_ENCRYPT_KEY` to verify `X-Lark-Signature` and decrypt encrypted event
   envelopes before challenge handling or event normalization.
 - Slack `signingSecret` or `SLACK_SIGNING_SECRET` verifies
-  `X-Slack-Request-Timestamp` and `X-Slack-Signature`.
+  `X-Slack-Request-Timestamp` and `X-Slack-Signature`; it is required when the
+  webhook host is non-loopback or `publicUrl` is set.
 - Telegram `secretToken` or `TELEGRAM_WEBHOOK_SECRET_TOKEN` verifies
   `X-Telegram-Bot-Api-Secret-Token`.
 - Zalo `webhookSecret` or `ZALO_WEBHOOK_SECRET` verifies
@@ -172,6 +179,11 @@ Server-backed channels currently include Mattermost, Matrix, Signal, Slack,
 Telegram, WhatsApp, and Zalo. Loopback binds retain stable local credentials for
 fixture compatibility. Non-loopback binds generate fresh provider-shaped
 credentials unless the corresponding token or secret option is supplied.
+
+Serve credential flags take precedence over their optional environment
+fallbacks: `--admin-token` over `CRABLINE_ADMIN_TOKEN`, `--access-token` over
+`CRABLINE_ACCESS_TOKEN`, `--bot-token` over `CRABLINE_BOT_TOKEN`, and
+`--signing-secret` over `CRABLINE_SIGNING_SECRET`.
 
 ### Mattermost
 
@@ -471,6 +483,10 @@ as `telegram:`, `discord:`, or `slack:`.
   `123456789012345678`
 - Google Chat spaces: `spaces/AAAABbbbCCC`
 - Google Chat threads: `spaces/AAAABbbbCCC/threads/BBBBccccDDD`
+- Matrix rooms: scoped ids such as `!abcdef:matrix.org` or Matrix v12
+  domainless room ids
+- Zalo users, OAs, and chats: provider-native non-whitespace string ids such as
+  `user-1` or `group-1`
 
 OpenClaw bridge QA targets reserve the exact forms `dm:<id>`, `group:<id>`,
 `channel:<id>`, and `thread:<id>/<thread-id>`. Reserved forms require non-blank

--- a/src/providers/builtin/discord.ts
+++ b/src/providers/builtin/discord.ts
@@ -95,6 +95,9 @@ function discordApplicationCommandText(data: Record<string, unknown>): string | 
       if (!isRecord(option)) {
         continue;
       }
+      if ((option.type === 1 || option.type === 2) && typeof option.name === "string") {
+        values.push(option.name);
+      }
       const value = option.value;
       if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
         values.push(String(value));
@@ -104,6 +107,45 @@ function discordApplicationCommandText(data: Record<string, unknown>): string | 
   };
   collectValues(data.options);
   return [name, ...values].join(" ");
+}
+
+function discordInteractionText(data: Record<string, unknown>): string | undefined {
+  const command = discordApplicationCommandText(data);
+  if (command) {
+    return command;
+  }
+
+  const values: string[] = [];
+  const collectValues = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      for (const child of value) {
+        collectValues(child);
+      }
+      return;
+    }
+    if (!isRecord(value)) {
+      return;
+    }
+    if (typeof value.value === "string") {
+      values.push(value.value);
+    }
+    if (Array.isArray(value.values)) {
+      for (const selected of value.values) {
+        if (
+          typeof selected === "string" ||
+          typeof selected === "number" ||
+          typeof selected === "boolean"
+        ) {
+          values.push(String(selected));
+        }
+      }
+    }
+    collectValues(value.components);
+  };
+  collectValues(data);
+  const customId = optionalString(data, "custom_id");
+  const parts = [...(customId ? [customId] : []), ...values];
+  return parts.length > 0 ? parts.join(" ") : undefined;
 }
 
 function toRecorderPath(providerId: string, config: ProviderConfig): string {
@@ -136,11 +178,7 @@ export function normalizeDiscordWebhookPayload(payload: unknown) {
   const channelId = optionalString(payload, "channel_id");
   const text =
     optionalString(payload, "content") ??
-    (data
-      ? (optionalString(data, "content") ??
-        discordApplicationCommandText(data) ??
-        optionalString(data, "custom_id"))
-      : undefined) ??
+    (data ? (optionalString(data, "content") ?? discordInteractionText(data)) : undefined) ??
     (message ? optionalString(message, "content") : undefined);
   if (!channelId || !text) {
     throw new CrablineError("Discord event payload requires channel_id and content", {

--- a/src/providers/builtin/googlechat.ts
+++ b/src/providers/builtin/googlechat.ts
@@ -298,7 +298,14 @@ function unwrapGoogleChatPubsubPayload(payload: unknown): unknown {
   }
 
   try {
-    return JSON.parse(Buffer.from(data, "base64").toString("utf8")) as unknown;
+    if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/u.test(data)) {
+      throw new Error("invalid base64");
+    }
+    const decoded = Buffer.from(data, "base64");
+    if (decoded.toString("base64") !== data) {
+      throw new Error("non-canonical base64");
+    }
+    return JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(decoded)) as unknown;
   } catch {
     throw new CrablineError("Google Pub/Sub message.data must contain base64-encoded JSON.", {
       kind: "inbound",

--- a/src/providers/builtin/imessage.ts
+++ b/src/providers/builtin/imessage.ts
@@ -12,6 +12,7 @@ import {
   optionalString,
   requireNativeInboundId,
 } from "./native-local-mock.js";
+import { requireExternalWebhookAuthentication } from "./external-webhook-auth.js";
 
 export function resolveIMessageAdapterConfig(
   config: ProviderConfig,
@@ -26,6 +27,13 @@ export function resolveIMessageAdapterConfig(
 
 export class IMessageProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
+    requireExternalWebhookAuthentication({
+      authenticated: false,
+      provider: "iMessage",
+      requirement:
+        "a provider-native authenticated ingress mode, which this adapter does not support",
+      webhook: config.imessage?.webhook,
+    });
     super({
       codec: getBuiltinTargetCodec("imessage"),
       config,

--- a/src/providers/builtin/mattermost.ts
+++ b/src/providers/builtin/mattermost.ts
@@ -12,6 +12,7 @@ import {
   optionalString,
   requireNativeInboundId,
 } from "./native-local-mock.js";
+import { requireExternalWebhookAuthentication } from "./external-webhook-auth.js";
 
 export function resolveMattermostAdapterConfig(
   config: ProviderConfig,
@@ -26,6 +27,13 @@ export function resolveMattermostAdapterConfig(
 
 export class MattermostProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
+    requireExternalWebhookAuthentication({
+      authenticated: false,
+      provider: "Mattermost",
+      requirement:
+        "a provider-native authenticated ingress mode, which this adapter does not support",
+      webhook: config.mattermost?.webhook,
+    });
     super({
       codec: getBuiltinTargetCodec("mattermost"),
       config,

--- a/src/providers/builtin/msteams.ts
+++ b/src/providers/builtin/msteams.ts
@@ -109,8 +109,8 @@ export function createMsTeamsWebhookAuthenticator(
       }
       const channelId = optionalString(payload, "channelId");
       const serviceUrl = optionalString(payload, "serviceUrl");
-      if (!channelId || !serviceUrl) {
-        throw new Error("Bot Connector activity omitted channelId or serviceUrl.");
+      if (channelId !== "msteams" || !serviceUrl) {
+        throw new Error("Bot Connector activity requires channelId=msteams and serviceUrl.");
       }
       const claims = await verifySignedJwt({
         audience: appId,
@@ -198,12 +198,16 @@ export function normalizeMsTeamsWebhookPayload(payload: unknown) {
   }
   const conversation = optionalRecord(payload, "conversation");
   const from = optionalRecord(payload, "from");
+  const channelId = optionalString(payload, "channelId");
   const conversationId = conversation ? optionalString(conversation, "id") : undefined;
   const text = optionalString(payload, "text");
-  if (!conversationId || !text) {
-    throw new CrablineError("Microsoft Teams activity payload requires conversation.id and text", {
-      kind: "inbound",
-    });
+  if (channelId !== "msteams" || !conversationId || !text) {
+    throw new CrablineError(
+      "Microsoft Teams activity payload requires channelId=msteams, conversation.id, and text",
+      {
+        kind: "inbound",
+      },
+    );
   }
 
   return {

--- a/src/providers/builtin/slack.ts
+++ b/src/providers/builtin/slack.ts
@@ -12,6 +12,7 @@ import {
   optionalString,
   requireNativeInboundId,
 } from "./native-local-mock.js";
+import { requireExternalWebhookAuthentication } from "./external-webhook-auth.js";
 
 const SLACK_SIGNATURE_TOLERANCE_SECONDS = 5 * 60;
 
@@ -71,8 +72,9 @@ function normalizeSlackEventsPayload(payload: unknown) {
 
   if (isRecord(payload.event)) {
     const event = payload.event;
-    const message =
-      event.subtype === "message_changed" && isRecord(event.message) ? event.message : event;
+    const changedMessage = isRecord(event.message) ? event.message : undefined;
+    const isMessageChanged = event.subtype === "message_changed" && changedMessage !== undefined;
+    const message = isMessageChanged ? changedMessage : event;
     const channel = event.channel;
     const text = message.text;
     if (typeof channel !== "string" || typeof text !== "string") {
@@ -81,11 +83,13 @@ function normalizeSlackEventsPayload(payload: unknown) {
       });
     }
     const threadTs = message.thread_ts;
-    const ts = message.ts;
+    const eventId = isMessageChanged
+      ? optionalString(event, "event_ts")
+      : optionalString(message, "ts");
     return {
       author: slackAuthorFromEvent(message),
-      ...(typeof ts === "string"
-        ? { id: requireNativeInboundId(ts, SLACK_TS_RULE, "Slack event.ts") }
+      ...(eventId
+        ? { id: requireNativeInboundId(eventId, SLACK_TS_RULE, "Slack event timestamp") }
         : {}),
       raw: payload,
       text,
@@ -165,6 +169,12 @@ export function handleSlackWebhookPayload(payload: unknown): Response | undefine
 export class SlackProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
     const resolvedConfig = resolveSlackAdapterConfig(config);
+    requireExternalWebhookAuthentication({
+      authenticated: Boolean(resolvedConfig.signingSecret),
+      provider: "Slack",
+      requirement: "slack.signingSecret or SLACK_SIGNING_SECRET",
+      webhook: config.slack?.webhook,
+    });
     super({
       codec: getBuiltinTargetCodec("slack"),
       config,

--- a/src/providers/local-mock.ts
+++ b/src/providers/local-mock.ts
@@ -346,6 +346,7 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
     const target = this.normalizeTarget(context.fixture.target);
     const expectedAuthor = context.fixture.inboundMatch.author;
     const channelId = context.threadId ?? target.threadId ?? target.channelId;
+    const excludedIds = new Set(context.excludeIds ?? []);
     const cursorKey = JSON.stringify([context.nonce, context.since, channelId, expectedAuthor]);
     const cursorState = this.#waitCursors.get(cursorKey) ?? { active: 0 };
     const cursor = cursorState.cursor
@@ -362,6 +363,7 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
         filePath: this.#recorderPath,
         matches: (candidate) =>
           candidate.provider === this.id &&
+          !excludedIds.has(candidate.id) &&
           (expectedAuthor === "any" || candidate.author === expectedAuthor) &&
           (this.#options.matchesThread ?? isAddressInChannel)(
             candidate.threadId,

--- a/src/providers/signed-jwt.ts
+++ b/src/providers/signed-jwt.ts
@@ -15,9 +15,21 @@ export type RemoteJwtKeySet<T> = {
 const DEFAULT_KEY_FETCH_TIMEOUT_MS = 5_000;
 const DEFAULT_UNKNOWN_KEY_COOLDOWN_MS = 30_000;
 const MAX_NEGATIVE_KEY_IDS = 128;
+const UTF8_DECODER = new TextDecoder("utf-8", { fatal: true });
+
+function decodeBase64UrlPart(value: string, label: string): Buffer {
+  if (!/^[A-Za-z0-9_-]+$/u.test(value)) {
+    throw new Error(`${label} must use unpadded base64url encoding.`);
+  }
+  const decoded = Buffer.from(value, "base64url");
+  if (decoded.length === 0 || decoded.toString("base64url") !== value) {
+    throw new Error(`${label} must use canonical base64url encoding.`);
+  }
+  return decoded;
+}
 
 function decodeJsonPart(value: string): Record<string, unknown> {
-  const decoded: unknown = JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+  const decoded: unknown = JSON.parse(UTF8_DECODER.decode(decodeBase64UrlPart(value, "JWT part")));
   if (!decoded || typeof decoded !== "object" || Array.isArray(decoded)) {
     throw new Error("JWT part must be a JSON object.");
   }
@@ -35,9 +47,18 @@ function hasAudience(claim: unknown, expected: string): boolean {
   return claim === expected || (Array.isArray(claim) && claim.includes(expected));
 }
 
-function numericClaim(claims: JwtClaims, name: string): number | undefined {
+function numericClaim(claims: JwtClaims, name: string, required = false): number | undefined {
+  if (!(name in claims)) {
+    if (required) {
+      throw new Error(`JWT ${name} claim is required.`);
+    }
+    return undefined;
+  }
   const value = claims[name];
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`JWT ${name} claim must be a finite number.`);
+  }
+  return value;
 }
 
 export function readBearerToken(request: Request): string | undefined {
@@ -198,7 +219,7 @@ export async function verifySignedJwt(params: {
   const header = readHeader(decodeJsonPart(encodedHeader));
   const claims = decodeJsonPart(encodedClaims);
   const key = await params.resolveKey(header);
-  const signature = Buffer.from(encodedSignature, "base64url");
+  const signature = decodeBase64UrlPart(encodedSignature, "JWT signature");
   if (!verify("RSA-SHA256", Buffer.from(`${encodedHeader}.${encodedClaims}`), key, signature)) {
     throw new Error("JWT signature is invalid.");
   }
@@ -212,8 +233,8 @@ export async function verifySignedJwt(params: {
 
   const now = Math.floor((params.now?.() ?? Date.now()) / 1000);
   const skew = params.clockSkewSeconds ?? 300;
-  const expiresAt = numericClaim(claims, "exp");
-  if (expiresAt === undefined || expiresAt < now - skew) {
+  const expiresAt = numericClaim(claims, "exp", true)!;
+  if (expiresAt <= now - skew) {
     throw new Error("JWT is expired.");
   }
   const notBefore = numericClaim(claims, "nbf");

--- a/src/providers/target-normalizers.ts
+++ b/src/providers/target-normalizers.ts
@@ -47,7 +47,7 @@ export const IMESSAGE_THREAD_RULE: NativeIdRule = {
 export const MATRIX_ROOM_ID_RULE: NativeIdRule = {
   example: "!abcdef:matrix.org",
   name: "Matrix room id",
-  pattern: /^![^:\s]+:[^\s]+$/u,
+  pattern: /^!(?:[^:\s]+:[^\s]+|[A-Za-z0-9_-]{43})$/u,
 };
 
 export const MATRIX_EVENT_ID_RULE: NativeIdRule = {
@@ -87,9 +87,9 @@ export const WHATSAPP_WA_ID_RULE: NativeIdRule = {
 };
 
 export const ZALO_ID_RULE: NativeIdRule = {
-  example: "123456789012345678",
-  name: "Zalo user or OA id",
-  pattern: /^\d{6,20}$/u,
+  example: "user-1",
+  name: "Zalo string id",
+  pattern: /^\S+$/u,
 };
 
 function requireNativeId(value: string, rule: NativeIdRule, label: string): string {

--- a/src/providers/webhook-server.ts
+++ b/src/providers/webhook-server.ts
@@ -6,16 +6,39 @@ export type StartedWebhookServer = {
 };
 
 const DEFAULT_MAX_BODY_BYTES = 1024 * 1024;
+const DEFAULT_BODY_TIMEOUT_MS = 5_000;
 
 class RequestBodyTooLargeError extends Error {}
+class RequestBodyTimeoutError extends Error {}
 
-async function readRequestBody(request: IncomingMessage, maxBodyBytes: number): Promise<Buffer> {
+async function readRequestBody(
+  request: IncomingMessage,
+  maxBodyBytes: number,
+  bodyTimeoutMs: number,
+): Promise<Buffer> {
   return await new Promise<Buffer>((resolve, reject) => {
     const chunks: Buffer[] = [];
     let bodyBytes = 0;
     let settled = false;
 
-    request.on("data", (chunk) => {
+    const cleanup = (preserveErrorListener = false) => {
+      clearTimeout(timeout);
+      request.off("data", onData);
+      request.off("end", onEnd);
+      if (!preserveErrorListener) {
+        request.off("error", onError);
+      }
+      request.off("aborted", onAborted);
+    };
+    const fail = (error: unknown) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup(true);
+      reject(error);
+    };
+    const onData = (chunk: Buffer | string) => {
       if (settled) {
         return;
       }
@@ -23,27 +46,31 @@ async function readRequestBody(request: IncomingMessage, maxBodyBytes: number): 
       const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
       bodyBytes += buffer.length;
       if (bodyBytes > maxBodyBytes) {
-        settled = true;
         request.resume();
-        reject(new RequestBodyTooLargeError());
+        fail(new RequestBodyTooLargeError());
         return;
       }
       chunks.push(buffer);
-    });
-    request.once("end", () => {
+    };
+    const onEnd = () => {
       if (settled) {
         return;
       }
       settled = true;
+      cleanup();
       resolve(Buffer.concat(chunks));
-    });
-    request.once("error", (error) => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      reject(error);
-    });
+    };
+    const onError = (error: Error) => fail(error);
+    const onAborted = () => fail(new Error("request body aborted"));
+    const timeout = setTimeout(() => {
+      request.resume();
+      fail(new RequestBodyTimeoutError());
+    }, bodyTimeoutMs);
+
+    request.on("data", onData);
+    request.once("end", onEnd);
+    request.once("error", onError);
+    request.once("aborted", onAborted);
   });
 }
 
@@ -51,11 +78,12 @@ async function toFetchRequest(
   request: IncomingMessage,
   url: URL,
   maxBodyBytes: number,
+  bodyTimeoutMs: number,
 ): Promise<Request> {
   const body =
     request.method === "GET" || request.method === "HEAD"
       ? undefined
-      : await readRequestBody(request, maxBodyBytes);
+      : await readRequestBody(request, maxBodyBytes, bodyTimeoutMs);
 
   const init: RequestInit = {
     headers: request.headers as Record<string, string>,
@@ -99,6 +127,7 @@ function closeServer(server: Server): Promise<void> {
       }
       resolve();
     });
+    server.closeAllConnections();
   });
 }
 
@@ -108,6 +137,7 @@ function formatUrlHost(host: string): string {
 
 export async function startWebhookServer(params: {
   handle(request: Request): Promise<Response>;
+  bodyTimeoutMs?: number | undefined;
   host: string;
   maxBodyBytes?: number;
   methods?: readonly string[] | undefined;
@@ -117,6 +147,7 @@ export async function startWebhookServer(params: {
 }): Promise<StartedWebhookServer> {
   const methods = new Set(params.methods ?? ["POST"]);
   const maxBodyBytes = params.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES;
+  const bodyTimeoutMs = params.bodyTimeoutMs ?? DEFAULT_BODY_TIMEOUT_MS;
   const server = createServer(async (request, response) => {
     try {
       const method = request.method ?? "GET";
@@ -128,10 +159,15 @@ export async function startWebhookServer(params: {
         return;
       }
 
-      const fetchRequest = await toFetchRequest(request, url, maxBodyBytes);
+      const fetchRequest = await toFetchRequest(request, url, maxBodyBytes, bodyTimeoutMs);
       await writeFetchResponse(response, await params.handle(fetchRequest));
     } catch (error) {
-      const status = error instanceof RequestBodyTooLargeError ? 413 : 500;
+      const status =
+        error instanceof RequestBodyTooLargeError
+          ? 413
+          : error instanceof RequestBodyTimeoutError
+            ? 408
+            : 500;
       if (status === 500) {
         try {
           params.onError?.(error);
@@ -141,9 +177,17 @@ export async function startWebhookServer(params: {
       }
       await writeFetchResponse(
         response,
-        new Response(status === 413 ? "request body too large" : "internal server error", {
-          status,
-        }),
+        new Response(
+          status === 413
+            ? "request body too large"
+            : status === 408
+              ? "request body timeout"
+              : "internal server error",
+          {
+            ...(status === 408 ? { headers: { connection: "close" } } : {}),
+            status,
+          },
+        ),
       );
     }
   });

--- a/test/discord-provider.test.ts
+++ b/test/discord-provider.test.ts
@@ -78,8 +78,43 @@ describe("Discord interaction responses", () => {
         type: 2,
       }),
     ).toMatchObject({
-      text: "deploy nonce-nested",
+      text: "deploy service environment nonce-nested",
     });
+  });
+
+  it.each([
+    [
+      {
+        channel_id: "123456789012345678",
+        data: {
+          component_type: 3,
+          custom_id: "environment",
+          values: ["staging", "nonce-select"],
+        },
+        id: "444456789012345678",
+        type: 3,
+      },
+      "environment staging nonce-select",
+    ],
+    [
+      {
+        channel_id: "123456789012345678",
+        data: {
+          components: [
+            {
+              components: [{ custom_id: "reason", type: 4, value: "deploy nonce-modal" }],
+              type: 1,
+            },
+          ],
+          custom_id: "deploy-form",
+        },
+        id: "444456789012345678",
+        type: 5,
+      },
+      "deploy-form deploy nonce-modal",
+    ],
+  ])("preserves native component and modal values", (payload, text) => {
+    expect(normalizeDiscordWebhookPayload(payload)).toMatchObject({ text });
   });
 });
 

--- a/test/googlechat-provider.test.ts
+++ b/test/googlechat-provider.test.ts
@@ -235,6 +235,18 @@ describe("Google Chat webhook authentication", () => {
     ).toBe(false);
   });
 
+  it.each(["e30", "%%%%", "e30=trailing"])(
+    "rejects non-canonical Pub/Sub base64 data: %s",
+    (data) => {
+      expect(() =>
+        normalizeGoogleChatWebhookPayload({
+          message: { data },
+          subscription: "projects/example/subscriptions/chat",
+        }),
+      ).toThrow(/base64-encoded JSON/u);
+    },
+  );
+
   it("rejects unbound Workspace add-on payloads and cross-space threads", () => {
     expect(() =>
       normalizeGoogleChatWebhookPayload({

--- a/test/imessage-provider.test.ts
+++ b/test/imessage-provider.test.ts
@@ -10,6 +10,20 @@ import {
 import { describe, expect, it } from "vitest";
 
 describe("iMessage thread matching", () => {
+  it("rejects externally reachable webhooks without provider-native authentication", async () => {
+    const config = await createLocalMockConfig("imessage", "/imessage/webhook");
+    config.imessage!.webhook.host = "0.0.0.0";
+    expect(() => new IMessageProviderAdapter("imessage", config, "crabline")).toThrow(
+      /provider-native authenticated ingress mode/u,
+    );
+
+    config.imessage!.webhook.host = "127.0.0.1";
+    config.imessage!.webhook.publicUrl = "https://imessage.example.test/webhook";
+    expect(() => new IMessageProviderAdapter("imessage", config, "crabline")).toThrow(
+      /provider-native authenticated ingress mode/u,
+    );
+  });
+
   it("matches GUID targets when payloads also provide a public recipient", () => {
     expect(
       matchesIMessageThread(

--- a/test/local-mock-provider.test.ts
+++ b/test/local-mock-provider.test.ts
@@ -789,6 +789,48 @@ describe("local mock provider", () => {
     });
   });
 
+  it("excludes inbound ids already consumed by the fixture runner", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const recorderPath = path.join(directory, "excluded-ids.jsonl");
+    const config = createConfig();
+    const provider = new LocalMockProviderAdapter({
+      codec: createGenericLocalMockTargetCodec("slack"),
+      config,
+      id: "provider-a",
+      options: {
+        defaultWebhook: { host: "127.0.0.1", path: "/slack/events", port: 0 },
+        endpointLabel: "events endpoint",
+        platform: "slack",
+        recorderPath,
+      },
+    });
+    providers.push(provider);
+    const context = createContext(config);
+    context.fixture.inboundMatch.author = "any";
+    for (const id of ["original", "edit"]) {
+      await appendRecordedInbound(recorderPath, {
+        author: "user",
+        id,
+        provider: "provider-a",
+        sentAt: new Date().toISOString(),
+        text: id,
+        threadId: "slack:C1234567890",
+      });
+    }
+
+    await expect(
+      provider.waitForInbound({
+        ...context,
+        excludeIds: ["original"],
+        nonce: "edit",
+        since: new Date(0).toISOString(),
+        threadId: "slack:C1234567890",
+        timeoutMs: 100,
+      }),
+    ).resolves.toMatchObject({ id: "edit" });
+  });
+
   it("persists incremental cursor progress after a timeout", async () => {
     const directory = await createTempDir();
     directories.push(directory);

--- a/test/matrix-provider.test.ts
+++ b/test/matrix-provider.test.ts
@@ -10,6 +10,17 @@ import {
 } from "./local-mock-provider-helpers.js";
 
 describe("Matrix webhook normalizer", () => {
+  it("accepts Matrix v12 domainless room ids through the shared target codec", async () => {
+    const config = await createLocalMockConfig("matrix", "/matrix/webhook");
+    const provider = new MatrixProviderAdapter("matrix", config, "crabline");
+    const roomId = `!${Buffer.alloc(32, 0xab).toString("base64url")}`;
+
+    expect(provider.normalizeTarget({ id: roomId, metadata: {} })).toMatchObject({
+      channelId: roomId,
+    });
+    await provider.cleanup();
+  });
+
   it("rejects externally reachable webhooks without native authentication", async () => {
     const config = await createLocalMockConfig("matrix", "/matrix/webhook");
     config.matrix!.webhook.host = "0.0.0.0";

--- a/test/mattermost-provider.test.ts
+++ b/test/mattermost-provider.test.ts
@@ -5,9 +5,26 @@ import {
   normalizeMattermostWebhookPayload,
 } from "../src/providers/builtin/mattermost.js";
 import { optionalStringish } from "../src/providers/builtin/native-local-mock.js";
-import { runLocalMockProviderContract } from "./local-mock-provider-helpers.js";
+import {
+  createLocalMockConfig,
+  runLocalMockProviderContract,
+} from "./local-mock-provider-helpers.js";
 
 describe("Mattermost webhook normalizer", () => {
+  it("rejects externally reachable webhooks without provider-native authentication", async () => {
+    const config = await createLocalMockConfig("mattermost", "/mattermost/webhook");
+    config.mattermost!.webhook.host = "0.0.0.0";
+    expect(() => new MattermostProviderAdapter("mattermost", config, "crabline")).toThrow(
+      /provider-native authenticated ingress mode/u,
+    );
+
+    config.mattermost!.webhook.host = "127.0.0.1";
+    config.mattermost!.webhook.publicUrl = "https://mattermost.example.test/webhook";
+    expect(() => new MattermostProviderAdapter("mattermost", config, "crabline")).toThrow(
+      /provider-native authenticated ingress mode/u,
+    );
+  });
+
   it("preserves the channel when normalizing thread replies", () => {
     expect(
       normalizeMattermostWebhookPayload({

--- a/test/msteams-provider.test.ts
+++ b/test/msteams-provider.test.ts
@@ -12,6 +12,17 @@ import {
 
 const conversationId = "a:opaque-conversation-id";
 describe("Microsoft Teams webhook authentication", () => {
+  it("requires the native msteams activity channel", () => {
+    expect(() =>
+      normalizeMsTeamsWebhookPayload({
+        channelId: "webchat",
+        conversation: { id: conversationId },
+        text: "wrong channel",
+        type: "message",
+      }),
+    ).toThrow(/channelId=msteams/u);
+  });
+
   it("rejects non-message activities", () => {
     expect(() => normalizeMsTeamsWebhookPayload({ type: "conversationUpdate" })).toThrow(
       /type=message/u,
@@ -178,6 +189,19 @@ describe("Microsoft Teams webhook authentication", () => {
       ),
     ).resolves.toMatchObject({ status: 401 });
 
+    const wrongChannelBody = JSON.stringify({
+      ...JSON.parse(body),
+      channelId: "webchat",
+    });
+    await expect(
+      authenticate!(
+        new Request(url, {
+          headers: { authorization: `Bearer ${header}.${payload}.${signature}` },
+        }),
+        wrongChannelBody,
+      ),
+    ).resolves.toMatchObject({ status: 401 });
+
     const emptyEndorsementsAuthenticator = createMsTeamsWebhookAuthenticator(config, {
       fetch: async (input: string | URL | Request) =>
         String(input).includes("openidconfiguration")
@@ -207,6 +231,7 @@ runLocalMockProviderContract({
   target: { id: conversationId, metadata: {} },
   webhookExpected: { author: "user", id: "teams-activity-1", text: "reply nonce-2" },
   webhookPayload: {
+    channelId: "msteams",
     conversation: { id: conversationId },
     from: { role: "user" },
     id: "teams-activity-1",

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -212,10 +212,10 @@ describe("registry", () => {
     [
       "zalo",
       {
-        channelId: "123456789012",
-        id: "123456789012",
+        channelId: "user-1",
+        id: "user-1",
         metadata: {},
-        threadId: "987654321012",
+        threadId: "group-1",
       },
     ],
   ] satisfies Array<
@@ -247,6 +247,13 @@ describe("registry", () => {
     expect(registry.resolve(adapter, fixture.id).normalizeTarget(target)).toEqual(
       normalizeBuiltinTarget(adapter, target),
     );
+  });
+
+  it("accepts Matrix v12 domainless room ids in lazy target normalization", () => {
+    const roomId = `!${Buffer.alloc(32, 0xab).toString("base64url")}`;
+    expect(normalizeBuiltinTarget("matrix", { id: roomId, metadata: {} })).toMatchObject({
+      channelId: roomId,
+    });
   });
 
   it("applies provider-specific validation through lazy adapters", () => {

--- a/test/signed-jwt.test.ts
+++ b/test/signed-jwt.test.ts
@@ -1,7 +1,62 @@
+import { generateKeyPairSync, sign } from "node:crypto";
 import { describe, expect, it } from "vitest";
-import { createCachedJwtKeyResolver, resolveHttpCacheExpiry } from "../src/providers/signed-jwt.js";
+import {
+  createCachedJwtKeyResolver,
+  resolveHttpCacheExpiry,
+  verifySignedJwt,
+} from "../src/providers/signed-jwt.js";
+
+function signedJwt(
+  privateKey: ReturnType<typeof generateKeyPairSync>["privateKey"],
+  claims: Record<string, unknown>,
+): string {
+  const header = Buffer.from(JSON.stringify({ alg: "RS256", kid: "test-key" })).toString(
+    "base64url",
+  );
+  const payload = Buffer.from(JSON.stringify(claims)).toString("base64url");
+  const signature = sign("RSA-SHA256", Buffer.from(`${header}.${payload}`), privateKey).toString(
+    "base64url",
+  );
+  return `${header}.${payload}.${signature}`;
+}
 
 describe("signed JWT remote key cache", () => {
+  it("requires canonical base64url, numeric nbf, and a future expiry boundary", async () => {
+    const keys = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const now = 1_700_000_000_000;
+    const verify = (token: string) =>
+      verifySignedJwt({
+        audience: "crabline",
+        clockSkewSeconds: 0,
+        issuers: ["issuer"],
+        now: () => now,
+        resolveKey: async () => keys.publicKey,
+        token,
+      });
+    const claims = {
+      aud: "crabline",
+      exp: Math.floor(now / 1000) + 1,
+      iss: "issuer",
+    };
+    const valid = signedJwt(keys.privateKey, claims);
+
+    await expect(verify(valid)).resolves.toMatchObject(claims);
+    const [header, payload, signature] = valid.split(".") as [string, string, string];
+    await expect(verify(`${header}=.${payload}.${signature}`)).rejects.toThrow(/base64url/u);
+    await expect(verify(`${header}.${payload}.${signature}=`)).rejects.toThrow(/base64url/u);
+    await expect(
+      verify(signedJwt(keys.privateKey, { ...claims, nbf: "1700000000" })),
+    ).rejects.toThrow(/nbf claim must be a finite number/u);
+    await expect(
+      verify(
+        signedJwt(keys.privateKey, {
+          ...claims,
+          exp: Math.floor(now / 1000),
+        }),
+      ),
+    ).rejects.toThrow(/expired/u);
+  });
+
   it("does not cache responses marked no-cache or no-store", () => {
     const now = 1_700_000_000_000;
 

--- a/test/slack-provider.test.ts
+++ b/test/slack-provider.test.ts
@@ -84,6 +84,24 @@ function endpointFromDetails(details: string[]): string {
 }
 
 describe("slack provider", () => {
+  it("requires request signatures for externally reachable event endpoints", async () => {
+    const config = await createSlackConfig(0);
+    config.slack!.webhook.host = "0.0.0.0";
+    expect(() => new SlackProviderAdapter("slack", config, "crabline")).toThrow(
+      /externally reachable webhooks require slack\.signingSecret/u,
+    );
+
+    config.slack!.webhook.host = "127.0.0.1";
+    config.slack!.webhook.publicUrl = "https://slack.example.test/events";
+    expect(() => new SlackProviderAdapter("slack", config, "crabline")).toThrow(
+      /externally reachable webhooks require slack\.signingSecret/u,
+    );
+
+    config.slack!.signingSecret = "test-token-placeholder";
+    const provider = new SlackProviderAdapter("slack", config, "crabline");
+    providers.push(provider);
+  });
+
   it("keeps native Slack conversation and thread timestamp ids", async () => {
     const config = await createSlackConfig(0);
     const provider = new SlackProviderAdapter("slack", config, "crabline");
@@ -255,6 +273,7 @@ describe("slack provider", () => {
       body: JSON.stringify({
         event: {
           channel: "C1234567890",
+          event_ts: "1700000002.000300",
           message: {
             text: "edited ACK edited-nonce",
             thread_ts: "1700000000.000100",
@@ -274,7 +293,7 @@ describe("slack provider", () => {
     expect(response.status).toBe(200);
     await expect(waiting).resolves.toMatchObject({
       author: "user",
-      id: "1700000001.000200",
+      id: "1700000002.000300",
       text: "edited ACK edited-nonce",
       threadId: "C1234567890:thread:1700000000.000100",
     });

--- a/test/webhook-server.test.ts
+++ b/test/webhook-server.test.ts
@@ -1,3 +1,5 @@
+import { once } from "node:events";
+import { connect } from "node:net";
 import { afterEach, describe, expect, it } from "vitest";
 import { startWebhookServer } from "../src/providers/webhook-server.js";
 
@@ -135,6 +137,10 @@ describe("webhook server", () => {
 
     expect(response.status).toBe(413);
     expect(handlerInvoked).toBe(false);
+
+    const healthy = await fetch(server.endpointUrl, { body: "1234", method: "POST" });
+    expect(healthy.status).toBe(200);
+    expect(handlerInvoked).toBe(true);
   });
 
   it("rejects a wrong route before reading an oversized body", async () => {
@@ -153,5 +159,85 @@ describe("webhook server", () => {
     });
 
     expect(response.status).toBe(404);
+  });
+
+  it("times out slow request bodies before invoking the handler", async () => {
+    let handlerInvoked = false;
+    const server = await startWebhookServer({
+      bodyTimeoutMs: 20,
+      async handle() {
+        handlerInvoked = true;
+        return new Response("ok");
+      },
+      host: "127.0.0.1",
+      path: "/slack/events",
+      port: 0,
+    });
+    cleanups.push(() => server.close());
+    const endpoint = new URL(server.endpointUrl);
+    const socket = connect(Number(endpoint.port), endpoint.hostname);
+    let response = "";
+    socket.setEncoding("utf8");
+    socket.on("data", (chunk) => {
+      response += chunk;
+    });
+    await once(socket, "connect");
+    socket.write(
+      "POST /slack/events HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: 5\r\nConnection: close\r\n\r\n1",
+    );
+    await once(socket, "close");
+
+    expect(response).toContain("HTTP/1.1 408");
+    expect(response).toContain("request body timeout");
+    expect(handlerInvoked).toBe(false);
+
+    const healthy = await fetch(server.endpointUrl, { body: "{}", method: "POST" });
+    expect(healthy.status).toBe(200);
+    expect(handlerInvoked).toBe(true);
+  });
+
+  it("does not let a slow request body block shutdown", async () => {
+    const server = await startWebhookServer({
+      bodyTimeoutMs: 10_000,
+      handle: async () => new Response("ok"),
+      host: "127.0.0.1",
+      path: "/slack/events",
+      port: 0,
+    });
+    const endpoint = new URL(server.endpointUrl);
+    const socket = connect(Number(endpoint.port), endpoint.hostname);
+    await once(socket, "connect");
+    socket.write("POST /slack/events HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: 5\r\n\r\n1");
+    socket.on("error", () => {});
+    const closed = new Promise<void>((resolve) => socket.once("close", () => resolve()));
+
+    await expect(
+      Promise.race([
+        server.close().then(() => "closed"),
+        new Promise<string>((resolve) => setTimeout(() => resolve("timed out"), 250)),
+      ]),
+    ).resolves.toBe("closed");
+    await closed;
+  });
+
+  it("survives clients aborting incomplete request bodies", async () => {
+    const server = await startWebhookServer({
+      bodyTimeoutMs: 10_000,
+      handle: async () => new Response("ok"),
+      host: "127.0.0.1",
+      path: "/slack/events",
+      port: 0,
+    });
+    cleanups.push(() => server.close());
+    const endpoint = new URL(server.endpointUrl);
+    const socket = connect(Number(endpoint.port), endpoint.hostname);
+    socket.on("error", () => {});
+    await once(socket, "connect");
+    socket.write("POST /slack/events HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: 5\r\n\r\n1");
+    socket.destroy();
+    await new Promise<void>((resolve) => socket.once("close", () => resolve()));
+
+    const response = await fetch(server.endpointUrl, { body: "{}", method: "POST" });
+    expect(response.status).toBe(200);
   });
 });

--- a/test/zalo-provider.test.ts
+++ b/test/zalo-provider.test.ts
@@ -44,9 +44,21 @@ describe("Zalo webhook normalizer", () => {
   it.each([
     ["not-an-object", "Zalo webhook payload must be an object"],
     [{ sender: { id: "123456789012" }, message: {} }, "requires"],
-    [{ message: { text: "hello" }, sender: { id: "invalid-id" } }, "native Zalo user or OA id"],
+    [{ message: { text: "hello" }, sender: { id: "" } }, "requires"],
   ])("rejects malformed or invalid payloads: %s", (payload, message) => {
     expect(() => normalizeZaloWebhookPayload(payload)).toThrow(message);
+  });
+
+  it("accepts provider-native opaque string targets", async () => {
+    const config = await createLocalMockConfig("zalo", "/zalo/webhook");
+    const provider = new ZaloProviderAdapter("zalo", config, "crabline");
+    try {
+      expect(provider.normalizeTarget({ id: "user-1", metadata: {} })).toMatchObject({
+        channelId: "user-1",
+      });
+    } finally {
+      await provider.cleanup();
+    }
   });
 
   it("preserves generic fallback thread payloads", () => {
@@ -112,13 +124,17 @@ describe("Zalo webhook normalizer", () => {
 runLocalMockProviderContract({
   Adapter: ZaloProviderAdapter,
   endpointPath: "/zalo/webhook",
-  expectedChannelId: "123456789012",
+  expectedChannelId: "user-1",
+  invalidTargets: [
+    { id: "", metadata: {} },
+    { id: "   ", metadata: {} },
+  ],
   platform: "zalo",
-  target: { id: "123456789012", metadata: {} },
+  target: { id: "user-1", metadata: {} },
   webhookExpected: { author: "user", id: "zalo-msg-1", text: "reply nonce-2" },
   webhookPayload: {
     message: { msg_id: "zalo-msg-1", text: "reply nonce-2" },
-    sender: { id: "123456789012" },
+    sender: { id: "user-1" },
   },
-  webhookThreadId: "123456789012",
+  webhookThreadId: "user-1",
 });


### PR DESCRIPTION
## Summary

- enforce authenticated exposure rules and bounded webhook body/shutdown handling
- preserve native Discord interaction values, Slack edit identities, Teams channel identity, and local mock exclusions
- tighten canonical JWT and Pub/Sub decoding while aligning Matrix and Zalo target identities
- document serve credential environment fallbacks and provider ingress requirements

## Validation

- `pnpm verify` (56 files, 866 tests)
- privacy scan clean

## Audit disposition

Quoted `max-age` handling and concurrent-wait deduplication were rejected as non-native changes. Feishu AES handling already matches the native IV-prefixed ciphertext contract.