### PR TITLE
fix(config): enforce Node timer ceilings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Normalize malformed callback URLs, artifact pointers, and loopback thread addresses into stable domain errors.
 - Generate Signal bundle public keys with the provider-required type prefix while preserving raw WhatsApp wire encoding.
 - Reject nonce fixture IDs outside the extractor alphabet and share one validation boundary.
+- Reject provider and fixture timer durations above Node's supported ceiling.
 - Bound shared JSON ingress, reject non-object payloads precisely, and strictly normalize loopback IP addresses.
 - Harden WhatsApp send evidence, direct-JID correlation, cursor and cleanup races, and cleartext listener exposure.
 - Revalidate npm package version, integrity, and provenance after every release publication outcome.

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -12,6 +12,10 @@ LOOPBACK_ADDRESSES.addAddress("::1", "ipv6");
 LOOPBACK_ADDRESSES.addSubnet("::ffff:127.0.0.0", 104, "ipv6");
 const MAX_FIXTURE_RETRIES = 10;
 const MAX_TIMER_MS = 2_147_483_647;
+const TimerMsSchema = z
+  .number()
+  .int()
+  .max(MAX_TIMER_MS, "timer duration must be at most 2147483647ms");
 export const INBOUND_AUTHORS = ["assistant", "user", "system", "any"] as const;
 export const INBOUND_STRATEGIES = ["contains", "exact", "regex"] as const;
 export const INBOUND_NONCE_MODES = ["contains", "exact", "ignore"] as const;
@@ -181,7 +185,7 @@ const ScriptCommandsSchema = z.strictObject({
 });
 
 const LoopbackConfigSchema = z.strictObject({
-  delayMs: z.number().int().min(0).max(MAX_TIMER_MS).default(25),
+  delayMs: TimerMsSchema.min(0).default(25),
 });
 
 const ScriptConfigSchema = z.strictObject({
@@ -225,7 +229,7 @@ const DiscordWebhookSchema = z.strictObject({
 const DiscordConfigSchema = z.strictObject({
   applicationId: z.string().min(1).optional(),
   botToken: z.string().min(1).optional(),
-  gatewayDurationMs: z.number().int().min(1000).default(180_000),
+  gatewayDurationMs: TimerMsSchema.min(1000).default(180_000),
   mentionRoleIds: z.array(z.string().min(1)).optional(),
   publicKey: z.string().min(1).optional(),
   recorder: DiscordRecorderSchema.default({}),
@@ -285,7 +289,7 @@ const MsTeamsConfigSchema = z.strictObject({
   appPassword: z.string().min(1).optional(),
   appTenantId: z.string().min(1).optional(),
   appType: z.enum(["MultiTenant", "SingleTenant"]).optional(),
-  dialogOpenTimeoutMs: z.number().int().min(0).optional(),
+  dialogOpenTimeoutMs: TimerMsSchema.min(0).optional(),
   federated: MsTeamsFederatedSchema.optional(),
   recorder: MsTeamsRecorderSchema.default({}),
   userName: z.string().min(1).optional(),
@@ -355,7 +359,7 @@ const TelegramLongPollingSchema = z.strictObject({
   deleteWebhook: z.boolean().optional(),
   dropPendingUpdates: z.boolean().optional(),
   limit: z.number().int().min(1).max(100).optional(),
-  retryDelayMs: z.number().int().min(0).optional(),
+  retryDelayMs: TimerMsSchema.min(0).optional(),
   timeout: z.number().int().min(0).optional(),
 });
 
@@ -425,8 +429,8 @@ const MattermostWebhookSchema = z.strictObject({
 
 const MattermostWebsocketSchema = z.strictObject({
   enabled: z.boolean().optional(),
-  maxReconnectDelayMs: z.number().int().min(0).optional(),
-  reconnectDelayMs: z.number().int().min(0).optional(),
+  maxReconnectDelayMs: TimerMsSchema.min(0).optional(),
+  reconnectDelayMs: TimerMsSchema.min(0).optional(),
 });
 
 const MattermostConfigSchema = z.strictObject({
@@ -502,7 +506,7 @@ const MatrixConfigSchema = z.strictObject({
 
 const IMessageConfigSchema = z.strictObject({
   apiKey: z.string().min(1).optional(),
-  gatewayDurationMs: z.number().int().min(1000).default(180_000),
+  gatewayDurationMs: TimerMsSchema.min(1000).default(180_000),
   local: z.boolean().optional(),
   recorder: z.strictObject({ path: z.string().min(1).optional() }).default({}),
   serverUrl: HttpUrlSchema.optional(),
@@ -717,7 +721,7 @@ export const FixtureSchema = z.strictObject({
   retries: z.number().int().min(0).max(MAX_FIXTURE_RETRIES).default(0),
   tags: z.array(z.string().min(1)).default([]),
   target: TargetSchema,
-  timeoutMs: z.number().int().min(100).max(MAX_TIMER_MS).default(30_000),
+  timeoutMs: TimerMsSchema.min(100).default(30_000),
 });
 
 const MANIFEST_EXTENSION_KEY_PATTERN = /^x-[a-z0-9][a-z0-9._-]*$/u;

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,6 +1,58 @@
 import { describe, expect, it } from "vitest";
 import { ManifestSchema } from "../src/config/schema.js";
 
+const TIMER_MAX_ERROR = "timer duration must be at most 2147483647ms";
+const TIMER_CONFIG_CASES = [
+  {
+    field: "discord.gatewayDurationMs",
+    path: ["providers", "timer", "discord", "gatewayDurationMs"],
+    provider: (value: number) => ({
+      adapter: "discord",
+      discord: { gatewayDurationMs: value },
+    }),
+  },
+  {
+    field: "imessage.gatewayDurationMs",
+    path: ["providers", "timer", "imessage", "gatewayDurationMs"],
+    provider: (value: number) => ({
+      adapter: "imessage",
+      imessage: { gatewayDurationMs: value },
+    }),
+  },
+  {
+    field: "msteams.dialogOpenTimeoutMs",
+    path: ["providers", "timer", "msteams", "dialogOpenTimeoutMs"],
+    provider: (value: number) => ({
+      adapter: "msteams",
+      msteams: { dialogOpenTimeoutMs: value },
+    }),
+  },
+  {
+    field: "telegram.longPolling.retryDelayMs",
+    path: ["providers", "timer", "telegram", "longPolling", "retryDelayMs"],
+    provider: (value: number) => ({
+      adapter: "telegram",
+      telegram: { longPolling: { retryDelayMs: value } },
+    }),
+  },
+  {
+    field: "mattermost.websocket.maxReconnectDelayMs",
+    path: ["providers", "timer", "mattermost", "websocket", "maxReconnectDelayMs"],
+    provider: (value: number) => ({
+      adapter: "mattermost",
+      mattermost: { websocket: { maxReconnectDelayMs: value } },
+    }),
+  },
+  {
+    field: "mattermost.websocket.reconnectDelayMs",
+    path: ["providers", "timer", "mattermost", "websocket", "reconnectDelayMs"],
+    provider: (value: number) => ({
+      adapter: "mattermost",
+      mattermost: { websocket: { reconnectDelayMs: value } },
+    }),
+  },
+] as const;
+
 describe("manifest schema", () => {
   it("rejects regex syntax unsupported by the linear-time matcher", () => {
     for (const pattern of [String.raw`^(a)\1$`, "(?=a)a"]) {
@@ -341,7 +393,39 @@ describe("manifest schema", () => {
           },
         },
       }),
-    ).toThrow(/2147483647/u);
+    ).toThrow(TIMER_MAX_ERROR);
+  });
+
+  it.each(TIMER_CONFIG_CASES)(
+    "rejects $field beyond the Node timer ceiling",
+    ({ path, provider }) => {
+      const result = ManifestSchema.safeParse({
+        configVersion: 1,
+        fixtures: [],
+        providers: { timer: provider(2_147_483_648) },
+      });
+
+      expect(result.success).toBe(false);
+      if (result.success) {
+        throw new Error("expected timer validation to fail");
+      }
+      expect(result.error.issues).toEqual([
+        expect.objectContaining({
+          message: TIMER_MAX_ERROR,
+          path,
+        }),
+      ]);
+    },
+  );
+
+  it.each(TIMER_CONFIG_CASES)("accepts $field at the Node timer ceiling", ({ provider }) => {
+    expect(() =>
+      ManifestSchema.parse({
+        configVersion: 1,
+        fixtures: [],
+        providers: { timer: provider(2_147_483_647) },
+      }),
+    ).not.toThrow();
   });
 
   it("rejects fixture ids that cannot be embedded in nonces", () => {
@@ -485,7 +569,7 @@ describe("manifest schema", () => {
         ],
         providers: { local: { adapter: "loopback" } },
       }),
-    ).toThrow(/2147483647/u);
+    ).toThrow(TIMER_MAX_ERROR);
   });
 
   it("rejects unknown keys throughout user-authored config", () => {


### PR DESCRIPTION
## Summary

- cap every millisecond timer field at Node's 2^31-1 maximum
- share one stable schema diagnostic across all affected providers
- cover both the accepted boundary and first rejected value

## Validation

- 56 focused tests
- typecheck, format, lint, and `git diff --check origin/main...HEAD`
- autoreview: clean (`gpt-5.6-sol`, high, confidence 0.96)
- privacy scan: clean
- GitHub CI: green at `4522c4f7c7ad9303fda63c240764e80c155cfca4`
- Crabbox `run_e99ab912629c`: `pnpm verify`, 60 files / 1139 tests passed
