### PR TITLE
fix(whatsapp): harden bridge and server lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Bound shared JSON ingress, reject non-object payloads precisely, and strictly normalize loopback IP addresses.
+- Harden WhatsApp send evidence, direct-JID correlation, cursor and cleanup races, and cleartext listener exposure.
 - Protect pnpm install-script policy and enforce immutable action pins across reusable workflows and composite actions.
 - Stop shipping a non-runnable OpenClaw script fixture and clarify source-checkout CLI invocation.
 - Bind npm and GitHub release mutations to the revalidated tag commit and fail closed on release lookup errors.

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -193,6 +193,8 @@ Server-backed channels currently include Mattermost, Matrix, Signal, Slack,
 Telegram, WhatsApp, and Zalo. Loopback binds retain stable local credentials for
 fixture compatibility. Non-loopback binds generate fresh provider-shaped
 credentials unless the corresponding token or secret option is supplied.
+WhatsApp is loopback-only because its HTTP and WebSocket endpoints carry bearer
+credentials over cleartext and the built-in server does not terminate TLS.
 
 Commands in this section use the installed-package form. In a source checkout,
 replace `crabline` with `pnpm dev`; `pnpm exec crabline` is not available.

--- a/src/openclaw/bridges/whatsapp.ts
+++ b/src/openclaw/bridges/whatsapp.ts
@@ -180,8 +180,8 @@ export const WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
         const isCloudTextSend =
           event.method === "POST" &&
           event.path === messagesPath &&
-          (messagingProduct === undefined || messagingProduct === "whatsapp") &&
-          (messageType === undefined || messageType === "text") &&
+          (!("messaging_product" in event.body) || messagingProduct === "whatsapp") &&
+          (!("type" in event.body) || messageType === "text") &&
           !("status" in event.body) &&
           !("message_id" in event.body);
         if (!isBaileysSend && !isCloudTextSend) {

--- a/src/openclaw/bridges/whatsapp.ts
+++ b/src/openclaw/bridges/whatsapp.ts
@@ -8,6 +8,7 @@ import {
   readString,
 } from "../shared.js";
 import {
+  canonicalizeWhatsAppChatCorrelationJid,
   canonicalizeWhatsAppChatJid,
   canonicalizeWhatsAppUserCorrelationJid,
   canonicalizeWhatsAppUserJid,
@@ -110,11 +111,12 @@ export const WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
         if (parsed.threadId !== undefined) {
           throw new Error("WhatsApp does not support thread targets.");
         }
-        const to = requireWhatsAppJid(parsed.id, "WhatsApp target");
-        requireWhatsAppTargetKind(parsed, to);
-        if (to.endsWith("@g.us")) {
+        const nativeTo = requireWhatsAppJid(parsed.id, "WhatsApp target");
+        requireWhatsAppTargetKind(parsed, nativeTo);
+        if (nativeTo.endsWith("@g.us")) {
           throw new Error("WhatsApp Crabline WebSocket outbound supports direct targets only.");
         }
+        const to = canonicalizeWhatsAppUserCorrelationJid(nativeTo)!;
         return {
           channel: "whatsapp",
           to,
@@ -126,9 +128,11 @@ export const WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
         if (input.threadId !== undefined) {
           throw new Error("WhatsApp does not support thread targets.");
         }
-        const chatJid = requireWhatsAppJid(input.conversation.id, "WhatsApp conversation");
-        requireWhatsAppConversationKind(input.conversation.kind, chatJid);
-        const senderJid = requireWhatsAppJid(input.senderId, "WhatsApp sender", true);
+        const nativeChatJid = requireWhatsAppJid(input.conversation.id, "WhatsApp conversation");
+        requireWhatsAppConversationKind(input.conversation.kind, nativeChatJid);
+        const nativeSenderJid = requireWhatsAppJid(input.senderId, "WhatsApp sender", true);
+        const chatJid = canonicalizeWhatsAppChatCorrelationJid(nativeChatJid)!;
+        const senderJid = canonicalizeWhatsAppUserCorrelationJid(nativeSenderJid)!;
         if (
           input.conversation.kind === "direct" &&
           canonicalizeWhatsAppUserCorrelationJid(chatJid) !==
@@ -172,7 +176,14 @@ export const WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
         const baileysKey = isRecord(event.body.key) ? event.body.key : undefined;
         const baileysMessage = isRecord(event.body.message) ? event.body.message : undefined;
         const isBaileysSend = event.method === "WEBSOCKET" && event.path === "/ws/chat";
-        if (!isBaileysSend && event.path !== messagesPath) {
+        const isCloudTextSend =
+          event.method === "POST" &&
+          event.path === messagesPath &&
+          readString(event.body.messaging_product) === "whatsapp" &&
+          readString(event.body.type) === "text" &&
+          !("status" in event.body) &&
+          !("message_id" in event.body);
+        if (!isBaileysSend && !isCloudTextSend) {
           return null;
         }
         const to = isBaileysSend ? readString(baileysKey?.remoteJid) : readString(event.body.to);

--- a/src/openclaw/bridges/whatsapp.ts
+++ b/src/openclaw/bridges/whatsapp.ts
@@ -131,12 +131,11 @@ export const WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
         const nativeChatJid = requireWhatsAppJid(input.conversation.id, "WhatsApp conversation");
         requireWhatsAppConversationKind(input.conversation.kind, nativeChatJid);
         const nativeSenderJid = requireWhatsAppJid(input.senderId, "WhatsApp sender", true);
-        const chatJid = canonicalizeWhatsAppChatCorrelationJid(nativeChatJid)!;
-        const senderJid = canonicalizeWhatsAppUserCorrelationJid(nativeSenderJid)!;
+        const providerTargetKey = canonicalizeWhatsAppChatCorrelationJid(nativeChatJid)!;
         if (
           input.conversation.kind === "direct" &&
-          canonicalizeWhatsAppUserCorrelationJid(chatJid) !==
-            canonicalizeWhatsAppUserCorrelationJid(senderJid)
+          canonicalizeWhatsAppUserCorrelationJid(nativeChatJid) !==
+            canonicalizeWhatsAppUserCorrelationJid(nativeSenderJid)
         ) {
           throw new Error(
             "WhatsApp direct conversation and sender must identify the same recipient.",
@@ -145,19 +144,19 @@ export const WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
         return {
           ...createAdminInboundRequest(whatsapp),
           providerBody: {
-            chatJid,
-            senderJid,
+            chatJid: nativeChatJid,
+            senderJid: nativeSenderJid,
             ...(input.senderName ? { pushName: input.senderName } : {}),
             text: input.text,
           },
-          providerTargetKey: chatJid,
+          providerTargetKey,
           qaTarget: qaTargetForInbound({
             ...input,
-            conversation: { ...input.conversation, id: chatJid },
+            conversation: { ...input.conversation, id: providerTargetKey },
           }),
           stateConversation: {
-            id: chatJid,
-            kind: chatJid.endsWith("@g.us") ? "group" : "direct",
+            id: nativeChatJid,
+            kind: nativeChatJid.endsWith("@g.us") ? "group" : "direct",
           },
         };
       },
@@ -176,11 +175,13 @@ export const WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
         const baileysKey = isRecord(event.body.key) ? event.body.key : undefined;
         const baileysMessage = isRecord(event.body.message) ? event.body.message : undefined;
         const isBaileysSend = event.method === "WEBSOCKET" && event.path === "/ws/chat";
+        const messagingProduct = readString(event.body.messaging_product);
+        const messageType = readString(event.body.type);
         const isCloudTextSend =
           event.method === "POST" &&
           event.path === messagesPath &&
-          readString(event.body.messaging_product) === "whatsapp" &&
-          readString(event.body.type) === "text" &&
+          (messagingProduct === undefined || messagingProduct === "whatsapp") &&
+          (messageType === undefined || messageType === "text") &&
           !("status" in event.body) &&
           !("message_id" in event.body);
         if (!isBaileysSend && !isCloudTextSend) {

--- a/src/providers/builtin/whatsapp.ts
+++ b/src/providers/builtin/whatsapp.ts
@@ -193,6 +193,13 @@ function pruneInactiveWaitCursors(cursors: Map<string, WaitCursorState>): void {
   }
 }
 
+function pruneSettledWaitCursors(cursors: Map<string, WaitCursorState>): void {
+  if ([...cursors.values()].some((state) => state.active > 0)) {
+    return;
+  }
+  pruneInactiveWaitCursors(cursors);
+}
+
 export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   readonly #config: ProviderConfig;
   readonly #lifecycleAbort = new AbortController();
@@ -277,7 +284,17 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
     if (context.signal?.aborted) {
       return null;
     }
-    await this.#ensureWebhookServer();
+    try {
+      await this.#ensureWebhookServer();
+    } catch (error) {
+      if (this.#cleanupBegun) {
+        return null;
+      }
+      throw error;
+    }
+    if (this.#cleanupBegun) {
+      return null;
+    }
     const target = this.normalizeTarget(context.fixture.target);
     const channelId = context.threadId ?? target.threadId ?? target.channelId ?? target.id;
     const cursorKey = JSON.stringify([
@@ -323,6 +340,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
       ) {
         this.#waitCursors.delete(cursorKey);
       }
+      pruneSettledWaitCursors(this.#waitCursors);
     }
   }
 
@@ -330,7 +348,17 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
     if (context.signal?.aborted) {
       return;
     }
-    await this.#ensureWebhookServer();
+    try {
+      await this.#ensureWebhookServer();
+    } catch (error) {
+      if (this.#cleanupBegun) {
+        return;
+      }
+      throw error;
+    }
+    if (this.#cleanupBegun) {
+      return;
+    }
     const target = this.normalizeTarget(context.fixture.target);
     for await (const event of watchRecordedInbound({
       filePath: this.#recorderPath,

--- a/src/servers/whatsapp-jid.ts
+++ b/src/servers/whatsapp-jid.ts
@@ -31,6 +31,10 @@ export function canonicalizeWhatsAppChatJid(value: string): string | undefined {
   return canonicalizeWhatsAppUserJid(value) ?? canonicalizeWhatsAppGroupJid(value);
 }
 
+export function canonicalizeWhatsAppChatCorrelationJid(value: string): string | undefined {
+  return canonicalizeWhatsAppUserCorrelationJid(value) ?? canonicalizeWhatsAppGroupJid(value);
+}
+
 export function isWhatsAppGroupJid(value: string): boolean {
   return canonicalizeWhatsAppGroupJid(value) !== undefined;
 }

--- a/src/servers/whatsapp.ts
+++ b/src/servers/whatsapp.ts
@@ -546,6 +546,11 @@ export async function startWhatsAppServer(
   params: StartWhatsAppServerParams = {},
 ): Promise<StartedWhatsAppServer> {
   const host = params.host ?? "127.0.0.1";
+  if (!isLoopbackHost(host)) {
+    throw new Error(
+      "WhatsApp server requires a loopback host because its HTTP and WebSocket endpoints carry credentials over cleartext.",
+    );
+  }
   if (
     params.accessToken !== undefined &&
     (!params.accessToken.trim() || params.accessToken !== params.accessToken.trim())

--- a/test/server-credentials.test.ts
+++ b/test/server-credentials.test.ts
@@ -42,15 +42,15 @@ describe("externally bound provider server credentials", () => {
     expect(first.telegram.manifest.env.TELEGRAM_BOT_TOKEN).toBe(first.telegram.manifest.botToken);
     expect(second.telegram.manifest.botToken).not.toBe(first.telegram.manifest.botToken);
 
-    expect(first.whatsapp.manifest.accessToken).toMatch(/^EAA[A-Za-z0-9_-]{32}$/u);
-    expect(first.whatsapp.manifest.env.CLOUD_API_ACCESS_TOKEN).toBe(
-      first.whatsapp.manifest.accessToken,
-    );
-    expect(second.whatsapp.manifest.accessToken).not.toBe(first.whatsapp.manifest.accessToken);
-
     expect(first.zalo.manifest.botToken).toMatch(/^[A-Za-z0-9_-]{43}$/u);
     expect(first.zalo.manifest.env.ZALO_BOT_TOKEN).toBe(first.zalo.manifest.botToken);
     expect(second.zalo.manifest.botToken).not.toBe(first.zalo.manifest.botToken);
+  });
+
+  it("rejects cleartext WhatsApp listeners on non-loopback hosts", async () => {
+    await expect(startWhatsAppServer({ host: "0.0.0.0" })).rejects.toThrow(
+      /requires a loopback host/u,
+    );
   });
 });
 
@@ -59,8 +59,7 @@ async function startServers() {
   const matrix = await startMatrixServer({ host: "0.0.0.0" });
   const slack = await startSlackServer({ host: "0.0.0.0" });
   const telegram = await startTelegramServer({ host: "0.0.0.0" });
-  const whatsapp = await startWhatsAppServer({ host: "0.0.0.0" });
   const zalo = await startZaloServer({ host: "0.0.0.0" });
-  servers.push(mattermost, matrix, slack, telegram, whatsapp, zalo);
-  return { mattermost, matrix, slack, telegram, whatsapp, zalo };
+  servers.push(mattermost, matrix, slack, telegram, zalo);
+  return { mattermost, matrix, slack, telegram, zalo };
 }

--- a/test/whatsapp-bridge.test.ts
+++ b/test/whatsapp-bridge.test.ts
@@ -72,6 +72,11 @@ describe("WhatsApp OpenClaw bridge", () => {
           body: { ...body, message_id: "wamid.status", status: "read" },
           method: "POST",
         },
+        {
+          ...base,
+          body: { ...body, messaging_product: null, type: 1 },
+          method: "POST",
+        },
         { ...base, body, method: "GET" },
         { ...base, body: { ...body, type: "image" }, method: "POST" },
       ]) {

--- a/test/whatsapp-bridge.test.ts
+++ b/test/whatsapp-bridge.test.ts
@@ -21,11 +21,15 @@ describe("WhatsApp OpenClaw bridge", () => {
       });
       expect(inbound).toMatchObject({
         providerBody: {
-          chatJid: "15551234567@s.whatsapp.net",
-          senderJid: "15551234567@s.whatsapp.net",
+          chatJid: "15551234567:2@s.whatsapp.net",
+          senderJid: "15551234567:7@s.whatsapp.net",
         },
         providerTargetKey: "15551234567@s.whatsapp.net",
         qaTarget: "dm:15551234567@s.whatsapp.net",
+        stateConversation: {
+          id: "15551234567:2@s.whatsapp.net",
+          kind: "direct",
+        },
       });
     } finally {
       await adapter.close();
@@ -54,7 +58,11 @@ describe("WhatsApp OpenClaw bridge", () => {
 
       expect(
         adapter.createOutboundFromRecorderEvent({
-          event: { ...base, body, method: "POST" },
+          event: {
+            ...base,
+            body: { text: body.text, to: body.to },
+            method: "POST",
+          },
           targetByProviderTarget,
         }),
       ).toMatchObject({ text: "hello", to: "dm:alice" });

--- a/test/whatsapp-bridge.test.ts
+++ b/test/whatsapp-bridge.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { startOpenClawCrablineAdapter } from "../src/index.js";
+
+describe("WhatsApp OpenClaw bridge", () => {
+  it("canonicalizes direct device JIDs across inbound and outbound mapping", async () => {
+    const adapter = await startOpenClawCrablineAdapter({ channel: "whatsapp" });
+    try {
+      expect(
+        adapter.createAgentDelivery({ target: "dm:15551234567:2@s.whatsapp.net" }),
+      ).toMatchObject({
+        replyTo: "15551234567@s.whatsapp.net",
+        to: "15551234567@s.whatsapp.net",
+      });
+
+      const inbound = adapter.createInbound({
+        input: {
+          conversation: { id: "15551234567:2@s.whatsapp.net", kind: "direct" },
+          senderId: "15551234567:7@s.whatsapp.net",
+          text: "device round trip",
+        },
+      });
+      expect(inbound).toMatchObject({
+        providerBody: {
+          chatJid: "15551234567@s.whatsapp.net",
+          senderJid: "15551234567@s.whatsapp.net",
+        },
+        providerTargetKey: "15551234567@s.whatsapp.net",
+        qaTarget: "dm:15551234567@s.whatsapp.net",
+      });
+    } finally {
+      await adapter.close();
+    }
+  });
+
+  it("normalizes only accepted exact-shape sends as outbound evidence", async () => {
+    const adapter = await startOpenClawCrablineAdapter({ channel: "whatsapp" });
+    try {
+      if (adapter.manifest.provider !== "whatsapp") {
+        throw new Error("Expected WhatsApp manifest.");
+      }
+      const path = new URL(adapter.manifest.endpoints.messagesUrl).pathname;
+      const targetByProviderTarget = new Map([["15551234567@s.whatsapp.net", "dm:alice"]]);
+      const base = {
+        accepted: true,
+        path,
+        type: "api",
+      };
+      const body = {
+        messaging_product: "whatsapp",
+        text: { body: "hello" },
+        to: "15551234567",
+        type: "text",
+      };
+
+      expect(
+        adapter.createOutboundFromRecorderEvent({
+          event: { ...base, body, method: "POST" },
+          targetByProviderTarget,
+        }),
+      ).toMatchObject({ text: "hello", to: "dm:alice" });
+      for (const event of [
+        {
+          ...base,
+          body: { ...body, message_id: "wamid.status", status: "read" },
+          method: "POST",
+        },
+        { ...base, body, method: "GET" },
+        { ...base, body: { ...body, type: "image" }, method: "POST" },
+      ]) {
+        expect(
+          adapter.createOutboundFromRecorderEvent({ event, targetByProviderTarget }),
+        ).toBeNull();
+      }
+    } finally {
+      await adapter.close();
+    }
+  });
+});

--- a/test/whatsapp-provider-cursor.test.ts
+++ b/test/whatsapp-provider-cursor.test.ts
@@ -250,6 +250,35 @@ describe("WhatsApp provider recorder cursors", () => {
     await Promise.all(waits.slice(1));
   });
 
+  it("prunes inactive cursor entries after a concurrent burst settles", async () => {
+    const config = await createLocalMockConfig("whatsapp", "/whatsapp/webhook");
+    const provider = new WhatsAppProviderAdapter("whatsapp", config, "crabline");
+    providers.push(provider);
+    const baseContext = createProviderContext("whatsapp", config, {
+      id: "15551234567",
+      metadata: {},
+    });
+    const startingOffsets: number[] = [];
+    recorderMocks.waitForRecordedInbound.mockImplementation(async ({ cursor }) => {
+      startingOffsets.push(cursor!.readState.offset);
+      cursor!.readState.offset = 1;
+      return null;
+    });
+    const contexts = Array.from({ length: 65 }, (_, index) => ({
+      ...baseContext,
+      nonce: `settled-cursor-${index}`,
+      since: new Date(0).toISOString(),
+      threadId: "15551234567",
+      timeoutMs: 100,
+    }));
+
+    await Promise.all(contexts.map((context) => provider.waitForInbound(context)));
+    await provider.waitForInbound(contexts[0]!);
+
+    expect(startingOffsets).toHaveLength(66);
+    expect(startingOffsets.at(-1)).toBe(0);
+  });
+
   it("retains recorder progress after a timeout", async () => {
     const config = await createLocalMockConfig("whatsapp", "/whatsapp/webhook");
     const provider = new WhatsAppProviderAdapter("whatsapp", config, "crabline");

--- a/test/whatsapp-provider-lifecycle.test.ts
+++ b/test/whatsapp-provider-lifecycle.test.ts
@@ -220,6 +220,42 @@ describe("WhatsApp provider lifecycle", () => {
     expect(webhookMocks.startWebhookServer).toHaveBeenCalledTimes(1);
   });
 
+  it("cancels waits and watches when cleanup wins deferred startup", async () => {
+    let resolveStart:
+      | ((server: { close(): Promise<void>; endpointUrl: string }) => void)
+      | undefined;
+    const close = vi.fn(async () => undefined);
+    webhookMocks.startWebhookServer.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveStart = resolve;
+      }),
+    );
+    const config = createConfig();
+    const provider = new WhatsAppProviderAdapter("whatsapp", config, "crabline");
+    const context = createContext(config);
+    const waiting = provider.waitForInbound({
+      ...context,
+      nonce: "deferred-cleanup",
+      since: new Date(0).toISOString(),
+      timeoutMs: 30_000,
+    });
+    const stream = provider.watch({ ...context, since: new Date(0).toISOString() });
+    const watching = stream[Symbol.asyncIterator]();
+    const next = watching.next();
+    await vi.waitFor(() => expect(webhookMocks.startWebhookServer).toHaveBeenCalledTimes(1));
+
+    const cleanup = provider.cleanup();
+    resolveStart?.({
+      close,
+      endpointUrl: "http://127.0.0.1:43210/whatsapp/webhook",
+    });
+
+    await expect(waiting).resolves.toBeNull();
+    await expect(next).resolves.toEqual({ done: true, value: undefined });
+    await cleanup;
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
   it("rechecks cleanup after awaiting an existing listener", async () => {
     const close = vi.fn(async () => undefined);
     webhookMocks.startWebhookServer.mockResolvedValueOnce({


### PR DESCRIPTION
## Summary

- canonicalize device-qualified direct JIDs and require provider-native send evidence
- prune settled wait cursors and make deferred startup cleanup-aware
- restrict cleartext WhatsApp HTTP/WebSocket listeners to loopback
- document the loopback-only server requirement and add regression coverage

## Validation

- `pnpm exec vitest run test/whatsapp-bridge.test.ts test/whatsapp-provider-cursor.test.ts test/whatsapp-provider-lifecycle.test.ts test/server-credentials.test.ts`
- `pnpm lint`
- `git diff --check origin/main...HEAD`
- autoreview: clean, confidence 0.86 (`gpt-5.6-sol`, high)
- privacy scan: clean