### PR TITLE
fix(core): harden CLI lifecycle and suite isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Harden provider adapter authentication, target identity, credential redaction, and webhook lifecycle behavior.
 - Harden release provenance retries, provider-native contract tests, cross-platform tooling, cleanup ordering, and channel setup coverage.
 - Stop `serve` after closed-pipe output, withdraw readiness before shutdown, and retain ownership when server close fails.
+- Harden serve shutdown ownership, manifest ingress validation, webhook paths, provider secrets, and fixture retry bounds.
 
 ## 0.1.11 - 2026-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Harden release provenance retries, provider-native contract tests, cross-platform tooling, cleanup ordering, and channel setup coverage.
 - Stop `serve` after closed-pipe output, withdraw readiness before shutdown, and retain ownership when server close fails.
 - Harden serve shutdown ownership, manifest ingress validation, webhook paths, provider secrets, and fixture retry bounds.
+- Harden core CLI lifecycle, manifest validation, retry bounds, error reporting, and suite isolation after unsettled provider cancellation.
 
 ## 0.1.11 - 2026-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Harden provider adapter authentication, target identity, credential redaction, and webhook lifecycle behavior.
 - Harden release provenance retries, provider-native contract tests, cross-platform tooling, cleanup ordering, and channel setup coverage.
+- Stop `serve` after closed-pipe output, withdraw readiness before shutdown, and retain ownership when server close fails.
 
 ## 0.1.11 - 2026-07-13
 

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -490,14 +490,42 @@ export function createProgram(
           settlePublication?.();
         }
       };
+      let releaseReadyLease: (() => Promise<void>) | undefined;
+      let publishedReady: { contents: string; identity: ReadyFileIdentity } | undefined;
       const close = onceAsync(async () => {
         await startup;
         await publication;
-        await server?.close();
+        const lifecycleErrors: unknown[] = [];
+        if (commandOptions.readyFile && publishedReady) {
+          try {
+            await removeReady(
+              commandOptions.readyFile,
+              publishedReady.contents,
+              publishedReady.identity,
+            );
+          } catch (error) {
+            lifecycleErrors.push(error);
+          }
+        }
+        let serverClosed = false;
+        try {
+          await server?.close();
+          serverClosed = true;
+        } catch (error) {
+          lifecycleErrors.push(error);
+        }
+        if (serverClosed && releaseReadyLease) {
+          try {
+            await releaseReadyLease();
+          } catch (error) {
+            lifecycleErrors.push(error);
+          }
+        }
+        if (lifecycleErrors.length > 0) {
+          throw combineLifecycleErrors(lifecycleErrors, "Crabline server shutdown failed.");
+        }
       });
       const shutdown = installShutdownHandler(close);
-      let releaseReadyLease: (() => Promise<void>) | undefined;
-      let publishedReady: { contents: string; identity: ReadyFileIdentity } | undefined;
       let actionFailed = false;
       let actionError: unknown;
       try {
@@ -527,6 +555,7 @@ export function createProgram(
             finishPublication();
             await shutdown.wait();
           } else {
+            let outputWritten = true;
             try {
               const payload = formatJson(server.manifest);
               if (commandOptions.readyFile) {
@@ -536,15 +565,21 @@ export function createProgram(
                   identity: await publish(commandOptions.readyFile, readyContents),
                 };
               }
-              await print(
+              outputWritten = await print(
                 options.json
                   ? payload
                   : renderServeText(server.manifest, commandOptions.showSecrets === true),
               );
+              if (!outputWritten) {
+                finishPublication();
+              }
+              if (!outputWritten) {
+                await close();
+              }
             } finally {
               finishPublication();
             }
-            if (shutdown.requested() || !commandOptions.once) {
+            if (outputWritten && (shutdown.requested() || !commandOptions.once)) {
               await shutdown.wait();
             }
           }
@@ -556,27 +591,11 @@ export function createProgram(
       finishStartup();
       finishPublication();
       const cleanupErrors: unknown[] = [];
-      const readyToRemove = publishedReady;
-      for (const cleanup of [
-        close,
-        ...(commandOptions.readyFile && readyToRemove
-          ? [
-              () =>
-                removeReady(
-                  commandOptions.readyFile!,
-                  readyToRemove.contents,
-                  readyToRemove.identity,
-                ),
-            ]
-          : []),
-        ...(releaseReadyLease ? [releaseReadyLease] : []),
-      ]) {
-        try {
-          await cleanup();
-        } catch (error) {
-          if (!actionFailed || error !== actionError) {
-            cleanupErrors.push(error);
-          }
+      try {
+        await close();
+      } catch (error) {
+        if (!actionFailed || error !== actionError) {
+          cleanupErrors.push(error);
         }
       }
       shutdown.dispose();

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -96,7 +96,8 @@ function isLoopbackHost(host: string): boolean {
   const normalized = host
     .trim()
     .replace(/^\[(.*)\]$/u, "$1")
-    .toLowerCase();
+    .toLowerCase()
+    .replace(/\.$/u, "");
   if (normalized === "localhost" || normalized.endsWith(".localhost")) {
     return true;
   }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,9 +1,14 @@
 import { validateHeaderValue } from "node:http";
+import { BlockList, isIP } from "node:net";
 import { z } from "zod";
 import { inboundRegexSafetyError } from "../core/safe-regex.js";
 
 export const FIXTURE_MODES = ["probe", "send", "roundtrip", "agent"] as const;
 const FIXTURE_ID_PATTERN = /^[a-z0-9-]+$/i;
+const LOOPBACK_ADDRESSES = new BlockList();
+LOOPBACK_ADDRESSES.addSubnet("127.0.0.0", 8, "ipv4");
+LOOPBACK_ADDRESSES.addAddress("::1", "ipv6");
+LOOPBACK_ADDRESSES.addSubnet("::ffff:127.0.0.0", 104, "ipv6");
 const MAX_FIXTURE_RETRIES = 10;
 const MAX_TIMER_MS = 2_147_483_647;
 export const INBOUND_AUTHORS = ["assistant", "user", "system", "any"] as const;
@@ -92,13 +97,15 @@ function isLoopbackHost(host: string): boolean {
     .trim()
     .replace(/^\[(.*)\]$/u, "$1")
     .toLowerCase();
-  return (
-    normalized === "localhost" ||
-    normalized.endsWith(".localhost") ||
-    normalized === "::1" ||
-    normalized.startsWith("::ffff:127.") ||
-    /^127(?:\.\d{1,3}){3}$/u.test(normalized)
-  );
+  if (normalized === "localhost" || normalized.endsWith(".localhost")) {
+    return true;
+  }
+  const family = isIP(normalized);
+  return family === 4
+    ? LOOPBACK_ADDRESSES.check(normalized, "ipv4")
+    : family === 6
+      ? LOOPBACK_ADDRESSES.check(normalized, "ipv6")
+      : false;
 }
 
 function inferProviderPlatform(adapter: BuiltinAdapterName): ProviderPlatformName | undefined {
@@ -325,6 +332,7 @@ const GoogleChatConfigSchema = z
   .superRefine((value, ctx) => {
     if (
       value.pubsubAudience &&
+      !value.disableSignatureVerification &&
       !value.pubsubServiceAccountEmail &&
       !value.credentials?.client_email
     ) {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,8 +1,10 @@
+import { validateHeaderValue } from "node:http";
 import { z } from "zod";
 import { inboundRegexSafetyError } from "../core/safe-regex.js";
 
 export const FIXTURE_MODES = ["probe", "send", "roundtrip", "agent"] as const;
 const FIXTURE_ID_PATTERN = /^[a-z0-9-]+$/i;
+const MAX_FIXTURE_RETRIES = 10;
 const MAX_TIMER_MS = 2_147_483_647;
 export const INBOUND_AUTHORS = ["assistant", "user", "system", "any"] as const;
 export const INBOUND_STRATEGIES = ["contains", "exact", "regex"] as const;
@@ -62,6 +64,42 @@ const HttpUrlSchema = z
       return false;
     }
   }, "URL must use http or https");
+
+const HttpsUrlSchema = HttpUrlSchema.refine((value) => {
+  try {
+    return new URL(value).protocol === "https:";
+  } catch {
+    return false;
+  }
+}, "URL must use https");
+
+const HeaderValueSchema = z
+  .string()
+  .min(1)
+  .refine((value) => {
+    try {
+      validateHeaderValue("x-crabline-secret", value);
+      return true;
+    } catch {
+      return false;
+    }
+  }, "secret must be a valid HTTP header value");
+
+const WebhookPathSchema = z.string().min(1).startsWith("/", "webhook path must start with /");
+
+function isLoopbackHost(host: string): boolean {
+  const normalized = host
+    .trim()
+    .replace(/^\[(.*)\]$/u, "$1")
+    .toLowerCase();
+  return (
+    normalized === "localhost" ||
+    normalized.endsWith(".localhost") ||
+    normalized === "::1" ||
+    normalized.startsWith("::ffff:127.") ||
+    /^127(?:\.\d{1,3}){3}$/u.test(normalized)
+  );
+}
 
 function inferProviderPlatform(adapter: BuiltinAdapterName): ProviderPlatformName | undefined {
   if (adapter === "script") {
@@ -145,7 +183,7 @@ const SlackRecorderSchema = z.strictObject({
 
 const SlackWebhookSchema = z.strictObject({
   host: z.string().min(1).default("127.0.0.1"),
-  path: z.string().min(1).default("/slack/events"),
+  path: WebhookPathSchema.default("/slack/events"),
   port: z.number().int().min(0).max(65_535).default(8787),
   publicUrl: HttpUrlSchema.optional(),
 });
@@ -166,7 +204,7 @@ const DiscordRecorderSchema = z.strictObject({
 
 const DiscordWebhookSchema = z.strictObject({
   host: z.string().min(1).default("127.0.0.1"),
-  path: z.string().min(1).default("/discord/interactions"),
+  path: WebhookPathSchema.default("/discord/interactions"),
   port: z.number().int().min(0).max(65_535).default(8788),
   publicUrl: HttpUrlSchema.optional(),
 });
@@ -191,7 +229,7 @@ const WhatsAppRecorderSchema = z.strictObject({
 
 const WhatsAppWebhookSchema = z.strictObject({
   host: z.string().min(1).default("127.0.0.1"),
-  path: z.string().min(1).default("/whatsapp/webhook"),
+  path: WebhookPathSchema.default("/whatsapp/webhook"),
   port: z.number().int().min(0).max(65_535).default(8789),
   publicUrl: HttpUrlSchema.optional(),
 });
@@ -223,9 +261,9 @@ const MsTeamsRecorderSchema = z.strictObject({
 
 const MsTeamsWebhookSchema = z.strictObject({
   host: z.string().min(1).default("127.0.0.1"),
-  path: z.string().min(1).default("/msteams/webhook"),
+  path: WebhookPathSchema.default("/msteams/webhook"),
   port: z.number().int().min(0).max(65_535).default(8791),
-  publicUrl: HttpUrlSchema.optional(),
+  publicUrl: HttpsUrlSchema.optional(),
 });
 
 const MsTeamsConfigSchema = z.strictObject({
@@ -259,30 +297,44 @@ const GoogleChatRecorderSchema = z.strictObject({
 
 const GoogleChatWebhookSchema = z.strictObject({
   host: z.string().min(1).default("127.0.0.1"),
-  path: z.string().min(1).default("/googlechat/webhook"),
+  path: WebhookPathSchema.default("/googlechat/webhook"),
   port: z.number().int().min(0).max(65_535).default(8792),
   publicUrl: HttpUrlSchema.optional(),
 });
 
-const GoogleChatConfigSchema = z.strictObject({
-  apiUrl: HttpUrlSchema.optional(),
-  credentials: GoogleChatCredentialsSchema.optional(),
-  disableSignatureVerification: z.boolean().optional(),
-  endpointUrl: HttpUrlSchema.optional(),
-  googleChatProjectNumber: z.string().min(1).optional(),
-  impersonateUser: z.string().min(1).optional(),
-  pubsubAudience: z.string().min(1).optional(),
-  pubsubServiceAccountEmail: z.string().min(1).optional(),
-  pubsubTopic: z.string().min(1).optional(),
-  recorder: GoogleChatRecorderSchema.default({}),
-  useApplicationDefaultCredentials: z.boolean().optional(),
-  userName: z.string().min(1).optional(),
-  webhook: GoogleChatWebhookSchema.default({
-    host: "127.0.0.1",
-    path: "/googlechat/webhook",
-    port: 8792,
-  }),
-});
+const GoogleChatConfigSchema = z
+  .strictObject({
+    apiUrl: HttpUrlSchema.optional(),
+    credentials: GoogleChatCredentialsSchema.optional(),
+    disableSignatureVerification: z.boolean().optional(),
+    endpointUrl: HttpUrlSchema.optional(),
+    googleChatProjectNumber: z.string().min(1).optional(),
+    impersonateUser: z.string().min(1).optional(),
+    pubsubAudience: z.string().min(1).optional(),
+    pubsubServiceAccountEmail: z.string().min(1).optional(),
+    pubsubTopic: z.string().min(1).optional(),
+    recorder: GoogleChatRecorderSchema.default({}),
+    useApplicationDefaultCredentials: z.boolean().optional(),
+    userName: z.string().min(1).optional(),
+    webhook: GoogleChatWebhookSchema.default({
+      host: "127.0.0.1",
+      path: "/googlechat/webhook",
+      port: 8792,
+    }),
+  })
+  .superRefine((value, ctx) => {
+    if (
+      value.pubsubAudience &&
+      !value.pubsubServiceAccountEmail &&
+      !value.credentials?.client_email
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "pubsubAudience requires a Pub/Sub service-account identity",
+        path: ["pubsubAudience"],
+      });
+    }
+  });
 
 const TelegramLongPollingSchema = z.strictObject({
   allowedUpdates: z.array(z.string().min(1)).optional(),
@@ -299,7 +351,7 @@ const TelegramRecorderSchema = z.strictObject({
 
 const TelegramWebhookSchema = z.strictObject({
   host: z.string().min(1).default("127.0.0.1"),
-  path: z.string().min(1).default("/telegram/webhook"),
+  path: WebhookPathSchema.default("/telegram/webhook"),
   port: z.number().int().min(0).max(65_535).default(8790),
   publicUrl: HttpUrlSchema.optional(),
 });
@@ -329,7 +381,7 @@ const FeishuConfigSchema = z.strictObject({
   webhook: z
     .strictObject({
       host: z.string().min(1).default("127.0.0.1"),
-      path: z.string().min(1).default("/feishu/webhook"),
+      path: WebhookPathSchema.default("/feishu/webhook"),
       port: z.number().int().min(0).max(65_535).default(8795),
       publicUrl: HttpUrlSchema.optional(),
     })
@@ -346,7 +398,7 @@ const MattermostRecorderSchema = z.strictObject({
 
 const MattermostWebhookSchema = z.strictObject({
   host: z.string().min(1).default("127.0.0.1"),
-  path: z.string().min(1).default("/mattermost/webhook"),
+  path: WebhookPathSchema.default("/mattermost/webhook"),
   port: z.number().int().min(0).max(65_535).default(8793),
   publicUrl: HttpUrlSchema.optional(),
 });
@@ -377,13 +429,13 @@ const ZaloRecorderSchema = z.strictObject({
 
 const ZaloWebhookSchema = z.strictObject({
   host: z.string().min(1).default("127.0.0.1"),
-  path: z.string().min(1).default("/zalo/webhook"),
+  path: WebhookPathSchema.default("/zalo/webhook"),
   port: z.number().int().min(0).max(65_535).default(8794),
   publicUrl: HttpUrlSchema.optional(),
 });
 
 const ZaloConfigSchema = z.strictObject({
-  botToken: z.string().min(1).optional(),
+  botToken: HeaderValueSchema.optional(),
   recorder: ZaloRecorderSchema.default({}),
   userName: z.string().min(1).optional(),
   webhook: ZaloWebhookSchema.default({
@@ -391,7 +443,7 @@ const ZaloConfigSchema = z.strictObject({
     path: "/zalo/webhook",
     port: 8794,
   }),
-  webhookSecret: z.string().min(1).optional(),
+  webhookSecret: HeaderValueSchema.optional(),
 });
 
 const MatrixAccessTokenAuthSchema = z.strictObject({
@@ -417,7 +469,7 @@ const MatrixConfigSchema = z.strictObject({
   webhook: z
     .strictObject({
       host: z.string().min(1).default("127.0.0.1"),
-      path: z.string().min(1).default("/matrix/webhook"),
+      path: WebhookPathSchema.default("/matrix/webhook"),
       port: z.number().int().min(0).max(65_535).default(8797),
       publicUrl: HttpUrlSchema.optional(),
     })
@@ -437,7 +489,7 @@ const IMessageConfigSchema = z.strictObject({
   webhook: z
     .strictObject({
       host: z.string().min(1).default("127.0.0.1"),
-      path: z.string().min(1).default("/imessage/webhook"),
+      path: WebhookPathSchema.default("/imessage/webhook"),
       port: z.number().int().min(0).max(65_535).default(8796),
       publicUrl: HttpUrlSchema.optional(),
     })
@@ -645,7 +697,7 @@ export const FixtureSchema = z.strictObject({
   mode: z.enum(FIXTURE_MODES),
   notes: z.string().optional(),
   provider: z.string().min(1),
-  retries: z.number().int().min(0).default(0),
+  retries: z.number().int().min(0).max(MAX_FIXTURE_RETRIES).default(0),
   tags: z.array(z.string().min(1)).default([]),
   target: TargetSchema,
   timeoutMs: z.number().int().min(100).max(MAX_TIMER_MS).default(30_000),
@@ -671,6 +723,24 @@ const StrictManifestSchema = z
     userName: z.string().min(1).default("crabline"),
   })
   .superRefine((manifest, ctx) => {
+    for (const [providerId, provider] of Object.entries(manifest.providers)) {
+      if (
+        provider.adapter !== "matrix" &&
+        provider.adapter !== "mattermost" &&
+        provider.adapter !== "imessage"
+      ) {
+        continue;
+      }
+      const webhook = provider[provider.adapter]?.webhook;
+      if (webhook?.publicUrl || (webhook && !isLoopbackHost(webhook.host))) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `${provider.adapter} provider ${providerId} does not support external webhook ingress`,
+          path: ["providers", providerId, provider.adapter, "webhook"],
+        });
+      }
+    }
+
     const seenFixtureIds = new Set<string>();
     for (const [index, fixture] of manifest.fixtures.entries()) {
       if (seenFixtureIds.has(fixture.id)) {

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -38,11 +38,10 @@ export class CrablineError extends Error {
 }
 
 export function ensureErrorMessage(error: unknown): string {
-  if (error instanceof Error) {
-    return error.message;
-  }
-
   try {
+    if (error instanceof Error) {
+      return error.message;
+    }
     return String(error);
   } catch {
     return "Unknown error";

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -27,11 +27,43 @@ const INBOUND_DEADLINE_REACHED = Symbol("inbound deadline reached");
 const INBOUND_ABORT_GRACE_MS = 250;
 const MAX_EXCLUDED_INBOUND_IDS = 1_024;
 const MAX_SCRIPT_STDIN_BYTES = 1024 * 1024;
+const suiteBlockingResults = new WeakSet<CommandRunResult>();
 
-class UnsettledProviderOperationError extends CrablineError {}
+type ObservedProviderOperation<T> = {
+  isSettled(): boolean;
+  promise: Promise<T>;
+  settled: Promise<void>;
+};
+
+class UnsettledProviderOperationError extends CrablineError {
+  constructor(
+    message: string,
+    options: { cause?: unknown; kind: FailureKind },
+    readonly operation: ObservedProviderOperation<unknown>,
+  ) {
+    super(message, options);
+  }
+}
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function observeProviderOperation<T>(promise: Promise<T>): ObservedProviderOperation<T> {
+  let operationSettled = false;
+  const settled = promise.then(
+    () => {
+      operationSettled = true;
+    },
+    () => {
+      operationSettled = true;
+    },
+  );
+  return {
+    isSettled: () => operationSettled,
+    promise,
+    settled,
+  };
 }
 
 async function raceInboundDeadline<T>(
@@ -57,8 +89,10 @@ async function withFixtureDeadline<T>(
   operationName: string,
 ): Promise<T> {
   const controller = new AbortController();
-  const pending = Promise.resolve().then(async () => await operation(controller.signal));
-  const result = await raceInboundDeadline(pending, timeoutMs);
+  const pending = observeProviderOperation(
+    Promise.resolve().then(async () => await operation(controller.signal)),
+  );
+  const result = await raceInboundDeadline(pending.promise, timeoutMs);
   if (result === INBOUND_DEADLINE_REACHED) {
     const timeoutError = new CrablineError(
       `Provider ${operationName} timed out after ${timeoutMs}ms.`,
@@ -67,17 +101,17 @@ async function withFixtureDeadline<T>(
       },
     );
     controller.abort(timeoutError);
-    const settled = pending.then(
-      () => true,
-      () => true,
-    );
-    if ((await raceInboundDeadline(settled, INBOUND_ABORT_GRACE_MS)) === INBOUND_DEADLINE_REACHED) {
+    if (
+      (await raceInboundDeadline(pending.settled, INBOUND_ABORT_GRACE_MS)) ===
+      INBOUND_DEADLINE_REACHED
+    ) {
       throw new UnsettledProviderOperationError(
         `Provider ${operationName} did not settle within ${INBOUND_ABORT_GRACE_MS}ms after abort.`,
         {
           cause: timeoutError,
           kind: "timeout",
         },
+        pending,
       );
     }
     throw timeoutError;
@@ -216,15 +250,14 @@ function scriptPayloadBase(context: {
 }
 
 async function abortAndDrainInboundWait(
-  operation: Promise<unknown>,
+  operation: ObservedProviderOperation<unknown>,
   controller: AbortController,
 ): Promise<boolean> {
   controller.abort(new Error("Inbound wait deadline reached."));
-  const settled = operation.then(
-    () => true,
-    () => true,
+  return (
+    (await raceInboundDeadline(operation.settled, INBOUND_ABORT_GRACE_MS)) !==
+    INBOUND_DEADLINE_REACHED
   );
-  return (await raceInboundDeadline(settled, INBOUND_ABORT_GRACE_MS)) !== INBOUND_DEADLINE_REACHED;
 }
 
 export async function runFixtureCommand(params: {
@@ -245,6 +278,7 @@ export async function runFixtureCommand(params: {
   const provider = params.registry.resolve(fixture.provider, fixture.id);
   const diagnostics: string[] = [];
   let abortDrainFailed = false;
+  const unsettledProviderOperations: ObservedProviderOperation<unknown>[] = [];
 
   const contextBase = {
     config: params.manifest.providers[fixture.provider]!,
@@ -309,6 +343,7 @@ export async function runFixtureCommand(params: {
       } catch (error) {
         if (error instanceof UnsettledProviderOperationError) {
           abortDrainFailed = true;
+          unsettledProviderOperations.push(error.operation);
         }
         return (result = toFailure(fixture.id, fixture.provider, mode, error, "connectivity"));
       }
@@ -373,6 +408,7 @@ export async function runFixtureCommand(params: {
             lastFailure = toFailure(fixture.id, fixture.provider, mode, error, "outbound", nonce);
             if (error instanceof UnsettledProviderOperationError) {
               abortDrainFailed = true;
+              unsettledProviderOperations.push(error.operation);
               break;
             }
             continue;
@@ -434,14 +470,16 @@ export async function runFixtureCommand(params: {
                   },
                 });
               }
-              const wait = provider.waitForInbound(waitContext);
-              const candidate = await raceInboundDeadline(wait, timeoutMs);
+              const wait = observeProviderOperation(provider.waitForInbound(waitContext));
+              const candidate = await raceInboundDeadline(wait.promise, timeoutMs);
               if (candidate === INBOUND_DEADLINE_REACHED) {
                 if (!(await abortAndDrainInboundWait(wait, controller))) {
                   abortDrainFailed = true;
+                  unsettledProviderOperations.push(wait);
                   throw new UnsettledProviderOperationError(
                     `Provider inbound wait did not settle within ${INBOUND_ABORT_GRACE_MS}ms after abort.`,
                     { kind: "inbound" },
+                    wait,
                   );
                 }
                 break;
@@ -574,6 +612,10 @@ export async function runFixtureCommand(params: {
         };
       }
     }
+    await Promise.resolve();
+    if (result && unsettledProviderOperations.some((operation) => !operation.isSettled())) {
+      suiteBlockingResults.add(result);
+    }
   }
 
   // The finally block can synthesize a result when provider cleanup fails.
@@ -589,14 +631,26 @@ export async function runSuite(params: {
 }): Promise<SuiteRunResult> {
   const results: CommandRunResult[] = [];
   for (const fixtureId of params.fixtureIds) {
-    results.push(
-      await runFixtureCommand({
+    let result: CommandRunResult;
+    try {
+      result = await runFixtureCommand({
         fixtureId,
         manifest: params.manifest,
         manifestPath: params.manifestPath,
         registry: params.registry,
-      }),
-    );
+      });
+    } catch (error) {
+      const fixture = params.manifest.fixtures.find((entry) => entry.id === fixtureId);
+      const provider = fixture ? params.manifest.providers[fixture.provider] : undefined;
+      if (!fixture || (provider?.status !== "disabled" && provider?.status !== "planned")) {
+        throw error;
+      }
+      result = toFailure(fixture.id, fixture.provider, fixture.mode, error, "config");
+    }
+    results.push(result);
+    if (suiteBlockingResults.has(result)) {
+      break;
+    }
   }
 
   return {

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -642,7 +642,12 @@ export async function runSuite(params: {
     } catch (error) {
       const fixture = params.manifest.fixtures.find((entry) => entry.id === fixtureId);
       const provider = fixture ? params.manifest.providers[fixture.provider] : undefined;
-      if (!fixture || (provider?.status !== "disabled" && provider?.status !== "planned")) {
+      if (
+        !fixture ||
+        (provider?.status !== "disabled" && provider?.status !== "planned") ||
+        !(error instanceof CrablineError) ||
+        error.kind !== "config"
+      ) {
         throw error;
       }
       result = toFailure(fixture.id, fixture.provider, fixture.mode, error, "config");

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1374,10 +1374,21 @@ describe("cli", () => {
 
   it("stops and cleans a serve command when stdout closes", async () => {
     const close = vi.fn(async () => undefined);
+    const release = vi.fn(async () => undefined);
+    const remove = vi.fn(async () => undefined);
     const write = vi.spyOn(process.stdout, "write").mockImplementation((() => {
       throw Object.assign(new Error("closed stdout"), { code: "EPIPE" });
     }) as typeof process.stdout.write);
     const program = createProgram(() => undefined, {
+      acquireReadyFileLease: async () => release,
+      publishReadyFile: async () => ({
+        birthtimeNs: 1n,
+        ctimeNs: 1n,
+        dev: 1n,
+        ino: 1n,
+        size: 1n,
+      }),
+      removeReadyFile: remove,
       startServer: async () => ({
         close,
         manifest: {
@@ -1398,13 +1409,23 @@ describe("cli", () => {
 
     try {
       await expect(
-        program.parseAsync(["node", "crabline", "--json", "serve", "telegram"]),
+        program.parseAsync([
+          "node",
+          "crabline",
+          "--json",
+          "serve",
+          "telegram",
+          "--ready-file",
+          "server.json",
+        ]),
       ).resolves.toBe(program);
     } finally {
       write.mockRestore();
     }
 
     expect(close).toHaveBeenCalledTimes(1);
+    expect(remove).toHaveBeenCalledTimes(1);
+    expect(release).toHaveBeenCalledTimes(1);
   });
 
   it("retains ready-file ownership when server close fails", async () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -697,7 +697,7 @@ describe("cli", () => {
     expect(removeReadyFileMock).not.toHaveBeenCalled();
   });
 
-  it("holds ready-file ownership until server shutdown completes", async () => {
+  it("withdraws readiness but holds ownership until server shutdown completes", async () => {
     const directory = await createTempDir();
     directories.push(directory);
     const readyFile = path.join(directory, "server.json");
@@ -705,8 +705,13 @@ describe("cli", () => {
     const closeBlocked = new Promise<void>((resolve) => {
       releaseClose = resolve;
     });
+    let markCloseStarted: (() => void) | undefined;
+    const closeStarted = new Promise<void>((resolve) => {
+      markCloseStarted = resolve;
+    });
     const server = {
       async close() {
+        markCloseStarted?.();
         await closeBlocked;
       },
       manifest: {
@@ -741,10 +746,7 @@ describe("cli", () => {
         "--ready-file",
         readyFile,
       ]);
-      await vi.waitFor(async () => {
-        await expect(fs.readFile(readyFile, "utf8")).resolves.toContain('"provider": "telegram"');
-      });
-      const originalContents = await fs.readFile(readyFile, "utf8");
+      await closeStarted;
       const secondStart = vi.fn(async () => server);
       const secondProgram = createProgram(() => undefined, { startServer: secondStart });
 
@@ -761,7 +763,7 @@ describe("cli", () => {
         ]),
       ).rejects.toBeInstanceOf(Error);
       expect(secondStart).not.toHaveBeenCalled();
-      await expect(fs.readFile(readyFile, "utf8")).resolves.toBe(originalContents);
+      await expect(fs.readFile(readyFile, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
 
       releaseClose?.();
       await first;
@@ -1366,8 +1368,93 @@ describe("cli", () => {
       .catch((error: unknown) => error);
 
     expect(failure).toBeInstanceOf(AggregateError);
-    expect((failure as AggregateError).errors).toEqual([closeError, removeError]);
-    expect((failure as AggregateError).cause).toBe(closeError);
+    expect((failure as AggregateError).errors).toEqual([removeError, closeError]);
+    expect((failure as AggregateError).cause).toBe(removeError);
+  });
+
+  it("stops and cleans a serve command when stdout closes", async () => {
+    const close = vi.fn(async () => undefined);
+    const write = vi.spyOn(process.stdout, "write").mockImplementation((() => {
+      throw Object.assign(new Error("closed stdout"), { code: "EPIPE" });
+    }) as typeof process.stdout.write);
+    const program = createProgram(() => undefined, {
+      startServer: async () => ({
+        close,
+        manifest: {
+          adminToken: "admin",
+          baseUrl: "http://127.0.0.1:12345",
+          botToken: "sample",
+          endpoints: {
+            adminInboundUrl: "http://127.0.0.1:12345/crabline/telegram/inbound",
+            apiRoot: "http://127.0.0.1:12345",
+          },
+          env: { TELEGRAM_BOT_TOKEN: "sample" },
+          provider: "telegram",
+          recorderPath: "telegram.jsonl",
+          version: 1,
+        },
+      }),
+    });
+
+    try {
+      await expect(
+        program.parseAsync(["node", "crabline", "--json", "serve", "telegram"]),
+      ).resolves.toBe(program);
+    } finally {
+      write.mockRestore();
+    }
+
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it("retains ready-file ownership when server close fails", async () => {
+    const release = vi.fn(async () => undefined);
+    const closeError = new Error("close exploded");
+    const remove = vi.fn(async () => undefined);
+    const program = createProgram(() => undefined, {
+      acquireReadyFileLease: async () => release,
+      publishReadyFile: async () => ({
+        birthtimeNs: 1n,
+        ctimeNs: 1n,
+        dev: 1n,
+        ino: 1n,
+        size: 1n,
+      }),
+      removeReadyFile: remove,
+      startServer: async () => ({
+        async close() {
+          throw closeError;
+        },
+        manifest: {
+          adminToken: "admin",
+          baseUrl: "http://127.0.0.1:12345",
+          botToken: "sample",
+          endpoints: {
+            adminInboundUrl: "http://127.0.0.1:12345/crabline/telegram/inbound",
+            apiRoot: "http://127.0.0.1:12345",
+          },
+          env: { TELEGRAM_BOT_TOKEN: "sample" },
+          provider: "telegram",
+          recorderPath: "telegram.jsonl",
+          version: 1,
+        },
+      }),
+    });
+
+    await expect(
+      program.parseAsync([
+        "node",
+        "crabline",
+        "--json",
+        "serve",
+        "telegram",
+        "--once",
+        "--ready-file",
+        "server.json",
+      ]),
+    ).rejects.toBe(closeError);
+    expect(remove).toHaveBeenCalledTimes(1);
+    expect(release).not.toHaveBeenCalled();
   });
 
   it("redacts serve credentials from text output unless explicitly requested", async () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -91,6 +91,137 @@ describe("manifest schema", () => {
     }
   });
 
+  it("requires slash-prefixed webhook paths", () => {
+    expect(() =>
+      ManifestSchema.parse({
+        configVersion: 1,
+        fixtures: [],
+        providers: {
+          slack: {
+            adapter: "slack",
+            slack: { webhook: { path: "slack/events" } },
+          },
+        },
+      }),
+    ).toThrow(/webhook path must start with \//u);
+  });
+
+  it("requires HTTPS for public Microsoft Teams webhooks", () => {
+    expect(() =>
+      ManifestSchema.parse({
+        configVersion: 1,
+        fixtures: [],
+        providers: {
+          msteams: {
+            adapter: "msteams",
+            msteams: {
+              appId: "teams-app",
+              webhook: { publicUrl: "http://teams.example.test/webhook" },
+            },
+          },
+        },
+      }),
+    ).toThrow(/URL must use https/u);
+  });
+
+  it("rejects unsupported external ingress in strict manifests", () => {
+    for (const adapter of ["matrix", "mattermost", "imessage"] as const) {
+      for (const webhook of [
+        { host: "0.0.0.0" },
+        { publicUrl: `https://${adapter}.example.test/webhook` },
+      ]) {
+        expect(() =>
+          ManifestSchema.parse({
+            configVersion: 1,
+            fixtures: [],
+            providers: {
+              provider: {
+                adapter,
+                [adapter]: {
+                  webhook,
+                },
+              },
+            },
+          }),
+        ).toThrow(/does not support external webhook ingress/u);
+      }
+    }
+  });
+
+  it("rejects header-invalid Zalo secrets", () => {
+    for (const [field, value] of [
+      ["botToken", "token\r\nx-injected: yes"],
+      ["webhookSecret", `secret${String.fromCharCode(0)}`],
+    ] as const) {
+      expect(() =>
+        ManifestSchema.parse({
+          configVersion: 1,
+          fixtures: [],
+          providers: {
+            zalo: {
+              adapter: "zalo",
+              zalo: { [field]: value },
+            },
+          },
+        }),
+      ).toThrow(/valid HTTP header value/u);
+    }
+  });
+
+  it("caps fixture retries", () => {
+    expect(() =>
+      ManifestSchema.parse({
+        configVersion: 1,
+        fixtures: [
+          {
+            id: "too-many-retries",
+            mode: "send",
+            provider: "local",
+            retries: 11,
+            target: { id: "sink" },
+          },
+        ],
+        providers: { local: { adapter: "loopback" } },
+      }),
+    ).toThrow(/<=10/u);
+  });
+
+  it("requires a service-account identity for Google Chat Pub/Sub audiences", () => {
+    expect(() =>
+      ManifestSchema.parse({
+        configVersion: 1,
+        fixtures: [],
+        providers: {
+          googlechat: {
+            adapter: "googlechat",
+            googlechat: {
+              pubsubAudience: "https://chat.example.test/webhook",
+            },
+          },
+        },
+      }),
+    ).toThrow(/requires a Pub\/Sub service-account identity/u);
+
+    expect(() =>
+      ManifestSchema.parse({
+        configVersion: 1,
+        fixtures: [],
+        providers: {
+          googlechat: {
+            adapter: "googlechat",
+            googlechat: {
+              credentials: {
+                client_email: "push@example.iam.gserviceaccount.com",
+                private_key: "secret",
+              },
+              pubsubAudience: "https://chat.example.test/webhook",
+            },
+          },
+        },
+      }),
+    ).not.toThrow();
+  });
+
   it("accepts the documented thread target shape", () => {
     expect(() =>
       ManifestSchema.parse({

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -149,7 +149,13 @@ describe("manifest schema", () => {
   });
 
   it("accepts equivalent IPv6 loopback hosts for local-only ingress", () => {
-    for (const host of ["0:0:0:0:0:0:0:1", "[0:0:0:0:0:0:0:1]", "0:0:0:0:0:ffff:7f00:1"]) {
+    for (const host of [
+      "0:0:0:0:0:0:0:1",
+      "[0:0:0:0:0:0:0:1]",
+      "0:0:0:0:0:ffff:7f00:1",
+      "localhost.",
+      "fixture.localhost.",
+    ]) {
       expect(() =>
         ManifestSchema.parse({
           configVersion: 1,

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -148,6 +148,23 @@ describe("manifest schema", () => {
     }
   });
 
+  it("accepts equivalent IPv6 loopback hosts for local-only ingress", () => {
+    for (const host of ["0:0:0:0:0:0:0:1", "[0:0:0:0:0:0:0:1]", "0:0:0:0:0:ffff:7f00:1"]) {
+      expect(() =>
+        ManifestSchema.parse({
+          configVersion: 1,
+          fixtures: [],
+          providers: {
+            matrix: {
+              adapter: "matrix",
+              matrix: { webhook: { host } },
+            },
+          },
+        }),
+      ).not.toThrow();
+    }
+  });
+
   it("rejects header-invalid Zalo secrets", () => {
     for (const [field, value] of [
       ["botToken", "token\r\nx-injected: yes"],
@@ -214,6 +231,24 @@ describe("manifest schema", () => {
                 client_email: "push@example.iam.gserviceaccount.com",
                 private_key: "secret",
               },
+              pubsubAudience: "https://chat.example.test/webhook",
+            },
+          },
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it("allows Google Chat Pub/Sub audiences when signature verification is disabled", () => {
+    expect(() =>
+      ManifestSchema.parse({
+        configVersion: 1,
+        fixtures: [],
+        providers: {
+          googlechat: {
+            adapter: "googlechat",
+            googlechat: {
+              disableSignatureVerification: true,
               pubsubAudience: "https://chat.example.test/webhook",
             },
           },

--- a/test/reporters-errors.test.ts
+++ b/test/reporters-errors.test.ts
@@ -17,6 +17,13 @@ describe("errors and reporters", () => {
       EXIT_CODES.FAILURE,
     );
     expect(ensureErrorMessage(Object.create(null))).toBe("Unknown error");
+    const throwingMessage = new Error("hidden");
+    Object.defineProperty(throwingMessage, "message", {
+      get() {
+        throw new Error("message getter exploded");
+      },
+    });
+    expect(ensureErrorMessage(throwingMessage)).toBe("Unknown error");
   });
 
   it("formats single and suite results", () => {

--- a/test/run.behavior.test.ts
+++ b/test/run.behavior.test.ts
@@ -1052,6 +1052,30 @@ describe("run behavior", () => {
     expect(suite.results.map((result) => result.providerId)).toEqual(["disabled", "planned"]);
   });
 
+  it("does not hide unexpected failures for disabled providers", async () => {
+    const disabledManifest: ManifestDefinition = {
+      ...manifest,
+      providers: {
+        mock: { ...manifest.providers.mock!, status: "disabled" },
+      },
+    };
+    const unexpected = new Error("unexpected registry failure");
+
+    await expect(
+      runSuite({
+        fixtureIds: ["fixture"],
+        manifest: disabledManifest,
+        manifestPath: "/tmp/crabline.yaml",
+        registry: {
+          catalog: OPENCLAW_SUPPORT_CATALOG,
+          resolve() {
+            throw unexpected;
+          },
+        },
+      }),
+    ).rejects.toBe(unexpected);
+  });
+
   it("stops the suite while aborted provider work remains unsettled", async () => {
     let releaseSend: (() => void) | undefined;
     const send = vi.fn(

--- a/test/run.behavior.test.ts
+++ b/test/run.behavior.test.ts
@@ -1054,6 +1054,12 @@ describe("run behavior", () => {
 
   it("stops the suite while aborted provider work remains unsettled", async () => {
     let releaseSend: (() => void) | undefined;
+    const send = vi.fn(
+      async () =>
+        await new Promise<{ accepted: boolean; messageId: string; threadId: string }>((resolve) => {
+          releaseSend = () => resolve({ accepted: true, messageId: "late", threadId: "thread" });
+        }),
+    );
     const unsettledProvider: ProviderAdapter = {
       id: "mock",
       platform: "loopback",
@@ -1063,10 +1069,7 @@ describe("run behavior", () => {
         return { id: target.id, metadata: target.metadata };
       },
       probe: async () => ({ details: [], healthy: true }),
-      send: async () =>
-        await new Promise((resolve) => {
-          releaseSend = () => resolve({ accepted: true, messageId: "late", threadId: "thread" });
-        }),
+      send,
       waitForInbound: async () => null,
       cleanup: async () => undefined,
     };
@@ -1078,7 +1081,7 @@ describe("run behavior", () => {
     const suiteManifest: ManifestDefinition = {
       ...withAllCapabilities(manifest),
       fixtures: [
-        { ...manifest.fixtures[0]!, id: "first", mode: "send", timeoutMs: 10 },
+        { ...manifest.fixtures[0]!, id: "first", mode: "send", retries: 1, timeoutMs: 10 },
         { ...manifest.fixtures[0]!, id: "second", mode: "send", timeoutMs: 10 },
       ],
     };
@@ -1096,9 +1099,11 @@ describe("run behavior", () => {
       });
 
       expect(suite.results).toHaveLength(1);
+      expect(suite.results[0]?.ok).toBe(false);
       expect(suite.results[0]?.diagnostics).toContain(
         "Provider send did not settle within 250ms after abort.",
       );
+      expect(send).toHaveBeenCalledTimes(1);
       expect(secondSend).not.toHaveBeenCalled();
     } finally {
       releaseSend?.();

--- a/test/run.behavior.test.ts
+++ b/test/run.behavior.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { CrablineError } from "../src/core/errors.js";
 import { EXIT_CODES } from "../src/core/exit-codes.js";
 import { computeExitCode, runFixtureCommand, runSuite } from "../src/core/run.js";
@@ -1020,5 +1020,88 @@ describe("run behavior", () => {
 
     expect(computeExitCode(suite)).toBe(0);
     expect(suite.totalPassed).toBe(1);
+  });
+
+  it("records disabled and planned provider failures and continues the suite", async () => {
+    const statusManifest: ManifestDefinition = {
+      ...manifest,
+      fixtures: [
+        { ...manifest.fixtures[0]!, id: "disabled", provider: "disabled" },
+        { ...manifest.fixtures[0]!, id: "planned", provider: "planned" },
+      ],
+      providers: {
+        disabled: { ...manifest.providers.mock!, status: "disabled" },
+        planned: { ...manifest.providers.mock!, status: "planned" },
+      },
+    };
+    const suite = await runSuite({
+      fixtureIds: ["disabled", "planned"],
+      manifest: statusManifest,
+      manifestPath: "/tmp/crabline.yaml",
+      registry: {
+        catalog: OPENCLAW_SUPPORT_CATALOG,
+        resolve(providerId) {
+          const status = statusManifest.providers[providerId]?.status;
+          throw new CrablineError(`Provider "${providerId}" is ${status}.`, { kind: "config" });
+        },
+      },
+    });
+
+    expect(suite.results).toHaveLength(2);
+    expect(suite.results.map((result) => result.failureKind)).toEqual(["config", "config"]);
+    expect(suite.results.map((result) => result.providerId)).toEqual(["disabled", "planned"]);
+  });
+
+  it("stops the suite while aborted provider work remains unsettled", async () => {
+    let releaseSend: (() => void) | undefined;
+    const unsettledProvider: ProviderAdapter = {
+      id: "mock",
+      platform: "loopback",
+      status: "ready",
+      supports: ["send"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      probe: async () => ({ details: [], healthy: true }),
+      send: async () =>
+        await new Promise((resolve) => {
+          releaseSend = () => resolve({ accepted: true, messageId: "late", threadId: "thread" });
+        }),
+      waitForInbound: async () => null,
+      cleanup: async () => undefined,
+    };
+    const secondProvider = {
+      ...unsettledProvider,
+      send: async () => ({ accepted: true, messageId: "second", threadId: "thread" }),
+    };
+    const secondSend = vi.spyOn(secondProvider, "send");
+    const suiteManifest: ManifestDefinition = {
+      ...withAllCapabilities(manifest),
+      fixtures: [
+        { ...manifest.fixtures[0]!, id: "first", mode: "send", timeoutMs: 10 },
+        { ...manifest.fixtures[0]!, id: "second", mode: "send", timeoutMs: 10 },
+      ],
+    };
+    try {
+      const suite = await runSuite({
+        fixtureIds: ["first", "second"],
+        manifest: suiteManifest,
+        manifestPath: "/tmp/crabline.yaml",
+        registry: {
+          catalog: OPENCLAW_SUPPORT_CATALOG,
+          resolve(_providerId, fixtureId) {
+            return fixtureId === "first" ? unsettledProvider : secondProvider;
+          },
+        },
+      });
+
+      expect(suite.results).toHaveLength(1);
+      expect(suite.results[0]?.diagnostics).toContain(
+        "Provider send did not settle within 250ms after abort.",
+      );
+      expect(secondSend).not.toHaveBeenCalled();
+    } finally {
+      releaseSend?.();
+    }
   });
 });


### PR DESCRIPTION
## Summary

- stop `serve` and clean up when stdout closes, withdraw ready markers before close, and retain the ready-file lease after close failure
- tighten strict manifest validation for webhook paths, Teams HTTPS URLs, unsupported external ingress, Zalo header secrets, Google Chat Pub/Sub identity, and retry bounds
- convert disabled/planned suite resolution failures into results, tolerate hostile error message getters, and stop suites while aborted provider work remains unsettled

## Testing

- `pnpm exec vitest run test/config.test.ts test/reporters-errors.test.ts test/run.behavior.test.ts test/run.retry-timeout.test.ts test/cli.test.ts`
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm lint`
- `pnpm test` (56 files, 930 tests)