### PR TITLE
fix(servers): harden provider protocol fidelity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Harden core CLI lifecycle, manifest validation, retry bounds, error reporting, and suite isolation after unsettled provider cancellation.
 - Pin and validate Slack Events API delivery targets across redirects while preserving native retries and installation authorization envelopes.
 - Harden provider recorder durability and replacement recovery, JWT cache expiry refresh, and LocalMock webhook shutdown draining.
+- Harden recorder append durability and provider-native HTTP, identity, profile, authentication, ingress, and redaction fidelity.
 
 ## 0.1.11 - 2026-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Harden core CLI lifecycle, manifest validation, retry bounds, error reporting, and suite isolation after unsettled provider cancellation.
 - Pin and validate Slack Events API delivery targets across redirects while preserving native retries and installation authorization envelopes.
 - Harden provider recorder durability and replacement recovery, JWT cache expiry refresh, and LocalMock webhook shutdown draining.
-- Harden recorder append durability and provider-native HTTP, identity, profile, authentication, ingress, and redaction fidelity.
+- Harden recorder append durability, Baileys shutdown draining, and provider-native HTTP, identity, profile, authentication, ingress, and redaction fidelity.
 
 ## 0.1.11 - 2026-07-13
 

--- a/src/servers/http.ts
+++ b/src/servers/http.ts
@@ -130,10 +130,10 @@ export async function parseUnknownRequestBody(
     return {};
   }
   const contentType = request.headers["content-type"] ?? "";
-  const includesJson = Array.isArray(contentType)
-    ? contentType.some((entry) => entry.toLowerCase().includes("json"))
-    : contentType.toLowerCase().includes("json");
-  if (includesJson) {
+  const isJson = Array.isArray(contentType)
+    ? contentType.some(isJsonMediaType)
+    : isJsonMediaType(contentType);
+  if (isJson) {
     try {
       return JSON.parse(body.toString("utf8")) as unknown;
     } catch (error) {
@@ -142,6 +142,14 @@ export async function parseUnknownRequestBody(
   }
   const params = new URLSearchParams(body.toString("utf8"));
   return Object.fromEntries(params.entries());
+}
+
+export function isJsonMediaType(value: string): boolean {
+  const mediaType = value.split(";", 1)[0]?.trim().toLowerCase();
+  return (
+    mediaType === "application/json" ||
+    /^[a-z0-9!#$%&'*+.^_`|~-]+\/[a-z0-9!#$%&'*+.^_`|~-]+\+json$/u.test(mediaType ?? "")
+  );
 }
 
 export async function parseRequestBody(request: IncomingMessage): Promise<Record<string, unknown>> {
@@ -181,6 +189,7 @@ export async function writeResponse(
   response: ServerResponse,
   fetchResponse: Response,
 ): Promise<void> {
+  const body = Buffer.from(await fetchResponse.arrayBuffer());
   response.statusCode = fetchResponse.status;
   for (const [name, value] of fetchResponse.headers) {
     if (name.toLowerCase() === "set-cookie") {
@@ -192,7 +201,6 @@ export async function writeResponse(
   if (setCookies.length > 0) {
     response.setHeader("set-cookie", setCookies);
   }
-  const body = Buffer.from(await fetchResponse.arrayBuffer());
   await new Promise<void>((resolve, reject) => {
     if (
       response.destroyed ||

--- a/src/servers/matrix.ts
+++ b/src/servers/matrix.ts
@@ -641,6 +641,13 @@ async function handleAdminInbound(params: {
       sequence: params.state.nextSequence++,
     });
   }
+  const roomAvatarUrl = room.users.get(sender)?.avatar_url;
+  if (roomAvatarUrl) {
+    params.state.profiles.set(sender, {
+      ...params.state.profiles.get(sender),
+      avatar_url: roomAvatarUrl,
+    });
+  }
   const content: Record<string, unknown> = { body: text, msgtype: "m.text" };
   if (threadId) {
     content["m.relates_to"] = {

--- a/src/servers/matrix.ts
+++ b/src/servers/matrix.ts
@@ -67,6 +67,7 @@ type MatrixServerState = {
   nextFilter: number;
   nextSequence: number;
   onEvent: ServerEventObserver | undefined;
+  profiles: Map<string, { avatar_url?: string; display_name?: string }>;
   recorderPath: string;
   rooms: Map<string, MatrixRoom>;
   serverName: string;
@@ -567,8 +568,8 @@ async function handleAdminInbound(params: {
 }): Promise<Response> {
   const roomId = readTrimmedString(params.body.roomId);
   const sender = readTrimmedString(params.body.sender ?? params.body.senderId);
-  const text = readTrimmedString(params.body.text);
-  if (!roomId || !sender || !text) {
+  const text = typeof params.body.text === "string" ? params.body.text : undefined;
+  if (!roomId || !sender || text === undefined || text.length === 0) {
     return jsonResponse({ error: "roomId, senderId, and text are required", ok: false }, 400);
   }
   const threadId = readTrimmedString(params.body.threadId);
@@ -593,6 +594,14 @@ async function handleAdminInbound(params: {
     });
   params.state.rooms.set(roomId, room);
   const senderName = readTrimmedString(params.body.senderName);
+  if (senderName) {
+    params.state.profiles.set(sender, {
+      ...params.state.profiles.get(sender),
+      display_name: senderName,
+    });
+  } else if (!params.state.profiles.has(sender)) {
+    params.state.profiles.set(sender, {});
+  }
   const existingProfile = room.users.get(sender);
   if (existingProfile === undefined) {
     room.users.set(sender, senderName ? { display_name: senderName } : {});
@@ -678,13 +687,11 @@ async function handleMatrixApi(params: {
   let match = /^\/profile\/([^/]+)$/u.exec(relativePath);
   if (params.method === "GET" && match) {
     const userId = decodeMatrixPathSegment(match[1]!);
-    const member = [...params.state.rooms.values()]
-      .map((room) => room.users.get(userId))
-      .find((profile) => profile !== undefined);
-    return member
+    const profile = params.state.profiles.get(userId);
+    return profile
       ? jsonResponse({
-          ...(member.avatar_url ? { avatar_url: member.avatar_url } : {}),
-          ...(member.display_name ? { displayname: member.display_name } : {}),
+          ...(profile.avatar_url ? { avatar_url: profile.avatar_url } : {}),
+          ...(profile.display_name ? { displayname: profile.display_name } : {}),
         })
       : matrixError("M_NOT_FOUND", "Unknown user", 404);
   }
@@ -908,6 +915,9 @@ export async function startMatrixServer(
     nextFilter: 1,
     nextSequence: 1,
     onEvent: params.onEvent,
+    profiles: new Map([
+      [params.botUserId ?? `@openclaw:${serverName}`, { display_name: "OpenClaw QA" }],
+    ]),
     recorderPath: params.recorderPath ?? path.resolve("artifacts/crabline/matrix.jsonl"),
     rooms: new Map(),
     serverName,

--- a/src/servers/mattermost.ts
+++ b/src/servers/mattermost.ts
@@ -135,20 +135,38 @@ async function appendEvent(
 }
 
 function authorized(request: IncomingMessage, token: string): boolean {
-  const [scheme, value] = request.headers.authorization?.trim().split(/\s+/, 2) ?? [];
-  return scheme?.toLowerCase() === "bearer" && value === token;
+  return /^Bearer ([^\s]+)$/iu.exec(request.headers.authorization ?? "")?.[1] === token;
 }
 
-function mattermostError(message: string, status: number): Response {
+function mattermostError(
+  message: string,
+  status: number,
+  options: { id?: string; requestId?: string } = {},
+): Response {
   return jsonResponse(
     {
-      id: `api.context.${status}`,
+      detailed_error: "",
+      id: options.id ?? `api.context.${status}.app_error`,
       message,
-      request_id: "",
+      request_id:
+        options.requestId ??
+        mattermostId(`request-${Date.now()}-${Math.random()}-${message}-${status}`),
       status_code: status,
     },
     status,
   );
+}
+
+function readMattermostString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function readMattermostMessage(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
 }
 
 function decodeMattermostPathSegment(value: string): string | Response {
@@ -321,9 +339,14 @@ function handleAdminInbound(params: {
   body: Record<string, unknown>;
   state: MattermostServerState;
 }): Response {
-  const channelId = readTrimmedString(params.body.channelId ?? params.body.channel_id);
-  const senderId = readTrimmedString(params.body.senderId ?? params.body.user_id);
-  const text = readTrimmedString(params.body.text ?? params.body.message);
+  for (const field of ["senderName", "channelType", "rootId", "root_id"] as const) {
+    if (params.body[field] !== undefined && typeof params.body[field] !== "string") {
+      return jsonResponse({ error: `${field} must be a string`, ok: false }, 400);
+    }
+  }
+  const channelId = readMattermostString(params.body.channelId ?? params.body.channel_id);
+  const senderId = readMattermostString(params.body.senderId ?? params.body.user_id);
+  const text = readMattermostMessage(params.body.text ?? params.body.message);
   if (!channelId || !senderId || !text) {
     return jsonResponse({ error: "channelId, senderId, and text are required", ok: false }, 400);
   }
@@ -336,8 +359,8 @@ function handleAdminInbound(params: {
   const previousUser = params.state.users.get(senderId);
   const previousChannel = params.state.channels.get(channelId);
   const senderName =
-    readTrimmedString(params.body.senderName) ?? previousUser?.username ?? senderId;
-  const channelType = readTrimmedString(params.body.channelType) ?? previousChannel?.type ?? "D";
+    readMattermostString(params.body.senderName) ?? previousUser?.username ?? senderId;
+  const channelType = readMattermostString(params.body.channelType) ?? previousChannel?.type ?? "D";
   const previousNextPost = params.state.nextPost;
   params.state.users.set(senderId, { id: senderId, update_at: Date.now(), username: senderName });
   params.state.channels.set(channelId, {
@@ -349,7 +372,7 @@ function handleAdminInbound(params: {
   const post = createPost({
     channelId,
     message: text,
-    rootId: readTrimmedString(params.body.rootId ?? params.body.root_id),
+    rootId: readMattermostString(params.body.rootId ?? params.body.root_id),
     state: params.state,
     userId: senderId,
   });
@@ -409,7 +432,7 @@ async function handleApi(params: {
     return channel ? jsonResponse(channel) : mattermostError("Channel not found", 404);
   }
   if (method === "POST" && apiPath === "/channels/direct") {
-    const userIds = Array.isArray(body) ? body.map(readTrimmedString) : [];
+    const userIds = Array.isArray(body) ? body.map(readMattermostString) : [];
     if (userIds.length !== 2 || userIds.some((value) => !value)) {
       return mattermostError("Two user IDs are required", 400);
     }
@@ -432,9 +455,12 @@ async function handleApi(params: {
     return mattermostError("Request body must be a JSON object", 400);
   }
   if (method === "POST" && apiPath === "/users/me/typing") {
-    const channelId = readTrimmedString(body.channel_id);
+    const channelId = readMattermostString(body.channel_id);
     if (!channelId) {
       return mattermostError("channel_id is required", 400);
+    }
+    if (body.parent_id !== undefined && typeof body.parent_id !== "string") {
+      return mattermostError("parent_id must be a string", 400);
     }
     if (!state.channels.has(channelId)) {
       return mattermostError("Channel not found", 404);
@@ -448,8 +474,8 @@ async function handleApi(params: {
         }),
         data: {
           channel_id: channelId,
-          ...(readTrimmedString(body.parent_id)
-            ? { parent_id: readTrimmedString(body.parent_id) }
+          ...(readMattermostString(body.parent_id)
+            ? { parent_id: readMattermostString(body.parent_id) }
             : {}),
           user_id: state.botUserId,
         },
@@ -460,16 +486,19 @@ async function handleApi(params: {
     return jsonResponse({ status: "OK" });
   }
   if (method === "POST" && apiPath === "/posts") {
-    const channelId = readTrimmedString(body.channel_id);
-    const message = readTrimmedString(body.message);
+    const channelId = readMattermostString(body.channel_id);
+    const message = readMattermostMessage(body.message);
     if (!channelId || !message) {
       return mattermostError("channel_id and message are required", 400);
+    }
+    const rootId = readMattermostString(body.root_id);
+    if (body.root_id !== undefined && typeof body.root_id !== "string") {
+      return mattermostError("root_id must be a string", 400);
     }
     const channel = state.channels.get(channelId);
     if (!channel) {
       return mattermostError("Channel not found", 404);
     }
-    const rootId = readTrimmedString(body.root_id);
     if (rootId) {
       const rootPost = state.posts.get(rootId);
       if (!rootPost) {
@@ -498,7 +527,11 @@ async function handleApi(params: {
     if (post.user_id !== state.botUserId) {
       return mattermostError("You do not have permission to edit this post", 403);
     }
-    const updated = { ...post, message: readTrimmedString(body.message) ?? post.message };
+    const message = body.message === undefined ? post.message : readMattermostMessage(body.message);
+    if (!message) {
+      return mattermostError("message must be a string", 400);
+    }
+    const updated = { ...post, message };
     state.posts.set(updated.id, updated);
     broadcast(
       state,
@@ -539,6 +572,7 @@ async function handleApi(params: {
 async function handleRequest(request: IncomingMessage, state: MattermostServerState) {
   const url = new URL(request.url ?? "/", "http://localhost");
   const method = request.method ?? "GET";
+  const requestId = mattermostId(`request-${Date.now()}-${Math.random()}`);
   if (url.pathname === "/crabline/mattermost/inbound" && method === "POST") {
     if (!hasAdminToken(request, state.adminToken)) {
       drainRequestBody(request);
@@ -558,12 +592,19 @@ async function handleRequest(request: IncomingMessage, state: MattermostServerSt
     });
     return handleAdminInbound({ body, state });
   }
-  if (!url.pathname.startsWith("/api/v4/")) {
-    return new Response("not found", { status: 404 });
+  if (url.pathname !== "/api/v4" && !url.pathname.startsWith("/api/v4/")) {
+    drainRequestBody(request);
+    return mattermostError("Sorry, we could not find the page.", 404, {
+      id: "api.context.404.app_error",
+      requestId,
+    });
   }
   if (!authorized(request, state.botToken)) {
     drainRequestBody(request);
-    return mattermostError("Invalid or missing token", 401);
+    return mattermostError("Invalid or expired session, please login again.", 401, {
+      id: "api.context.session_expired.app_error",
+      requestId,
+    });
   }
   const body =
     method === "GET" || method === "DELETE" ? {} : await parseUnknownRequestBody(request);

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -374,9 +374,21 @@ async function appendRecorderAttempt(params: {
                 (opened.created ? path.resolve(params.filePath) : undefined);
               await syncRecorderPathAncestry(params.filePath, firstCreatedPath);
             }
-            rememberDurableRecorderIdentity(path.resolve(params.filePath), identity);
-            committed = true;
-            result = "committed";
+            if (!(await recorderPathHasIdentity(params.filePath, identity))) {
+              await rollbackRecorderAppend(
+                params.filePath,
+                file,
+                appendStart,
+                new ServerRecorderRotationError(
+                  "Server recorder rotated while syncing path ancestry.",
+                ),
+              );
+              result = "retry";
+            } else {
+              rememberDurableRecorderIdentity(path.resolve(params.filePath), identity);
+              committed = true;
+              result = "committed";
+            }
           }
         } catch (error) {
           if (

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -1,9 +1,24 @@
-import { chmod, mkdir, open } from "node:fs/promises";
+import { chmod, mkdir, open, stat as statPath } from "node:fs/promises";
 import path from "node:path";
 import { lock } from "proper-lockfile";
 import type { ServerRequestEvent } from "./http.js";
 
 export type ServerEventObserver = (event: ServerRequestEvent) => void | Promise<void>;
+
+export class ServerRecorderCommittedError extends AggregateError {
+  readonly committed = true;
+
+  constructor(filePath: string, operationError: unknown, relatedErrors: unknown[] = []) {
+    super(
+      [operationError, ...relatedErrors],
+      `Server recorder append committed for "${filePath}", but subsequent work failed.`,
+      { cause: operationError },
+    );
+    this.name = "ServerRecorderCommittedError";
+  }
+}
+
+class ServerRecorderRotationError extends Error {}
 
 const pendingAppends = new Map<string, Promise<void>>();
 const durableRecorderIdentities = new Map<string, string>();
@@ -144,6 +159,28 @@ function recorderIdentity(stats: {
   return `${stats.dev}:${stats.ino}`;
 }
 
+async function recorderPathHasIdentity(
+  filePath: string,
+  expectedIdentity: string,
+): Promise<boolean> {
+  try {
+    return recorderIdentity(await statPath(filePath)) === expectedIdentity;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function requireRecorderIdentity(stats: { dev?: bigint | number; ino?: bigint | number }): string {
+  const identity = recorderIdentity(stats);
+  if (identity === undefined) {
+    throw new Error("Server recorder file identity is unavailable.");
+  }
+  return identity;
+}
+
 function rememberDurableRecorderIdentity(filePath: string, identity: string): void {
   durableRecorderIdentities.delete(filePath);
   durableRecorderIdentities.set(filePath, identity);
@@ -218,7 +255,158 @@ async function withRecorderLock<T>(filePath: string, operation: () => Promise<T>
   return result as T;
 }
 
-async function appendJsonLine(filePath: string, line: string, durable: boolean): Promise<void> {
+async function rollbackRecorderAppend(
+  filePath: string,
+  file: Awaited<ReturnType<typeof open>>,
+  appendStart: number,
+  operationError: unknown,
+): Promise<void> {
+  try {
+    await file.truncate(appendStart);
+    await file.sync();
+  } catch (rollbackError) {
+    throw new ServerRecorderCommittedError(filePath, operationError, [rollbackError]);
+  }
+}
+
+async function closeRecorderAttempt(params: {
+  committed: boolean;
+  file: Awaited<ReturnType<typeof open>>;
+  filePath: string;
+  operationFailed: boolean;
+  operationError: unknown;
+}): Promise<void> {
+  let closeFailed = false;
+  let closeError: unknown;
+  try {
+    await params.file.close();
+  } catch (error) {
+    closeFailed = true;
+    closeError = error;
+  }
+  if (closeFailed) {
+    if (params.operationFailed) {
+      if (params.operationError instanceof ServerRecorderCommittedError) {
+        throw new ServerRecorderCommittedError(params.filePath, params.operationError, [
+          closeError,
+        ]);
+      }
+      throw new AggregateError(
+        [params.operationError, closeError],
+        "Server recorder operation and file close both failed.",
+        { cause: closeError },
+      );
+    }
+    if (params.committed) {
+      throw new ServerRecorderCommittedError(params.filePath, closeError);
+    }
+    throw closeError;
+  }
+  if (params.operationFailed) {
+    throw params.operationError;
+  }
+}
+
+async function appendRecorderAttempt(params: {
+  createdDirectory: string | undefined;
+  filePath: string;
+  line: string;
+}): Promise<"committed" | "retry"> {
+  const opened = await openRecorderFile(params.filePath);
+  const { file } = opened;
+  let committed = false;
+  let operationFailed = false;
+  let operationError: unknown;
+  let result: "committed" | "retry" | undefined;
+  try {
+    await file.chmod(0o600);
+    let stats = await file.stat();
+    let identity = requireRecorderIdentity(stats);
+    if (!(await recorderPathHasIdentity(params.filePath, identity))) {
+      result = "retry";
+    } else {
+      const needsPathDurability =
+        opened.created || durableRecorderIdentities.get(path.resolve(params.filePath)) !== identity;
+      if (stats.size > 0) {
+        const finalByte = await readBufferAt(file, 1, stats.size - 1);
+        if (finalByte[0] !== 0x0a) {
+          const tailStart = await findIncompleteTailStart(file, stats.size);
+          const tailLength = stats.size - tailStart;
+          if (tailLength > MAX_RECOVERY_VALIDATION_BYTES) {
+            throw recoveryValidationLimitError();
+          }
+          const tail = await readBufferAt(file, tailLength, tailStart);
+          if (tail.length !== tailLength) {
+            throw new Error("Server recorder changed while repairing its final record.");
+          }
+          try {
+            JSON.parse(tail.toString("utf8"));
+            await file.appendFile("\n", { encoding: "utf8" });
+          } catch (error) {
+            if (!(error instanceof SyntaxError)) {
+              throw error;
+            }
+            await file.truncate(tailStart);
+          }
+        }
+      }
+      stats = await file.stat();
+      identity = requireRecorderIdentity(stats);
+      if (!(await recorderPathHasIdentity(params.filePath, identity))) {
+        result = "retry";
+      } else {
+        const appendStart = stats.size;
+        try {
+          await file.appendFile(params.line, { encoding: "utf8" });
+          await file.sync();
+          if (!(await recorderPathHasIdentity(params.filePath, identity))) {
+            await rollbackRecorderAppend(
+              params.filePath,
+              file,
+              appendStart,
+              new ServerRecorderRotationError("Server recorder rotated during append."),
+            );
+            result = "retry";
+          } else {
+            if (needsPathDurability) {
+              const firstCreatedPath =
+                params.createdDirectory ??
+                (opened.created ? path.resolve(params.filePath) : undefined);
+              await syncRecorderPathAncestry(params.filePath, firstCreatedPath);
+            }
+            rememberDurableRecorderIdentity(path.resolve(params.filePath), identity);
+            committed = true;
+            result = "committed";
+          }
+        } catch (error) {
+          if (
+            error instanceof ServerRecorderCommittedError &&
+            error.cause instanceof ServerRecorderRotationError
+          ) {
+            await rollbackRecorderAppend(params.filePath, file, appendStart, error);
+            result = "retry";
+          } else if (result !== "retry") {
+            await rollbackRecorderAppend(params.filePath, file, appendStart, error);
+            throw error;
+          }
+        }
+      }
+    }
+  } catch (error) {
+    operationFailed = true;
+    operationError = error;
+  }
+  await closeRecorderAttempt({
+    committed,
+    file,
+    filePath: params.filePath,
+    operationError,
+    operationFailed,
+  });
+  return result ?? "retry";
+}
+
+async function appendJsonLine(filePath: string, line: string): Promise<void> {
   const key = path.resolve(filePath);
   const previous = pendingAppends.get(key) ?? Promise.resolve();
   const current = previous
@@ -229,56 +417,16 @@ async function appendJsonLine(filePath: string, line: string, durable: boolean):
       if (createdDirectory !== undefined || isManagedRecorderDirectory(path.resolve(directory))) {
         await chmod(directory, 0o700);
       }
+      // Keep the cross-process lock through append verification and any rollback.
       await withRecorderLock(key, async () => {
-        const opened = await openRecorderFile(filePath);
-        const { file } = opened;
-        try {
-          await file.chmod(0o600);
-          const stats = await file.stat();
-          const identity = recorderIdentity(stats);
-          const needsPathDurability =
-            opened.created ||
-            identity === undefined ||
-            durableRecorderIdentities.get(key) !== identity;
-          if (stats.size > 0) {
-            const finalByte = await readBufferAt(file, 1, stats.size - 1);
-            if (finalByte[0] !== 0x0a) {
-              const tailStart = await findIncompleteTailStart(file, stats.size);
-              const tailLength = stats.size - tailStart;
-              if (tailLength > MAX_RECOVERY_VALIDATION_BYTES) {
-                throw recoveryValidationLimitError();
-              }
-              const tail = await readBufferAt(file, tailLength, tailStart);
-              if (tail.length !== tailLength) {
-                throw new Error("Server recorder changed while repairing its final record.");
-              }
-              try {
-                JSON.parse(tail.toString("utf8"));
-                await file.appendFile("\n", { encoding: "utf8" });
-              } catch (error) {
-                if (!(error instanceof SyntaxError)) {
-                  throw error;
-                }
-                await file.truncate(tailStart);
-              }
-            }
-          }
-          await file.appendFile(line, { encoding: "utf8" });
-          if (durable || needsPathDurability) {
-            await file.sync();
-          }
-          if (needsPathDurability) {
-            const firstCreatedPath =
-              createdDirectory ?? (opened.created ? path.resolve(filePath) : undefined);
-            await syncRecorderPathAncestry(filePath, firstCreatedPath);
-            if (identity === undefined) {
-              durableRecorderIdentities.delete(key);
-            } else {
-              rememberDurableRecorderIdentity(key, identity);
-            }
-          }
-        } finally {
-          await file.close();
+        while (
+          (await appendRecorderAttempt({
+            createdDirectory,
+            filePath,
+            line,
+          })) === "retry"
+        ) {
+          // Reopen until the descriptor matches the current recorder path.
         }
       });
     });
@@ -298,13 +446,12 @@ export async function recordServerEvent(params: {
   onEvent: ServerEventObserver | undefined;
   recorderPath: string;
 }): Promise<void> {
-  // Observers only see events after the recorder append is durable.
-  await appendJsonLine(
-    params.recorderPath,
-    `${JSON.stringify(params.event)}\n`,
-    params.onEvent !== undefined,
-  );
-  await params.onEvent?.(params.event);
+  await appendJsonLine(params.recorderPath, `${JSON.stringify(params.event)}\n`);
+  try {
+    await params.onEvent?.(params.event);
+  } catch (error) {
+    throw new ServerRecorderCommittedError(params.recorderPath, error);
+  }
 }
 
 export async function recordCommittedServerEvent(params: {
@@ -313,7 +460,8 @@ export async function recordCommittedServerEvent(params: {
   recorderPath: string;
 }): Promise<void> {
   try {
-    await recordServerEvent(params);
+    await appendJsonLine(params.recorderPath, `${JSON.stringify(params.event)}\n`);
+    await params.onEvent?.(params.event);
   } catch {
     // The provider mutation already committed, so telemetry failure cannot change its response.
   }

--- a/src/servers/signal.ts
+++ b/src/servers/signal.ts
@@ -6,6 +6,7 @@ import {
   adminAuthError,
   closeServer,
   drainRequestBody,
+  formatUrlHost,
   hasAdminToken,
   InvalidJsonBodyError,
   isJsonObject,
@@ -845,7 +846,9 @@ export async function startSignalServer(
     }
   }, SIGNAL_CLI_SSE_KEEPALIVE_MS);
   keepalive.unref();
-  const baseUrl = `http://${host.includes(":") ? `[${host}]` : host}:${address.port}`;
+  const advertisedHost =
+    normalizedHost === "0.0.0.0" ? "127.0.0.1" : normalizedHost === "::" ? "::1" : host;
+  const baseUrl = `http://${formatUrlHost(advertisedHost)}:${address.port}`;
   return {
     async close() {
       clearInterval(keepalive);

--- a/src/servers/signal.ts
+++ b/src/servers/signal.ts
@@ -1,5 +1,6 @@
 import { randomBytes } from "node:crypto";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { isIP } from "node:net";
 import path from "node:path";
 import {
   adminAuthError,
@@ -88,6 +89,7 @@ export type StartedSignalServer = {
 export type StartSignalServerParams = {
   account?: string | undefined;
   adminToken?: string | undefined;
+  allowedHosts?: string[] | undefined;
   host?: string | undefined;
   onEvent?: ServerEventObserver | undefined;
   port?: number | undefined;
@@ -384,7 +386,15 @@ async function handleAdminInbound(params: {
       400,
     );
   }
-  const timestamp = readInteger(params.body.timestamp) ?? params.state.nextTimestamp++;
+  const suppliedTimestamp =
+    params.body.timestamp === undefined ? undefined : readInteger(params.body.timestamp);
+  if (
+    params.body.timestamp !== undefined &&
+    (suppliedTimestamp === undefined || suppliedTimestamp < 0)
+  ) {
+    return jsonResponse({ error: "timestamp must be a non-negative safe integer", ok: false }, 400);
+  }
+  const timestamp = suppliedTimestamp ?? params.state.nextTimestamp++;
   const groupId = readTrimmedString(params.body.groupId);
   const payload = {
     envelope: {
@@ -688,6 +698,70 @@ async function handleRequest(params: {
   await writeResponse(params.response, fetchResponse);
 }
 
+function normalizeSignalHost(value: string): string {
+  const normalized = value
+    .trim()
+    .replace(/^\[(.*)\]$/u, "$1")
+    .toLowerCase();
+  if (isIP(normalized) !== 6) {
+    return normalized;
+  }
+  const canonical = new URL(`http://[${normalized}]`).hostname.slice(1, -1);
+  const mapped = /^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/u.exec(canonical);
+  if (!mapped?.[1] || !mapped[2]) {
+    return canonical;
+  }
+  const high = Number.parseInt(mapped[1], 16);
+  const low = Number.parseInt(mapped[2], 16);
+  return `${high >>> 8}.${high & 0xff}.${low >>> 8}.${low & 0xff}`;
+}
+
+function parseSignalHostHeader(value: string): string | undefined {
+  const match = value.startsWith("[")
+    ? /^\[([^\]]+)\](?::(\d{1,5}))?$/u.exec(value)
+    : /^([^:]+)(?::(\d{1,5}))?$/u.exec(value);
+  if (!match?.[1]) {
+    return undefined;
+  }
+  const port = match[2] === undefined ? undefined : Number(match[2]);
+  if (port !== undefined && port > 65_535) {
+    return undefined;
+  }
+  const hostname = normalizeSignalHost(match[1]);
+  if (isIP(hostname) !== 0) {
+    return hostname;
+  }
+  const labels = hostname.split(".");
+  return hostname.length <= 253 &&
+    labels.every((label) => /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/u.test(label))
+    ? hostname
+    : undefined;
+}
+
+function signalRequestHostAllowed(
+  request: IncomingMessage,
+  bindHost: string,
+  allowedHosts: ReadonlySet<string>,
+): boolean {
+  const hostHeader = request.headers.host;
+  if (!hostHeader) {
+    return false;
+  }
+  const requestedHost = parseSignalHostHeader(hostHeader);
+  if (requestedHost === undefined) {
+    return false;
+  }
+  const normalizedBindHost = normalizeSignalHost(bindHost);
+  if (allowedHosts.has(requestedHost)) {
+    return true;
+  }
+  if (normalizedBindHost !== "0.0.0.0" && normalizedBindHost !== "::") {
+    return false;
+  }
+  const localAddress = normalizeSignalHost(request.socket.localAddress ?? "");
+  return isIP(requestedHost) !== 0 && requestedHost === localAddress;
+}
+
 export async function startSignalServer(
   params: StartSignalServerParams = {},
 ): Promise<StartedSignalServer> {
@@ -710,7 +784,20 @@ export async function startSignalServer(
     recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "signal.jsonl"),
   };
   const host = params.host ?? "127.0.0.1";
+  const normalizedHost = normalizeSignalHost(host);
+  const allowedHosts = new Set([
+    ...(normalizedHost === "0.0.0.0" || normalizedHost === "::" ? [] : [normalizedHost]),
+    ...(params.allowedHosts ?? []).map((allowedHost) => normalizeSignalHost(allowedHost)),
+  ]);
   const server = createServer((request, response) => {
+    if (!signalRequestHostAllowed(request, host, allowedHosts)) {
+      drainRequestBody(request);
+      void writeResponse(
+        response,
+        jsonResponse({ error: "Host header is not allowed", ok: false }, 400),
+      ).catch(() => response.destroy());
+      return;
+    }
     void handleRequest({ request, response, state }).catch(async (error) => {
       if (!response.headersSent) {
         let errorResponse: Response;

--- a/src/servers/signal.ts
+++ b/src/servers/signal.ts
@@ -702,7 +702,8 @@ function normalizeSignalHost(value: string): string {
   const normalized = value
     .trim()
     .replace(/^\[(.*)\]$/u, "$1")
-    .toLowerCase();
+    .toLowerCase()
+    .replace(/\.$/u, "");
   if (isIP(normalized) !== 6) {
     return normalized;
   }

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -1,5 +1,6 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { randomBytes } from "node:crypto";
+import { Buffer } from "node:buffer";
 import path from "node:path";
 import { CrablineError } from "../core/errors.js";
 import {
@@ -444,10 +445,11 @@ function createOutboundMediaMessage(
   const duration = Math.max(0, toIntegerValue(body.duration) ?? 0);
   const height = Math.max(1, toIntegerValue(body.height) ?? 1);
   const width = Math.max(1, toIntegerValue(body.width) ?? 1);
+  const chatIdentity = Buffer.from(telegramChatKey(chatId)).toString("base64url");
   const media = {
-    file_id: `crabline-${mediaKind}-${messageId}`,
+    file_id: `crabline-${mediaKind}-${chatIdentity}-${messageId}`,
     file_name: fileName,
-    file_unique_id: `crabline-${mediaKind}-unique-${messageId}`,
+    file_unique_id: `crabline-${mediaKind}-unique-${chatIdentity}-${messageId}`,
   };
   return {
     chat: createChat(chatId),

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -85,6 +85,10 @@ const TELEGRAM_MESSAGE_REFERENCE_FIELDS = [
   "edited_channel_post",
   "edited_message",
 ] as const;
+const TELEGRAM_MESSAGE_UPDATE_FIELDS = [
+  ...TELEGRAM_NEW_MESSAGE_UPDATE_FIELDS,
+  ...TELEGRAM_MESSAGE_REFERENCE_FIELDS,
+] as const;
 
 type TelegramServerEvent = {
   accepted?: boolean | undefined;
@@ -643,7 +647,7 @@ function explicitTelegramMessageChatId(
     }
     chatIds.push(chatId);
   }
-  for (const field of TELEGRAM_NEW_MESSAGE_UPDATE_FIELDS) {
+  for (const field of TELEGRAM_MESSAGE_UPDATE_FIELDS) {
     const message = body[field];
     if (!isJsonObject(message) || message.message_id === undefined) {
       continue;
@@ -788,8 +792,20 @@ async function handleTelegramAdminInbound(params: {
     }
     if (!update) {
       if (isValidIgnoredTelegramUpdate(params.body)) {
-        if (explicitMessageId.present && messageChatKey !== undefined) {
-          params.state.nextMessageIds.set(messageChatKey, explicitMessageId.value + 1);
+        if (messageChatKey !== undefined) {
+          const observedNextMessageIds = [
+            ...(explicitMessageId.present ? [explicitMessageId.value + 1] : []),
+            ...(referencedMessageId.present ? [referencedMessageId.value + 1] : []),
+          ];
+          if (observedNextMessageIds.length > 0) {
+            params.state.nextMessageIds.set(
+              messageChatKey,
+              Math.max(
+                params.state.nextMessageIds.get(messageChatKey) ?? 1,
+                ...observedNextMessageIds,
+              ),
+            );
+          }
         }
         if (explicitUpdateId.present) {
           params.state.nextUpdateId = explicitUpdateId.value + 1;
@@ -807,7 +823,11 @@ async function handleTelegramAdminInbound(params: {
     const updateChatKey = telegramChatKey(update.message.chat.id);
     params.state.nextMessageIds.set(
       updateChatKey,
-      Math.max(params.state.nextMessageIds.get(updateChatKey) ?? 1, update.message.message_id + 1),
+      Math.max(
+        params.state.nextMessageIds.get(updateChatKey) ?? 1,
+        update.message.message_id + 1,
+        ...(referencedMessageId.present ? [referencedMessageId.value + 1] : []),
+      ),
     );
     params.state.nextUpdateId = Math.max(params.state.nextUpdateId, update.update_id + 1);
     const reservedNextMessageId = params.state.nextMessageIds.get(updateChatKey)!;

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -10,6 +10,7 @@ import {
   hasAdminToken,
   InvalidJsonBodyError,
   isJsonObject,
+  isJsonMediaType,
   isLoopbackHost,
   jsonResponse,
   queryRecord,
@@ -77,6 +78,12 @@ const TELEGRAM_UNSUPPORTED_UPDATE_FIELDS = [
   "removed_chat_boost",
   "shipping_query",
 ] as const;
+const TELEGRAM_NEW_MESSAGE_UPDATE_FIELDS = ["business_message", "channel_post", "message"] as const;
+const TELEGRAM_MESSAGE_REFERENCE_FIELDS = [
+  "edited_business_message",
+  "edited_channel_post",
+  "edited_message",
+] as const;
 
 type TelegramServerEvent = {
   accepted?: boolean | undefined;
@@ -107,7 +114,7 @@ type TelegramServerState = {
   closing: boolean;
   inboundAdmission: Promise<void>;
   maxPendingInboundEvents: number;
-  nextMessageId: number;
+  nextMessageIds: Map<string, number>;
   nextUpdateId: number;
   onEvent: ServerEventObserver | undefined;
   recorderPath: string;
@@ -246,7 +253,7 @@ async function parseRequestBody(request: IncomingMessage): Promise<unknown> {
   }
   const contentType = request.headers["content-type"] ?? "";
   const contentTypes = Array.isArray(contentType) ? contentType : [contentType];
-  if (contentTypes.some((entry) => entry.toLowerCase().includes("json"))) {
+  if (contentTypes.some(isJsonMediaType)) {
     try {
       return JSON.parse(body.toString("utf8")) as unknown;
     } catch (error) {
@@ -366,6 +373,26 @@ function createChat(chatId: number | string): TelegramMessage["chat"] {
   };
 }
 
+function telegramChatKey(chatId: number | string): string {
+  return `${typeof chatId}:${chatId}`;
+}
+
+function nextTelegramMessageId(state: TelegramServerState, chatId: number | string): number {
+  return state.nextMessageIds.get(telegramChatKey(chatId)) ?? 1;
+}
+
+function takeNextTelegramMessageId(
+  state: TelegramServerState,
+  chatId: number | string,
+): number | undefined {
+  const messageId = nextTelegramMessageId(state, chatId);
+  if (messageId >= Number.MAX_SAFE_INTEGER) {
+    return undefined;
+  }
+  state.nextMessageIds.set(telegramChatKey(chatId), messageId + 1);
+  return messageId;
+}
+
 function createOutboundMessage(
   state: TelegramServerState,
   body: Record<string, unknown>,
@@ -379,12 +406,16 @@ function createOutboundMessage(
   if (body.message_thread_id !== undefined && parsedThreadId === undefined) {
     return undefined;
   }
+  const messageId = takeNextTelegramMessageId(state, chatId);
+  if (messageId === undefined) {
+    return undefined;
+  }
   const threadId = parsedThreadId !== undefined && parsedThreadId > 0 ? parsedThreadId : undefined;
   return {
     chat: createChat(chatId),
     date: Math.floor(Date.now() / 1000),
     from: createBotUser(state),
-    message_id: state.nextMessageId++,
+    message_id: messageId,
     ...(threadId !== undefined ? { message_thread_id: threadId } : {}),
     text,
   };
@@ -404,15 +435,19 @@ function createOutboundMediaMessage(
   if (body.message_thread_id !== undefined && parsedThreadId === undefined) {
     return undefined;
   }
+  const messageId = takeNextTelegramMessageId(state, chatId);
+  if (messageId === undefined) {
+    return undefined;
+  }
   const threadId = parsedThreadId !== undefined && parsedThreadId > 0 ? parsedThreadId : undefined;
   const caption = toStringValue(body.caption);
   const duration = Math.max(0, toIntegerValue(body.duration) ?? 0);
   const height = Math.max(1, toIntegerValue(body.height) ?? 1);
   const width = Math.max(1, toIntegerValue(body.width) ?? 1);
   const media = {
-    file_id: `crabline-${mediaKind}-${state.nextMessageId}`,
+    file_id: `crabline-${mediaKind}-${messageId}`,
     file_name: fileName,
-    file_unique_id: `crabline-${mediaKind}-unique-${state.nextMessageId}`,
+    file_unique_id: `crabline-${mediaKind}-unique-${messageId}`,
   };
   return {
     chat: createChat(chatId),
@@ -421,7 +456,14 @@ function createOutboundMediaMessage(
     ...(caption ? { caption } : {}),
     [mediaKind]:
       mediaKind === "photo"
-        ? [{ ...media, height: 1, width: 1 }]
+        ? [
+            {
+              file_id: media.file_id,
+              file_unique_id: media.file_unique_id,
+              height: 1,
+              width: 1,
+            },
+          ]
         : {
             ...media,
             ...(mediaKind === "audio"
@@ -431,7 +473,7 @@ function createOutboundMediaMessage(
                 : {}),
             mime_type: "application/octet-stream",
           },
-    message_id: state.nextMessageId++,
+    message_id: messageId,
     ...(threadId !== undefined ? { message_thread_id: threadId } : {}),
   };
 }
@@ -502,7 +544,7 @@ function createInboundUpdate(
         is_bot: false,
         ...(fromUsername ? { username: fromUsername } : {}),
       },
-      message_id: messageId ?? state.nextMessageId,
+      message_id: messageId ?? nextTelegramMessageId(state, chatId),
       ...(entities && entities.length > 0 ? { entities } : {}),
       ...(threadId !== undefined ? { message_thread_id: threadId } : {}),
       text,
@@ -546,6 +588,89 @@ function parseTelegramEntities(
 
 function hasTelegramMedia(value: Record<string, unknown>): boolean {
   return TELEGRAM_MEDIA_FIELDS.some((field) => value[field] !== undefined);
+}
+
+function explicitTelegramId(
+  body: Record<string, unknown>,
+  names: readonly string[],
+  additionalValues: readonly unknown[] = [],
+): { present: false } | { present: true; value: number } | undefined {
+  const values = [
+    ...names.flatMap((name) => (body[name] === undefined ? [] : [body[name]])),
+    ...additionalValues.filter((value) => value !== undefined),
+  ];
+  if (values.length === 0) {
+    return { present: false };
+  }
+  const parsed = values.map(toIntegerValue);
+  if (
+    parsed.some((value) => value === undefined || value < 1 || value >= Number.MAX_SAFE_INTEGER) ||
+    new Set(parsed).size !== 1
+  ) {
+    return undefined;
+  }
+  return { present: true, value: parsed[0]! };
+}
+
+function explicitTelegramMessageIdValues(body: Record<string, unknown>): unknown[] {
+  return TELEGRAM_NEW_MESSAGE_UPDATE_FIELDS.flatMap((field) => {
+    const message = body[field];
+    return isJsonObject(message) ? [message.message_id] : [];
+  });
+}
+
+function referencedTelegramMessageIdValues(body: Record<string, unknown>): unknown[] {
+  const values = TELEGRAM_MESSAGE_REFERENCE_FIELDS.flatMap((field) => {
+    const message = body[field];
+    return isJsonObject(message) ? [message.message_id] : [];
+  });
+  const callbackQuery = isJsonObject(body.callback_query) ? body.callback_query : undefined;
+  const callbackMessage =
+    callbackQuery && isJsonObject(callbackQuery.message) ? callbackQuery.message : undefined;
+  return callbackMessage ? [...values, callbackMessage.message_id] : values;
+}
+
+function explicitTelegramMessageChatId(
+  body: Record<string, unknown>,
+): number | string | undefined | false {
+  const chatIds: Array<number | string> = [];
+  if (body.messageId !== undefined || body.message_id !== undefined) {
+    const chatId = telegramChatId(body.chatId ?? body.chat_id);
+    if (chatId === undefined) {
+      return false;
+    }
+    chatIds.push(chatId);
+  }
+  for (const field of TELEGRAM_NEW_MESSAGE_UPDATE_FIELDS) {
+    const message = body[field];
+    if (!isJsonObject(message) || message.message_id === undefined) {
+      continue;
+    }
+    const chat = isJsonObject(message.chat) ? message.chat : undefined;
+    const chatId = telegramChatId(chat?.id);
+    if (chatId === undefined) {
+      return false;
+    }
+    chatIds.push(chatId);
+  }
+  const callbackQuery = isJsonObject(body.callback_query) ? body.callback_query : undefined;
+  const callbackMessage =
+    callbackQuery && isJsonObject(callbackQuery.message) ? callbackQuery.message : undefined;
+  if (callbackMessage?.message_id !== undefined) {
+    const chat = isJsonObject(callbackMessage.chat) ? callbackMessage.chat : undefined;
+    const chatId = telegramChatId(chat?.id);
+    if (chatId === undefined) {
+      return false;
+    }
+    chatIds.push(chatId);
+  }
+  if (chatIds.length === 0) {
+    return undefined;
+  }
+  const firstChatId = chatIds[0]!;
+  return chatIds.every((chatId) => telegramChatKey(chatId) === telegramChatKey(firstChatId))
+    ? firstChatId
+    : false;
 }
 
 function hasValidExplicitTelegramIdentities(body: Record<string, unknown>): boolean {
@@ -617,13 +742,56 @@ async function handleTelegramAdminInbound(params: {
   });
   await previousAdmission;
   try {
-    const nextMessageId = params.state.nextMessageId;
     const nextUpdateId = params.state.nextUpdateId;
+    const explicitMessageId = explicitTelegramId(
+      params.body,
+      ["messageId", "message_id"],
+      explicitTelegramMessageIdValues(params.body),
+    );
+    const explicitMessageChatId = explicitTelegramMessageChatId(params.body);
+    const explicitUpdateId = explicitTelegramId(params.body, ["updateId", "update_id"]);
+    const referencedMessageId = explicitTelegramId(
+      {},
+      [],
+      referencedTelegramMessageIdValues(params.body),
+    );
+    const topLevelChatId = telegramChatId(params.body.chatId ?? params.body.chat_id);
+    const messageChatId =
+      explicitMessageChatId === false ? undefined : (explicitMessageChatId ?? topLevelChatId);
+    const messageChatKey = messageChatId === undefined ? undefined : telegramChatKey(messageChatId);
+    const previousNextMessageId =
+      messageChatKey === undefined ? undefined : params.state.nextMessageIds.get(messageChatKey);
+    const nextMessageId =
+      messageChatId === undefined ? undefined : nextTelegramMessageId(params.state, messageChatId);
+    if (
+      explicitMessageId === undefined ||
+      explicitMessageChatId === false ||
+      explicitUpdateId === undefined ||
+      referencedMessageId === undefined ||
+      (explicitMessageId.present &&
+        (nextMessageId === undefined || explicitMessageId.value < nextMessageId)) ||
+      (explicitUpdateId.present && explicitUpdateId.value < nextUpdateId)
+    ) {
+      return telegramError("Bad Request: explicit IDs must be positive and monotonic");
+    }
     const update = createInboundUpdate(params.state, params.body);
-    params.state.nextMessageId = nextMessageId;
     params.state.nextUpdateId = nextUpdateId;
+    if (
+      update &&
+      ((!explicitMessageId.present &&
+        (nextMessageId ?? Number.MAX_SAFE_INTEGER) >= Number.MAX_SAFE_INTEGER) ||
+        (!explicitUpdateId.present && nextUpdateId >= Number.MAX_SAFE_INTEGER))
+    ) {
+      return telegramError("Bad Request: generated ID space is exhausted");
+    }
     if (!update) {
       if (isValidIgnoredTelegramUpdate(params.body)) {
+        if (explicitMessageId.present && messageChatKey !== undefined) {
+          params.state.nextMessageIds.set(messageChatKey, explicitMessageId.value + 1);
+        }
+        if (explicitUpdateId.present) {
+          params.state.nextUpdateId = explicitUpdateId.value + 1;
+        }
         return jsonResponse({ ok: true });
       }
       return telegramError("Bad Request: chatId and text are required");
@@ -634,12 +802,13 @@ async function handleTelegramAdminInbound(params: {
         429,
       );
     }
-    params.state.nextMessageId = Math.max(
-      params.state.nextMessageId,
-      update.message.message_id + 1,
+    const updateChatKey = telegramChatKey(update.message.chat.id);
+    params.state.nextMessageIds.set(
+      updateChatKey,
+      Math.max(params.state.nextMessageIds.get(updateChatKey) ?? 1, update.message.message_id + 1),
     );
     params.state.nextUpdateId = Math.max(params.state.nextUpdateId, update.update_id + 1);
-    const reservedNextMessageId = params.state.nextMessageId;
+    const reservedNextMessageId = params.state.nextMessageIds.get(updateChatKey)!;
     const reservedNextUpdateId = params.state.nextUpdateId;
     try {
       await appendEvent(params.state, {
@@ -651,8 +820,12 @@ async function handleTelegramAdminInbound(params: {
         type: "admin",
       });
     } catch (error) {
-      if (params.state.nextMessageId === reservedNextMessageId) {
-        params.state.nextMessageId = nextMessageId;
+      if (params.state.nextMessageIds.get(updateChatKey) === reservedNextMessageId) {
+        if (previousNextMessageId === undefined) {
+          params.state.nextMessageIds.delete(updateChatKey);
+        } else {
+          params.state.nextMessageIds.set(updateChatKey, previousNextMessageId);
+        }
       }
       if (params.state.nextUpdateId === reservedNextUpdateId) {
         params.state.nextUpdateId = nextUpdateId;
@@ -1062,12 +1235,21 @@ async function handleTelegramApi(params: {
         pending_update_count: params.state.updates.length,
         url: params.state.webhook?.url ?? "",
       });
-    case "createforumtopic":
+    case "createforumtopic": {
+      const chatId = telegramChatId(params.body.chat_id);
+      if (chatId === undefined) {
+        return telegramError("Bad Request: chat_id is required");
+      }
+      const messageThreadId = takeNextTelegramMessageId(params.state, chatId);
+      if (messageThreadId === undefined) {
+        return telegramError("Bad Request: generated ID space is exhausted");
+      }
       return telegramOk({
         icon_color: 0x6fb9f0,
-        message_thread_id: params.state.nextMessageId++,
+        message_thread_id: messageThreadId,
         name: toStringValue(params.body.name) ?? "Crabline Topic",
       });
+    }
     case "editmessagetext": {
       const message = createEditedMessage(params.state, params.body);
       return message
@@ -1075,6 +1257,13 @@ async function handleTelegramApi(params: {
         : telegramError("Bad Request: chat_id, message_id, and text are required");
     }
     case "sendmessage": {
+      const chatId = telegramChatId(params.body.chat_id);
+      if (
+        chatId !== undefined &&
+        nextTelegramMessageId(params.state, chatId) >= Number.MAX_SAFE_INTEGER
+      ) {
+        return telegramError("Bad Request: generated ID space is exhausted");
+      }
       const message = createOutboundMessage(params.state, params.body);
       return message
         ? telegramOk(message)
@@ -1091,6 +1280,13 @@ async function handleTelegramApi(params: {
         | "document"
         | "photo"
         | "video";
+      const chatId = telegramChatId(params.body.chat_id);
+      if (
+        chatId !== undefined &&
+        nextTelegramMessageId(params.state, chatId) >= Number.MAX_SAFE_INTEGER
+      ) {
+        return telegramError("Bad Request: generated ID space is exhausted");
+      }
       const message = createOutboundMediaMessage(params.state, params.body, mediaKind);
       return message
         ? telegramOk(message)
@@ -1359,7 +1555,7 @@ export async function startTelegramServer(
     botUsername: params.botUsername ?? "crabline_bot",
     inboundAdmission: Promise.resolve(),
     maxPendingInboundEvents: resolveMaxPendingInboundEvents(params.maxPendingInboundEvents),
-    nextMessageId: 1,
+    nextMessageIds: new Map(),
     nextUpdateId: 1,
     onEvent: params.onEvent,
     recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "telegram.jsonl"),

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -600,6 +600,7 @@ function explicitTelegramId(
   body: Record<string, unknown>,
   names: readonly string[],
   additionalValues: readonly unknown[] = [],
+  options: { allowZero?: boolean } = {},
 ): { present: false } | { present: true; value: number } | undefined {
   const values = [
     ...names.flatMap((name) => (body[name] === undefined ? [] : [body[name]])),
@@ -609,8 +610,11 @@ function explicitTelegramId(
     return { present: false };
   }
   const parsed = values.map(toIntegerValue);
+  const minimum = options.allowZero ? 0 : 1;
   if (
-    parsed.some((value) => value === undefined || value < 1 || value >= Number.MAX_SAFE_INTEGER) ||
+    parsed.some(
+      (value) => value === undefined || value < minimum || value >= Number.MAX_SAFE_INTEGER,
+    ) ||
     new Set(parsed).size !== 1
   ) {
     return undefined;
@@ -753,6 +757,7 @@ async function handleTelegramAdminInbound(params: {
       params.body,
       ["messageId", "message_id"],
       explicitTelegramMessageIdValues(params.body),
+      { allowZero: true },
     );
     const explicitMessageChatId = explicitTelegramMessageChatId(params.body);
     const explicitUpdateId = explicitTelegramId(params.body, ["updateId", "update_id"]);
@@ -760,6 +765,7 @@ async function handleTelegramAdminInbound(params: {
       {},
       [],
       referencedTelegramMessageIdValues(params.body),
+      { allowZero: true },
     );
     const topLevelChatId = telegramChatId(params.body.chatId ?? params.body.chat_id);
     const messageChatId =
@@ -775,10 +781,11 @@ async function handleTelegramAdminInbound(params: {
       explicitUpdateId === undefined ||
       referencedMessageId === undefined ||
       (explicitMessageId.present &&
+        explicitMessageId.value > 0 &&
         (nextMessageId === undefined || explicitMessageId.value < nextMessageId)) ||
       (explicitUpdateId.present && explicitUpdateId.value < nextUpdateId)
     ) {
-      return telegramError("Bad Request: explicit IDs must be positive and monotonic");
+      return telegramError("Bad Request: explicit IDs must be valid and monotonic");
     }
     const update = createInboundUpdate(params.state, params.body);
     params.state.nextUpdateId = nextUpdateId;
@@ -794,8 +801,12 @@ async function handleTelegramAdminInbound(params: {
       if (isValidIgnoredTelegramUpdate(params.body)) {
         if (messageChatKey !== undefined) {
           const observedNextMessageIds = [
-            ...(explicitMessageId.present ? [explicitMessageId.value + 1] : []),
-            ...(referencedMessageId.present ? [referencedMessageId.value + 1] : []),
+            ...(explicitMessageId.present && explicitMessageId.value > 0
+              ? [explicitMessageId.value + 1]
+              : []),
+            ...(referencedMessageId.present && referencedMessageId.value > 0
+              ? [referencedMessageId.value + 1]
+              : []),
           ];
           if (observedNextMessageIds.length > 0) {
             params.state.nextMessageIds.set(
@@ -826,7 +837,9 @@ async function handleTelegramAdminInbound(params: {
       Math.max(
         params.state.nextMessageIds.get(updateChatKey) ?? 1,
         update.message.message_id + 1,
-        ...(referencedMessageId.present ? [referencedMessageId.value + 1] : []),
+        ...(referencedMessageId.present && referencedMessageId.value > 0
+          ? [referencedMessageId.value + 1]
+          : []),
       ),
     );
     params.state.nextUpdateId = Math.max(params.state.nextUpdateId, update.update_id + 1);

--- a/src/servers/whatsapp-baileys-websocket.ts
+++ b/src/servers/whatsapp-baileys-websocket.ts
@@ -1014,8 +1014,17 @@ export function attachWhatsAppBaileysWebSocketServer(
       params.httpServer.off("upgrade", handleUpgrade);
       pendingMessages.length = 0;
       await closeWebSocketServer(wss);
-      await Promise.all([...pendingSessionMessages]);
+      const messageResults = await Promise.allSettled([...pendingSessionMessages]);
       await flushPromise;
+      const messageErrors = messageResults.flatMap((result) =>
+        result.status === "rejected" ? [result.reason] : [],
+      );
+      if (messageErrors.length === 1) {
+        throw messageErrors[0];
+      }
+      if (messageErrors.length > 1) {
+        throw new AggregateError(messageErrors, "WhatsApp WebSocket message drain failed.");
+      }
     },
     prepareInboundMessage(message) {
       if (pendingMessages.length + pendingReservations >= maxPendingInboundMessages) {

--- a/src/servers/whatsapp-baileys-websocket.ts
+++ b/src/servers/whatsapp-baileys-websocket.ts
@@ -554,8 +554,8 @@ class WhatsAppBaileysWebSocketSession {
     return this.#handshakeState === "open" && this.socket.readyState === WebSocket.OPEN;
   }
 
-  handleMessage(data: WhatsAppWebSocketRawData): void {
-    void this.#handleSerializedMessage(data);
+  handleMessage(data: WhatsAppWebSocketRawData): Promise<void> {
+    return this.#handleSerializedMessage(data);
   }
 
   async deliverInboundMessage(message: WhatsAppBaileysInboundMessage): Promise<boolean> {
@@ -921,6 +921,7 @@ export function attachWhatsAppBaileysWebSocketServer(
 ): WhatsAppBaileysWebSocketServer {
   const signalBundles = new WhatsAppSignalBundleStore();
   const sessions = new Set<WhatsAppBaileysWebSocketSession>();
+  const pendingSessionMessages = new Set<Promise<void>>();
   const pendingMessages: WhatsAppBaileysInboundMessage[] = [];
   const maxPendingInboundMessages = resolveMaxPendingWhatsAppInboundMessages(
     params.maxPendingInboundMessages,
@@ -998,7 +999,14 @@ export function attachWhatsAppBaileysWebSocketServer(
       sessions.delete(session);
       socket.terminate();
     });
-    socket.on("message", (data) => session.handleMessage(data));
+    socket.on("message", (data) => {
+      const pending = session.handleMessage(data);
+      pendingSessionMessages.add(pending);
+      void pending.then(
+        () => pendingSessionMessages.delete(pending),
+        () => pendingSessionMessages.delete(pending),
+      );
+    });
   });
   return {
     async close() {
@@ -1006,6 +1014,7 @@ export function attachWhatsAppBaileysWebSocketServer(
       params.httpServer.off("upgrade", handleUpgrade);
       pendingMessages.length = 0;
       await closeWebSocketServer(wss);
+      await Promise.all([...pendingSessionMessages]);
       await flushPromise;
     },
     prepareInboundMessage(message) {

--- a/src/servers/zalo.ts
+++ b/src/servers/zalo.ts
@@ -687,6 +687,7 @@ async function handleAdminInbound(
   state.inboundAdmission = new Promise<void>((resolve) => {
     releaseAdmission = resolve;
   });
+  let admissionPending = true;
   try {
     const parsedBody = await parseUnknownRequestBody(request);
     await previousAdmission;
@@ -736,17 +737,23 @@ async function handleAdminInbound(
       if (error) {
         return error;
       }
-    } else if (!deliverPollingUpdate(state, update)) {
-      return zaloError(
-        `Pending inbound queue is full (${state.maxPendingInboundEvents} updates)`,
-        429,
-      );
+    } else {
+      state.pendingInboundAdmissions -= 1;
+      admissionPending = false;
+      if (!deliverPollingUpdate(state, update)) {
+        return zaloError(
+          `Pending inbound queue is full (${state.maxPendingInboundEvents} updates)`,
+          429,
+        );
+      }
     }
     return zaloOk(update);
   } finally {
     await previousAdmission;
     releaseAdmission();
-    state.pendingInboundAdmissions -= 1;
+    if (admissionPending) {
+      state.pendingInboundAdmissions -= 1;
+    }
   }
 }
 

--- a/src/servers/zalo.ts
+++ b/src/servers/zalo.ts
@@ -87,6 +87,7 @@ type ZaloServerState = {
   nextMessage: number;
   nextUpdateOrder: number;
   onEvent: ServerEventObserver | undefined;
+  pendingInboundAdmissions: number;
   pendingRequest: PendingUpdateRequest | undefined;
   recorderPath: string;
   reservedUpdateOrders: Set<number>;
@@ -199,16 +200,32 @@ function isSensitiveParam(name: string): boolean {
   );
 }
 
+function isUrlParam(name: string): boolean {
+  return /(?:urls?|uris?)$/iu.test(name.normalize("NFKC").replace(/[^A-Za-z0-9]/gu, ""));
+}
+
+function redactParamValue(value: unknown, key: string): unknown {
+  if (isSensitiveParam(key)) {
+    return "<redacted>";
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactParamValue(entry, key));
+  }
+  if (isJsonObject(value)) {
+    return redactParams(value);
+  }
+  if (
+    typeof value === "string" &&
+    (isUrlParam(key) || /^(?:\s*[a-z][a-z0-9+.-]*:)?\/\//iu.test(value))
+  ) {
+    return redactUrlCredentials(value);
+  }
+  return value;
+}
+
 function redactParams(params: Record<string, unknown>): Record<string, unknown> {
   return Object.fromEntries(
-    Object.entries(params).map(([key, value]) => [
-      key,
-      isSensitiveParam(key)
-        ? "<redacted>"
-        : key === "url" && typeof value === "string"
-          ? redactUrlCredentials(value)
-          : value,
-    ]),
+    Object.entries(params).map(([key, value]) => [key, redactParamValue(value, key)]),
   );
 }
 
@@ -655,69 +672,83 @@ async function handleAdminInbound(
     drainRequestBody(request);
     return adminAuthError();
   }
-  const parsedBody = await parseUnknownRequestBody(request);
-  if (!isJsonObject(parsedBody)) {
-    return zaloError("Bad Request: can't parse JSON object", 400);
+  const queued =
+    state.webhook?.url === undefined ? state.updates.length + state.reservedUpdateOrders.size : 0;
+  if (queued + state.pendingInboundAdmissions >= state.maxPendingInboundEvents) {
+    drainRequestBody(request);
+    return zaloError(
+      `Pending inbound queue is full (${state.maxPendingInboundEvents} updates)`,
+      429,
+    );
   }
-  const body = parsedBody;
-  const chatId = requireParam(body, "chatId");
-  const senderId = requireParam(body, "senderId");
-  const text = requireParam(body, "text");
-  if (chatId instanceof Response || senderId instanceof Response || text instanceof Response) {
-    return [chatId, senderId, text].find((value) => value instanceof Response) as Response;
-  }
-  let releaseAdmission!: () => void;
-  const previousAdmission = state.inboundAdmission;
-  state.inboundAdmission = new Promise<void>((resolve) => {
-    releaseAdmission = resolve;
-  });
-  await previousAdmission;
+  state.pendingInboundAdmissions += 1;
   try {
-    if (
-      !state.webhook?.url &&
-      state.updates.length + state.reservedUpdateOrders.size >= state.maxPendingInboundEvents
-    ) {
-      return zaloError(
-        `Pending inbound queue is full (${state.maxPendingInboundEvents} updates)`,
-        429,
-      );
+    const parsedBody = await parseUnknownRequestBody(request);
+    if (!isJsonObject(parsedBody)) {
+      return zaloError("Bad Request: can't parse JSON object", 400);
     }
-    const update: ZaloUpdate = {
-      event_name: "message.text.received",
-      message: {
-        chat: { chat_type: readChatType(body.chatType), id: chatId },
-        date: Date.now(),
-        from: {
-          display_name: readTrimmedString(body.senderName) ?? senderId,
-          id: senderId,
-          is_bot: false,
-        },
-        message_id: messageId(state),
-        text,
-      },
-    };
-    await appendEvent(state, {
-      at: new Date().toISOString(),
-      body,
-      method: request.method ?? "POST",
-      path: url.pathname,
-      query: queryRecord(url),
-      type: "admin",
+    const body = parsedBody;
+    const chatId = requireParam(body, "chatId");
+    const senderId = requireParam(body, "senderId");
+    const text = requireParam(body, "text");
+    if (chatId instanceof Response || senderId instanceof Response || text instanceof Response) {
+      return [chatId, senderId, text].find((value) => value instanceof Response) as Response;
+    }
+    let releaseAdmission!: () => void;
+    const previousAdmission = state.inboundAdmission;
+    state.inboundAdmission = new Promise<void>((resolve) => {
+      releaseAdmission = resolve;
     });
-    if (state.webhook?.url) {
-      const error = await deliverWebhookUpdate(state, state.webhook, update);
-      if (error) {
-        return error;
+    await previousAdmission;
+    try {
+      if (
+        !state.webhook?.url &&
+        state.updates.length + state.reservedUpdateOrders.size >= state.maxPendingInboundEvents
+      ) {
+        return zaloError(
+          `Pending inbound queue is full (${state.maxPendingInboundEvents} updates)`,
+          429,
+        );
       }
-    } else if (!deliverPollingUpdate(state, update)) {
-      return zaloError(
-        `Pending inbound queue is full (${state.maxPendingInboundEvents} updates)`,
-        429,
-      );
+      const update: ZaloUpdate = {
+        event_name: "message.text.received",
+        message: {
+          chat: { chat_type: readChatType(body.chatType), id: chatId },
+          date: Date.now(),
+          from: {
+            display_name: readTrimmedString(body.senderName) ?? senderId,
+            id: senderId,
+            is_bot: false,
+          },
+          message_id: messageId(state),
+          text,
+        },
+      };
+      await appendEvent(state, {
+        at: new Date().toISOString(),
+        body: redactParams(body),
+        method: request.method ?? "POST",
+        path: url.pathname,
+        query: redactParams(queryRecord(url)) as Record<string, string>,
+        type: "admin",
+      });
+      if (state.webhook?.url) {
+        const error = await deliverWebhookUpdate(state, state.webhook, update);
+        if (error) {
+          return error;
+        }
+      } else if (!deliverPollingUpdate(state, update)) {
+        return zaloError(
+          `Pending inbound queue is full (${state.maxPendingInboundEvents} updates)`,
+          429,
+        );
+      }
+      return zaloOk(update);
+    } finally {
+      releaseAdmission();
     }
-    return zaloOk(update);
   } finally {
-    releaseAdmission();
+    state.pendingInboundAdmissions -= 1;
   }
 }
 
@@ -868,6 +899,7 @@ export async function startZaloServer(
     nextMessage: 1,
     nextUpdateOrder: 1,
     onEvent: params.onEvent,
+    pendingInboundAdmissions: 0,
     pendingRequest: undefined,
     recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "zalo.jsonl"),
     reservedUpdateOrders: new Set(),

--- a/src/servers/zalo.ts
+++ b/src/servers/zalo.ts
@@ -682,8 +682,14 @@ async function handleAdminInbound(
     );
   }
   state.pendingInboundAdmissions += 1;
+  let releaseAdmission!: () => void;
+  const previousAdmission = state.inboundAdmission;
+  state.inboundAdmission = new Promise<void>((resolve) => {
+    releaseAdmission = resolve;
+  });
   try {
     const parsedBody = await parseUnknownRequestBody(request);
+    await previousAdmission;
     if (!isJsonObject(parsedBody)) {
       return zaloError("Bad Request: can't parse JSON object", 400);
     }
@@ -694,60 +700,52 @@ async function handleAdminInbound(
     if (chatId instanceof Response || senderId instanceof Response || text instanceof Response) {
       return [chatId, senderId, text].find((value) => value instanceof Response) as Response;
     }
-    let releaseAdmission!: () => void;
-    const previousAdmission = state.inboundAdmission;
-    state.inboundAdmission = new Promise<void>((resolve) => {
-      releaseAdmission = resolve;
-    });
-    await previousAdmission;
-    try {
-      if (
-        !state.webhook?.url &&
-        state.updates.length + state.reservedUpdateOrders.size >= state.maxPendingInboundEvents
-      ) {
-        return zaloError(
-          `Pending inbound queue is full (${state.maxPendingInboundEvents} updates)`,
-          429,
-        );
-      }
-      const update: ZaloUpdate = {
-        event_name: "message.text.received",
-        message: {
-          chat: { chat_type: readChatType(body.chatType), id: chatId },
-          date: Date.now(),
-          from: {
-            display_name: readTrimmedString(body.senderName) ?? senderId,
-            id: senderId,
-            is_bot: false,
-          },
-          message_id: messageId(state),
-          text,
-        },
-      };
-      await appendEvent(state, {
-        at: new Date().toISOString(),
-        body: redactParams(body),
-        method: request.method ?? "POST",
-        path: url.pathname,
-        query: redactParams(queryRecord(url)) as Record<string, string>,
-        type: "admin",
-      });
-      if (state.webhook?.url) {
-        const error = await deliverWebhookUpdate(state, state.webhook, update);
-        if (error) {
-          return error;
-        }
-      } else if (!deliverPollingUpdate(state, update)) {
-        return zaloError(
-          `Pending inbound queue is full (${state.maxPendingInboundEvents} updates)`,
-          429,
-        );
-      }
-      return zaloOk(update);
-    } finally {
-      releaseAdmission();
+    if (
+      !state.webhook?.url &&
+      state.updates.length + state.reservedUpdateOrders.size >= state.maxPendingInboundEvents
+    ) {
+      return zaloError(
+        `Pending inbound queue is full (${state.maxPendingInboundEvents} updates)`,
+        429,
+      );
     }
+    const update: ZaloUpdate = {
+      event_name: "message.text.received",
+      message: {
+        chat: { chat_type: readChatType(body.chatType), id: chatId },
+        date: Date.now(),
+        from: {
+          display_name: readTrimmedString(body.senderName) ?? senderId,
+          id: senderId,
+          is_bot: false,
+        },
+        message_id: messageId(state),
+        text,
+      },
+    };
+    await appendEvent(state, {
+      at: new Date().toISOString(),
+      body: redactParams(body),
+      method: request.method ?? "POST",
+      path: url.pathname,
+      query: redactParams(queryRecord(url)) as Record<string, string>,
+      type: "admin",
+    });
+    if (state.webhook?.url) {
+      const error = await deliverWebhookUpdate(state, state.webhook, update);
+      if (error) {
+        return error;
+      }
+    } else if (!deliverPollingUpdate(state, update)) {
+      return zaloError(
+        `Pending inbound queue is full (${state.maxPendingInboundEvents} updates)`,
+        429,
+      );
+    }
+    return zaloOk(update);
   } finally {
+    await previousAdmission;
+    releaseAdmission();
     state.pendingInboundAdmissions -= 1;
   }
 }

--- a/test/http-server.test.ts
+++ b/test/http-server.test.ts
@@ -60,6 +60,25 @@ describe("server HTTP body reader", () => {
     await expect(parsed).resolves.toEqual({ ok: true });
   });
 
+  it("accepts structured JSON suffixes without matching arbitrary json substrings", async () => {
+    const structured = createRequest({ "content-type": "application/problem+json; charset=utf-8" });
+    const structuredParsed = parseUnknownRequestBody(structured);
+    structured.end('{"ok":true}');
+    await expect(structuredParsed).resolves.toEqual({ ok: true });
+
+    const extendedRequest = createRequest({
+      "content-type": "application/vnd.acme~event+json",
+    });
+    const extendedParsed = parseUnknownRequestBody(extendedRequest);
+    extendedRequest.end('{"extended":true}');
+    await expect(extendedParsed).resolves.toEqual({ extended: true });
+
+    const arbitrary = createRequest({ "content-type": "text/notjson" });
+    const arbitraryParsed = parseUnknownRequestBody(arbitrary);
+    arbitrary.end("value=%7B%22ok%22%3Atrue%7D");
+    await expect(arbitraryParsed).resolves.toEqual({ value: '{"ok":true}' });
+  });
+
   it("does not expose unexpected exception details", async () => {
     const server = await startHttpJsonServer({
       async handle() {
@@ -98,6 +117,36 @@ describe("server HTTP body reader", () => {
     try {
       const response = await fetch(server.baseUrl);
       expect(response.status).toBe(500);
+      await expect(response.json()).resolves.toEqual({
+        error: "internal server error",
+        ok: false,
+      });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("buffers response bodies before staging status and headers", async () => {
+    const server = await startHttpJsonServer({
+      async handle() {
+        return new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.error(new Error("response body failed"));
+            },
+          }),
+          { headers: { "x-uncommitted": "true" }, status: 201 },
+        );
+      },
+      host: "127.0.0.1",
+      port: 0,
+      serverName: "test",
+    });
+
+    try {
+      const response = await fetch(server.baseUrl);
+      expect(response.status).toBe(500);
+      expect(response.headers.get("x-uncommitted")).toBeNull();
       await expect(response.json()).resolves.toEqual({
         error: "internal server error",
         ok: false,

--- a/test/matrix-server.test.ts
+++ b/test/matrix-server.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { ClientEvent, createClient, RoomEvent, SyncState, type MatrixEvent } from "matrix-js-sdk";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { startMatrixServer, type StartedMatrixServer } from "../src/index.js";
 import { ADMIN_TOKEN_HEADER } from "../src/servers/http.js";
 import { createTempDir, disposeTempDir, requestHttp } from "./test-helpers.js";
@@ -10,6 +10,7 @@ const servers: StartedMatrixServer[] = [];
 const directories: string[] = [];
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   await Promise.all(servers.splice(0).map((server) => server.close()));
   await Promise.all(directories.splice(0).map(disposeTempDir));
 });
@@ -696,6 +697,53 @@ describe("Matrix local provider server", () => {
     }
   });
 
+  it("preserves whitespace-only message content and keeps global profiles separate", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const server = await startMatrixServer({
+      accessToken: "test-token-placeholder",
+      adminToken: "admin",
+      recorderPath: path.join(directory, "matrix-profile.jsonl"),
+    });
+    servers.push(server);
+    const senderId = "@alice:matrix.test";
+
+    for (const [roomId, senderName, text] of [
+      ["!first:matrix.test", "Alice", " \t "],
+      ["!second:matrix.test", "Alicia", "second room"],
+    ] as const) {
+      const response = await fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({ roomId, senderId, senderName, text }),
+        headers: {
+          "content-type": "application/json",
+          [ADMIN_TOKEN_HEADER]: "admin",
+        },
+        method: "POST",
+      });
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toMatchObject({
+        event: { content: { body: text } },
+      });
+    }
+
+    const profile = await fetch(
+      `${server.manifest.endpoints.clientApiRoot}/profile/${encodeURIComponent(senderId)}`,
+      { headers: auth("test-token-placeholder") },
+    );
+    await expect(profile.json()).resolves.toEqual({ displayname: "Alicia" });
+
+    for (const [roomId, displayname] of [
+      ["!first:matrix.test", "Alice"],
+      ["!second:matrix.test", "Alicia"],
+    ] as const) {
+      const member = await fetch(
+        `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent(roomId)}/state/m.room.member/${encodeURIComponent(senderId)}`,
+        { headers: auth("test-token-placeholder") },
+      );
+      await expect(member.json()).resolves.toMatchObject({ displayname });
+    }
+  });
+
   it("replays a transaction room error after the room is created", async () => {
     const directory = await createTempDir();
     directories.push(directory);
@@ -1075,8 +1123,17 @@ describe("Matrix local provider server", () => {
   });
 
   it("bounds timelines and retains recently replayed transactions", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const probe = await fs.open(path.join(directory, "sync-probe"), "w");
+    const fileHandlePrototype = Object.getPrototypeOf(probe) as {
+      sync(): Promise<void>;
+    };
+    vi.spyOn(fileHandlePrototype, "sync").mockResolvedValue();
+    await probe.close();
     const server = await startMatrixServer({
       accessToken: "test-token-placeholder",
+      recorderPath: path.join(directory, "matrix-bounded.jsonl"),
       roomId: "!bounded:matrix.test",
     });
     servers.push(server);
@@ -1195,5 +1252,5 @@ describe("Matrix local provider server", () => {
       },
     );
     await expect(untouchedRetry.json()).resolves.toEqual({ event_id: secondEventId });
-  });
+  }, 15_000);
 });

--- a/test/mattermost-server.test.ts
+++ b/test/mattermost-server.test.ts
@@ -122,6 +122,83 @@ describe("Mattermost local provider server", () => {
       message: "Request body is too large",
       status_code: 413,
     });
+
+    for (const body of [
+      { channel_id: 123, message: "numeric channel" },
+      { channel_id: "channel-1", message: 123 },
+      { channel_id: "channel-1", message: "reply", root_id: 123 },
+    ]) {
+      const invalid = await fetch(postsUrl, {
+        body: JSON.stringify(body),
+        headers: {
+          authorization: "Bearer fake",
+          "content-type": "application/json",
+        },
+        method: "POST",
+      });
+      expect(invalid.status).toBe(400);
+      await expect(invalid.json()).resolves.toMatchObject({
+        request_id: expect.stringMatching(/^[a-z0-9]{26}$/u),
+        status_code: 400,
+      });
+    }
+
+    const invalidDirect = await fetch(`${server.manifest.endpoints.apiRoot}/channels/direct`, {
+      body: JSON.stringify([server.manifest.botUserId, 123]),
+      headers: {
+        authorization: "Bearer fake",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+    expect(invalidDirect.status).toBe(400);
+  });
+
+  it("returns native route errors with request IDs and parses Bearer credentials exactly", async () => {
+    const server = await startMattermostServer({ botToken: "fake" });
+    servers.push(server);
+
+    for (const authorization of ["Bearer  fake", "Bearer\tfake", "Basic fake"]) {
+      const response = await fetch(`${server.manifest.endpoints.apiRoot}/users/me`, {
+        headers: { authorization },
+      });
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toMatchObject({
+        detailed_error: "",
+        id: "api.context.session_expired.app_error",
+        message: "Invalid or expired session, please login again.",
+        request_id: expect.stringMatching(/^[a-z0-9]{26}$/u),
+        status_code: 401,
+      });
+    }
+
+    const requestIds: string[] = [];
+    for (const url of [
+      `${server.manifest.endpoints.apiRoot}/missing`,
+      `${server.manifest.baseUrl}/missing`,
+    ]) {
+      const response = await fetch(url, {
+        headers: { authorization: "Bearer fake" },
+      });
+      expect(response.status).toBe(404);
+      const body = (await response.json()) as {
+        id: string;
+        request_id: string;
+        status_code: number;
+      };
+      expect(body).toMatchObject({
+        id: "api.context.404.app_error",
+        status_code: 404,
+      });
+      expect(body.request_id).toMatch(/^[a-z0-9]{26}$/u);
+      requestIds.push(body.request_id);
+    }
+    expect(new Set(requestIds).size).toBe(requestIds.length);
+
+    const accepted = await fetch(`${server.manifest.endpoints.apiRoot}/users/me`, {
+      headers: { authorization: "bEaReR fake" },
+    });
+    expect(accepted.status).toBe(200);
   });
 
   it("serves authenticated REST and delivers admin inbound over the native WebSocket", async () => {

--- a/test/recorder-concurrency.test.ts
+++ b/test/recorder-concurrency.test.ts
@@ -16,6 +16,7 @@ const fsMocks = vi.hoisted(() => ({
   serverDirectorySync: vi.fn<(directoryPath: string) => Promise<void>>(),
   serverFileExists: false,
   serverOpen: vi.fn<(filePath: string, flags: string) => void>(),
+  serverStat: vi.fn<(filePath: string) => Promise<{ dev: number; ino: number; size: number }>>(),
   serverSync: vi.fn<(filePath: string) => Promise<void>>(),
   serverWrite: vi.fn<(filePath: string, data: string) => Promise<void>>(),
 }));
@@ -85,6 +86,12 @@ vi.mock("node:fs/promises", async (importOriginal) => {
       }
       return handle;
     },
+    stat: async (filePath: Parameters<typeof actual.stat>[0]) => {
+      if (String(filePath).includes("crabline-server-recorder")) {
+        return await fsMocks.serverStat(String(filePath));
+      }
+      return await actual.stat(filePath);
+    },
   };
 });
 
@@ -133,6 +140,8 @@ beforeEach(() => {
   fsMocks.serverDirectorySync.mockResolvedValue(undefined);
   fsMocks.serverFileExists = false;
   fsMocks.serverOpen.mockReset();
+  fsMocks.serverStat.mockReset();
+  fsMocks.serverStat.mockResolvedValue({ dev: 1, ino: 1, size: 0 });
   fsMocks.serverSync.mockReset();
   fsMocks.serverSync.mockResolvedValue(undefined);
   fsMocks.serverWrite.mockReset();

--- a/test/server-recorder.test.ts
+++ b/test/server-recorder.test.ts
@@ -556,6 +556,31 @@ describe("server recorder", () => {
     expect(fsMocks.file.close).toHaveBeenCalledTimes(2);
   });
 
+  it("rolls back and reopens when rotation happens during ancestry sync", async () => {
+    const recorderPath = path.join("/tmp", "crabline-server-recorder-rotated-during-sync.jsonl");
+    fsMocks.file.stat
+      .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
+      .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
+      .mockResolvedValue({ dev: 1, ino: 2, size: 0 });
+    fsMocks.stat
+      .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
+      .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
+      .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
+      .mockResolvedValue({ dev: 1, ino: 2, size: 0 });
+
+    await recordServerEvent({
+      event: serverEvent("/after-sync-rotation"),
+      onEvent: undefined,
+      recorderPath,
+    });
+
+    expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(2);
+    expect(fsMocks.file.truncate).toHaveBeenCalledWith(0);
+    expect(fsMocks.file.sync).toHaveBeenCalledTimes(3);
+    expect(fsMocks.directory.sync).toHaveBeenCalledTimes(4);
+    expect(fsMocks.file.close).toHaveBeenCalledTimes(2);
+  });
+
   it("retries rotation after a second rollback succeeds", async () => {
     const recorderPath = path.join("/tmp", "crabline-server-recorder-rotation-retry.jsonl");
     fsMocks.file.stat

--- a/test/server-recorder.test.ts
+++ b/test/server-recorder.test.ts
@@ -4,7 +4,11 @@ import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ServerRequestEvent } from "../src/servers/http.js";
-import { recordCommittedServerEvent, recordServerEvent } from "../src/servers/recorder.js";
+import {
+  recordCommittedServerEvent,
+  recordServerEvent,
+  ServerRecorderCommittedError,
+} from "../src/servers/recorder.js";
 
 const lockMocks = vi.hoisted(() => {
   const release = vi.fn<() => Promise<void>>();
@@ -51,6 +55,7 @@ const fsMocks = vi.hoisted(() => {
     open: vi.fn<
       (filePath: string, flags: string, mode?: number) => Promise<typeof directory | typeof file>
     >(),
+    stat: vi.fn<(filePath: string) => Promise<{ dev?: number; ino?: number; size: number }>>(),
   };
 });
 
@@ -69,6 +74,7 @@ vi.mock("node:fs/promises", async (importOriginal) => {
     chmod: fsMocks.chmod,
     mkdir: fsMocks.mkdir,
     open: fsMocks.open,
+    stat: fsMocks.stat,
   };
 });
 
@@ -170,6 +176,8 @@ beforeEach(() => {
     }
     return flags === "r" ? fsMocks.directory : fsMocks.file;
   });
+  fsMocks.stat.mockReset();
+  fsMocks.stat.mockResolvedValue({ dev: 1, ino: 1, size: 0 });
 });
 
 describe("server recorder", () => {
@@ -234,6 +242,7 @@ describe("server recorder", () => {
     let recorderExists = false;
     fsMocks.mkdir.mockResolvedValueOnce(firstParent).mockResolvedValueOnce(undefined);
     fsMocks.file.stat.mockResolvedValue({ dev: 42, ino: 84, size: 0 });
+    fsMocks.stat.mockResolvedValue({ dev: 42, ino: 84, size: 0 });
     fsMocks.directory.sync.mockRejectedValueOnce(ancestrySyncFailure).mockResolvedValue(undefined);
     fsMocks.open.mockImplementation(async (openedPath, flags) => {
       if (flags === "r") {
@@ -268,7 +277,7 @@ describe("server recorder", () => {
     });
 
     expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(2);
-    expect(fsMocks.file.sync).toHaveBeenCalledTimes(2);
+    expect(fsMocks.file.sync).toHaveBeenCalledTimes(3);
     expect(fsMocks.directory.sync).toHaveBeenCalledTimes(3);
     expect(fsMocks.open).not.toHaveBeenCalledWith(path.parse(recorderPath).root, "r");
     expect(observer).toHaveBeenCalledOnce();
@@ -285,6 +294,7 @@ describe("server recorder", () => {
     const observer = vi.fn<(event: ServerRequestEvent) => void>();
     let immediateAttempts = 0;
     fsMocks.file.stat.mockResolvedValue({ dev: 61, ino: 62, size: 0 });
+    fsMocks.stat.mockResolvedValue({ dev: 61, ino: 62, size: 0 });
     fsMocks.open.mockImplementation(async (openedPath, flags) => {
       if (flags === "ax+") {
         throw Object.assign(new Error("Recorder already exists"), { code: "EEXIST" });
@@ -318,7 +328,7 @@ describe("server recorder", () => {
     });
 
     expect(immediateAttempts).toBe(2);
-    expect(fsMocks.file.sync).toHaveBeenCalledTimes(2);
+    expect(fsMocks.file.sync).toHaveBeenCalledTimes(3);
     expect(fsMocks.directory.sync).toHaveBeenCalledOnce();
     expect(observer).toHaveBeenCalledOnce();
     expect(observer).toHaveBeenCalledWith(retryEvent);
@@ -336,6 +346,7 @@ describe("server recorder", () => {
     let denyCreatedBoundary = true;
     fsMocks.mkdir.mockResolvedValueOnce(firstParent).mockResolvedValueOnce(undefined);
     fsMocks.file.stat.mockResolvedValue({ dev: 71, ino: 72, size: 0 });
+    fsMocks.stat.mockResolvedValue({ dev: 71, ino: 72, size: 0 });
     fsMocks.open.mockImplementation(async (openedPath, flags) => {
       if (flags === "ax+") {
         if (recorderExists) {
@@ -373,7 +384,7 @@ describe("server recorder", () => {
       recorderPath,
     });
 
-    expect(fsMocks.file.sync).toHaveBeenCalledTimes(2);
+    expect(fsMocks.file.sync).toHaveBeenCalledTimes(3);
     expect(fsMocks.directory.sync).toHaveBeenCalledTimes(4);
     expect(observer).toHaveBeenCalledOnce();
     expect(observer).toHaveBeenCalledWith(retryEvent);
@@ -474,6 +485,174 @@ describe("server recorder", () => {
     ).resolves.toBeUndefined();
 
     expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(2);
+    expect(fsMocks.file.truncate).toHaveBeenCalledWith(0);
+    expect(fsMocks.file.sync).toHaveBeenCalledTimes(2);
+  });
+
+  it("syncs every accepted append without requiring an observer", async () => {
+    await recordServerEvent({
+      event: serverEvent("/durable"),
+      onEvent: undefined,
+      recorderPath: path.join("/tmp", "crabline-server-recorder-durable.jsonl"),
+    });
+
+    expect(fsMocks.file.appendFile).toHaveBeenCalledOnce();
+    expect(fsMocks.file.sync).toHaveBeenCalledOnce();
+  });
+
+  it("reopens the recorder when rotation happens before append", async () => {
+    const recorderPath = path.join("/tmp", "crabline-server-recorder-rotated-before.jsonl");
+    fsMocks.file.stat
+      .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
+      .mockResolvedValue({ dev: 1, ino: 2, size: 0 });
+    fsMocks.stat.mockResolvedValue({ dev: 1, ino: 2, size: 0 });
+
+    await recordServerEvent({
+      event: serverEvent("/after-rotation"),
+      onEvent: undefined,
+      recorderPath,
+    });
+
+    expect(fsMocks.file.close).toHaveBeenCalledTimes(2);
+    expect(fsMocks.file.appendFile).toHaveBeenCalledOnce();
+    expect(fsMocks.file.sync).toHaveBeenCalledOnce();
+  });
+
+  it("fails when recorder identity cannot be verified", async () => {
+    fsMocks.file.stat.mockResolvedValue({ size: 0 });
+
+    await expect(
+      recordServerEvent({
+        event: serverEvent("/identity-unavailable"),
+        onEvent: undefined,
+        recorderPath: path.join("/tmp", "crabline-server-recorder-no-identity.jsonl"),
+      }),
+    ).rejects.toThrow("Server recorder file identity is unavailable.");
+
+    expect(fsMocks.file.appendFile).not.toHaveBeenCalled();
+    expect(fsMocks.file.close).toHaveBeenCalledOnce();
+  });
+
+  it("rolls back and reopens when rotation happens after append", async () => {
+    const recorderPath = path.join("/tmp", "crabline-server-recorder-rotated-after.jsonl");
+    fsMocks.file.stat
+      .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
+      .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
+      .mockResolvedValue({ dev: 1, ino: 2, size: 0 });
+    fsMocks.stat
+      .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
+      .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
+      .mockResolvedValue({ dev: 1, ino: 2, size: 0 });
+
+    await recordServerEvent({
+      event: serverEvent("/after-rotation"),
+      onEvent: undefined,
+      recorderPath,
+    });
+
+    expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(2);
+    expect(fsMocks.file.truncate).toHaveBeenCalledWith(0);
+    expect(fsMocks.file.sync).toHaveBeenCalledTimes(3);
+    expect(fsMocks.file.close).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries rotation after a second rollback succeeds", async () => {
+    const recorderPath = path.join("/tmp", "crabline-server-recorder-rotation-retry.jsonl");
+    fsMocks.file.stat
+      .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
+      .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
+      .mockResolvedValue({ dev: 1, ino: 2, size: 0 });
+    fsMocks.stat
+      .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
+      .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
+      .mockResolvedValue({ dev: 1, ino: 2, size: 0 });
+    fsMocks.file.sync
+      .mockResolvedValueOnce()
+      .mockRejectedValueOnce(new Error("simulated rollback sync failure"))
+      .mockResolvedValue();
+
+    await expect(
+      recordServerEvent({
+        event: serverEvent("/after-rotation-retry"),
+        onEvent: undefined,
+        recorderPath,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(2);
+    expect(fsMocks.file.truncate).toHaveBeenCalledTimes(2);
+    expect(fsMocks.file.sync).toHaveBeenCalledTimes(4);
+  });
+
+  it("rolls back an append when post-append sync fails", async () => {
+    const syncFailure = new Error("simulated fsync failure");
+    const observer = vi.fn<(event: ServerRequestEvent) => void>();
+    fsMocks.file.sync.mockRejectedValueOnce(syncFailure).mockResolvedValue(undefined);
+
+    await expect(
+      recordServerEvent({
+        event: serverEvent("/sync-failed"),
+        onEvent: observer,
+        recorderPath: path.join("/tmp", "crabline-server-recorder-sync-failed.jsonl"),
+      }),
+    ).rejects.toBe(syncFailure);
+
+    expect(fsMocks.file.truncate).toHaveBeenCalledWith(0);
+    expect(fsMocks.file.sync).toHaveBeenCalledTimes(2);
+    expect(observer).not.toHaveBeenCalled();
+  });
+
+  it("exposes a committed result when append rollback fails", async () => {
+    const syncFailure = new Error("simulated fsync failure");
+    const rollbackFailure = new Error("simulated rollback failure");
+    fsMocks.file.sync.mockRejectedValueOnce(syncFailure);
+    fsMocks.file.truncate.mockRejectedValueOnce(rollbackFailure);
+
+    const recording = recordServerEvent({
+      event: serverEvent("/rollback-failed"),
+      onEvent: undefined,
+      recorderPath: path.join("/tmp", "crabline-server-recorder-rollback-failed.jsonl"),
+    });
+
+    await expect(recording).rejects.toMatchObject({
+      committed: true,
+      name: "ServerRecorderCommittedError",
+    });
+    await expect(recording).rejects.toBeInstanceOf(ServerRecorderCommittedError);
+  });
+
+  it("preserves committed status when rollback and close both fail", async () => {
+    fsMocks.file.sync.mockRejectedValueOnce(new Error("simulated fsync failure"));
+    fsMocks.file.truncate.mockRejectedValueOnce(new Error("simulated rollback failure"));
+    fsMocks.file.close.mockRejectedValueOnce(new Error("simulated close failure"));
+
+    await expect(
+      recordServerEvent({
+        event: serverEvent("/rollback-and-close-failed"),
+        onEvent: undefined,
+        recorderPath: path.join("/tmp", "crabline-server-recorder-close-failed.jsonl"),
+      }),
+    ).rejects.toMatchObject({
+      committed: true,
+      name: "ServerRecorderCommittedError",
+    });
+  });
+
+  it("exposes committed status when close fails after a durable append", async () => {
+    const closeFailure = new Error("simulated close failure");
+    fsMocks.file.close.mockRejectedValueOnce(closeFailure);
+
+    await expect(
+      recordServerEvent({
+        event: serverEvent("/close-failed-after-commit"),
+        onEvent: undefined,
+        recorderPath: path.join("/tmp", "crabline-server-recorder-committed-close-failed.jsonl"),
+      }),
+    ).rejects.toMatchObject({
+      cause: closeFailure,
+      committed: true,
+      name: "ServerRecorderCommittedError",
+    });
   });
 
   it("fills short tail reads before repairing a torn final append", async () => {
@@ -823,6 +1002,25 @@ describe("server recorder", () => {
     expect(observer).toHaveBeenCalledWith(event);
   });
 
+  it("allows observers to append reentrantly to the same recorder", async () => {
+    const recorderPath = path.join("/tmp", "crabline-server-recorder-reentrant.jsonl");
+
+    await recordServerEvent({
+      event: serverEvent("/outer"),
+      onEvent: async () => {
+        await recordServerEvent({
+          event: serverEvent("/nested"),
+          onEvent: undefined,
+          recorderPath,
+        });
+      },
+      recorderPath,
+    });
+
+    expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(2);
+    expect(fsMocks.file.sync).toHaveBeenCalledTimes(2);
+  });
+
   it("keeps later appends available after an observer failure", async () => {
     const recorderPath = path.join("/tmp", "crabline-server-recorder-observer.jsonl");
     const observerFailure = new Error("observer failed");
@@ -835,7 +1033,11 @@ describe("server recorder", () => {
         },
         recorderPath,
       }),
-    ).rejects.toBe(observerFailure);
+    ).rejects.toMatchObject({
+      cause: observerFailure,
+      committed: true,
+      name: "ServerRecorderCommittedError",
+    });
     await expect(
       recordServerEvent({
         event: serverEvent("/second"),
@@ -845,6 +1047,27 @@ describe("server recorder", () => {
     ).resolves.toBeUndefined();
 
     expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(2);
+    expect(fsMocks.file.truncate).not.toHaveBeenCalled();
+    expect(fsMocks.file.sync).toHaveBeenCalledTimes(2);
+  });
+
+  it("propagates an undefined observer rejection without retrying", async () => {
+    const error = await recordServerEvent({
+      event: serverEvent("/undefined-rejection"),
+      onEvent: async () => await Promise.reject(),
+      recorderPath: path.join("/tmp", "crabline-server-recorder-undefined-rejection.jsonl"),
+    }).then(
+      () => undefined,
+      (rejection: unknown) => rejection,
+    );
+
+    expect(error).toMatchObject({
+      cause: undefined,
+      committed: true,
+      name: "ServerRecorderCommittedError",
+    });
+    expect(fsMocks.file.appendFile).toHaveBeenCalledOnce();
+    expect(fsMocks.file.truncate).not.toHaveBeenCalled();
   });
 
   it("does not surface telemetry failure after a committed mutation", async () => {

--- a/test/signal-server.test.ts
+++ b/test/signal-server.test.ts
@@ -91,6 +91,80 @@ describe("signal local provider server", () => {
     expect(new URL(server.manifest.baseUrl).hostname).toBe("[::1]");
     const check = await fetch(`${server.manifest.baseUrl}/api/v1/check`);
     expect(check.status).toBe(200);
+    const expandedHost = await requestHttp({
+      headers: { host: "[0:0:0:0:0:0:0:1]" },
+      method: "GET",
+      url: `${server.manifest.baseUrl}/api/v1/check`,
+    });
+    expect(expandedHost.status).toBe(200);
+  });
+
+  it("allowlists Host headers when bound externally", async () => {
+    const server = await startSignalServer({
+      allowedHosts: ["signal.internal"],
+      host: "0.0.0.0",
+    });
+    servers.push(server);
+    const url = new URL(server.manifest.baseUrl);
+    url.hostname = "127.0.0.1";
+
+    const rejected = await requestHttp({
+      headers: { host: "attacker.invalid" },
+      method: "GET",
+      url: `${url.origin}/api/v1/check`,
+    });
+    expect(rejected.status).toBe(400);
+    expect(JSON.parse(rejected.body)).toEqual({
+      error: "Host header is not allowed",
+      ok: false,
+    });
+
+    const wildcard = await requestHttp({
+      headers: { host: `0.0.0.0:${url.port}` },
+      method: "GET",
+      url: `${url.origin}/api/v1/check`,
+    });
+    expect(wildcard.status).toBe(400);
+
+    const allowedDns = await requestHttp({
+      headers: { host: `signal.internal:${url.port}` },
+      method: "GET",
+      url: `${url.origin}/api/v1/check`,
+    });
+    expect(allowedDns.status).toBe(200);
+
+    for (const host of [
+      "attacker.invalid@signal.internal",
+      "signal.internal/path",
+      "signal.internal?query",
+      "signal.internal#fragment",
+    ]) {
+      const malformed = await requestHttp({
+        headers: { host },
+        method: "GET",
+        url: `${url.origin}/api/v1/check`,
+      });
+      expect(malformed.status).toBe(400);
+    }
+
+    const accepted = await requestHttp({
+      headers: { host: `127.0.0.1:${url.port}` },
+      method: "GET",
+      url: `${url.origin}/api/v1/check`,
+    });
+    expect(accepted.status).toBe(200);
+  });
+
+  it("rejects unlisted Host headers on the default loopback binding", async () => {
+    const server = await startSignalServer();
+    servers.push(server);
+
+    const rejected = await requestHttp({
+      headers: { host: "attacker.invalid" },
+      method: "GET",
+      url: `${server.manifest.baseUrl}/api/v1/check`,
+    });
+    expect(rejected.status).toBe(400);
   });
 
   it("serves native RPC and delivers authenticated inbound messages over SSE", async () => {
@@ -363,6 +437,40 @@ describe("signal local provider server", () => {
     await expect(missingIdentity.json()).resolves.toEqual({
       error: "text and at least one source identity are required",
       ok: false,
+    });
+  });
+
+  it("rejects invalid or negative supplied inbound timestamps", async () => {
+    const server = await startSignalServer({ adminToken: "admin" });
+    servers.push(server);
+
+    for (const timestamp of [-1, 1.5, "not-a-timestamp", "9007199254740992", null]) {
+      const response = await fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({ sourceNumber: "+15557654321", text: "invalid", timestamp }),
+        headers: {
+          "content-type": "application/json",
+          "x-crabline-admin-token": "admin",
+        },
+        method: "POST",
+      });
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({
+        error: "timestamp must be a non-negative safe integer",
+        ok: false,
+      });
+    }
+
+    const zero = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({ sourceNumber: "+15557654321", text: "epoch", timestamp: 0 }),
+      headers: {
+        "content-type": "application/json",
+        "x-crabline-admin-token": "admin",
+      },
+      method: "POST",
+    });
+    expect(zero.status).toBe(200);
+    await expect(zero.json()).resolves.toMatchObject({
+      event: { envelope: { timestamp: 0 } },
     });
   });
 

--- a/test/signal-server.test.ts
+++ b/test/signal-server.test.ts
@@ -133,6 +133,13 @@ describe("signal local provider server", () => {
     });
     expect(allowedDns.status).toBe(200);
 
+    const allowedFqdn = await requestHttp({
+      headers: { host: `signal.internal.:${url.port}` },
+      method: "GET",
+      url: `${url.origin}/api/v1/check`,
+    });
+    expect(allowedFqdn.status).toBe(200);
+
     for (const host of [
       "attacker.invalid@signal.internal",
       "signal.internal/path",

--- a/test/signal-server.test.ts
+++ b/test/signal-server.test.ts
@@ -106,7 +106,7 @@ describe("signal local provider server", () => {
     });
     servers.push(server);
     const url = new URL(server.manifest.baseUrl);
-    url.hostname = "127.0.0.1";
+    expect(url.hostname).toBe("127.0.0.1");
 
     const rejected = await requestHttp({
       headers: { host: "attacker.invalid" },
@@ -160,6 +160,15 @@ describe("signal local provider server", () => {
       url: `${url.origin}/api/v1/check`,
     });
     expect(accepted.status).toBe(200);
+  });
+
+  it("advertises IPv6 loopback when bound to the IPv6 wildcard", async () => {
+    const server = await startSignalServer({ host: "::" });
+    servers.push(server);
+
+    expect(new URL(server.manifest.baseUrl).hostname).toBe("[::1]");
+    const check = await fetch(`${server.manifest.baseUrl}/api/v1/check`);
+    expect(check.status).toBe(200);
   });
 
   it("rejects unlisted Host headers on the default loopback binding", async () => {

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -1623,6 +1623,32 @@ describe("telegram local provider server", () => {
     }
   });
 
+  it("accepts callbacks after the referenced chat exhausts generated message IDs", async () => {
+    const server = await startTelegramServer({ botToken: "test-token-placeholder" });
+    servers.push(server);
+
+    expect(
+      (
+        await injectUpdate(server, {
+          chatId: 123,
+          messageId: Number.MAX_SAFE_INTEGER - 1,
+          text: "last generated message ID",
+          updateId: 1,
+        })
+      ).status,
+    ).toBe(200);
+
+    const callback = await injectUpdate(server, {
+      callback_query: {
+        id: "callback-after-message-exhaustion",
+        message: { chat: { id: 123 }, message_id: 1 },
+      },
+      update_id: 2,
+    });
+    expect(callback.status).toBe(200);
+    await expect(callback.json()).resolves.toEqual({ ok: true });
+  });
+
   it("tracks explicit message IDs independently per chat", async () => {
     const server = await startTelegramServer({ botToken: "test-token-placeholder" });
     servers.push(server);

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -1649,6 +1649,33 @@ describe("telegram local provider server", () => {
     await expect(callback.json()).resolves.toEqual({ ok: true });
   });
 
+  it("keeps generated media file identities unique across chats", async () => {
+    const server = await startTelegramServer({ botToken: "test-token-placeholder" });
+    servers.push(server);
+    const apiRoot = `${server.manifest.baseUrl}/bottest-token-placeholder`;
+
+    const media = await Promise.all(
+      [100, 200].map(async (chatId) => {
+        const response = await fetch(`${apiRoot}/sendPhoto`, {
+          body: JSON.stringify({ chat_id: chatId, photo: "fixture.png" }),
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        });
+        expect(response.status).toBe(200);
+        return (await response.json()) as {
+          result: {
+            message_id: number;
+            photo: Array<{ file_id: string; file_unique_id: string }>;
+          };
+        };
+      }),
+    );
+
+    expect(media.map((entry) => entry.result.message_id)).toEqual([1, 1]);
+    expect(new Set(media.map((entry) => entry.result.photo[0]?.file_id)).size).toBe(2);
+    expect(new Set(media.map((entry) => entry.result.photo[0]?.file_unique_id)).size).toBe(2);
+  });
+
   it("tracks explicit message IDs independently per chat", async () => {
     const server = await startTelegramServer({ botToken: "test-token-placeholder" });
     servers.push(server);

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -1754,6 +1754,42 @@ describe("telegram local provider server", () => {
     });
   });
 
+  it("advances per-chat message IDs from edits and callbacks", async () => {
+    const server = await startTelegramServer({ botToken: "test-token-placeholder" });
+    servers.push(server);
+
+    for (const body of [
+      {
+        edited_message: {
+          chat: { id: 100 },
+          message_id: 10,
+          text: "edited existing message",
+        },
+        update_id: 1,
+      },
+      {
+        callback_query: {
+          id: "callback-existing-message",
+          message: { chat: { id: 200 }, message_id: 20 },
+        },
+        update_id: 2,
+      },
+    ]) {
+      expect((await injectUpdate(server, body)).status).toBe(200);
+    }
+
+    await expect(
+      (await injectUpdate(server, { chatId: 100, text: "after edit" })).json(),
+    ).resolves.toMatchObject({
+      update: { message: { message_id: 11 }, update_id: 3 },
+    });
+    await expect(
+      (await injectUpdate(server, { chatId: 200, text: "after callback" })).json(),
+    ).resolves.toMatchObject({
+      update: { message: { message_id: 21 }, update_id: 4 },
+    });
+  });
+
   it("allocates forum topic roots from the chat message sequence", async () => {
     const server = await startTelegramServer({ botToken: "test-token-placeholder" });
     servers.push(server);

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -328,7 +328,10 @@ describe("telegram local provider server", () => {
       body: mediaBody,
       method: "POST",
     });
-    await expect(sendPhoto.json()).resolves.toMatchObject({
+    const sendPhotoBody = (await sendPhoto.json()) as {
+      result: { photo: Array<Record<string, unknown>> };
+    };
+    expect(sendPhotoBody).toMatchObject({
       ok: true,
       result: {
         caption: "hello fake telegram media",
@@ -337,6 +340,7 @@ describe("telegram local provider server", () => {
         photo: [{ height: 1, width: 1 }],
       },
     });
+    expect(sendPhotoBody.result.photo[0]).not.toHaveProperty("file_name");
 
     const boundary = "CrablineBoundary";
     const unicodeCaption = "\u4f60\u597d, Telegram";
@@ -554,10 +558,6 @@ describe("telegram local provider server", () => {
         },
         update_id: 1,
       },
-      ...(["guest_message", "managed_bot"] as const).map((field, index) => ({
-        [field]: {},
-        update_id: index + 10,
-      })),
       {
         message: {
           chat: { id: -1001234567890, type: "supergroup" },
@@ -590,6 +590,10 @@ describe("telegram local provider server", () => {
           update_id: index + 4,
         }),
       ),
+      ...(["guest_message", "managed_bot"] as const).map((field, index) => ({
+        [field]: {},
+        update_id: index + 10,
+      })),
     ]) {
       const response = await injectUpdate(server, body);
       expect(response.status).toBe(200);
@@ -672,7 +676,7 @@ describe("telegram local provider server", () => {
 
     const inbound = injectUpdate(server, { chatId: 42, text: "rejected inbound" });
     await inboundObserved;
-    const firstSend = await fetch(
+    const firstSendPromise = fetch(
       `${server.manifest.baseUrl}/bottest-token-placeholder/sendMessage`,
       {
         body: JSON.stringify({ chat_id: 42, text: "first API send" }),
@@ -680,10 +684,11 @@ describe("telegram local provider server", () => {
         method: "POST",
       },
     );
+    releaseInbound();
+    const firstSend = await firstSendPromise;
     const firstBody = (await firstSend.json()) as {
       result: { message_id: number };
     };
-    releaseInbound();
     expect((await inbound).status).toBe(500);
 
     const secondSend = await fetch(
@@ -928,7 +933,7 @@ describe("telegram local provider server", () => {
     }
   });
 
-  it("dequeues the delivered webhook update when pending updates reorder", async () => {
+  it("rejects a lower update ID while webhook delivery is in flight", async () => {
     const delivered: number[] = [];
     let releaseFirst!: () => void;
     const firstBlocked = new Promise<void>((resolve) => {
@@ -987,8 +992,8 @@ describe("telegram local provider server", () => {
       await new Promise((resolve) => setTimeout(resolve, 25));
       releaseFirst();
 
-      expect((await lowerUpdate).status).toBe(200);
-      await expect.poll(() => delivered).toEqual([10, 5]);
+      expect((await lowerUpdate).status).toBe(400);
+      await expect.poll(() => delivered).toEqual([10]);
     } finally {
       releaseFirst();
       await new Promise<void>((resolve, reject) =>
@@ -997,7 +1002,7 @@ describe("telegram local provider server", () => {
     }
   });
 
-  it("resets the retry budget when a lower update becomes head during delivery", async () => {
+  it("does not reset the retry budget for a rejected lower update", async () => {
     const attemptedUpdateIds: number[] = [];
     let releaseFinal!: () => void;
     const finalBlocked = new Promise<void>((resolve) => {
@@ -1056,13 +1061,9 @@ describe("telegram local provider server", () => {
       await new Promise((resolve) => setTimeout(resolve, 25));
       releaseFinal();
 
-      expect((await lowerUpdate).status).toBe(200);
-      await expect
-        .poll(() => attemptedUpdateIds.filter((updateId) => updateId === 5).length, {
-          timeout: 5_000,
-        })
-        .toBe(6);
+      expect((await lowerUpdate).status).toBe(400);
       expect(attemptedUpdateIds.filter((updateId) => updateId === 10)).toHaveLength(6);
+      expect(attemptedUpdateIds.filter((updateId) => updateId === 5)).toHaveLength(0);
     } finally {
       releaseFinal();
       await new Promise<void>((resolve, reject) =>
@@ -1500,6 +1501,233 @@ describe("telegram local provider server", () => {
         update_id: 101,
       },
     });
+  });
+
+  it("requires explicit inbound IDs to stay positive, unique, and monotonic", async () => {
+    const server = await startTelegramServer({ botToken: "test-token-placeholder" });
+    servers.push(server);
+
+    expect(
+      (
+        await injectUpdate(server, {
+          chatId: 123,
+          messageId: 10,
+          text: "explicit",
+          updateId: 20,
+        })
+      ).status,
+    ).toBe(200);
+
+    for (const body of [
+      { chatId: 123, messageId: 10, text: "duplicate message", updateId: 21 },
+      { chatId: 123, messageId: 11, text: "duplicate update", updateId: 20 },
+      { chatId: 123, messageId: 9, text: "decreasing message", updateId: 21 },
+      { chatId: 123, messageId: 11, text: "decreasing update", updateId: 19 },
+      { chatId: 123, messageId: 0, text: "zero message", updateId: 21 },
+      { chatId: 123, messageId: 11, text: "negative update", updateId: -1 },
+      {
+        chatId: 123,
+        messageId: Number.MAX_SAFE_INTEGER,
+        text: "message counter overflow",
+        updateId: 21,
+      },
+      {
+        chatId: 123,
+        messageId: 11,
+        text: "update counter overflow",
+        updateId: Number.MAX_SAFE_INTEGER,
+      },
+      {
+        chatId: 123,
+        messageId: 11,
+        message_id: 12,
+        text: "conflicting aliases",
+        updateId: 21,
+      },
+    ]) {
+      const response = await injectUpdate(server, body);
+      expect(response.status).toBe(400);
+    }
+
+    const generated = await injectUpdate(server, { chatId: 123, text: "generated" });
+    await expect(generated.json()).resolves.toMatchObject({
+      update: { message: { message_id: 11 }, update_id: 21 },
+    });
+
+    const ignored = await injectUpdate(server, {
+      message: {
+        chat: { id: 123 },
+        message_id: 12,
+        photo: [{ file_id: "photo", file_unique_id: "unique", height: 1, width: 1 }],
+      },
+      update_id: 22,
+    });
+    expect(ignored.status).toBe(200);
+
+    const afterIgnored = await injectUpdate(server, { chatId: 123, text: "after ignored" });
+    await expect(afterIgnored.json()).resolves.toMatchObject({
+      update: { message: { message_id: 13 }, update_id: 23 },
+    });
+
+    const channelPost = await injectUpdate(server, {
+      channel_post: {
+        chat: { id: -1001234567890, type: "channel" },
+        message_id: 30,
+        text: "channel post",
+      },
+      update_id: 30,
+    });
+    expect(channelPost.status).toBe(200);
+
+    const afterChannelPost = await injectUpdate(server, {
+      chatId: -1001234567890,
+      text: "after channel post",
+    });
+    await expect(afterChannelPost.json()).resolves.toMatchObject({
+      update: { message: { message_id: 31 }, update_id: 31 },
+    });
+  });
+
+  it("fails cleanly after explicit IDs exhaust generated ID space", async () => {
+    const server = await startTelegramServer({ botToken: "test-token-placeholder" });
+    servers.push(server);
+    const finalGeneratedId = Number.MAX_SAFE_INTEGER - 1;
+
+    const explicit = await injectUpdate(server, {
+      chatId: 123,
+      messageId: finalGeneratedId,
+      text: "last explicit IDs",
+      updateId: finalGeneratedId,
+    });
+    expect(explicit.status).toBe(200);
+
+    const outbound = await fetch(
+      `${server.manifest.baseUrl}/bottest-token-placeholder/sendMessage`,
+      {
+        body: JSON.stringify({ chat_id: 123, text: "outbound after exhaustion" }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      },
+    );
+    expect(outbound.status).toBe(400);
+    await expect(outbound.json()).resolves.toMatchObject({
+      description: "Bad Request: generated ID space is exhausted",
+    });
+
+    for (const text of ["first rejected generated IDs", "second rejected generated IDs"]) {
+      const generated = await injectUpdate(server, { chatId: 123, text });
+      expect(generated.status).toBe(400);
+      await expect(generated.json()).resolves.toMatchObject({
+        description: "Bad Request: generated ID space is exhausted",
+      });
+    }
+  });
+
+  it("tracks explicit message IDs independently per chat", async () => {
+    const server = await startTelegramServer({ botToken: "test-token-placeholder" });
+    servers.push(server);
+
+    expect(
+      (
+        await injectUpdate(server, {
+          chatId: 100,
+          messageId: 10,
+          text: "chat A",
+          updateId: 20,
+        })
+      ).status,
+    ).toBe(200);
+    expect(
+      (
+        await injectUpdate(server, {
+          chatId: 200,
+          messageId: 1,
+          text: "chat B",
+          updateId: 21,
+        })
+      ).status,
+    ).toBe(200);
+
+    await expect(
+      (await injectUpdate(server, { chatId: 100, text: "next chat A" })).json(),
+    ).resolves.toMatchObject({
+      update: { message: { message_id: 11 }, update_id: 22 },
+    });
+    await expect(
+      (await injectUpdate(server, { chatId: 200, text: "next chat B" })).json(),
+    ).resolves.toMatchObject({
+      update: { message: { message_id: 2 }, update_id: 23 },
+    });
+  });
+
+  it("accepts edits and callbacks that reference earlier message IDs", async () => {
+    const server = await startTelegramServer({ botToken: "test-token-placeholder" });
+    servers.push(server);
+
+    expect(
+      (
+        await injectUpdate(server, {
+          chatId: 100,
+          messageId: 10,
+          text: "original",
+          updateId: 20,
+        })
+      ).status,
+    ).toBe(200);
+    for (const body of [
+      {
+        edited_message: {
+          chat: { id: 100 },
+          message_id: 10,
+          text: "edited",
+        },
+        update_id: 21,
+      },
+      {
+        callback_query: {
+          id: "callback-1",
+          message: { chat: { id: 100 }, message_id: 10 },
+        },
+        update_id: 22,
+      },
+    ]) {
+      expect((await injectUpdate(server, body)).status).toBe(200);
+    }
+
+    await expect(
+      (await injectUpdate(server, { chatId: 100, text: "next message" })).json(),
+    ).resolves.toMatchObject({
+      update: { message: { message_id: 11 }, update_id: 23 },
+    });
+  });
+
+  it("allocates forum topic roots from the chat message sequence", async () => {
+    const server = await startTelegramServer({ botToken: "test-token-placeholder" });
+    servers.push(server);
+    const apiRoot = `${server.manifest.baseUrl}/bottest-token-placeholder`;
+
+    const first = await fetch(`${apiRoot}/sendMessage`, {
+      body: JSON.stringify({ chat_id: 42, text: "before topic" }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    await expect(first.json()).resolves.toMatchObject({ result: { message_id: 1 } });
+
+    const topic = await fetch(`${apiRoot}/createForumTopic`, {
+      body: JSON.stringify({ chat_id: 42, name: "topic" }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    await expect(topic.json()).resolves.toMatchObject({
+      result: { message_thread_id: 2 },
+    });
+
+    const after = await fetch(`${apiRoot}/sendMessage`, {
+      body: JSON.stringify({ chat_id: 42, text: "after topic" }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    await expect(after.json()).resolves.toMatchObject({ result: { message_id: 3 } });
   });
 
   it("rejects unsafe integer identities without consuming generated IDs", async () => {

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -1503,7 +1503,7 @@ describe("telegram local provider server", () => {
     });
   });
 
-  it("requires explicit inbound IDs to stay positive, unique, and monotonic", async () => {
+  it("keeps explicit inbound IDs valid, unique, and monotonic", async () => {
     const server = await startTelegramServer({ botToken: "test-token-placeholder" });
     servers.push(server);
 
@@ -1523,7 +1523,6 @@ describe("telegram local provider server", () => {
       { chatId: 123, messageId: 11, text: "duplicate update", updateId: 20 },
       { chatId: 123, messageId: 9, text: "decreasing message", updateId: 21 },
       { chatId: 123, messageId: 11, text: "decreasing update", updateId: 19 },
-      { chatId: 123, messageId: 0, text: "zero message", updateId: 21 },
       { chatId: 123, messageId: 11, text: "negative update", updateId: -1 },
       {
         chatId: 123,
@@ -1549,9 +1548,20 @@ describe("telegram local provider server", () => {
       expect(response.status).toBe(400);
     }
 
+    const scheduled = await injectUpdate(server, {
+      chatId: 123,
+      messageId: 0,
+      text: "automatically scheduled",
+      updateId: 21,
+    });
+    expect(scheduled.status).toBe(200);
+    await expect(scheduled.json()).resolves.toMatchObject({
+      update: { message: { message_id: 0 }, update_id: 21 },
+    });
+
     const generated = await injectUpdate(server, { chatId: 123, text: "generated" });
     await expect(generated.json()).resolves.toMatchObject({
-      update: { message: { message_id: 11 }, update_id: 21 },
+      update: { message: { message_id: 11 }, update_id: 22 },
     });
 
     const ignored = await injectUpdate(server, {
@@ -1560,13 +1570,13 @@ describe("telegram local provider server", () => {
         message_id: 12,
         photo: [{ file_id: "photo", file_unique_id: "unique", height: 1, width: 1 }],
       },
-      update_id: 22,
+      update_id: 23,
     });
     expect(ignored.status).toBe(200);
 
     const afterIgnored = await injectUpdate(server, { chatId: 123, text: "after ignored" });
     await expect(afterIgnored.json()).resolves.toMatchObject({
-      update: { message: { message_id: 13 }, update_id: 23 },
+      update: { message: { message_id: 13 }, update_id: 24 },
     });
 
     const channelPost = await injectUpdate(server, {

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -286,6 +286,49 @@ describe("whatsapp local provider server", () => {
     expect(new URL(replacement.manifest.baseUrl).port).toBe(String(port));
   });
 
+  it("waits for admitted Baileys recorder work before shutdown completes", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    let releaseRecorder!: () => void;
+    const recorderBlocked = new Promise<void>((resolve) => {
+      releaseRecorder = resolve;
+    });
+    let markRecorderStarted!: () => void;
+    const recorderStarted = new Promise<void>((resolve) => {
+      markRecorderStarted = resolve;
+    });
+    let blockNextWebSocketEvent = true;
+    const server = await startWhatsAppServer({
+      onEvent: async (event) => {
+        if (blockNextWebSocketEvent && event.method === "WEBSOCKET") {
+          blockNextWebSocketEvent = false;
+          markRecorderStarted();
+          await recorderBlocked;
+        }
+      },
+      recorderPath: path.join(directory, "whatsapp-shutdown.jsonl"),
+    });
+    const socket = createBaileysTestSocket(server);
+    let closePromise: Promise<void> | undefined;
+
+    try {
+      await recorderStarted;
+      let closeSettled = false;
+      closePromise = server.close().finally(() => {
+        closeSettled = true;
+      });
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(closeSettled).toBe(false);
+
+      releaseRecorder();
+      await closePromise;
+    } finally {
+      releaseRecorder();
+      socket.end(undefined);
+      await closePromise?.catch(() => undefined);
+    }
+  });
+
   it("serves Cloud API sends and injected inbound webhook payloads", async () => {
     const directory = await createTempDir();
     directories.push(directory);

--- a/test/zalo-server.test.ts
+++ b/test/zalo-server.test.ts
@@ -1,4 +1,10 @@
-import { Agent, createServer, ServerResponse, type ClientRequest } from "node:http";
+import {
+  Agent,
+  createServer,
+  request as httpRequest,
+  ServerResponse,
+  type ClientRequest,
+} from "node:http";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -344,6 +350,68 @@ describe("Zalo local provider server", () => {
 
     releaseFirst();
     expect((await first).status).toBe(200);
+  });
+
+  it("preserves inbound arrival order across concurrent body parsing", async () => {
+    const server = await startZaloServer({
+      adminToken: "admin",
+      maxPendingInboundEvents: 2,
+    });
+    servers.push(server);
+    const firstBody = JSON.stringify({
+      chatId: "chat-1",
+      senderId: "user-1",
+      text: "first",
+    });
+    const firstResponse = new Promise<{ status: number }>((resolve, reject) => {
+      const request = httpRequest(
+        server.manifest.endpoints.adminInboundUrl,
+        {
+          headers: {
+            "content-type": "application/json",
+            "x-crabline-admin-token": "admin",
+          },
+          method: "POST",
+        },
+        (response) => {
+          response.once("error", reject);
+          response.once("end", () => {
+            resolve({
+              status: response.statusCode ?? 0,
+            });
+          });
+          response.resume();
+        },
+      );
+      request.once("error", reject);
+      request.flushHeaders();
+      request.write(firstBody.slice(0, -1));
+
+      setTimeout(() => request.end(firstBody.slice(-1)), 100);
+    });
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    let secondSettled = false;
+    const secondResponse = fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({ chatId: "chat-1", senderId: "user-1", text: "second" }),
+      headers: adminHeaders(server),
+      method: "POST",
+    }).finally(() => {
+      secondSettled = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(secondSettled).toBe(false);
+    expect((await firstResponse).status).toBe(200);
+    expect((await secondResponse).status).toBe(200);
+
+    for (const text of ["first", "second"]) {
+      const response = await fetch(
+        `${server.manifest.baseUrl}/bot${server.manifest.botToken}/getUpdates?timeout=0`,
+      );
+      await expect(response.json()).resolves.toMatchObject({
+        result: { message: { text } },
+      });
+    }
   });
 
   it("rejects oversized or header-unsafe webhook secrets", async () => {

--- a/test/zalo-server.test.ts
+++ b/test/zalo-server.test.ts
@@ -195,6 +195,15 @@ describe("Zalo local provider server", () => {
         `${server.manifest.baseUrl}/bottest-token-placeholder/setWebhook`,
         {
           body: JSON.stringify({
+            metadata: {
+              authorization: "placeholder",
+              callbacks: [
+                {
+                  callbackUrl:
+                    "http://fixture-user:placeholder@example.com/hook?api_key=placeholder",
+                },
+              ],
+            },
             secret_token: "test-auth-token",
             url: webhookUrl.href,
           }),
@@ -275,6 +284,10 @@ describe("Zalo local provider server", () => {
       expect(recorder).not.toContain("sample");
       expect(recorder).not.toContain("credential-placeholder");
       expect(recorder).not.toContain("protocol-user");
+      expect(recorder).not.toContain("fixture-user");
+      expect(recorder).toContain(
+        '"callbackUrl":"http://<redacted>@example.com/hook?api_key=<redacted>"',
+      );
       for (const secret of ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot"]) {
         expect(recorder).not.toContain(secret);
       }
@@ -283,6 +296,54 @@ describe("Zalo local provider server", () => {
         webhook.close((error) => (error ? reject(error) : resolve())),
       );
     }
+  });
+
+  it("bounds inbound admission before parsing request bodies", async () => {
+    let observeFirst!: () => void;
+    let releaseFirst!: () => void;
+    const firstObserved = new Promise<void>((resolve) => {
+      observeFirst = resolve;
+    });
+    const firstReleased = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const server = await startZaloServer({
+      adminToken: "admin",
+      maxPendingInboundEvents: 1,
+      async onEvent(event) {
+        if (event.path === "/crabline/zalo/inbound") {
+          observeFirst();
+          await firstReleased;
+        }
+      },
+    });
+    servers.push(server);
+
+    const first = fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({ chatId: "chat-1", senderId: "user-1", text: "first" }),
+      headers: {
+        "content-type": "application/json",
+        "x-crabline-admin-token": "admin",
+      },
+      method: "POST",
+    });
+    await firstObserved;
+
+    const overloaded = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: "{",
+      headers: {
+        "content-type": "application/json",
+        "x-crabline-admin-token": "admin",
+      },
+      method: "POST",
+    });
+    expect(overloaded.status).toBe(429);
+    await expect(overloaded.json()).resolves.toMatchObject({
+      description: "Pending inbound queue is full (1 updates)",
+    });
+
+    releaseFirst();
+    expect((await first).status).toBe(200);
   });
 
   it("rejects oversized or header-unsafe webhook secrets", async () => {


### PR DESCRIPTION
## Summary

- make recorder appends durable, rotation-aware, and explicit about committed post-append failures
- tighten shared HTTP JSON handling and response buffering
- align Matrix, Mattermost, Signal, Telegram, and Zalo behavior with provider-native identity, authentication, profile, ingress, and redaction contracts

## Validation

- `pnpm lint`
- `pnpm exec vitest run test/http-server.test.ts test/matrix-server.test.ts test/mattermost-server.test.ts test/recorder-concurrency.test.ts test/server-recorder.test.ts test/signal-server.test.ts test/telegram-server.test.ts test/zalo-server.test.ts` (173 tests)
- structured review completed; all actionable findings addressed

## Scope

- no Slack or WhatsApp files changed
- includes one Unreleased changelog bullet