### PR TITLE
fix(whatsapp): preserve handshake codec variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Generate Signal bundle public keys with the provider-required type prefix while preserving raw WhatsApp wire encoding.
 - Reject nonce fixture IDs outside the extractor alphabet and share one validation boundary.
 - Reject provider and fixture timer durations above Node's supported ceiling.
+- Round-trip every supported WhatsApp handshake protobuf variant without dropping fields.
 - Bound shared JSON ingress, reject non-object payloads precisely, and strictly normalize loopback IP addresses.
 - Harden WhatsApp send evidence, direct-JID correlation, cursor and cleanup races, and cleartext listener exposure.
 - Revalidate npm package version, integrity, and provenance after every release publication outcome.

--- a/src/servers/whatsapp-wire/handshake.ts
+++ b/src/servers/whatsapp-wire/handshake.ts
@@ -4,16 +4,22 @@ type BytesField = Buffer | undefined;
 
 export type HandshakeMessage = {
   clientFinish?: {
+    extendedCiphertext?: Buffer;
     payload?: Buffer;
     staticKey?: Buffer;
   };
   clientHello?: {
     ephemeral?: Buffer;
+    extendedCiphertext?: Buffer;
+    payload?: Buffer;
+    staticKey?: Buffer;
+    useExtended?: boolean;
   };
   serverHello?: {
-    ephemeral: Uint8Array;
-    payload: Uint8Array;
-    staticKey: Uint8Array;
+    ephemeral?: Uint8Array;
+    extendedStatic?: Uint8Array;
+    payload?: Uint8Array;
+    staticKey?: Uint8Array;
   };
 };
 
@@ -26,6 +32,9 @@ export function decodeHandshakeMessage(data: Uint8Array): HandshakeMessage {
     if (field === 2) {
       requireBytesWireType(tag, field);
       message.clientHello = decodeClientHello(reader.bytes());
+    } else if (field === 3) {
+      requireBytesWireType(tag, field);
+      message.serverHello = decodeServerHello(reader.bytes());
     } else if (field === 4) {
       requireBytesWireType(tag, field);
       message.clientFinish = decodeClientFinish(reader.bytes());
@@ -38,8 +47,14 @@ export function decodeHandshakeMessage(data: Uint8Array): HandshakeMessage {
 
 export function encodeHandshakeMessage(message: HandshakeMessage): Buffer {
   const writer = new ProtoWriter();
+  if (message.clientHello) {
+    writer.bytesField(2, encodeClientHello(message.clientHello));
+  }
   if (message.serverHello) {
     writer.bytesField(3, encodeServerHello(message.serverHello));
+  }
+  if (message.clientFinish) {
+    writer.bytesField(4, encodeClientFinish(message.clientFinish));
   }
   return writer.finish();
 }
@@ -47,20 +62,77 @@ export function encodeHandshakeMessage(message: HandshakeMessage): Buffer {
 function decodeClientHello(data: Uint8Array): NonNullable<HandshakeMessage["clientHello"]> {
   const reader = new ProtoReader(data);
   let ephemeral: BytesField;
+  let extendedCiphertext: BytesField;
+  let payload: BytesField;
+  let staticKey: BytesField;
+  let useExtended: boolean | undefined;
   while (!reader.done()) {
     const tag = reader.tag();
-    if (tag >>> 3 === 1) {
-      requireBytesWireType(tag, 1);
+    const field = tag >>> 3;
+    if (field === 1) {
+      requireBytesWireType(tag, field);
       ephemeral = reader.bytes();
+    } else if (field === 2) {
+      requireBytesWireType(tag, field);
+      staticKey = reader.bytes();
+    } else if (field === 3) {
+      requireBytesWireType(tag, field);
+      payload = reader.bytes();
+    } else if (field === 4) {
+      requireVarintWireType(tag, field);
+      useExtended = reader.uint32() !== 0;
+    } else if (field === 5) {
+      requireBytesWireType(tag, field);
+      extendedCiphertext = reader.bytes();
     } else {
       reader.skip(tag & 7);
     }
   }
-  return ephemeral === undefined ? {} : { ephemeral };
+  return {
+    ...(ephemeral === undefined ? {} : { ephemeral }),
+    ...(extendedCiphertext === undefined ? {} : { extendedCiphertext }),
+    ...(payload === undefined ? {} : { payload }),
+    ...(staticKey === undefined ? {} : { staticKey }),
+    ...(useExtended === undefined ? {} : { useExtended }),
+  };
+}
+
+function decodeServerHello(data: Uint8Array): NonNullable<HandshakeMessage["serverHello"]> {
+  const reader = new ProtoReader(data);
+  let ephemeral: BytesField;
+  let extendedStatic: BytesField;
+  let payload: BytesField;
+  let staticKey: BytesField;
+  while (!reader.done()) {
+    const tag = reader.tag();
+    const field = tag >>> 3;
+    if (field === 1) {
+      requireBytesWireType(tag, field);
+      ephemeral = reader.bytes();
+    } else if (field === 2) {
+      requireBytesWireType(tag, field);
+      staticKey = reader.bytes();
+    } else if (field === 3) {
+      requireBytesWireType(tag, field);
+      payload = reader.bytes();
+    } else if (field === 4) {
+      requireBytesWireType(tag, field);
+      extendedStatic = reader.bytes();
+    } else {
+      reader.skip(tag & 7);
+    }
+  }
+  return {
+    ...(ephemeral === undefined ? {} : { ephemeral }),
+    ...(extendedStatic === undefined ? {} : { extendedStatic }),
+    ...(payload === undefined ? {} : { payload }),
+    ...(staticKey === undefined ? {} : { staticKey }),
+  };
 }
 
 function decodeClientFinish(data: Uint8Array): NonNullable<HandshakeMessage["clientFinish"]> {
   const reader = new ProtoReader(data);
+  let extendedCiphertext: BytesField;
   let payload: BytesField;
   let staticKey: BytesField;
   while (!reader.done()) {
@@ -72,14 +144,52 @@ function decodeClientFinish(data: Uint8Array): NonNullable<HandshakeMessage["cli
     } else if (field === 2) {
       requireBytesWireType(tag, field);
       payload = reader.bytes();
+    } else if (field === 3) {
+      requireBytesWireType(tag, field);
+      extendedCiphertext = reader.bytes();
     } else {
       reader.skip(tag & 7);
     }
   }
   return {
+    ...(extendedCiphertext === undefined ? {} : { extendedCiphertext }),
     ...(payload === undefined ? {} : { payload }),
     ...(staticKey === undefined ? {} : { staticKey }),
   };
+}
+
+function encodeClientHello(clientHello: NonNullable<HandshakeMessage["clientHello"]>): Buffer {
+  const writer = new ProtoWriter();
+  if (clientHello.ephemeral !== undefined) {
+    writer.bytesField(1, clientHello.ephemeral);
+  }
+  if (clientHello.staticKey !== undefined) {
+    writer.bytesField(2, clientHello.staticKey);
+  }
+  if (clientHello.payload !== undefined) {
+    writer.bytesField(3, clientHello.payload);
+  }
+  if (clientHello.useExtended !== undefined) {
+    writer.boolField(4, clientHello.useExtended);
+  }
+  if (clientHello.extendedCiphertext !== undefined) {
+    writer.bytesField(5, clientHello.extendedCiphertext);
+  }
+  return writer.finish();
+}
+
+function encodeClientFinish(clientFinish: NonNullable<HandshakeMessage["clientFinish"]>): Buffer {
+  const writer = new ProtoWriter();
+  if (clientFinish.staticKey !== undefined) {
+    writer.bytesField(1, clientFinish.staticKey);
+  }
+  if (clientFinish.payload !== undefined) {
+    writer.bytesField(2, clientFinish.payload);
+  }
+  if (clientFinish.extendedCiphertext !== undefined) {
+    writer.bytesField(3, clientFinish.extendedCiphertext);
+  }
+  return writer.finish();
 }
 
 function requireBytesWireType(tag: number, field: number): void {
@@ -91,11 +201,27 @@ function requireBytesWireType(tag: number, field: number): void {
   }
 }
 
+function requireVarintWireType(tag: number, field: number): void {
+  const wireType = tag & 7;
+  if (wireType !== 0) {
+    throw new Error(`Invalid WhatsApp handshake wire type ${wireType} for varint field ${field}.`);
+  }
+}
+
 function encodeServerHello(serverHello: NonNullable<HandshakeMessage["serverHello"]>): Buffer {
   const writer = new ProtoWriter();
-  writer.bytesField(1, serverHello.ephemeral);
-  writer.bytesField(2, serverHello.staticKey);
-  writer.bytesField(3, serverHello.payload);
+  if (serverHello.ephemeral !== undefined) {
+    writer.bytesField(1, serverHello.ephemeral);
+  }
+  if (serverHello.staticKey !== undefined) {
+    writer.bytesField(2, serverHello.staticKey);
+  }
+  if (serverHello.payload !== undefined) {
+    writer.bytesField(3, serverHello.payload);
+  }
+  if (serverHello.extendedStatic !== undefined) {
+    writer.bytesField(4, serverHello.extendedStatic);
+  }
   return writer.finish();
 }
 
@@ -197,6 +323,11 @@ class ProtoReader {
 
 class ProtoWriter {
   readonly #parts: Buffer[] = [];
+
+  boolField(field: number, value: boolean): void {
+    this.uint32(field << 3);
+    this.uint32(value ? 1 : 0);
+  }
 
   bytesField(field: number, value: Uint8Array): void {
     this.uint32((field << 3) | 2);

--- a/test/whatsapp-wire.test.ts
+++ b/test/whatsapp-wire.test.ts
@@ -1,5 +1,5 @@
 import { deflateSync } from "node:zlib";
-import { Curve as BaileysCurve } from "baileys";
+import { Curve as BaileysCurve, proto } from "baileys";
 import { describe, expect, it, vi } from "vitest";
 import { WebSocket } from "ws";
 import {
@@ -21,7 +21,11 @@ import {
   NOISE_WA_HEADER,
   signedKeyPair,
 } from "../src/servers/whatsapp-wire/crypto.js";
-import { decodeHandshakeMessage } from "../src/servers/whatsapp-wire/handshake.js";
+import {
+  decodeHandshakeMessage,
+  encodeHandshakeMessage,
+  type HandshakeMessage,
+} from "../src/servers/whatsapp-wire/handshake.js";
 import { xmppPreKey, xmppSignedPreKey } from "../src/servers/whatsapp-wire/signal.js";
 import {
   createSerializedMessageHandler,
@@ -399,6 +403,77 @@ describe("WhatsApp WebSocket message processing", () => {
 });
 
 describe("WhatsApp handshake protobufs", () => {
+  const variants: Array<{
+    baileys: proto.IHandshakeMessage;
+    message: HandshakeMessage;
+    name: string;
+  }> = [
+    {
+      baileys: {
+        clientHello: {
+          ephemeral: Buffer.from([1]),
+          extendedCiphertext: Buffer.from([5]),
+          payload: Buffer.alloc(0),
+          static: Buffer.from([2]),
+          useExtended: false,
+        },
+      },
+      message: {
+        clientHello: {
+          ephemeral: Buffer.from([1]),
+          extendedCiphertext: Buffer.from([5]),
+          payload: Buffer.alloc(0),
+          staticKey: Buffer.from([2]),
+          useExtended: false,
+        },
+      },
+      name: "client hello",
+    },
+    {
+      baileys: {
+        serverHello: {
+          ephemeral: Buffer.from([1]),
+          extendedStatic: Buffer.from([4]),
+          payload: Buffer.from([3]),
+          static: Buffer.from([2]),
+        },
+      },
+      message: {
+        serverHello: {
+          ephemeral: Buffer.from([1]),
+          extendedStatic: Buffer.from([4]),
+          payload: Buffer.from([3]),
+          staticKey: Buffer.from([2]),
+        },
+      },
+      name: "server hello",
+    },
+    {
+      baileys: {
+        clientFinish: {
+          extendedCiphertext: Buffer.from([3]),
+          payload: Buffer.from([2]),
+          static: Buffer.from([1]),
+        },
+      },
+      message: {
+        clientFinish: {
+          extendedCiphertext: Buffer.from([3]),
+          payload: Buffer.from([2]),
+          staticKey: Buffer.from([1]),
+        },
+      },
+      name: "client finish",
+    },
+  ];
+
+  it.each(variants)("round trips the complete $name variant", ({ baileys, message }) => {
+    const encoded = encodeHandshakeMessage(message);
+
+    expect(encoded).toEqual(Buffer.from(proto.HandshakeMessage.encode(baileys).finish()));
+    expect(decodeHandshakeMessage(encoded)).toEqual(message);
+  });
+
   it("skips unknown ten-byte uint64 varints", () => {
     const message = decodeHandshakeMessage(
       Buffer.from([
@@ -416,6 +491,8 @@ describe("WhatsApp handshake protobufs", () => {
       Buffer.from([0x11, 0, 0, 0, 0, 0, 0, 0, 0]),
       Buffer.from([0x15, 0, 0, 0, 0]),
       Buffer.from([0x12, 0x02, 0x08, 0x00]),
+      Buffer.from([0x12, 0x02, 0x22, 0x00]),
+      Buffer.from([0x1a, 0x02, 0x08, 0x00]),
       Buffer.from([0x22, 0x02, 0x10, 0x00]),
     ]) {
       expect(() => decodeHandshakeMessage(message)).toThrow("Invalid WhatsApp handshake wire type");


### PR DESCRIPTION
## Summary

- implement the provider-native protobuf field mapping for client hello, server hello, and client finish
- preserve optional false and empty values instead of silently dropping them
- round-trip every supported handshake variant in focused tests

## Validation

- 42 focused tests
- typecheck, format, lint, and `git diff --check origin/main...HEAD`
- autoreview: clean (`gpt-5.6-sol`, high, confidence 0.97)
- privacy scan: clean
- exact head: `7173f0b23fed5e0c4f30237a793e20d7f3d893d2`
- GitHub CI: green
- Crabbox `run_f5949f87d5c8`: `pnpm verify`, 60 files / 1142 tests passed
