### PR TITLE
fix(auth): validate signed JWT boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate signed-JWT registered claims, clock skew, and synchronous key-loader failure cleanup.
 - Bound shared JSON ingress, reject non-object payloads precisely, and strictly normalize loopback IP addresses.
 - Harden WhatsApp send evidence, direct-JID correlation, cursor and cleanup races, and cleartext listener exposure.
 - Revalidate npm package version, integrity, and provenance after every release publication outcome.

--- a/src/providers/signed-jwt.ts
+++ b/src/providers/signed-jwt.ts
@@ -45,7 +45,12 @@ function readHeader(value: Record<string, unknown>): JwtHeader {
 }
 
 function hasAudience(claim: unknown, expected: string): boolean {
-  return claim === expected || (Array.isArray(claim) && claim.includes(expected));
+  return (
+    claim === expected ||
+    (Array.isArray(claim) &&
+      claim.every((candidate): candidate is string => typeof candidate === "string") &&
+      claim.includes(expected))
+  );
 }
 
 function numericClaim(claims: JwtClaims, name: string, required = false): number | undefined {
@@ -145,7 +150,8 @@ export function createCachedJwtKeyResolver<T>(params: {
         reject(new Error("JWT signing key fetch timed out."));
       }, timeoutMs);
     });
-    fetchInFlight = Promise.race([params.fetchKeys(controller.signal), timedOut])
+    const keyFetch = Promise.resolve().then(() => params.fetchKeys(controller.signal));
+    fetchInFlight = Promise.race([keyFetch, timedOut])
       .then((keySet) => {
         cached = keySet.expiresAt > now() ? keySet : undefined;
         fetchFailureCooldownUntil = 0;
@@ -257,7 +263,7 @@ export async function verifySignedJwt(params: {
     throw new Error("JWT signature is invalid.");
   }
 
-  if (!params.issuers.includes(String(claims.iss ?? ""))) {
+  if (typeof claims.iss !== "string" || !params.issuers.includes(claims.iss)) {
     throw new Error("JWT issuer is invalid.");
   }
   if (!hasAudience(claims.aud, params.audience)) {
@@ -266,6 +272,9 @@ export async function verifySignedJwt(params: {
 
   const now = Math.floor((params.now?.() ?? Date.now()) / 1000);
   const skew = params.clockSkewSeconds ?? 300;
+  if (!Number.isFinite(skew) || skew < 0) {
+    throw new Error("JWT clock skew must be a finite non-negative number.");
+  }
   const expiresAt = numericClaim(claims, "exp", true)!;
   if (expiresAt <= now - skew) {
     throw new Error("JWT is expired.");

--- a/test/signed-jwt.test.ts
+++ b/test/signed-jwt.test.ts
@@ -1,5 +1,5 @@
 import { generateKeyPairSync, sign } from "node:crypto";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   createCachedJwtKeyResolver,
   resolveHttpCacheExpiry,
@@ -55,6 +55,59 @@ describe("signed JWT remote key cache", () => {
         }),
       ),
     ).rejects.toThrow(/expired/u);
+  });
+
+  it("rejects malformed registered claim types", async () => {
+    const keys = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const now = 1_700_000_000_000;
+    const claims = {
+      aud: "crabline",
+      exp: Math.floor(now / 1000) + 60,
+      iss: "issuer",
+    };
+    const verify = (overrides: Record<string, unknown>) =>
+      verifySignedJwt({
+        audience: "crabline",
+        issuers: ["issuer"],
+        now: () => now,
+        resolveKey: async () => keys.publicKey,
+        token: signedJwt(keys.privateKey, { ...claims, ...overrides }),
+      });
+
+    for (const iss of [["issuer"], 1, true, { value: "issuer" }]) {
+      await expect(verify({ iss })).rejects.toThrow(/issuer is invalid/u);
+    }
+    for (const aud of [["crabline", 1], ["crabline", null], { value: "crabline" }]) {
+      await expect(verify({ aud })).rejects.toThrow(/audience is invalid/u);
+    }
+  });
+
+  it("rejects non-finite and negative clock skew", async () => {
+    const keys = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const now = 1_700_000_000_000;
+    const token = signedJwt(keys.privateKey, {
+      aud: "crabline",
+      exp: 0,
+      iss: "issuer",
+    });
+
+    for (const clockSkewSeconds of [
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+      -1,
+    ]) {
+      await expect(
+        verifySignedJwt({
+          audience: "crabline",
+          clockSkewSeconds,
+          issuers: ["issuer"],
+          now: () => now,
+          resolveKey: async () => keys.publicKey,
+          token,
+        }),
+      ).rejects.toThrow(/clock skew must be a finite non-negative number/u);
+    }
   });
 
   it("does not cache responses marked no-cache or no-store", () => {
@@ -274,6 +327,32 @@ describe("signed JWT remote key cache", () => {
     now += 10_001;
     await expect(resolveKey({ alg: "RS256", kid: "missing" })).rejects.toBe(fetchError);
     expect(fetches).toBe(2);
+  });
+
+  it("backs off synchronously thrown key fetches and clears their timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchError = new Error("JWKS unavailable");
+      let fetches = 0;
+      const resolveKey = createCachedJwtKeyResolver<string>({
+        fetchKeys() {
+          fetches += 1;
+          throw fetchError;
+        },
+        keyId: (value) => value,
+        now: () => 1_700_000_000_000,
+        refreshCooldownMs: 10_000,
+        timeoutMs: 5_000,
+        unknownKeyMessage: "unknown key",
+      });
+
+      await expect(resolveKey({ alg: "RS256", kid: "missing" })).rejects.toBe(fetchError);
+      await expect(resolveKey({ alg: "RS256", kid: "missing" })).rejects.toBe(fetchError);
+      expect(fetches).toBe(1);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("backs off failed unknown-key refreshes while a positive cache remains fresh", async () => {


### PR DESCRIPTION
## Summary

- reject non-string registered JWT claims instead of coercing them
- reject non-finite clock skew values before lifetime validation
- convert synchronous key-loader failures into the existing cooldown and cleanup path

## Validation

- focused signed-JWT suite (18 tests)
- GitHub CI: green at `0030b0a`
- Crabbox `pnpm verify`: 60 files / 1118 tests (`run_e21f5d344b4e`)
- autoreview: clean, confidence 0.97 (`gpt-5.6-sol`, high)
- privacy review: clean; heuristic-only false positive on generated test variable `const token = signedJwt(...)`