### PR TITLE
fix(http): harden JSON ingress and loopback parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Bound shared JSON ingress, reject non-object payloads precisely, and strictly normalize loopback IP addresses.
 - Protect pnpm install-script policy and enforce immutable action pins across reusable workflows and composite actions.
 - Stop shipping a non-runnable OpenClaw script fixture and clarify source-checkout CLI invocation.
 - Bind npm and GitHub release mutations to the revalidated tag commit and fail closed on release lookup errors.

--- a/src/servers/http.ts
+++ b/src/servers/http.ts
@@ -1,5 +1,6 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { timingSafeEqual } from "node:crypto";
+import { BlockList, isIP } from "node:net";
 import { CrablineError } from "../core/errors.js";
 
 export type ServerRequestEvent = {
@@ -22,10 +23,14 @@ export type HttpJsonHandlerResult =
 export const ADMIN_TOKEN_HEADER = "x-crabline-admin-token";
 export const DEFAULT_MAX_REQUEST_BODY_BYTES = 1024 * 1024;
 export const DEFAULT_SERVER_SHUTDOWN_GRACE_MS = 250;
+const LOOPBACK_ADDRESSES = new BlockList();
+LOOPBACK_ADDRESSES.addSubnet("127.0.0.0", 8, "ipv4");
+LOOPBACK_ADDRESSES.addAddress("::1", "ipv6");
+LOOPBACK_ADDRESSES.addSubnet("::ffff:127.0.0.0", 104, "ipv6");
 
 export class InvalidJsonBodyError extends Error {
-  constructor(cause: unknown) {
-    super("Request body is not valid JSON.", { cause });
+  constructor(cause: unknown, message = "Request body is not valid JSON.") {
+    super(message, { cause });
     this.name = "InvalidJsonBodyError";
   }
 }
@@ -153,10 +158,11 @@ export function isJsonMediaType(value: string): boolean {
 }
 
 export async function parseRequestBody(request: IncomingMessage): Promise<Record<string, unknown>> {
-  return (await parseUnknownRequestBody(request, Number.MAX_SAFE_INTEGER)) as Record<
-    string,
-    unknown
-  >;
+  const body = await parseUnknownRequestBody(request);
+  if (!isJsonObject(body)) {
+    throw new InvalidJsonBodyError(undefined, "Request body must be a JSON object.");
+  }
+  return body;
 }
 
 export function isJsonObject(value: unknown): value is Record<string, unknown> {
@@ -175,14 +181,17 @@ export function isLoopbackHost(host: string): boolean {
   const normalized = host
     .trim()
     .replace(/^\[(.*)\]$/u, "$1")
-    .toLowerCase();
-  return (
-    normalized === "localhost" ||
-    normalized.endsWith(".localhost") ||
-    normalized === "::1" ||
-    normalized.startsWith("::ffff:127.") ||
-    /^127(?:\.\d{1,3}){3}$/u.test(normalized)
-  );
+    .toLowerCase()
+    .replace(/\.$/u, "");
+  if (normalized === "localhost" || normalized.endsWith(".localhost")) {
+    return true;
+  }
+  const family = isIP(normalized);
+  return family === 4
+    ? LOOPBACK_ADDRESSES.check(normalized, "ipv4")
+    : family === 6
+      ? LOOPBACK_ADDRESSES.check(normalized, "ipv6")
+      : false;
 }
 
 export async function writeResponse(

--- a/test/http-server.test.ts
+++ b/test/http-server.test.ts
@@ -2,7 +2,11 @@ import { get, type IncomingMessage } from "node:http";
 import { PassThrough } from "node:stream";
 import { describe, expect, it } from "vitest";
 import {
+  DEFAULT_MAX_REQUEST_BODY_BYTES,
   drainRequestBody,
+  InvalidJsonBodyError,
+  isLoopbackHost,
+  parseRequestBody,
   parseUnknownRequestBody,
   readBody,
   readInteger,
@@ -77,6 +81,53 @@ describe("server HTTP body reader", () => {
     const arbitraryParsed = parseUnknownRequestBody(arbitrary);
     arbitrary.end("value=%7B%22ok%22%3Atrue%7D");
     await expect(arbitraryParsed).resolves.toEqual({ value: '{"ok":true}' });
+  });
+
+  it("enforces the default request limit for JSON object parsing", async () => {
+    const declared = createRequest({
+      "content-length": String(DEFAULT_MAX_REQUEST_BODY_BYTES + 1),
+      "content-type": "application/json",
+    });
+    const declaredParsed = parseRequestBody(declared);
+    await expect(declaredParsed).rejects.toBeInstanceOf(RequestBodyTooLargeError);
+    declared.end();
+
+    const streamed = createRequest({ "content-type": "application/json" });
+    const streamedParsed = parseRequestBody(streamed);
+    streamed.end(Buffer.alloc(DEFAULT_MAX_REQUEST_BODY_BYTES + 1, 0x20));
+    await expect(streamedParsed).rejects.toBeInstanceOf(RequestBodyTooLargeError);
+  });
+
+  it("classifies malformed and non-object JSON without conflating their messages", async () => {
+    const malformed = createRequest({ "content-type": "application/json" });
+    const malformedParsed = parseRequestBody(malformed);
+    malformed.end("{");
+    await expect(malformedParsed).rejects.toMatchObject({
+      message: "Request body is not valid JSON.",
+      name: "InvalidJsonBodyError",
+    });
+
+    for (const value of ["null", "[]", '"text"', "1", "true"]) {
+      const request = createRequest({ "content-type": "application/json" });
+      const parsed = parseRequestBody(request);
+      request.end(value);
+      await expect(parsed).rejects.toMatchObject({
+        message: "Request body must be a JSON object.",
+        name: "InvalidJsonBodyError",
+      });
+      await expect(parsed).rejects.toBeInstanceOf(InvalidJsonBodyError);
+    }
+  });
+
+  it.each([
+    ["127.999.1.1", false],
+    ["::ffff:127.999.1.1", false],
+    ["0:0:0:0:0:0:0:1", true],
+    ["[0:0:0:0:0:0:0:1]", true],
+    ["::ffff:127.0.0.1", true],
+    ["0:0:0:0:0:ffff:7f00:1", true],
+  ])("classifies loopback host %s strictly", (host, expected) => {
+    expect(isLoopbackHost(host)).toBe(expected);
   });
 
   it.each([


### PR DESCRIPTION
## Summary

- enforce the shared JSON request-size limit and distinguish non-object payloads
- parse loopback addresses strictly across IPv4, IPv6, and mapped IPv4 forms
- add regressions for malformed hosts and body-limit handling

## Validation

- `pnpm exec vitest run test/http-server.test.ts`
- format, typecheck, and targeted oxlint
- `git diff --check origin/main...HEAD`
- autoreview: clean, confidence 0.95 (`gpt-5.6-sol`, high)
- privacy scan: clean