### PR TITLE
fix(ci): harden action security policy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 # Protect ownership and automation rules.
 /.github/CODEOWNERS @openclaw/openclaw-secops
+/.github/actions/ @openclaw/openclaw-secops
 /.github/actionlint.yaml @openclaw/openclaw-secops
 /.github/codeql/ @openclaw/openclaw-secops
 /.github/dependabot.yml @openclaw/openclaw-secops

--- a/.github/codeql/codeql-actions-security.yml
+++ b/.github/codeql/codeql-actions-security.yml
@@ -11,4 +11,5 @@ query-filters:
       tags contain: security
 
 paths:
+  - .github/actions
   - .github/workflows

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,7 @@ on:
   push:
     branches: [main]
     paths:
+      - ".github/actions/**"
       - ".github/codeql/**"
       - ".github/workflows/**"
       - "src/**"
@@ -21,6 +22,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
+      - ".github/actions/**"
       - ".github/codeql/**"
       - ".github/workflows/**"
       - "src/**"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Revalidate npm package version, integrity, and provenance after every release publication outcome.
 - Authenticate Feishu signatures before encrypted callback decryption and bound callback ciphertext work.
 - Correct Slack edited-message identity and text fallback handling, acknowledge unsupported callbacks, and fairly budget Events API address failover.
+- Cover local GitHub Actions with ownership, CodeQL, immutable image, and test-tool runtime policies.
 - Protect pnpm install-script policy and enforce immutable action pins across reusable workflows and composite actions.
 - Stop shipping a non-runnable OpenClaw script fixture and clarify source-checkout CLI invocation.
 - Bind npm and GitHub release mutations to the revalidated tag commit and fail closed on release lookup errors.

--- a/test/ci-workflow.test.ts
+++ b/test/ci-workflow.test.ts
@@ -21,6 +21,7 @@ type Workflow = {
 
 type CompositeAction = {
   runs?: {
+    image?: string;
     steps?: WorkflowStep[];
     using?: string;
   };
@@ -43,12 +44,12 @@ describe("CI workflow hardening", () => {
     );
   });
 
-  it("pins every external workflow action to immutable revisions", async () => {
+  it("pins every external workflow action and image to immutable revisions", async () => {
     const actionRefs = await collectExternalActionRefs(process.cwd());
 
     expect(actionRefs).not.toEqual([]);
     for (const actionRef of actionRefs) {
-      expect(actionRef).toMatch(/^[^@]+@[0-9a-f]{40}$/u);
+      expect(isImmutableActionRef(actionRef)).toBe(true);
     }
   });
 
@@ -58,6 +59,7 @@ describe("CI workflow hardening", () => {
       await Promise.all([
         fs.mkdir(path.join(root, ".github", "workflows"), { recursive: true }),
         fs.mkdir(path.join(root, ".github", "actions", "example"), { recursive: true }),
+        fs.mkdir(path.join(root, ".github", "actions", "container"), { recursive: true }),
       ]);
       await Promise.all([
         fs.writeFile(
@@ -70,14 +72,39 @@ describe("CI workflow hardening", () => {
         ),
         fs.writeFile(
           path.join(root, ".github", "actions", "example", "action.yml"),
-          ["runs:", "  using: composite", "  steps:", "    - uses: owner/action@v1"].join("\n"),
+          [
+            "runs:",
+            "  using: composite",
+            "  steps:",
+            "    - uses: owner/action@v1",
+            "    - uses: docker://alpine:3.20",
+            `    - uses: docker://ghcr.io/owner/action@sha256:${"0".repeat(64)}`,
+          ].join("\n"),
+        ),
+        fs.writeFile(
+          path.join(root, ".github", "actions", "container", "action.yml"),
+          ["runs:", "  using: docker", "  image: docker://busybox:1.37"].join("\n"),
         ),
       ]);
 
-      await expect(collectExternalActionRefs(root)).resolves.toEqual([
-        "owner/repository/.github/workflows/check.yml@main",
-        "owner/action@v1",
-      ]);
+      const actionRefs = await collectExternalActionRefs(root);
+      expect(actionRefs.toSorted()).toEqual(
+        [
+          "owner/repository/.github/workflows/check.yml@main",
+          "owner/action@v1",
+          "docker://alpine:3.20",
+          `docker://ghcr.io/owner/action@sha256:${"0".repeat(64)}`,
+          "docker://busybox:1.37",
+        ].toSorted(),
+      );
+      expect(actionRefs.filter((actionRef) => !isImmutableActionRef(actionRef)).toSorted()).toEqual(
+        [
+          "owner/repository/.github/workflows/check.yml@main",
+          "owner/action@v1",
+          "docker://alpine:3.20",
+          "docker://busybox:1.37",
+        ].toSorted(),
+      );
     } finally {
       await fs.rm(root, { force: true, recursive: true });
     }
@@ -138,17 +165,24 @@ async function collectExternalActionRefs(root: string): Promise<string[]> {
     await Promise.all(
       actionFiles.map(async (filePath) => {
         const action = parse(await fs.readFile(filePath, "utf8")) as CompositeAction;
-        if (action.runs?.using !== "composite") {
-          return [];
+        if (action.runs?.using === "composite") {
+          return action.runs.steps?.flatMap((step) => (step.uses ? [step.uses] : [])) ?? [];
         }
-        return action.runs.steps?.flatMap((step) => (step.uses ? [step.uses] : [])) ?? [];
+        return action.runs?.using === "docker" && action.runs.image?.startsWith("docker://")
+          ? [action.runs.image]
+          : [];
       }),
     )
   ).flat();
 
-  return [...workflowRefs, ...compositeRefs].filter(
-    (uses) => !uses.startsWith("./") && !uses.startsWith("docker://"),
-  );
+  return [...workflowRefs, ...compositeRefs].filter((uses) => !uses.startsWith("./"));
+}
+
+function isImmutableActionRef(actionRef: string): boolean {
+  if (actionRef.startsWith("docker://")) {
+    return /^docker:\/\/[^@\s]+@sha256:[0-9a-f]{64}$/u.test(actionRef);
+  }
+  return /^[^@\s]+@[0-9a-f]{40}$/u.test(actionRef);
 }
 
 async function listYamlFiles(directory: string): Promise<string[]> {

--- a/test/ci-workflow.test.ts
+++ b/test/ci-workflow.test.ts
@@ -13,6 +13,10 @@ type WorkflowStep = {
 
 type Workflow = {
   jobs?: Record<string, { steps?: WorkflowStep[]; uses?: string }>;
+  on?: {
+    pull_request?: { paths?: string[] };
+    push?: { paths?: string[] };
+  };
 };
 
 type CompositeAction = {
@@ -87,6 +91,21 @@ describe("CI workflow hardening", () => {
 
     expect(codeowners).toContain("/pnpm-workspace.yaml @openclaw/openclaw-secops");
     expect(dependencyReview).toContain("      - pnpm-workspace.yaml");
+  });
+
+  it("protects and scans local action changes", async () => {
+    const [codeowners, codeqlWorkflow, actionsConfig] = await Promise.all([
+      fs.readFile(".github/CODEOWNERS", "utf8"),
+      readWorkflow(".github/workflows/codeql.yml"),
+      fs
+        .readFile(".github/codeql/codeql-actions-security.yml", "utf8")
+        .then((contents) => parse(contents) as { paths?: string[] }),
+    ]);
+
+    expect(codeowners).toContain("/.github/actions/ @openclaw/openclaw-secops");
+    expect(codeqlWorkflow.on?.push?.paths).toContain(".github/actions/**");
+    expect(codeqlWorkflow.on?.pull_request?.paths).toContain(".github/actions/**");
+    expect(actionsConfig.paths).toContain(".github/actions");
   });
 
   it("exempts security pull requests from stale automation", async () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -10,7 +10,13 @@ import {
   waitForShutdown,
 } from "../src/cli/program.js";
 import type { StartCrablineServerParams, StartedCrablineServer } from "../src/servers/index.js";
-import { captureWrites, createTempDir, disposeTempDir, writeText } from "./test-helpers.js";
+import {
+  captureWrites,
+  createTempDir,
+  createWriteCapture,
+  disposeTempDir,
+  writeText,
+} from "./test-helpers.js";
 
 const lockState = vi.hoisted(() => ({
   options: [] as unknown[],
@@ -82,14 +88,10 @@ const createConfig = async (): Promise<string> => {
 describe("cli", () => {
   it("lists providers and fixtures", async () => {
     const configPath = await createConfig();
-    const captured = captureWrites();
-
-    try {
+    const captured = await captureWrites(async () => {
       expect(await runCli(["node", "crabline", "--config", configPath, "providers"])).toBe(0);
       expect(await runCli(["node", "crabline", "--config", configPath, "fixtures"])).toBe(0);
-    } finally {
-      captured.restore();
-    }
+    });
 
     expect(captured.stdout.join("")).toContain("configured providers:");
     expect(captured.stdout.join("")).toContain("roundtrip-fixture");
@@ -116,13 +118,9 @@ describe("cli", () => {
         },
       }),
     );
-    const captured = captureWrites();
-
-    try {
+    const captured = await captureWrites(async () => {
       expect(await runCli(["node", "crabline", "--config", configPath, "fixtures"])).toBe(0);
-    } finally {
-      captured.restore();
-    }
+    });
 
     const output = captured.stdout.join("");
     expect(output).toContain(String.raw`provider=local\x1b[2J`);
@@ -133,9 +131,7 @@ describe("cli", () => {
 
   it("runs doctor, probe, send, roundtrip, and suite commands", async () => {
     const configPath = await createConfig();
-    const captured = captureWrites();
-
-    try {
+    const captured = await captureWrites(async () => {
       expect(await runCli(["node", "crabline", "--config", configPath, "doctor"])).toBe(0);
       expect(
         await runCli(["node", "crabline", "--config", configPath, "probe", "roundtrip-fixture"]),
@@ -164,9 +160,7 @@ describe("cli", () => {
           "send-fixture",
         ]),
       ).toBe(0);
-    } finally {
-      captured.restore();
-    }
+    });
 
     const stdout = stripAnsi(captured.stdout.join(""));
     expect(stdout).toContain("doctor ok");
@@ -176,14 +170,11 @@ describe("cli", () => {
 
   it("reports CLI errors to stderr", async () => {
     const configPath = await createConfig();
-    const captured = captureWrites();
-
     let exitCode: number;
-    try {
+
+    const captured = await captureWrites(async () => {
       exitCode = await runCli(["node", "crabline", "--config", configPath, "probe", "missing"]);
-    } finally {
-      captured.restore();
-    }
+    });
 
     expect(exitCode!).toBe(10);
     expect(captured.stderr.join("")).toContain("Unknown fixture");
@@ -217,10 +208,9 @@ describe("cli", () => {
 
   it("reports JSON failures as one machine-readable document", async () => {
     const configPath = await createConfig();
-    const captured = captureWrites();
-
     let exitCode: number;
-    try {
+
+    const captured = await captureWrites(async () => {
       exitCode = await runCli([
         "node",
         "crabline",
@@ -230,9 +220,7 @@ describe("cli", () => {
         "probe",
         "missing",
       ]);
-    } finally {
-      captured.restore();
-    }
+    });
 
     expect(exitCode!).toBe(10);
     expect(captured.stdout).toEqual([]);
@@ -250,15 +238,14 @@ describe("cli", () => {
     const exit = vi.spyOn(process, "exit").mockImplementation(() => {
       throw new Error("process.exit must not be called");
     });
-    const captured = captureWrites();
-
-    try {
-      expect(await runCli(["node", "crabline", "not-a-command"])).toBe(1);
-      expect(await runCli(["node", "crabline", "--help"])).toBe(0);
-    } finally {
-      captured.restore();
-      exit.mockRestore();
-    }
+    const captured = await captureWrites(async () => {
+      try {
+        expect(await runCli(["node", "crabline", "not-a-command"])).toBe(1);
+        expect(await runCli(["node", "crabline", "--help"])).toBe(0);
+      } finally {
+        exit.mockRestore();
+      }
+    });
 
     expect(exit).not.toHaveBeenCalled();
     expect(captured.stderr.join("").match(/unknown command 'not-a-command'/gu)).toHaveLength(1);
@@ -266,14 +253,11 @@ describe("cli", () => {
   });
 
   it("serializes Commander failures when JSON output is requested", async () => {
-    const captured = captureWrites();
-
     let exitCode: number;
-    try {
+
+    const captured = await captureWrites(async () => {
       exitCode = await runCli(["node", "crabline", "--json", "not-a-command"]);
-    } finally {
-      captured.restore();
-    }
+    });
 
     expect(exitCode!).toBe(1);
     expect(captured.stdout).toEqual([]);
@@ -288,14 +272,11 @@ describe("cli", () => {
   });
 
   it("suppresses subcommand parser output in JSON mode", async () => {
-    const captured = captureWrites();
-
     let exitCode: number;
-    try {
+
+    const captured = await captureWrites(async () => {
       exitCode = await runCli(["node", "crabline", "--json", "probe"]);
-    } finally {
-      captured.restore();
-    }
+    });
 
     expect(exitCode!).toBe(1);
     expect(captured.stdout).toEqual([]);
@@ -310,14 +291,11 @@ describe("cli", () => {
   });
 
   it("reports a useful JSON error when no command is specified", async () => {
-    const captured = captureWrites();
-
     let exitCode: number;
-    try {
+
+    const captured = await captureWrites(async () => {
       exitCode = await runCli(["node", "crabline", "--json"]);
-    } finally {
-      captured.restore();
-    }
+    });
 
     expect(exitCode!).toBe(1);
     expect(captured.stdout).toEqual([]);
@@ -333,14 +311,11 @@ describe("cli", () => {
 
   it("normalizes missing-command exit codes independently of process state", async () => {
     process.exitCode = 10;
-    const captured = captureWrites();
-
     let exitCode: number;
-    try {
+
+    const captured = await captureWrites(async () => {
       exitCode = await runCli(["node", "crabline", "--json"]);
-    } finally {
-      captured.restore();
-    }
+    });
 
     expect(exitCode!).toBe(1);
     expect(JSON.parse(captured.stderr.join(""))).toEqual({
@@ -355,16 +330,12 @@ describe("cli", () => {
 
   it("does not treat --json option values or positional arguments as the global flag", async () => {
     const configPath = await createConfig();
-    const captured = captureWrites();
-
-    try {
+    const captured = await captureWrites(async () => {
       expect(await runCli(["node", "crabline", "--config", "--json", "doctor"])).toBe(10);
       expect(
         await runCli(["node", "crabline", "--config", configPath, "probe", "--", "--json"]),
       ).toBe(10);
-    } finally {
-      captured.restore();
-    }
+    });
 
     const stderr = captured.stderr.join("");
     expect(stderr).toMatch(/Unable to load config file ".*\/--json"/u);
@@ -421,9 +392,7 @@ describe("cli", () => {
       }),
     );
     const program = createProgram(() => undefined, { startServer });
-    const captured = captureWrites();
-
-    try {
+    await captureWrites(async () => {
       await program.parseAsync([
         "node",
         "crabline",
@@ -434,9 +403,7 @@ describe("cli", () => {
         "placeholder",
         "--once",
       ]);
-    } finally {
-      captured.restore();
-    }
+    });
 
     expect(startServer).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -473,19 +440,19 @@ describe("cli", () => {
         "      behavior: sink",
       ].join("\n"),
     );
-    const captured = captureWrites();
     const originalEnv = process.env.CRABLINE_TEST_MISSING_ENV;
     delete process.env.CRABLINE_TEST_MISSING_ENV;
 
-    try {
-      expect(await runCli(["node", "crabline", "--config", configPath, "doctor"])).toBe(10);
-      expect(await runCli(["node", "crabline", "--config", configPath, "fixtures"])).toBe(0);
-    } finally {
-      captured.restore();
-      if (originalEnv !== undefined) {
-        process.env.CRABLINE_TEST_MISSING_ENV = originalEnv;
+    await captureWrites(async () => {
+      try {
+        expect(await runCli(["node", "crabline", "--config", configPath, "doctor"])).toBe(10);
+        expect(await runCli(["node", "crabline", "--config", configPath, "fixtures"])).toBe(0);
+      } finally {
+        if (originalEnv !== undefined) {
+          process.env.CRABLINE_TEST_MISSING_ENV = originalEnv;
+        }
       }
-    }
+    });
   });
 
   it("classifies malformed config as a config error", async () => {
@@ -493,14 +460,11 @@ describe("cli", () => {
     directories.push(directory);
     const configPath = path.join(directory, "crabline.yaml");
     await writeText(configPath, "providers: [\n");
-    const captured = captureWrites();
-
     let exitCode: number;
-    try {
+
+    const captured = await captureWrites(async () => {
       exitCode = await runCli(["node", "crabline", "--config", configPath, "doctor"]);
-    } finally {
-      captured.restore();
-    }
+    });
 
     expect(exitCode!).toBe(10);
     expect(captured.stderr.join("")).toContain(`Unable to load config file "${configPath}"`);
@@ -510,14 +474,11 @@ describe("cli", () => {
     const directory = await createTempDir();
     directories.push(directory);
     const configPath = path.join(directory, "missing.yaml");
-    const captured = captureWrites();
-
     let exitCode: number;
-    try {
+
+    const captured = await captureWrites(async () => {
       exitCode = await runCli(["node", "crabline", "--config", configPath, "doctor"]);
-    } finally {
-      captured.restore();
-    }
+    });
 
     expect(exitCode!).toBe(10);
     expect(captured.stderr.join("")).toContain(`Unable to load config file "${configPath}"`);
@@ -733,25 +694,9 @@ describe("cli", () => {
     const firstProgram = createProgram(() => undefined, {
       startServer: async () => server,
     });
-    const captured = captureWrites();
-
-    try {
-      const first = firstProgram.parseAsync([
-        "node",
-        "crabline",
-        "--json",
-        "serve",
-        "telegram",
-        "--once",
-        "--ready-file",
-        readyFile,
-      ]);
-      await closeStarted;
-      const secondStart = vi.fn(async () => server);
-      const secondProgram = createProgram(() => undefined, { startServer: secondStart });
-
-      await expect(
-        secondProgram.parseAsync([
+    await captureWrites(async () => {
+      try {
+        const first = firstProgram.parseAsync([
           "node",
           "crabline",
           "--json",
@@ -760,17 +705,32 @@ describe("cli", () => {
           "--once",
           "--ready-file",
           readyFile,
-        ]),
-      ).rejects.toBeInstanceOf(Error);
-      expect(secondStart).not.toHaveBeenCalled();
-      await expect(fs.readFile(readyFile, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+        ]);
+        await closeStarted;
+        const secondStart = vi.fn(async () => server);
+        const secondProgram = createProgram(() => undefined, { startServer: secondStart });
 
-      releaseClose?.();
-      await first;
-    } finally {
-      releaseClose?.();
-      captured.restore();
-    }
+        await expect(
+          secondProgram.parseAsync([
+            "node",
+            "crabline",
+            "--json",
+            "serve",
+            "telegram",
+            "--once",
+            "--ready-file",
+            readyFile,
+          ]),
+        ).rejects.toBeInstanceOf(Error);
+        expect(secondStart).not.toHaveBeenCalled();
+        await expect(fs.readFile(readyFile, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+
+        releaseClose?.();
+        await first;
+      } finally {
+        releaseClose?.();
+      }
+    });
 
     await expect(fs.readFile(readyFile, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
   });
@@ -1285,7 +1245,6 @@ describe("cli", () => {
         "      id: echo-bot",
       ].join("\n"),
     );
-    const captured = captureWrites();
     const provider = {
       async *watch() {
         yield {
@@ -1305,11 +1264,9 @@ describe("cli", () => {
         }) as never,
     });
 
-    try {
+    const captured = await captureWrites(async () => {
       await program.parseAsync(["node", "crabline", "--config", configPath, "watch", "watched"]);
-    } finally {
-      captured.restore();
-    }
+    });
 
     expect(captured.stdout.join("")).toContain(String.raw`first\x1b[2J\nsecond`);
     expect(captured.stdout.join("")).not.toContain("\u001b");
@@ -1481,9 +1438,7 @@ describe("cli", () => {
   it("redacts serve credentials from text output unless explicitly requested", async () => {
     const directory = await createTempDir();
     directories.push(directory);
-    const captured = captureWrites();
-
-    try {
+    const captured = await captureWrites(async () => {
       expect(
         await runCli([
           "node",
@@ -1530,9 +1485,7 @@ describe("cli", () => {
           path.join(directory, "visible.jsonl"),
         ]),
       ).toBe(0);
-    } finally {
-      captured.restore();
-    }
+    });
 
     const stdout = captured.stdout.join("");
     expect(stdout).not.toContain("adminToken: fake");
@@ -1551,9 +1504,7 @@ describe("cli", () => {
     const readyFile = path.join(directory, ".crabline", "telegram-server.json");
     await fs.mkdir(path.dirname(readyFile), { recursive: true });
     await fs.writeFile(readyFile, "stale\n", { mode: 0o644 });
-    const captured = captureWrites();
-
-    try {
+    const captured = await captureWrites(async () => {
       expect(
         await runCli([
           "node",
@@ -1570,9 +1521,7 @@ describe("cli", () => {
           path.join(directory, "telegram.jsonl"),
         ]),
       ).toBe(0);
-    } finally {
-      captured.restore();
-    }
+    });
 
     const manifest = JSON.parse(captured.stdout.join("")) as {
       adminToken?: string;
@@ -1595,9 +1544,7 @@ describe("cli", () => {
     const directory = await createTempDir();
     directories.push(directory);
     const readyFile = path.join(directory, ".crabline", "zalo-server.json");
-    const captured = captureWrites();
-
-    try {
+    const captured = await captureWrites(async () => {
       expect(
         await runCli([
           "node",
@@ -1616,9 +1563,7 @@ describe("cli", () => {
           path.join(directory, "zalo.jsonl"),
         ]),
       ).toBe(0);
-    } finally {
-      captured.restore();
-    }
+    });
 
     const manifest = JSON.parse(captured.stdout.join("")) as {
       adminToken?: string;
@@ -1645,9 +1590,7 @@ describe("cli", () => {
     const directory = await createTempDir();
     directories.push(directory);
     const readyFile = path.join(directory, ".crabline", "slack-server.json");
-    const captured = captureWrites();
-
-    try {
+    const captured = await captureWrites(async () => {
       expect(
         await runCli([
           "node",
@@ -1668,9 +1611,7 @@ describe("cli", () => {
           path.join(directory, "slack.jsonl"),
         ]),
       ).toBe(0);
-    } finally {
-      captured.restore();
-    }
+    });
 
     const manifest = JSON.parse(captured.stdout.join("")) as {
       adminToken?: string;
@@ -1695,9 +1636,7 @@ describe("cli", () => {
     const directory = await createTempDir();
     directories.push(directory);
     const readyFile = path.join(directory, ".crabline", "whatsapp-server.json");
-    const captured = captureWrites();
-
-    try {
+    const captured = await captureWrites(async () => {
       expect(
         await runCli([
           "node",
@@ -1716,9 +1655,7 @@ describe("cli", () => {
           path.join(directory, "whatsapp.jsonl"),
         ]),
       ).toBe(0);
-    } finally {
-      captured.restore();
-    }
+    });
 
     const manifest = JSON.parse(captured.stdout.join("")) as {
       accessToken?: string;
@@ -1784,10 +1721,12 @@ describe("cli", () => {
     delete process.env.SLACK_BOT_TOKEN;
     delete process.env.SLACK_SIGNING_SECRET;
 
-    const captured = captureWrites();
+    const captured = createWriteCapture();
     let exitCode: number;
     try {
-      exitCode = await runCli(["node", "crabline", "--config", configPath, "doctor"]);
+      exitCode = await captured.run(() =>
+        runCli(["node", "crabline", "--config", configPath, "doctor"]),
+      );
     } finally {
       captured.restore();
       if (originalBotToken !== undefined) {
@@ -1833,10 +1772,12 @@ describe("cli", () => {
     delete process.env.DISCORD_PUBLIC_KEY;
     delete process.env.DISCORD_APPLICATION_ID;
 
-    const captured = captureWrites();
+    const captured = createWriteCapture();
     let exitCode: number;
     try {
-      exitCode = await runCli(["node", "crabline", "--config", configPath, "doctor"]);
+      exitCode = await captured.run(() =>
+        runCli(["node", "crabline", "--config", configPath, "doctor"]),
+      );
     } finally {
       captured.restore();
       if (originalBotToken !== undefined) {
@@ -1898,18 +1839,19 @@ describe("cli", () => {
     delete process.env.WHATSAPP_PHONE_NUMBER_ID;
     delete process.env.WHATSAPP_VERIFY_TOKEN;
 
-    const captured = captureWrites();
     let exitCode: number;
-    try {
-      exitCode = await runCli(["node", "crabline", "--config", configPath, "doctor"]);
-    } finally {
-      captured.restore();
-      for (const [name, value] of Object.entries(originals)) {
-        if (value !== undefined) {
-          process.env[name] = value;
+
+    const captured = await captureWrites(async () => {
+      try {
+        exitCode = await runCli(["node", "crabline", "--config", configPath, "doctor"]);
+      } finally {
+        for (const [name, value] of Object.entries(originals)) {
+          if (value !== undefined) {
+            process.env[name] = value;
+          }
         }
       }
-    }
+    });
 
     expect(exitCode!).toBe(0);
     expect(captured.stdout.join("")).toContain("doctor ok");
@@ -1941,13 +1883,9 @@ describe("cli", () => {
         "fixtures: []",
       ].join("\n"),
     );
-    const captured = captureWrites();
-
-    try {
+    const captured = await captureWrites(async () => {
       expect(await runCli(["node", "crabline", "--config", configPath, "doctor"])).toBe(0);
-    } finally {
-      captured.restore();
-    }
+    });
 
     expect(captured.stdout.join("")).toContain("doctor ok");
   });

--- a/test/package-production.test.ts
+++ b/test/package-production.test.ts
@@ -407,12 +407,16 @@ describe("production package", () => {
   });
 
   it("runs autoreview Python tests in the verify gate", async () => {
-    const pkg = JSON.parse(await fs.readFile("package.json", "utf8")) as {
-      scripts?: Record<string, string>;
-    };
+    const [pkgContents, launcher] = await Promise.all([
+      fs.readFile("package.json", "utf8"),
+      fs.readFile("tools/run-autoreview-tests.mjs", "utf8"),
+    ]);
+    const pkg = JSON.parse(pkgContents) as { scripts?: Record<string, string> };
 
     expect(pkg.scripts?.["test:autoreview"]).toBe("node tools/run-autoreview-tests.mjs");
     expect(pkg.scripts?.verify).toContain("pnpm test:autoreview");
+    expect(launcher).toContain("sys.version_info >= (3, 10)");
+    expect(launcher).toContain("Python 3.10 or newer is required");
   });
 
   it("documents source-checkout and user-supplied script bridge commands", async () => {

--- a/test/test-helpers.test.ts
+++ b/test/test-helpers.test.ts
@@ -139,6 +139,43 @@ describe("test helpers", () => {
     }
   });
 
+  it("forwards detached writes after their capture is restored", async () => {
+    const stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    let releaseDetached!: () => void;
+    let releaseSecond!: () => void;
+    const detachedGate = new Promise<void>((resolve) => {
+      releaseDetached = resolve;
+    });
+    const secondGate = new Promise<void>((resolve) => {
+      releaseSecond = resolve;
+    });
+    let detachedWrite!: Promise<void>;
+
+    try {
+      const first = await captureWrites(() => {
+        process.stdout.write("first");
+        detachedWrite = detachedGate.then(() => {
+          process.stdout.write("detached");
+        });
+      });
+      const secondPromise = captureWrites(async () => {
+        await secondGate;
+        process.stdout.write("second");
+      });
+
+      releaseDetached();
+      await detachedWrite;
+      releaseSecond();
+      const second = await secondPromise;
+
+      expect(first.stdout).toEqual(["first"]);
+      expect(second.stdout).toEqual(["second"]);
+      expect(stdoutWrite.mock.calls.map(([chunk]) => chunk)).toEqual(["detached"]);
+    } finally {
+      stdoutWrite.mockRestore();
+    }
+  });
+
   it("runs every cleanup operation before reporting failures", async () => {
     const completed: string[] = [];
 

--- a/test/test-helpers.test.ts
+++ b/test/test-helpers.test.ts
@@ -60,17 +60,14 @@ describe("test helpers", () => {
   });
 
   it("preserves write overload callbacks while capturing output", async () => {
-    const captured = captureWrites();
     const stdoutCallback = vi.fn();
     const stderrCallback = vi.fn();
 
-    try {
+    const captured = await captureWrites(async () => {
       process.stdout.write("text", "utf8", stdoutCallback);
       process.stderr.write(Buffer.from("bytes"), stderrCallback);
       await Promise.resolve();
-    } finally {
-      captured.restore();
-    }
+    });
 
     expect(captured.stdout).toEqual(["text"]);
     expect(captured.stderr).toEqual(["bytes"]);
@@ -78,24 +75,67 @@ describe("test helpers", () => {
     expect(stderrCallback).toHaveBeenCalledWith(null);
   });
 
-  it("restores nested output captures in either order", () => {
+  it("restores the outer capture after a nested capture settles", async () => {
     const stdoutWrite = process.stdout.write;
     const stderrWrite = process.stderr.write;
 
-    for (const order of ["outer-first", "inner-first"] as const) {
-      const outer = captureWrites();
-      const inner = captureWrites();
+    const outer = await captureWrites(async () => {
+      process.stdout.write("outer-before");
+      const inner = await captureWrites(async () => {
+        process.stdout.write("inner");
+      });
+      process.stdout.write("outer-after");
+      return inner;
+    });
 
-      if (order === "outer-first") {
-        outer.restore();
-        inner.restore();
-      } else {
-        inner.restore();
-        outer.restore();
-      }
+    expect(outer.stdout).toEqual(["outer-before", "outer-after"]);
+    expect(outer.result.stdout).toEqual(["inner"]);
+    expect(process.stdout.write).toBe(stdoutWrite);
+    expect(process.stderr.write).toBe(stderrWrite);
+  });
 
-      expect(process.stdout.write).toBe(stdoutWrite);
-      expect(process.stderr.write).toBe(stderrWrite);
+  it("isolates overlapping asynchronous output captures", async () => {
+    const stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    let releaseFirst!: () => void;
+    let releaseSecond!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const secondGate = new Promise<void>((resolve) => {
+      releaseSecond = resolve;
+    });
+
+    const runCapture = (label: string, gate: Promise<void>) =>
+      captureWrites(async () => {
+        await gate;
+        process.stdout.write(`${label}-stdout`);
+        process.stderr.write(`${label}-stderr`);
+      });
+
+    try {
+      const firstPromise = runCapture("first", firstGate);
+      const secondPromise = runCapture("second", secondGate);
+      process.stdout.write("parent-stdout");
+      process.stderr.write("parent-stderr");
+      releaseFirst();
+      const first = await firstPromise;
+      process.stdout.write("parent-after-first");
+      releaseSecond();
+      const second = await secondPromise;
+
+      expect(first.stdout).toEqual(["first-stdout"]);
+      expect(first.stderr).toEqual(["first-stderr"]);
+      expect(second.stdout).toEqual(["second-stdout"]);
+      expect(second.stderr).toEqual(["second-stderr"]);
+      expect(stdoutWrite.mock.calls.map(([chunk]) => chunk)).toEqual([
+        "parent-stdout",
+        "parent-after-first",
+      ]);
+      expect(stderrWrite.mock.calls.map(([chunk]) => chunk)).toEqual(["parent-stderr"]);
+    } finally {
+      stdoutWrite.mockRestore();
+      stderrWrite.mockRestore();
     }
   });
 

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -105,6 +105,7 @@ export async function settleCleanup(operations: Promise<unknown>[]): Promise<voi
 }
 
 type WriteCapture = {
+  active: boolean;
   stderr: string[];
   stdout: string[];
 };
@@ -128,7 +129,7 @@ const createCaptureWriter =
     callback?: (error?: Error | null) => void,
   ) => {
     const capture = writeCaptureStorage.getStore();
-    if (!capture) {
+    if (!capture?.active) {
       const target = stream === "stdout" ? process.stdout : process.stderr;
       const originalWrite = (
         stream === "stdout" ? originalStdoutWrite : originalStderrWrite
@@ -152,8 +153,7 @@ export const createWriteCapture = (): {
   stderr: string[];
   stdout: string[];
 } => {
-  const capture: WriteCapture = { stderr: [], stdout: [] };
-  let active = true;
+  const capture: WriteCapture = { active: true, stderr: [], stdout: [] };
   if (activeWriteCaptureCount === 0) {
     originalStdoutWrite = process.stdout.write;
     originalStderrWrite = process.stderr.write;
@@ -164,10 +164,10 @@ export const createWriteCapture = (): {
 
   return {
     restore() {
-      if (!active) {
+      if (!capture.active) {
         return;
       }
-      active = false;
+      capture.active = false;
       activeWriteCaptureCount -= 1;
       if (activeWriteCaptureCount === 0) {
         process.stdout.write = originalStdoutWrite!;
@@ -177,7 +177,7 @@ export const createWriteCapture = (): {
       }
     },
     async run<T>(operation: () => Promise<T> | T): Promise<T> {
-      if (!active) {
+      if (!capture.active) {
         throw new Error("Cannot run a restored output capture.");
       }
       return await writeCaptureStorage.run(capture, operation);

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { request as httpRequest } from "node:http";
 import { tmpdir } from "node:os";
@@ -104,12 +105,18 @@ export async function settleCleanup(operations: Promise<unknown>[]): Promise<voi
 }
 
 type WriteCapture = {
-  active: boolean;
   stderr: string[];
   stdout: string[];
 };
 
-const writeCaptures: WriteCapture[] = [];
+type CaptureWrite = (
+  chunk: string | Uint8Array,
+  encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+  callback?: (error?: Error | null) => void,
+) => boolean;
+
+const writeCaptureStorage = new AsyncLocalStorage<WriteCapture>();
+let activeWriteCaptureCount = 0;
 let originalStdoutWrite: typeof process.stdout.write | undefined;
 let originalStderrWrite: typeof process.stderr.write | undefined;
 
@@ -120,9 +127,16 @@ const createCaptureWriter =
     encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
     callback?: (error?: Error | null) => void,
   ) => {
-    const capture = writeCaptures.findLast((entry) => entry.active);
+    const capture = writeCaptureStorage.getStore();
+    if (!capture) {
+      const target = stream === "stdout" ? process.stdout : process.stderr;
+      const originalWrite = (
+        stream === "stdout" ? originalStdoutWrite : originalStderrWrite
+      ) as CaptureWrite;
+      return originalWrite.call(target, chunk, encodingOrCallback, callback);
+    }
     const encoding = typeof encodingOrCallback === "string" ? encodingOrCallback : undefined;
-    capture?.[stream].push(
+    capture[stream].push(
       typeof chunk === "string" ? chunk : Buffer.from(chunk).toString(encoding ?? "utf8"),
     );
     const completion = typeof encodingOrCallback === "function" ? encodingOrCallback : callback;
@@ -132,37 +146,60 @@ const createCaptureWriter =
     return true;
   };
 
-export const captureWrites = (): {
+export const createWriteCapture = (): {
   restore: () => void;
+  run: <T>(operation: () => Promise<T> | T) => Promise<T>;
   stderr: string[];
   stdout: string[];
 } => {
-  const capture: WriteCapture = { active: true, stderr: [], stdout: [] };
-  if (writeCaptures.length === 0) {
+  const capture: WriteCapture = { stderr: [], stdout: [] };
+  let active = true;
+  if (activeWriteCaptureCount === 0) {
     originalStdoutWrite = process.stdout.write;
     originalStderrWrite = process.stderr.write;
     process.stdout.write = createCaptureWriter("stdout") as typeof process.stdout.write;
     process.stderr.write = createCaptureWriter("stderr") as typeof process.stderr.write;
   }
-  writeCaptures.push(capture);
+  activeWriteCaptureCount += 1;
 
   return {
     restore() {
-      if (!capture.active) {
+      if (!active) {
         return;
       }
-      capture.active = false;
-      while (writeCaptures.at(-1)?.active === false) {
-        writeCaptures.pop();
-      }
-      if (writeCaptures.length === 0) {
+      active = false;
+      activeWriteCaptureCount -= 1;
+      if (activeWriteCaptureCount === 0) {
         process.stdout.write = originalStdoutWrite!;
         process.stderr.write = originalStderrWrite!;
         originalStdoutWrite = undefined;
         originalStderrWrite = undefined;
       }
     },
+    async run<T>(operation: () => Promise<T> | T): Promise<T> {
+      if (!active) {
+        throw new Error("Cannot run a restored output capture.");
+      }
+      return await writeCaptureStorage.run(capture, operation);
+    },
     stderr: capture.stderr,
     stdout: capture.stdout,
   };
+};
+
+export const captureWrites = async <T>(
+  operation: () => Promise<T> | T,
+): Promise<{
+  result: T;
+  stderr: string[];
+  stdout: string[];
+}> => {
+  const capture = createWriteCapture();
+
+  try {
+    const result = await capture.run(operation);
+    return { result, stderr: capture.stderr, stdout: capture.stdout };
+  } finally {
+    capture.restore();
+  }
 };

--- a/tools/run-autoreview-tests.mjs
+++ b/tools/run-autoreview-tests.mjs
@@ -21,7 +21,7 @@ const python = candidates.find(([command, launcherArgs]) => {
     [
       ...launcherArgs,
       "-c",
-      "import sys; raise SystemExit(0 if sys.version_info.major == 3 else 1)",
+      "import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)",
     ],
     { stdio: "ignore" },
   );
@@ -29,7 +29,7 @@ const python = candidates.find(([command, launcherArgs]) => {
 });
 
 if (!python) {
-  console.error("Python 3 is required to run the autoreview tests.");
+  console.error("Python 3.10 or newer is required to run the autoreview tests.");
   process.exit(127);
 }
 


### PR DESCRIPTION
## Summary

- enforce security-policy coverage for local actions and digest-pinned Docker actions
- require Python 3.10 for autoreview tooling
- isolate overlapping output captures while forwarding detached writes after capture restoration

## Validation

- 71 focused workflow, CLI, package, and helper tests
- 198 autoreview self-tests
- `pnpm lint`
- actionlint 1.7.7 with the repository concurrency exception
- `git diff --check origin/main...HEAD`
- autoreview: clean (`gpt-5.6-sol`, high, confidence 0.94)
- privacy scan: clean
- exact head: `b54d7a03d36501d4a61512e3c4b8e9b100931518`
- GitHub CI: green
- Crabbox `run_61fb96d3e1dd`: `pnpm verify`, 60 files / 1147 tests passed

## Review remediation

- Exact-head autoreview found that restored `AsyncLocalStorage` capture contexts could swallow detached writes while another capture remained active. The final stack invalidates restored stores, forwards those writes to the original stream, and includes a deterministic regression test.
