### PR TITLE
fix(telegram): contain disconnected response writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## Unreleased
+## 0.1.11 - 2026-07-13
 
+- Contain Telegram response delivery failures when clients disconnect during request handling.
 - Recover interrupted artifact and recorder writes, publish immutable readiness evidence, and harden private-directory and smoke-lock durability.
 
 ## 0.1.10 - 2026-07-13

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/crabline",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Standalone CLI for deterministic messaging provider E2E tests",
   "homepage": "https://github.com/openclaw/crabline#readme",
   "bugs": {

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -1,4 +1,4 @@
-import { createServer, type IncomingMessage } from "node:http";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { randomBytes } from "node:crypto";
 import path from "node:path";
 import { CrablineError } from "../core/errors.js";
@@ -1310,6 +1310,32 @@ async function handleRequest(params: { request: IncomingMessage; state: Telegram
   });
 }
 
+async function serveRequest(params: {
+  request: IncomingMessage;
+  response: ServerResponse;
+  state: TelegramServerState;
+}): Promise<void> {
+  let fetchResponse: Response;
+  try {
+    fetchResponse = await handleRequest({ request: params.request, state: params.state });
+  } catch (error) {
+    fetchResponse =
+      error instanceof InvalidJsonBodyError
+        ? telegramError("Bad Request: can't parse JSON object")
+        : error instanceof RequestBodyTooLargeError
+          ? telegramError("Request Entity Too Large", 413)
+          : jsonResponse({ error: "internal server error", ok: false }, 500);
+  }
+
+  try {
+    await writeResponse(params.response, fetchResponse);
+  } catch {
+    // A disconnected client cannot receive an error fallback. End delivery here
+    // so the Node request callback never leaks an unhandled rejection.
+    params.response.destroy();
+  }
+}
+
 export async function startTelegramServer(
   params: StartTelegramServerParams = {},
 ): Promise<StartedTelegramServer> {
@@ -1348,19 +1374,8 @@ export async function startTelegramServer(
     webhookRetryUpdateId: undefined,
   };
   const port = params.port ?? 0;
-  const server = createServer(async (request, response) => {
-    try {
-      await writeResponse(response, await handleRequest({ request, state }));
-    } catch (error) {
-      await writeResponse(
-        response,
-        error instanceof InvalidJsonBodyError
-          ? telegramError("Bad Request: can't parse JSON object")
-          : error instanceof RequestBodyTooLargeError
-            ? telegramError("Request Entity Too Large", 413)
-            : jsonResponse({ error: "internal server error", ok: false }, 500),
-      );
-    }
+  const server = createServer((request, response) => {
+    void serveRequest({ request, response, state });
   });
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject);

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -1884,6 +1884,39 @@ describe("telegram local provider server", () => {
     ]);
   });
 
+  it("survives a client disconnect while preparing a response", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    let releaseObserver: (() => void) | undefined;
+    const observerReleased = new Promise<void>((resolve) => {
+      releaseObserver = resolve;
+    });
+    let markObserverEntered: (() => void) | undefined;
+    const observerEntered = new Promise<void>((resolve) => {
+      markObserverEntered = resolve;
+    });
+    const server = await startTelegramServer({
+      botToken: "test-token-placeholder",
+      onEvent: async () => {
+        markObserverEntered?.();
+        await observerReleased;
+      },
+      recorderPath: path.join(directory, "telegram-disconnect.jsonl"),
+    });
+    servers.push(server);
+
+    const request = httpRequest(`${server.manifest.baseUrl}/bottest-token-placeholder/getMe`);
+    request.on("error", () => {});
+    request.end();
+    await observerEntered;
+    request.destroy();
+    releaseObserver?.();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    const response = await fetch(`${server.manifest.baseUrl}/bottest-token-placeholder/getMe`);
+    await expect(response.json()).resolves.toMatchObject({ ok: true });
+  });
+
   it("bounds webhook DNS validation with the delivery deadline", async () => {
     const controller = new AbortController();
     await expect(


### PR DESCRIPTION
## What Problem This Solves

Closes #106.

Crabline 0.1.10 could leak an unhandled rejection when a Telegram API client disconnected while the local provider server was preparing a response. OpenClaw qa-lab exposed this after its 0.1.10 upgrade: both QA Smoke profiles completed their scenarios, then failed during shutdown because response delivery retried against an already-closed socket.

## Why This Change Was Made

Request-handler failures and response-delivery failures now have separate terminal paths. Handler failures retain the existing Telegram error mapping; delivery failures destroy the response without attempting a second write. The release metadata prepares 0.1.11 so OpenClaw can consume the fix.

## User Impact

Telegram-backed Crabline QA runs can shut down after client disconnects without leaking an unhandled rejection, and the server remains usable for later requests.

## Evidence

- Focused Telegram server suite: 41/41 passed.
- Full serial coverage: 56/56 files and 920/920 tests passed.
- Lint, formatting, typecheck, and build passed.
- Fresh autoreview: clean, 0.91.
- Packed 0.1.11 source-blind validation: public import passed; client disconnect emitted zero unhandled rejections; later Telegram API request passed.
- OpenClaw failing evidence: exact-head CI run 29221395742, both QA Smoke profiles.

The normal parallel local coverage lane also reproduced existing timing/cleanup flakes under workstation contention; all affected files passed serially, and the full single-worker coverage run passed.
