### PR TITLE
fix(tooling): harden release and test contracts

### DIFF
--- a/.agents/skills/autoreview/scripts/test-review-harness.py
+++ b/.agents/skills/autoreview/scripts/test-review-harness.py
@@ -196,7 +196,10 @@ def run_reviews(repo: Path, script_dir: Path, fixture: str, engines: list[str]) 
 def cleanup_repo(repo: Path) -> None:
     def make_writable_and_retry(function: Callable[[str], object], path: str, _exc_info: object) -> None:
         try:
-            os.chmod(path, stat.S_IREAD | stat.S_IWRITE)
+            mode = stat.S_IREAD | stat.S_IWRITE
+            if os.path.isdir(path):
+                mode |= stat.S_IEXEC
+            os.chmod(path, mode)
             function(path)
         except OSError as exc:
             print(f"warning: unable to remove temp path {path}: {exc}", file=sys.stderr)

--- a/.agents/skills/autoreview/tests/test_autoreview_hardening.py
+++ b/.agents/skills/autoreview/tests/test_autoreview_hardening.py
@@ -73,6 +73,30 @@ class AutoreviewHardeningTests(unittest.TestCase):
         for disabled_engine in ("droid", "copilot", "opencode", "cursor"):
             self.assertNotIn(f"'{disabled_engine}'", harness)
 
+    @unittest.skipIf(os.name == "nt", "POSIX directory traversal mode test")
+    def test_harness_cleanup_restores_directory_traversal_before_retry(self) -> None:
+        harness = SCRIPT.with_name("test-review-harness.py")
+        cleanup_repo = runpy.run_path(str(harness))["cleanup_repo"]
+        with tempfile.TemporaryDirectory() as tempdir:
+            repo = Path(tempdir) / "repo"
+            repo.mkdir()
+            repo.chmod(0o600)
+            retried_modes: list[int] = []
+
+            def fake_rmtree(path: Path, *, onerror: object) -> None:
+                callback = onerror
+
+                def retry(target: str) -> None:
+                    retried_modes.append(stat.S_IMODE(os.stat(target).st_mode))
+
+                callback(retry, str(path), None)
+
+            with mock.patch.object(shutil, "rmtree", side_effect=fake_rmtree):
+                cleanup_repo(repo)
+
+            self.assertEqual(retried_modes, [0o700])
+            repo.chmod(0o700)
+
     def test_powershell_wrappers_launch_only_verified_python3(self) -> None:
         scripts = SCRIPT.parent
         wrappers = {
@@ -89,6 +113,63 @@ class AutoreviewHardeningTests(unittest.TestCase):
                 self.assertIn("-CommandType Application", wrapper)
                 self.assertIn("sys.version_info.major == 3", wrapper)
                 self.assertIn(f"Join-Path $PSScriptRoot '{helper}'", wrapper)
+
+    @unittest.skipUnless(os.name == "nt", "native PowerShell wrapper execution test")
+    def test_powershell_wrappers_fallback_quote_and_propagate_exit(self) -> None:
+        powershell = shutil.which("powershell") or shutil.which("pwsh")
+        if powershell is None:
+            self.skipTest("PowerShell is unavailable")
+
+        scripts = SCRIPT.parent
+        cases = (
+            ("autoreview.ps1", ["--help", "two words"], "autoreview"),
+            (
+                "test-review-harness.ps1",
+                ["-Fixture", "benign", "-Engine", "codex"],
+                "test-review-harness.py",
+            ),
+        )
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            log_path = root / "launch.log"
+            (root / "py.cmd").write_text("@echo off\r\nexit /b 1\r\n", encoding="utf-8")
+            (root / "python3.cmd").write_text(
+                "@echo off\r\n"
+                'if "%~1"=="-c" exit /b 0\r\n'
+                'echo %*>>"%WRAPPER_LOG%"\r\n'
+                "exit /b 23\r\n",
+                encoding="utf-8",
+            )
+            env = os.environ.copy()
+            env.update(
+                {
+                    "PATH": f"{root}{os.pathsep}{env.get('PATH', '')}",
+                    "WRAPPER_LOG": str(log_path),
+                }
+            )
+
+            for filename, arguments, helper in cases:
+                with self.subTest(filename=filename):
+                    result = subprocess.run(
+                        [
+                            powershell,
+                            "-NoProfile",
+                            "-ExecutionPolicy",
+                            "Bypass",
+                            "-File",
+                            str(scripts / filename),
+                            *arguments,
+                        ],
+                        check=False,
+                        env=env,
+                        text=True,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                    )
+                    self.assertEqual(result.returncode, 23, result.stderr)
+                    launched = log_path.read_text(encoding="utf-8").splitlines()[-1]
+                    self.assertIn(helper, launched)
+                    self.assertIn("two words" if filename == "autoreview.ps1" else "--fixture benign", launched)
 
     @unittest.skipIf(os.name == "nt", "POSIX harness wrapper test")
     def test_posix_harness_skips_non_python3_fallbacks(self) -> None:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,12 +255,20 @@ jobs:
           PACKAGE_TARBALL="${tarballs[0]}"
 
           check_existing_package() {
-            local actual_integrity
+            local actual_integrity actual_provenance
             if ! actual_integrity="$(npm view "$PACKAGE_NAME@$RELEASE_VERSION" dist.integrity 2>/dev/null)"; then
               return 1
             fi
+            if ! actual_provenance="$(npm view "$PACKAGE_NAME@$RELEASE_VERSION" dist.attestations.provenance.predicateType 2>/dev/null)"; then
+              echo "::error::Published $PACKAGE_NAME@$RELEASE_VERSION is missing npm provenance."
+              return 2
+            fi
             if [[ "$actual_integrity" != "$PACKAGE_INTEGRITY" ]]; then
               echo "::error::Published $PACKAGE_NAME@$RELEASE_VERSION has integrity $actual_integrity, expected $PACKAGE_INTEGRITY."
+              return 2
+            fi
+            if [[ "$actual_provenance" != "https://slsa.dev/provenance/v1" ]]; then
+              echo "::error::Published $PACKAGE_NAME@$RELEASE_VERSION has unsupported provenance predicate $actual_provenance."
               return 2
             fi
             return 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Harden provider adapter authentication, target identity, credential redaction, and webhook lifecycle behavior.
+- Harden release provenance retries, provider-native contract tests, cross-platform tooling, cleanup ordering, and channel setup coverage.
 
 ## 0.1.11 - 2026-07-13
 

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -72,8 +72,8 @@ providers:
 ```
 
 Provider credential fields such as `botToken`, `accessToken`, `baseURL`, or
-`serverUrl` are optional mock metadata. They are not required for local mock
-execution.
+`serverUrl` are optional mock metadata for loopback execution. Externally
+reachable Discord webhooks require `publicKey` or `DISCORD_PUBLIC_KEY`.
 
 Optional webhook credentials enforce each provider's native authentication
 header before JSON parsing or recorder writes:
@@ -155,7 +155,7 @@ Each command receives one JSON document on stdin. Every payload contains the
 parsed `fixture` plus `provider.config`, `provider.id`, and
 `provider.manifestPath`. `send` adds `outbound` with `mode`, `nonce`, normalized
 `target`, and `text`; `waitForInbound` adds `wait` with `excludeIds`, `nonce`,
-`since`, normalized `target`, and `timeoutMs`. A stateless wait bridge must
+`since`, `threadId`, normalized `target`, and `timeoutMs`. A stateless wait bridge must
 exclude messages whose IDs are listed in `excludeIds` while retaining later
 messages with the same timestamp. Crabline retains at most 1024 unmatched IDs
 per wait. `watch` adds `watch` with optional `since` and normalized `target`.
@@ -340,6 +340,11 @@ The admin ingress accepts JSON like:
 OpenClaw consumes that message through Telegram `getUpdates`; outbound adapter
 sends are recorded through Telegram `sendMessage` and the media send endpoints
 `sendPhoto`, `sendDocument`, `sendVideo`, `sendAudio`, and `sendAnimation`.
+Compatible clients may switch to webhook delivery with `setWebhook`, including
+an optional `secret_token` that Crabline returns as
+`X-Telegram-Bot-Api-Secret-Token`. `deleteWebhook` restores polling. While a
+webhook is configured, `getUpdates` returns Telegram's native conflict error
+instead of consuming updates.
 
 WhatsApp:
 

--- a/test/ci-workflow.test.ts
+++ b/test/ci-workflow.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { parse } from "yaml";
 
@@ -29,11 +30,25 @@ describe("CI workflow hardening", () => {
     );
   });
 
-  it("pins CodeQL actions to immutable revisions", async () => {
-    const workflow = await readWorkflow(".github/workflows/codeql.yml");
-    const actionRefs = Object.values(workflow.jobs ?? {}).flatMap(
-      (job) => job.steps?.map((step) => step.uses).filter(Boolean) ?? [],
-    );
+  it("pins every external workflow action to immutable revisions", async () => {
+    const workflowDirectory = ".github/workflows";
+    const workflowFiles = (await fs.readdir(workflowDirectory))
+      .filter((entry) => /\.ya?ml$/u.test(entry))
+      .map((entry) => path.join(workflowDirectory, entry));
+    const actionRefs = (
+      await Promise.all(
+        workflowFiles.map(async (filePath) => {
+          const workflow = await readWorkflow(filePath);
+          return Object.values(workflow.jobs ?? {}).flatMap(
+            (job) =>
+              job.steps
+                ?.map((step) => step.uses)
+                .filter((uses): uses is string => uses !== undefined && !uses.startsWith("./")) ??
+              [],
+          );
+        }),
+      )
+    ).flat();
 
     expect(actionRefs).not.toEqual([]);
     for (const actionRef of actionRefs) {

--- a/test/feishu-provider.test.ts
+++ b/test/feishu-provider.test.ts
@@ -568,4 +568,14 @@ runLocalMockProviderContract({
     },
   },
   webhookThreadId: "oc_abc123",
+  userWebhookPayload: (nonce) => ({
+    event: {
+      message: {
+        chat_id: "oc_abc123",
+        content: JSON.stringify({ text: `user ${nonce}` }),
+        message_id: "om_user123",
+        message_type: "text",
+      },
+    },
+  }),
 });

--- a/test/googlechat-provider.test.ts
+++ b/test/googlechat-provider.test.ts
@@ -340,4 +340,13 @@ runLocalMockProviderContract({
     },
   },
   webhookThreadId: "spaces/AAAABbbbCCC/threads/BBBBccccDDD",
+  userWebhookPayload: (nonce) => ({
+    message: {
+      name: "spaces/AAAABbbbCCC/messages/user-inbound",
+      sender: { type: "HUMAN" },
+      space: { name: "spaces/AAAABbbbCCC" },
+      text: `user ${nonce}`,
+      thread: { name: "spaces/AAAABbbbCCC/threads/BBBBccccDDD" },
+    },
+  }),
 });

--- a/test/imessage-provider.test.ts
+++ b/test/imessage-provider.test.ts
@@ -192,4 +192,11 @@ runLocalMockProviderContract({
     text: "reply nonce-2",
   },
   webhookThreadId: "iMessage;-;chat-guid-1",
+  userWebhookPayload: (nonce) => ({
+    chatIdentifier: "+15551234567",
+    chatGuid: "iMessage;-;chat-guid-1",
+    guid: "imsg-user-inbound",
+    isFromMe: false,
+    text: `user ${nonce}`,
+  }),
 });

--- a/test/local-mock-provider-helpers.ts
+++ b/test/local-mock-provider-helpers.ts
@@ -36,6 +36,7 @@ type ContractOptions = {
   };
   webhookPayload: unknown;
   webhookThreadId: string;
+  userWebhookPayload: (nonce: string) => unknown;
   platform: ProviderPlatform;
 };
 
@@ -43,10 +44,23 @@ const directories: string[] = [];
 const providers: ProviderAdapter[] = [];
 
 afterEach(async () => {
-  await settleCleanup([
-    ...providers.splice(0).map(async (provider) => provider.cleanup?.()),
-    ...directories.splice(0).map(disposeTempDir),
-  ]);
+  const failures: unknown[] = [];
+  try {
+    await settleCleanup(providers.splice(0).map(async (provider) => provider.cleanup?.()));
+  } catch (error) {
+    failures.push(error);
+  }
+  try {
+    await settleCleanup(directories.splice(0).map(disposeTempDir));
+  } catch (error) {
+    failures.push(error);
+  }
+  if (failures.length === 1) {
+    throw failures[0];
+  }
+  if (failures.length > 1) {
+    throw new AggregateError(failures, "Provider and recorder cleanup failed.");
+  }
 });
 
 export async function createLocalMockConfig(
@@ -257,14 +271,7 @@ export function runLocalMockProviderContract(options: ContractOptions): void {
       const endpoint = endpointFromDetails((await provider.probe(context)).details);
       const since = new Date(Date.now() - 1000).toISOString();
 
-      const webhookBody = JSON.stringify({
-        message: {
-          author: "user",
-          id: `${options.platform}-user-inbound`,
-          text: `user ${nonce}`,
-          threadId: options.expectedChannelId,
-        },
-      });
+      const webhookBody = JSON.stringify(options.userWebhookPayload(nonce));
       const response = await fetch(endpoint, {
         body: webhookBody,
         headers: webhookHeaders(options.platform, config, webhookBody),
@@ -282,7 +289,6 @@ export function runLocalMockProviderContract(options: ContractOptions): void {
         }),
       ).resolves.toMatchObject({
         author: "user",
-        id: `${options.platform}-user-inbound`,
         text: `user ${nonce}`,
       });
     });

--- a/test/local-mock-provider.test.ts
+++ b/test/local-mock-provider.test.ts
@@ -36,10 +36,23 @@ beforeEach(() => {
 });
 
 afterEach(async () => {
-  await settleCleanup([
-    ...providers.splice(0).map(async (provider) => provider.cleanup?.()),
-    ...directories.splice(0).map(disposeTempDir),
-  ]);
+  const failures: unknown[] = [];
+  try {
+    await settleCleanup(providers.splice(0).map(async (provider) => provider.cleanup?.()));
+  } catch (error) {
+    failures.push(error);
+  }
+  try {
+    await settleCleanup(directories.splice(0).map(disposeTempDir));
+  } catch (error) {
+    failures.push(error);
+  }
+  if (failures.length === 1) {
+    throw failures[0];
+  }
+  if (failures.length > 1) {
+    throw new AggregateError(failures, "Provider and recorder cleanup failed.");
+  }
 });
 
 function sleep(ms: number): Promise<void> {

--- a/test/matrix-provider.test.ts
+++ b/test/matrix-provider.test.ts
@@ -172,4 +172,11 @@ runLocalMockProviderContract({
     type: "m.room.message",
   },
   webhookThreadId: "!abc123:matrix.org",
+  userWebhookPayload: (nonce) => ({
+    content: { body: `user ${nonce}`, msgtype: "m.text" },
+    event_id: "$user-inbound:matrix.org",
+    room_id: "!abc123:matrix.org",
+    sender: "@user:matrix.org",
+    type: "m.room.message",
+  }),
 });

--- a/test/mattermost-provider.test.ts
+++ b/test/mattermost-provider.test.ts
@@ -106,4 +106,10 @@ runLocalMockProviderContract({
     text: "reply nonce-2",
   },
   webhookThreadId: "aaaaaaaaaaaaaaaaaaaaaaaaaa:thread:bbbbbbbbbbbbbbbbbbbbbbbbbb",
+  userWebhookPayload: (nonce) => ({
+    channel_id: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+    post_id: "dddddddddddddddddddddddddd",
+    root_id: "bbbbbbbbbbbbbbbbbbbbbbbbbb",
+    text: `user ${nonce}`,
+  }),
 });

--- a/test/msteams-provider.test.ts
+++ b/test/msteams-provider.test.ts
@@ -239,4 +239,12 @@ runLocalMockProviderContract({
     type: "message",
   },
   webhookThreadId: conversationId,
+  userWebhookPayload: (nonce) => ({
+    channelId: "msteams",
+    conversation: { id: conversationId },
+    from: { role: "user" },
+    id: "teams-user-inbound",
+    text: `user ${nonce}`,
+    type: "message",
+  }),
 });

--- a/test/package-production.test.ts
+++ b/test/package-production.test.ts
@@ -6,6 +6,7 @@ import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
 
 const execFileAsync = promisify(execFile);
+const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
 const DEV_ONLY_RUNTIME_PACKAGES = ["baileys"] as const;
 const PUBLIC_RUNTIME_EXPORTS = [
   "BUILTIN_ADAPTERS",
@@ -229,7 +230,7 @@ describe("production package", () => {
         JSON.stringify({ name: "crabline-production-consumer", private: true, type: "module" }),
       );
       await execFileAsync(
-        "npm",
+        npmCommand,
         [
           "install",
           "--ignore-scripts",
@@ -375,12 +376,12 @@ describe("production package", () => {
         fs.mkdir(path.join(tempDir, "dist"), { recursive: true }),
       ]);
 
-      await execFileAsync("npm", ["run", "prebuild"], { cwd: tempDir });
+      await execFileAsync(npmCommand, ["run", "prebuild"], { cwd: tempDir });
       await expect(fs.stat(path.join(tempDir, "dist"))).rejects.toMatchObject({ code: "ENOENT" });
       expect(await fs.stat(path.join(tempDir, "coverage"))).toBeDefined();
 
       await fs.mkdir(path.join(tempDir, "dist"), { recursive: true });
-      await execFileAsync("npm", ["run", "clean"], { cwd: tempDir });
+      await execFileAsync(npmCommand, ["run", "clean"], { cwd: tempDir });
       await expect(fs.stat(path.join(tempDir, "dist"))).rejects.toMatchObject({ code: "ENOENT" });
       await expect(fs.stat(path.join(tempDir, "coverage"))).rejects.toMatchObject({
         code: "ENOENT",
@@ -432,7 +433,7 @@ type NpmPackMetadata = {
 };
 
 async function npmPackDryRun(root: string): Promise<NpmPackMetadata> {
-  const { stdout } = await execFileAsync("npm", ["pack", "--dry-run", "--json"], {
+  const { stdout } = await execFileAsync(npmCommand, ["pack", "--dry-run", "--json"], {
     cwd: root,
     maxBuffer: 10 * 1024 * 1024,
   });
@@ -441,7 +442,7 @@ async function npmPackDryRun(root: string): Promise<NpmPackMetadata> {
 
 async function npmPack(root: string, destination: string): Promise<NpmPackMetadata> {
   const { stdout } = await execFileAsync(
-    "npm",
+    npmCommand,
     ["pack", "--json", "--pack-destination", destination],
     {
       cwd: root,

--- a/test/package-production.test.ts
+++ b/test/package-production.test.ts
@@ -423,6 +423,12 @@ describe("production package", () => {
       expect(parseNpmPackOutput(output)).toEqual(pack);
     }
   });
+
+  it("wraps Windows npm commands for cmd /s /c quote stripping", () => {
+    expect(buildWindowsNpmCommand(["pack", "--pack-destination", "C:\\path with spaces"])).toBe(
+      '""npm.cmd" "pack" "--pack-destination" "C:\\path with spaces""',
+    );
+  });
 });
 
 type NpmPackMetadata = {
@@ -454,14 +460,18 @@ async function execNpm(
     process.platform === "win32"
       ? await execFileAsync(
           process.env.ComSpec ?? "cmd.exe",
-          ["/d", "/s", "/c", ["npm.cmd", ...args].map(quoteCmdArgument).join(" ")],
-          options,
+          ["/d", "/s", "/c", buildWindowsNpmCommand(args)],
+          { ...options, windowsVerbatimArguments: true },
         )
       : await execFileAsync("npm", args, options);
   return {
     stderr: String(result.stderr),
     stdout: String(result.stdout),
   };
+}
+
+function buildWindowsNpmCommand(args: string[]): string {
+  return `"${["npm.cmd", ...args].map(quoteCmdArgument).join(" ")}"`;
 }
 
 function quoteCmdArgument(value: string): string {

--- a/test/package-production.test.ts
+++ b/test/package-production.test.ts
@@ -6,7 +6,6 @@ import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
 
 const execFileAsync = promisify(execFile);
-const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
 const DEV_ONLY_RUNTIME_PACKAGES = ["baileys"] as const;
 const PUBLIC_RUNTIME_EXPORTS = [
   "BUILTIN_ADAPTERS",
@@ -229,8 +228,7 @@ describe("production package", () => {
         path.join(consumerDirectory, "package.json"),
         JSON.stringify({ name: "crabline-production-consumer", private: true, type: "module" }),
       );
-      await execFileAsync(
-        npmCommand,
+      await execNpm(
         [
           "install",
           "--ignore-scripts",
@@ -376,12 +374,12 @@ describe("production package", () => {
         fs.mkdir(path.join(tempDir, "dist"), { recursive: true }),
       ]);
 
-      await execFileAsync(npmCommand, ["run", "prebuild"], { cwd: tempDir });
+      await execNpm(["run", "prebuild"], { cwd: tempDir });
       await expect(fs.stat(path.join(tempDir, "dist"))).rejects.toMatchObject({ code: "ENOENT" });
       expect(await fs.stat(path.join(tempDir, "coverage"))).toBeDefined();
 
       await fs.mkdir(path.join(tempDir, "dist"), { recursive: true });
-      await execFileAsync(npmCommand, ["run", "clean"], { cwd: tempDir });
+      await execNpm(["run", "clean"], { cwd: tempDir });
       await expect(fs.stat(path.join(tempDir, "dist"))).rejects.toMatchObject({ code: "ENOENT" });
       await expect(fs.stat(path.join(tempDir, "coverage"))).rejects.toMatchObject({
         code: "ENOENT",
@@ -433,7 +431,7 @@ type NpmPackMetadata = {
 };
 
 async function npmPackDryRun(root: string): Promise<NpmPackMetadata> {
-  const { stdout } = await execFileAsync(npmCommand, ["pack", "--dry-run", "--json"], {
+  const { stdout } = await execNpm(["pack", "--dry-run", "--json"], {
     cwd: root,
     maxBuffer: 10 * 1024 * 1024,
   });
@@ -441,15 +439,33 @@ async function npmPackDryRun(root: string): Promise<NpmPackMetadata> {
 }
 
 async function npmPack(root: string, destination: string): Promise<NpmPackMetadata> {
-  const { stdout } = await execFileAsync(
-    npmCommand,
-    ["pack", "--json", "--pack-destination", destination],
-    {
-      cwd: root,
-      maxBuffer: 10 * 1024 * 1024,
-    },
-  );
+  const { stdout } = await execNpm(["pack", "--json", "--pack-destination", destination], {
+    cwd: root,
+    maxBuffer: 10 * 1024 * 1024,
+  });
   return parseNpmPackOutput(stdout);
+}
+
+async function execNpm(
+  args: string[],
+  options: Parameters<typeof execFileAsync>[2],
+): Promise<{ stderr: string; stdout: string }> {
+  const result =
+    process.platform === "win32"
+      ? await execFileAsync(
+          process.env.ComSpec ?? "cmd.exe",
+          ["/d", "/s", "/c", ["npm.cmd", ...args].map(quoteCmdArgument).join(" ")],
+          options,
+        )
+      : await execFileAsync("npm", args, options);
+  return {
+    stderr: String(result.stderr),
+    stdout: String(result.stdout),
+  };
+}
+
+function quoteCmdArgument(value: string): string {
+  return `"${value.replaceAll("%", "%%").replaceAll('"', '""')}"`;
 }
 
 function parseNpmPackOutput(output: string): NpmPackMetadata {

--- a/test/release-workflow.test.ts
+++ b/test/release-workflow.test.ts
@@ -126,6 +126,9 @@ describe("release workflow", () => {
     expect(packageStep).toContain('execFileSync("tar", ["-xzf", tarballPath');
     expect(uploadStep?.with?.path).toBe("${{ steps.package.outputs.tarball }}");
     expect(publishStep).toContain('npm view "$PACKAGE_NAME@$RELEASE_VERSION" dist.integrity');
+    expect(publishStep).toContain(
+      'npm view "$PACKAGE_NAME@$RELEASE_VERSION" dist.attestations.provenance.predicateType',
+    );
     expect(publishStep).toContain('npm view "$PACKAGE_NAME@latest" version');
     expect(publishStep).toContain('"Refusing to publish " +');
     expect(publishStep).toContain('" because npm latest is newer at " +');
@@ -274,7 +277,10 @@ describe("release workflow", () => {
     const matchingCalls = await runPublishStep(publishStep, {
       MOCK_VIEW_RESULT: "matching",
     });
-    expect(matchingCalls).toEqual(["view @openclaw/crabline@1.2.3 dist.integrity"]);
+    expect(matchingCalls).toEqual([
+      "view @openclaw/crabline@1.2.3 dist.integrity",
+      "view @openclaw/crabline@1.2.3 dist.attestations.provenance.predicateType",
+    ]);
 
     await expect(
       runPublishStep(publishStep, {
@@ -282,6 +288,20 @@ describe("release workflow", () => {
       }),
     ).rejects.toThrow(
       "::error::Published @openclaw/crabline@1.2.3 has integrity sha512-different, expected sha512-expected.",
+    );
+    await expect(
+      runPublishStep(publishStep, {
+        MOCK_PROVENANCE_RESULT: "missing",
+        MOCK_VIEW_RESULT: "matching",
+      }),
+    ).rejects.toThrow("::error::Published @openclaw/crabline@1.2.3 is missing npm provenance.");
+    await expect(
+      runPublishStep(publishStep, {
+        MOCK_PROVENANCE_RESULT: "unsupported",
+        MOCK_VIEW_RESULT: "matching",
+      }),
+    ).rejects.toThrow(
+      "::error::Published @openclaw/crabline@1.2.3 has unsupported provenance predicate https://example.invalid/provenance.",
     );
 
     const racedCalls = await runPublishStep(publishStep, {
@@ -295,6 +315,7 @@ describe("release workflow", () => {
         /publish .*\/release\/crabline-1\.2\.3\.tgz --access public --provenance$/u,
       ),
       "view @openclaw/crabline@1.2.3 dist.integrity",
+      "view @openclaw/crabline@1.2.3 dist.attestations.provenance.predicateType",
     ]);
 
     await expect(
@@ -505,6 +526,14 @@ if [[ "$2" == "$PACKAGE_NAME@latest" ]]; then
     exit "$MOCK_LATEST_STATUS"
   fi
   echo "\${MOCK_LATEST_VERSION:-1.2.2}"
+  exit 0
+fi
+if [[ "$3" == "dist.attestations.provenance.predicateType" ]]; then
+  case "\${MOCK_PROVENANCE_RESULT:-matching}" in
+    matching) echo "https://slsa.dev/provenance/v1" ;;
+    unsupported) echo "https://example.invalid/provenance" ;;
+    *) exit 1 ;;
+  esac
   exit 0
 fi
 count=0

--- a/test/server-credentials.test.ts
+++ b/test/server-credentials.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
   startMattermostServer,
+  startMatrixServer,
   startSlackServer,
   startTelegramServer,
   startWhatsAppServer,
@@ -24,6 +25,11 @@ describe("externally bound provider server credentials", () => {
       first.mattermost.manifest.botToken,
     );
     expect(second.mattermost.manifest.botToken).not.toBe(first.mattermost.manifest.botToken);
+
+    expect(first.matrix.manifest.accessToken).toMatch(/^syt_crabline_[a-f0-9]{24}$/u);
+    expect(first.matrix.manifest.env.MATRIX_ACCESS_TOKEN).toBe(first.matrix.manifest.accessToken);
+    expect(first.matrix.manifest.env.MATRIX_USER_ID).toBe(first.matrix.manifest.botUserId);
+    expect(second.matrix.manifest.accessToken).not.toBe(first.matrix.manifest.accessToken);
 
     expect(first.slack.manifest.botToken).toMatch(/^xoxb-\d{12}-\d{12}-[A-Za-z0-9_-]{24}$/u);
     expect(first.slack.manifest.signingSecret).toMatch(/^[a-f0-9]{32}$/u);
@@ -50,10 +56,11 @@ describe("externally bound provider server credentials", () => {
 
 async function startServers() {
   const mattermost = await startMattermostServer({ host: "0.0.0.0" });
+  const matrix = await startMatrixServer({ host: "0.0.0.0" });
   const slack = await startSlackServer({ host: "0.0.0.0" });
   const telegram = await startTelegramServer({ host: "0.0.0.0" });
   const whatsapp = await startWhatsAppServer({ host: "0.0.0.0" });
   const zalo = await startZaloServer({ host: "0.0.0.0" });
-  servers.push(mattermost, slack, telegram, whatsapp, zalo);
-  return { mattermost, slack, telegram, whatsapp, zalo };
+  servers.push(mattermost, matrix, slack, telegram, whatsapp, zalo);
+  return { mattermost, matrix, slack, telegram, whatsapp, zalo };
 }

--- a/test/whatsapp-provider.test.ts
+++ b/test/whatsapp-provider.test.ts
@@ -566,4 +566,24 @@ runLocalMockProviderContract({
     ],
   },
   webhookThreadId: "15551234567",
+  userWebhookPayload: (nonce) => ({
+    entry: [
+      {
+        changes: [
+          {
+            value: {
+              metadata: { phone_number_id: "local-mock-phone" },
+              messages: [
+                {
+                  from: "15551234567",
+                  id: "wamid.user-inbound",
+                  text: { body: `user ${nonce}` },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  }),
 });

--- a/test/zalo-provider.test.ts
+++ b/test/zalo-provider.test.ts
@@ -137,4 +137,8 @@ runLocalMockProviderContract({
     sender: { id: "user-1" },
   },
   webhookThreadId: "user-1",
+  userWebhookPayload: (nonce) => ({
+    message: { msg_id: "zalo-user-inbound", text: `user ${nonce}` },
+    sender: { id: "user-1" },
+  }),
 });


### PR DESCRIPTION
## Summary
- require npm provenance when accepting existing release artifacts
- exercise native provider webhook payloads and ordered cleanup
- harden cross-platform autoreview/package tooling and workflow pin coverage
- document Discord, script wait, and Telegram webhook contracts

## Testing
- `pnpm exec vitest run test/release-workflow.test.ts test/ci-workflow.test.ts test/server-credentials.test.ts test/package-production.test.ts test/local-mock-provider.test.ts test/feishu-provider.test.ts test/whatsapp-provider.test.ts test/imessage-provider.test.ts test/mattermost-provider.test.ts test/zalo-provider.test.ts test/googlechat-provider.test.ts test/msteams-provider.test.ts test/matrix-provider.test.ts` (140 passed)
- `pnpm typecheck`
- focused autoreview hardening tests (2 passed, Windows execution test skipped off Windows)
- full autoreview Python suite: 190 passed, 2 skipped; 4 existing environment failures because Java is unavailable
- privacy scan clean