### PR TITLE
fix(feishu): authenticate before decrypting callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Bound shared JSON ingress, reject non-object payloads precisely, and strictly normalize loopback IP addresses.
 - Harden WhatsApp send evidence, direct-JID correlation, cursor and cleanup races, and cleartext listener exposure.
 - Revalidate npm package version, integrity, and provenance after every release publication outcome.
+- Authenticate Feishu signatures before encrypted callback decryption and bound callback ciphertext work.
 - Protect pnpm install-script policy and enforce immutable action pins across reusable workflows and composite actions.
 - Stop shipping a non-runnable OpenClaw script fixture and clarify source-checkout CLI invocation.
 - Bind npm and GitHub release mutations to the revalidated tag commit and fail closed on release lookup errors.

--- a/src/providers/builtin/feishu.ts
+++ b/src/providers/builtin/feishu.ts
@@ -40,7 +40,11 @@ type FeishuReplayState = {
 };
 
 const FEISHU_MAX_CALLBACK_AGE_MS = 5 * 60_000;
+const FEISHU_MAX_ENCRYPTED_PAYLOAD_BYTES = 1024 * 1024;
+const FEISHU_MAX_ENCRYPTED_PAYLOAD_BASE64_LENGTH =
+  Math.ceil(FEISHU_MAX_ENCRYPTED_PAYLOAD_BYTES / 3) * 4;
 const FEISHU_REPLAY_CACHE_LIMIT = 2_048;
+const FEISHU_MAX_WEBHOOK_BODY_BYTES = 1024 * 1024;
 
 export function resolveFeishuAdapterConfig(
   config: ProviderConfig,
@@ -104,6 +108,18 @@ function createFeishuWebhookAuthenticatorWithReplay(
     return undefined;
   }
   return async (request: Request, rawBody: string): Promise<Response | undefined> => {
+    if (!isFeishuWebhookBodyWithinLimit(rawBody)) {
+      return unauthorizedFeishuWebhook();
+    }
+    const signaturePresent = request.headers.has("x-lark-signature");
+    let signedRequest = false;
+    if (signaturePresent) {
+      if (!resolved.encryptKey || !verifyFeishuSignature(request, rawBody, resolved.encryptKey)) {
+        return unauthorizedFeishuWebhook();
+      }
+      signedRequest = true;
+    }
+
     let payload: unknown;
     try {
       payload = JSON.parse(rawBody) as unknown;
@@ -116,7 +132,6 @@ function createFeishuWebhookAuthenticatorWithReplay(
     const encryptedEnvelope = payload;
 
     const encrypted = typeof payload.encrypt === "string";
-    let signedRequest = false;
     if (encrypted) {
       if (!resolved.encryptKey) {
         return unauthorizedFeishuWebhook();
@@ -126,7 +141,6 @@ function createFeishuWebhookAuthenticatorWithReplay(
       } catch {
         return unauthorizedFeishuWebhook();
       }
-      signedRequest = verifyFeishuSignature(request, rawBody, resolved.encryptKey);
       if (!signedRequest && !(isFeishuUrlVerification(payload) && validateCallback)) {
         return unauthorizedFeishuWebhook();
       }
@@ -324,7 +338,13 @@ export function decryptFeishuWebhookPayload(payload: unknown, encryptKey: string
   if (!isRecord(payload) || typeof payload.encrypt !== "string") {
     return payload;
   }
+  if (payload.encrypt.length > FEISHU_MAX_ENCRYPTED_PAYLOAD_BASE64_LENGTH) {
+    throw new Error("Feishu encrypted payload is too large.");
+  }
   const encrypted = Buffer.from(payload.encrypt, "base64");
+  if (encrypted.length > FEISHU_MAX_ENCRYPTED_PAYLOAD_BYTES) {
+    throw new Error("Feishu encrypted payload is too large.");
+  }
   if (encrypted.length <= 16 || (encrypted.length - 16) % 16 !== 0) {
     throw new Error("Feishu encrypted payload is truncated.");
   }
@@ -356,6 +376,13 @@ function isFeishuUrlVerification(payload: unknown): boolean {
   );
 }
 
+function isFeishuWebhookBodyWithinLimit(rawBody: string): boolean {
+  return (
+    rawBody.length <= FEISHU_MAX_WEBHOOK_BODY_BYTES &&
+    Buffer.byteLength(rawBody, "utf8") <= FEISHU_MAX_WEBHOOK_BODY_BYTES
+  );
+}
+
 function verifyFeishuSignature(request: Request, rawBody: string, encryptKey: string): boolean {
   const timestamp = request.headers.get("x-lark-request-timestamp");
   const nonce = request.headers.get("x-lark-request-nonce");
@@ -364,7 +391,10 @@ function verifyFeishuSignature(request: Request, rawBody: string, encryptKey: st
     return false;
   }
   const expected = createHash("sha256")
-    .update(timestamp + nonce + encryptKey + rawBody)
+    .update(timestamp)
+    .update(nonce)
+    .update(encryptKey)
+    .update(rawBody)
     .digest();
   return timingSafeEqual(expected, Buffer.from(signature, "hex"));
 }

--- a/test/feishu-provider.test.ts
+++ b/test/feishu-provider.test.ts
@@ -1,6 +1,6 @@
 import { createCipheriv, createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   createFeishuWebhookAuthenticator,
   decryptFeishuWebhookPayload,
@@ -155,7 +155,13 @@ describe("Feishu webhook normalizer", () => {
     ).toThrow(/truncated/u);
   });
 
-  it("accepts token-authenticated encrypted URL verification without signature headers", async () => {
+  it("rejects encrypted payloads that exceed the ciphertext limit", () => {
+    expect(() =>
+      decryptFeishuWebhookPayload({ encrypt: "A".repeat(2 * 1024 * 1024) }, "encrypt-key"),
+    ).toThrow(/too large/u);
+  });
+
+  it("accepts token-authenticated encrypted URL verification with absent or valid signatures", async () => {
     const config = await createLocalMockConfig("feishu", "/feishu/webhook");
     const encryptKey = "encrypt-key";
     config.feishu!.encryptKey = encryptKey;
@@ -293,6 +299,61 @@ describe("Feishu webhook normalizer", () => {
         }),
       ),
     ).resolves.toMatchObject({ status: 401 });
+  });
+
+  it("rejects a present invalid signature before decrypting an encrypted challenge", async () => {
+    const config = await createLocalMockConfig("feishu", "/feishu/webhook");
+    const encryptKey = "encrypt-key";
+    config.feishu!.encryptKey = encryptKey;
+    config.feishu!.verificationToken = "sample";
+    const authenticate = createFeishuWebhookAuthenticator(config, {});
+    const encryptedPayload = {
+      encrypt: encryptFeishuPayload(
+        {
+          challenge: "challenge-token",
+          token: "sample",
+          type: "url_verification",
+        },
+        encryptKey,
+      ),
+    };
+    const rawBody = JSON.stringify(encryptedPayload);
+    const bufferFrom = vi.spyOn(Buffer, "from");
+
+    try {
+      await expect(
+        authenticate!(
+          new Request("https://feishu.example.test/webhook", {
+            headers: {
+              "x-lark-request-nonce": "challenge-nonce",
+              "x-lark-request-timestamp": "1700000000",
+              "x-lark-signature": "0".repeat(64),
+            },
+          }),
+          rawBody,
+        ),
+      ).resolves.toMatchObject({ status: 401 });
+      expect(bufferFrom).not.toHaveBeenCalledWith(encryptedPayload.encrypt, "base64");
+    } finally {
+      bufferFrom.mockRestore();
+    }
+  });
+
+  it("rejects oversized encrypted callback bodies before parsing them", async () => {
+    const config = await createLocalMockConfig("feishu", "/feishu/webhook");
+    config.feishu!.encryptKey = "encrypt-key";
+    const authenticate = createFeishuWebhookAuthenticator(config, {});
+    const rawBody = JSON.stringify({ encrypt: "A".repeat(1024 * 1024) });
+    const parse = vi.spyOn(JSON, "parse");
+
+    try {
+      await expect(
+        authenticate!(new Request("https://feishu.example.test/webhook"), rawBody),
+      ).resolves.toMatchObject({ status: 401 });
+      expect(parse).not.toHaveBeenCalled();
+    } finally {
+      parse.mockRestore();
+    }
   });
 
   it("rejects token-authenticated plaintext when encryption is configured", async () => {


### PR DESCRIPTION
## Summary

- reject any present invalid Feishu signature before challenge handling
- authenticate raw callback bodies before decrypting encrypted payloads
- bound raw, encoded, and decoded callback sizes

## Validation

- `pnpm exec vitest run test/feishu-provider.test.ts` (24 tests)
- format, typecheck, and targeted oxlint
- `git diff --check origin/main...HEAD`
- autoreview: clean, confidence 0.95 (`gpt-5.6-sol`, high)
- privacy scan: clean