### PR TITLE
fix(providers): harden webhook and key runtime boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Bind npm and GitHub release mutations to the revalidated tag commit and fail closed on release lookup errors.
 - Correct the OpenClaw artifact setup guide to reflect runtime pruning of abandoned generations.
 - Enforce native Telegram username bounds, map OpenClaw inbound usernames to numeric chat identities, and align direct sender identity.
+- Expose synchronous provider cleanup fences and prune inactive LocalMock wait cursors after concurrent waits settle.
 - Harden provider adapter authentication, target identity, credential redaction, and webhook lifecycle behavior.
 - Harden release provenance retries, provider-native contract tests, cross-platform tooling, cleanup ordering, and channel setup coverage.
 - Stop `serve` after closed-pipe output, withdraw readiness before shutdown, and retain ownership when server close fails.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Bind npm and GitHub release mutations to the revalidated tag commit and fail closed on release lookup errors.
 - Correct the OpenClaw artifact setup guide to reflect runtime pruning of abandoned generations.
 - Enforce native Telegram username bounds, map OpenClaw inbound usernames to numeric chat identities, and align direct sender identity.
+- Require HTTPS public URLs for authenticated external webhook ingress while preserving loopback-local HTTP.
 - Reject webhook paths changed by URL normalization and clear stale response headers before fallback errors.
 - Expose synchronous provider cleanup fences and prune inactive LocalMock wait cursors after concurrent waits settle.
 - Harden provider adapter authentication, target identity, credential redaction, and webhook lifecycle behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Bind npm and GitHub release mutations to the revalidated tag commit and fail closed on release lookup errors.
 - Correct the OpenClaw artifact setup guide to reflect runtime pruning of abandoned generations.
 - Enforce native Telegram username bounds, map OpenClaw inbound usernames to numeric chat identities, and align direct sender identity.
+- Bound JWKS cache lifetimes and start unknown-key refresh cooldowns after refresh completion.
 - Require HTTPS public URLs for authenticated external webhook ingress while preserving loopback-local HTTP.
 - Reject webhook paths changed by URL normalization and clear stale response headers before fallback errors.
 - Expose synchronous provider cleanup fences and prune inactive LocalMock wait cursors after concurrent waits settle.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Bind npm and GitHub release mutations to the revalidated tag commit and fail closed on release lookup errors.
 - Correct the OpenClaw artifact setup guide to reflect runtime pruning of abandoned generations.
 - Enforce native Telegram username bounds, map OpenClaw inbound usernames to numeric chat identities, and align direct sender identity.
+- Reject webhook paths changed by URL normalization and clear stale response headers before fallback errors.
 - Expose synchronous provider cleanup fences and prune inactive LocalMock wait cursors after concurrent waits settle.
 - Harden provider adapter authentication, target identity, credential redaction, and webhook lifecycle behavior.
 - Harden release provenance retries, provider-native contract tests, cross-platform tooling, cleanup ordering, and channel setup coverage.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ Telegram `secretToken`, and Zalo `webhookSecret` enforce provider-native
 webhook authentication. Feishu `verificationToken` remains an additional or
 loopback-only callback check. Microsoft Teams also requires `appId` for
 non-loopback or explicitly public webhook endpoints.
+Authenticated external webhook ingress must advertise an HTTPS `publicUrl`;
+plain HTTP is limited to loopback-local testing.
 
 ## Built-In Mock Channels
 
@@ -411,6 +413,8 @@ Nested message payloads are also accepted:
 ```
 
 Malformed webhooks return `400`, and non-JSON requests return `415`.
+Configured webhook paths must be canonical URL pathnames without normalization,
+query, or fragment ambiguity.
 
 ## Evidence Flow
 

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -78,6 +78,11 @@ reachable Discord webhooks require `publicKey` or `DISCORD_PUBLIC_KEY`.
 Optional webhook credentials enforce each provider's native authentication
 header before JSON parsing or recorder writes:
 
+- Authenticated external ingress must set `webhook.publicUrl` to an HTTPS URL;
+  Google Chat may use its HTTPS `endpointUrl` as the signed public callback
+  instead. A non-loopback bind without a public HTTPS endpoint is rejected even
+  when request credentials are configured. Plain HTTP is reserved for local
+  tests where both the listener host and advertised URL host are loopback.
 - Discord `publicKey` or `DISCORD_PUBLIC_KEY` verifies
   `X-Signature-Ed25519` over `X-Signature-Timestamp` plus the raw request body.
 - Google Chat `endpointUrl` verifies Google ID tokens for the configured HTTP
@@ -115,6 +120,10 @@ header before JSON parsing or recorder writes:
   `X-Telegram-Bot-Api-Secret-Token`.
 - Zalo `webhookSecret` or `ZALO_WEBHOOK_SECRET` verifies
   `X-Bot-Api-Secret-Token`.
+
+Webhook `path` values must already be canonical URL pathnames. Authority-form
+paths, dot-segment or backslash traversal, query strings, fragments, spaces,
+and other values changed by URL normalization are rejected.
 
 The built-in `whatsapp` adapter implements Meta's GET verification challenge
 and requires `X-Hub-Signature-256` on POST requests. Set `whatsapp.appSecret`

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,6 +1,7 @@
 import { validateHeaderValue } from "node:http";
 import { BlockList, isIP } from "node:net";
 import { z } from "zod";
+import { isCanonicalHttpPath } from "../core/http-path.js";
 import { inboundRegexSafetyError } from "../core/safe-regex.js";
 
 export const FIXTURE_MODES = ["probe", "send", "roundtrip", "agent"] as const;
@@ -90,7 +91,11 @@ const HeaderValueSchema = z
     }
   }, "secret must be a valid HTTP header value");
 
-const WebhookPathSchema = z.string().min(1).startsWith("/", "webhook path must start with /");
+const WebhookPathSchema = z
+  .string()
+  .min(1)
+  .startsWith("/", "webhook path must start with /")
+  .refine(isCanonicalHttpPath, "webhook path must be a canonical URL pathname");
 
 function isLoopbackHost(host: string): boolean {
   const normalized = host

--- a/src/core/http-path.ts
+++ b/src/core/http-path.ts
@@ -1,0 +1,15 @@
+const PATH_BASE_URL = "http://localhost";
+
+export function isCanonicalHttpPath(value: string): boolean {
+  try {
+    const url = new URL(value, PATH_BASE_URL);
+    return (
+      url.origin === PATH_BASE_URL &&
+      url.pathname === value &&
+      url.search.length === 0 &&
+      url.hash.length === 0
+    );
+  } catch {
+    return false;
+  }
+}

--- a/src/providers/builtin/external-webhook-auth.ts
+++ b/src/providers/builtin/external-webhook-auth.ts
@@ -8,15 +8,37 @@ type WebhookConfig = {
 
 export function requireExternalWebhookAuthentication(params: {
   authenticated: boolean;
+  authenticatedIngressUrl?: string | undefined;
   provider: string;
   requirement: string;
   webhook: WebhookConfig | undefined;
 }): void {
   const host = params.webhook?.host ?? "127.0.0.1";
-  const externallyReachable = Boolean(params.webhook?.publicUrl) || !isLoopbackHost(host);
+  const hostIsLoopback = isLoopbackHost(host);
+  const publicUrl = params.authenticatedIngressUrl ?? params.webhook?.publicUrl;
+  const externallyReachable = Boolean(publicUrl) || !hostIsLoopback;
   if (externallyReachable && !params.authenticated) {
     throw new CrablineError(
       `${params.provider} externally reachable webhooks require ${params.requirement}.`,
+      { kind: "config" },
+    );
+  }
+  if (!externallyReachable) {
+    return;
+  }
+  if (!publicUrl) {
+    throw new CrablineError(
+      `${params.provider} authenticated external webhooks require a public callback URL with HTTPS.`,
+      { kind: "config" },
+    );
+  }
+
+  const url = new URL(publicUrl);
+  const safeLoopbackHttp =
+    url.protocol === "http:" && hostIsLoopback && isLoopbackHost(url.hostname);
+  if (url.protocol !== "https:" && !safeLoopbackHttp) {
+    throw new CrablineError(
+      `${params.provider} authenticated external webhooks require HTTPS; plain HTTP is allowed only for loopback-local ingress.`,
       { kind: "config" },
     );
   }

--- a/src/providers/builtin/googlechat.ts
+++ b/src/providers/builtin/googlechat.ts
@@ -207,6 +207,7 @@ export class GoogleChatProviderAdapter extends LocalMockProviderAdapter implemen
       );
     requireExternalWebhookAuthentication({
       authenticated: authenticationConfigured,
+      authenticatedIngressUrl: endpointAudience,
       provider: "Google Chat",
       requirement:
         "googlechat.endpointUrl, googlechat.googleChatProjectNumber, or googlechat.pubsubAudience with a Pub/Sub service-account identity and signature verification enabled",

--- a/src/providers/local-mock.ts
+++ b/src/providers/local-mock.ts
@@ -249,6 +249,7 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
     this.#options = params.options;
     this.#publicUrl = params.options.publicUrl ?? params.options.webhook?.publicUrl;
     this.#recorderPath = toRecorderPath(params.id, params.options.recorderPath);
+    this.#installCleanupFence();
   }
 
   normalizeTarget(target: ProviderContext["fixture"]["target"]): NormalizedTarget {
@@ -429,8 +430,14 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
     this.#waitCursors.clear();
   }
 
-  beginCleanup(): void {
-    this.#beginCleanup();
+  #installCleanupFence(): void {
+    const adapter = this as ProviderAdapter;
+    if (adapter.beginCleanup) {
+      return;
+    }
+    Object.defineProperty(adapter, "beginCleanup", {
+      value: () => this.#beginCleanup(),
+    });
   }
 
   async cleanup(): Promise<void> {

--- a/src/providers/local-mock.ts
+++ b/src/providers/local-mock.ts
@@ -393,6 +393,7 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
       ) {
         this.#waitCursors.delete(cursorKey);
       }
+      pruneInactiveWaitCursors(this.#waitCursors);
     }
   }
 
@@ -426,6 +427,10 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
     this.#cleanupBegun = true;
     this.#cleanupController.abort(this.#cleanedUpError());
     this.#waitCursors.clear();
+  }
+
+  beginCleanup(): void {
+    this.#beginCleanup();
   }
 
   async cleanup(): Promise<void> {

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -290,11 +290,18 @@ export class LazyProviderAdapter implements ProviderAdapter {
     return iterator;
   }
 
-  async cleanup(): Promise<void> {
+  beginCleanup(): void {
+    if (this.#cleanedUp) {
+      return;
+    }
     this.#cleanedUp = true;
     for (const watch of this.#activeWatches) {
       watch.abort();
     }
+  }
+
+  async cleanup(): Promise<void> {
+    this.beginCleanup();
     this.#cleanupPromise ??= (async () => {
       const operations = [...this.#inFlightOperations];
       const watches = [...this.#activeWatches];

--- a/src/providers/signed-jwt.ts
+++ b/src/providers/signed-jwt.ts
@@ -14,6 +14,7 @@ export type RemoteJwtKeySet<T> = {
 
 const DEFAULT_KEY_FETCH_TIMEOUT_MS = 5_000;
 const DEFAULT_UNKNOWN_KEY_COOLDOWN_MS = 30_000;
+const MAX_HTTP_CACHE_AGE_SECONDS = 24 * 60 * 60;
 const MAX_NEGATIVE_KEY_IDS = 128;
 const UTF8_DECODER = new TextDecoder("utf-8", { fatal: true });
 
@@ -76,14 +77,22 @@ export function resolveHttpCacheExpiry(response: Response, now: number): number 
   const ageSeconds = ageHeader && /^\d+$/u.test(ageHeader) ? Number.parseInt(ageHeader, 10) : 0;
   const maxAge = /(?:^|,)\s*max-age=(\d+)/iu.exec(cacheControl ?? "");
   if (maxAge) {
-    return now + Math.max(0, Number(maxAge[1]) - ageSeconds) * 1_000;
+    const maxAgeSeconds = Number(maxAge[1]);
+    if (!Number.isSafeInteger(maxAgeSeconds)) {
+      return now;
+    }
+    return (
+      now + Math.min(MAX_HTTP_CACHE_AGE_SECONDS, Math.max(0, maxAgeSeconds - ageSeconds)) * 1_000
+    );
   }
   const expiresHeader = response.headers.get("expires");
   if (expiresHeader === null) {
     return now + Math.max(0, 60 * 60 - ageSeconds) * 1_000;
   }
   const expires = Date.parse(expiresHeader);
-  return Number.isFinite(expires) && expires > now ? expires : now;
+  return Number.isFinite(expires) && expires > now
+    ? Math.min(expires, now + MAX_HTTP_CACHE_AGE_SECONDS * 1_000)
+    : now;
 }
 
 export function createCachedJwtKeyResolver<T>(params: {
@@ -198,14 +207,24 @@ export function createCachedJwtKeyResolver<T>(params: {
     if (refreshInFlight) {
       refreshed = await refreshInFlight;
     } else {
-      const refreshTime = now();
-      if (refreshCooldownUntil > refreshTime) {
+      if (refreshCooldownUntil > now()) {
         return rejectUnknownKey(header.kid, refreshCooldownUntil);
       }
-      refreshCooldownUntil = refreshTime + refreshCooldownMs;
-      refreshInFlight = fetchKeys().finally(() => {
-        refreshInFlight = undefined;
-      });
+      refreshInFlight = Promise.resolve()
+        .then(fetchKeys)
+        .then(
+          (refreshedKeySet) => {
+            refreshCooldownUntil = now() + refreshCooldownMs;
+            return refreshedKeySet;
+          },
+          (error: unknown) => {
+            refreshCooldownUntil = now() + refreshCooldownMs;
+            throw error;
+          },
+        )
+        .finally(() => {
+          refreshInFlight = undefined;
+        });
       refreshed = await refreshInFlight;
     }
 

--- a/src/providers/webhook-server.ts
+++ b/src/providers/webhook-server.ts
@@ -1,4 +1,5 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { isCanonicalHttpPath } from "../core/http-path.js";
 
 export type StartedWebhookServer = {
   close(): Promise<void>;
@@ -118,6 +119,15 @@ async function writeFetchResponse(
   response.end(body);
 }
 
+function clearUnsentResponseHeaders(response: ServerResponse<IncomingMessage>): void {
+  if (response.headersSent) {
+    return;
+  }
+  for (const name of response.getHeaderNames()) {
+    response.removeHeader(name);
+  }
+}
+
 function closeServer(server: Server): Promise<void> {
   return new Promise((resolve, reject) => {
     server.close((error) => {
@@ -145,6 +155,9 @@ export async function startWebhookServer(params: {
   path: string;
   port: number;
 }): Promise<StartedWebhookServer> {
+  if (!isCanonicalHttpPath(params.path)) {
+    throw new Error("Webhook path must be a canonical URL pathname.");
+  }
   const methods = new Set(params.methods ?? ["POST"]);
   const maxBodyBytes = params.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES;
   const bodyTimeoutMs = params.bodyTimeoutMs ?? DEFAULT_BODY_TIMEOUT_MS;
@@ -175,6 +188,7 @@ export async function startWebhookServer(params: {
           // Error reporting must not change the public response.
         }
       }
+      clearUnsentResponseHeaders(response);
       await writeFetchResponse(
         response,
         new Response(

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -106,6 +106,28 @@ describe("manifest schema", () => {
     ).toThrow(/webhook path must start with \//u);
   });
 
+  it.each([
+    "/slack/../events",
+    "/slack\\events",
+    "//example.test/events",
+    "/slack events",
+    "/slack/events?challenge=1",
+    "/slack/events#fragment",
+  ])("rejects webhook paths changed by URL normalization: %s", (webhookPath) => {
+    expect(() =>
+      ManifestSchema.parse({
+        configVersion: 1,
+        fixtures: [],
+        providers: {
+          slack: {
+            adapter: "slack",
+            slack: { webhook: { path: webhookPath } },
+          },
+        },
+      }),
+    ).toThrow(/webhook path must be a canonical URL pathname/u);
+  });
+
   it("requires HTTPS for public Microsoft Teams webhooks", () => {
     expect(() =>
       ManifestSchema.parse({

--- a/test/external-webhook-auth.test.ts
+++ b/test/external-webhook-auth.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { requireExternalWebhookAuthentication } from "../src/providers/builtin/external-webhook-auth.js";
+
+const base = {
+  provider: "Example",
+  requirement: "example.signingSecret",
+};
+
+describe("external webhook authentication policy", () => {
+  it("requires authentication before exposing webhook ingress", () => {
+    expect(() =>
+      requireExternalWebhookAuthentication({
+        ...base,
+        authenticated: false,
+        webhook: { host: "0.0.0.0" },
+      }),
+    ).toThrow(/externally reachable webhooks require example\.signingSecret/u);
+  });
+
+  it("requires an HTTPS public URL for authenticated external ingress", () => {
+    expect(() =>
+      requireExternalWebhookAuthentication({
+        ...base,
+        authenticated: true,
+        webhook: { host: "0.0.0.0" },
+      }),
+    ).toThrow(/public callback URL with HTTPS/u);
+
+    expect(() =>
+      requireExternalWebhookAuthentication({
+        ...base,
+        authenticated: true,
+        authenticatedIngressUrl: "http://hooks.example.test/events",
+        webhook: { host: "0.0.0.0" },
+      }),
+    ).toThrow(/require HTTPS/u);
+
+    expect(() =>
+      requireExternalWebhookAuthentication({
+        ...base,
+        authenticated: true,
+        webhook: {
+          host: "127.0.0.1",
+          publicUrl: "http://hooks.example.test/events",
+        },
+      }),
+    ).toThrow(/require HTTPS/u);
+  });
+
+  it("allows HTTPS frontends and loopback-local HTTP", () => {
+    expect(() =>
+      requireExternalWebhookAuthentication({
+        ...base,
+        authenticated: true,
+        webhook: {
+          host: "0.0.0.0",
+          publicUrl: "https://hooks.example.test/events",
+        },
+      }),
+    ).not.toThrow();
+
+    expect(() =>
+      requireExternalWebhookAuthentication({
+        ...base,
+        authenticated: true,
+        authenticatedIngressUrl: "https://hooks.example.test/events",
+        webhook: { host: "0.0.0.0" },
+      }),
+    ).not.toThrow();
+
+    for (const publicUrl of [
+      "http://127.0.0.1:8787/events",
+      "http://localhost:8787/events",
+      "http://[::1]:8787/events",
+    ]) {
+      expect(() =>
+        requireExternalWebhookAuthentication({
+          ...base,
+          authenticated: true,
+          webhook: { host: "127.0.0.1", publicUrl },
+        }),
+      ).not.toThrow();
+    }
+  });
+
+  it("allows unauthenticated ingress only when it stays on loopback", () => {
+    expect(() =>
+      requireExternalWebhookAuthentication({
+        ...base,
+        authenticated: false,
+        webhook: { host: "localhost" },
+      }),
+    ).not.toThrow();
+  });
+});

--- a/test/feishu-provider.test.ts
+++ b/test/feishu-provider.test.ts
@@ -37,6 +37,7 @@ describe("Feishu webhook normalizer", () => {
     );
 
     config.feishu!.encryptKey = "encrypt-key";
+    config.feishu!.webhook.publicUrl = "https://hooks.example.test/feishu/webhook";
     expect(
       () => new FeishuProviderAdapter("feishu", config, "crabline", { env: {} }),
     ).not.toThrow();

--- a/test/local-mock-provider.test.ts
+++ b/test/local-mock-provider.test.ts
@@ -224,7 +224,7 @@ describe("local mock provider", () => {
     providers.push(provider);
     const probe = provider.probe(createContext(config));
     await vi.waitFor(() => expect(webhookMocks.startWebhookServer).toHaveBeenCalledTimes(1));
-    provider.beginCleanup();
+    (provider as ProviderAdapter).beginCleanup?.();
     const cleanup = provider.cleanup();
 
     resolveStart?.({

--- a/test/local-mock-provider.test.ts
+++ b/test/local-mock-provider.test.ts
@@ -224,6 +224,7 @@ describe("local mock provider", () => {
     providers.push(provider);
     const probe = provider.probe(createContext(config));
     await vi.waitFor(() => expect(webhookMocks.startWebhookServer).toHaveBeenCalledTimes(1));
+    provider.beginCleanup();
     const cleanup = provider.cleanup();
 
     resolveStart?.({
@@ -1046,7 +1047,7 @@ describe("local mock provider", () => {
     await expect(provider.waitForInbound(contexts.at(-1)!)).resolves.toBeNull();
   });
 
-  it("does not evict active wait cursors when concurrency exceeds the retained limit", async () => {
+  it("prunes an overflow wait cursor as soon as it becomes inactive", async () => {
     const directory = await createTempDir();
     directories.push(directory);
     const recorderPath = path.join(directory, "active-waits.jsonl");
@@ -1074,31 +1075,31 @@ describe("local mock provider", () => {
         timeoutMs: 1_000,
       };
     });
-    const waits = contexts.map((context) => provider.waitForInbound(context));
+    const controllers = contexts.map(() => new AbortController());
+    const waits = contexts.map((context, index) =>
+      provider.waitForInbound({ ...context, signal: controllers[index]!.signal }),
+    );
     await new Promise((resolve) => setTimeout(resolve, 50));
-    for (const [index, context] of contexts.entries()) {
-      await appendRecordedInbound(recorderPath, {
-        author: "assistant",
-        id: `first-${index}`,
-        provider: "provider-a",
-        sentAt: new Date().toISOString(),
-        text: `first ${index}`,
-        threadId: context.threadId,
-      });
-    }
-    await expect(Promise.all(waits)).resolves.toHaveLength(65);
-
     await appendRecordedInbound(recorderPath, {
       author: "assistant",
-      id: "second-0",
+      id: "first-0",
       provider: "provider-a",
       sentAt: new Date().toISOString(),
-      text: "second 0",
+      text: "first 0",
       threadId: contexts[0]!.threadId,
     });
+    await expect(waits[0]).resolves.toMatchObject({ id: "first-0" });
+
     await expect(provider.waitForInbound(contexts[0]!)).resolves.toMatchObject({
-      id: "second-0",
+      id: "first-0",
     });
+
+    for (const controller of controllers.slice(1)) {
+      controller.abort();
+    }
+    await expect(Promise.all(waits.slice(1))).resolves.toEqual(
+      Array.from({ length: 64 }, () => null),
+    );
   });
 
   it("keeps concurrent same-key waits on independent cursors", async () => {

--- a/test/registry-lifecycle.test.ts
+++ b/test/registry-lifecycle.test.ts
@@ -442,10 +442,12 @@ describe("lazy provider lifecycle", () => {
         context.fixture.id,
       );
       const probing = provider.probe(context);
+      provider.beginCleanup?.();
       const cleanup = provider.cleanup?.();
 
       await Promise.resolve();
       expect(events).toEqual([]);
+      await expect(provider.probe(context)).rejects.toThrow(/has been cleaned up/u);
 
       releaseImport?.();
       await expect(probing).resolves.toEqual({ details: [], healthy: true });
@@ -458,6 +460,48 @@ describe("lazy provider lifecycle", () => {
       telegramLifecycle.onProbe = undefined;
       await disposeTempDir(directory);
     }
+  });
+
+  it("deduplicates concurrent cleanup after the synchronous fence", async () => {
+    const beginCleanup = vi.fn();
+    const cleanup = vi.fn(async () => undefined);
+    const concrete: ProviderAdapter = {
+      id: "test",
+      platform: "loopback",
+      status: "ready",
+      supports: ["probe"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      async probe() {
+        return { details: [], healthy: true };
+      },
+      async send() {
+        return { accepted: true, messageId: "sent", threadId: "thread" };
+      },
+      async waitForInbound() {
+        return null;
+      },
+      beginCleanup,
+      cleanup,
+    };
+    const provider = new LazyProviderAdapter({
+      adapterName: "test",
+      factory: async () => concrete,
+      id: "test",
+      normalizeTarget: concrete.normalizeTarget.bind(concrete),
+      platform: "loopback",
+      status: "ready",
+      supports: ["probe"],
+    });
+    const { context } = createTelegramManifest("/tmp/unused.jsonl");
+    await provider.probe(context);
+
+    provider.beginCleanup();
+    await Promise.all([provider.cleanup(), provider.cleanup()]);
+
+    expect(beginCleanup).toHaveBeenCalledOnce();
+    expect(cleanup).toHaveBeenCalledOnce();
   });
 
   it("drains an operation admitted before provider materialization", async () => {

--- a/test/signed-jwt.test.ts
+++ b/test/signed-jwt.test.ts
@@ -97,6 +97,35 @@ describe("signed JWT remote key cache", () => {
         now,
       ),
     ).toBe(now);
+    expect(
+      resolveHttpCacheExpiry(
+        new Response(null, {
+          headers: { age: "172800", "cache-control": "public, max-age=604800" },
+        }),
+        now,
+      ),
+    ).toBe(now + 86_400_000);
+  });
+
+  it("clamps absurd cache lifetimes and rejects unsafe max-age values", () => {
+    const now = 1_700_000_000_000;
+
+    expect(
+      resolveHttpCacheExpiry(
+        new Response(null, {
+          headers: { "cache-control": "public, max-age=999999" },
+        }),
+        now,
+      ),
+    ).toBe(now + 86_400_000);
+    expect(
+      resolveHttpCacheExpiry(
+        new Response(null, {
+          headers: { "cache-control": `public, max-age=${"9".repeat(400)}` },
+        }),
+        now,
+      ),
+    ).toBe(now);
   });
 
   it("distinguishes absent Expires from invalid or stale values", () => {
@@ -112,6 +141,19 @@ describe("signed JWT remote key cache", () => {
         now,
       ),
     ).toBe(now);
+  });
+
+  it("clamps far-future Expires cache lifetimes", () => {
+    const now = 1_700_000_000_000;
+
+    expect(
+      resolveHttpCacheExpiry(
+        new Response(null, {
+          headers: { expires: new Date(now + 7 * 24 * 60 * 60 * 1_000).toUTCString() },
+        }),
+        now,
+      ),
+    ).toBe(now + 86_400_000);
   });
 
   it("single-flights unknown-key refreshes and applies a global cooldown", async () => {
@@ -145,6 +187,32 @@ describe("signed JWT remote key cache", () => {
     now += 10_001;
     await expect(resolveKey({ alg: "RS256", kid: "missing-c" })).rejects.toThrow("unknown key");
     expect(fetches).toBe(3);
+  });
+
+  it("starts the unknown-key cooldown after refresh completion", async () => {
+    let now = 1_700_000_000_000;
+    let fetches = 0;
+    const resolveKey = createCachedJwtKeyResolver<string>({
+      async fetchKeys() {
+        fetches += 1;
+        if (fetches === 2) {
+          now += 20_000;
+        }
+        return {
+          expiresAt: now + 60_000,
+          values: ["known"],
+        };
+      },
+      keyId: (value) => value,
+      now: () => now,
+      refreshCooldownMs: 10_000,
+      unknownKeyMessage: "unknown key",
+    });
+
+    await expect(resolveKey({ alg: "RS256", kid: "known" })).resolves.toBe("known");
+    await expect(resolveKey({ alg: "RS256", kid: "missing-a" })).rejects.toThrow("unknown key");
+    await expect(resolveKey({ alg: "RS256", kid: "missing-b" })).rejects.toThrow("unknown key");
+    expect(fetches).toBe(2);
   });
 
   it("refetches cache-control no-store key sets for each verification", async () => {
@@ -206,6 +274,37 @@ describe("signed JWT remote key cache", () => {
     now += 10_001;
     await expect(resolveKey({ alg: "RS256", kid: "missing" })).rejects.toBe(fetchError);
     expect(fetches).toBe(2);
+  });
+
+  it("backs off failed unknown-key refreshes while a positive cache remains fresh", async () => {
+    let now = 1_700_000_000_000;
+    let fetches = 0;
+    const fetchError = new Error("JWKS unavailable");
+    const resolveKey = createCachedJwtKeyResolver<string>({
+      fetchKeys() {
+        fetches += 1;
+        if (fetches > 1) {
+          throw fetchError;
+        }
+        return Promise.resolve({
+          expiresAt: now + 60_000,
+          values: ["known"],
+        });
+      },
+      keyId: (value) => value,
+      now: () => now,
+      refreshCooldownMs: 10_000,
+      unknownKeyMessage: "unknown key",
+    });
+
+    await expect(resolveKey({ alg: "RS256", kid: "known" })).resolves.toBe("known");
+    await expect(resolveKey({ alg: "RS256", kid: "missing-a" })).rejects.toBe(fetchError);
+    await expect(resolveKey({ alg: "RS256", kid: "missing-b" })).rejects.toThrow("unknown key");
+    expect(fetches).toBe(2);
+
+    now += 10_001;
+    await expect(resolveKey({ alg: "RS256", kid: "missing-c" })).rejects.toBe(fetchError);
+    expect(fetches).toBe(3);
   });
 
   it("invalidates negative entries when a refreshed key set contains them", async () => {

--- a/test/webhook-server.test.ts
+++ b/test/webhook-server.test.ts
@@ -62,6 +62,17 @@ describe("webhook server", () => {
     expect(response.status).toBe(404);
   });
 
+  it("rejects configured paths changed by URL normalization", async () => {
+    await expect(
+      startWebhookServer({
+        handle: async () => new Response("ok"),
+        host: "127.0.0.1",
+        path: "/slack/../events",
+        port: 0,
+      }),
+    ).rejects.toThrow(/canonical URL pathname/u);
+  });
+
   it("can serve explicit GET webhook routes", async () => {
     const server = await startWebhookServer({
       async handle(request) {
@@ -114,6 +125,44 @@ describe("webhook server", () => {
     expect(observedErrors).toEqual([
       expect.objectContaining({ message: "sensitive internal detail" }),
     ]);
+  });
+
+  it("clears response headers before a fallback 500", async () => {
+    const observedErrors: unknown[] = [];
+    const server = await startWebhookServer({
+      async handle() {
+        return new Response(
+          new ReadableStream({
+            pull(controller) {
+              controller.error(new Error("response body failed"));
+            },
+          }),
+          {
+            headers: {
+              "content-encoding": "gzip",
+              "content-length": "999",
+              "content-type": "application/json",
+              "x-response-kind": "provider",
+            },
+          },
+        );
+      },
+      host: "127.0.0.1",
+      onError: (error) => observedErrors.push(error),
+      path: "/slack/events",
+      port: 0,
+    });
+    cleanups.push(() => server.close());
+
+    const response = await fetch(server.endpointUrl, { method: "POST" });
+
+    expect(response.status).toBe(500);
+    expect(response.headers.get("content-encoding")).toBeNull();
+    expect(response.headers.get("content-length")).not.toBe("999");
+    expect(response.headers.get("content-type")).toBe("text/plain;charset=UTF-8");
+    expect(response.headers.get("x-response-kind")).toBeNull();
+    await expect(response.text()).resolves.toBe("internal server error");
+    expect(observedErrors).toEqual([expect.objectContaining({ message: "response body failed" })]);
   });
 
   it("returns 413 for oversized request bodies without invoking the handler", async () => {


### PR DESCRIPTION
## Summary
- normalize webhook ingress paths and require TLS for external authenticated endpoints
- bound signed-JWT key refresh caching and cooldowns
- preserve cleanup admission fences across specialized provider adapters

## Validation
- `pnpm lint`
- `pnpm build`
- 181 targeted tests
- gpt-5.6-sol high autoreview: clean