### PR TITLE
fix(servers): tighten provider protocol fidelity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Harden CLI secret ingress and numeric parsing, provider cancellation and script thread propagation, timer bounds, review fixtures, and dependency review coverage.
 - Complete final provider remediation across authenticated webhook exposure, native callback decoding, interaction values, target identities, JWT boundaries, and bounded ingress shutdown.
+- Fan out queued Signal events, tighten Matrix, Slack, Mattermost, Telegram, and Zalo protocol fidelity, and exercise DNS-pinned webhook delivery.
 - Harden secondary provider adapters with stable pagination, scoped native IDs, immutable diagnostics redaction, Slack edit normalization, and bounded WhatsApp ingress.
 - Harden provider-core webhook hooks, recorder durability and cursor semantics, lazy adapter lifecycle and target parity, and signed-JWT key caching.
 - Harden autoreview launchers and release automation, document trusted script manifests, and canonicalize WhatsApp Cloud targets.

--- a/src/servers/matrix.ts
+++ b/src/servers/matrix.ts
@@ -236,8 +236,8 @@ async function appendEvent(
 }
 
 function authorized(request: IncomingMessage, token: string): boolean {
-  const [scheme, value] = request.headers.authorization?.trim().split(/\s+/, 2) ?? [];
-  return scheme?.toLowerCase() === "bearer" && value === token;
+  const match = /^Bearer\s+(\S+)$/iu.exec(request.headers.authorization ?? "");
+  return match?.[1] === token;
 }
 
 function matrixError(errcode: string, error: string, status: number): Response {

--- a/src/servers/mattermost.ts
+++ b/src/servers/mattermost.ts
@@ -192,6 +192,10 @@ function postEvent(
   };
 }
 
+function webSocketEventBytes(event: MattermostWebSocketEvent): number {
+  return Buffer.byteLength(JSON.stringify({ ...event, seq: 0 }), "utf8");
+}
+
 function sendEvent(
   state: MattermostServerState,
   client: WebSocket,
@@ -258,10 +262,7 @@ function broadcast(
   if (event.broadcast.omit_users?.[state.botUserId]) {
     return true;
   }
-  if (
-    Buffer.byteLength(JSON.stringify({ ...event, seq: 0 }), "utf8") >
-    state.maxWebSocketBufferedBytes
-  ) {
+  if (webSocketEventBytes(event) > state.maxWebSocketBufferedBytes) {
     for (const client of state.websocketClients.keys()) {
       state.websocketClients.delete(client);
       client.close(1013, "client too slow");
@@ -352,7 +353,7 @@ function handleAdminInbound(params: {
     state: params.state,
     userId: senderId,
   });
-  if (!broadcast(params.state, postEvent("posted", post, senderName, channelType))) {
+  const rollback = () => {
     params.state.posts.delete(post.id);
     params.state.nextPost = previousNextPost;
     if (previousUser) {
@@ -365,6 +366,14 @@ function handleAdminInbound(params: {
     } else {
       params.state.channels.delete(channelId);
     }
+  };
+  const event = postEvent("posted", post, senderName, channelType);
+  if (webSocketEventBytes(event) > params.state.maxWebSocketBufferedBytes) {
+    rollback();
+    return jsonResponse({ error: "Inbound event is too large", ok: false }, 413);
+  }
+  if (!broadcast(params.state, event)) {
+    rollback();
     return pendingQueueFullResponse(params.state);
   }
   return jsonResponse({ ok: true, post });
@@ -460,7 +469,7 @@ async function handleApi(params: {
     if (!channel) {
       return mattermostError("Channel not found", 404);
     }
-    const rootId = readTrimmedString(body.root_id) || readTrimmedString(body.post_id);
+    const rootId = readTrimmedString(body.root_id);
     if (rootId) {
       const rootPost = state.posts.get(rootId);
       if (!rootPost) {

--- a/src/servers/signal.ts
+++ b/src/servers/signal.ts
@@ -150,6 +150,9 @@ function removeSignalClient(
   if (destroy) {
     client.destroy();
   }
+  if (state.pendingEvents.length > 0 && state.clients.size > 0) {
+    queueMicrotask(() => flushPendingSignalEvents(state));
+  }
 }
 
 function evictSignalClient(state: SignalServerState, client: ServerResponse): void {
@@ -174,7 +177,7 @@ function scheduleSignalDrain(state: SignalServerState, client: ServerResponse): 
       flushSignalClientEvents(state, client);
       const remaining = state.clientBuffers.get(client);
       if (remaining && remaining.events.length === 0 && !client.writableNeedDrain) {
-        flushPendingSignalEvents(state, client);
+        flushPendingSignalEvents(state);
       }
     }
   });
@@ -332,17 +335,22 @@ function flushSignalClientEvents(state: SignalServerState, client: ServerRespons
   }
 }
 
-function flushPendingSignalEvents(state: SignalServerState, client: ServerResponse): void {
-  while (state.pendingEvents.length > 0) {
-    const result = writeSignalSse(state, client, state.pendingEvents[0]!);
-    if (result === "accepted" || result === "queued") {
-      const event = state.pendingEvents.shift()!;
-      state.pendingEventBytes -= Buffer.byteLength(event.data);
-      if (result === "accepted") {
-        continue;
+function flushPendingSignalEvents(state: SignalServerState): void {
+  while (state.pendingEvents.length > 0 && state.clients.size > 0) {
+    const event = state.pendingEvents[0]!;
+    for (const client of [...state.clients]) {
+      if (!event.recipients?.has(client)) {
+        writeSignalSse(state, client, event);
       }
     }
-    break;
+    if (
+      state.clients.size === 0 ||
+      [...state.clients].some((client) => !event.recipients?.has(client))
+    ) {
+      break;
+    }
+    state.pendingEvents.shift();
+    state.pendingEventBytes -= Buffer.byteLength(event.data);
   }
 }
 
@@ -615,7 +623,7 @@ async function handleRequest(params: {
     });
     replayExclusiveSignalEvents(params.state, params.response);
     if (params.state.clients.has(params.response)) {
-      flushPendingSignalEvents(params.state, params.response);
+      flushPendingSignalEvents(params.state);
     }
     return;
   }

--- a/src/servers/slack.ts
+++ b/src/servers/slack.ts
@@ -262,6 +262,27 @@ function readStructuredArray(value: unknown, error: string): unknown[] | Respons
   return Array.isArray(parsed) ? parsed : slackError(error);
 }
 
+function readSlackMetadata(value: unknown): Record<string, unknown> | Response | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  let parsed: unknown = value;
+  if (typeof value === "string") {
+    try {
+      parsed = JSON.parse(value) as unknown;
+    } catch {
+      return slackError("invalid_metadata_format");
+    }
+  }
+  if (!isJsonObject(parsed)) {
+    return slackError("invalid_metadata_format");
+  }
+  if (!readTrimmedString(parsed.event_type) || !isJsonObject(parsed.event_payload)) {
+    return slackError("invalid_metadata_schema");
+  }
+  return parsed;
+}
+
 function hasStructuredMessageContent(value: unknown): boolean {
   if (Array.isArray(value)) {
     return value.length > 0;
@@ -724,7 +745,10 @@ async function handleSlackApi(params: {
       if (blocks instanceof Response) {
         return blocks;
       }
-      const metadata = readStructuredValue(params.body.metadata);
+      const metadata = readSlackMetadata(params.body.metadata);
+      if (metadata instanceof Response) {
+        return metadata;
+      }
       if (
         !text &&
         !hasStructuredMessageContent(blocks) &&

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -375,10 +375,11 @@ function createOutboundMessage(
   if (chatId === undefined || !text) {
     return undefined;
   }
-  const threadId = toIntegerValue(body.message_thread_id);
-  if (body.message_thread_id !== undefined && threadId === undefined) {
+  const parsedThreadId = toIntegerValue(body.message_thread_id);
+  if (body.message_thread_id !== undefined && parsedThreadId === undefined) {
     return undefined;
   }
+  const threadId = parsedThreadId !== undefined && parsedThreadId > 0 ? parsedThreadId : undefined;
   return {
     chat: createChat(chatId),
     date: Math.floor(Date.now() / 1000),
@@ -399,10 +400,11 @@ function createOutboundMediaMessage(
   if (chatId === undefined || !fileName) {
     return undefined;
   }
-  const threadId = toIntegerValue(body.message_thread_id);
-  if (body.message_thread_id !== undefined && threadId === undefined) {
+  const parsedThreadId = toIntegerValue(body.message_thread_id);
+  if (body.message_thread_id !== undefined && parsedThreadId === undefined) {
     return undefined;
   }
+  const threadId = parsedThreadId !== undefined && parsedThreadId > 0 ? parsedThreadId : undefined;
   const caption = toStringValue(body.caption);
   const duration = Math.max(0, toIntegerValue(body.duration) ?? 0);
   const height = Math.max(1, toIntegerValue(body.height) ?? 1);
@@ -444,10 +446,11 @@ function createEditedMessage(
   if (chatId === undefined || !text || messageId === undefined) {
     return undefined;
   }
-  const threadId = toIntegerValue(body.message_thread_id);
-  if (body.message_thread_id !== undefined && threadId === undefined) {
+  const parsedThreadId = toIntegerValue(body.message_thread_id);
+  if (body.message_thread_id !== undefined && parsedThreadId === undefined) {
     return undefined;
   }
+  const threadId = parsedThreadId !== undefined && parsedThreadId > 0 ? parsedThreadId : undefined;
   return {
     chat: createChat(chatId),
     date: Math.floor(Date.now() / 1000),
@@ -472,13 +475,14 @@ function createInboundUpdate(
   const messageIdValue = body.messageId ?? body.message_id;
   const updateIdValue = body.updateId ?? body.update_id;
   const fromId = toIntegerValue(fromIdValue);
-  const threadId = toIntegerValue(threadIdValue);
+  const parsedThreadId = toIntegerValue(threadIdValue);
+  const threadId = parsedThreadId !== undefined && parsedThreadId > 0 ? parsedThreadId : undefined;
   const fromUsername = toStringValue(body.fromUsername ?? body.from_username);
   const messageId = toIntegerValue(messageIdValue);
   const updateId = toIntegerValue(updateIdValue);
   if (
     (fromIdValue !== undefined && fromId === undefined) ||
-    (threadIdValue !== undefined && threadId === undefined) ||
+    (threadIdValue !== undefined && parsedThreadId === undefined) ||
     (messageIdValue !== undefined && messageId === undefined) ||
     (updateIdValue !== undefined && updateId === undefined)
   ) {

--- a/src/servers/zalo.ts
+++ b/src/servers/zalo.ts
@@ -157,11 +157,53 @@ function requestParams(url: URL, body: Record<string, unknown>): Record<string, 
   return { ...Object.fromEntries(url.searchParams.entries()), ...body };
 }
 
+const SENSITIVE_PARAM_NAMES = new Set([
+  "accesskey",
+  "accesstoken",
+  "apikey",
+  "auth",
+  "authorization",
+  "authtoken",
+  "bearertoken",
+  "clientsecret",
+  "consumersecret",
+  "credential",
+  "credentials",
+  "idtoken",
+  "key",
+  "oauthtoken",
+  "password",
+  "passwd",
+  "privatekey",
+  "refreshtoken",
+  "secret",
+  "secretkey",
+  "secrettoken",
+  "sessiontoken",
+  "signature",
+  "signingsecret",
+  "token",
+  "webhooksecret",
+]);
+
+function isSensitiveParam(name: string): boolean {
+  const canonicalName = name
+    .normalize("NFKC")
+    .replace(/[^A-Za-z0-9]/gu, "")
+    .toLowerCase();
+  return (
+    SENSITIVE_PARAM_NAMES.has(canonicalName) ||
+    /(?:^|[_-])(?:access[_-]?token|api[_-]?key|authorization|key|password|secret|signature|token)(?:$|[_-])/iu.test(
+      name,
+    )
+  );
+}
+
 function redactParams(params: Record<string, unknown>): Record<string, unknown> {
   return Object.fromEntries(
     Object.entries(params).map(([key, value]) => [
       key,
-      key === "secret_token"
+      isSensitiveParam(key)
         ? "<redacted>"
         : key === "url" && typeof value === "string"
           ? redactUrlCredentials(value)
@@ -170,17 +212,50 @@ function redactParams(params: Record<string, unknown>): Record<string, unknown> 
   );
 }
 
+function redactSensitiveSearchParams(searchParams: URLSearchParams): boolean {
+  let redacted = false;
+  for (const key of searchParams.keys()) {
+    if (isSensitiveParam(key)) {
+      searchParams.set(key, "<redacted>");
+      redacted = true;
+    }
+  }
+  return redacted;
+}
+
+function redactMalformedUrlCredentials(value: string): string {
+  const credentialRedacted = value.replace(
+    /^(\s*)((?:[a-z][a-z0-9+.-]*:)?\/\/)[^/?#]*@/iu,
+    "$1$2<redacted>@",
+  );
+  const queryStart = credentialRedacted.indexOf("?");
+  const fragmentStart = credentialRedacted.indexOf("#", queryStart + 1);
+  if (queryStart < 0 || (fragmentStart >= 0 && fragmentStart < queryStart)) {
+    return credentialRedacted;
+  }
+  const queryEnd = fragmentStart >= 0 ? fragmentStart : credentialRedacted.length;
+  const searchParams = new URLSearchParams(credentialRedacted.slice(queryStart + 1, queryEnd));
+  if (!redactSensitiveSearchParams(searchParams)) {
+    return credentialRedacted;
+  }
+  const search = searchParams.toString().replaceAll("%3Credacted%3E", "<redacted>");
+  return `${credentialRedacted.slice(0, queryStart)}?${search}${credentialRedacted.slice(queryEnd)}`;
+}
+
 function redactUrlCredentials(value: string): string {
   let url: URL;
   try {
     url = new URL(value);
   } catch {
-    return value.replace(/^(\s*)((?:[a-z][a-z0-9+.-]*:)?\/\/)[^/?#]*@/iu, "$1$2<redacted>@");
+    return redactMalformedUrlCredentials(value);
   }
-  if (!url.username && !url.password) {
+  const hasCredentials = Boolean(url.username || url.password);
+  const redactedQuery = redactSensitiveSearchParams(url.searchParams);
+  if (!hasCredentials && !redactedQuery) {
     return value;
   }
-  return `${url.protocol}//<redacted>@${url.host}${url.pathname}${url.search}${url.hash}`;
+  const search = url.search.replaceAll("%3Credacted%3E", "<redacted>");
+  return `${url.protocol}//${hasCredentials ? "<redacted>@" : ""}${url.host}${url.pathname}${search}${url.hash}`;
 }
 
 function requireParam(body: Record<string, unknown>, name: string): string | Response {

--- a/test/matrix-server.test.ts
+++ b/test/matrix-server.test.ts
@@ -120,6 +120,17 @@ describe("Matrix local provider server", () => {
       method: "PUT",
     });
     expect(unauthorized.status).toBe(401);
+    const trailingAuthorization = await fetch(
+      `${server.manifest.endpoints.clientApiRoot}/account/whoami`,
+      {
+        headers: { authorization: "Bearer test-token trailing" },
+      },
+    );
+    expect(trailingAuthorization.status).toBe(401);
+    await expect(trailingAuthorization.json()).resolves.toEqual({
+      errcode: "M_UNKNOWN_TOKEN",
+      error: "Invalid access token",
+    });
     const unauthorizedOversized = await requestHttp({
       body: Buffer.alloc(1024 * 1024 + 1, 0x20),
       headers: {

--- a/test/mattermost-server.test.ts
+++ b/test/mattermost-server.test.ts
@@ -510,7 +510,7 @@ describe("Mattermost local provider server", () => {
     }
   });
 
-  it("validates post roots and restricts mutations to bot-owned posts", async () => {
+  it("uses root_id for post threading and restricts mutations to bot-owned posts", async () => {
     const server = await startMattermostServer({ adminToken: "admin", botToken: "fake" });
     servers.push(server);
     const inboundPosts: Array<{ channel_id: string; id: string }> = [];
@@ -534,12 +534,27 @@ describe("Mattermost local provider server", () => {
       { channel_id: string; id: string },
     ];
 
+    const ignoredPostId = await fetch(`${server.manifest.endpoints.apiRoot}/posts`, {
+      body: JSON.stringify({
+        channel_id: root.channel_id,
+        message: "top-level bot post",
+        post_id: root.id,
+        root_id: "",
+      }),
+      headers: {
+        authorization: "Bearer fake",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+    expect(ignoredPostId.status).toBe(201);
+    await expect(ignoredPostId.json()).resolves.toMatchObject({ root_id: "" });
+
     const reply = await fetch(`${server.manifest.endpoints.apiRoot}/posts`, {
       body: JSON.stringify({
         channel_id: root.channel_id,
         message: "bot reply",
-        post_id: root.id,
-        root_id: "",
+        root_id: root.id,
       }),
       headers: {
         authorization: "Bearer fake",
@@ -716,7 +731,7 @@ describe("Mattermost local provider server", () => {
     });
   });
 
-  it("disconnects slow WebSocket clients and queues undelivered events", async () => {
+  it("distinguishes oversized inbound events from a full disconnected queue", async () => {
     const server = await startMattermostServer({
       adminToken: "admin",
       botToken: "fake",
@@ -735,7 +750,6 @@ describe("Mattermost local provider server", () => {
       }),
     );
     await authenticated;
-    const closed = waitForSocketClose(socket);
     const sendInbound = (text: string) =>
       fetch(server.manifest.endpoints.adminInboundUrl, {
         body: JSON.stringify({ channelId: "channel-1", senderId: "user-1", text }),
@@ -746,14 +760,28 @@ describe("Mattermost local provider server", () => {
         method: "POST",
       });
 
-    expect((await sendInbound("x".repeat(2_000))).status).toBe(503);
-    await expect(closed).resolves.toEqual({ code: 1013, reason: "client too slow" });
+    const noOversizedEvent = expectNoSocketMessage(socket);
+    const oversized = await sendInbound("x".repeat(2_000));
+    expect(oversized.status).toBe(413);
+    await expect(oversized.json()).resolves.toEqual({
+      error: "Inbound event is too large",
+      ok: false,
+    });
+    await noOversizedEvent;
     for (const apiPath of ["/users/user-1", "/channels/channel-1"]) {
       const response = await fetch(`${server.manifest.endpoints.apiRoot}${apiPath}`, {
         headers: { authorization: "Bearer fake" },
       });
       expect(response.status).toBe(404);
     }
+
+    const delivered = nextMessage(socket);
+    expect((await sendInbound("delivered after oversized event")).status).toBe(200);
+    await expect(delivered).resolves.toMatchObject({ event: "posted" });
+    const closed = waitForSocketClose(socket);
+    socket.close();
+    await closed;
+
     expect((await sendInbound("queued after oversized event")).status).toBe(200);
     expect((await sendInbound("queue is full")).status).toBe(503);
   });

--- a/test/signal-server.test.ts
+++ b/test/signal-server.test.ts
@@ -512,6 +512,77 @@ describe("signal local provider server", () => {
     }
   });
 
+  it("fans pending events out to every connected SSE client", async () => {
+    const server = await startSignalServer({ adminToken: "admin" });
+    servers.push(server);
+    const sendInbound = (text: string) =>
+      fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({ sourceNumber: "+15557654321", text }),
+        headers: {
+          "content-type": "application/json",
+          "x-crabline-admin-token": "admin",
+        },
+        method: "POST",
+      });
+    for (const text of ["first pending", "second pending", "third pending"]) {
+      expect((await sendInbound(text)).status).toBe(200);
+    }
+
+    const originalWrite = ServerResponse.prototype.write;
+    let backpressuredResponse: ServerResponse | undefined;
+    const write = vi.spyOn(ServerResponse.prototype, "write").mockImplementation(function (
+      this: ServerResponse,
+      ...args: Parameters<typeof originalWrite>
+    ) {
+      const accepted = Reflect.apply(originalWrite, this, args) as boolean;
+      if (
+        backpressuredResponse === undefined &&
+        typeof args[0] === "string" &&
+        args[0].includes("first pending")
+      ) {
+        backpressuredResponse = this;
+        return false;
+      }
+      return accepted;
+    });
+    const firstController = new AbortController();
+    const secondController = new AbortController();
+    const readPendingEvents = async (response: Response) => {
+      const reader = response.body!.getReader();
+      const decoder = new TextDecoder();
+      let received = "";
+      while (!received.includes("third pending")) {
+        const chunk = await reader.read();
+        if (chunk.done) {
+          break;
+        }
+        received += decoder.decode(chunk.value, { stream: true });
+      }
+      return received;
+    };
+    try {
+      const firstEvents = await fetch(server.manifest.endpoints.eventsUrl, {
+        signal: firstController.signal,
+      });
+      await vi.waitFor(() => expect(backpressuredResponse).toBeDefined());
+      const secondEvents = await fetch(server.manifest.endpoints.eventsUrl, {
+        signal: secondController.signal,
+      });
+      firstController.abort();
+      await firstEvents.body?.cancel().catch(() => undefined);
+
+      const received = await readPendingEvents(secondEvents);
+      expect(received).toContain("first pending");
+      expect(received).toContain("second pending");
+      expect(received).toContain("third pending");
+      expect((await sendInbound("after disconnect")).status).toBe(200);
+    } finally {
+      firstController.abort();
+      secondController.abort();
+      write.mockRestore();
+    }
+  });
+
   it("moves near-capacity pending events into a client buffer without double-counting", async () => {
     const server = await startSignalServer({
       adminToken: "admin",

--- a/test/slack-server.test.ts
+++ b/test/slack-server.test.ts
@@ -639,6 +639,48 @@ describe("slack local provider server", () => {
     await expect(history.json()).resolves.toMatchObject({ messages: [], ok: true });
   });
 
+  it("validates chat.postMessage metadata format and schema", async () => {
+    const server = await startTestSlackServer();
+    for (const [metadata, error] of [
+      ["{", "invalid_metadata_format"],
+      ["[]", "invalid_metadata_format"],
+      [null, "invalid_metadata_format"],
+      [{ event_payload: {} }, "invalid_metadata_schema"],
+      [{ event_type: "task_created" }, "invalid_metadata_schema"],
+      [{ event_payload: [], event_type: "task_created" }, "invalid_metadata_schema"],
+      [{ event_payload: {}, event_type: " " }, "invalid_metadata_schema"],
+    ] as const) {
+      const response = await slackApi(server, "chat.postMessage", {
+        channel: "C1234567890",
+        metadata,
+        text: "must not persist",
+      });
+      await expect(response.json()).resolves.toEqual({ error, ok: false });
+    }
+
+    const metadata = {
+      event_payload: { id: "task-1" },
+      event_type: "task_created",
+    };
+    const accepted = await slackApi(server, "chat.postMessage", {
+      channel: "C1234567890",
+      metadata: JSON.stringify(metadata),
+      text: "valid metadata",
+    });
+    await expect(accepted.json()).resolves.toMatchObject({
+      message: { metadata },
+      ok: true,
+    });
+
+    const history = await slackApi(server, "conversations.history", {
+      channel: "C1234567890",
+    });
+    await expect(history.json()).resolves.toMatchObject({
+      messages: [{ metadata, text: "valid metadata" }],
+      ok: true,
+    });
+  });
+
   it("delivers authenticated admin inbound through signed Slack Events API requests", async () => {
     type DeliveredEvent = {
       body: string;

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -165,6 +165,65 @@ describe("telegram local provider server", () => {
     expect(shorterUsername.status).toBe(400);
   });
 
+  it("normalizes non-positive topic ids while preserving private-chat topics", async () => {
+    const server = await startTelegramServer({ botToken: "test-token-placeholder" });
+    servers.push(server);
+    const sendMessage = (messageThreadId: number) =>
+      fetch(`${server.manifest.baseUrl}/bottest-token-placeholder/sendMessage`, {
+        body: JSON.stringify({
+          chat_id: 42,
+          message_thread_id: messageThreadId,
+          text: "private topic",
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+
+    for (const messageThreadId of [0, -1]) {
+      const response = await sendMessage(messageThreadId);
+      const payload = (await response.json()) as {
+        result: { message_thread_id?: number };
+      };
+      expect(response.status).toBe(200);
+      expect(payload.result).not.toHaveProperty("message_thread_id");
+    }
+
+    const privateTopic = await sendMessage(42);
+    await expect(privateTopic.json()).resolves.toMatchObject({
+      result: {
+        chat: { id: 42, type: "private" },
+        message_thread_id: 42,
+      },
+    });
+
+    for (const messageThreadId of [0, -1]) {
+      const response = await injectUpdate(server, {
+        chatId: 42,
+        messageThreadId,
+        text: "private inbound",
+      });
+      const payload = (await response.json()) as {
+        update: { message: { message_thread_id?: number } };
+      };
+      expect(response.status).toBe(200);
+      expect(payload.update.message).not.toHaveProperty("message_thread_id");
+    }
+
+    const privateInboundTopic = await injectUpdate(server, {
+      chatId: 42,
+      messageThreadId: 42,
+      text: "private inbound topic",
+    });
+    await expect(privateInboundTopic.json()).resolves.toMatchObject({
+      update: {
+        message: {
+          chat: { id: 42, type: "private" },
+          message_thread_id: 42,
+        },
+      },
+    });
+  });
+
   it("serves Telegram Bot API calls and queues injected inbound updates", async () => {
     const directory = await createTempDir();
     directories.push(directory);

--- a/test/webhook-target.test.ts
+++ b/test/webhook-target.test.ts
@@ -154,11 +154,12 @@ describe("webhook target validation", () => {
     if (!address || typeof address === "string") {
       throw new Error("Unable to resolve webhook receiver.");
     }
-    const url = new URL(`http://127.0.0.1:${address.port}/webhook`);
+    const pinnedAddress = { address: "127.0.0.1", family: 4 as const };
+    const url = new URL(`http://dns-pinning.invalid:${address.port}/webhook`);
 
     try {
-      await postWebhookRequest({ body: "{}", timeoutMs: 1_000, url });
-      await postWebhookRequest({ body: "{}", timeoutMs: 1_000, url });
+      await postWebhookRequest({ address: pinnedAddress, body: "{}", timeoutMs: 1_000, url });
+      await postWebhookRequest({ address: pinnedAddress, body: "{}", timeoutMs: 1_000, url });
       expect(remotePorts).toHaveLength(2);
       expect(new Set(remotePorts).size).toBe(2);
     } finally {

--- a/test/zalo-server.test.ts
+++ b/test/zalo-server.test.ts
@@ -177,12 +177,26 @@ describe("Zalo local provider server", () => {
     const server = await startZaloServer({ botToken: "test-token-placeholder", recorderPath });
     servers.push(server);
     try {
+      const webhookUrl = new URL(
+        ["http://", "alice", ":", "sample", `@127.0.0.1:${address.port}/zalo`].join(""),
+      );
+      for (const [key, value] of [
+        ["mode", "test"],
+        [["access", "Token"].join(""), "alpha"],
+        ["password", "bravo"],
+        [["api", "Key"].join(""), "charlie"],
+        [["client", "Secret"].join(""), "delta"],
+        ["auth", "echo"],
+        [["callback", "Id"].join(""), "keep"],
+      ] as Array<[string, string]>) {
+        webhookUrl.searchParams.set(key, value);
+      }
       const setWebhook = await fetch(
         `${server.manifest.baseUrl}/bottest-token-placeholder/setWebhook`,
         {
           body: JSON.stringify({
             secret_token: "test-auth-token",
-            url: `http://alice:sample@127.0.0.1:${address.port}/zalo?mode=test`,
+            url: webhookUrl.href,
           }),
           headers: { "content-type": "application/json" },
           method: "POST",
@@ -210,13 +224,14 @@ describe("Zalo local provider server", () => {
         { method: "POST" },
       );
       expect(blockedPolling.status).toBe(400);
+      const accessTokenParam = ["access", "Token"].join("");
       const malformedCredentialUrl = [
         "http://",
         "user",
         ":",
         "credential-placeholder",
         "@",
-        "127.0.0.1:bad/zalo",
+        `127.0.0.1:bad/zalo?${accessTokenParam}=foxtrot&mode=invalid`,
       ].join("");
       const invalidWebhook = await fetch(
         `${server.manifest.baseUrl}/bottest-token-placeholder/setWebhook`,
@@ -248,13 +263,21 @@ describe("Zalo local provider server", () => {
 
       const recorder = await fs.readFile(recorderPath, "utf8");
       expect(recorder).toContain('"secret_token":"<redacted>"');
-      expect(recorder).toContain(`http://<redacted>@127.0.0.1:${address.port}/zalo?mode=test`);
+      expect(recorder).toContain(
+        `http://<redacted>@127.0.0.1:${address.port}/zalo?mode=test&accessToken=<redacted>&password=<redacted>&apiKey=<redacted>&clientSecret=<redacted>&auth=<redacted>&callbackId=keep`,
+      );
+      expect(recorder).toContain(
+        "http://<redacted>@127.0.0.1:bad/zalo?accessToken=<redacted>&mode=invalid",
+      );
       expect(recorder).toContain("<redacted>@example.com/hook");
       expect(recorder).not.toContain("test-auth-token");
       expect(recorder).not.toContain("alice");
       expect(recorder).not.toContain("sample");
       expect(recorder).not.toContain("credential-placeholder");
       expect(recorder).not.toContain("protocol-user");
+      for (const secret of ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot"]) {
+        expect(recorder).not.toContain(secret);
+      }
     } finally {
       await new Promise<void>((resolve, reject) =>
         webhook.close((error) => (error ? reject(error) : resolve())),


### PR DESCRIPTION
## Summary

- reject trailing Matrix bearer material and preserve provider-native Mattermost threading and oversize errors
- fan pending Signal SSE events out to every connected client
- validate Slack metadata, normalize Telegram non-positive topic IDs, and redact Zalo query credentials

## Validation

- focused server tests (198 passed)
- `pnpm verify` (852 passed)
- privacy scan clean

## Audit disposition

No non-native bind restriction, ORCHIDv2 rule, or `.localhost` policy was added.