### PR TITLE
fix(openclaw): harden bridge identity and smoke locking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Pin and validate Slack Events API delivery targets across redirects while preserving native retries and installation authorization envelopes.
 - Harden provider recorder durability and replacement recovery, JWT cache expiry refresh, and LocalMock webhook shutdown draining.
 - Harden recorder append durability, Baileys shutdown draining, and provider-native HTTP, identity, profile, authentication, ingress, and redaction fidelity.
+- Preserve OpenClaw thread and direct-recipient identity, persist recorder and directory metadata, and prevent stale smoke-lock release from fencing successors.
 
 ## 0.1.11 - 2026-07-13
 

--- a/src/openclaw.ts
+++ b/src/openclaw.ts
@@ -331,6 +331,7 @@ type ProviderReadinessDependencies = {
   publishGeneration?: typeof publishOpenClawCrablineArtifactGeneration;
   releaseLock?: typeof releaseOpenClawCrablineSmokeRunLock;
   startAdapter?: typeof startOpenClawCrablineAdapter;
+  syncParent?: typeof syncParentDirectory;
 };
 
 export function runOpenClawCrablineProviderReadiness(params: {
@@ -346,6 +347,7 @@ export async function runOpenClawCrablineProviderReadiness(
 ): Promise<OpenClawCrablineProviderReadinessResult> {
   const outputDir = path.resolve(params.outputDir);
   const releaseLock = dependencies.releaseLock ?? releaseOpenClawCrablineSmokeRunLock;
+  const syncRecorderParent = dependencies.syncParent ?? syncParentDirectory;
   const smokeLock = await (dependencies.acquireLock ?? acquireOpenClawCrablineSmokeRunLock)({
     channel: params.selection.channel,
     outputDir,
@@ -456,6 +458,7 @@ export async function runOpenClawCrablineProviderReadiness(
     let recorderCleanupWarning: string | undefined;
     try {
       await fs.rm(recorderPath, { force: true });
+      await syncRecorderParent(recorderPath);
       recorderPath = undefined;
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
@@ -488,6 +491,7 @@ export async function runOpenClawCrablineProviderReadiness(
     if (recorderPath) {
       try {
         await fs.rm(recorderPath, { force: true });
+        await syncRecorderParent(recorderPath);
         recorderPath = undefined;
       } catch (cleanupError) {
         if (primaryError instanceof Error) {

--- a/src/openclaw/bridges/matrix.ts
+++ b/src/openclaw/bridges/matrix.ts
@@ -236,7 +236,8 @@ export const MATRIX_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablinePr
           senderId: matrix.botUserId,
           senderName: "OpenClaw QA",
           text,
-          to: targetByProviderTarget.get(targetKey(roomId, threadId)) ?? roomId,
+          to:
+            targetByProviderTarget.get(targetKey(roomId, threadId)) ?? targetKey(roomId, threadId),
         };
       },
     };

--- a/src/openclaw/bridges/mattermost.ts
+++ b/src/openclaw/bridges/mattermost.ts
@@ -102,11 +102,18 @@ export const MATTERMOST_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabli
           throw new Error("Mattermost conversation id is required.");
         }
         const senderId = nativeId(input.senderId);
+        const recipientId = kind === "direct" ? nativeId(conversationId) : undefined;
+        if (recipientId !== undefined && recipientId !== senderId) {
+          throw new Error(
+            "Mattermost direct conversation and sender must identify the same recipient.",
+          );
+        }
         const channelId =
           kind === "direct"
             ? directChannelId(mattermost.botUserId, senderId)
             : nativeId(conversationId);
-        const rootId = input.threadId ? threadRootId(channelId, input.threadId) : undefined;
+        const threadId = input.threadId?.trim();
+        const rootId = threadId ? threadRootId(channelId, threadId) : undefined;
         return {
           ...createAdminInboundRequest(mattermost),
           providerBody: {

--- a/src/openclaw/bridges/signal.ts
+++ b/src/openclaw/bridges/signal.ts
@@ -126,6 +126,14 @@ export const SIGNAL_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablinePr
           throw new Error("Signal conversation and sender are required.");
         }
         const senderIdentity = signalDirectIdentity(senderId);
+        if (
+          kind === "direct" &&
+          signalDirectIdentity(conversationId).recipient !== senderIdentity.recipient
+        ) {
+          throw new Error(
+            "Signal direct conversation and sender must identify the same recipient.",
+          );
+        }
         return {
           ...createAdminInboundRequest(signal),
           providerBody: {

--- a/src/openclaw/private-file.ts
+++ b/src/openclaw/private-file.ts
@@ -392,6 +392,7 @@ export async function securePrivateDirectory(
     currentUserId?: number;
     platform?: NodeJS.Platform;
     secureWindowsDirectory?: (directoryPath: string) => Promise<void>;
+    syncDirectory?: () => Promise<void>;
     syncParent?: (filePath: string, platform?: NodeJS.Platform) => Promise<void>;
   } = {},
 ): Promise<SecuredPrivateDirectory> {
@@ -451,6 +452,7 @@ export async function securePrivateDirectory(
         throw new Error("Private directory must be owned by the current POSIX user.");
       }
       await handle.chmod(0o700);
+      await (options.syncDirectory ?? (() => handle.sync()))();
     }
     await secured.assertIdentityAt();
     const syncParent = options.syncParent ?? syncParentDirectory;

--- a/src/openclaw/smoke-lock.ts
+++ b/src/openclaw/smoke-lock.ts
@@ -58,12 +58,13 @@ type StartHeartbeat = (renew: () => Promise<void>, intervalMs: number) => Heartb
 type BeforeRecoveryClaim = () => Promise<void>;
 type BeforeRecoveryDeleteClaim = () => Promise<void>;
 type BeforeReleaseClaim = () => Promise<void>;
+type BeforeReleaseRename = () => Promise<void>;
 type BeforeCommitClaim = () => Promise<void>;
 type BeforeCommitFileRename = () => Promise<void>;
 type BeforeCommitRename = () => Promise<void>;
 type SecureWindowsDirectory = (directoryPath: string) => Promise<void>;
 type AfterLockDirectoryWrite = (directoryPath: string) => Promise<void>;
-type LockClaimKind = "commit" | "recovering" | "release";
+type LockClaimKind = "commit" | "owned" | "recovering" | "release";
 type LockClaim = {
   directoryPath: string;
   kind: LockClaimKind;
@@ -89,6 +90,7 @@ const LOCK_COMMIT_STAGE_FILE_PREFIX = "commit-stage";
 const LOCK_LEASE_FILE_PREFIX = "lease.";
 const LEGACY_RECOVERY_SUFFIX = ".recovering";
 const COMMIT_CLAIM_SUFFIX = ".commit";
+const OWNED_CLAIM_SUFFIX = ".owned";
 const RELEASE_CLAIM_SUFFIX = ".release";
 const LOCK_LEASE_MS = 10 * 60 * 1000;
 const RELEASE_ATTEMPTS = 3;
@@ -530,8 +532,15 @@ function isLockOwnerActive(record: SmokeLockRecord, runtime: SmokeLockRuntime): 
   return ageMs >= -runtime.leaseMs && ageMs <= runtime.leaseMs;
 }
 
+function isRetiredCompatibilityMarker(record: SmokeLockRecord): boolean {
+  return (
+    isRenewableOwner(record.owner) && record.owner.createdAtMs === 1 && record.renewedAtMs <= 1
+  );
+}
+
 function needsLiveOwnerConfirmation(record: SmokeLockRecord, runtime: SmokeLockRuntime): boolean {
   return (
+    !isRetiredCompatibilityMarker(record) &&
     isRenewableOwner(record.owner) &&
     runtime.isProcessAlive(record.owner.pid) &&
     !hasProcessIdentityMismatch(record.owner, runtime) &&
@@ -577,6 +586,7 @@ function activeRunError(params: {
 
 async function removeOwnedLock(params: {
   beforeClaim?: () => Promise<void>;
+  beforeRename?: () => Promise<void>;
   lockDirectory: string;
   onOwnedDirectoryChange?: (directoryPath: string) => void;
   ownedDirectory: string;
@@ -584,6 +594,7 @@ async function removeOwnedLock(params: {
   runtime?: SmokeLockRuntime;
   token: string;
 }): Promise<boolean> {
+  await params.beforeClaim?.();
   const observed = await readLockRecord(params.ownedDirectory);
   if (observed.kind === "missing" || observed.record.owner.token !== params.token) {
     return false;
@@ -592,8 +603,18 @@ async function removeOwnedLock(params: {
   if (observedIdentity === null) {
     return false;
   }
+  const revalidated = await readLockRecord(params.ownedDirectory);
+  const revalidatedIdentity = await readDirectoryIdentity(params.ownedDirectory);
+  if (
+    revalidated.kind === "missing" ||
+    revalidated.record.owner.token !== params.token ||
+    !hasSameDirectoryIdentity(observedIdentity, revalidatedIdentity) ||
+    (params.runtime !== undefined && isLockOwnerActive(revalidated.record, params.runtime))
+  ) {
+    return false;
+  }
 
-  await params.beforeClaim?.();
+  await params.beforeRename?.();
   const releaseClaim = `${params.lockDirectory}${RELEASE_CLAIM_SUFFIX}.${params.token}.${randomUUID()}`;
   try {
     await fs.rename(params.ownedDirectory, releaseClaim);
@@ -644,6 +665,44 @@ async function removeOwnedLock(params: {
 
   await (params.removeDirectory ?? removeLockDirectory)(releaseClaim);
   return true;
+}
+
+async function renewCompatibilityMarker(params: {
+  handle: FileHandle;
+  lockDirectory: string;
+  renewedAtMs: number;
+  securedDirectory: Awaited<ReturnType<typeof securePrivateDirectory>>;
+  token: string;
+}): Promise<boolean> {
+  await params.securedDirectory.assertIdentityAt(params.lockDirectory);
+  const observed = await readLockRecord(params.lockDirectory);
+  if (observed.kind === "missing" || observed.record.owner.token !== params.token) {
+    return false;
+  }
+  const renewedAt = new Date(params.renewedAtMs);
+  await params.handle.utimes(renewedAt, renewedAt);
+  await params.handle.sync();
+  await params.securedDirectory.assertIdentityAt(params.lockDirectory);
+  const revalidated = await readLockRecord(params.lockDirectory);
+  return revalidated.kind === "record" && revalidated.record.owner.token === params.token;
+}
+
+async function assertCompatibilityMarkerOwned(params: {
+  lockDirectory: string;
+  securedDirectory: Awaited<ReturnType<typeof securePrivateDirectory>>;
+  token: string;
+}): Promise<void> {
+  await params.securedDirectory.assertIdentityAt(params.lockDirectory);
+  const observed = await readLockRecord(params.lockDirectory);
+  if (observed.kind === "missing" || observed.record.owner.token !== params.token) {
+    throw new Error("OpenClaw Crabline smoke lock compatibility marker was lost.");
+  }
+}
+
+async function retireCompatibilityMarker(handle: FileHandle): Promise<void> {
+  const retiredAt = new Date(1);
+  await handle.utimes(retiredAt, retiredAt);
+  await handle.sync();
 }
 
 async function renewOwnedLock(
@@ -701,6 +760,7 @@ async function listLockClaims(lockDirectory: string): Promise<LockClaim[]> {
   const prefixes: Array<{ kind: LockClaimKind; prefix: string }> = [
     { kind: "recovering", prefix: claimPrefix(lockDirectory, LEGACY_RECOVERY_SUFFIX) },
     { kind: "commit", prefix: claimPrefix(lockDirectory, COMMIT_CLAIM_SUFFIX) },
+    { kind: "owned", prefix: claimPrefix(lockDirectory, OWNED_CLAIM_SUFFIX) },
     { kind: "release", prefix: claimPrefix(lockDirectory, RELEASE_CLAIM_SUFFIX) },
   ];
   const entries = await fs.readdir(directory, { withFileTypes: true });
@@ -918,6 +978,8 @@ async function resolveLockContention(params: {
 
 async function createLockCandidate(params: {
   afterOwnerWrite?: AfterLockDirectoryWrite;
+  candidateDirectory?: string;
+  includeLease?: boolean;
   lockDirectory: string;
   owner: RenewableSmokeLockOwner;
   platform?: NodeJS.Platform;
@@ -926,7 +988,9 @@ async function createLockCandidate(params: {
   candidateDirectory: string;
   securedDirectory: Awaited<ReturnType<typeof securePrivateDirectory>>;
 }> {
-  const candidateDirectory = `${params.lockDirectory}.${params.owner.pid}.${params.owner.token}.tmp`;
+  const candidateDirectory =
+    params.candidateDirectory ??
+    `${params.lockDirectory}.${params.owner.pid}.${params.owner.token}.tmp`;
   await fs.mkdir(candidateDirectory, { mode: 0o700 });
   try {
     const securedDirectory = await securePrivateDirectory(candidateDirectory, {
@@ -948,18 +1012,20 @@ async function createLockCandidate(params: {
     await params.afterOwnerWrite?.(candidateDirectory);
     await securedDirectory.assertIdentityAt();
 
-    const leasePath = path.join(candidateDirectory, leaseFileName(params.owner.token));
-    await fs.writeFile(
-      leasePath,
-      `${JSON.stringify({ renewedAtMs: params.owner.createdAtMs, token: params.owner.token })}\n`,
-      {
-        encoding: "utf8",
-        flag: "wx",
-        mode: 0o600,
-      },
-    );
-    await fs.chmod(leasePath, 0o600);
-    await fs.utimes(leasePath, createdAt, createdAt);
+    if (params.includeLease !== false) {
+      const leasePath = path.join(candidateDirectory, leaseFileName(params.owner.token));
+      await fs.writeFile(
+        leasePath,
+        `${JSON.stringify({ renewedAtMs: params.owner.createdAtMs, token: params.owner.token })}\n`,
+        {
+          encoding: "utf8",
+          flag: "wx",
+          mode: 0o600,
+        },
+      );
+      await fs.chmod(leasePath, 0o600);
+      await fs.utimes(leasePath, createdAt, createdAt);
+    }
     await securedDirectory.assertIdentityAt();
     return { candidateDirectory, securedDirectory };
   } catch (error) {
@@ -975,6 +1041,7 @@ export async function acquireOpenClawCrablineSmokeRunLock(
   },
   dependencies: {
     afterLockCandidateInstall?: AfterLockDirectoryWrite;
+    afterLockOwnerClaimInstall?: AfterLockDirectoryWrite;
     afterLockOwnerWrite?: AfterLockDirectoryWrite;
     getProcessIdentity?: GetProcessIdentity;
     isProcessAlive?: IsProcessAlive;
@@ -991,6 +1058,7 @@ export async function acquireOpenClawCrablineSmokeRunLock(
     beforeRecoveryDeleteClaim?: BeforeRecoveryDeleteClaim;
     beforeRecoveryClaim?: BeforeRecoveryClaim;
     beforeReleaseClaim?: BeforeReleaseClaim;
+    beforeReleaseRename?: BeforeReleaseRename;
     removeDirectory?: RemoveLockDirectory;
     sleep?: Sleep;
     startHeartbeat?: StartHeartbeat;
@@ -1035,6 +1103,10 @@ export async function acquireOpenClawCrablineSmokeRunLock(
     processStartedAtMs: runtime.currentProcessStartedAtMs,
     token,
   };
+  const compatibilityOwner: RenewableSmokeLockOwner = {
+    ...owner,
+    createdAtMs: 1,
+  };
 
   await fs.mkdir(outputDir, { recursive: true });
   for (;;) {
@@ -1051,21 +1123,67 @@ export async function acquireOpenClawCrablineSmokeRunLock(
       continue;
     }
 
+    const ownerDirectory = `${lockDirectory}${OWNED_CLAIM_SUFFIX}.${token}`;
     const { candidateDirectory, securedDirectory } = await createLockCandidate({
       ...(dependencies.afterLockOwnerWrite
         ? { afterOwnerWrite: dependencies.afterLockOwnerWrite }
         : {}),
+      includeLease: false,
       lockDirectory,
-      owner,
+      owner: compatibilityOwner,
       ...(dependencies.platform ? { platform: dependencies.platform } : {}),
       ...(dependencies.secureWindowsDirectory
         ? { secureWindowsDirectory: dependencies.secureWindowsDirectory }
         : {}),
     });
+    let ownerCandidate: Awaited<ReturnType<typeof createLockCandidate>>;
+    try {
+      ownerCandidate = await createLockCandidate({
+        candidateDirectory: `${lockDirectory}.${runtime.currentPid}.${token}.owned.tmp`,
+        lockDirectory: ownerDirectory,
+        owner,
+        ...(dependencies.platform ? { platform: dependencies.platform } : {}),
+        ...(dependencies.secureWindowsDirectory
+          ? { secureWindowsDirectory: dependencies.secureWindowsDirectory }
+          : {}),
+      });
+    } catch (error) {
+      await fs.rm(candidateDirectory, { force: true, recursive: true }).catch(() => undefined);
+      throw error;
+    }
+    let compatibilityMarkerHandle: FileHandle | undefined;
+    try {
+      compatibilityMarkerHandle = await fs.open(
+        path.join(candidateDirectory, LOCK_OWNER_FILE),
+        "r+",
+      );
+      const compatibilityRecord = await readLockRecordFromHandle(compatibilityMarkerHandle);
+      if (compatibilityRecord.owner.token !== token) {
+        throw new Error("OpenClaw Crabline smoke lock compatibility marker was replaced.");
+      }
+      const activeAt = new Date(createdAtMs);
+      await compatibilityMarkerHandle.utimes(activeAt, activeAt);
+      await compatibilityMarkerHandle.sync();
+    } catch (error) {
+      await compatibilityMarkerHandle?.close().catch(() => undefined);
+      await fs.rm(candidateDirectory, { force: true, recursive: true }).catch(() => undefined);
+      await fs
+        .rm(ownerCandidate.candidateDirectory, { force: true, recursive: true })
+        .catch(() => undefined);
+      throw error;
+    }
+    if (!compatibilityMarkerHandle) {
+      throw new Error("OpenClaw Crabline smoke lock compatibility marker was not opened.");
+    }
+    const markerHandle = compatibilityMarkerHandle;
     try {
       await fs.rename(candidateDirectory, lockDirectory);
     } catch (error) {
+      await markerHandle.close().catch(() => undefined);
       await fs.rm(candidateDirectory, { force: true, recursive: true }).catch(() => undefined);
+      await fs
+        .rm(ownerCandidate.candidateDirectory, { force: true, recursive: true })
+        .catch(() => undefined);
       await resolveLockContention({
         beforeRecoveryDeleteClaim:
           dependencies.beforeRecoveryDeleteClaim ?? (async () => undefined),
@@ -1078,18 +1196,80 @@ export async function acquireOpenClawCrablineSmokeRunLock(
       });
       continue;
     }
-    await dependencies.afterLockCandidateInstall?.(lockDirectory);
-    await securedDirectory.assertIdentityAt(lockDirectory);
+    let ownerInstalled = false;
+    try {
+      await dependencies.afterLockCandidateInstall?.(lockDirectory);
+      await securedDirectory.assertIdentityAt(lockDirectory);
+      const installed = await readLockRecord(lockDirectory);
+      if (installed.kind !== "record" || installed.record.owner.token !== token) {
+        await retireCompatibilityMarker(markerHandle);
+        await markerHandle.close();
+        await fs.rm(ownerCandidate.candidateDirectory, { force: true, recursive: true });
+        continue;
+      }
+      await fs.rename(ownerCandidate.candidateDirectory, ownerDirectory);
+      ownerInstalled = true;
+      await dependencies.afterLockOwnerClaimInstall?.(ownerDirectory);
+      await ownerCandidate.securedDirectory.assertIdentityAt(ownerDirectory);
+    } catch (error) {
+      let cleanupError: unknown;
+      try {
+        if (ownerInstalled) {
+          await removeOwnedLock({
+            lockDirectory,
+            ownedDirectory: ownerDirectory,
+            token,
+          });
+        } else {
+          await fs.rm(ownerCandidate.candidateDirectory, { force: true, recursive: true });
+        }
+        await retireCompatibilityMarker(markerHandle);
+      } catch (caughtCleanupError) {
+        cleanupError = caughtCleanupError;
+      }
+      try {
+        await markerHandle.close();
+      } catch (closeError) {
+        cleanupError =
+          cleanupError === undefined
+            ? closeError
+            : new AggregateError(
+                [cleanupError, closeError],
+                "OpenClaw Crabline smoke lock setup cleanup also failed.",
+              );
+      }
+      if (cleanupError !== undefined) {
+        const aggregateError = new AggregateError(
+          [error, cleanupError],
+          "OpenClaw Crabline smoke lock setup and cleanup failed.",
+        );
+        aggregateError.cause = error;
+        throw aggregateError;
+      }
+      throw error;
+    }
 
+    const competingClaims = (await listLockClaims(lockDirectory)).filter(
+      (claim) => claim.directoryPath !== ownerDirectory,
+    );
     if (
-      (await listLockClaims(lockDirectory)).length > 0 ||
+      competingClaims.length > 0 ||
       (await pathExists(`${lockDirectory}${LEGACY_RECOVERY_SUFFIX}`))
     ) {
-      await removeOwnedLock({
+      const removed = await removeOwnedLock({
         lockDirectory,
-        ownedDirectory: lockDirectory,
+        ownedDirectory: ownerDirectory,
         token,
       });
+      if (!removed) {
+        await markerHandle.close();
+        throw new Error("OpenClaw Crabline smoke lock ownership was lost.");
+      }
+      try {
+        await retireCompatibilityMarker(markerHandle);
+      } finally {
+        await markerHandle.close();
+      }
       await resolveLockClaims({
         beforeRecoveryDeleteClaim:
           dependencies.beforeRecoveryDeleteClaim ?? (async () => undefined),
@@ -1100,18 +1280,26 @@ export async function acquireOpenClawCrablineSmokeRunLock(
       });
       continue;
     }
-    const installed = await readLockRecord(lockDirectory);
-    if (installed.kind !== "record" || installed.record.owner.token !== token) {
-      continue;
-    }
 
-    let ownedDirectory = lockDirectory;
+    let ownedDirectory = ownerDirectory;
     let clockRegressed = false;
     let lastObservedNowMs = createdAtMs;
     let lastRenewedAtMs = createdAtMs;
     let pendingRenewal = Promise.resolve();
     let commitFenceConsumed = false;
+    let markerClosed = false;
+    let markerRetired = false;
     let heartbeat: HeartbeatController;
+    const retireMarker = async () => {
+      if (!markerRetired) {
+        await retireCompatibilityMarker(markerHandle);
+        markerRetired = true;
+      }
+      if (!markerClosed) {
+        await markerHandle.close();
+        markerClosed = true;
+      }
+    };
     const renew = async () => {
       const renewal = pendingRenewal
         .catch(() => undefined)
@@ -1130,6 +1318,17 @@ export async function acquireOpenClawCrablineSmokeRunLock(
           if (!(await renewOwnedLock(ownedDirectory, token, renewedAtMs))) {
             throw new Error("OpenClaw Crabline smoke lock ownership was lost.");
           }
+          if (
+            !(await renewCompatibilityMarker({
+              handle: markerHandle,
+              lockDirectory,
+              renewedAtMs,
+              securedDirectory,
+              token,
+            }))
+          ) {
+            throw new Error("OpenClaw Crabline smoke lock compatibility marker was lost.");
+          }
           lastRenewedAtMs = renewedAtMs;
         });
       pendingRenewal = renewal;
@@ -1141,11 +1340,21 @@ export async function acquireOpenClawCrablineSmokeRunLock(
         Math.max(1, Math.floor(runtime.leaseMs / 3)),
       );
     } catch (error) {
-      await removeOwnedLock({
-        lockDirectory,
-        ownedDirectory: lockDirectory,
-        token,
-      });
+      try {
+        await removeOwnedLock({
+          lockDirectory,
+          ownedDirectory: ownerDirectory,
+          token,
+        });
+        await retireMarker();
+      } catch (cleanupError) {
+        const aggregateError = new AggregateError(
+          [error, cleanupError],
+          "OpenClaw Crabline smoke lock heartbeat startup and cleanup failed.",
+        );
+        aggregateError.cause = error;
+        throw aggregateError;
+      }
       throw error;
     }
     let heartbeatStopped = false;
@@ -1158,12 +1367,17 @@ export async function acquireOpenClawCrablineSmokeRunLock(
         heartbeat.assertHealthy();
         await renew();
         heartbeat.assertHealthy();
+        await assertCompatibilityMarkerOwned({
+          lockDirectory,
+          securedDirectory,
+          token,
+        });
       },
       async commitFileAtomically({ contents, destinationPath, stageDirectory, stageFile }) {
         if (released) {
           throw new Error("OpenClaw Crabline smoke lock has already been released.");
         }
-        if (commitFenceConsumed || heartbeatStopped || ownedDirectory !== lockDirectory) {
+        if (commitFenceConsumed || heartbeatStopped || ownedDirectory !== ownerDirectory) {
           throw new Error("OpenClaw Crabline smoke lock has already committed its fence.");
         }
         heartbeat.assertHealthy();
@@ -1171,19 +1385,26 @@ export async function acquireOpenClawCrablineSmokeRunLock(
         heartbeat.assertHealthy();
 
         const stagedFileName = `.commit-file.${token}.${randomUUID()}.tmp`;
-        const stagedFilePath = path.join(stageDirectory ?? lockDirectory, stagedFileName);
+        const stagedFilePath = path.join(stageDirectory ?? ownerDirectory, stagedFileName);
         let committed = false;
         try {
           await stageFile(stagedFilePath, contents);
           if (stageDirectory) {
-            await writeCommitStagePath(lockDirectory, stagedFilePath, token);
+            await writeCommitStagePath(ownerDirectory, stagedFilePath, token);
           }
           heartbeat.assertHealthy();
           await renew();
           heartbeat.assertHealthy();
 
-          const observedIdentity = await readDirectoryIdentity(lockDirectory);
-          const observed = await readLockRecord(lockDirectory);
+          await dependencies.beforeCommitClaim?.();
+          await assertCompatibilityMarkerOwned({
+            lockDirectory,
+            securedDirectory,
+            token,
+          });
+          const commitClaim = `${lockDirectory}${COMMIT_CLAIM_SUFFIX}.${token}.${randomUUID()}`;
+          const observedIdentity = await readDirectoryIdentity(ownerDirectory);
+          const observed = await readLockRecord(ownerDirectory);
           if (
             observedIdentity === null ||
             observed.kind === "missing" ||
@@ -1192,10 +1413,8 @@ export async function acquireOpenClawCrablineSmokeRunLock(
             throw new Error("OpenClaw Crabline smoke lock ownership was lost.");
           }
 
-          await dependencies.beforeCommitClaim?.();
-          const commitClaim = `${lockDirectory}${COMMIT_CLAIM_SUFFIX}.${token}.${randomUUID()}`;
           try {
-            await fs.rename(lockDirectory, commitClaim);
+            await fs.rename(ownerDirectory, commitClaim);
           } catch (error) {
             if (isMissingPathError(error)) {
               throw new Error("OpenClaw Crabline smoke lock ownership was lost.", {
@@ -1214,10 +1433,10 @@ export async function acquireOpenClawCrablineSmokeRunLock(
             claimed.record.owner.token !== token ||
             !hasSameDirectoryIdentity(observedIdentity, claimedIdentity)
           ) {
-            if (!(await pathExists(lockDirectory))) {
+            if (!(await pathExists(ownerDirectory))) {
               try {
-                await fs.rename(commitClaim, lockDirectory);
-                ownedDirectory = lockDirectory;
+                await fs.rename(commitClaim, ownerDirectory);
+                ownedDirectory = ownerDirectory;
               } catch (error) {
                 if (!isMissingPathError(error)) {
                   throw error;
@@ -1234,6 +1453,11 @@ export async function acquireOpenClawCrablineSmokeRunLock(
           await heartbeat.settle();
           heartbeat.assertHealthy();
           await dependencies.beforeCommitRename?.();
+          await assertCompatibilityMarkerOwned({
+            lockDirectory,
+            securedDirectory,
+            token,
+          });
           await fs.rename(
             stageDirectory ? stagedFilePath : path.join(commitClaim, stagedFileName),
             destinationPath,
@@ -1257,6 +1481,9 @@ export async function acquireOpenClawCrablineSmokeRunLock(
           ...(dependencies.beforeReleaseClaim
             ? { beforeClaim: dependencies.beforeReleaseClaim }
             : {}),
+          ...(dependencies.beforeReleaseRename
+            ? { beforeRename: dependencies.beforeReleaseRename }
+            : {}),
           lockDirectory,
           onOwnedDirectoryChange: (directoryPath) => {
             ownedDirectory = directoryPath;
@@ -1278,6 +1505,7 @@ export async function acquireOpenClawCrablineSmokeRunLock(
             token,
           });
         }
+        await retireMarker();
         released = true;
       },
     };

--- a/src/openclaw/smoke-lock.ts
+++ b/src/openclaw/smoke-lock.ts
@@ -57,6 +57,7 @@ type GetProcessIdentity = (pid: number) => string | null;
 type StartHeartbeat = (renew: () => Promise<void>, intervalMs: number) => HeartbeatController;
 type BeforeRecoveryClaim = () => Promise<void>;
 type BeforeRecoveryDeleteClaim = () => Promise<void>;
+type BeforeCompatibilityMarkerRenew = () => Promise<void>;
 type BeforeReleaseClaim = () => Promise<void>;
 type BeforeReleaseRename = () => Promise<void>;
 type BeforeCommitClaim = () => Promise<void>;
@@ -1055,6 +1056,7 @@ export async function acquireOpenClawCrablineSmokeRunLock(
     beforeCommitClaim?: BeforeCommitClaim;
     beforeCommitFileRename?: BeforeCommitFileRename;
     beforeCommitRename?: BeforeCommitRename;
+    beforeCompatibilityMarkerRenew?: BeforeCompatibilityMarkerRenew;
     beforeRecoveryDeleteClaim?: BeforeRecoveryDeleteClaim;
     beforeRecoveryClaim?: BeforeRecoveryClaim;
     beforeReleaseClaim?: BeforeReleaseClaim;
@@ -1318,6 +1320,7 @@ export async function acquireOpenClawCrablineSmokeRunLock(
           if (!(await renewOwnedLock(ownedDirectory, token, renewedAtMs))) {
             throw new Error("OpenClaw Crabline smoke lock ownership was lost.");
           }
+          await dependencies.beforeCompatibilityMarkerRenew?.();
           if (
             !(await renewCompatibilityMarker({
               handle: markerHandle,
@@ -1361,7 +1364,7 @@ export async function acquireOpenClawCrablineSmokeRunLock(
     let released = false;
     return {
       async assertOwned() {
-        if (released) {
+        if (released || heartbeatStopped) {
           throw new Error("OpenClaw Crabline smoke lock has already been released.");
         }
         heartbeat.assertHealthy();
@@ -1474,8 +1477,14 @@ export async function acquireOpenClawCrablineSmokeRunLock(
           return;
         }
         if (!heartbeatStopped) {
-          await heartbeat.stop();
           heartbeatStopped = true;
+          try {
+            await heartbeat.stop();
+          } finally {
+            await pendingRenewal.catch(() => undefined);
+          }
+        } else {
+          await pendingRenewal.catch(() => undefined);
         }
         await removeOwnedLock({
           ...(dependencies.beforeReleaseClaim

--- a/src/openclaw/smoke-lock.ts
+++ b/src/openclaw/smoke-lock.ts
@@ -533,15 +533,8 @@ function isLockOwnerActive(record: SmokeLockRecord, runtime: SmokeLockRuntime): 
   return ageMs >= -runtime.leaseMs && ageMs <= runtime.leaseMs;
 }
 
-function isRetiredCompatibilityMarker(record: SmokeLockRecord): boolean {
-  return (
-    isRenewableOwner(record.owner) && record.owner.createdAtMs === 1 && record.renewedAtMs <= 1
-  );
-}
-
 function needsLiveOwnerConfirmation(record: SmokeLockRecord, runtime: SmokeLockRuntime): boolean {
   return (
-    !isRetiredCompatibilityMarker(record) &&
     isRenewableOwner(record.owner) &&
     runtime.isProcessAlive(record.owner.pid) &&
     !hasProcessIdentityMismatch(record.owner, runtime) &&
@@ -700,7 +693,27 @@ async function assertCompatibilityMarkerOwned(params: {
   }
 }
 
-async function retireCompatibilityMarker(handle: FileHandle): Promise<void> {
+async function retireCompatibilityMarker(
+  handle: FileHandle,
+  owner: RenewableSmokeLockOwner,
+): Promise<void> {
+  const retiredOwner: RenewableSmokeLockOwner = {
+    ...owner,
+    createdAtMs: 1,
+    pid: MAX_PROCESS_ID,
+    ...(owner.processIdentity ? { processIdentity: "retired" } : {}),
+    processStartedAtMs: 1,
+  };
+  const originalBytes = Buffer.byteLength(`${JSON.stringify(owner)}\n`, "utf8");
+  const retiredJson = JSON.stringify(retiredOwner);
+  const retiredBytes = Buffer.byteLength(retiredJson, "utf8") + 1;
+  const targetBytes = Math.max(originalBytes, retiredBytes);
+  const paddingBytes = targetBytes - retiredBytes;
+  const retiredContents = `${retiredJson}${" ".repeat(paddingBytes)}\n`;
+  const written = await handle.write(retiredContents, 0, "utf8");
+  if (written.bytesWritten !== targetBytes) {
+    throw new Error("OpenClaw Crabline smoke lock compatibility marker retirement was incomplete.");
+  }
   const retiredAt = new Date(1);
   await handle.utimes(retiredAt, retiredAt);
   await handle.sync();
@@ -1204,7 +1217,7 @@ export async function acquireOpenClawCrablineSmokeRunLock(
       await securedDirectory.assertIdentityAt(lockDirectory);
       const installed = await readLockRecord(lockDirectory);
       if (installed.kind !== "record" || installed.record.owner.token !== token) {
-        await retireCompatibilityMarker(markerHandle);
+        await retireCompatibilityMarker(markerHandle, compatibilityOwner);
         await markerHandle.close();
         await fs.rm(ownerCandidate.candidateDirectory, { force: true, recursive: true });
         continue;
@@ -1225,7 +1238,7 @@ export async function acquireOpenClawCrablineSmokeRunLock(
         } else {
           await fs.rm(ownerCandidate.candidateDirectory, { force: true, recursive: true });
         }
-        await retireCompatibilityMarker(markerHandle);
+        await retireCompatibilityMarker(markerHandle, compatibilityOwner);
       } catch (caughtCleanupError) {
         cleanupError = caughtCleanupError;
       }
@@ -1268,7 +1281,7 @@ export async function acquireOpenClawCrablineSmokeRunLock(
         throw new Error("OpenClaw Crabline smoke lock ownership was lost.");
       }
       try {
-        await retireCompatibilityMarker(markerHandle);
+        await retireCompatibilityMarker(markerHandle, compatibilityOwner);
       } finally {
         await markerHandle.close();
       }
@@ -1294,7 +1307,7 @@ export async function acquireOpenClawCrablineSmokeRunLock(
     let heartbeat: HeartbeatController;
     const retireMarker = async () => {
       if (!markerRetired) {
-        await retireCompatibilityMarker(markerHandle);
+        await retireCompatibilityMarker(markerHandle, compatibilityOwner);
         markerRetired = true;
       }
       if (!markerClosed) {

--- a/test/openclaw-private-file.test.ts
+++ b/test/openclaw-private-file.test.ts
@@ -61,6 +61,31 @@ describe("OpenClaw private file publication", () => {
     }
   });
 
+  it("syncs a POSIX directory handle after persisting mode 0700", async () => {
+    const directory = await createTempDir();
+    try {
+      const generationPath = path.join(directory, "generation");
+      const events: string[] = [];
+      await fs.mkdir(generationPath, { mode: 0o777 });
+      await fs.chmod(generationPath, 0o777);
+
+      await securePrivateDirectory(generationPath, {
+        platform: "linux",
+        syncDirectory: async () => {
+          events.push("directory");
+          expect((await fs.stat(generationPath)).mode & 0o777).toBe(0o700);
+        },
+        syncParent: async () => {
+          events.push("parent");
+        },
+      });
+
+      expect(events).toEqual(["directory", "parent"]);
+    } finally {
+      await disposeTempDir(directory);
+    }
+  });
+
   it("resyncs an existing private directory after an interrupted creation", async () => {
     const directory = await createTempDir();
     try {

--- a/test/openclaw-smoke-lock.test.ts
+++ b/test/openclaw-smoke-lock.test.ts
@@ -19,6 +19,15 @@ const disableHeartbeat = (_renew: () => Promise<void>, _intervalMs: number) => (
   async stop() {},
 });
 
+async function findOwnedLockDirectory(outputDir: string): Promise<string> {
+  const prefix = `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock.owned.`;
+  const matches = (await fs.readdir(outputDir)).filter((entry) => entry.startsWith(prefix));
+  if (matches.length !== 1) {
+    throw new Error(`Expected one owned smoke-lock directory, found ${matches.length}.`);
+  }
+  return path.join(outputDir, matches[0]!);
+}
+
 describe("OpenClaw smoke lock cleanup", () => {
   it("extracts the exact Linux process start token", () => {
     expect(
@@ -132,24 +141,28 @@ describe("OpenClaw smoke lock cleanup", () => {
         },
       );
 
-      const lockDirectory = path.join(
-        path.resolve(outputDir),
+      const ownedDirectory = await findOwnedLockDirectory(outputDir);
+      const compatibilityDirectory = path.join(
+        outputDir,
         `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`,
       );
-      expect(await fs.readdir(lockDirectory)).toEqual(expect.arrayContaining(["owner.json"]));
+      expect(await fs.readdir(ownedDirectory)).toEqual(expect.arrayContaining(["owner.json"]));
+      expect(await fs.readdir(compatibilityDirectory)).toEqual(
+        expect.arrayContaining(["owner.json"]),
+      );
 
       await lock.commitFileAtomically({
         contents: "private\n",
         destinationPath,
         stageFile: async (filePath, contents) => {
           events.push("stage");
-          expect(events).toEqual(["secure", "stage"]);
+          expect(events).toEqual(["secure", "secure", "stage"]);
           await fs.writeFile(filePath, contents);
         },
       });
 
-      expect(secureWindowsDirectory).toHaveBeenCalledTimes(1);
-      expect(events).toEqual(["secure", "stage"]);
+      expect(secureWindowsDirectory).toHaveBeenCalledTimes(2);
+      expect(events).toEqual(["secure", "secure", "stage"]);
       await expect(fs.readFile(destinationPath, "utf8")).resolves.toBe("private\n");
       await lock.release();
     } finally {
@@ -248,6 +261,44 @@ describe("OpenClaw smoke lock cleanup", () => {
     }
   });
 
+  it("retires an installed compatibility marker when owner-claim setup fails", async () => {
+    const outputDir = await createTempDir();
+    const params = { channel: "telegram" as const, outputDir };
+    const setupFailure = new Error("owner claim setup failed");
+    try {
+      await expect(
+        acquireOpenClawCrablineSmokeRunLock(params, {
+          afterLockOwnerClaimInstall: async () => {
+            throw setupFailure;
+          },
+          startHeartbeat: disableHeartbeat,
+        }),
+      ).rejects.toBe(setupFailure);
+      expect(
+        (await fs.readdir(outputDir)).filter((entry) =>
+          entry.startsWith(`.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock.owned.`),
+        ),
+      ).toEqual([]);
+      const compatibilityOwnerPath = path.join(
+        outputDir,
+        `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`,
+        "owner.json",
+      );
+      expect(JSON.parse(await fs.readFile(compatibilityOwnerPath, "utf8"))).toMatchObject({
+        createdAtMs: 1,
+      });
+      expect((await fs.stat(compatibilityOwnerPath)).mtimeMs).toBeCloseTo(1, 0);
+
+      const replacementLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+        startHeartbeat: disableHeartbeat,
+      });
+      await expect(replacementLock.assertOwned()).resolves.toBeUndefined();
+      await replacementLock.release();
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
   it("retries release with bounded backoff before unwinding", async () => {
     const releaseError = new Error("transient removal failure");
     const release = vi
@@ -310,14 +361,11 @@ describe("OpenClaw smoke lock cleanup", () => {
     }
   });
 
-  it("does not delete a successor lock when a paused owner resumes release", async () => {
+  it("does not transiently relocate a successor while its heartbeat runs", async () => {
     const outputDir = await createTempDir();
     const params = { channel: "telegram" as const, outputDir };
-    const lockDirectory = path.join(
-      path.resolve(outputDir),
-      `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`,
-    );
-    const suspendedOwnerDirectory = `${lockDirectory}.suspended-owner`;
+    let suspendedMarkerDirectory = "";
+    let suspendedOwnerDirectory = "";
     let resumeRelease: (() => void) | undefined;
     let releaseValidated: (() => void) | undefined;
     const resumeReleasePromise = new Promise<void>((resolve) => {
@@ -327,30 +375,49 @@ describe("OpenClaw smoke lock cleanup", () => {
       releaseValidated = resolve;
     });
     let successorLock: Awaited<ReturnType<typeof acquireOpenClawCrablineSmokeRunLock>> | undefined;
+    let successorRenew: (() => Promise<void>) | undefined;
     try {
       const oldLock = await acquireOpenClawCrablineSmokeRunLock(params, {
-        beforeReleaseClaim: async () => {
+        beforeReleaseRename: async () => {
           releaseValidated?.();
           await resumeReleasePromise;
         },
         startHeartbeat: disableHeartbeat,
       });
+      const oldOwnerDirectory = await findOwnedLockDirectory(outputDir);
+      suspendedOwnerDirectory = path.join(
+        outputDir,
+        `.suspended-${path.basename(oldOwnerDirectory)}`,
+      );
+      const markerDirectory = path.join(outputDir, `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`);
+      suspendedMarkerDirectory = path.join(outputDir, ".suspended-compatibility-marker");
       const oldRelease = oldLock.release();
       await releaseValidatedPromise;
 
-      await fs.rename(lockDirectory, suspendedOwnerDirectory);
+      await fs.rename(oldOwnerDirectory, suspendedOwnerDirectory);
+      await fs.rename(markerDirectory, suspendedMarkerDirectory);
       successorLock = await acquireOpenClawCrablineSmokeRunLock(params, {
-        startHeartbeat: disableHeartbeat,
+        startHeartbeat: (renew, intervalMs) => {
+          successorRenew = renew;
+          return disableHeartbeat(renew, intervalMs);
+        },
       });
       resumeRelease?.();
 
       await expect(oldRelease).resolves.toBeUndefined();
+      await expect(successorRenew!()).resolves.toBeUndefined();
       await expect(successorLock.assertOwned()).resolves.toBeUndefined();
-      expect(await fs.stat(lockDirectory)).toBeDefined();
+      await expect(fs.stat(await findOwnedLockDirectory(outputDir))).resolves.toBeDefined();
+      await expect(fs.stat(markerDirectory)).resolves.toBeDefined();
     } finally {
       resumeRelease?.();
       await successorLock?.release();
-      await fs.rm(suspendedOwnerDirectory, { force: true, recursive: true });
+      if (suspendedOwnerDirectory) {
+        await fs.rm(suspendedOwnerDirectory, { force: true, recursive: true });
+      }
+      if (suspendedMarkerDirectory) {
+        await fs.rm(suspendedMarkerDirectory, { force: true, recursive: true });
+      }
       await disposeTempDir(outputDir);
     }
   });
@@ -714,17 +781,17 @@ describe("OpenClaw smoke lock cleanup", () => {
     }
   });
 
-  it("does not renew a lock after a recovery claimant moves it", async () => {
+  it("does not renew a lock after its owned claim is moved", async () => {
     const outputDir = await createTempDir();
     const params = { channel: "telegram" as const, outputDir };
-    const lockDirectory = path.join(
-      path.resolve(outputDir),
-      `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`,
-    );
-    const recoveryDirectory = `${lockDirectory}.recovering.11111111-1111-4111-8111-111111111111`;
     let now = 1_000;
     let renew: (() => Promise<void>) | undefined;
     const stop = vi.fn(async () => undefined);
+    let suspendedMarkerDirectory = "";
+    let suspendedOwnerDirectory = "";
+    let replacementLock:
+      | Awaited<ReturnType<typeof acquireOpenClawCrablineSmokeRunLock>>
+      | undefined;
     try {
       const lock = await acquireOpenClawCrablineSmokeRunLock(params, {
         isProcessAlive: () => true,
@@ -741,39 +808,47 @@ describe("OpenClaw smoke lock cleanup", () => {
 
       now = 1_800;
       await renew!();
-      await fs.rename(lockDirectory, recoveryDirectory);
+      const ownerDirectory = await findOwnedLockDirectory(outputDir);
+      const markerDirectory = path.join(outputDir, `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`);
+      const markerOwnerPath = path.join(markerDirectory, "owner.json");
+      const ownedOwner = JSON.parse(
+        await fs.readFile(path.join(ownerDirectory, "owner.json"), "utf8"),
+      );
+      const markerOwner = JSON.parse(await fs.readFile(markerOwnerPath, "utf8"));
+      expect(markerOwner.token).toBe(ownedOwner.token);
+      expect((await fs.stat(markerOwnerPath)).mtimeMs).toBeCloseTo(1_800, 0);
+      suspendedOwnerDirectory = path.join(outputDir, `.suspended-${path.basename(ownerDirectory)}`);
+      suspendedMarkerDirectory = path.join(outputDir, ".suspended-compatibility-marker");
+      await fs.rename(ownerDirectory, suspendedOwnerDirectory);
+      await fs.rename(markerDirectory, suspendedMarkerDirectory);
       now = 2_600;
       await expect(renew!()).rejects.toThrow("smoke lock ownership was lost");
-      await expect(
-        acquireOpenClawCrablineSmokeRunLock(params, {
-          isProcessAlive: () => true,
-          leaseMs: 1_000,
-          now: () => 2_600,
-          pid: 5_252,
-          processStartedAtMs: 200,
-        }),
-      ).rejects.toThrow("OpenClaw Crabline smoke is already running");
+      replacementLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+        isProcessAlive: () => true,
+        leaseMs: 1_000,
+        now: () => 2_600,
+        pid: 5_252,
+        processStartedAtMs: 200,
+      });
 
-      expect(await fs.stat(lockDirectory)).toBeDefined();
-      await expect(fs.stat(recoveryDirectory)).rejects.toMatchObject({ code: "ENOENT" });
-      expect(
-        (await fs.readdir(outputDir)).filter((entry) => entry.includes(".recovering")),
-      ).toEqual([]);
+      await expect(replacementLock.assertOwned()).resolves.toBeUndefined();
       await lock.release();
       expect(stop).toHaveBeenCalledTimes(1);
     } finally {
+      await replacementLock?.release();
+      if (suspendedOwnerDirectory) {
+        await fs.rm(suspendedOwnerDirectory, { force: true, recursive: true });
+      }
+      if (suspendedMarkerDirectory) {
+        await fs.rm(suspendedMarkerDirectory, { force: true, recursive: true });
+      }
       await disposeTempDir(outputDir);
     }
   });
 
-  it("revalidates a stale owner after claiming recovery before deletion", async () => {
+  it("revalidates a stale owned claim before deletion", async () => {
     const outputDir = await createTempDir();
     const params = { channel: "telegram" as const, outputDir };
-    const lockDirectory = path.join(
-      path.resolve(outputDir),
-      `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`,
-    );
-    const recoveryDirectory = `${lockDirectory}.recovering`;
     let now = 1_000;
     let renew: (() => Promise<void>) | undefined;
     try {
@@ -792,7 +867,7 @@ describe("OpenClaw smoke lock cleanup", () => {
       now = 2_001;
       await expect(
         acquireOpenClawCrablineSmokeRunLock(params, {
-          beforeRecoveryClaim: async () => {
+          beforeRecoveryDeleteClaim: async () => {
             now = 1_999;
             await renew!();
             now = 2_001;
@@ -806,11 +881,7 @@ describe("OpenClaw smoke lock cleanup", () => {
         }),
       ).rejects.toThrow("OpenClaw Crabline smoke is already running");
 
-      expect(await fs.stat(lockDirectory)).toBeDefined();
-      await expect(fs.stat(recoveryDirectory)).rejects.toMatchObject({ code: "ENOENT" });
-      expect(
-        (await fs.readdir(outputDir)).filter((entry) => entry.includes(".recovering")),
-      ).toEqual([]);
+      await expect(fs.stat(await findOwnedLockDirectory(outputDir))).resolves.toBeDefined();
       await lock.release();
     } finally {
       await disposeTempDir(outputDir);
@@ -889,7 +960,7 @@ describe("OpenClaw smoke lock cleanup", () => {
     }
   });
 
-  it("revokes an expired commit stage before a successor publishes", async () => {
+  it("fences an expired commit after a successor replaces its compatibility marker", async () => {
     const outputDir = await createTempDir();
     const stageDirectory = path.join(outputDir, "artifacts");
     const destinationPath = path.join(stageDirectory, "current.json");
@@ -952,7 +1023,9 @@ describe("OpenClaw smoke lock cleanup", () => {
       });
 
       allowOldCommit?.();
-      await expect(oldCommit).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(oldCommit).rejects.toThrow(
+        "Private directory path identity changed during publication.",
+      );
       await expect(fs.readFile(destinationPath, "utf8")).resolves.toBe("successor\n");
       await oldLock.release();
       await successorLock.release();
@@ -1003,10 +1076,6 @@ describe("OpenClaw smoke lock cleanup", () => {
 
   it("ignores an interrupted temporary stage record while recovering an expired lock", async () => {
     const outputDir = await createTempDir();
-    const lockDirectory = path.join(
-      path.resolve(outputDir),
-      `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`,
-    );
     let now = 1_000;
     try {
       const expiredLock = await acquireOpenClawCrablineSmokeRunLock(
@@ -1020,9 +1089,10 @@ describe("OpenClaw smoke lock cleanup", () => {
           startHeartbeat: disableHeartbeat,
         },
       );
-      const owner = JSON.parse(await fs.readFile(path.join(lockDirectory, "owner.json"), "utf8"));
+      const ownedDirectory = await findOwnedLockDirectory(outputDir);
+      const owner = JSON.parse(await fs.readFile(path.join(ownedDirectory, "owner.json"), "utf8"));
       await fs.writeFile(
-        path.join(lockDirectory, `.commit-stage.${owner.token}.interrupted.tmp`),
+        path.join(ownedDirectory, `.commit-stage.${owner.token}.interrupted.tmp`),
         "{",
       );
 
@@ -1040,7 +1110,9 @@ describe("OpenClaw smoke lock cleanup", () => {
       );
 
       expect(
-        (await fs.readdir(lockDirectory)).some((entry) => entry.endsWith(".interrupted.tmp")),
+        (await fs.readdir(await findOwnedLockDirectory(outputDir))).some((entry) =>
+          entry.endsWith(".interrupted.tmp"),
+        ),
       ).toBe(false);
       await successorLock.release();
       await expiredLock.release();
@@ -1091,10 +1163,6 @@ describe("OpenClaw smoke lock cleanup", () => {
   it("expires a far-future heartbeat whose PID belongs to another live process", async () => {
     const outputDir = await createTempDir();
     const params = { channel: "telegram" as const, outputDir };
-    const lockDirectory = path.join(
-      path.resolve(outputDir),
-      `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`,
-    );
     try {
       const firstLock = await acquireOpenClawCrablineSmokeRunLock(params, {
         isProcessAlive: () => true,
@@ -1105,7 +1173,17 @@ describe("OpenClaw smoke lock cleanup", () => {
         startHeartbeat: disableHeartbeat,
       });
       const future = new Date(10_000);
-      await fs.utimes(path.join(lockDirectory, "owner.json"), future, future);
+      const compatibilityOwnerPath = path.join(
+        outputDir,
+        `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`,
+        "owner.json",
+      );
+      await fs.utimes(
+        path.join(await findOwnedLockDirectory(outputDir), "owner.json"),
+        future,
+        future,
+      );
+      await fs.utimes(compatibilityOwnerPath, future, future);
 
       const replacementLock = await acquireOpenClawCrablineSmokeRunLock(params, {
         isProcessAlive: () => true,
@@ -1205,15 +1283,11 @@ describe("OpenClaw smoke lock cleanup", () => {
   it("retries strict owner parsing failures during release", async () => {
     const outputDir = await createTempDir();
     const params = { channel: "telegram" as const, outputDir };
-    const ownerPath = path.join(
-      path.resolve(outputDir),
-      `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`,
-      "owner.json",
-    );
     try {
       const lock = await acquireOpenClawCrablineSmokeRunLock(params, {
         startHeartbeat: disableHeartbeat,
       });
+      const ownerPath = path.join(await findOwnedLockDirectory(outputDir), "owner.json");
       const owner = await fs.readFile(ownerPath, "utf8");
       await fs.writeFile(ownerPath, "not json\n");
       const sleep = vi.fn(async () => {
@@ -1230,15 +1304,11 @@ describe("OpenClaw smoke lock cleanup", () => {
   it("fails pointer fencing after a heartbeat renewal error", async () => {
     const outputDir = await createTempDir();
     const params = { channel: "telegram" as const, outputDir };
-    const ownerPath = path.join(
-      path.resolve(outputDir),
-      `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`,
-      "owner.json",
-    );
     try {
       const lock = await acquireOpenClawCrablineSmokeRunLock(params, {
         leaseMs: 30,
       });
+      const ownerPath = path.join(await findOwnedLockDirectory(outputDir), "owner.json");
       const owner = await fs.readFile(ownerPath, "utf8");
       await fs.writeFile(
         ownerPath,

--- a/test/openclaw-smoke-lock.test.ts
+++ b/test/openclaw-smoke-lock.test.ts
@@ -286,12 +286,17 @@ describe("OpenClaw smoke lock cleanup", () => {
       );
       expect(JSON.parse(await fs.readFile(compatibilityOwnerPath, "utf8"))).toMatchObject({
         createdAtMs: 1,
+        pid: 2_147_483_647,
+        processStartedAtMs: 1,
       });
       expect((await fs.stat(compatibilityOwnerPath)).mtimeMs).toBeCloseTo(1, 0);
 
+      const sleep = vi.fn(async () => undefined);
       const replacementLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+        sleep,
         startHeartbeat: disableHeartbeat,
       });
+      expect(sleep).not.toHaveBeenCalled();
       await expect(replacementLock.assertOwned()).resolves.toBeUndefined();
       await replacementLock.release();
     } finally {
@@ -1376,6 +1381,11 @@ describe("OpenClaw smoke lock cleanup", () => {
         `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`,
         "owner.json",
       );
+      expect(JSON.parse(await fs.readFile(compatibilityOwnerPath, "utf8"))).toMatchObject({
+        createdAtMs: 1,
+        pid: 2_147_483_647,
+        processStartedAtMs: 1,
+      });
       expect((await fs.stat(compatibilityOwnerPath)).mtimeMs).toBeCloseTo(1, 0);
 
       const replacementLock = await acquireOpenClawCrablineSmokeRunLock(params, {

--- a/test/openclaw-smoke-lock.test.ts
+++ b/test/openclaw-smoke-lock.test.ts
@@ -1333,6 +1333,62 @@ describe("OpenClaw smoke lock cleanup", () => {
     }
   });
 
+  it("drains an in-flight renewal before retiring the compatibility marker", async () => {
+    const outputDir = await createTempDir();
+    const params = { channel: "telegram" as const, outputDir };
+    let allowMarkerRenewal: (() => void) | undefined;
+    let markerRenewalStarted: (() => void) | undefined;
+    let renew: (() => Promise<void>) | undefined;
+    const markerRenewalGate = new Promise<void>((resolve) => {
+      allowMarkerRenewal = resolve;
+    });
+    const markerRenewalStartedPromise = new Promise<void>((resolve) => {
+      markerRenewalStarted = resolve;
+    });
+    let lock: Awaited<ReturnType<typeof acquireOpenClawCrablineSmokeRunLock>> | undefined;
+    try {
+      lock = await acquireOpenClawCrablineSmokeRunLock(params, {
+        beforeCompatibilityMarkerRenew: async () => {
+          markerRenewalStarted?.();
+          await markerRenewalGate;
+        },
+        startHeartbeat: (heartbeat, intervalMs) => {
+          renew = heartbeat;
+          return disableHeartbeat(heartbeat, intervalMs);
+        },
+      });
+      const renewal = renew!();
+      await markerRenewalStartedPromise;
+
+      let releaseSettled = false;
+      const release = lock.release().then(() => {
+        releaseSettled = true;
+      });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(releaseSettled).toBe(false);
+
+      allowMarkerRenewal?.();
+      await renewal;
+      await release;
+
+      const compatibilityOwnerPath = path.join(
+        outputDir,
+        `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`,
+        "owner.json",
+      );
+      expect((await fs.stat(compatibilityOwnerPath)).mtimeMs).toBeCloseTo(1, 0);
+
+      const replacementLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+        startHeartbeat: disableHeartbeat,
+      });
+      await replacementLock.release();
+    } finally {
+      allowMarkerRenewal?.();
+      await lock?.release().catch(() => undefined);
+      await disposeTempDir(outputDir);
+    }
+  });
+
   it("rejects a pointer commit when a pending final renewal fails during heartbeat drain", async () => {
     const outputDir = await createTempDir();
     const params = { channel: "telegram" as const, outputDir };

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -55,6 +55,7 @@ type ProviderReadinessTestDependencies = {
   publishGeneration?: typeof publishOpenClawCrablineArtifactGeneration;
   releaseLock?: (lock: { release(): Promise<void> }) => Promise<void>;
   startAdapter?: typeof startOpenClawCrablineAdapter;
+  syncParent?: (filePath: string) => Promise<void>;
 };
 
 const runProviderReadinessWithDependencies = runOpenClawCrablineProviderReadiness as unknown as (
@@ -1763,6 +1764,16 @@ describe("OpenClaw local provider bridge", () => {
     });
     expect(directInbound.providerBody).toMatchObject({ sourceUuid: directDelivery.to });
     expect(directInbound.providerTargetKey).toBe(directDelivery.to);
+    expect(() =>
+      createOpenClawCrablineInbound({
+        manifest: signalManifest,
+        input: {
+          conversation: { id: "qa-operator", kind: "direct" },
+          senderId: "different-recipient",
+          text: "hello",
+        },
+      }),
+    ).toThrow("Signal direct conversation and sender must identify the same recipient.");
 
     expect(
       createOpenClawCrablineOutboundFromRecorderEvent({
@@ -2154,6 +2165,16 @@ describe("OpenClaw local provider bridge", () => {
       },
     });
     expect(inbound.providerBody.senderId).toBe(delivery.to.slice("user:".length));
+    expect(() =>
+      createOpenClawCrablineInbound({
+        manifest: mattermostManifest,
+        input: {
+          conversation: { id: "alice", kind: "direct" },
+          senderId: "bob",
+          text: "hello",
+        },
+      }),
+    ).toThrow("Mattermost direct conversation and sender must identify the same recipient.");
     for (const conversationId of ["", " \n\t"]) {
       expect(() =>
         createOpenClawCrablineInbound({
@@ -2228,6 +2249,33 @@ describe("OpenClaw local provider bridge", () => {
       },
     });
     expect(otherThreadInbound.providerBody.rootId).not.toBe(threadInbound.providerBody.rootId);
+    const blankThreadInbound = createOpenClawCrablineInbound({
+      manifest: mattermostManifest,
+      input: {
+        conversation: { id: "general", kind: "group" },
+        senderId: "alice",
+        text: "top-level reply",
+        threadId: " \n\t",
+      },
+    });
+    expect(blankThreadInbound).not.toHaveProperty("threadId");
+    expect(blankThreadInbound.providerBody).not.toHaveProperty("rootId");
+    expect(
+      createOpenClawCrablineOutboundFromRecorderEvent({
+        manifest: mattermostManifest,
+        targetByProviderTarget: new Map([[blankThreadInbound.providerTargetKey, "group:general"]]),
+        event: {
+          body: {
+            channel_id: blankThreadInbound.providerBody.channelId,
+            message: "top-level response",
+            root_id: " \n\t",
+          },
+          method: "POST",
+          path: "/api/v4/posts",
+          type: "api",
+        },
+      }),
+    ).toMatchObject({ to: "group:general" });
     const nativeRootId = "bbbbbbbbbbbbbbbbbbbbbbbbbb";
     expect(
       createOpenClawCrablineInbound({
@@ -2409,6 +2457,28 @@ describe("OpenClaw local provider bridge", () => {
         kind: "group",
       },
       threadId: "$root:matrix.test",
+    });
+    expect(
+      createOpenClawCrablineOutboundFromRecorderEvent({
+        manifest: matrixManifest,
+        targetByProviderTarget: new Map(),
+        event: {
+          body: {
+            body: "unmapped thread reply",
+            msgtype: "m.text",
+            "m.relates_to": {
+              event_id: "$root:matrix.test",
+              rel_type: "m.thread",
+            },
+          },
+          method: "PUT",
+          path: `/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/send/m.room.message/thread-fallback`,
+          type: "api",
+        },
+      }),
+    ).toMatchObject({
+      text: "unmapped thread reply",
+      to: `${roomId}:thread:$root:matrix.test`,
     });
 
     expect(() =>
@@ -2675,6 +2745,53 @@ describe("OpenClaw local provider bridge", () => {
       await fs.rm(outputDir, { recursive: true, force: true });
     }
   });
+
+  it.each(["committed", "failed"] as const)(
+    "syncs the recorder directory after the final %s temporary unlink",
+    async (outcome) => {
+      const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-recorder-unlink-"));
+      const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
+      const probeFailure = new Error("probe failed");
+      let recorderPath: string | undefined;
+      const syncParent = vi.fn(async (unlinkedPath: string) => {
+        expect(unlinkedPath).toBe(recorderPath);
+        await expect(fs.stat(unlinkedPath)).rejects.toMatchObject({ code: "ENOENT" });
+      });
+      try {
+        const readiness = runProviderReadinessWithDependencies(
+          { outputDir, selection },
+          {
+            startAdapter: async (params) => {
+              recorderPath = params.recorderPath;
+              await fs.writeFile(recorderPath!, '{"event":"probe"}\n');
+              return {
+                close: async () => undefined,
+                manifest: { ...manifest, recorderPath: recorderPath! },
+                probe: async () => {
+                  if (outcome === "failed") {
+                    throw probeFailure;
+                  }
+                  return { ok: true };
+                },
+              } as Awaited<ReturnType<typeof startOpenClawCrablineAdapter>>;
+            },
+            syncParent,
+          },
+        );
+
+        const settled = await readiness.then(
+          () => ({ outcome: "committed" as const }),
+          (error: unknown) => ({ error, outcome: "failed" as const }),
+        );
+        expect(settled).toEqual(
+          outcome === "failed" ? { error: probeFailure, outcome } : { outcome },
+        );
+        expect(syncParent).toHaveBeenCalledTimes(1);
+      } finally {
+        await fs.rm(outputDir, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("keeps readiness recorder snapshots immutable across later generations", async () => {
     const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-recorder-snapshots-"));


### PR DESCRIPTION
## Summary
- preserve Matrix thread fallback keys and normalize Mattermost thread routing
- reject mismatched Mattermost and Signal direct recipients
- persist directory and recorder cleanup metadata with fsync
- isolate smoke-lock owners while retaining canonical compatibility fencing

## Validation
- `pnpm exec vitest run test/openclaw.test.ts test/openclaw-private-file.test.ts test/openclaw-smoke-lock.test.ts` (146 passed)
- `pnpm lint`
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` (clean)