### PR TITLE
fix(providers): harden final adapter contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Harden provider adapter authentication, target identity, credential redaction, and webhook lifecycle behavior.
+
 ## 0.1.11 - 2026-07-13
 
 - Contain Telegram response delivery failures when clients disconnect during request handling.

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -104,8 +104,10 @@ header before JSON parsing or recorder writes:
 - Feishu `verificationToken` or `FEISHU_VERIFICATION_TOKEN` verifies plaintext
   callback tokens on loopback and remains an additional check when configured
   with encryption. Externally reachable webhooks require `encryptKey` or
-  `FEISHU_ENCRYPT_KEY` to verify `X-Lark-Signature` and decrypt encrypted event
-  envelopes before challenge handling or event normalization.
+  `FEISHU_ENCRYPT_KEY` to verify `X-Lark-Signature` on event callbacks and
+  decrypt encrypted envelopes before normalization. Initial encrypted
+  `url_verification` challenges may omit signature headers and are accepted
+  only when their decrypted token matches the configured verification token.
 - Slack `signingSecret` or `SLACK_SIGNING_SECRET` verifies
   `X-Slack-Request-Timestamp` and `X-Slack-Signature`; it is required when the
   webhook host is non-loopback or `publicUrl` is set.

--- a/src/providers/builtin/discord.ts
+++ b/src/providers/builtin/discord.ts
@@ -106,7 +106,16 @@ function discordApplicationCommandText(data: Record<string, unknown>): string | 
     }
   };
   collectValues(data.options);
-  return [name, ...values].join(" ");
+  const targetId = optionalString(data, "target_id");
+  const resolved = optionalRecord(data, "resolved");
+  const context =
+    targetId === undefined
+      ? undefined
+      : JSON.stringify({
+          target_id: targetId,
+          ...(resolved ? { resolved } : {}),
+        });
+  return [name, ...values, ...(context ? [context] : [])].join(" ");
 }
 
 function discordInteractionText(data: Record<string, unknown>): string | undefined {

--- a/src/providers/builtin/feishu.ts
+++ b/src/providers/builtin/feishu.ts
@@ -115,18 +115,15 @@ function createFeishuWebhookAuthenticatorWithReplay(
       if (!resolved.encryptKey) {
         return unauthorizedFeishuWebhook();
       }
+      if (!verifyFeishuSignature(request, rawBody, resolved.encryptKey)) {
+        return unauthorizedFeishuWebhook();
+      }
       try {
         payload = decryptFeishuWebhookPayload(payload, resolved.encryptKey);
       } catch {
         return unauthorizedFeishuWebhook();
       }
-      if (
-        !verifyFeishuSignature(request, rawBody, resolved.encryptKey) &&
-        !isFeishuUrlVerification(payload)
-      ) {
-        return unauthorizedFeishuWebhook();
-      }
-      signedRequest = !isFeishuUrlVerification(payload);
+      signedRequest = true;
     } else if (resolved.encryptKey) {
       return unauthorizedFeishuWebhook();
     }
@@ -260,10 +257,13 @@ export function normalizeFeishuWebhookPayload(payload: unknown) {
       kind: "inbound",
     });
   }
-  if (!chatId || !text) {
-    throw new CrablineError("Feishu event payload requires message.chat_id and message.content", {
-      kind: "inbound",
-    });
+  if (!chatId || !messageId || !text) {
+    throw new CrablineError(
+      "Feishu event payload requires message.chat_id, message.message_id, and message.content",
+      {
+        kind: "inbound",
+      },
+    );
   }
 
   return {
@@ -274,9 +274,7 @@ export function normalizeFeishuWebhookPayload(payload: unknown) {
           )
         : false,
     ),
-    ...(messageId
-      ? { id: requireNativeInboundId(messageId, FEISHU_MESSAGE_ID_RULE, "Feishu message_id") }
-      : {}),
+    id: requireNativeInboundId(messageId, FEISHU_MESSAGE_ID_RULE, "Feishu message_id"),
     raw: payload,
     text,
     threadId: rootId

--- a/src/providers/builtin/feishu.ts
+++ b/src/providers/builtin/feishu.ts
@@ -115,15 +115,15 @@ function createFeishuWebhookAuthenticatorWithReplay(
       if (!resolved.encryptKey) {
         return unauthorizedFeishuWebhook();
       }
-      if (!verifyFeishuSignature(request, rawBody, resolved.encryptKey)) {
-        return unauthorizedFeishuWebhook();
-      }
       try {
         payload = decryptFeishuWebhookPayload(payload, resolved.encryptKey);
       } catch {
         return unauthorizedFeishuWebhook();
       }
-      signedRequest = true;
+      signedRequest = verifyFeishuSignature(request, rawBody, resolved.encryptKey);
+      if (!signedRequest && !(isFeishuUrlVerification(payload) && validateCallback)) {
+        return unauthorizedFeishuWebhook();
+      }
     } else if (resolved.encryptKey) {
       return unauthorizedFeishuWebhook();
     }

--- a/src/providers/builtin/googlechat.ts
+++ b/src/providers/builtin/googlechat.ts
@@ -114,7 +114,10 @@ export function createGoogleChatWebhookAuthenticator(
       try {
         payload = JSON.parse(rawBody) as unknown;
       } catch {
-        return undefined;
+        return new Response("unauthorized", {
+          headers: { "www-authenticate": "Bearer" },
+          status: 401,
+        });
       }
       const isPubsub =
         isRecord(payload) &&

--- a/src/providers/builtin/matrix.ts
+++ b/src/providers/builtin/matrix.ts
@@ -5,6 +5,8 @@ import { LocalMockProviderAdapter } from "../local-mock.js";
 import type { ProviderAdapter } from "../types.js";
 import {
   getBuiltinTargetCodec,
+  isMatrixEventId,
+  isMatrixRoomId,
   MATRIX_EVENT_ID_RULE,
   MATRIX_ROOM_ID_RULE,
 } from "../target-normalizers.js";
@@ -18,16 +20,21 @@ import {
 } from "./native-local-mock.js";
 import { requireExternalWebhookAuthentication } from "./external-webhook-auth.js";
 
+const DEFAULT_MATRIX_ACCESS = "local-mock-matrix-token";
+
 export function resolveMatrixAdapterConfig(
   config: ProviderConfig,
   userName: string,
   env: NodeJS.ProcessEnv = process.env,
 ) {
+  const fallbackUserId = env.MATRIX_USER_ID?.trim() || `@${userName}:matrix.local`;
   return {
-    auth: config.matrix?.auth ?? {
-      accessToken: env.MATRIX_ACCESS_TOKEN ?? "local-mock-matrix-token",
-      type: "accessToken" as const,
-      userID: env.MATRIX_USER_ID?.trim() || `@${userName}:matrix.local`,
+    auth: {
+      ...(config.matrix?.auth ?? {
+        accessToken: env.MATRIX_ACCESS_TOKEN ?? DEFAULT_MATRIX_ACCESS,
+        type: "accessToken" as const,
+      }),
+      userID: config.matrix?.auth?.userID?.trim() || fallbackUserId,
     },
     baseURL: config.matrix?.baseURL ?? env.MATRIX_BASE_URL ?? "http://matrix.local",
     commandPrefix: config.matrix?.commandPrefix,
@@ -79,14 +86,13 @@ export function matchesMatrixThread(
     return true;
   }
   const scopedExpected =
-    target.channelId && MATRIX_EVENT_ID_RULE.pattern.test(expectedThreadId)
+    target.channelId && isMatrixEventId(expectedThreadId)
       ? matrixThreadKey(target.channelId, expectedThreadId)
       : expectedThreadId;
   return (
     candidateThreadId === expectedThreadId ||
     candidateThreadId === scopedExpected ||
-    (MATRIX_ROOM_ID_RULE.pattern.test(scopedExpected) &&
-      candidateThreadId.startsWith(`${scopedExpected}:thread:`))
+    (isMatrixRoomId(scopedExpected) && candidateThreadId.startsWith(`${scopedExpected}:thread:`))
   );
 }
 

--- a/src/providers/builtin/matrix.ts
+++ b/src/providers/builtin/matrix.ts
@@ -20,21 +20,23 @@ import {
 } from "./native-local-mock.js";
 import { requireExternalWebhookAuthentication } from "./external-webhook-auth.js";
 
-const DEFAULT_MATRIX_ACCESS = "local-mock-matrix-token";
-
 export function resolveMatrixAdapterConfig(
   config: ProviderConfig,
   userName: string,
   env: NodeJS.ProcessEnv = process.env,
 ) {
   const fallbackUserId = env.MATRIX_USER_ID?.trim() || `@${userName}:matrix.local`;
+  const configuredAuth = config.matrix?.auth
+    ? {
+        ...config.matrix.auth,
+        userID: config.matrix.auth.userID?.trim() || fallbackUserId,
+      }
+    : undefined;
   return {
-    auth: {
-      ...(config.matrix?.auth ?? {
-        accessToken: env.MATRIX_ACCESS_TOKEN ?? DEFAULT_MATRIX_ACCESS,
-        type: "accessToken" as const,
-      }),
-      userID: config.matrix?.auth?.userID?.trim() || fallbackUserId,
+    auth: configuredAuth ?? {
+      accessToken: env.MATRIX_ACCESS_TOKEN ?? "local-mock-matrix-token",
+      type: "accessToken" as const,
+      userID: fallbackUserId,
     },
     baseURL: config.matrix?.baseURL ?? env.MATRIX_BASE_URL ?? "http://matrix.local",
     commandPrefix: config.matrix?.commandPrefix,

--- a/src/providers/builtin/mattermost.ts
+++ b/src/providers/builtin/mattermost.ts
@@ -19,7 +19,11 @@ export function resolveMattermostAdapterConfig(
   env: NodeJS.ProcessEnv = process.env,
 ) {
   return {
-    baseUrl: config.mattermost?.baseUrl ?? env.MATTERMOST_BASE_URL ?? "http://mattermost.local",
+    baseUrl:
+      config.mattermost?.baseUrl ??
+      env.MATTERMOST_URL ??
+      env.MATTERMOST_BASE_URL ??
+      "http://mattermost.local",
     botToken: config.mattermost?.botToken ?? env.MATTERMOST_BOT_TOKEN ?? "local-mock-token",
     userName: config.mattermost?.userName,
   };

--- a/src/providers/builtin/script.ts
+++ b/src/providers/builtin/script.ts
@@ -144,7 +144,7 @@ function redactCredentialSyntax(detail: string): string {
       `${prefix}${scheme ? `${scheme} ` : ""}[redacted credential]`,
   );
   redacted = redacted.replace(
-    /\b([A-Za-z_][A-Za-z0-9_-]*)\s*(\+?=|:)\s*("[^"]*"|'[^']*'|[^\s,;}\]]+)/gu,
+    /\b([A-Za-z_][A-Za-z0-9_-]*)\s*(\+?=|:)\s*("[^"]*"|'[^']*'|[^,;}\]\r\n]+)/gu,
     (match, name: string, operator: string) =>
       name.toLowerCase() !== "authorization" && isSensitiveEnvironmentName(name)
         ? `${name}${operator}[redacted credential]`

--- a/src/providers/builtin/script.ts
+++ b/src/providers/builtin/script.ts
@@ -133,7 +133,36 @@ function isSensitiveEnvironmentName(name: string): boolean {
   );
 }
 
+function redactCredentialSyntax(detail: string): string {
+  let redacted = detail.replace(
+    /\b([a-z][a-z0-9+.-]*:\/\/)([^/\s@]+)@/giu,
+    "$1[redacted credentials]@",
+  );
+  redacted = redacted.replace(
+    /(\bauthorization\b["']?\s*[:=]\s*["']?\s*)(?:(basic|bearer)\s+)?([^\s"',;}]+)/giu,
+    (_match, prefix: string, scheme: string | undefined) =>
+      `${prefix}${scheme ? `${scheme} ` : ""}[redacted credential]`,
+  );
+  redacted = redacted.replace(
+    /\b([A-Za-z_][A-Za-z0-9_-]*)\s*(\+?=|:)\s*("[^"]*"|'[^']*'|[^\s,;}\]]+)/gu,
+    (match, name: string, operator: string) =>
+      name.toLowerCase() !== "authorization" && isSensitiveEnvironmentName(name)
+        ? `${name}${operator}[redacted credential]`
+        : match,
+  );
+  return redacted.replace(
+    /--([A-Za-z0-9][A-Za-z0-9_-]*)(=|\s+)("[^"]*"|'[^']*'|[^\s,;]+)/gu,
+    (match, name: string, separator: string) =>
+      isSensitiveEnvironmentName(name.replaceAll("-", "_"))
+        ? `--${name}${separator}[redacted credential]`
+        : match,
+  );
+}
+
 function commandContainsSensitiveValue(command: string): boolean {
+  if (redactCredentialSyntax(command) !== command) {
+    return true;
+  }
   const assignments = [
     ...command.matchAll(/(?:^|[\s;&|])["']?([A-Za-z_][A-Za-z0-9_]*)\s*\+?=/gu),
     ...command.matchAll(/\$env:([A-Za-z_][A-Za-z0-9_]*)\s*\+?=/giu),
@@ -251,6 +280,7 @@ function formatScriptError(
     redactSensitiveEnvironmentValues(detail, diagnostics.sensitiveEnvironmentValues),
     diagnostics.sensitivePayloadValues,
   );
+  redacted = redactCredentialSyntax(redacted);
   for (const configuredCommand of diagnostics.configuredCommands) {
     redacted = redacted.split(configuredCommand).join("[configured script command]");
   }

--- a/src/providers/builtin/telegram.ts
+++ b/src/providers/builtin/telegram.ts
@@ -59,6 +59,25 @@ function normalizeGenericTelegramPayload(payload: Record<string, unknown>) {
     ? optionalString(message, "threadId")
     : optionalString(payload, "threadId");
   const canonicalTopic = threadId ? parseCanonicalTelegramTopic(threadId) : undefined;
+  const channelIds = [
+    optionalString(payload, "channelId"),
+    ...(message ? [optionalString(message, "channelId")] : []),
+  ].filter((value): value is string => value !== undefined);
+  if (canonicalTopic) {
+    for (const channelId of channelIds) {
+      if (
+        requireNativeInboundId(channelId, TELEGRAM_CHAT_ID_RULE, "Telegram channelId") !==
+        canonicalTopic.chatId
+      ) {
+        throw new CrablineError(
+          "Telegram canonical topic chat_id must match the inbound channelId.",
+          {
+            kind: "inbound",
+          },
+        );
+      }
+    }
+  }
   const genericPayload = canonicalTopic
     ? message
       ? {

--- a/src/providers/builtin/whatsapp.ts
+++ b/src/providers/builtin/whatsapp.ts
@@ -153,8 +153,9 @@ export function resolveWhatsAppAdapterConfig(
   return {
     accessToken: config.whatsapp?.accessToken ?? env.WHATSAPP_ACCESS_TOKEN ?? "local-mock-token",
     appSecret,
-    phoneNumberId:
-      config.whatsapp?.phoneNumberId ?? env.WHATSAPP_PHONE_NUMBER_ID ?? "local-mock-phone",
+    ...((config.whatsapp?.phoneNumberId ?? env.WHATSAPP_PHONE_NUMBER_ID)
+      ? { phoneNumberId: config.whatsapp?.phoneNumberId ?? env.WHATSAPP_PHONE_NUMBER_ID! }
+      : {}),
     verifyToken,
   };
 }
@@ -220,6 +221,9 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
   override async probe(context: ProviderContext): Promise<ProbeResult> {
     context.signal?.throwIfAborted();
     const server = await this.#ensureWebhookServer();
+    if (this.#cleanupBegun || this.#cleanedUp) {
+      throw this.#cleanedUpError();
+    }
     context.signal?.throwIfAborted();
     const target = this.normalizeTarget(context.fixture.target);
     const details = [
@@ -284,7 +288,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
         signal: this.#operationSignal(context.signal),
         timeoutMs: context.timeoutMs,
       });
-      if (event && this.#waitCursors.get(cursorKey) === cursorState) {
+      if (this.#waitCursors.get(cursorKey) === cursorState) {
         cursorState.cursor = cursor;
       }
       return event;

--- a/src/providers/target-normalizers.ts
+++ b/src/providers/target-normalizers.ts
@@ -1,3 +1,4 @@
+import { isIP } from "node:net";
 import type { BuiltinAdapterId, FixtureDefinition, ProviderPlatform } from "../config/schema.js";
 import { CrablineError } from "../core/errors.js";
 import type { LocalMockTargetCodec } from "./local-mock.js";
@@ -55,6 +56,93 @@ export const MATRIX_EVENT_ID_RULE: NativeIdRule = {
   name: "Matrix event id",
   pattern: /^\$[^\s]+(?::[^\s]+)?$/u,
 };
+
+const MAX_MATRIX_IDENTIFIER_BYTES = 255;
+
+function isMatrixIpv4Address(value: string): boolean {
+  const octets = value.split(".");
+  return (
+    octets.length === 4 && octets.every((octet) => /^\d{1,3}$/u.test(octet) && Number(octet) <= 255)
+  );
+}
+
+function isMatrixServerName(value: string): boolean {
+  const ipv6 = /^\[([^\]]+)\](?::(\d{1,5}))?$/u.exec(value);
+  if (ipv6) {
+    return isIP(ipv6[1]!) === 6;
+  }
+  const hostAndPort = /^([^:]+?)(?::(\d{1,5}))?$/u.exec(value);
+  if (!hostAndPort) {
+    return false;
+  }
+  const hostname = hostAndPort[1]!;
+  if (isMatrixIpv4Address(hostname)) {
+    return true;
+  }
+  if (/^\d+\.\d+\.\d+\.\d+$/u.test(hostname)) {
+    return false;
+  }
+  return hostname.length <= 255 && /^[A-Za-z0-9.-]+$/u.test(hostname);
+}
+
+function hasLoneSurrogate(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (next < 0xdc00 || next > 0xdfff) {
+        return true;
+      }
+      index += 1;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isMatrixScopedIdentifier(value: string, sigil: "!" | "$"): boolean {
+  const separator = value.indexOf(":");
+  const localpart = value.slice(1, separator);
+  return (
+    value.startsWith(sigil) &&
+    Buffer.byteLength(value, "utf8") <= MAX_MATRIX_IDENTIFIER_BYTES &&
+    separator >= 2 &&
+    !localpart.includes("\0") &&
+    !hasLoneSurrogate(localpart) &&
+    isMatrixServerName(value.slice(separator + 1))
+  );
+}
+
+function isMatrixHashIdentifier(
+  value: string,
+  sigil: "!" | "$",
+  allowLegacyBase64: boolean,
+): boolean {
+  if (!value.startsWith(sigil) || Buffer.byteLength(value, "utf8") > MAX_MATRIX_IDENTIFIER_BYTES) {
+    return false;
+  }
+  const opaqueId = value.slice(1);
+  const encoding =
+    allowLegacyBase64 && /^[A-Za-z0-9+/]{43}$/u.test(opaqueId)
+      ? "base64"
+      : /^[A-Za-z0-9_-]{43}$/u.test(opaqueId)
+        ? "base64url"
+        : undefined;
+  if (!encoding) {
+    return false;
+  }
+  const decoded = Buffer.from(opaqueId, encoding);
+  return decoded.length === 32 && decoded.toString(encoding).replace(/=+$/u, "") === opaqueId;
+}
+
+export function isMatrixRoomId(value: string): boolean {
+  return isMatrixScopedIdentifier(value, "!") || isMatrixHashIdentifier(value, "!", false);
+}
+
+export function isMatrixEventId(value: string): boolean {
+  return isMatrixScopedIdentifier(value, "$") || isMatrixHashIdentifier(value, "$", true);
+}
 
 export const MATTERMOST_ID_RULE: NativeIdRule = {
   example: "abcdefghijklmnopqrstuvwx12",
@@ -278,6 +366,70 @@ const TELEGRAM_TARGET_CODEC: LocalMockTargetCodec = {
   },
 };
 
+const GOOGLE_CHAT_TARGET_CODEC: LocalMockTargetCodec = {
+  normalize(target) {
+    const channelId = requireNativeId(
+      target.channelId ?? target.id,
+      GOOGLE_CHAT_SPACE_RULE,
+      "Google Chat space.name",
+    );
+    const normalized: NormalizedTarget = {
+      channelId,
+      id: target.id,
+      metadata: target.metadata,
+    };
+    if (target.threadId) {
+      const threadId = requireNativeId(
+        target.threadId,
+        GOOGLE_CHAT_THREAD_RULE,
+        "Google Chat thread.name",
+      );
+      if (!threadId.startsWith(`${channelId}/threads/`)) {
+        throw new CrablineError("Google Chat thread.name must belong to the target space.name.", {
+          kind: "config",
+        });
+      }
+      normalized.threadId = threadId;
+    }
+    return normalized;
+  },
+  resolveThreadId(target) {
+    const normalized = this.normalize(target);
+    return normalized.threadId ?? normalized.channelId ?? normalized.id;
+  },
+};
+
+const MATRIX_TARGET_CODEC: LocalMockTargetCodec = {
+  normalize(target) {
+    const channelId = target.channelId ?? target.id;
+    if (!isMatrixRoomId(channelId)) {
+      throw new CrablineError(
+        `Matrix room_id must be a native ${MATRIX_ROOM_ID_RULE.name} such as ${MATRIX_ROOM_ID_RULE.example}.`,
+        { kind: "config" },
+      );
+    }
+    const normalized: NormalizedTarget = {
+      channelId,
+      id: target.id,
+      metadata: target.metadata,
+    };
+    if (target.threadId) {
+      if (!isMatrixEventId(target.threadId)) {
+        throw new CrablineError(
+          `Matrix event_id must be a native ${MATRIX_EVENT_ID_RULE.name} such as ${MATRIX_EVENT_ID_RULE.example}.`,
+          { kind: "config" },
+        );
+      }
+      normalized.threadId = target.threadId;
+    }
+    return normalized;
+  },
+  resolveThreadId(target) {
+    const normalized = this.normalize(target);
+    return normalized.threadId ?? normalized.channelId ?? normalized.id;
+  },
+};
+
 const BUILTIN_TARGET_CODECS = {
   discord: createNativeTargetCodec({
     channel: DISCORD_SNOWFLAKE_RULE,
@@ -291,23 +443,13 @@ const BUILTIN_TARGET_CODECS = {
     thread: FEISHU_MESSAGE_ID_RULE,
     threadLabel: "Feishu message_id",
   }),
-  googlechat: createNativeTargetCodec({
-    channel: GOOGLE_CHAT_SPACE_RULE,
-    channelLabel: "Google Chat space.name",
-    thread: GOOGLE_CHAT_THREAD_RULE,
-    threadLabel: "Google Chat thread.name",
-  }),
+  googlechat: GOOGLE_CHAT_TARGET_CODEC,
   imessage: createNativeTargetCodec({
     channel: IMESSAGE_THREAD_RULE,
     channelLabel: "iMessage recipient or chat GUID",
   }),
   loopback: createGenericLocalMockTargetCodec("loopback"),
-  matrix: createNativeTargetCodec({
-    channel: MATRIX_ROOM_ID_RULE,
-    channelLabel: "Matrix room_id",
-    thread: MATRIX_EVENT_ID_RULE,
-    threadLabel: "Matrix event_id",
-  }),
+  matrix: MATRIX_TARGET_CODEC,
   mattermost: createNativeTargetCodec({
     channel: MATTERMOST_ID_RULE,
     channelLabel: "Mattermost channel_id",

--- a/test/discord-provider.test.ts
+++ b/test/discord-provider.test.ts
@@ -82,6 +82,34 @@ describe("Discord interaction responses", () => {
     });
   });
 
+  it("preserves context-command target and resolved data", () => {
+    expect(
+      normalizeDiscordWebhookPayload({
+        channel_id: "123456789012345678",
+        data: {
+          name: "inspect user",
+          resolved: {
+            members: {
+              "555456789012345678": { nick: "Target User" },
+            },
+            users: {
+              "555456789012345678": {
+                id: "555456789012345678",
+                username: "target-user",
+              },
+            },
+          },
+          target_id: "555456789012345678",
+          type: 2,
+        },
+        id: "444456789012345678",
+        type: 2,
+      }),
+    ).toMatchObject({
+      text: 'inspect user {"target_id":"555456789012345678","resolved":{"members":{"555456789012345678":{"nick":"Target User"}},"users":{"555456789012345678":{"id":"555456789012345678","username":"target-user"}}}}',
+    });
+  });
+
   it.each([
     [
       {

--- a/test/feishu-provider.test.ts
+++ b/test/feishu-provider.test.ts
@@ -154,16 +154,18 @@ describe("Feishu webhook normalizer", () => {
     ).toThrow(/truncated/u);
   });
 
-  it("authenticates encrypted URL verification before decryption", async () => {
+  it("accepts token-authenticated encrypted URL verification without signature headers", async () => {
     const config = await createLocalMockConfig("feishu", "/feishu/webhook");
     const encryptKey = "encrypt-key";
     config.feishu!.encryptKey = encryptKey;
+    config.feishu!.verificationToken = "sample";
     const now = 1_700_000_000_000;
     const authenticate = createFeishuWebhookAuthenticator(config, {}, { now: () => now });
     const encryptedPayload = {
       encrypt: encryptFeishuPayload(
         {
           challenge: "challenge-token",
+          token: "sample",
           type: "url_verification",
         },
         encryptKey,
@@ -178,7 +180,7 @@ describe("Feishu webhook normalizer", () => {
 
     await expect(
       authenticate!(new Request("https://feishu.example.test/webhook"), rawBody),
-    ).resolves.toMatchObject({ status: 401 });
+    ).resolves.toBeUndefined();
     await expect(
       authenticate!(
         new Request("https://feishu.example.test/webhook", {
@@ -191,6 +193,21 @@ describe("Feishu webhook normalizer", () => {
         rawBody,
       ),
     ).resolves.toBeUndefined();
+    await expect(
+      authenticate!(
+        new Request("https://feishu.example.test/webhook"),
+        JSON.stringify({
+          encrypt: encryptFeishuPayload(
+            {
+              challenge: "challenge-token",
+              token: "wrong",
+              type: "url_verification",
+            },
+            encryptKey,
+          ),
+        }),
+      ),
+    ).resolves.toMatchObject({ status: 401 });
     await expect(
       authenticate!(
         new Request("https://feishu.example.test/webhook", {

--- a/test/feishu-provider.test.ts
+++ b/test/feishu-provider.test.ts
@@ -154,33 +154,105 @@ describe("Feishu webhook normalizer", () => {
     ).toThrow(/truncated/u);
   });
 
-  it("accepts unsigned encrypted URL verification only", async () => {
+  it("authenticates encrypted URL verification before decryption", async () => {
+    const config = await createLocalMockConfig("feishu", "/feishu/webhook");
+    const encryptKey = "encrypt-key";
+    config.feishu!.encryptKey = encryptKey;
+    const now = 1_700_000_000_000;
+    const authenticate = createFeishuWebhookAuthenticator(config, {}, { now: () => now });
+    const encryptedPayload = {
+      encrypt: encryptFeishuPayload(
+        {
+          challenge: "challenge-token",
+          type: "url_verification",
+        },
+        encryptKey,
+      ),
+    };
+    const rawBody = JSON.stringify(encryptedPayload);
+    const timestamp = String(now / 1_000);
+    const nonce = "challenge-nonce";
+    const signature = createHash("sha256")
+      .update(timestamp + nonce + encryptKey + rawBody)
+      .digest("hex");
+
+    await expect(
+      authenticate!(new Request("https://feishu.example.test/webhook"), rawBody),
+    ).resolves.toMatchObject({ status: 401 });
+    await expect(
+      authenticate!(
+        new Request("https://feishu.example.test/webhook", {
+          headers: {
+            "x-lark-request-nonce": nonce,
+            "x-lark-request-timestamp": timestamp,
+            "x-lark-signature": signature,
+          },
+        }),
+        rawBody,
+      ),
+    ).resolves.toBeUndefined();
+    await expect(
+      authenticate!(
+        new Request("https://feishu.example.test/webhook", {
+          headers: {
+            "x-lark-request-nonce": nonce,
+            "x-lark-request-timestamp": timestamp,
+            "x-lark-signature": "0".repeat(64),
+          },
+        }),
+        JSON.stringify({ encrypt: Buffer.alloc(16).toString("base64") }),
+      ),
+    ).resolves.toMatchObject({ status: 401 });
+  });
+
+  it("rejects native messages without stable identifiers", () => {
+    const payload = {
+      event: {
+        message: {
+          chat_id: "oc_abc123",
+          content: JSON.stringify({ text: "identifier required" }),
+          message_type: "text",
+        },
+      },
+      header: { event_id: "event-without-message-id" },
+      schema: "2.0",
+    };
+
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      expect(() => normalizeFeishuWebhookPayload(payload)).toThrow(/message\.message_id/u);
+    }
+  });
+
+  it("rejects unsigned encrypted event callbacks", async () => {
     const config = await createLocalMockConfig("feishu", "/feishu/webhook");
     const encryptKey = "encrypt-key";
     config.feishu!.encryptKey = encryptKey;
     const authenticate = createFeishuWebhookAuthenticator(config, {});
-    const challenge = JSON.stringify({
-      challenge: "challenge-token",
-      type: "url_verification",
+    const event = JSON.stringify({
+      event: {
+        message: {
+          chat_id: "oc_abc123",
+          content: JSON.stringify({ text: "unsigned" }),
+          message_id: "om_unsigned123",
+          message_type: "text",
+        },
+      },
     });
 
     await expect(
       authenticate!(
         new Request("https://feishu.example.test/webhook"),
-        JSON.stringify({ encrypt: encryptFeishuPayload(JSON.parse(challenge), encryptKey) }),
-      ),
-    ).resolves.toBeUndefined();
-    await expect(
-      authenticate!(
-        new Request("https://feishu.example.test/webhook"),
-        JSON.stringify({
-          encrypt: encryptFeishuPayload(
-            { event: { message: { content: "{}", message_type: "text" } } },
-            encryptKey,
-          ),
-        }),
+        JSON.stringify({ encrypt: encryptFeishuPayload(JSON.parse(event), encryptKey) }),
       ),
     ).resolves.toMatchObject({ status: 401 });
+  });
+
+  it("still recognizes plaintext URL verification payloads", () => {
+    const challenge = {
+      challenge: "challenge-token",
+      type: "url_verification",
+    };
+    expect(handleFeishuWebhookPayload(challenge)?.status).toBe(200);
   });
 
   it("rejects plaintext callbacks when only encrypted ingress is configured", async () => {

--- a/test/googlechat-provider.test.ts
+++ b/test/googlechat-provider.test.ts
@@ -158,6 +158,25 @@ describe("Google Chat webhook authentication", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("rejects malformed JSON before accepting an arbitrary bearer token", async () => {
+    const config = await createLocalMockConfig("googlechat", "/googlechat/webhook");
+    config.googlechat!.endpointUrl = "https://chat.example.test/googlechat/webhook";
+    const authenticate = createGoogleChatWebhookAuthenticator(config, {
+      fetch: async () => {
+        throw new Error("certificate lookup must not run for malformed JSON");
+      },
+    });
+
+    await expect(
+      authenticate!(
+        new Request(config.googlechat!.endpointUrl!, {
+          headers: { authorization: "Bearer arbitrary-token" },
+        }),
+        "{",
+      ),
+    ).resolves.toMatchObject({ status: 401 });
+  });
+
   it("defaults the Pub/Sub audience to the endpoint URL", async () => {
     const config = await createLocalMockConfig("googlechat", "/googlechat/webhook");
     config.googlechat!.endpointUrl = "https://chat.example.test/pubsub";
@@ -273,6 +292,23 @@ describe("Google Chat webhook authentication", () => {
         },
       }),
     ).toThrow(/must belong to message\.space\.name/u);
+  });
+
+  it("requires configured thread targets to belong to their space", async () => {
+    const config = await createLocalMockConfig("googlechat", "/googlechat/webhook");
+    const provider = new GoogleChatProviderAdapter("googlechat", config, "crabline");
+    try {
+      expect(() =>
+        provider.normalizeTarget({
+          channelId: "spaces/AAAABbbbCCC",
+          id: "spaces/AAAABbbbCCC",
+          metadata: {},
+          threadId: "spaces/OtherSpace/threads/BBBBccccDDD",
+        }),
+      ).toThrow(/must belong to the target space\.name/u);
+    } finally {
+      await provider.cleanup();
+    }
   });
 });
 

--- a/test/matrix-provider.default-runtime.test.ts
+++ b/test/matrix-provider.default-runtime.test.ts
@@ -63,6 +63,30 @@ describe("matrix provider default runtime", () => {
     ).toMatchObject({ author: "assistant" });
   });
 
+  it("fills inline auth userID from the environment or local default", () => {
+    const config = createConfig({
+      auth: {
+        accessToken: "test-token-placeholder",
+        type: "accessToken",
+      },
+    });
+
+    expect(
+      resolveMatrixAdapterConfig(config, "crabline", {
+        MATRIX_USER_ID: "@env-bot:example.com",
+      }).auth,
+    ).toEqual({
+      accessToken: "test-token-placeholder",
+      type: "accessToken",
+      userID: "@env-bot:example.com",
+    });
+    expect(resolveMatrixAdapterConfig(config, "crabline", {}).auth).toEqual({
+      accessToken: "test-token-placeholder",
+      type: "accessToken",
+      userID: "@crabline:matrix.local",
+    });
+  });
+
   it("preserves configured Matrix metadata when provided", () => {
     expect(
       resolveMatrixAdapterConfig(

--- a/test/matrix-provider.test.ts
+++ b/test/matrix-provider.test.ts
@@ -21,6 +21,37 @@ describe("Matrix webhook normalizer", () => {
     await provider.cleanup();
   });
 
+  it("aligns target identifiers with the Matrix server validator", async () => {
+    const config = await createLocalMockConfig("matrix", "/matrix/webhook");
+    const provider = new MatrixProviderAdapter("matrix", config, "crabline");
+    try {
+      for (const roomId of ["!room:123", "!room:01.2.003.4", "!room:[2001:db8::1]:8448"]) {
+        expect(provider.normalizeTarget({ id: roomId, metadata: {} })).toMatchObject({
+          channelId: roomId,
+        });
+      }
+      for (const roomId of [
+        "!room:999.1.1.1",
+        "!room:invalid_host",
+        `!${"a".repeat(250)}:matrix.test`,
+      ]) {
+        expect(() => provider.normalizeTarget({ id: roomId, metadata: {} })).toThrow(
+          /Matrix room_id/u,
+        );
+      }
+      expect(() =>
+        provider.normalizeTarget({
+          channelId: "!room:matrix.test",
+          id: "!room:matrix.test",
+          metadata: {},
+          threadId: "$event:invalid_host",
+        }),
+      ).toThrow(/Matrix event_id/u);
+    } finally {
+      await provider.cleanup();
+    }
+  });
+
   it("rejects externally reachable webhooks without native authentication", async () => {
     const config = await createLocalMockConfig("matrix", "/matrix/webhook");
     config.matrix!.webhook.host = "0.0.0.0";

--- a/test/mattermost-provider.test.ts
+++ b/test/mattermost-provider.test.ts
@@ -3,6 +3,7 @@ import {
   MattermostProviderAdapter,
   matchesMattermostThread,
   normalizeMattermostWebhookPayload,
+  resolveMattermostAdapterConfig,
 } from "../src/providers/builtin/mattermost.js";
 import { optionalStringish } from "../src/providers/builtin/native-local-mock.js";
 import {
@@ -11,6 +12,22 @@ import {
 } from "./local-mock-provider-helpers.js";
 
 describe("Mattermost webhook normalizer", () => {
+  it("prefers MATTERMOST_URL while retaining the legacy base URL fallback", async () => {
+    const config = await createLocalMockConfig("mattermost", "/mattermost/webhook");
+
+    expect(
+      resolveMattermostAdapterConfig(config, {
+        MATTERMOST_BASE_URL: "https://legacy.example.test",
+        MATTERMOST_URL: "https://current.example.test",
+      }),
+    ).toMatchObject({ baseUrl: "https://current.example.test" });
+    expect(
+      resolveMattermostAdapterConfig(config, {
+        MATTERMOST_BASE_URL: "https://legacy.example.test",
+      }),
+    ).toMatchObject({ baseUrl: "https://legacy.example.test" });
+  });
+
   it("rejects externally reachable webhooks without provider-native authentication", async () => {
     const config = await createLocalMockConfig("mattermost", "/mattermost/webhook");
     config.mattermost!.webhook.host = "0.0.0.0";

--- a/test/script-provider.test.ts
+++ b/test/script-provider.test.ts
@@ -847,6 +847,7 @@ describe("script provider", () => {
           process.env.${headerEnvName},
           "Authorization=Basic sample",
           "API_TOKEN=dummy",
+          "API_TOKEN=Bearer secret-token",
           "--client-secret fake"
         ].join("\\n"));process.exitCode=7;`,
       );
@@ -867,7 +868,14 @@ describe("script provider", () => {
       expect(message).toContain("Authorization=Basic [redacted credential]");
       expect(message).toContain("API_TOKEN=[redacted credential]");
       expect(message).toContain("--client-secret [redacted credential]");
-      for (const secret of ["sample", "test-token-placeholder", "placeholder", "dummy", "fake"]) {
+      for (const secret of [
+        "sample",
+        "test-token-placeholder",
+        "placeholder",
+        "dummy",
+        "secret-token",
+        "fake",
+      ]) {
         expect(message).not.toContain(secret);
       }
     } finally {

--- a/test/script-provider.test.ts
+++ b/test/script-provider.test.ts
@@ -827,6 +827,60 @@ describe("script provider", () => {
     }
   });
 
+  it("redacts URL userinfo and Authorization credential forms", async () => {
+    const context = await createContext();
+    const urlEnvName = "CRABLINE_DATABASE_URL";
+    const headerEnvName = "CRABLINE_HTTP_HEADER";
+    const originalValues = new Map([
+      [urlEnvName, process.env[urlEnvName]],
+      [headerEnvName, process.env[headerEnvName]],
+    ]);
+    process.env[urlEnvName] = "https://sample:test-token-placeholder@service.test/database";
+    process.env[headerEnvName] = "Authorization: Bearer placeholder";
+
+    try {
+      const failingScript = path.join(path.dirname(context.manifestPath), "send-auth-forms.mjs");
+      await writeText(
+        failingScript,
+        `process.stderr.write([
+          process.env.${urlEnvName},
+          process.env.${headerEnvName},
+          "Authorization=Basic sample",
+          "API_TOKEN=dummy",
+          "--client-secret fake"
+        ].join("\\n"));process.exitCode=7;`,
+      );
+      context.config.script!.commands.send = `node ${JSON.stringify(failingScript)}`;
+      const provider = new ScriptProviderAdapter(context);
+      const failure = await provider
+        .send({
+          ...context,
+          mode: "send",
+          nonce: "nonce",
+          text: "payload",
+        })
+        .catch((error: unknown) => error);
+      const message = ensureErrorMessage(failure);
+
+      expect(message).toContain("https://[redacted credentials]@service.test/database");
+      expect(message).toContain("Authorization: Bearer [redacted credential]");
+      expect(message).toContain("Authorization=Basic [redacted credential]");
+      expect(message).toContain("API_TOKEN=[redacted credential]");
+      expect(message).toContain("--client-secret [redacted credential]");
+      for (const secret of ["sample", "test-token-placeholder", "placeholder", "dummy", "fake"]) {
+        expect(message).not.toContain(secret);
+      }
+    } finally {
+      for (const [name, originalValue] of originalValues) {
+        if (originalValue === undefined) {
+          delete process.env[name];
+        } else {
+          process.env[name] = originalValue;
+        }
+      }
+    }
+  });
+
   it("redacts environment secrets before configured command substrings", async () => {
     const context = await createContext();
     const envName = ["SCRIPT", "TOKEN"].join("_");

--- a/test/slack-provider.test.ts
+++ b/test/slack-provider.test.ts
@@ -319,6 +319,17 @@ describe("slack provider", () => {
       .update(`v0:${timestamp}:${body}`)
       .digest("hex")}`;
 
+    const malformed = await fetch(endpoint, {
+      body: "{",
+      headers: {
+        "content-type": "application/json",
+        "x-slack-request-timestamp": timestamp,
+        "x-slack-signature": "v0=invalid",
+      },
+      method: "POST",
+    });
+    expect(malformed.status).toBe(401);
+
     const rejected = await fetch(endpoint, {
       body,
       headers: {

--- a/test/telegram-provider.test.ts
+++ b/test/telegram-provider.test.ts
@@ -169,6 +169,7 @@ describe("telegram provider", () => {
   it("round-trips canonical topic ids through generic ingress", () => {
     const topLevel = {
       authorIsBot: true,
+      channelId: "-100123",
       id: "generic-1",
       text: "generic topic reply",
       threadId: "-100123:42",
@@ -183,6 +184,7 @@ describe("telegram provider", () => {
     const nested = {
       message: {
         authorIsBot: true,
+        channelId: "-100123",
         id: "generic-2",
         text: "nested topic reply",
         threadId: "-100123:42",
@@ -197,6 +199,25 @@ describe("telegram provider", () => {
         threadId: "-100123:42",
       },
     });
+
+    expect(() =>
+      normalizeTelegramWebhookPayload({
+        channelId: "-100999",
+        message: {
+          text: "wrong top-level channel",
+          threadId: "-100123:42",
+        },
+      }),
+    ).toThrow(/must match the inbound channelId/u);
+    expect(() =>
+      normalizeTelegramWebhookPayload({
+        message: {
+          channelId: "-100999",
+          text: "wrong nested channel",
+          threadId: "-100123:42",
+        },
+      }),
+    ).toThrow(/must match the inbound channelId/u);
   });
 
   it("normalizes edited channel posts", () => {

--- a/test/whatsapp-provider-cursor.test.ts
+++ b/test/whatsapp-provider-cursor.test.ts
@@ -120,6 +120,16 @@ describe("WhatsApp provider recorder cursors", () => {
 
     await expect(olderWait).resolves.toMatchObject({ id: "fifth" });
     await expect(provider.waitForInbound({ ...waitContext, timeoutMs: 30 })).resolves.toBeNull();
+
+    await appendRecordedInbound(recorderPath, {
+      author: "user",
+      id: "sixth",
+      provider: "whatsapp",
+      sentAt: new Date().toISOString(),
+      text: "sixth",
+      threadId: "15551234567",
+    });
+    await expect(provider.waitForInbound(waitContext)).resolves.toMatchObject({ id: "sixth" });
   });
 
   it("does not evict cursor state while distinct waits are active", async () => {
@@ -175,5 +185,52 @@ describe("WhatsApp provider recorder cursors", () => {
 
     controllers.slice(1).forEach((controller) => controller.abort());
     await Promise.all(waits.slice(1));
+  });
+
+  it("retains recorder progress after a timeout", async () => {
+    const config = await createLocalMockConfig("whatsapp", "/whatsapp/webhook");
+    const provider = new WhatsAppProviderAdapter("whatsapp", config, "crabline");
+    providers.push(provider);
+    const context = createProviderContext("whatsapp", config, {
+      id: "15551234567",
+      metadata: {},
+    });
+    let authorReads = 0;
+    context.fixture.inboundMatch = {
+      get author() {
+        authorReads += 1;
+        return "assistant" as const;
+      },
+      nonce: "ignore",
+      strategy: "contains",
+    };
+    const recorderPath = path.resolve(config.whatsapp!.recorder.path!);
+    const waitContext = {
+      ...context,
+      nonce: "cursor-timeout",
+      since: new Date(0).toISOString(),
+      threadId: "15551234567",
+      timeoutMs: 30,
+    };
+    await appendRecordedInbound(recorderPath, {
+      author: "user",
+      id: "stale",
+      provider: "whatsapp",
+      sentAt: new Date().toISOString(),
+      text: "stale",
+      threadId: "15551234567",
+    });
+
+    await expect(provider.waitForInbound(waitContext)).resolves.toBeNull();
+    await appendRecordedInbound(recorderPath, {
+      author: "assistant",
+      id: "fresh",
+      provider: "whatsapp",
+      sentAt: new Date().toISOString(),
+      text: "fresh",
+      threadId: "15551234567",
+    });
+    await expect(provider.waitForInbound(waitContext)).resolves.toMatchObject({ id: "fresh" });
+    expect(authorReads).toBe(6);
   });
 });

--- a/test/whatsapp-provider-lifecycle.test.ts
+++ b/test/whatsapp-provider-lifecycle.test.ts
@@ -192,6 +192,25 @@ describe("WhatsApp provider lifecycle", () => {
     expect(webhookMocks.startWebhookServer).toHaveBeenCalledTimes(1);
   });
 
+  it("rechecks cleanup after awaiting an existing listener", async () => {
+    const close = vi.fn(async () => undefined);
+    webhookMocks.startWebhookServer.mockResolvedValueOnce({
+      close,
+      endpointUrl: "http://127.0.0.1:43210/whatsapp/webhook",
+    });
+    const config = createConfig();
+    const provider = new WhatsAppProviderAdapter("whatsapp", config, "crabline");
+    const context = createContext(config);
+
+    await expect(provider.probe(context)).resolves.toMatchObject({ healthy: true });
+    const racingProbe = provider.probe(context);
+    const cleanup = provider.cleanup();
+
+    await expect(racingProbe).rejects.toThrow(/has been cleaned up/u);
+    await cleanup;
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
   it("rejects sends after cleanup without mutating the recorder", async () => {
     const directory = await createTempDir();
     const recorderPath = path.join(directory, "whatsapp.jsonl");

--- a/test/whatsapp-provider.test.ts
+++ b/test/whatsapp-provider.test.ts
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 import {
   normalizeWhatsAppWebhookPayload,
+  resolveWhatsAppAdapterConfig,
   WhatsAppProviderAdapter,
 } from "../src/providers/builtin/whatsapp.js";
 import { appendRecordedInbound, readRecordedInbound } from "../src/providers/recorder.js";
@@ -71,6 +72,39 @@ describe("WhatsApp webhook normalizer", () => {
 
     expect(normalized.map((message) => message.raw)).toEqual([first, second]);
     expect(normalized.every((message) => message.raw !== payload)).toBe(true);
+  });
+
+  it("does not filter inbound messages when phoneNumberId is omitted", () => {
+    const payload = {
+      entry: [
+        {
+          changes: [
+            {
+              value: {
+                metadata: { phone_number_id: "phone-b" },
+                messages: [
+                  {
+                    from: "15551234567",
+                    id: "wamid.unfiltered",
+                    text: { body: "accepted without configured filter" },
+                    type: "text",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(normalizeWhatsAppWebhookPayload(payload)).toHaveLength(1);
+    expect(normalizeWhatsAppWebhookPayload(payload, "phone-a")).toEqual([]);
+  });
+
+  it("leaves phoneNumberId unset when no inbound filter is configured", async () => {
+    const config = await createLocalMockConfig("whatsapp", "/whatsapp/webhook");
+
+    expect(resolveWhatsAppAdapterConfig(config, {})).not.toHaveProperty("phoneNumberId");
   });
 
   it.each([


### PR DESCRIPTION
## Summary

- preserve provider-native callback identity and authenticate malformed or encrypted ingress before parsing/decryption
- align Google Chat, Matrix, Telegram, Mattermost, and WhatsApp target/config behavior with their native contracts
- redact credential-shaped script diagnostics and preserve WhatsApp cleanup/cursor progress

## Validation

- `pnpm test` (56 files, 934 tests)
- `pnpm typecheck`
- `pnpm build`
- targeted `oxfmt --check`
- targeted type-aware `oxlint --deny-warnings`