### PR TITLE
fix(providers): harden recorder and runtime lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Harden serve shutdown ownership, manifest ingress validation, webhook paths, provider secrets, and fixture retry bounds.
 - Harden core CLI lifecycle, manifest validation, retry bounds, error reporting, and suite isolation after unsettled provider cancellation.
 - Pin and validate Slack Events API delivery targets across redirects while preserving native retries and installation authorization envelopes.
+- Harden provider recorder durability and replacement recovery, JWT cache expiry refresh, and LocalMock webhook shutdown draining.
 
 ## 0.1.11 - 2026-07-13
 

--- a/src/providers/local-mock.ts
+++ b/src/providers/local-mock.ts
@@ -227,6 +227,7 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
   readonly #publicUrl: string | undefined;
   readonly #recorderPath: string;
   readonly #activeSends = new Set<Promise<SendResult>>();
+  readonly #activeWebhookHandlers = new Set<Promise<Response>>();
   readonly #cleanupController = new AbortController();
   readonly #waitCursors = new Map<string, WaitCursorState>();
   #cleanupBegun = false;
@@ -431,7 +432,12 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
     this.#beginCleanup();
     this.#cleanupPromise ??= (async () => {
       const sends = [...this.#activeSends];
-      const [serverResult] = await Promise.allSettled([this.#closeWebhookServer(), ...sends]);
+      const webhookHandlers = [...this.#activeWebhookHandlers];
+      const [serverResult] = await Promise.allSettled([
+        this.#closeWebhookServer(),
+        ...sends,
+        ...webhookHandlers,
+      ]);
       if (serverResult?.status === "rejected") {
         throw serverResult.reason;
       }
@@ -439,10 +445,20 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
     await this.#cleanupPromise;
   }
 
-  async #handleWebhook(request: Request): Promise<Response> {
+  #handleWebhook(request: Request): Promise<Response> {
     if (this.#cleanupBegun) {
-      return new Response("provider is shutting down", { status: 503 });
+      return Promise.resolve(new Response("provider is shutting down", { status: 503 }));
     }
+    const handling = this.#handleAdmittedWebhook(request);
+    this.#activeWebhookHandlers.add(handling);
+    void handling.then(
+      () => this.#activeWebhookHandlers.delete(handling),
+      () => this.#activeWebhookHandlers.delete(handling),
+    );
+    return handling;
+  }
+
+  async #handleAdmittedWebhook(request: Request): Promise<Response> {
     const rawBody = await request.text();
     const authenticationFailure = await this.#options.authenticateWebhookRequest?.(
       request,
@@ -513,10 +529,6 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
           new Response("payload requires message.threadId and message.text", { status: 400 }),
         );
       }
-      if (this.#cleanupBegun) {
-        return respond(new Response("provider is shutting down", { status: 503 }));
-      }
-
       await appendRecordedInbound(this.#recorderPath, {
         author: authorFromPayload(payload),
         id,

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -28,6 +28,8 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
 
 const pendingAppends = new Map<string, Promise<void>>();
 const recordIdentityIndexes = new Map<string, RecordIdentityIndex>();
+const durableRecorderIdentities = new Map<string, string>();
+const MAX_DURABLE_RECORDER_IDENTITIES = 128;
 const MAX_RECORD_IDENTITY_INDEXES = 128;
 const MAX_RECENT_RECORD_KEYS = 4096;
 const RECORDER_BATCH_VERSION = 1;
@@ -315,6 +317,18 @@ function sameRecorderFileIdentity(
   return left?.dev === right?.dev && left?.ino === right?.ino;
 }
 
+function recorderFileIdentityKey(identity: RecorderFileIdentity): string {
+  return `${identity.dev}:${identity.ino}`;
+}
+
+function rememberDurableRecorderIdentity(filePath: string, identity: RecorderFileIdentity): void {
+  durableRecorderIdentities.delete(filePath);
+  durableRecorderIdentities.set(filePath, recorderFileIdentityKey(identity));
+  if (durableRecorderIdentities.size > MAX_DURABLE_RECORDER_IDENTITIES) {
+    durableRecorderIdentities.delete(durableRecorderIdentities.keys().next().value!);
+  }
+}
+
 async function resolveRecorderPublicationPath(filePath: string): Promise<string> {
   try {
     return await realpath(filePath);
@@ -336,6 +350,37 @@ async function resolveRecorderPublicationPath(filePath: string): Promise<string>
     }
   }
   return path.join(await realpath(path.dirname(filePath)), path.basename(filePath));
+}
+
+async function openRecorderForAppend(
+  filePath: string,
+): Promise<{ created: boolean; handle: Awaited<ReturnType<typeof open>> }> {
+  try {
+    return {
+      created: true,
+      handle: await open(filePath, "ax+", 0o600),
+    };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+      throw error;
+    }
+    return {
+      created: false,
+      handle: await open(filePath, "a+", 0o600),
+    };
+  }
+}
+
+async function syncParentDirectory(filePath: string): Promise<void> {
+  if (process.platform === "win32") {
+    return;
+  }
+  const directory = await open(path.dirname(filePath), "r");
+  try {
+    await directory.sync();
+  } finally {
+    await directory.close();
+  }
 }
 
 async function prepareRecorderTailForAppend(
@@ -363,7 +408,7 @@ async function prepareRecorderTailForAppend(
   const tailStart = stats.size - windowSize + lastNewline + 1;
   const tail = tailWindow.subarray(lastNewline + 1).toString("utf8");
   try {
-    JSON.parse(tail);
+    parseRecordedLine(tail);
     await handle.writeFile("\n", "utf8");
     return true;
   } catch (error) {
@@ -379,8 +424,9 @@ async function prepareRecorderPathForAppend(
   publicationPath: string,
   logicalPath: string,
   durable: boolean,
-): Promise<RecorderFileIdentity> {
-  const handle = await open(publicationPath, "a+");
+): Promise<{ created: boolean; identity: RecorderFileIdentity }> {
+  const opened = await openRecorderForAppend(publicationPath);
+  const { handle } = opened;
   const identity = await handle.stat({ bigint: true });
   const recorderIdentity = { dev: identity.dev, ino: identity.ino };
   try {
@@ -400,7 +446,7 @@ async function prepareRecorderPathForAppend(
   ) {
     throw new RecorderRotatedError("Recorder rotated while preparing a committed line.");
   }
-  return recorderIdentity;
+  return { created: opened.created, identity: recorderIdentity };
 }
 
 async function appendCommittedLine(
@@ -409,10 +455,16 @@ async function appendCommittedLine(
   line: string,
   durable: boolean,
   expectedIdentity?: RecorderFileIdentity,
+  syncCreatedParent = false,
 ): Promise<void> {
-  const handle = await open(publicationPath, "a+");
+  const opened = await openRecorderForAppend(publicationPath);
+  const { handle } = opened;
   const identity = await handle.stat({ bigint: true });
   const recorderIdentity = { dev: identity.dev, ino: identity.ino };
+  const needsParentSync =
+    opened.created ||
+    syncCreatedParent ||
+    durableRecorderIdentities.get(publicationPath) !== recorderFileIdentityKey(recorderIdentity);
   try {
     if (
       expectedIdentity !== undefined &&
@@ -424,6 +476,10 @@ async function appendCommittedLine(
     await handle.writeFile(line, "utf8");
     if (durable) {
       await handle.sync();
+    }
+    if (durable && needsParentSync) {
+      await syncParentDirectory(publicationPath);
+      rememberDurableRecorderIdentity(publicationPath, recorderIdentity);
     }
   } finally {
     await handle.close();
@@ -636,11 +692,18 @@ export async function appendRecordedInboundBatch(
               `Recorder record exceeded ${MAX_PENDING_RECORD_BYTES} bytes without a newline.`,
             );
           }
-          await appendCommittedLine(publicationPath, logicalPath, line, true, generation);
+          await appendCommittedLine(
+            publicationPath,
+            logicalPath,
+            line,
+            true,
+            generation.identity,
+            generation.created,
+          );
           await syncRecordIdentityIndex(publicationPath);
         } else if (
           !sameRecorderFileIdentity(
-            generation,
+            generation.identity,
             await readRecorderFileIdentity(await resolveRecorderPublicationPath(logicalPath)),
           )
         ) {
@@ -680,6 +743,11 @@ async function syncRecordIdentityIndex(filePath: string): Promise<Set<string>> {
     if (index.readState.generation !== generation) {
       index.seen.clear();
       generation = index.readState.generation;
+      index.readState.caughtUp = false;
+      index.readState.continuity = Buffer.alloc(0);
+      index.readState.offset = 0;
+      index.readState.pending = Buffer.alloc(0);
+      continue;
     }
     for (const event of appended) {
       rememberRecentRecord(index.seen, event);

--- a/src/providers/signed-jwt.ts
+++ b/src/providers/signed-jwt.ts
@@ -78,10 +78,12 @@ export function resolveHttpCacheExpiry(response: Response, now: number): number 
   if (maxAge) {
     return now + Math.max(0, Number(maxAge[1]) - ageSeconds) * 1_000;
   }
-  const expires = Date.parse(response.headers.get("expires") ?? "");
-  return Number.isFinite(expires) && expires > now
-    ? expires
-    : now + Math.max(0, 60 * 60 - ageSeconds) * 1_000;
+  const expiresHeader = response.headers.get("expires");
+  if (expiresHeader === null) {
+    return now + Math.max(0, 60 * 60 - ageSeconds) * 1_000;
+  }
+  const expires = Date.parse(expiresHeader);
+  return Number.isFinite(expires) && expires > now ? expires : now;
 }
 
 export function createCachedJwtKeyResolver<T>(params: {
@@ -163,13 +165,25 @@ export function createCachedJwtKeyResolver<T>(params: {
 
   return async (header: JwtHeader): Promise<T> => {
     const currentTime = now();
+    const freshCache = cached && cached.expiresAt > currentTime ? cached : undefined;
+    if (!freshCache && cached) {
+      const refreshed = await fetchKeys();
+      const refreshedKey = refreshed.values.find(
+        (candidate) => params.keyId(candidate) === header.kid,
+      );
+      if (refreshedKey) {
+        return refreshedKey;
+      }
+      refreshCooldownUntil = now() + refreshCooldownMs;
+      return rejectUnknownKey(header.kid, refreshCooldownUntil);
+    }
+
     const negativeExpiry = negativeKeyIds.get(header.kid);
     if (negativeExpiry && negativeExpiry > currentTime) {
       throw new Error(params.unknownKeyMessage);
     }
     negativeKeyIds.delete(header.kid);
 
-    const freshCache = cached && cached.expiresAt > currentTime ? cached : undefined;
     const keySet = freshCache ?? (await fetchKeys());
     const key = keySet.values.find((candidate) => params.keyId(candidate) === header.kid);
     if (key) {

--- a/test/local-mock-provider.test.ts
+++ b/test/local-mock-provider.test.ts
@@ -566,6 +566,73 @@ describe("local mock provider", () => {
     expect((await readFile(recorderPath, "utf8")).trim().split("\n")).toHaveLength(2);
   });
 
+  it("drains webhook handlers admitted before cleanup", async () => {
+    let handleRequest: ((request: Request) => Promise<Response>) | undefined;
+    let releaseHandler!: () => void;
+    const handlerReleased = new Promise<void>((resolve) => {
+      releaseHandler = resolve;
+    });
+    let reportAdmission!: () => void;
+    const admitted = new Promise<void>((resolve) => {
+      reportAdmission = resolve;
+    });
+    const close = vi.fn(async () => undefined);
+    webhookMocks.startWebhookServer.mockImplementationOnce(async (params) => {
+      handleRequest = params.handle;
+      return {
+        close,
+        endpointUrl: "http://127.0.0.1:43210/slack/events",
+      };
+    });
+    const config = createConfig();
+    const provider = new LocalMockProviderAdapter({
+      codec: createGenericLocalMockTargetCodec("slack"),
+      config,
+      id: "provider-a",
+      options: {
+        defaultWebhook: { host: "127.0.0.1", path: "/slack/events", port: 0 },
+        endpointLabel: "events endpoint",
+        async handleWebhookPayload() {
+          reportAdmission();
+          await handlerReleased;
+          return new Response("accepted", { status: 202 });
+        },
+        platform: "slack",
+      },
+    });
+    providers.push(provider);
+    await provider.probe(createContext(config));
+
+    const handling = handleRequest!(
+      new Request("http://127.0.0.1:43210/slack/events", {
+        body: "{}",
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      }),
+    );
+    await admitted;
+    let cleanupResolved = false;
+    const cleanup = provider.cleanup().then(() => {
+      cleanupResolved = true;
+    });
+
+    await vi.waitFor(() => expect(close).toHaveBeenCalledOnce());
+    expect(cleanupResolved).toBe(false);
+    await expect(
+      handleRequest!(
+        new Request("http://127.0.0.1:43210/slack/events", {
+          body: "{}",
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        }),
+      ),
+    ).resolves.toMatchObject({ status: 503 });
+
+    releaseHandler();
+    await expect(handling).resolves.toMatchObject({ status: 202 });
+    await expect(cleanup).resolves.toBeUndefined();
+  });
+
   it("does not watch events from another provider sharing its recorder", async () => {
     const directory = await createTempDir();
     directories.push(directory);

--- a/test/recorder-concurrency.test.ts
+++ b/test/recorder-concurrency.test.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { rm } from "node:fs/promises";
+import { realpath, rm } from "node:fs/promises";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { appendRecordedInbound } from "../src/providers/recorder.js";
 import { recordServerEvent } from "../src/servers/recorder.js";
@@ -7,6 +7,9 @@ import { recordServerEvent } from "../src/servers/recorder.js";
 const fsMocks = vi.hoisted(() => ({
   lock: vi.fn<() => Promise<() => Promise<void>>>(),
   lockRelease: vi.fn<() => Promise<void>>(),
+  providerDirectory: "",
+  providerDirectorySync: vi.fn<(directoryPath: string) => Promise<void>>(),
+  providerOpen: vi.fn<(filePath: string, flags: string, mode?: number | string) => void>(),
   providerSync: vi.fn<(filePath: string) => Promise<void>>(),
   providerWrite: vi.fn<(filePath: string, data: string) => Promise<void>>(),
   serverDirectory: "",
@@ -37,6 +40,12 @@ vi.mock("node:fs/promises", async (importOriginal) => {
           sync: async () => await fsMocks.serverDirectorySync(filePath),
         } as unknown as Awaited<ReturnType<typeof actual.open>>;
       }
+      if (args[1] === "r" && filePath === fsMocks.providerDirectory) {
+        return {
+          close: async () => {},
+          sync: async () => await fsMocks.providerDirectorySync(filePath),
+        } as unknown as Awaited<ReturnType<typeof actual.open>>;
+      }
       if (
         (args[1] === "a+" || args[1] === "ax+") &&
         filePath.includes("crabline-server-recorder")
@@ -56,13 +65,22 @@ vi.mock("node:fs/promises", async (importOriginal) => {
           truncate: async () => {},
         } as unknown as Awaited<ReturnType<typeof actual.open>>;
       }
+      if (
+        (args[1] === "a+" || args[1] === "ax+") &&
+        filePath.includes("crabline-provider-recorder")
+      ) {
+        fsMocks.providerOpen(filePath, args[1], args[2]);
+      }
       const handle = await actual.open(...args);
-      if (args[1] === "a+" && String(args[0]).includes("crabline-provider-recorder")) {
+      if (
+        (args[1] === "a+" || args[1] === "ax+") &&
+        filePath.includes("crabline-provider-recorder")
+      ) {
         handle.sync = async () => {
-          await fsMocks.providerSync(String(args[0]));
+          await fsMocks.providerSync(filePath);
         };
         handle.writeFile = async (data) => {
-          await fsMocks.providerWrite(String(args[0]), String(data));
+          await fsMocks.providerWrite(filePath, String(data));
         };
       }
       return handle;
@@ -103,6 +121,10 @@ beforeEach(() => {
   fsMocks.lockRelease.mockResolvedValue();
   fsMocks.lock.mockReset();
   fsMocks.lock.mockResolvedValue(fsMocks.lockRelease);
+  fsMocks.providerDirectory = "";
+  fsMocks.providerDirectorySync.mockReset();
+  fsMocks.providerDirectorySync.mockResolvedValue(undefined);
+  fsMocks.providerOpen.mockReset();
   fsMocks.providerSync.mockReset();
   fsMocks.providerSync.mockResolvedValue(undefined);
   fsMocks.providerWrite.mockReset();
@@ -191,6 +213,7 @@ describe("recorder append serialization", () => {
       "/tmp",
       `crabline-provider-recorder-${process.pid}-${Date.now()}.jsonl`,
     );
+    fsMocks.providerDirectory = await realpath(path.dirname(recorderPath));
     const firstEvent = {
       author: "assistant" as const,
       id: "first",
@@ -216,8 +239,50 @@ describe("recorder append serialization", () => {
         expect.objectContaining({ id: "second" }),
       ]);
       expect(fsMocks.providerSync).toHaveBeenCalledTimes(2);
+      expect(fsMocks.providerDirectorySync).toHaveBeenCalledTimes(
+        process.platform === "win32" ? 0 : 1,
+      );
+      expect(fsMocks.providerOpen.mock.calls.map(([, flags, mode]) => [flags, mode])).toEqual([
+        ["ax+", 0o600],
+        ["ax+", 0o600],
+        ["a+", 0o600],
+      ]);
     } finally {
       await rm(recorderPath, { force: true });
     }
   });
+
+  it.skipIf(process.platform === "win32")(
+    "retries parent durability for a newly created provider recorder",
+    async () => {
+      const recorderPath = path.join(
+        "/tmp",
+        `crabline-provider-recorder-durability-${process.pid}-${Date.now()}.jsonl`,
+      );
+      fsMocks.providerDirectory = await realpath(path.dirname(recorderPath));
+      const parentSyncFailure = new Error("simulated recorder parent sync failure");
+      fsMocks.providerWrite.mockResolvedValue(undefined);
+      fsMocks.providerDirectorySync
+        .mockRejectedValueOnce(parentSyncFailure)
+        .mockResolvedValue(undefined);
+      const event = {
+        author: "assistant" as const,
+        id: "durable",
+        provider: "slack",
+        sentAt: "2026-07-12T10:00:00.000Z",
+        text: "durable",
+        threadId: "slack:C123",
+      };
+
+      try {
+        await expect(appendRecordedInbound(recorderPath, event)).rejects.toBe(parentSyncFailure);
+        await expect(
+          appendRecordedInbound(recorderPath, { ...event, id: "retry" }),
+        ).resolves.toMatchObject({ id: "retry" });
+        expect(fsMocks.providerDirectorySync).toHaveBeenCalledTimes(2);
+      } finally {
+        await rm(recorderPath, { force: true });
+      }
+    },
+  );
 });

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -1,9 +1,11 @@
 import {
   appendFile,
+  chmod,
   open,
   readFile,
   rename,
   rm,
+  stat,
   symlink,
   writeFile,
   type FileHandle,
@@ -69,6 +71,28 @@ describe("recorder", () => {
     expect(events[0]?.recordedAt).toBeTypeOf("string");
     expect(events[0]?.text).toBe("hello");
   });
+
+  it.skipIf(process.platform === "win32")(
+    "creates owner-only recorder files without changing existing permissions",
+    async () => {
+      const filePath = await createRecorderPath();
+      const event = {
+        author: "assistant" as const,
+        id: "private-recorder",
+        provider: "slack",
+        sentAt: new Date().toISOString(),
+        text: "private",
+        threadId: "slack:C123",
+      };
+
+      await appendRecordedInbound(filePath, event);
+      expect((await stat(filePath)).mode & 0o777).toBe(0o600);
+
+      await chmod(filePath, 0o640);
+      await appendRecordedInbound(filePath, { ...event, id: "preserve-mode" });
+      expect((await stat(filePath)).mode & 0o777).toBe(0o640);
+    },
+  );
 
   it("round-trips empty message text", async () => {
     const filePath = await createRecorderPath();
@@ -262,6 +286,32 @@ describe("recorder", () => {
     await expect(readRecordedInbound(filePath)).resolves.toEqual([
       expect.objectContaining({ id: "unterminated-retry" }),
     ]);
+  });
+
+  it("rejects a complete invalid recorder tail instead of sealing it", async () => {
+    const filePath = await createRecorderPath();
+    const invalidTail = JSON.stringify({
+      author: "assistant",
+      id: "invalid-tail",
+      provider: "slack",
+      recordedAt: new Date().toISOString(),
+      sentAt: new Date().toISOString(),
+      text: 42,
+      threadId: "slack:C123",
+    });
+    await writeFile(filePath, invalidTail, "utf8");
+
+    await expect(
+      appendRecordedInbound(filePath, {
+        author: "assistant",
+        id: "after-invalid-tail",
+        provider: "slack",
+        sentAt: new Date().toISOString(),
+        text: "must not append",
+        threadId: "slack:C123",
+      }),
+    ).rejects.toThrow(/envelope text must be a string/u);
+    expect(await readFile(filePath, "utf8")).toBe(invalidTail);
   });
 
   it("rejects a batch record larger than the incremental reader limit", async () => {
@@ -688,6 +738,26 @@ describe("recorder", () => {
     await expect(appendRecordedInboundBatch(filePath, [event])).resolves.toEqual([
       expect.objectContaining({ id: event.id }),
     ]);
+  });
+
+  it("rebuilds batch identities when a replacement preserves the consumed prefix", async () => {
+    const filePath = await createRecorderPath();
+    const replacementPath = `${filePath}.replacement`;
+    const event = {
+      author: "user" as const,
+      id: "same-prefix-replacement",
+      provider: "whatsapp",
+      sentAt: new Date().toISOString(),
+      text: "deduplicate after inode replacement",
+      threadId: "15551234567",
+    };
+    await appendRecordedInboundBatch(filePath, [event]);
+    const contents = await readFile(filePath, "utf8");
+    await writeFile(replacementPath, contents, "utf8");
+    await rename(replacementPath, filePath);
+
+    await expect(appendRecordedInboundBatch(filePath, [event])).resolves.toEqual([]);
+    expect(await readFile(filePath, "utf8")).toBe(contents);
   });
 
   it("retries duplicate suppression when the recorder rotates during indexing", async () => {

--- a/test/signed-jwt.test.ts
+++ b/test/signed-jwt.test.ts
@@ -99,6 +99,21 @@ describe("signed JWT remote key cache", () => {
     ).toBe(now);
   });
 
+  it("distinguishes absent Expires from invalid or stale values", () => {
+    const now = 1_700_000_000_000;
+
+    expect(resolveHttpCacheExpiry(new Response(), now)).toBe(now + 3_600_000);
+    expect(
+      resolveHttpCacheExpiry(new Response(null, { headers: { expires: "not-a-date" } }), now),
+    ).toBe(now);
+    expect(
+      resolveHttpCacheExpiry(
+        new Response(null, { headers: { expires: new Date(now - 1_000).toUTCString() } }),
+        now,
+      ),
+    ).toBe(now);
+  });
+
   it("single-flights unknown-key refreshes and applies a global cooldown", async () => {
     let now = 1_700_000_000_000;
     let fetches = 0;
@@ -217,6 +232,59 @@ describe("signed JWT remote key cache", () => {
     now += 2_000;
     await expect(resolveKey({ alg: "RS256", kid: "known" })).resolves.toBe("known");
     await expect(resolveKey({ alg: "RS256", kid: "rotated" })).resolves.toBe("rotated");
+    expect(fetches).toBe(3);
+  });
+
+  it("refreshes an expired positive key set before consulting negative entries", async () => {
+    let now = 1_700_000_000_000;
+    let fetches = 0;
+    const resolveKey = createCachedJwtKeyResolver<string>({
+      async fetchKeys() {
+        fetches += 1;
+        return {
+          expiresAt: now + 1_000,
+          values: fetches < 3 ? ["known"] : ["known", "rotated"],
+        };
+      },
+      keyId: (value) => value,
+      now: () => now,
+      refreshCooldownMs: 10_000,
+      unknownKeyMessage: "unknown key",
+    });
+
+    await expect(resolveKey({ alg: "RS256", kid: "known" })).resolves.toBe("known");
+    await expect(resolveKey({ alg: "RS256", kid: "rotated" })).rejects.toThrow("unknown key");
+    expect(fetches).toBe(2);
+
+    now += 1_001;
+    await expect(resolveKey({ alg: "RS256", kid: "rotated" })).resolves.toBe("rotated");
+    expect(fetches).toBe(3);
+  });
+
+  it("throttles negatives after an expired refresh returns an uncacheable key set", async () => {
+    let now = 1_700_000_000_000;
+    let fetches = 0;
+    const resolveKey = createCachedJwtKeyResolver<string>({
+      async fetchKeys() {
+        fetches += 1;
+        return {
+          expiresAt: fetches < 3 ? now + 1_000 : now,
+          values: ["known"],
+        };
+      },
+      keyId: (value) => value,
+      now: () => now,
+      refreshCooldownMs: 10_000,
+      unknownKeyMessage: "unknown key",
+    });
+
+    await expect(resolveKey({ alg: "RS256", kid: "known" })).resolves.toBe("known");
+    await expect(resolveKey({ alg: "RS256", kid: "missing" })).rejects.toThrow("unknown key");
+    expect(fetches).toBe(2);
+
+    now += 1_001;
+    await expect(resolveKey({ alg: "RS256", kid: "missing" })).rejects.toThrow("unknown key");
+    await expect(resolveKey({ alg: "RS256", kid: "missing" })).rejects.toThrow("unknown key");
     expect(fetches).toBe(3);
   });
 });


### PR DESCRIPTION
## Summary

- validate complete recorder tails before sealing, create recorder files owner-only, and durably sync first publication
- rebuild bounded batch identity state after same-prefix inode replacement and refresh expired JWT keysets before negative-cache rejection
- drain webhook handlers admitted before LocalMock cleanup begins

## Validation

- `pnpm exec vitest run test/recorder.test.ts test/recorder-concurrency.test.ts test/signed-jwt.test.ts test/local-mock-provider.test.ts` (83 tests)
- `pnpm test` (928 tests)
- `pnpm lint`
- `pnpm build`
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` (clean; no accepted/actionable findings)
- GitHub `CI / verify` passed on the pushed head