### PR TITLE
fix(openclaw): emit nested streaming config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Emit nested OpenClaw streaming config from the Matrix and Mattermost provider bridges.
 - Harden CLI secret ingress and numeric parsing, provider cancellation and script thread propagation, timer bounds, review fixtures, and dependency review coverage.
 - Complete final provider remediation across authenticated webhook exposure, native callback decoding, interaction values, target identities, JWT boundaries, and bounded ingress shutdown.
 - Fan out queued Signal events, tighten Matrix, Slack, Mattermost, Telegram, and Zalo protocol fidelity, and exercise DNS-pinned webhook delivery.

--- a/src/openclaw/bridges/matrix.ts
+++ b/src/openclaw/bridges/matrix.ts
@@ -129,7 +129,6 @@ export const MATRIX_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablinePr
                 matrix: {
                   ...matrixConfig,
                   accessToken: matrix.accessToken,
-                  blockStreaming: false,
                   dm: {
                     ...dmConfig,
                     allowFrom: ["*"],
@@ -141,7 +140,10 @@ export const MATRIX_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablinePr
                   groupPolicy: "open",
                   homeserver: matrix.baseUrl,
                   network: { dangerouslyAllowPrivateNetwork: true },
-                  streaming: "off",
+                  streaming: {
+                    mode: "off",
+                    block: { enabled: false },
+                  },
                   userId: matrix.botUserId,
                 },
               },

--- a/src/openclaw/bridges/mattermost.ts
+++ b/src/openclaw/bridges/mattermost.ts
@@ -79,7 +79,7 @@ export const MATTERMOST_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabli
                   groupAllowFrom: ["*"],
                   groupPolicy: "open",
                   network: { dangerouslyAllowPrivateNetwork: true },
-                  streaming: "off",
+                  streaming: { mode: "off" },
                 },
               },
             };

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -281,6 +281,26 @@ const zaloManifest: CrablineServerManifest = {
 };
 
 describe("OpenClaw local provider bridge", () => {
+  it.each([
+    ["mattermost", mattermostManifest],
+    ["matrix", matrixManifest],
+    ["signal", signalManifest],
+    ["slack", slackManifest],
+    ["telegram", manifest],
+    ["whatsapp", whatsappManifest],
+    ["zalo", zaloManifest],
+  ] as const)("emits canonical streaming config for the %s bridge", (channel, providerManifest) => {
+    const config = createOpenClawCrablineProviderBinding(providerManifest).createGatewayConfig();
+    const channels = isRecord(config.channels) ? config.channels : {};
+    const channelConfig = isRecord(channels[channel]) ? channels[channel] : {};
+
+    expect(channelConfig).not.toHaveProperty("blockStreaming");
+    expect(channelConfig).not.toHaveProperty("blockStreamingCoalesce");
+    expect(channelConfig).not.toHaveProperty("chunkMode");
+    expect(channelConfig).not.toHaveProperty("draftChunk");
+    expect(channelConfig.streaming === undefined || isRecord(channelConfig.streaming)).toBe(true);
+  });
+
   it("keeps legacy fake-provider root aliases", () => {
     const legacyManifest: CrablineFakeProviderManifest = manifest;
     const conversation: OpenClawCrablineConversation = {
@@ -2184,7 +2204,7 @@ describe("OpenClaw local provider bridge", () => {
       requiredPluginIds: ["mattermost"],
     });
     expect(binding.createGatewayConfig()).toMatchObject({
-      channels: { mattermost: { chatmode: "onmessage", streaming: "off" } },
+      channels: { mattermost: { chatmode: "onmessage", streaming: { mode: "off" } } },
     });
 
     const threadInbound = createOpenClawCrablineInbound({
@@ -2431,6 +2451,7 @@ describe("OpenClaw local provider bridge", () => {
           encryption: false,
           homeserver: "http://127.0.0.1:8642",
           network: { dangerouslyAllowPrivateNetwork: true },
+          streaming: { mode: "off", block: { enabled: false } },
           userId: "@openclaw:matrix.test",
         },
       },


### PR DESCRIPTION
## What Problem This Solves

Fixes #103.

`@openclaw/crabline` 0.1.9 generates legacy scalar/flat channel streaming config. OpenClaw's current schema rejects that output, blocking qa-lab gateway startup without an OpenClaw-side normalization workaround.

## Why This Change Was Made

- Emit Matrix `streaming.mode` and `streaming.block.enabled` in the supported nested shape.
- Emit Mattermost `streaming.mode` in the supported nested shape.
- Audit all seven bridge outputs with a shared regression assertion that rejects legacy root keys and scalar `streaming` values.
- Preserve existing behavior: preview streaming remains off; Matrix block streaming remains disabled.

## User Impact

OpenClaw can consume Crabline-generated Matrix and Mattermost configs directly. After release, OpenClaw can bump its pin and remove the qa-lab compatibility seam.

## Evidence

- `pnpm verify` — 56 test files, 888 tests; lint, typecheck, coverage pass.
- `pnpm build` — pass.
- `pnpm test test/openclaw.test.ts` — 72 tests pass.
- Source-blind package probe: registry 0.1.9 reproduces Matrix `streaming: "off"` plus `blockStreaming`, and Mattermost `streaming: "off"`; packed candidate emits the required nested objects and no legacy root keys across all seven bridges.
- Autoreview — no accepted/actionable findings.

OpenClaw follow-up: https://github.com/openclaw/openclaw/pull/105808
