### PR TITLE
fix(whatsapp): commit inbound evidence transactionally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Harden provider recorder durability and replacement recovery, JWT cache expiry refresh, and LocalMock webhook shutdown draining.
 - Harden recorder append durability, Baileys shutdown draining, and provider-native HTTP, identity, profile, authentication, ingress, and redaction fidelity.
 - Preserve OpenClaw thread and direct-recipient identity, persist recorder and directory metadata, and prevent stale smoke-lock release from fencing successors.
+- Make WhatsApp Web inbound acceptance failure-atomic across recorder persistence, Signal ratchets, one-time prekeys, and acknowledgements; bound identity mappings and tighten request and crypto fallback handling.
 
 ## 0.1.11 - 2026-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Harden provider recorder durability and replacement recovery, JWT cache expiry refresh, and LocalMock webhook shutdown draining.
 - Harden recorder append durability, Baileys shutdown draining, and provider-native HTTP, identity, profile, authentication, ingress, and redaction fidelity.
 - Preserve OpenClaw thread and direct-recipient identity, persist recorder and directory metadata, and prevent stale smoke-lock release from fencing successors.
-- Make WhatsApp Web inbound acceptance failure-atomic across recorder persistence, Signal ratchets, one-time prekeys, and acknowledgements; bound identity mappings and tighten request and crypto fallback handling.
+- Make WhatsApp Web inbound acceptance retry-safe across recorder persistence, Signal ratchets, one-time prekeys, and acknowledgements; bound identity mappings and tighten request and crypto fallback handling.
 
 ## 0.1.11 - 2026-07-13
 

--- a/src/servers/whatsapp-baileys-websocket.ts
+++ b/src/servers/whatsapp-baileys-websocket.ts
@@ -220,7 +220,7 @@ export class WhatsAppSignalBundleStore {
       return { status: "unavailable" };
     }
     const address = new ProtocolAddress(remoteAddress.name, remoteAddress.deviceId);
-    return await this.#runTransaction(address.toString(), async () => {
+    return await this.#runTransaction(identityKey, async () => {
       const sessions = this.#sessions.get(identityKey) ?? new Map<string, SessionRecord>();
       const stagedPreKeyRemovals = new Set<number>();
       const stagedSessions = new Map<string, SessionRecord>();
@@ -256,16 +256,16 @@ export class WhatsAppSignalBundleStore {
       } catch (error) {
         return { error, status: "decrypt-failed" };
       }
-      const accepted = await params.accept(plaintext);
-      if (accepted === undefined) {
-        return { status: "rejected" };
-      }
       const replacementPreKey = stagedPreKeyRemovals.has(bundle.preKeyId)
         ? {
             id: bundle.preKeyId === 0xff_ff_ff ? 1 : bundle.preKeyId + 1,
             keyPair: Curve.generateKeyPair(),
           }
         : undefined;
+      const accepted = await params.accept(plaintext);
+      if (accepted === undefined) {
+        return { status: "rejected" };
+      }
       for (const [id, session] of stagedSessions) {
         sessions.set(id, session);
       }
@@ -1198,7 +1198,7 @@ function children(node: BinaryNode): BinaryNode[] {
   return Array.isArray(node.content) ? node.content : [];
 }
 
-async function persistAcceptedBaileysMessage(params: {
+export async function persistAcceptedBaileysMessage(params: {
   appendEvent(event: ServerRequestEvent): Promise<void>;
   node: BinaryNode;
   path: string;
@@ -1226,30 +1226,29 @@ async function persistAcceptedBaileysMessage(params: {
         try {
           text = readWhatsAppConversation(unpadRandomMax16(decrypted));
         } catch {
-          return undefined;
+          text = undefined;
         }
-        if (!text) {
-          return undefined;
-        }
-        const message: WhatsAppBaileysInboundMessage = {
-          key: {
-            fromMe: true,
-            id: messageId,
-            remoteJid: peer,
-          },
-          message: { conversation: text },
-          messageTimestamp: Math.floor(Date.now() / 1000),
-        };
+        const message: WhatsAppBaileysInboundMessage | undefined = text
+          ? {
+              key: {
+                fromMe: true,
+                id: messageId,
+                remoteJid: peer,
+              },
+              message: { conversation: text },
+              messageTimestamp: Math.floor(Date.now() / 1000),
+            }
+          : undefined;
         await params.appendEvent({
           accepted: true,
           at: new Date().toISOString(),
-          body: message,
+          body: message ?? sanitizeNodeForJson(params.node),
           method: "WEBSOCKET",
           path: params.path,
           query: {},
           type: "api",
         } as ServerRequestEvent & { accepted: true });
-        return message;
+        return true;
       },
       ciphertext: candidate.ciphertext,
       recipientJid: candidate.recipientJid,

--- a/src/servers/whatsapp-baileys-websocket.ts
+++ b/src/servers/whatsapp-baileys-websocket.ts
@@ -41,7 +41,7 @@ export const MAX_WHATSAPP_NOISE_FRAMES_PER_MESSAGE = 1_024;
 export const WHATSAPP_WEBSOCKET_SEND_TIMEOUT_MS = 5_000;
 const MAX_PENDING_WEBSOCKET_BYTES = 8 * 1024 * 1024;
 const MAX_PENDING_WEBSOCKET_MESSAGES = 32;
-const MAX_WHATSAPP_ACCEPTED_MESSAGE_IDS = 10_000;
+const MAX_WHATSAPP_PENDING_ACKNOWLEDGEMENTS = 10_000;
 export const MAX_WHATSAPP_WEBSOCKET_FRAGMENTS = 1_024;
 export const MAX_WHATSAPP_SIGNAL_BUNDLES = 1_024;
 export const MAX_WHATSAPP_WEBSOCKET_CLOSE_REASON_BYTES = 123;
@@ -116,16 +116,22 @@ export type WhatsAppSignalDecryptResult<T> =
   | { status: "rejected" };
 
 export class WhatsAppSignalBundleStore {
-  readonly #acceptedMessageIds = new Map<string, true>();
   readonly #bundles = new Map<string, MockSignalBundle>();
   readonly #lidByPhoneNumber = new Map<string, string>();
   readonly #pendingMessageAcceptances = new Map<string, Promise<void>>();
+  readonly #pendingAcknowledgements = new Set<string>();
   readonly #pendingTransactions = new Map<string, Promise<void>>();
   readonly #sessions = new Map<string, Map<string, SessionRecord>>();
 
-  constructor(private readonly maxBundles = MAX_WHATSAPP_SIGNAL_BUNDLES) {
+  constructor(
+    private readonly maxBundles = MAX_WHATSAPP_SIGNAL_BUNDLES,
+    private readonly maxPendingAcknowledgements = MAX_WHATSAPP_PENDING_ACKNOWLEDGEMENTS,
+  ) {
     if (!Number.isSafeInteger(maxBundles) || maxBundles < 1) {
       throw new Error("WhatsApp maxSignalBundles must be a positive safe integer.");
+    }
+    if (!Number.isSafeInteger(maxPendingAcknowledgements) || maxPendingAcknowledgements < 1) {
+      throw new Error("WhatsApp maxPendingAcknowledgements must be a positive safe integer.");
     }
   }
 
@@ -138,24 +144,29 @@ export class WhatsAppSignalBundleStore {
   }
 
   async acceptMessageOnce(messageKey: string, operation: () => Promise<boolean>): Promise<boolean> {
-    return await this.#runSerialized(this.#pendingMessageAcceptances, messageKey, async () => {
-      if (this.#acceptedMessageIds.delete(messageKey)) {
-        this.#acceptedMessageIds.set(messageKey, true);
+    return await this.#runSerialized(this.#pendingMessageAcceptances, "messages", async () => {
+      if (this.#pendingAcknowledgements.has(messageKey)) {
         return true;
+      }
+      if (this.#pendingAcknowledgements.size >= this.maxPendingAcknowledgements) {
+        throw new Error(
+          `WhatsApp pending acknowledgement limit exceeded (${this.maxPendingAcknowledgements}).`,
+        );
       }
       const accepted = await operation();
       if (!accepted) {
         return false;
       }
-      this.#acceptedMessageIds.set(messageKey, true);
-      if (this.#acceptedMessageIds.size > MAX_WHATSAPP_ACCEPTED_MESSAGE_IDS) {
-        const oldestMessageKey = this.#acceptedMessageIds.keys().next().value;
-        if (oldestMessageKey !== undefined) {
-          this.#acceptedMessageIds.delete(oldestMessageKey);
-        }
-      }
+      this.#pendingAcknowledgements.add(messageKey);
       return true;
     });
+  }
+
+  markMessageAcknowledged(peerJid: string, messageId: string): void {
+    const peer = canonicalizeWhatsAppUserCorrelationJid(peerJid);
+    if (peer && messageId) {
+      this.#pendingAcknowledgements.delete(`${peer}\0${messageId}`);
+    }
   }
 
   associateLid(phoneNumberJid: string, lidJid: string): void {
@@ -726,6 +737,7 @@ class WhatsAppBaileysWebSocketSession {
     }
     if (node.tag === "message") {
       const peer = requireAttr(node, "to");
+      const messageId = requireAttr(node, "id");
       const accepted = await persistAcceptedBaileysMessage({
         appendEvent: this.params.appendEvent,
         node,
@@ -740,12 +752,13 @@ class WhatsAppBaileysWebSocketSession {
         attrs: {
           class: "message",
           from: peer,
-          id: requireAttr(node, "id"),
+          id: messageId,
           to: this.params.selfJid,
           ...(node.attrs.type ? { type: node.attrs.type } : {}),
         },
         tag: "ack",
       });
+      this.params.signalBundles.markMessageAcknowledged(peer, messageId);
     }
   }
 

--- a/src/servers/whatsapp-baileys-websocket.ts
+++ b/src/servers/whatsapp-baileys-websocket.ts
@@ -1211,6 +1211,18 @@ export async function persistAcceptedBaileysMessage(params: {
     return false;
   }
   const candidates = encryptedMessageCandidates(params.node);
+  if (candidates.length === 0) {
+    await params.appendEvent({
+      accepted: true,
+      at: new Date().toISOString(),
+      body: sanitizeNodeForJson(params.node),
+      method: "WEBSOCKET",
+      path: params.path,
+      query: {},
+      type: "api",
+    } as ServerRequestEvent & { accepted: true });
+    return true;
+  }
   const remoteCorrelationJid = canonicalizeWhatsAppUserCorrelationJid(params.remoteJid);
   candidates.sort((left, right) => {
     const leftIsSelf =

--- a/src/servers/whatsapp-baileys-websocket.ts
+++ b/src/servers/whatsapp-baileys-websocket.ts
@@ -694,6 +694,17 @@ class WhatsAppBaileysWebSocketSession {
     if (node.tag === "message") {
       const peer = requireAttr(node, "to");
       const accepted = await persistAcceptedBaileysMessage({
+        acknowledge: () =>
+          this.#sendNode({
+            attrs: {
+              class: "message",
+              from: peer,
+              id: requireAttr(node, "id"),
+              to: this.params.selfJid,
+              ...(node.attrs.type ? { type: node.attrs.type } : {}),
+            },
+            tag: "ack",
+          }),
         appendEvent: this.params.appendEvent,
         node,
         path: this.params.path,
@@ -703,16 +714,6 @@ class WhatsAppBaileysWebSocketSession {
       if (!accepted) {
         return;
       }
-      await this.#sendNode({
-        attrs: {
-          class: "message",
-          from: peer,
-          id: requireAttr(node, "id"),
-          to: this.params.selfJid,
-          ...(node.attrs.type ? { type: node.attrs.type } : {}),
-        },
-        tag: "ack",
-      });
     }
   }
 
@@ -1199,6 +1200,7 @@ function children(node: BinaryNode): BinaryNode[] {
 }
 
 export async function persistAcceptedBaileysMessage(params: {
+  acknowledge?(): Promise<void>;
   appendEvent(event: ServerRequestEvent): Promise<void>;
   node: BinaryNode;
   path: string;
@@ -1221,6 +1223,7 @@ export async function persistAcceptedBaileysMessage(params: {
       query: {},
       type: "api",
     } as ServerRequestEvent & { accepted: true });
+    await params.acknowledge?.();
     return true;
   }
   const remoteCorrelationJid = canonicalizeWhatsAppUserCorrelationJid(params.remoteJid);
@@ -1260,6 +1263,7 @@ export async function persistAcceptedBaileysMessage(params: {
           query: {},
           type: "api",
         } as ServerRequestEvent & { accepted: true });
+        await params.acknowledge?.();
         return true;
       },
       ciphertext: candidate.ciphertext,

--- a/src/servers/whatsapp-baileys-websocket.ts
+++ b/src/servers/whatsapp-baileys-websocket.ts
@@ -41,6 +41,7 @@ export const MAX_WHATSAPP_NOISE_FRAMES_PER_MESSAGE = 1_024;
 export const WHATSAPP_WEBSOCKET_SEND_TIMEOUT_MS = 5_000;
 const MAX_PENDING_WEBSOCKET_BYTES = 8 * 1024 * 1024;
 const MAX_PENDING_WEBSOCKET_MESSAGES = 32;
+const MAX_WHATSAPP_ACCEPTED_MESSAGE_IDS = 10_000;
 export const MAX_WHATSAPP_WEBSOCKET_FRAGMENTS = 1_024;
 export const MAX_WHATSAPP_SIGNAL_BUNDLES = 1_024;
 export const MAX_WHATSAPP_WEBSOCKET_CLOSE_REASON_BYTES = 123;
@@ -115,8 +116,10 @@ export type WhatsAppSignalDecryptResult<T> =
   | { status: "rejected" };
 
 export class WhatsAppSignalBundleStore {
+  readonly #acceptedMessageIds = new Map<string, true>();
   readonly #bundles = new Map<string, MockSignalBundle>();
   readonly #lidByPhoneNumber = new Map<string, string>();
+  readonly #pendingMessageAcceptances = new Map<string, Promise<void>>();
   readonly #pendingTransactions = new Map<string, Promise<void>>();
   readonly #sessions = new Map<string, Map<string, SessionRecord>>();
 
@@ -132,6 +135,27 @@ export class WhatsAppSignalBundleStore {
 
   get lidMappingSize(): number {
     return this.#lidByPhoneNumber.size;
+  }
+
+  async acceptMessageOnce(messageKey: string, operation: () => Promise<boolean>): Promise<boolean> {
+    return await this.#runSerialized(this.#pendingMessageAcceptances, messageKey, async () => {
+      if (this.#acceptedMessageIds.delete(messageKey)) {
+        this.#acceptedMessageIds.set(messageKey, true);
+        return true;
+      }
+      const accepted = await operation();
+      if (!accepted) {
+        return false;
+      }
+      this.#acceptedMessageIds.set(messageKey, true);
+      if (this.#acceptedMessageIds.size > MAX_WHATSAPP_ACCEPTED_MESSAGE_IDS) {
+        const oldestMessageKey = this.#acceptedMessageIds.keys().next().value;
+        if (oldestMessageKey !== undefined) {
+          this.#acceptedMessageIds.delete(oldestMessageKey);
+        }
+      }
+      return true;
+    });
   }
 
   associateLid(phoneNumberJid: string, lidJid: string): void {
@@ -174,6 +198,7 @@ export class WhatsAppSignalBundleStore {
       }
     }
     if (this.#bundles.size + uniqueNewIdentities.size > this.maxBundles) {
+      // Published bundle identities stay stable for the store lifetime.
       throw new Error(`WhatsApp signal bundle limit exceeded (${this.maxBundles}).`);
     }
     return identityKeys.map((identityKey) => this.#resolve(identityKey));
@@ -298,18 +323,26 @@ export class WhatsAppSignalBundleStore {
   }
 
   async #runTransaction<T>(key: string, operation: () => Promise<T>): Promise<T> {
-    const previous = this.#pendingTransactions.get(key) ?? Promise.resolve();
+    return await this.#runSerialized(this.#pendingTransactions, key, operation);
+  }
+
+  async #runSerialized<T>(
+    pending: Map<string, Promise<void>>,
+    key: string,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    const previous = pending.get(key) ?? Promise.resolve();
     const result = previous.catch(() => undefined).then(operation);
     const settled = result.then(
       () => undefined,
       () => undefined,
     );
-    this.#pendingTransactions.set(key, settled);
+    pending.set(key, settled);
     try {
       return await result;
     } finally {
-      if (this.#pendingTransactions.get(key) === settled) {
-        this.#pendingTransactions.delete(key);
+      if (pending.get(key) === settled) {
+        pending.delete(key);
       }
     }
   }
@@ -694,17 +727,6 @@ class WhatsAppBaileysWebSocketSession {
     if (node.tag === "message") {
       const peer = requireAttr(node, "to");
       const accepted = await persistAcceptedBaileysMessage({
-        acknowledge: () =>
-          this.#sendNode({
-            attrs: {
-              class: "message",
-              from: peer,
-              id: requireAttr(node, "id"),
-              to: this.params.selfJid,
-              ...(node.attrs.type ? { type: node.attrs.type } : {}),
-            },
-            tag: "ack",
-          }),
         appendEvent: this.params.appendEvent,
         node,
         path: this.params.path,
@@ -714,6 +736,16 @@ class WhatsAppBaileysWebSocketSession {
       if (!accepted) {
         return;
       }
+      await this.#sendNode({
+        attrs: {
+          class: "message",
+          from: peer,
+          id: requireAttr(node, "id"),
+          to: this.params.selfJid,
+          ...(node.attrs.type ? { type: node.attrs.type } : {}),
+        },
+        tag: "ack",
+      });
     }
   }
 
@@ -1200,7 +1232,6 @@ function children(node: BinaryNode): BinaryNode[] {
 }
 
 export async function persistAcceptedBaileysMessage(params: {
-  acknowledge?(): Promise<void>;
   appendEvent(event: ServerRequestEvent): Promise<void>;
   node: BinaryNode;
   path: string;
@@ -1212,70 +1243,70 @@ export async function persistAcceptedBaileysMessage(params: {
   if (!peer || !messageId) {
     return false;
   }
-  const candidates = encryptedMessageCandidates(params.node);
-  if (candidates.length === 0) {
-    await params.appendEvent({
-      accepted: true,
-      at: new Date().toISOString(),
-      body: sanitizeNodeForJson(params.node),
-      method: "WEBSOCKET",
-      path: params.path,
-      query: {},
-      type: "api",
-    } as ServerRequestEvent & { accepted: true });
-    await params.acknowledge?.();
-    return true;
-  }
-  const remoteCorrelationJid = canonicalizeWhatsAppUserCorrelationJid(params.remoteJid);
-  candidates.sort((left, right) => {
-    const leftIsSelf =
-      canonicalizeWhatsAppUserCorrelationJid(left.recipientJid) === remoteCorrelationJid;
-    const rightIsSelf =
-      canonicalizeWhatsAppUserCorrelationJid(right.recipientJid) === remoteCorrelationJid;
-    return Number(leftIsSelf) - Number(rightIsSelf);
-  });
-  for (const candidate of candidates) {
-    const result = await params.signalBundles.transactDirectMessage({
-      accept: async (decrypted) => {
-        let text: string | undefined;
-        try {
-          text = readWhatsAppConversation(unpadRandomMax16(decrypted));
-        } catch {
-          text = undefined;
-        }
-        const message: WhatsAppBaileysInboundMessage | undefined = text
-          ? {
-              key: {
-                fromMe: true,
-                id: messageId,
-                remoteJid: peer,
-              },
-              message: { conversation: text },
-              messageTimestamp: Math.floor(Date.now() / 1000),
-            }
-          : undefined;
-        await params.appendEvent({
-          accepted: true,
-          at: new Date().toISOString(),
-          body: message ?? sanitizeNodeForJson(params.node),
-          method: "WEBSOCKET",
-          path: params.path,
-          query: {},
-          type: "api",
-        } as ServerRequestEvent & { accepted: true });
-        await params.acknowledge?.();
-        return true;
-      },
-      ciphertext: candidate.ciphertext,
-      recipientJid: candidate.recipientJid,
-      remoteJid: params.remoteJid,
-      type: candidate.type,
-    });
-    if (result.status === "accepted") {
+  return await params.signalBundles.acceptMessageOnce(`${peer}\0${messageId}`, async () => {
+    const candidates = encryptedMessageCandidates(params.node);
+    if (candidates.length === 0) {
+      await params.appendEvent({
+        accepted: true,
+        at: new Date().toISOString(),
+        body: sanitizeNodeForJson(params.node),
+        method: "WEBSOCKET",
+        path: params.path,
+        query: {},
+        type: "api",
+      } as ServerRequestEvent & { accepted: true });
       return true;
     }
-  }
-  return false;
+    const remoteCorrelationJid = canonicalizeWhatsAppUserCorrelationJid(params.remoteJid);
+    candidates.sort((left, right) => {
+      const leftIsSelf =
+        canonicalizeWhatsAppUserCorrelationJid(left.recipientJid) === remoteCorrelationJid;
+      const rightIsSelf =
+        canonicalizeWhatsAppUserCorrelationJid(right.recipientJid) === remoteCorrelationJid;
+      return Number(leftIsSelf) - Number(rightIsSelf);
+    });
+    for (const candidate of candidates) {
+      const result = await params.signalBundles.transactDirectMessage({
+        accept: async (decrypted) => {
+          let text: string | undefined;
+          try {
+            text = readWhatsAppConversation(unpadRandomMax16(decrypted));
+          } catch {
+            text = undefined;
+          }
+          const message: WhatsAppBaileysInboundMessage | undefined = text
+            ? {
+                key: {
+                  fromMe: true,
+                  id: messageId,
+                  remoteJid: peer,
+                },
+                message: { conversation: text },
+                messageTimestamp: Math.floor(Date.now() / 1000),
+              }
+            : undefined;
+          await params.appendEvent({
+            accepted: true,
+            at: new Date().toISOString(),
+            body: message ?? sanitizeNodeForJson(params.node),
+            method: "WEBSOCKET",
+            path: params.path,
+            query: {},
+            type: "api",
+          } as ServerRequestEvent & { accepted: true });
+          return true;
+        },
+        ciphertext: candidate.ciphertext,
+        recipientJid: candidate.recipientJid,
+        remoteJid: params.remoteJid,
+        type: candidate.type,
+      });
+      if (result.status === "accepted") {
+        return true;
+      }
+    }
+    return false;
+  });
 }
 
 function encryptedMessageCandidates(node: BinaryNode): Array<{

--- a/src/servers/whatsapp-baileys-websocket.ts
+++ b/src/servers/whatsapp-baileys-websocket.ts
@@ -42,6 +42,7 @@ export const WHATSAPP_WEBSOCKET_SEND_TIMEOUT_MS = 5_000;
 const MAX_PENDING_WEBSOCKET_BYTES = 8 * 1024 * 1024;
 const MAX_PENDING_WEBSOCKET_MESSAGES = 32;
 const MAX_WHATSAPP_PENDING_ACKNOWLEDGEMENTS = 10_000;
+const MAX_WHATSAPP_RECENT_ACKNOWLEDGEMENTS = 10_000;
 export const MAX_WHATSAPP_WEBSOCKET_FRAGMENTS = 1_024;
 export const MAX_WHATSAPP_SIGNAL_BUNDLES = 1_024;
 export const MAX_WHATSAPP_WEBSOCKET_CLOSE_REASON_BYTES = 123;
@@ -116,6 +117,7 @@ export type WhatsAppSignalDecryptResult<T> =
   | { status: "rejected" };
 
 export class WhatsAppSignalBundleStore {
+  readonly #acknowledgedMessageIds = new Map<string, true>();
   readonly #bundles = new Map<string, MockSignalBundle>();
   readonly #lidByPhoneNumber = new Map<string, string>();
   readonly #pendingMessageAcceptances = new Map<string, Promise<void>>();
@@ -126,12 +128,16 @@ export class WhatsAppSignalBundleStore {
   constructor(
     private readonly maxBundles = MAX_WHATSAPP_SIGNAL_BUNDLES,
     private readonly maxPendingAcknowledgements = MAX_WHATSAPP_PENDING_ACKNOWLEDGEMENTS,
+    private readonly maxRecentAcknowledgements = MAX_WHATSAPP_RECENT_ACKNOWLEDGEMENTS,
   ) {
     if (!Number.isSafeInteger(maxBundles) || maxBundles < 1) {
       throw new Error("WhatsApp maxSignalBundles must be a positive safe integer.");
     }
     if (!Number.isSafeInteger(maxPendingAcknowledgements) || maxPendingAcknowledgements < 1) {
       throw new Error("WhatsApp maxPendingAcknowledgements must be a positive safe integer.");
+    }
+    if (!Number.isSafeInteger(maxRecentAcknowledgements) || maxRecentAcknowledgements < 1) {
+      throw new Error("WhatsApp maxRecentAcknowledgements must be a positive safe integer.");
     }
   }
 
@@ -146,6 +152,10 @@ export class WhatsAppSignalBundleStore {
   async acceptMessageOnce(messageKey: string, operation: () => Promise<boolean>): Promise<boolean> {
     return await this.#runSerialized(this.#pendingMessageAcceptances, "messages", async () => {
       if (this.#pendingAcknowledgements.has(messageKey)) {
+        return true;
+      }
+      if (this.#acknowledgedMessageIds.delete(messageKey)) {
+        this.#acknowledgedMessageIds.set(messageKey, true);
         return true;
       }
       if (this.#pendingAcknowledgements.size >= this.maxPendingAcknowledgements) {
@@ -165,7 +175,17 @@ export class WhatsAppSignalBundleStore {
   markMessageAcknowledged(peerJid: string, messageId: string): void {
     const peer = canonicalizeWhatsAppUserCorrelationJid(peerJid);
     if (peer && messageId) {
-      this.#pendingAcknowledgements.delete(`${peer}\0${messageId}`);
+      const messageKey = `${peer}\0${messageId}`;
+      if (!this.#pendingAcknowledgements.delete(messageKey)) {
+        return;
+      }
+      this.#acknowledgedMessageIds.set(messageKey, true);
+      if (this.#acknowledgedMessageIds.size > this.maxRecentAcknowledgements) {
+        const oldestMessageKey = this.#acknowledgedMessageIds.keys().next().value;
+        if (oldestMessageKey !== undefined) {
+          this.#acknowledgedMessageIds.delete(oldestMessageKey);
+        }
+      }
     }
   }
 

--- a/src/servers/whatsapp-baileys-websocket.ts
+++ b/src/servers/whatsapp-baileys-websocket.ts
@@ -108,9 +108,16 @@ export type MockSignalBundle = {
   signedPreKey: SignedKeyPair;
 };
 
+export type WhatsAppSignalDecryptResult<T> =
+  | { status: "accepted"; value: T }
+  | { error: unknown; status: "decrypt-failed" }
+  | { status: "unavailable" }
+  | { status: "rejected" };
+
 export class WhatsAppSignalBundleStore {
   readonly #bundles = new Map<string, MockSignalBundle>();
   readonly #lidByPhoneNumber = new Map<string, string>();
+  readonly #pendingTransactions = new Map<string, Promise<void>>();
   readonly #sessions = new Map<string, Map<string, SessionRecord>>();
 
   constructor(private readonly maxBundles = MAX_WHATSAPP_SIGNAL_BUNDLES) {
@@ -123,13 +130,33 @@ export class WhatsAppSignalBundleStore {
     return this.#bundles.size;
   }
 
+  get lidMappingSize(): number {
+    return this.#lidByPhoneNumber.size;
+  }
+
   associateLid(phoneNumberJid: string, lidJid: string): void {
     const phoneNumber = canonicalizeWhatsAppUserCorrelationJid(phoneNumberJid);
     const lid = canonicalizeWhatsAppUserCorrelationJid(lidJid);
     if (!phoneNumber?.endsWith("@s.whatsapp.net") || !lid?.endsWith("@lid")) {
       throw new Error("Invalid WhatsApp PN/LID signal mapping.");
     }
-    this.#lidByPhoneNumber.set(signalBundleIdentityKey(phoneNumber), signalBundleIdentityKey(lid));
+    const phoneNumberKey = signalBundleIdentityKey(phoneNumber);
+    this.#lidByPhoneNumber.delete(phoneNumberKey);
+    this.#lidByPhoneNumber.set(phoneNumberKey, signalBundleIdentityKey(lid));
+    if (this.#lidByPhoneNumber.size > this.maxBundles) {
+      const oldestPhoneNumber = this.#lidByPhoneNumber.keys().next().value;
+      if (oldestPhoneNumber !== undefined) {
+        this.#lidByPhoneNumber.delete(oldestPhoneNumber);
+      }
+    }
+  }
+
+  resolveAssociatedLid(phoneNumberJid: string): string | undefined {
+    const phoneNumber = canonicalizeWhatsAppUserCorrelationJid(phoneNumberJid);
+    if (!phoneNumber?.endsWith("@s.whatsapp.net")) {
+      return undefined;
+    }
+    return this.#lidByPhoneNumber.get(signalBundleIdentityKey(phoneNumber));
   }
 
   resolveMany(jids: string[]): MockSignalBundle[] {
@@ -158,10 +185,27 @@ export class WhatsAppSignalBundleStore {
     remoteJid: string;
     type: "msg" | "pkmsg";
   }): Promise<Buffer | undefined> {
+    const result = await this.transactDirectMessage({
+      ...params,
+      accept: async (plaintext) => plaintext,
+    });
+    if (result.status === "decrypt-failed") {
+      throw result.error;
+    }
+    return result.status === "accepted" ? result.value : undefined;
+  }
+
+  async transactDirectMessage<T>(params: {
+    accept(plaintext: Buffer): Promise<T | undefined>;
+    ciphertext: Uint8Array;
+    recipientJid: string;
+    remoteJid: string;
+    type: "msg" | "pkmsg";
+  }): Promise<WhatsAppSignalDecryptResult<T>> {
     const recipientJid = canonicalizeWhatsAppUserCorrelationJid(params.recipientJid);
     const recipientIdentityKey = recipientJid ? signalBundleIdentityKey(recipientJid) : undefined;
     const mappedLidIdentityKey = recipientIdentityKey
-      ? this.#lidByPhoneNumber.get(recipientIdentityKey)
+      ? this.resolveAssociatedLid(recipientIdentityKey)
       : undefined;
     const identityKey =
       mappedLidIdentityKey && this.#bundles.has(mappedLidIdentityKey)
@@ -169,47 +213,71 @@ export class WhatsAppSignalBundleStore {
         : recipientIdentityKey;
     const bundle = identityKey ? this.#bundles.get(identityKey) : undefined;
     if (!identityKey || !bundle) {
-      return undefined;
+      return { status: "unavailable" };
     }
     const remoteAddress = signalProtocolAddress(params.remoteJid);
     if (!remoteAddress) {
-      return undefined;
+      return { status: "unavailable" };
     }
-    const sessions = this.#sessions.get(identityKey) ?? new Map<string, SessionRecord>();
-    this.#sessions.set(identityKey, sessions);
-    const stagedSessions = new Map<string, SessionRecord>();
-    const storage: SignalStorage = {
-      async loadSession(id) {
-        const session = stagedSessions.get(id) ?? sessions.get(id);
-        return session ? cloneSignalSession(session) : undefined;
-      },
-      async storeSession(id, session) {
-        stagedSessions.set(id, cloneSignalSession(session));
-      },
-      isTrustedIdentity: () => true,
-      async loadPreKey(id) {
-        if (String(id) !== String(bundle.preKeyId)) {
-          return undefined;
-        }
-        return signalKeyPair(bundle.preKey);
-      },
-      removePreKey: () => undefined,
-      loadSignedPreKey: () => signalKeyPair(bundle.signedPreKey.keyPair),
-      getOurRegistrationId: () => bundle.registrationId,
-      getOurIdentity: () => signalKeyPair(bundle.identityKey),
-    };
-    const cipher = new SessionCipher(
-      storage,
-      new ProtocolAddress(remoteAddress.name, remoteAddress.deviceId),
-    );
-    const plaintext =
-      params.type === "pkmsg"
-        ? await cipher.decryptPreKeyWhisperMessage(params.ciphertext)
-        : await cipher.decryptWhisperMessage(params.ciphertext);
-    for (const [id, session] of stagedSessions) {
-      sessions.set(id, session);
-    }
-    return plaintext;
+    const address = new ProtocolAddress(remoteAddress.name, remoteAddress.deviceId);
+    return await this.#runTransaction(address.toString(), async () => {
+      const sessions = this.#sessions.get(identityKey) ?? new Map<string, SessionRecord>();
+      const stagedPreKeyRemovals = new Set<number>();
+      const stagedSessions = new Map<string, SessionRecord>();
+      const storage: SignalStorage = {
+        async loadSession(id) {
+          const session = stagedSessions.get(id) ?? sessions.get(id);
+          return session ? cloneSignalSession(session) : undefined;
+        },
+        async storeSession(id, session) {
+          stagedSessions.set(id, cloneSignalSession(session));
+        },
+        isTrustedIdentity: () => true,
+        async loadPreKey(id) {
+          if (String(id) !== String(bundle.preKeyId)) {
+            return undefined;
+          }
+          return signalKeyPair(bundle.preKey);
+        },
+        removePreKey(id) {
+          stagedPreKeyRemovals.add(id);
+        },
+        loadSignedPreKey: () => signalKeyPair(bundle.signedPreKey.keyPair),
+        getOurRegistrationId: () => bundle.registrationId,
+        getOurIdentity: () => signalKeyPair(bundle.identityKey),
+      };
+      const cipher = new SessionCipher(storage, address);
+      let plaintext: Buffer;
+      try {
+        plaintext =
+          params.type === "pkmsg"
+            ? await cipher.decryptPreKeyWhisperMessage(params.ciphertext)
+            : await cipher.decryptWhisperMessage(params.ciphertext);
+      } catch (error) {
+        return { error, status: "decrypt-failed" };
+      }
+      const accepted = await params.accept(plaintext);
+      if (accepted === undefined) {
+        return { status: "rejected" };
+      }
+      const replacementPreKey = stagedPreKeyRemovals.has(bundle.preKeyId)
+        ? {
+            id: bundle.preKeyId === 0xff_ff_ff ? 1 : bundle.preKeyId + 1,
+            keyPair: Curve.generateKeyPair(),
+          }
+        : undefined;
+      for (const [id, session] of stagedSessions) {
+        sessions.set(id, session);
+      }
+      if (stagedSessions.size > 0) {
+        this.#sessions.set(identityKey, sessions);
+      }
+      if (replacementPreKey) {
+        bundle.preKey = replacementPreKey.keyPair;
+        bundle.preKeyId = replacementPreKey.id;
+      }
+      return { status: "accepted", value: accepted };
+    });
   }
 
   #resolve(bundleKey: string): MockSignalBundle {
@@ -227,6 +295,23 @@ export class WhatsAppSignalBundleStore {
     };
     this.#bundles.set(bundleKey, bundle);
     return bundle;
+  }
+
+  async #runTransaction<T>(key: string, operation: () => Promise<T>): Promise<T> {
+    const previous = this.#pendingTransactions.get(key) ?? Promise.resolve();
+    const result = previous.catch(() => undefined).then(operation);
+    const settled = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.#pendingTransactions.set(key, settled);
+    try {
+      return await result;
+    } finally {
+      if (this.#pendingTransactions.get(key) === settled) {
+        this.#pendingTransactions.delete(key);
+      }
+    }
   }
 }
 
@@ -608,11 +693,16 @@ class WhatsAppBaileysWebSocketSession {
     }
     if (node.tag === "message") {
       const peer = requireAttr(node, "to");
-      const normalizedMessage = await normalizeAcceptedBaileysMessage({
+      const accepted = await persistAcceptedBaileysMessage({
+        appendEvent: this.params.appendEvent,
         node,
+        path: this.params.path,
         remoteJid: this.params.selfJid,
         signalBundles: this.params.signalBundles,
       });
+      if (!accepted) {
+        return;
+      }
       await this.#sendNode({
         attrs: {
           class: "message",
@@ -623,17 +713,6 @@ class WhatsAppBaileysWebSocketSession {
         },
         tag: "ack",
       });
-      if (normalizedMessage) {
-        await this.params.appendEvent({
-          accepted: true,
-          at: new Date().toISOString(),
-          body: normalizedMessage,
-          method: "WEBSOCKET",
-          path: this.params.path,
-          query: {},
-          type: "api",
-        } as ServerRequestEvent & { accepted: true });
-      }
     }
   }
 
@@ -1119,15 +1198,17 @@ function children(node: BinaryNode): BinaryNode[] {
   return Array.isArray(node.content) ? node.content : [];
 }
 
-async function normalizeAcceptedBaileysMessage(params: {
+async function persistAcceptedBaileysMessage(params: {
+  appendEvent(event: ServerRequestEvent): Promise<void>;
   node: BinaryNode;
+  path: string;
   remoteJid: string;
   signalBundles: WhatsAppSignalBundleStore;
-}): Promise<WhatsAppBaileysInboundMessage | undefined> {
+}): Promise<boolean> {
   const peer = canonicalizeWhatsAppUserCorrelationJid(params.node.attrs.to ?? "");
   const messageId = params.node.attrs.id;
   if (!peer || !messageId) {
-    return undefined;
+    return false;
   }
   const candidates = encryptedMessageCandidates(params.node);
   const remoteCorrelationJid = canonicalizeWhatsAppUserCorrelationJid(params.remoteJid);
@@ -1139,16 +1220,18 @@ async function normalizeAcceptedBaileysMessage(params: {
     return Number(leftIsSelf) - Number(rightIsSelf);
   });
   for (const candidate of candidates) {
-    try {
-      const decrypted = await params.signalBundles.decryptDirectMessage({
-        ciphertext: candidate.ciphertext,
-        recipientJid: candidate.recipientJid,
-        remoteJid: params.remoteJid,
-        type: candidate.type,
-      });
-      const text = decrypted ? readWhatsAppConversation(unpadRandomMax16(decrypted)) : undefined;
-      if (text) {
-        return {
+    const result = await params.signalBundles.transactDirectMessage({
+      accept: async (decrypted) => {
+        let text: string | undefined;
+        try {
+          text = readWhatsAppConversation(unpadRandomMax16(decrypted));
+        } catch {
+          return undefined;
+        }
+        if (!text) {
+          return undefined;
+        }
+        const message: WhatsAppBaileysInboundMessage = {
           key: {
             fromMe: true,
             id: messageId,
@@ -1157,12 +1240,27 @@ async function normalizeAcceptedBaileysMessage(params: {
           message: { conversation: text },
           messageTimestamp: Math.floor(Date.now() / 1000),
         };
-      }
-    } catch {
-      // Other participant envelopes may not belong to this mock server identity.
+        await params.appendEvent({
+          accepted: true,
+          at: new Date().toISOString(),
+          body: message,
+          method: "WEBSOCKET",
+          path: params.path,
+          query: {},
+          type: "api",
+        } as ServerRequestEvent & { accepted: true });
+        return message;
+      },
+      ciphertext: candidate.ciphertext,
+      recipientJid: candidate.recipientJid,
+      remoteJid: params.remoteJid,
+      type: candidate.type,
+    });
+    if (result.status === "accepted") {
+      return true;
     }
   }
-  return undefined;
+  return false;
 }
 
 function encryptedMessageCandidates(node: BinaryNode): Array<{

--- a/src/servers/whatsapp-wire/crypto.ts
+++ b/src/servers/whatsapp-wire/crypto.ts
@@ -97,7 +97,10 @@ export function createCurve(nativeBackend: NativeCurveBackend = nativeCurveBacke
       if (nativeAvailable) {
         try {
           return nativeBackend.generateKeyPair();
-        } catch {
+        } catch (error) {
+          if (!isUnsupportedNativeCurveError(error)) {
+            throw error;
+          }
           nativeAvailable = false;
         }
       }

--- a/src/servers/whatsapp.ts
+++ b/src/servers/whatsapp.ts
@@ -428,7 +428,7 @@ async function handleRequest(params: { request: IncomingMessage; state: WhatsApp
       return new Response("not found", { status: 404 });
     }
     if (!hasAdminToken(params.request, params.state.adminToken)) {
-      params.request.resume();
+      drainRequestBody(params.request);
       return adminAuthError();
     }
     const body = await parseUnknownRequestBody(params.request);
@@ -481,7 +481,7 @@ async function handleRequest(params: { request: IncomingMessage; state: WhatsApp
   const phoneNumberPath = `/${params.state.graphVersion}/${params.state.phoneNumberId}`;
   const messagesPath = `${phoneNumberPath}/messages`;
   if (!requireAuth(params.request, params.state)) {
-    params.request.resume();
+    drainRequestBody(params.request);
     return graphAuthError();
   }
   if (url.pathname === phoneNumberPath && params.request.method === "GET") {
@@ -523,6 +523,7 @@ async function handleRequest(params: { request: IncomingMessage; state: WhatsApp
       );
     } else if ("status" in body || "message_id" in body) {
       response = handleMessageStatus(body);
+      event.accepted = response.ok;
     } else {
       const prepared = prepareSendMessage({ body, state: params.state });
       if (!(prepared instanceof Response)) {
@@ -533,7 +534,7 @@ async function handleRequest(params: { request: IncomingMessage; state: WhatsApp
       }
       response = prepared;
     }
-    event.accepted = false;
+    event.accepted ??= false;
     await appendEvent(params.state, event);
     return response;
   }

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -964,6 +964,40 @@ describe("whatsapp local provider server", () => {
       },
     });
     expect(bundle.preKeyId).toBe(originalPreKeyId + 1);
+    receiver.markMessageAcknowledged("15557654321@s.whatsapp.net", "retry-ack");
+  });
+
+  it("preserves unresolved acknowledgements when their safety limit is reached", async () => {
+    const receiver = new WhatsAppSignalBundleStore(1, 1);
+    const firstNode: BinaryNode = {
+      attrs: { id: "first", to: "15557654321@s.whatsapp.net" },
+      tag: "message",
+    };
+    const secondNode: BinaryNode = {
+      attrs: { id: "second", to: "15557654321@s.whatsapp.net" },
+      tag: "message",
+    };
+    const events: unknown[] = [];
+    const persist = (node: BinaryNode) =>
+      persistAcceptedBaileysMessage({
+        appendEvent: async (event) => {
+          events.push(event);
+        },
+        node,
+        path: "/ws/chat",
+        remoteJid: "15550000001@s.whatsapp.net",
+        signalBundles: receiver,
+      });
+
+    await expect(persist(firstNode)).resolves.toBe(true);
+    await expect(persist(secondNode)).rejects.toThrow(
+      "WhatsApp pending acknowledgement limit exceeded (1).",
+    );
+    expect(events).toHaveLength(1);
+
+    receiver.markMessageAcknowledged("15557654321@s.whatsapp.net", "first");
+    await expect(persist(secondNode)).resolves.toBe(true);
+    expect(events).toHaveLength(2);
   });
 
   it("commits and acknowledges decryptable unsupported payloads before later text", async () => {

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -974,6 +974,57 @@ describe("whatsapp local provider server", () => {
     );
   });
 
+  it("persists unsupported message envelopes before allowing acknowledgement", async () => {
+    const node: BinaryNode = {
+      attrs: {
+        id: "unsupported-envelope",
+        to: "15557654321@s.whatsapp.net",
+      },
+      content: [
+        {
+          attrs: { type: "skmsg" },
+          content: Buffer.from("sender-key-envelope"),
+          tag: "enc",
+        },
+      ],
+      tag: "message",
+    };
+    const events: Array<{ accepted?: boolean; body?: unknown }> = [];
+
+    await expect(
+      persistAcceptedBaileysMessage({
+        appendEvent: async (event) => {
+          events.push(event);
+        },
+        node,
+        path: "/ws/chat",
+        remoteJid: "15550000001@s.whatsapp.net",
+        signalBundles: new WhatsAppSignalBundleStore(1),
+      }),
+    ).resolves.toBe(true);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        accepted: true,
+        body: expect.objectContaining({
+          attrs: expect.objectContaining({ id: "unsupported-envelope" }),
+          tag: "message",
+        }),
+      }),
+    );
+
+    await expect(
+      persistAcceptedBaileysMessage({
+        appendEvent: async () => {
+          throw new Error("simulated recorder failure");
+        },
+        node,
+        path: "/ws/chat",
+        remoteJid: "15550000001@s.whatsapp.net",
+        signalBundles: new WhatsAppSignalBundleStore(1),
+      }),
+    ).rejects.toThrow("simulated recorder failure");
+  });
+
   it("serializes first-contact Signal transactions by recipient bundle", async () => {
     const recipientJid = "15551234567@s.whatsapp.net";
     const receiver = new WhatsAppSignalBundleStore(1);

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -896,7 +896,7 @@ describe("whatsapp local provider server", () => {
     expect(bundle.preKeyId).toBe(originalPreKeyId + 1);
   });
 
-  it("keeps Signal ciphertext retryable when acknowledgement fails", async () => {
+  it("deduplicates accepted evidence when acknowledgement retries", async () => {
     const recipientJid = "15551234567@s.whatsapp.net";
     const senderJid = "15550000001@s.whatsapp.net";
     const receiver = new WhatsAppSignalBundleStore(1);
@@ -932,27 +932,6 @@ describe("whatsapp local provider server", () => {
 
     await expect(
       persistAcceptedBaileysMessage({
-        acknowledge: async () => {
-          throw new Error("simulated acknowledgement failure");
-        },
-        appendEvent: async (event) => {
-          events.push(event);
-        },
-        node,
-        path: "/ws/chat",
-        remoteJid: senderJid,
-        signalBundles: receiver,
-      }),
-    ).rejects.toThrow("simulated acknowledgement failure");
-    expect(bundle.preKey).toBe(originalPreKey);
-    expect(bundle.preKeyId).toBe(originalPreKeyId);
-
-    let acknowledged = false;
-    await expect(
-      persistAcceptedBaileysMessage({
-        acknowledge: async () => {
-          acknowledged = true;
-        },
         appendEvent: async (event) => {
           events.push(event);
         },
@@ -962,14 +941,28 @@ describe("whatsapp local provider server", () => {
         signalBundles: receiver,
       }),
     ).resolves.toBe(true);
-    expect(acknowledged).toBe(true);
+    expect(events).toHaveLength(1);
+    expect(bundle.preKey).not.toBe(originalPreKey);
+    expect(bundle.preKeyId).toBe(originalPreKeyId + 1);
+
+    await expect(
+      persistAcceptedBaileysMessage({
+        appendEvent: async (event) => {
+          events.push(event);
+        },
+        node,
+        path: "/ws/chat",
+        remoteJid: senderJid,
+        signalBundles: receiver,
+      }),
+    ).resolves.toBe(true);
+    expect(events).toHaveLength(1);
     expect(events.at(-1)).toMatchObject({
       accepted: true,
       body: {
         message: { conversation: "retry" },
       },
     });
-    expect(bundle.preKey).not.toBe(originalPreKey);
     expect(bundle.preKeyId).toBe(originalPreKeyId + 1);
   });
 

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -965,6 +965,19 @@ describe("whatsapp local provider server", () => {
     });
     expect(bundle.preKeyId).toBe(originalPreKeyId + 1);
     receiver.markMessageAcknowledged("15557654321@s.whatsapp.net", "retry-ack");
+
+    await expect(
+      persistAcceptedBaileysMessage({
+        appendEvent: async (event) => {
+          events.push(event);
+        },
+        node,
+        path: "/ws/chat",
+        remoteJid: senderJid,
+        signalBundles: receiver,
+      }),
+    ).resolves.toBe(true);
+    expect(events).toHaveLength(1);
   });
 
   it("preserves unresolved acknowledgements when their safety limit is reached", async () => {

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -896,6 +896,83 @@ describe("whatsapp local provider server", () => {
     expect(bundle.preKeyId).toBe(originalPreKeyId + 1);
   });
 
+  it("keeps Signal ciphertext retryable when acknowledgement fails", async () => {
+    const recipientJid = "15551234567@s.whatsapp.net";
+    const senderJid = "15550000001@s.whatsapp.net";
+    const receiver = new WhatsAppSignalBundleStore(1);
+    const bundle = receiver.resolveMany([recipientJid])[0]!;
+    const originalPreKey = bundle.preKey;
+    const originalPreKeyId = bundle.preKeyId;
+    const senderIdentity = Curve.generateKeyPair();
+    const senderStorage = createSignalTestStorage(senderIdentity, 2);
+    const senderAddress = new ProtocolAddress("15551234567", 0);
+    await new SessionBuilder(senderStorage, senderAddress).initOutgoing({
+      identityKey: signalTestKeyPair(bundle.identityKey).pubKey,
+      preKey: {
+        keyId: bundle.preKeyId,
+        publicKey: signalTestKeyPair(bundle.preKey).pubKey,
+      },
+      registrationId: bundle.registrationId,
+      signedPreKey: {
+        keyId: bundle.signedPreKey.keyId,
+        publicKey: signalTestKeyPair(bundle.signedPreKey.keyPair).pubKey,
+        signature: bundle.signedPreKey.signature,
+      },
+    });
+    const encrypted = await new SessionCipher(senderStorage, senderAddress).encrypt(
+      padSignalMessage(Buffer.from([0x0a, 0x05, ...Buffer.from("retry")])),
+    );
+    const node = signalMessageNode({
+      ciphertext: signalCiphertext(encrypted.body),
+      id: "retry-ack",
+      recipientJid,
+      type: encrypted.type,
+    });
+    const events: Array<{ accepted?: boolean; body?: unknown }> = [];
+
+    await expect(
+      persistAcceptedBaileysMessage({
+        acknowledge: async () => {
+          throw new Error("simulated acknowledgement failure");
+        },
+        appendEvent: async (event) => {
+          events.push(event);
+        },
+        node,
+        path: "/ws/chat",
+        remoteJid: senderJid,
+        signalBundles: receiver,
+      }),
+    ).rejects.toThrow("simulated acknowledgement failure");
+    expect(bundle.preKey).toBe(originalPreKey);
+    expect(bundle.preKeyId).toBe(originalPreKeyId);
+
+    let acknowledged = false;
+    await expect(
+      persistAcceptedBaileysMessage({
+        acknowledge: async () => {
+          acknowledged = true;
+        },
+        appendEvent: async (event) => {
+          events.push(event);
+        },
+        node,
+        path: "/ws/chat",
+        remoteJid: senderJid,
+        signalBundles: receiver,
+      }),
+    ).resolves.toBe(true);
+    expect(acknowledged).toBe(true);
+    expect(events.at(-1)).toMatchObject({
+      accepted: true,
+      body: {
+        message: { conversation: "retry" },
+      },
+    });
+    expect(bundle.preKey).not.toBe(originalPreKey);
+    expect(bundle.preKeyId).toBe(originalPreKeyId + 1);
+  });
+
   it("commits and acknowledges decryptable unsupported payloads before later text", async () => {
     const recipientJid = "15551234567@s.whatsapp.net";
     const senderJid = "15550000001@s.whatsapp.net";

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -724,7 +724,145 @@ describe("whatsapp local provider server", () => {
     ).resolves.toEqual(Buffer.from("second direct message"));
   });
 
-  it("authenticates Graph requests before reading or recording their bodies", async () => {
+  it("commits Signal ratchets and prekey replacement only after accepted evidence persists", async () => {
+    const recipientJid = "15551234567@s.whatsapp.net";
+    const senderJid = "15550000001@s.whatsapp.net";
+    const receiver = new WhatsAppSignalBundleStore(1);
+    const bundle = receiver.resolveMany([recipientJid])[0]!;
+    const originalPreKey = bundle.preKey;
+    const originalPreKeyId = bundle.preKeyId;
+    const senderIdentity = Curve.generateKeyPair();
+    const senderStorage = createSignalTestStorage(senderIdentity, 2);
+    const senderAddress = new ProtocolAddress("15551234567", 0);
+    await new SessionBuilder(senderStorage, senderAddress).initOutgoing({
+      identityKey: signalTestKeyPair(bundle.identityKey).pubKey,
+      preKey: {
+        keyId: bundle.preKeyId,
+        publicKey: signalTestKeyPair(bundle.preKey).pubKey,
+      },
+      registrationId: bundle.registrationId,
+      signedPreKey: {
+        keyId: bundle.signedPreKey.keyId,
+        publicKey: signalTestKeyPair(bundle.signedPreKey.keyPair).pubKey,
+        signature: bundle.signedPreKey.signature,
+      },
+    });
+    const encrypted = await new SessionCipher(senderStorage, senderAddress).encrypt(
+      Buffer.from("transactional inbound"),
+    );
+    const ciphertext = signalCiphertext(encrypted.body);
+    const ordering: string[] = [];
+
+    await expect(
+      receiver.transactDirectMessage({
+        accept: async (plaintext) => {
+          ordering.push("persist:start");
+          expect(plaintext).toEqual(Buffer.from("transactional inbound"));
+          expect(bundle.preKey).toBe(originalPreKey);
+          expect(bundle.preKeyId).toBe(originalPreKeyId);
+          ordering.push("persist:done");
+          return true;
+        },
+        ciphertext,
+        recipientJid,
+        remoteJid: senderJid,
+        type: "pkmsg",
+      }),
+    ).resolves.toEqual({ status: "accepted", value: true });
+    ordering.push("ack");
+
+    expect(ordering).toEqual(["persist:start", "persist:done", "ack"]);
+    expect(bundle.preKey).not.toBe(originalPreKey);
+    expect(bundle.preKeyId).toBe(originalPreKeyId + 1);
+    expect(receiver.resolveMany([recipientJid])[0]).toMatchObject({
+      preKey: bundle.preKey,
+      preKeyId: originalPreKeyId + 1,
+    });
+    await expect(
+      receiver.transactDirectMessage({
+        accept: async () => true,
+        ciphertext,
+        recipientJid,
+        remoteJid: senderJid,
+        type: "pkmsg",
+      }),
+    ).resolves.toMatchObject({ status: "decrypt-failed" });
+  });
+
+  it("keeps Signal ciphertext retryable when accepted evidence persistence fails", async () => {
+    const recipientJid = "15551234567@s.whatsapp.net";
+    const senderJid = "15550000001@s.whatsapp.net";
+    const receiver = new WhatsAppSignalBundleStore(1);
+    const bundle = receiver.resolveMany([recipientJid])[0]!;
+    const originalPreKey = bundle.preKey;
+    const originalPreKeyId = bundle.preKeyId;
+    const senderIdentity = Curve.generateKeyPair();
+    const senderStorage = createSignalTestStorage(senderIdentity, 2);
+    const senderAddress = new ProtocolAddress("15551234567", 0);
+    await new SessionBuilder(senderStorage, senderAddress).initOutgoing({
+      identityKey: signalTestKeyPair(bundle.identityKey).pubKey,
+      preKey: {
+        keyId: bundle.preKeyId,
+        publicKey: signalTestKeyPair(bundle.preKey).pubKey,
+      },
+      registrationId: bundle.registrationId,
+      signedPreKey: {
+        keyId: bundle.signedPreKey.keyId,
+        publicKey: signalTestKeyPair(bundle.signedPreKey.keyPair).pubKey,
+        signature: bundle.signedPreKey.signature,
+      },
+    });
+    const encrypted = await new SessionCipher(senderStorage, senderAddress).encrypt(
+      Buffer.from("retry recorder failure"),
+    );
+    const ciphertext = signalCiphertext(encrypted.body);
+    let markPersistenceStarted: () => void = () => undefined;
+    let releasePersistence: () => void = () => undefined;
+    const persistenceStarted = new Promise<void>((resolve) => {
+      markPersistenceStarted = resolve;
+    });
+    const persistenceBlocked = new Promise<void>((resolve) => {
+      releasePersistence = resolve;
+    });
+    const failedAttempt = receiver.transactDirectMessage({
+      accept: async () => {
+        markPersistenceStarted();
+        await persistenceBlocked;
+        throw new Error("simulated recorder failure");
+      },
+      ciphertext,
+      recipientJid,
+      remoteJid: senderJid,
+      type: "pkmsg",
+    });
+    await persistenceStarted;
+    let retryAccepted = false;
+    const retry = receiver.transactDirectMessage({
+      accept: async (plaintext) => {
+        retryAccepted = true;
+        return plaintext.toString("utf8");
+      },
+      ciphertext,
+      recipientJid,
+      remoteJid: senderJid,
+      type: "pkmsg",
+    });
+    await Promise.resolve();
+
+    expect(retryAccepted).toBe(false);
+    expect(bundle.preKey).toBe(originalPreKey);
+    expect(bundle.preKeyId).toBe(originalPreKeyId);
+    releasePersistence();
+    await expect(failedAttempt).rejects.toThrow("simulated recorder failure");
+    await expect(retry).resolves.toEqual({
+      status: "accepted",
+      value: "retry recorder failure",
+    });
+    expect(bundle.preKey).not.toBe(originalPreKey);
+    expect(bundle.preKeyId).toBe(originalPreKeyId + 1);
+  });
+
+  it("drains unauthorized request bodies before reusing the connection", async () => {
     const directory = await createTempDir();
     directories.push(directory);
     const observed: unknown[] = [];
@@ -736,6 +874,7 @@ describe("whatsapp local provider server", () => {
       recorderPath: path.join(directory, "whatsapp-auth.jsonl"),
     });
     servers.push(server);
+    const agent = new Agent({ keepAlive: true, maxSockets: 1 });
 
     const unauthenticated = await fetch(server.manifest.endpoints.messagesUrl, {
       body: JSON.stringify({
@@ -748,17 +887,54 @@ describe("whatsapp local provider server", () => {
       method: "POST",
     });
     expect(unauthenticated.status).toBe(401);
-    const unauthorizedOversized = await requestHttp({
-      body: Buffer.alloc(1024 * 1024 + 1, 0x20),
-      headers: {
-        authorization: "Bearer wrong-token",
-        "content-length": String(1024 * 1024 + 1),
-        "content-type": "application/json",
-      },
-      method: "POST",
-      url: server.manifest.endpoints.messagesUrl,
-    });
-    expect(unauthorizedOversized.status).toBe(401);
+    try {
+      const unauthorizedOversized = await requestHttp({
+        agent,
+        body: Buffer.alloc(1024 * 1024 + 1, 0x20),
+        headers: {
+          authorization: "Bearer wrong-token",
+          "content-length": String(1024 * 1024 + 1),
+          "content-type": "application/json",
+        },
+        method: "POST",
+        url: server.manifest.endpoints.messagesUrl,
+      });
+      expect(unauthorizedOversized.status).toBe(401);
+      expect(
+        (
+          await requestHttp({
+            agent,
+            headers: { authorization: "Bearer fake" },
+            method: "GET",
+            url: server.manifest.endpoints.phoneNumberUrl,
+          })
+        ).status,
+      ).toBe(200);
+
+      const unauthorizedAdmin = await requestHttp({
+        agent,
+        body: Buffer.alloc(1024 * 1024 + 1, 0x20),
+        headers: {
+          "content-length": String(1024 * 1024 + 1),
+          "content-type": "application/json",
+        },
+        method: "POST",
+        url: server.manifest.endpoints.adminInboundUrl,
+      });
+      expect(unauthorizedAdmin.status).toBe(401);
+      expect(
+        (
+          await requestHttp({
+            agent,
+            headers: { authorization: "Bearer fake" },
+            method: "GET",
+            url: server.manifest.endpoints.phoneNumberUrl,
+          })
+        ).status,
+      ).toBe(200);
+    } finally {
+      agent.destroy();
+    }
 
     const oversized = await requestHttp({
       body: Buffer.alloc(1024 * 1024 + 1, 0x20),
@@ -790,13 +966,16 @@ describe("whatsapp local provider server", () => {
 
     const recorder = await fs.readFile(server.manifest.recorderPath, "utf8");
     expect(recorder).not.toContain("untrusted whatsapp body");
-    expect(observed).toEqual([
-      expect.objectContaining({
-        method: "GET",
-        path: new URL(server.manifest.endpoints.phoneNumberUrl).pathname,
-        type: "api",
-      }),
-    ]);
+    expect(observed).toHaveLength(3);
+    expect(observed).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          method: "GET",
+          path: new URL(server.manifest.endpoints.phoneNumberUrl).pathname,
+          type: "api",
+        }),
+      ]),
+    );
   });
 
   it("drains request bodies on early 404 routes", async () => {
@@ -882,7 +1061,7 @@ describe("whatsapp local provider server", () => {
     });
   });
 
-  it("does not mark successful status requests as accepted sends", async () => {
+  it("records successful read-status requests as accepted provider operations", async () => {
     const directory = await createTempDir();
     directories.push(directory);
     const observed: Array<{ accepted?: boolean; body?: unknown }> = [];
@@ -913,7 +1092,7 @@ describe("whatsapp local provider server", () => {
     expect(response.status).toBe(200);
     expect(observed).toContainEqual(
       expect.objectContaining({
-        accepted: false,
+        accepted: true,
         body: expect.objectContaining({ message_id: "wamid.status", status: "read" }),
       }),
     );

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -27,9 +27,11 @@ import {
 import { ADMIN_TOKEN_HEADER } from "../src/servers/http.js";
 import {
   MAX_WHATSAPP_WEBSOCKET_FRAGMENTS,
+  persistAcceptedBaileysMessage,
   signalBundleIdentityKey,
   WhatsAppSignalBundleStore,
 } from "../src/servers/whatsapp-baileys-websocket.js";
+import type { BinaryNode } from "../src/servers/whatsapp-wire/binary-node.js";
 import { Curve, KEY_BUNDLE_TYPE, type KeyPair } from "../src/servers/whatsapp-wire/crypto.js";
 import { createTempDir, disposeTempDir, requestHttp } from "./test-helpers.js";
 
@@ -127,6 +129,38 @@ function createSignalTestStorage(identityKey: KeyPair, registrationId: number): 
 
 function signalCiphertext(body: string): Buffer {
   return Buffer.isBuffer(body) ? Buffer.from(body) : Buffer.from(body, "binary");
+}
+
+function signalMessageNode(params: {
+  ciphertext: Buffer;
+  id: string;
+  recipientJid: string;
+  type: number;
+}): BinaryNode {
+  return {
+    attrs: {
+      id: params.id,
+      to: "15557654321@s.whatsapp.net",
+    },
+    content: [
+      {
+        attrs: { jid: params.recipientJid },
+        content: [
+          {
+            attrs: { type: params.type === 3 ? "pkmsg" : "msg" },
+            content: params.ciphertext,
+            tag: "enc",
+          },
+        ],
+        tag: "to",
+      },
+    ],
+    tag: "message",
+  };
+}
+
+function padSignalMessage(message: Buffer): Buffer {
+  return Buffer.concat([message, Buffer.from([1])]);
 }
 
 function createBaileysTestSocket(server: StartedWhatsAppServer) {
@@ -860,6 +894,196 @@ describe("whatsapp local provider server", () => {
     });
     expect(bundle.preKey).not.toBe(originalPreKey);
     expect(bundle.preKeyId).toBe(originalPreKeyId + 1);
+  });
+
+  it("commits and acknowledges decryptable unsupported payloads before later text", async () => {
+    const recipientJid = "15551234567@s.whatsapp.net";
+    const senderJid = "15550000001@s.whatsapp.net";
+    const receiver = new WhatsAppSignalBundleStore(1);
+    const bundle = receiver.resolveMany([recipientJid])[0]!;
+    const senderIdentity = Curve.generateKeyPair();
+    const senderStorage = createSignalTestStorage(senderIdentity, 2);
+    const senderAddress = new ProtocolAddress("15551234567", 0);
+    await new SessionBuilder(senderStorage, senderAddress).initOutgoing({
+      identityKey: signalTestKeyPair(bundle.identityKey).pubKey,
+      preKey: {
+        keyId: bundle.preKeyId,
+        publicKey: signalTestKeyPair(bundle.preKey).pubKey,
+      },
+      registrationId: bundle.registrationId,
+      signedPreKey: {
+        keyId: bundle.signedPreKey.keyId,
+        publicKey: signalTestKeyPair(bundle.signedPreKey.keyPair).pubKey,
+        signature: bundle.signedPreKey.signature,
+      },
+    });
+    const sender = new SessionCipher(senderStorage, senderAddress);
+    const unsupported = await sender.encrypt(padSignalMessage(Buffer.from([0x12, 0x01, 0x00])));
+    const events: Array<{ accepted?: boolean; body?: unknown }> = [];
+
+    await expect(
+      persistAcceptedBaileysMessage({
+        appendEvent: async (event) => {
+          events.push(event);
+        },
+        node: signalMessageNode({
+          ciphertext: signalCiphertext(unsupported.body),
+          id: "unsupported",
+          recipientJid,
+          type: unsupported.type,
+        }),
+        path: "/ws/chat",
+        remoteJid: senderJid,
+        signalBundles: receiver,
+      }),
+    ).resolves.toBe(true);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        accepted: true,
+        body: expect.objectContaining({ tag: "message" }),
+      }),
+    );
+
+    const text = Buffer.from("text after unsupported", "utf8");
+    const supported = await sender.encrypt(
+      padSignalMessage(Buffer.from([0x0a, text.byteLength, ...text])),
+    );
+    await expect(
+      persistAcceptedBaileysMessage({
+        appendEvent: async (event) => {
+          events.push(event);
+        },
+        node: signalMessageNode({
+          ciphertext: signalCiphertext(supported.body),
+          id: "supported",
+          recipientJid,
+          type: supported.type,
+        }),
+        path: "/ws/chat",
+        remoteJid: senderJid,
+        signalBundles: receiver,
+      }),
+    ).resolves.toBe(true);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        accepted: true,
+        body: expect.objectContaining({
+          message: { conversation: "text after unsupported" },
+        }),
+      }),
+    );
+  });
+
+  it("serializes first-contact Signal transactions by recipient bundle", async () => {
+    const recipientJid = "15551234567@s.whatsapp.net";
+    const receiver = new WhatsAppSignalBundleStore(1);
+    const bundle = receiver.resolveMany([recipientJid])[0]!;
+    const createSender = async (senderJid: string, registrationId: number) => {
+      const identity = Curve.generateKeyPair();
+      const storage = createSignalTestStorage(identity, registrationId);
+      const address = new ProtocolAddress("15551234567", 0);
+      await new SessionBuilder(storage, address).initOutgoing({
+        identityKey: signalTestKeyPair(bundle.identityKey).pubKey,
+        preKey: {
+          keyId: bundle.preKeyId,
+          publicKey: signalTestKeyPair(bundle.preKey).pubKey,
+        },
+        registrationId: bundle.registrationId,
+        signedPreKey: {
+          keyId: bundle.signedPreKey.keyId,
+          publicKey: signalTestKeyPair(bundle.signedPreKey.keyPair).pubKey,
+          signature: bundle.signedPreKey.signature,
+        },
+      });
+      const encrypted = await new SessionCipher(storage, address).encrypt(
+        Buffer.from(`first contact from ${senderJid}`),
+      );
+      return { ciphertext: signalCiphertext(encrypted.body), senderJid };
+    };
+    const firstSender = await createSender("15550000001@s.whatsapp.net", 2);
+    const secondSender = await createSender("15550000002@s.whatsapp.net", 3);
+    let releaseFirst: () => void = () => undefined;
+    let markFirstStarted: () => void = () => undefined;
+    const firstBlocked = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const firstStarted = new Promise<void>((resolve) => {
+      markFirstStarted = resolve;
+    });
+    let secondStarted = false;
+    const first = receiver.transactDirectMessage({
+      accept: async () => {
+        markFirstStarted();
+        await firstBlocked;
+        return true;
+      },
+      ciphertext: firstSender.ciphertext,
+      recipientJid,
+      remoteJid: firstSender.senderJid,
+      type: "pkmsg",
+    });
+    await firstStarted;
+    const second = receiver.transactDirectMessage({
+      accept: async () => {
+        secondStarted = true;
+        return true;
+      },
+      ciphertext: secondSender.ciphertext,
+      recipientJid,
+      remoteJid: secondSender.senderJid,
+      type: "pkmsg",
+    });
+    await Promise.resolve();
+
+    expect(secondStarted).toBe(false);
+    releaseFirst();
+    await expect(first).resolves.toEqual({ status: "accepted", value: true });
+    await expect(second).resolves.toMatchObject({ status: "decrypt-failed" });
+  });
+
+  it("generates replacement prekeys before accepted evidence persists", async () => {
+    const recipientJid = "15551234567@s.whatsapp.net";
+    const senderJid = "15550000001@s.whatsapp.net";
+    const receiver = new WhatsAppSignalBundleStore(1);
+    const bundle = receiver.resolveMany([recipientJid])[0]!;
+    const senderIdentity = Curve.generateKeyPair();
+    const senderStorage = createSignalTestStorage(senderIdentity, 2);
+    const senderAddress = new ProtocolAddress("15551234567", 0);
+    await new SessionBuilder(senderStorage, senderAddress).initOutgoing({
+      identityKey: signalTestKeyPair(bundle.identityKey).pubKey,
+      preKey: {
+        keyId: bundle.preKeyId,
+        publicKey: signalTestKeyPair(bundle.preKey).pubKey,
+      },
+      registrationId: bundle.registrationId,
+      signedPreKey: {
+        keyId: bundle.signedPreKey.keyId,
+        publicKey: signalTestKeyPair(bundle.signedPreKey.keyPair).pubKey,
+        signature: bundle.signedPreKey.signature,
+      },
+    });
+    const encrypted = await new SessionCipher(senderStorage, senderAddress).encrypt(
+      Buffer.from("prekey generation ordering"),
+    );
+    const generateKeyPair = vi.spyOn(Curve, "generateKeyPair").mockImplementationOnce(() => {
+      throw new Error("simulated replacement prekey failure");
+    });
+    let persisted = false;
+
+    await expect(
+      receiver.transactDirectMessage({
+        accept: async () => {
+          persisted = true;
+          return true;
+        },
+        ciphertext: signalCiphertext(encrypted.body),
+        recipientJid,
+        remoteJid: senderJid,
+        type: "pkmsg",
+      }),
+    ).rejects.toThrow("simulated replacement prekey failure");
+    expect(persisted).toBe(false);
+    generateKeyPair.mockRestore();
   });
 
   it("drains unauthorized request bodies before reusing the connection", async () => {

--- a/test/whatsapp-wire.test.ts
+++ b/test/whatsapp-wire.test.ts
@@ -506,6 +506,19 @@ describe("WhatsApp signal bundle store", () => {
     );
     expect(store.size).toBe(1);
   });
+
+  it("bounds PN-to-LID associations and evicts the least recently associated entry", () => {
+    const store = new WhatsAppSignalBundleStore(2);
+    store.associateLid("15550000001@s.whatsapp.net", "15550000001@lid");
+    store.associateLid("15550000002@s.whatsapp.net", "15550000002@lid");
+    store.associateLid("15550000001@s.whatsapp.net", "15550000011@lid");
+    store.associateLid("15550000003@s.whatsapp.net", "15550000003@lid");
+
+    expect(store.lidMappingSize).toBe(2);
+    expect(store.resolveAssociatedLid("15550000001:2@s.whatsapp.net")).toBe("15550000011@lid");
+    expect(store.resolveAssociatedLid("15550000002@s.whatsapp.net")).toBeUndefined();
+    expect(store.resolveAssociatedLid("15550000003@s.whatsapp.net")).toBe("15550000003@lid");
+  });
 });
 
 function nestedNode(depth: number): BinaryNode {

--- a/test/whatsapp-wire.test.ts
+++ b/test/whatsapp-wire.test.ts
@@ -76,7 +76,9 @@ describe("WhatsApp X25519 agreement", () => {
     let nativeSharedKeyCalls = 0;
     const curve = createCurve({
       generateKeyPair() {
-        throw new Error("native X25519 unavailable");
+        throw Object.assign(new Error("native X25519 unavailable"), {
+          code: "ERR_OSSL_EVP_UNSUPPORTED",
+        });
       },
       sharedKey() {
         nativeSharedKeyCalls += 1;
@@ -95,7 +97,9 @@ describe("WhatsApp X25519 agreement", () => {
   it("rejects low-order peers when the JS backend derives an all-zero secret", () => {
     const curve = createCurve({
       generateKeyPair() {
-        throw new Error("native X25519 unavailable");
+        throw Object.assign(new Error("native X25519 unavailable"), {
+          code: "ERR_OSSL_EVP_UNSUPPORTED",
+        });
       },
       sharedKey() {
         throw new Error("native shared key should not run");
@@ -111,6 +115,22 @@ describe("WhatsApp X25519 agreement", () => {
     expect(() =>
       curve.sharedKey(RFC_7748_ALICE_PRIVATE, Buffer.concat([Buffer.from([5]), lowOrderPeer])),
     ).toThrow("failed during derivation");
+  });
+
+  it("does not hide unexpected native key generation failures", () => {
+    const generateKeyPair = vi.fn(() => {
+      throw new Error("native entropy source failed");
+    });
+    const curve = createCurve({
+      generateKeyPair,
+      sharedKey() {
+        throw new Error("not reached");
+      },
+    });
+
+    expect(() => curve.generateKeyPair()).toThrow("native entropy source failed");
+    expect(() => curve.generateKeyPair()).toThrow("native entropy source failed");
+    expect(generateKeyPair).toHaveBeenCalledTimes(2);
   });
 });
 


### PR DESCRIPTION
## Summary

- stage inbound Signal decrypt/session/prekey mutations until accepted recorder evidence persists, then acknowledge
- preserve retryability across recorder failure, rotate consumed one-time prekeys, and bound PN-to-LID mappings
- drain unauthorized bodies, record successful read status as accepted, and restrict native X25519 fallback to known unsupported errors

## Validation

- `pnpm exec vitest run test/whatsapp-wire.test.ts test/whatsapp-server.test.ts`
- `pnpm lint`
- `pnpm build`