### PR TITLE
fix(slack): align callback and failover behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Harden WhatsApp send evidence, direct-JID correlation, cursor and cleanup races, and cleartext listener exposure.
 - Revalidate npm package version, integrity, and provenance after every release publication outcome.
 - Authenticate Feishu signatures before encrypted callback decryption and bound callback ciphertext work.
+- Correct Slack edited-message identity and text fallback handling, acknowledge unsupported callbacks, and fairly budget Events API address failover.
 - Protect pnpm install-script policy and enforce immutable action pins across reusable workflows and composite actions.
 - Stop shipping a non-runnable OpenClaw script fixture and clarify source-checkout CLI invocation.
 - Bind npm and GitHub release mutations to the revalidated tag commit and fail closed on release lookup errors.

--- a/src/providers/builtin/slack.ts
+++ b/src/providers/builtin/slack.ts
@@ -81,6 +81,9 @@ function slackInlineText(value: unknown): string {
   if (typeof value.text === "string") {
     return value.text;
   }
+  if (value.type === "link" && typeof value.url === "string") {
+    return value.url;
+  }
   return slackInlineText(value.elements);
 }
 
@@ -126,7 +129,16 @@ function collectSlackBlockText(value: unknown, output: string[]): void {
     collectSlackTextValue(value[key], output);
   }
   collectSlackTextValue(value.text, output);
-  for (const key of ["blocks", "elements", "fields", "rows", "tasks"] as const) {
+  for (const key of [
+    "blocks",
+    "elements",
+    "fields",
+    "rows",
+    "tasks",
+    "actions",
+    "hero_image",
+    "icon",
+  ] as const) {
     collectSlackBlockText(value[key], output);
   }
 }
@@ -287,7 +299,7 @@ export function handleSlackWebhookPayload(payload: unknown): Response | undefine
     if (!eventType) {
       return undefined;
     }
-    if (eventType !== "message") {
+    if (eventType !== "message" && eventType !== "app_mention") {
       return new Response(null, { status: 200 });
     }
     const isMessageChanged = payload.event.subtype === "message_changed";

--- a/src/providers/builtin/slack.ts
+++ b/src/providers/builtin/slack.ts
@@ -252,10 +252,14 @@ export function handleSlackWebhookPayload(payload: unknown): Response | undefine
     if (eventType !== "message") {
       return new Response(null, { status: 200 });
     }
-    const message =
-      payload.event.subtype === "message_changed" && isRecord(payload.event.message)
-        ? payload.event.message
-        : payload.event;
+    const isMessageChanged = payload.event.subtype === "message_changed";
+    if (isMessageChanged && !isRecord(payload.event.message)) {
+      return undefined;
+    }
+    const message = isMessageChanged ? payload.event.message : payload.event;
+    if (!isRecord(message)) {
+      return undefined;
+    }
     if (typeof payload.event.channel !== "string" || hasMalformedSlackMessageContent(message)) {
       return undefined;
     }

--- a/src/providers/builtin/slack.ts
+++ b/src/providers/builtin/slack.ts
@@ -81,13 +81,15 @@ function collectSlackBlockText(value: unknown, output: string[]): void {
   if (!isRecord(value)) {
     return;
   }
-  pushSlackText(value.alt_text, output);
+  for (const key of ["alt_text", "title", "details", "output"] as const) {
+    pushSlackText(value[key], output);
+  }
   if (isRecord(value.text)) {
     pushSlackText(value.text.text, output);
   } else {
     pushSlackText(value.text, output);
   }
-  for (const key of ["blocks", "elements", "fields"] as const) {
+  for (const key of ["blocks", "elements", "fields", "rows", "tasks"] as const) {
     collectSlackBlockText(value[key], output);
   }
 }

--- a/src/providers/builtin/slack.ts
+++ b/src/providers/builtin/slack.ts
@@ -65,6 +65,77 @@ function slackAuthorFromEvent(event: Record<string, unknown>): InboundEnvelope["
   return "user";
 }
 
+function pushSlackText(value: unknown, output: string[]): void {
+  if (typeof value === "string" && value.trim()) {
+    output.push(value);
+  }
+}
+
+function collectSlackBlockText(value: unknown, output: string[]): void {
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      collectSlackBlockText(entry, output);
+    }
+    return;
+  }
+  if (!isRecord(value)) {
+    return;
+  }
+  pushSlackText(value.alt_text, output);
+  if (isRecord(value.text)) {
+    pushSlackText(value.text.text, output);
+  } else {
+    pushSlackText(value.text, output);
+  }
+  for (const key of ["blocks", "elements", "fields"] as const) {
+    collectSlackBlockText(value[key], output);
+  }
+}
+
+function collectSlackAttachmentText(value: unknown, output: string[]): void {
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      collectSlackAttachmentText(entry, output);
+    }
+    return;
+  }
+  if (!isRecord(value)) {
+    return;
+  }
+  for (const key of ["fallback", "pretext", "author_name", "title", "text", "footer"] as const) {
+    pushSlackText(value[key], output);
+  }
+  if (Array.isArray(value.fields)) {
+    for (const field of value.fields) {
+      if (!isRecord(field)) {
+        continue;
+      }
+      pushSlackText(field.title, output);
+      pushSlackText(field.value, output);
+    }
+  }
+  collectSlackBlockText(value.blocks, output);
+}
+
+function slackMessageText(message: Record<string, unknown>): string | undefined {
+  if (typeof message.text === "string" && message.text.trim()) {
+    return message.text;
+  }
+  const fallback: string[] = [];
+  collectSlackBlockText(message.blocks, fallback);
+  collectSlackAttachmentText(message.attachments, fallback);
+  const unique = [...new Set(fallback)];
+  return unique.length > 0 ? unique.join("\n") : undefined;
+}
+
+function hasMalformedSlackMessageContent(message: Record<string, unknown>): boolean {
+  return (
+    (message.text !== undefined && typeof message.text !== "string") ||
+    (message.blocks !== undefined && !Array.isArray(message.blocks)) ||
+    (message.attachments !== undefined && !Array.isArray(message.attachments))
+  );
+}
+
 function normalizeSlackEventsPayload(payload: unknown) {
   if (!isRecord(payload)) {
     throw new CrablineError("Slack webhook payload must be an object", { kind: "inbound" });
@@ -72,20 +143,28 @@ function normalizeSlackEventsPayload(payload: unknown) {
 
   if (isRecord(payload.event)) {
     const event = payload.event;
+    const isMessageChanged = event.subtype === "message_changed";
     const changedMessage = isRecord(event.message) ? event.message : undefined;
-    const isMessageChanged = event.subtype === "message_changed" && changedMessage !== undefined;
+    if (isMessageChanged && !changedMessage) {
+      throw new CrablineError("Slack message_changed event requires event.message", {
+        kind: "inbound",
+      });
+    }
     const message = isMessageChanged ? changedMessage : event;
+    if (!message || hasMalformedSlackMessageContent(message)) {
+      throw new CrablineError("Slack event payload contains malformed message content", {
+        kind: "inbound",
+      });
+    }
     const channel = event.channel;
-    const text = message.text;
-    if (typeof channel !== "string" || typeof text !== "string") {
+    const text = slackMessageText(message);
+    if (typeof channel !== "string" || text === undefined) {
       throw new CrablineError("Slack event payload requires event.channel and event.text", {
         kind: "inbound",
       });
     }
     const threadTs = message.thread_ts;
-    const eventId = isMessageChanged
-      ? optionalString(event, "event_ts")
-      : optionalString(message, "ts");
+    const eventId = optionalString(message, "ts");
     return {
       author: slackAuthorFromEvent(message),
       ...(eventId
@@ -156,19 +235,36 @@ function matchesSlackThread(
 }
 
 export function handleSlackWebhookPayload(payload: unknown): Response | undefined {
-  if (
-    isRecord(payload) &&
-    payload.type === "url_verification" &&
-    typeof payload.challenge === "string"
-  ) {
+  if (!isRecord(payload)) {
+    return undefined;
+  }
+  if (payload.type === "url_verification" && typeof payload.challenge === "string") {
     return Response.json({ challenge: payload.challenge });
   }
-  if (
-    isRecord(payload) &&
-    payload.type === "event_callback" &&
-    isRecord(payload.event) &&
-    (payload.event.type === "reaction_added" || payload.event.type === "reaction_removed")
-  ) {
+  if (payload.type === "event_callback") {
+    if (!isRecord(payload.event)) {
+      return undefined;
+    }
+    const eventType = optionalString(payload.event, "type");
+    if (!eventType) {
+      return undefined;
+    }
+    if (eventType !== "message") {
+      return new Response(null, { status: 200 });
+    }
+    const message =
+      payload.event.subtype === "message_changed" && isRecord(payload.event.message)
+        ? payload.event.message
+        : payload.event;
+    if (typeof payload.event.channel !== "string" || hasMalformedSlackMessageContent(message)) {
+      return undefined;
+    }
+    if (slackMessageText(message) === undefined) {
+      return new Response(null, { status: 200 });
+    }
+    return undefined;
+  }
+  if (typeof payload.type === "string" && payload.type.trim()) {
     return new Response(null, { status: 200 });
   }
   return undefined;

--- a/src/providers/builtin/slack.ts
+++ b/src/providers/builtin/slack.ts
@@ -71,6 +71,31 @@ function pushSlackText(value: unknown, output: string[]): void {
   }
 }
 
+function slackInlineText(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value.map(slackInlineText).join("");
+  }
+  if (!isRecord(value)) {
+    return "";
+  }
+  if (typeof value.text === "string") {
+    return value.text;
+  }
+  return slackInlineText(value.elements);
+}
+
+function collectSlackTextValue(value: unknown, output: string[]): void {
+  if (typeof value === "string") {
+    pushSlackText(value, output);
+    return;
+  }
+  if (isRecord(value) && typeof value.text === "string") {
+    pushSlackText(value.text, output);
+    return;
+  }
+  collectSlackBlockText(value, output);
+}
+
 function collectSlackBlockText(value: unknown, output: string[]): void {
   if (Array.isArray(value)) {
     for (const entry of value) {
@@ -81,23 +106,27 @@ function collectSlackBlockText(value: unknown, output: string[]): void {
   if (!isRecord(value)) {
     return;
   }
-  for (const key of ["alt_text", "title", "details", "output"] as const) {
-    pushSlackText(value[key], output);
-  }
-  if (isRecord(value.text)) {
-    pushSlackText(value.text.text, output);
-  } else {
-    pushSlackText(value.text, output);
+  if (
+    value.type === "rich_text_section" ||
+    value.type === "rich_text_preformatted" ||
+    value.type === "rich_text_quote"
+  ) {
+    pushSlackText(slackInlineText(value.elements), output);
+    return;
   }
   for (const key of [
-    "blocks",
-    "elements",
-    "fields",
-    "rows",
+    "alt_text",
+    "title",
+    "body",
+    "subtitle",
+    "subtext",
     "details",
     "output",
-    "tasks",
   ] as const) {
+    collectSlackTextValue(value[key], output);
+  }
+  collectSlackTextValue(value.text, output);
+  for (const key of ["blocks", "elements", "fields", "rows", "tasks"] as const) {
     collectSlackBlockText(value[key], output);
   }
 }
@@ -134,8 +163,7 @@ function slackMessageText(message: Record<string, unknown>): string | undefined 
   const fallback: string[] = [];
   collectSlackBlockText(message.blocks, fallback);
   collectSlackAttachmentText(message.attachments, fallback);
-  const unique = [...new Set(fallback)];
-  return unique.length > 0 ? unique.join("\n") : undefined;
+  return fallback.length > 0 ? fallback.join("\n") : undefined;
 }
 
 function hasMalformedSlackMessageContent(message: Record<string, unknown>): boolean {

--- a/src/providers/builtin/slack.ts
+++ b/src/providers/builtin/slack.ts
@@ -89,7 +89,15 @@ function collectSlackBlockText(value: unknown, output: string[]): void {
   } else {
     pushSlackText(value.text, output);
   }
-  for (const key of ["blocks", "elements", "fields", "rows", "tasks"] as const) {
+  for (const key of [
+    "blocks",
+    "elements",
+    "fields",
+    "rows",
+    "details",
+    "output",
+    "tasks",
+  ] as const) {
     collectSlackBlockText(value[key], output);
   }
 }

--- a/src/servers/slack.ts
+++ b/src/servers/slack.ts
@@ -639,6 +639,45 @@ function slackTargetRetryReason(error: WebhookTargetError): SlackRetryReason {
   return error === "https-required" ? "ssl_error" : "connection_failed";
 }
 
+/** @internal */
+export async function postSlackEventToAddresses(params: {
+  addresses?: ReadonlyArray<WebhookAddress> | undefined;
+  body: string;
+  headerEntries: ReadonlyArray<readonly [string, string]>;
+  request?: typeof postWebhookRequestWithResponse;
+  signal: AbortSignal;
+  timeoutAt: number;
+  url: URL;
+}): Promise<WebhookResponse> {
+  const addresses: Array<WebhookAddress | undefined> =
+    params.addresses && params.addresses.length > 0 ? [...params.addresses] : [undefined];
+  const request = params.request ?? postWebhookRequestWithResponse;
+  let lastError: unknown;
+  for (const [index, address] of addresses.entries()) {
+    const remainingMs = params.timeoutAt - Date.now();
+    if (remainingMs <= 0) {
+      throw new DOMException("Slack Events API delivery timed out", "TimeoutError");
+    }
+    const attemptsRemaining = addresses.length - index;
+    try {
+      return await request({
+        address,
+        body: params.body,
+        headerEntries: params.headerEntries,
+        signal: params.signal,
+        timeoutMs: Math.max(1, Math.floor(remainingMs / attemptsRemaining)),
+        url: params.url,
+      });
+    } catch (error) {
+      lastError = error;
+      if (params.signal.aborted) {
+        throw error;
+      }
+    }
+  }
+  throw lastError;
+}
+
 async function postSlackEventRequest(params: {
   body: string;
   headerEntries: ReadonlyArray<readonly [string, string]>;
@@ -657,31 +696,14 @@ async function postSlackEventRequest(params: {
     throw new SlackEventTargetError(slackTargetRetryReason(target.error), target.error);
   }
 
-  const addresses: Array<WebhookAddress | undefined> =
-    target.addresses && target.addresses.length > 0 ? target.addresses : [undefined];
-  let lastError: unknown;
-  for (const address of addresses) {
-    const remainingMs = params.timeoutAt - Date.now();
-    if (remainingMs <= 0) {
-      throw new DOMException("Slack Events API delivery timed out", "TimeoutError");
-    }
-    try {
-      return await postWebhookRequestWithResponse({
-        address,
-        body: params.body,
-        headerEntries: params.headerEntries,
-        signal: params.signal,
-        timeoutMs: Math.max(1, Math.floor(remainingMs)),
-        url: params.url,
-      });
-    } catch (error) {
-      lastError = error;
-      if (params.signal.aborted) {
-        throw error;
-      }
-    }
-  }
-  throw lastError;
+  return await postSlackEventToAddresses({
+    addresses: target.addresses,
+    body: params.body,
+    headerEntries: params.headerEntries,
+    signal: params.signal,
+    timeoutAt: params.timeoutAt,
+    url: params.url,
+  });
 }
 
 async function waitForSlackRetry(delayMs: number, signal: AbortSignal): Promise<boolean> {

--- a/test/slack-provider.test.ts
+++ b/test/slack-provider.test.ts
@@ -380,8 +380,24 @@ describe("slack provider", () => {
               type: "table",
             },
             {
-              details: "task details",
-              output: "task output",
+              details: {
+                elements: [
+                  {
+                    elements: [{ text: "task details", type: "text" }],
+                    type: "rich_text_section",
+                  },
+                ],
+                type: "rich_text",
+              },
+              output: {
+                elements: [
+                  {
+                    elements: [{ text: "task output", type: "text" }],
+                    type: "rich_text_section",
+                  },
+                ],
+                type: "rich_text",
+              },
               tasks: [{ title: "nested task" }],
               title: "task title",
               type: "task_card",

--- a/test/slack-provider.test.ts
+++ b/test/slack-provider.test.ts
@@ -451,20 +451,32 @@ describe("slack provider", () => {
       expect(await response.text()).toBe("");
     }
 
-    const malformedBody = JSON.stringify({
-      event: { channel: "C1234567890", text: 42, type: "message" },
-      type: "event_callback",
-    });
-    const malformed = await fetch(endpoint, {
-      body: malformedBody,
-      headers: {
-        "content-type": "application/json",
-        "x-slack-request-timestamp": timestamp,
-        "x-slack-signature": slackSignature(signingSecret, timestamp, malformedBody),
+    for (const payload of [
+      {
+        event: { channel: "C1234567890", text: 42, type: "message" },
+        type: "event_callback",
       },
-      method: "POST",
-    });
-    expect(malformed.status).toBe(400);
+      {
+        event: {
+          channel: "C1234567890",
+          subtype: "message_changed",
+          type: "message",
+        },
+        type: "event_callback",
+      },
+    ]) {
+      const malformedBody = JSON.stringify(payload);
+      const malformed = await fetch(endpoint, {
+        body: malformedBody,
+        headers: {
+          "content-type": "application/json",
+          "x-slack-request-timestamp": timestamp,
+          "x-slack-signature": slackSignature(signingSecret, timestamp, malformedBody),
+        },
+        method: "POST",
+      });
+      expect(malformed.status).toBe(400);
+    }
     await expect(readFile(config.slack!.recorder.path!, "utf8")).rejects.toMatchObject({
       code: "ENOENT",
     });

--- a/test/slack-provider.test.ts
+++ b/test/slack-provider.test.ts
@@ -350,6 +350,61 @@ describe("slack provider", () => {
     });
   });
 
+  it("extracts table and task-card block-only text", async () => {
+    const config = await createSlackConfig(0);
+    const provider = new SlackProviderAdapter("slack", config, "crabline");
+    providers.push(provider);
+    const context = createContext(config);
+    context.fixture.inboundMatch = { author: "user", nonce: "contains", strategy: "contains" };
+    const endpoint = endpointFromDetails((await provider.probe(context)).details);
+    const waiting = provider.waitForInbound({
+      ...context,
+      nonce: "table-cell",
+      since: new Date(Date.now() - 1_000).toISOString(),
+      timeoutMs: 500,
+    });
+
+    const response = await fetch(endpoint, {
+      body: JSON.stringify({
+        event: {
+          blocks: [
+            {
+              rows: [
+                [
+                  {
+                    elements: [{ text: "table-cell", type: "text" }],
+                    type: "rich_text",
+                  },
+                ],
+              ],
+              type: "table",
+            },
+            {
+              details: "task details",
+              output: "task output",
+              tasks: [{ title: "nested task" }],
+              title: "task title",
+              type: "task_card",
+            },
+          ],
+          channel: "C1234567890",
+          ts: "1700000001.000201",
+          type: "message",
+          user: "U1234567890",
+        },
+        type: "event_callback",
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(waiting).resolves.toMatchObject({
+      id: "1700000001.000201",
+      text: "table-cell\ntask title\ntask details\ntask output\nnested task",
+    });
+  });
+
   it("verifies Slack request signatures before parsing", async () => {
     const signingSecret = "test-token-placeholder";
     const config = await createSlackConfig(0, signingSecret);

--- a/test/slack-provider.test.ts
+++ b/test/slack-provider.test.ts
@@ -430,7 +430,7 @@ describe("slack provider", () => {
     const endpoint = endpointFromDetails((await provider.probe(context)).details);
     const waiting = provider.waitForInbound({
       ...context,
-      nonce: "inline-nonce",
+      nonce: "inline-https://example.test/nonce-tail",
       since: new Date(Date.now() - 1_000).toISOString(),
       timeoutMs: 500,
     });
@@ -444,7 +444,8 @@ describe("slack provider", () => {
                 {
                   elements: [
                     { text: "inline-", type: "text" },
-                    { style: { bold: true }, text: "nonce", type: "text" },
+                    { type: "link", url: "https://example.test/nonce" },
+                    { style: { bold: true }, text: "-tail", type: "text" },
                   ],
                   type: "rich_text_section",
                 },
@@ -474,7 +475,7 @@ describe("slack provider", () => {
     expect(response.status).toBe(200);
     await expect(waiting).resolves.toMatchObject({
       id: "1700000001.000202",
-      text: "inline-nonce\nrepeat\nrepeat",
+      text: "inline-https://example.test/nonce-tail\nrepeat\nrepeat",
     });
   });
 
@@ -487,7 +488,7 @@ describe("slack provider", () => {
     const endpoint = endpointFromDetails((await provider.probe(context)).details);
     const waiting = provider.waitForInbound({
       ...context,
-      nonce: "card-body",
+      nonce: "card-action",
       since: new Date(Date.now() - 1_000).toISOString(),
       timeoutMs: 500,
     });
@@ -497,7 +498,15 @@ describe("slack provider", () => {
         event: {
           blocks: [
             {
+              actions: [
+                {
+                  text: { text: "card-action", type: "plain_text" },
+                  type: "button",
+                },
+              ],
               body: { text: "card-body", type: "mrkdwn" },
+              hero_image: { alt_text: "hero image", url: "https://example.test/hero.png" },
+              icon: { alt_text: "card icon", url: "https://example.test/icon.png" },
               subtitle: { text: "card subtitle", type: "plain_text" },
               subtext: { text: "card subtext", type: "plain_text" },
               type: "card",
@@ -517,7 +526,43 @@ describe("slack provider", () => {
     expect(response.status).toBe(200);
     await expect(waiting).resolves.toMatchObject({
       id: "1700000001.000203",
-      text: "card-body\ncard subtitle\ncard subtext",
+      text: "card-body\ncard subtitle\ncard subtext\ncard-action\nhero image\ncard icon",
+    });
+  });
+
+  it("records message-shaped app mentions", async () => {
+    const config = await createSlackConfig(0);
+    const provider = new SlackProviderAdapter("slack", config, "crabline");
+    providers.push(provider);
+    const context = createContext(config);
+    context.fixture.inboundMatch = { author: "user", nonce: "contains", strategy: "contains" };
+    const endpoint = endpointFromDetails((await provider.probe(context)).details);
+    const waiting = provider.waitForInbound({
+      ...context,
+      nonce: "mention-nonce",
+      since: new Date(Date.now() - 1_000).toISOString(),
+      timeoutMs: 500,
+    });
+
+    const response = await fetch(endpoint, {
+      body: JSON.stringify({
+        event: {
+          channel: "C1234567890",
+          text: "<@UAPP> mention-nonce",
+          ts: "1700000001.000204",
+          type: "app_mention",
+          user: "U1234567890",
+        },
+        type: "event_callback",
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(waiting).resolves.toMatchObject({
+      id: "1700000001.000204",
+      text: "<@UAPP> mention-nonce",
     });
   });
 

--- a/test/slack-provider.test.ts
+++ b/test/slack-provider.test.ts
@@ -84,6 +84,12 @@ function endpointFromDetails(details: string[]): string {
   return detail.replace("events endpoint ", "");
 }
 
+function slackSignature(signingSecret: string, timestamp: string, body: string): string {
+  return `v0=${createHmac("sha256", signingSecret)
+    .update(`v0:${timestamp}:${body}`)
+    .digest("hex")}`;
+}
+
 describe("slack provider", () => {
   it("requires request signatures for externally reachable event endpoints", async () => {
     const config = await createSlackConfig(0);
@@ -294,9 +300,53 @@ describe("slack provider", () => {
     expect(response.status).toBe(200);
     await expect(waiting).resolves.toMatchObject({
       author: "user",
-      id: "1700000002.000300",
+      id: "1700000001.000200",
       text: "edited ACK edited-nonce",
       threadId: "C1234567890:thread:1700000000.000100",
+    });
+  });
+
+  it("extracts native block and attachment fallback text", async () => {
+    const config = await createSlackConfig(0);
+    const provider = new SlackProviderAdapter("slack", config, "crabline");
+    providers.push(provider);
+    const context = createContext(config);
+    context.fixture.inboundMatch = { author: "user", nonce: "contains", strategy: "contains" };
+    const endpoint = endpointFromDetails((await provider.probe(context)).details);
+    const waiting = provider.waitForInbound({
+      ...context,
+      nonce: "attachment-value",
+      since: new Date(Date.now() - 1_000).toISOString(),
+      timeoutMs: 500,
+    });
+
+    const response = await fetch(endpoint, {
+      body: JSON.stringify({
+        event: {
+          attachments: [{ fields: [{ value: "attachment-value" }] }],
+          blocks: [
+            {
+              fields: [{ text: "block fallback", type: "mrkdwn" }],
+              text: { text: " \n\t", type: "plain_text" },
+              type: "section",
+            },
+          ],
+          channel: "C1234567890",
+          text: "",
+          ts: "1700000001.000200",
+          type: "message",
+          user: "U1234567890",
+        },
+        type: "event_callback",
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(waiting).resolves.toMatchObject({
+      id: "1700000001.000200",
+      text: "block fallback\nattachment-value",
     });
   });
 
@@ -316,9 +366,7 @@ describe("slack provider", () => {
       },
       type: "event_callback",
     });
-    const signature = `v0=${createHmac("sha256", signingSecret)
-      .update(`v0:${timestamp}:${body}`)
-      .digest("hex")}`;
+    const signature = slackSignature(signingSecret, timestamp, body);
 
     const malformed = await fetch(endpoint, {
       body: "{",
@@ -354,38 +402,69 @@ describe("slack provider", () => {
     expect(accepted.status).toBe(200);
   });
 
-  it("acknowledges authenticated reaction callbacks without recording them", async () => {
+  it("acknowledges authenticated unsupported and textless callbacks without recording them", async () => {
     const signingSecret = "test-token-placeholder";
     const config = await createSlackConfig(0, signingSecret);
     const provider = new SlackProviderAdapter("slack", config, "crabline");
     providers.push(provider);
     const endpoint = endpointFromDetails((await provider.probe(createContext(config))).details);
     const timestamp = Math.floor(Date.now() / 1000).toString();
-    const body = JSON.stringify({
-      event: {
-        item: { channel: "C1234567890", ts: "1700000001.000200", type: "message" },
-        reaction: "white_check_mark",
-        type: "reaction_added",
-        user: "U1234567890",
+    for (const payload of [
+      {
+        event: {
+          item: { channel: "C1234567890", ts: "1700000001.000200", type: "message" },
+          reaction: "white_check_mark",
+          type: "reaction_added",
+          user: "U1234567890",
+        },
+        event_id: "Ev1234567890",
+        type: "event_callback",
       },
-      event_id: "Ev1234567890",
+      {
+        event: {
+          channel: "C1234567890",
+          deleted_ts: "1700000001.000200",
+          subtype: "message_deleted",
+          ts: "1700000002.000300",
+          type: "message",
+        },
+        type: "event_callback",
+      },
+      {
+        api_app_id: "ACRABLINE",
+        minute_rate_limited: 1_700_000_000,
+        team_id: "TCRABLINE",
+        type: "app_rate_limited",
+      },
+    ]) {
+      const body = JSON.stringify(payload);
+      const response = await fetch(endpoint, {
+        body,
+        headers: {
+          "content-type": "application/json",
+          "x-slack-request-timestamp": timestamp,
+          "x-slack-signature": slackSignature(signingSecret, timestamp, body),
+        },
+        method: "POST",
+      });
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe("");
+    }
+
+    const malformedBody = JSON.stringify({
+      event: { channel: "C1234567890", text: 42, type: "message" },
       type: "event_callback",
     });
-    const signature = `v0=${createHmac("sha256", signingSecret)
-      .update(`v0:${timestamp}:${body}`)
-      .digest("hex")}`;
-
-    const response = await fetch(endpoint, {
-      body,
+    const malformed = await fetch(endpoint, {
+      body: malformedBody,
       headers: {
         "content-type": "application/json",
         "x-slack-request-timestamp": timestamp,
-        "x-slack-signature": signature,
+        "x-slack-signature": slackSignature(signingSecret, timestamp, malformedBody),
       },
       method: "POST",
     });
-
-    expect(response.status).toBe(200);
+    expect(malformed.status).toBe(400);
     await expect(readFile(config.slack!.recorder.path!, "utf8")).rejects.toMatchObject({
       code: "ENOENT",
     });

--- a/test/slack-provider.test.ts
+++ b/test/slack-provider.test.ts
@@ -421,6 +421,106 @@ describe("slack provider", () => {
     });
   });
 
+  it("preserves inline rich-text adjacency and repeated block text", async () => {
+    const config = await createSlackConfig(0);
+    const provider = new SlackProviderAdapter("slack", config, "crabline");
+    providers.push(provider);
+    const context = createContext(config);
+    context.fixture.inboundMatch = { author: "user", nonce: "contains", strategy: "contains" };
+    const endpoint = endpointFromDetails((await provider.probe(context)).details);
+    const waiting = provider.waitForInbound({
+      ...context,
+      nonce: "inline-nonce",
+      since: new Date(Date.now() - 1_000).toISOString(),
+      timeoutMs: 500,
+    });
+
+    const response = await fetch(endpoint, {
+      body: JSON.stringify({
+        event: {
+          blocks: [
+            {
+              elements: [
+                {
+                  elements: [
+                    { text: "inline-", type: "text" },
+                    { style: { bold: true }, text: "nonce", type: "text" },
+                  ],
+                  type: "rich_text_section",
+                },
+                {
+                  elements: [{ text: "repeat", type: "text" }],
+                  type: "rich_text_section",
+                },
+                {
+                  elements: [{ text: "repeat", type: "text" }],
+                  type: "rich_text_section",
+                },
+              ],
+              type: "rich_text",
+            },
+          ],
+          channel: "C1234567890",
+          ts: "1700000001.000202",
+          type: "message",
+          user: "U1234567890",
+        },
+        type: "event_callback",
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(waiting).resolves.toMatchObject({
+      id: "1700000001.000202",
+      text: "inline-nonce\nrepeat\nrepeat",
+    });
+  });
+
+  it("extracts valid card composition fields", async () => {
+    const config = await createSlackConfig(0);
+    const provider = new SlackProviderAdapter("slack", config, "crabline");
+    providers.push(provider);
+    const context = createContext(config);
+    context.fixture.inboundMatch = { author: "user", nonce: "contains", strategy: "contains" };
+    const endpoint = endpointFromDetails((await provider.probe(context)).details);
+    const waiting = provider.waitForInbound({
+      ...context,
+      nonce: "card-body",
+      since: new Date(Date.now() - 1_000).toISOString(),
+      timeoutMs: 500,
+    });
+
+    const response = await fetch(endpoint, {
+      body: JSON.stringify({
+        event: {
+          blocks: [
+            {
+              body: { text: "card-body", type: "mrkdwn" },
+              subtitle: { text: "card subtitle", type: "plain_text" },
+              subtext: { text: "card subtext", type: "plain_text" },
+              type: "card",
+            },
+          ],
+          channel: "C1234567890",
+          ts: "1700000001.000203",
+          type: "message",
+          user: "U1234567890",
+        },
+        type: "event_callback",
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(waiting).resolves.toMatchObject({
+      id: "1700000001.000203",
+      text: "card-body\ncard subtitle\ncard subtext",
+    });
+  });
+
   it("verifies Slack request signatures before parsing", async () => {
     const signingSecret = "test-token-placeholder";
     const config = await createSlackConfig(0, signingSecret);

--- a/test/slack-server.test.ts
+++ b/test/slack-server.test.ts
@@ -9,7 +9,7 @@ import {
   type StartSlackServerParams,
 } from "../src/index.js";
 import { ADMIN_TOKEN_HEADER } from "../src/servers/http.js";
-import { classifySlackRetryReason } from "../src/servers/slack.js";
+import { classifySlackRetryReason, postSlackEventToAddresses } from "../src/servers/slack.js";
 import { createTempDir, disposeTempDir, requestHttp } from "./test-helpers.js";
 
 const servers: StartedSlackServer[] = [];
@@ -1297,6 +1297,42 @@ describe("slack local provider server", () => {
     for (const { expected, failure } of failures) {
       expect(classifySlackRetryReason(failure)).toBe(expected);
     }
+  });
+
+  it("shares the Events API deadline fairly across resolved addresses", async () => {
+    let now = 1_000;
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    const addresses = [
+      { address: "192.0.2.1", family: 4 },
+      { address: "192.0.2.2", family: 4 },
+    ] as const;
+    const attemptedAddresses: string[] = [];
+    const attemptTimeouts: number[] = [];
+    const request: NonNullable<Parameters<typeof postSlackEventToAddresses>[0]["request"]> = async (
+      params,
+    ) => {
+      attemptedAddresses.push(params.address?.address ?? "unresolved");
+      attemptTimeouts.push(params.timeoutMs);
+      if (params.address?.address === addresses[0].address) {
+        now += params.timeoutMs;
+        throw new DOMException("first address timed out", "TimeoutError");
+      }
+      return { headers: {}, status: 200 };
+    };
+
+    await expect(
+      postSlackEventToAddresses({
+        addresses,
+        body: "{}",
+        headerEntries: [],
+        request,
+        signal: new AbortController().signal,
+        timeoutAt: now + 3_000,
+        url: new URL("https://events.example.test/slack/events"),
+      }),
+    ).resolves.toEqual({ headers: {}, status: 200 });
+    expect(attemptedAddresses).toEqual(["192.0.2.1", "192.0.2.2"]);
+    expect(attemptTimeouts).toEqual([1_500, 1_500]);
   });
 
   it("cancels unread Events API response bodies", async () => {


### PR DESCRIPTION
## Summary

- preserve edited-message identity and acknowledge unsupported Slack callbacks without retry loops
- extract native blocks, attachments, rich text, cards, and app mentions without corrupting inline text
- share outbound address deadlines so later resolved addresses can still be attempted

## Validation

- focused Slack suite (17 tests)
- GitHub CI: green at `adc7be3`
- Crabbox `pnpm verify`: 60 files / 1115 tests (`run_cfd8907bda72`)
- autoreview: clean, confidence 0.87 (`gpt-5.6-sol`, high)
- privacy scan: clean