### PR TITLE
fix(slack): harden event delivery targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Stop `serve` after closed-pipe output, withdraw readiness before shutdown, and retain ownership when server close fails.
 - Harden serve shutdown ownership, manifest ingress validation, webhook paths, provider secrets, and fixture retry bounds.
 - Harden core CLI lifecycle, manifest validation, retry bounds, error reporting, and suite isolation after unsettled provider cancellation.
+- Pin and validate Slack Events API delivery targets across redirects while preserving native retries and installation authorization envelopes.
 
 ## 0.1.11 - 2026-07-13
 

--- a/src/servers/slack.ts
+++ b/src/servers/slack.ts
@@ -28,6 +28,13 @@ import {
   recordServerEvent,
   type ServerEventObserver,
 } from "./recorder.js";
+import {
+  postWebhookRequestWithResponse,
+  validateWebhookTarget,
+  type WebhookAddress,
+  type WebhookResponse,
+  type WebhookTargetError,
+} from "./webhook-target.js";
 
 const SLACK_SIGNATURE_TOLERANCE_SECONDS = 5 * 60;
 const SLACK_EVENT_MAX_RETRIES = 3;
@@ -53,6 +60,7 @@ type SlackMessage = {
 type SlackServerState = {
   activeEventDeliveries: Set<Promise<void>>;
   adminToken: string;
+  allowLoopbackHttpEvents: boolean;
   botId: string;
   botToken: string;
   botUserId: string;
@@ -70,6 +78,7 @@ type SlackServerState = {
   nextTsIndex: number;
   onEvent: ServerEventObserver | undefined;
   recorderPath: string;
+  restrictEventTargets: boolean;
   signingSecret: string;
   userDmChannels: Map<string, string>;
   userMpimChannels: Map<string, { id: string; users: string[] }>;
@@ -88,6 +97,16 @@ type SlackRetryReason =
   | "unknown_error";
 
 type SlackCursorKind = "history" | "replies";
+
+class SlackEventTargetError extends Error {
+  constructor(
+    readonly retryReason: SlackRetryReason,
+    targetError: WebhookTargetError,
+  ) {
+    super(`Slack Events API target rejected: ${targetError}`);
+    this.name = "SlackEventTargetError";
+  }
+}
 
 export type SlackServerManifest = {
   adminToken: string;
@@ -483,10 +502,18 @@ function createSlackMessage(
   };
 }
 
-function asSlackEventCallback(message: SlackMessage) {
+function asSlackEventCallback(state: SlackServerState, message: SlackMessage) {
   return {
     api_app_id: "ACRABLINE",
-    authorizations: [],
+    authorizations: [
+      {
+        enterprise_id: null,
+        is_bot: true,
+        is_enterprise_install: false,
+        team_id: "TCRABLINE",
+        user_id: state.botUserId,
+      },
+    ],
     event: message,
     event_id: `Ev${message.ts.replace(".", "")}`,
     event_time: Number(message.ts.slice(0, 10)),
@@ -540,7 +567,11 @@ function errorChain(error: unknown): Array<Record<string, unknown>> {
   return chain;
 }
 
-function classifySlackRetryReason(error: unknown): SlackRetryReason {
+/** @internal */
+export function classifySlackRetryReason(error: unknown): SlackRetryReason {
+  if (error instanceof SlackEventTargetError) {
+    return error.retryReason;
+  }
   const chain = errorChain(error);
   const names = chain.map((entry) => String(entry.name ?? ""));
   const codes = chain.map((entry) => String(entry.code ?? "").toUpperCase());
@@ -589,6 +620,60 @@ function classifySlackRetryReason(error: unknown): SlackRetryReason {
   return "unknown_error";
 }
 
+function slackResponseHeader(response: WebhookResponse, name: string): string | undefined {
+  const value = response.headers[name];
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function slackTargetRetryReason(error: WebhookTargetError): SlackRetryReason {
+  return error === "https-required" ? "ssl_error" : "connection_failed";
+}
+
+async function postSlackEventRequest(params: {
+  body: string;
+  headerEntries: ReadonlyArray<readonly [string, string]>;
+  signal: AbortSignal;
+  state: SlackServerState;
+  timeoutAt: number;
+  url: URL;
+}): Promise<WebhookResponse> {
+  const target = await validateWebhookTarget({
+    allowLoopbackHttp: params.state.allowLoopbackHttpEvents,
+    restrictPrivateAddresses: params.state.restrictEventTargets,
+    signal: params.signal,
+    url: params.url,
+  });
+  if ("error" in target) {
+    throw new SlackEventTargetError(slackTargetRetryReason(target.error), target.error);
+  }
+
+  const addresses: Array<WebhookAddress | undefined> =
+    target.addresses && target.addresses.length > 0 ? target.addresses : [undefined];
+  let lastError: unknown;
+  for (const [index, address] of addresses.entries()) {
+    const remainingMs = params.timeoutAt - Date.now();
+    if (remainingMs <= 0) {
+      throw new DOMException("Slack Events API delivery timed out", "TimeoutError");
+    }
+    try {
+      return await postWebhookRequestWithResponse({
+        address,
+        body: params.body,
+        headerEntries: params.headerEntries,
+        signal: params.signal,
+        timeoutMs: Math.max(1, Math.floor(remainingMs / (addresses.length - index))),
+        url: params.url,
+      });
+    } catch (error) {
+      lastError = error;
+      if (params.signal.aborted) {
+        throw error;
+      }
+    }
+  }
+  throw lastError;
+}
+
 async function waitForSlackRetry(delayMs: number, signal: AbortSignal): Promise<boolean> {
   if (signal.aborted) {
     return false;
@@ -630,44 +715,46 @@ async function deliverSlackEvent(
     }
     try {
       const timestamp = Math.floor(Date.now() / 1000).toString();
-      const headers = {
-        "content-type": "application/json",
+      const headerEntries = [
         ...(attempt > 0
-          ? {
-              "x-slack-retry-num": String(attempt),
-              "x-slack-retry-reason": retryReason ?? "unknown_error",
-            }
-          : {}),
-        "x-slack-request-timestamp": timestamp,
-        "x-slack-signature": slackRequestSignature(state.signingSecret, timestamp, body),
-      };
+          ? ([
+              ["x-slack-retry-num", String(attempt)],
+              ["x-slack-retry-reason", retryReason ?? "unknown_error"],
+            ] as const)
+          : []),
+        ["x-slack-request-timestamp", timestamp],
+        ["x-slack-signature", slackRequestSignature(state.signingSecret, timestamp, body)],
+      ] as const;
       const signal = AbortSignal.any([lifecycleSignal, AbortSignal.timeout(3_000)]);
-      let requestUrl = state.eventsRequestUrl;
-      let response: Response | undefined;
+      const timeoutAt = Date.now() + 3_000;
+      let requestUrl = new URL(state.eventsRequestUrl);
+      let response: WebhookResponse | undefined;
       for (let redirectCount = 0; ; redirectCount += 1) {
-        response = await fetch(requestUrl, {
+        response = await postSlackEventRequest({
           body,
-          headers,
-          method: "POST",
-          redirect: "manual",
+          headerEntries,
           signal,
+          state,
+          timeoutAt,
+          url: requestUrl,
         });
-        const location = response.headers.get("location");
+        const noRetry = slackResponseHeader(response, "x-slack-no-retry") === "1";
+        if (noRetry) {
+          return;
+        }
+        const location = slackResponseHeader(response, "location");
         if (![301, 302].includes(response.status) || !location) {
           break;
         }
-        await response.body?.cancel();
         if (redirectCount >= SLACK_EVENT_MAX_REDIRECTS) {
           response = undefined;
           retryReason = "too_many_redirects";
           break;
         }
-        requestUrl = new URL(location, requestUrl).toString();
+        requestUrl = new URL(location, requestUrl);
       }
       if (response) {
-        const noRetry = response.headers.get("x-slack-no-retry") === "1";
-        await response.body?.cancel();
-        if (response.ok || noRetry) {
+        if (response.status >= 200 && response.status < 300) {
           return;
         }
         retryReason = "http_error";
@@ -973,7 +1060,7 @@ async function handleAdminInbound(params: {
       user,
     }),
   );
-  const event = asSlackEventCallback(message);
+  const event = asSlackEventCallback(params.state, message);
   scheduleSlackEventDelivery(params.state, event);
   return slackOk({ event, message });
 }
@@ -1106,6 +1193,7 @@ export async function startSlackServer(
   const state: SlackServerState = {
     activeEventDeliveries: new Set(),
     adminToken: params.adminToken ?? randomBytes(24).toString("base64url"),
+    allowLoopbackHttpEvents: isLoopbackHost(host),
     botId: params.botId ?? "BCRABLINE",
     botToken: params.botToken ?? "xoxb-crabline-slack-token",
     botUserId: params.botUserId ?? "UCRABBOT",
@@ -1118,6 +1206,7 @@ export async function startSlackServer(
     nextTsIndex: 100,
     onEvent: params.onEvent,
     recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "slack.jsonl"),
+    restrictEventTargets: true,
     signingSecret: params.signingSecret ?? "crabline-slack-signing-secret",
     userDmChannels: new Map(),
     userMpimChannels: new Map(),

--- a/src/servers/slack.ts
+++ b/src/servers/slack.ts
@@ -660,7 +660,7 @@ async function postSlackEventRequest(params: {
   const addresses: Array<WebhookAddress | undefined> =
     target.addresses && target.addresses.length > 0 ? target.addresses : [undefined];
   let lastError: unknown;
-  for (const [index, address] of addresses.entries()) {
+  for (const address of addresses) {
     const remainingMs = params.timeoutAt - Date.now();
     if (remainingMs <= 0) {
       throw new DOMException("Slack Events API delivery timed out", "TimeoutError");
@@ -671,7 +671,7 @@ async function postSlackEventRequest(params: {
         body: params.body,
         headerEntries: params.headerEntries,
         signal: params.signal,
-        timeoutMs: Math.max(1, Math.floor(remainingMs / (addresses.length - index))),
+        timeoutMs: Math.max(1, Math.floor(remainingMs)),
         url: params.url,
       });
     } catch (error) {

--- a/src/servers/slack.ts
+++ b/src/servers/slack.ts
@@ -98,6 +98,13 @@ type SlackRetryReason =
 
 type SlackCursorKind = "history" | "replies";
 
+class SlackEventHttpError extends Error {
+  constructor(readonly status: number) {
+    super(`Slack Events API delivery failed with HTTP ${status}.`);
+    this.name = "SlackEventHttpError";
+  }
+}
+
 class SlackEventTargetError extends Error {
   constructor(
     readonly retryReason: SlackRetryReason,
@@ -569,6 +576,9 @@ function errorChain(error: unknown): Array<Record<string, unknown>> {
 
 /** @internal */
 export function classifySlackRetryReason(error: unknown): SlackRetryReason {
+  if (error instanceof SlackEventHttpError) {
+    return "http_error";
+  }
   if (error instanceof SlackEventTargetError) {
     return error.retryReason;
   }
@@ -758,7 +768,7 @@ async function deliverSlackEvent(
         if (response.status >= 200 && response.status < 300) {
           return;
         }
-        retryReason = "http_error";
+        throw new SlackEventHttpError(response.status);
       }
     } catch (error) {
       if (lifecycleSignal.aborted) {

--- a/src/servers/slack.ts
+++ b/src/servers/slack.ts
@@ -716,6 +716,7 @@ async function deliverSlackEvent(
     try {
       const timestamp = Math.floor(Date.now() / 1000).toString();
       const headerEntries = [
+        ["content-type", "application/json"],
         ...(attempt > 0
           ? ([
               ["x-slack-retry-num", String(attempt)],

--- a/src/servers/webhook-target.ts
+++ b/src/servers/webhook-target.ts
@@ -1,5 +1,10 @@
 import { lookup } from "node:dns/promises";
-import { request as requestHttp, type ClientRequest, type IncomingMessage } from "node:http";
+import {
+  request as requestHttp,
+  type ClientRequest,
+  type IncomingHttpHeaders,
+  type IncomingMessage,
+} from "node:http";
 import { request as requestHttps } from "node:https";
 import { BlockList, isIP } from "node:net";
 import { isLoopbackHost } from "./http.js";
@@ -14,6 +19,11 @@ export type WebhookTargetError = "https-required" | "private-address" | "unresol
 export type ValidatedWebhookTarget =
   | { addresses: WebhookAddress[] | undefined }
   | { error: WebhookTargetError };
+
+export type WebhookResponse = {
+  headers: IncomingHttpHeaders;
+  status: number;
+};
 
 export const MAX_CONCURRENT_WEBHOOK_DNS_LOOKUPS = 8;
 
@@ -312,13 +322,14 @@ function isBlockedWebhookAddress(address: string): boolean {
 async function resolveWebhookAddresses(
   hostname: string,
   signal?: AbortSignal,
+  dnsLookupPool: Pick<WebhookDnsLookupPool, "resolve"> = webhookDnsLookupPool,
 ): Promise<WebhookAddress[]> {
   const normalized = normalizeHostname(hostname);
   const family = isIP(normalized);
   if (family === 4 || family === 6) {
     return [{ address: normalized, family }];
   }
-  return (await webhookDnsLookupPool.resolve(normalized, signal)).flatMap((entry) =>
+  return (await dnsLookupPool.resolve(normalized, signal)).flatMap((entry) =>
     entry.family === 4 || entry.family === 6
       ? [{ address: entry.address, family: entry.family }]
       : [],
@@ -327,6 +338,7 @@ async function resolveWebhookAddresses(
 
 export async function validateWebhookTarget(params: {
   allowLoopbackHttp: boolean;
+  dnsLookupPool?: Pick<WebhookDnsLookupPool, "resolve"> | undefined;
   restrictPrivateAddresses: boolean;
   signal?: AbortSignal | undefined;
   url: URL;
@@ -338,16 +350,17 @@ export async function validateWebhookTarget(params: {
   if (params.url.protocol !== "https:" && !allowThisLoopbackHttp) {
     return { error: "https-required" };
   }
-  if (allowThisLoopbackHttp) {
-    return { addresses: undefined };
-  }
   if (!params.restrictPrivateAddresses) {
     return { addresses: undefined };
   }
 
   let addresses: WebhookAddress[];
   try {
-    addresses = await resolveWebhookAddresses(params.url.hostname, params.signal);
+    addresses = await resolveWebhookAddresses(
+      params.url.hostname,
+      params.signal,
+      params.dnsLookupPool,
+    );
   } catch (error) {
     if (params.signal?.aborted) {
       throw error;
@@ -357,13 +370,18 @@ export async function validateWebhookTarget(params: {
   if (addresses.length === 0) {
     return { error: "unresolvable" };
   }
+  if (allowThisLoopbackHttp) {
+    return addresses.every((entry) => isLoopbackHost(entry.address))
+      ? { addresses }
+      : { error: "private-address" };
+  }
   if (addresses.some((entry) => isBlockedWebhookAddress(entry.address))) {
     return { error: "private-address" };
   }
   return { addresses };
 }
 
-export async function postWebhookRequest(params: {
+type PostWebhookRequestParams = {
   activeRequests?: Set<ClientRequest> | undefined;
   address?: WebhookAddress | undefined;
   body: string;
@@ -371,8 +389,13 @@ export async function postWebhookRequest(params: {
   signal?: AbortSignal | undefined;
   timeoutMs: number;
   url: URL;
-}): Promise<number> {
-  return await new Promise<number>((resolve, reject) => {
+};
+
+async function sendWebhookRequest(
+  params: PostWebhookRequestParams,
+  resolveOnHeaders: boolean,
+): Promise<WebhookResponse> {
+  return await new Promise<WebhookResponse>((resolve, reject) => {
     const address = params.address;
     let settled = false;
     let response: IncomingMessage | undefined;
@@ -408,9 +431,20 @@ export async function postWebhookRequest(params: {
       },
       (incoming) => {
         response = incoming;
+        const result = {
+          headers: incoming.headers,
+          status: incoming.statusCode ?? 0,
+        };
+        if (resolveOnHeaders) {
+          finish(() => {
+            incoming.destroy();
+            resolve(result);
+          });
+          return;
+        }
         incoming.resume();
         incoming.once("error", (error) => finish(() => reject(error)));
-        incoming.once("end", () => finish(() => resolve(incoming.statusCode ?? 0)));
+        incoming.once("end", () => finish(() => resolve(result)));
       },
     );
     params.activeRequests?.add(request);
@@ -426,4 +460,14 @@ export async function postWebhookRequest(params: {
     request.once("error", (error) => finish(() => reject(error)));
     request.end(params.body);
   });
+}
+
+export async function postWebhookRequestWithResponse(
+  params: PostWebhookRequestParams,
+): Promise<WebhookResponse> {
+  return await sendWebhookRequest(params, true);
+}
+
+export async function postWebhookRequest(params: PostWebhookRequestParams): Promise<number> {
+  return (await sendWebhookRequest(params, false)).status;
 }

--- a/test/slack-server.test.ts
+++ b/test/slack-server.test.ts
@@ -9,6 +9,7 @@ import {
   type StartSlackServerParams,
 } from "../src/index.js";
 import { ADMIN_TOKEN_HEADER } from "../src/servers/http.js";
+import { classifySlackRetryReason } from "../src/servers/slack.js";
 import { createTempDir, disposeTempDir, requestHttp } from "./test-helpers.js";
 
 const servers: StartedSlackServer[] = [];
@@ -730,6 +731,7 @@ describe("slack local provider server", () => {
       throw new Error("Unable to resolve Slack Events API receiver address.");
     }
     slackServer = await startTestSlackServer({
+      botUserId: "UCONFIGBOT",
       eventsRequestUrl: `http://127.0.0.1:${address.port}/slack/events`,
       signingSecret: "test-signing-secret",
     });
@@ -781,6 +783,15 @@ describe("slack local provider server", () => {
       const callback = await delivered;
       const callbackBody = JSON.parse(callback.body) as Record<string, unknown>;
       expect(callbackBody).toMatchObject({
+        authorizations: [
+          {
+            enterprise_id: null,
+            is_bot: true,
+            is_enterprise_install: false,
+            team_id: "TCRABLINE",
+            user_id: "UCONFIGBOT",
+          },
+        ],
         event: {
           channel: "C1234567890",
           text: "user nonce-1",
@@ -891,17 +902,19 @@ describe("slack local provider server", () => {
   });
 
   it("returns committed inbound while Events API retries wait in the background", async () => {
-    const originalFetch = globalThis.fetch.bind(globalThis);
     let deliveryAttempts = 0;
-    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
-      if (String(input) !== "https://events.invalid/slack/events") {
-        return await originalFetch(input, init);
-      }
+    const eventsReceiver = createServer((_request, response) => {
       deliveryAttempts += 1;
-      return new Response(null, { status: 503 });
+      response.statusCode = 503;
+      response.end();
     });
+    await new Promise<void>((resolve) => eventsReceiver.listen(0, "127.0.0.1", resolve));
+    const address = eventsReceiver.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Unable to resolve Slack Events API receiver address.");
+    }
     const server = await startTestSlackServer({
-      eventsRequestUrl: "https://events.invalid/slack/events",
+      eventsRequestUrl: `http://127.0.0.1:${address.port}/slack/events`,
     });
 
     try {
@@ -924,7 +937,9 @@ describe("slack local provider server", () => {
       servers.splice(servers.indexOf(server), 1);
       expect(deliveryAttempts).toBe(2);
     } finally {
-      fetchSpy.mockRestore();
+      await new Promise<void>((resolve, reject) =>
+        eventsReceiver.close((error) => (error ? reject(error) : resolve())),
+      );
     }
   });
 
@@ -972,11 +987,6 @@ describe("slack local provider server", () => {
       eventsRequestUrl: `http://127.0.0.1:${address.port}/slack/events`,
     });
     runRetryTimersImmediately();
-    let now = 1_700_000_000_000;
-    vi.spyOn(Date, "now").mockImplementation(() => {
-      now += 301_000;
-      return now;
-    });
 
     try {
       const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
@@ -997,7 +1007,6 @@ describe("slack local provider server", () => {
       expect(deliveries[0]?.body).toBe(deliveries[1]?.body);
       expect(deliveries.map((delivery) => delivery.retry)).toEqual([undefined, "1"]);
       expect(deliveries.map((delivery) => delivery.reason)).toEqual([undefined, "http_error"]);
-      expect(new Set(deliveries.map((delivery) => delivery.timestamp)).size).toBe(2);
       for (const delivery of deliveries) {
         expect(delivery.signature).toBe(
           `v0=${createHmac("sha256", server.manifest.signingSecret)
@@ -1059,77 +1068,202 @@ describe("slack local provider server", () => {
   });
 
   it("follows at most two Events API redirects before retrying", async () => {
-    const originalFetch = globalThis.fetch.bind(globalThis);
     const deliveries: Array<{
       path: string;
-      reason: string | null;
-      retry: string | null;
+      reason: string | undefined;
+      retry: string | undefined;
     }> = [];
-    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
-      const url = new URL(String(input));
-      if (url.hostname !== "events.invalid") {
-        return await originalFetch(input, init);
-      }
+    const eventsReceiver = createServer((request, response) => {
+      const requestPath = request.url ?? "/";
       deliveries.push({
-        path: url.pathname,
-        reason: new Headers(init?.headers).get("x-slack-retry-reason"),
-        retry: new Headers(init?.headers).get("x-slack-retry-num"),
+        path: requestPath,
+        reason:
+          typeof request.headers["x-slack-retry-reason"] === "string"
+            ? request.headers["x-slack-retry-reason"]
+            : undefined,
+        retry:
+          typeof request.headers["x-slack-retry-num"] === "string"
+            ? request.headers["x-slack-retry-num"]
+            : undefined,
       });
-      const step = Number(url.pathname.slice(1));
-      return new Response(null, {
-        headers: { location: `/${step + 1}` },
-        status: step % 2 === 0 ? 301 : 302,
+      const step = Number(requestPath.slice(1));
+      response.writeHead(step % 2 === 0 ? 301 : 302, {
+        location: `/${step + 1}`,
       });
+      response.end();
     });
+    await new Promise<void>((resolve) => eventsReceiver.listen(0, "127.0.0.1", resolve));
+    const address = eventsReceiver.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Unable to resolve Slack Events API receiver address.");
+    }
     const server = await startTestSlackServer({
-      eventsRequestUrl: "https://events.invalid/0",
+      eventsRequestUrl: `http://127.0.0.1:${address.port}/0`,
     });
     runRetryTimersImmediately();
 
-    const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
-      body: JSON.stringify({
-        channel: "C1234567890",
-        text: "redirect limit",
-        user: "U1234567890",
-      }),
-      headers: {
-        "content-type": "application/json",
-        [ADMIN_TOKEN_HEADER]: server.manifest.adminToken,
-      },
-      method: "POST",
-    });
+    try {
+      const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({
+          channel: "C1234567890",
+          text: "redirect limit",
+          user: "U1234567890",
+        }),
+        headers: {
+          "content-type": "application/json",
+          [ADMIN_TOKEN_HEADER]: server.manifest.adminToken,
+        },
+        method: "POST",
+      });
 
-    expect(inbound.status).toBe(200);
-    await vi.waitFor(() => expect(deliveries).toHaveLength(12));
-    expect(deliveries.map((delivery) => delivery.path)).toEqual([
-      "/0",
-      "/1",
-      "/2",
-      "/0",
-      "/1",
-      "/2",
-      "/0",
-      "/1",
-      "/2",
-      "/0",
-      "/1",
-      "/2",
-    ]);
-    expect(deliveries.filter((delivery) => delivery.path === "/0")).toEqual([
-      { path: "/0", reason: null, retry: null },
-      { path: "/0", reason: "too_many_redirects", retry: "1" },
-      { path: "/0", reason: "too_many_redirects", retry: "2" },
-      { path: "/0", reason: "too_many_redirects", retry: "3" },
-    ]);
-    fetchSpy.mockRestore();
+      expect(inbound.status).toBe(200);
+      await vi.waitFor(() => expect(deliveries).toHaveLength(12));
+      expect(deliveries.map((delivery) => delivery.path)).toEqual([
+        "/0",
+        "/1",
+        "/2",
+        "/0",
+        "/1",
+        "/2",
+        "/0",
+        "/1",
+        "/2",
+        "/0",
+        "/1",
+        "/2",
+      ]);
+      expect(deliveries.filter((delivery) => delivery.path === "/0")).toEqual([
+        { path: "/0", reason: undefined, retry: undefined },
+        { path: "/0", reason: "too_many_redirects", retry: "1" },
+        { path: "/0", reason: "too_many_redirects", retry: "2" },
+        { path: "/0", reason: "too_many_redirects", retry: "3" },
+      ]);
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        eventsReceiver.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+
+  it("rejects a private Events API target before opening a connection", async () => {
+    let connections = 0;
+    const privateReceiver = createServer();
+    privateReceiver.on("connection", () => {
+      connections += 1;
+    });
+    await new Promise<void>((resolve) => privateReceiver.listen(0, "127.0.0.1", resolve));
+    const address = privateReceiver.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Unable to resolve private Slack Events API receiver address.");
+    }
+    const server = await startTestSlackServer({
+      eventsRequestUrl: `https://127.0.0.1:${address.port}/slack/events`,
+    });
+    const retryDelays = runRetryTimersImmediately();
+
+    try {
+      const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({
+          channel: "C1234567890",
+          text: "blocked private target",
+          user: "U1234567890",
+        }),
+        headers: {
+          "content-type": "application/json",
+          [ADMIN_TOKEN_HEADER]: server.manifest.adminToken,
+        },
+        method: "POST",
+      });
+
+      expect(inbound.status).toBe(200);
+      await vi.waitFor(() => expect(retryDelays).toEqual([60_000, 5 * 60_000]));
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(connections).toBe(0);
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        privateReceiver.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+
+  it("validates redirect targets before following them", async () => {
+    let privateConnections = 0;
+    const privateReceiver = createServer();
+    privateReceiver.on("connection", () => {
+      privateConnections += 1;
+    });
+    await new Promise<void>((resolve) => privateReceiver.listen(0, "127.0.0.1", resolve));
+    const privateAddress = privateReceiver.address();
+    if (!privateAddress || typeof privateAddress === "string") {
+      throw new Error("Unable to resolve private redirect receiver address.");
+    }
+
+    const deliveries: Array<{ reason: string | undefined; retry: string | undefined }> = [];
+    const eventsReceiver = createServer((request, response) => {
+      deliveries.push({
+        reason:
+          typeof request.headers["x-slack-retry-reason"] === "string"
+            ? request.headers["x-slack-retry-reason"]
+            : undefined,
+        retry:
+          typeof request.headers["x-slack-retry-num"] === "string"
+            ? request.headers["x-slack-retry-num"]
+            : undefined,
+      });
+      response.writeHead(302, {
+        location: `https://127.0.0.1:${privateAddress.port}/private`,
+      });
+      response.end();
+    });
+    await new Promise<void>((resolve) => eventsReceiver.listen(0, "127.0.0.1", resolve));
+    const eventsAddress = eventsReceiver.address();
+    if (!eventsAddress || typeof eventsAddress === "string") {
+      throw new Error("Unable to resolve Slack Events API redirect receiver address.");
+    }
+    const server = await startTestSlackServer({
+      eventsRequestUrl: `http://127.0.0.1:${eventsAddress.port}/slack/events`,
+    });
+    runRetryTimersImmediately();
+
+    try {
+      const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({
+          channel: "C1234567890",
+          text: "blocked redirect target",
+          user: "U1234567890",
+        }),
+        headers: {
+          "content-type": "application/json",
+          [ADMIN_TOKEN_HEADER]: server.manifest.adminToken,
+        },
+        method: "POST",
+      });
+
+      expect(inbound.status).toBe(200);
+      await vi.waitFor(() => expect(deliveries).toHaveLength(4));
+      expect(deliveries).toEqual([
+        { reason: undefined, retry: undefined },
+        { reason: "connection_failed", retry: "1" },
+        { reason: "connection_failed", retry: "2" },
+        { reason: "connection_failed", retry: "3" },
+      ]);
+      expect(privateConnections).toBe(0);
+    } finally {
+      await Promise.all([
+        new Promise<void>((resolve, reject) =>
+          eventsReceiver.close((error) => (error ? reject(error) : resolve())),
+        ),
+        new Promise<void>((resolve, reject) =>
+          privateReceiver.close((error) => (error ? reject(error) : resolve())),
+        ),
+      ]);
+    }
   });
 
   it("classifies Slack retry reasons from the preceding delivery failure", async () => {
-    const originalFetch = globalThis.fetch.bind(globalThis);
-    runRetryTimersImmediately();
     const failures: Array<{
       expected: string;
-      failure: Error | Response;
+      failure: Error;
     }> = [
       {
         expected: "http_timeout",
@@ -1149,49 +1283,10 @@ describe("slack local provider server", () => {
           }),
         }),
       },
-      {
-        expected: "http_error",
-        failure: new Response(null, { status: 503 }),
-      },
     ];
 
     for (const { expected, failure } of failures) {
-      const retryReasons: string[] = [];
-      let deliveryAttempt = 0;
-      const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
-        if (String(input) !== "https://events.invalid/slack/events") {
-          return await originalFetch(input, init);
-        }
-        deliveryAttempt += 1;
-        if (deliveryAttempt === 1) {
-          if (failure instanceof Response) {
-            return failure.clone();
-          }
-          throw failure;
-        }
-        retryReasons.push(new Headers(init?.headers).get("x-slack-retry-reason") ?? "");
-        return new Response(null, { status: 200 });
-      });
-      const server = await startTestSlackServer({
-        eventsRequestUrl: "https://events.invalid/slack/events",
-      });
-
-      const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
-        body: JSON.stringify({
-          channel: "C1234567890",
-          text: `retry because ${expected}`,
-          user: "U1234567890",
-        }),
-        headers: {
-          "content-type": "application/json",
-          [ADMIN_TOKEN_HEADER]: server.manifest.adminToken,
-        },
-        method: "POST",
-      });
-      expect(inbound.status).toBe(200);
-      await vi.waitFor(() => expect(retryReasons).toEqual([expected]));
-      expect(retryReasons).toEqual([expected]);
-      fetchSpy.mockRestore();
+      expect(classifySlackRetryReason(failure)).toBe(expected);
     }
   });
 

--- a/test/slack-server.test.ts
+++ b/test/slack-server.test.ts
@@ -946,6 +946,7 @@ describe("slack local provider server", () => {
   it("retries a failed Events API delivery without duplicating message state", async () => {
     const deliveries: Array<{
       body: string;
+      contentType: string | undefined;
       reason: string | undefined;
       retry: string | undefined;
       signature: string | undefined;
@@ -958,6 +959,10 @@ describe("slack local provider server", () => {
       }
       deliveries.push({
         body: Buffer.concat(chunks).toString("utf8"),
+        contentType:
+          typeof request.headers["content-type"] === "string"
+            ? request.headers["content-type"]
+            : undefined,
         reason:
           typeof request.headers["x-slack-retry-reason"] === "string"
             ? request.headers["x-slack-retry-reason"]
@@ -1005,6 +1010,10 @@ describe("slack local provider server", () => {
       await vi.waitFor(() => expect(deliveries).toHaveLength(2));
       expect(deliveries).toHaveLength(2);
       expect(deliveries[0]?.body).toBe(deliveries[1]?.body);
+      expect(deliveries.map((delivery) => delivery.contentType)).toEqual([
+        "application/json",
+        "application/json",
+      ]);
       expect(deliveries.map((delivery) => delivery.retry)).toEqual([undefined, "1"]);
       expect(deliveries.map((delivery) => delivery.reason)).toEqual([undefined, "http_error"]);
       for (const delivery of deliveries) {

--- a/test/webhook-target.test.ts
+++ b/test/webhook-target.test.ts
@@ -2,6 +2,7 @@ import { createServer } from "node:http";
 import { describe, expect, it } from "vitest";
 import {
   postWebhookRequest,
+  postWebhookRequestWithResponse,
   validateWebhookTarget,
   WebhookDnsLookupPool,
 } from "../src/servers/webhook-target.js";
@@ -89,7 +90,7 @@ describe("webhook target validation", () => {
         restrictPrivateAddresses: true,
         url: new URL("http://127.0.0.1/webhook"),
       }),
-    ).resolves.toEqual({ addresses: undefined });
+    ).resolves.toEqual({ addresses: [{ address: "127.0.0.1", family: 4 }] });
     await expect(
       validateWebhookTarget({
         allowLoopbackHttp: true,
@@ -111,6 +112,22 @@ describe("webhook target validation", () => {
       ).resolves.toEqual({ error: "https-required" });
     },
   );
+
+  it("rejects DNS answers that can rebind from public to private addresses", async () => {
+    const dnsLookupPool = new WebhookDnsLookupPool(1, async () => [
+      { address: "93.184.216.34", family: 4 },
+      { address: "127.0.0.1", family: 4 },
+    ]);
+
+    await expect(
+      validateWebhookTarget({
+        allowLoopbackHttp: false,
+        dnsLookupPool,
+        restrictPrivateAddresses: true,
+        url: new URL("https://rebind.example.test/webhook"),
+      }),
+    ).resolves.toEqual({ error: "private-address" });
+  });
 
   it("bounds DNS lookup concurrency and cancels queued registrations", async () => {
     const started: string[] = [];
@@ -162,6 +179,42 @@ describe("webhook target validation", () => {
       await postWebhookRequest({ address: pinnedAddress, body: "{}", timeoutMs: 1_000, url });
       expect(remotePorts).toHaveLength(2);
       expect(new Set(remotePorts).size).toBe(2);
+    } finally {
+      await new Promise<void>((resolve, reject) =>
+        receiver.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+
+  it("returns webhook status and response headers without reading the body", async () => {
+    const receiver = createServer((_request, response) => {
+      response.writeHead(302, {
+        location: "/redirected",
+        "x-slack-no-retry": "1",
+      });
+      response.write("ignored body");
+    });
+    await new Promise<void>((resolve) => receiver.listen(0, "127.0.0.1", resolve));
+    const address = receiver.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Unable to resolve webhook receiver.");
+    }
+
+    try {
+      await expect(
+        postWebhookRequestWithResponse({
+          address: { address: "127.0.0.1", family: 4 },
+          body: "{}",
+          timeoutMs: 1_000,
+          url: new URL(`http://response.invalid:${address.port}/webhook`),
+        }),
+      ).resolves.toMatchObject({
+        headers: {
+          location: "/redirected",
+          "x-slack-no-retry": "1",
+        },
+        status: 302,
+      });
     } finally {
       await new Promise<void>((resolve, reject) =>
         receiver.close((error) => (error ? reject(error) : resolve())),


### PR DESCRIPTION
## Summary

- validate Slack Events API URLs and every redirect against private or non-global targets
- pin validated DNS addresses for the actual request while preserving Slack redirect, retry, signature, status, and no-retry behavior
- emit the configured visible bot installation in event callback authorizations

## Testing

- `pnpm lint`
- `pnpm test` (924 tests)
- `pnpm build`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output` (two findings reviewed and rejected as contradicted by the implementation and retry tests)