### PR TITLE
chore: prepare Crabline 0.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.1.10 - 2026-07-13
 
 - Emit nested OpenClaw streaming config from the Matrix and Mattermost provider bridges.
 - Harden CLI secret ingress and numeric parsing, provider cancellation and script thread propagation, timer bounds, review fixtures, and dependency review coverage.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/crabline",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Standalone CLI for deterministic messaging provider E2E tests",
   "homepage": "https://github.com/openclaw/crabline#readme",
   "bugs": {


### PR DESCRIPTION
## What Problem This Solves

Prepare the first Crabline release containing the nested OpenClaw streaming config fix from #104, plus the accumulated `Unreleased` changes.

## Why This Change Was Made

- Set `@openclaw/crabline` to 0.1.10.
- Date the existing changelog section for the release workflow's exact metadata gate.

## User Impact

Publishing 0.1.10 lets OpenClaw replace its 0.1.9 pin and delete the qa-lab streaming normalization workaround.

## Evidence

- Release metadata check mirrors `.github/workflows/release.yml` and passes.
- `git diff --check` passes.
- Exact parent `main` commit passed local `pnpm verify`: 56 test files, 888 tests; lint, typecheck, coverage pass.
- Tag publication remains gated on the release workflow's build, verify, tarball-integrity, OIDC publication, registry, and GitHub Release checks.

Related: #103, #104, https://github.com/openclaw/openclaw/pull/105808
