### PR TITLE
fix(zalo): reject unsupported thread targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Reject nonce fixture IDs outside the extractor alphabet and share one validation boundary.
 - Reject provider and fixture timer durations above Node's supported ceiling.
 - Round-trip every supported WhatsApp handshake protobuf variant without dropping fields.
+- Reject unsupported Zalo thread targets during normalization, matching OpenClaw bridge execution.
 - Bound shared JSON ingress, reject non-object payloads precisely, and strictly normalize loopback IP addresses.
 - Harden WhatsApp send evidence, direct-JID correlation, cursor and cleanup races, and cleartext listener exposure.
 - Revalidate npm package version, integrity, and provenance after every release publication outcome.

--- a/src/openclaw/bridges/zalo.ts
+++ b/src/openclaw/bridges/zalo.ts
@@ -1,3 +1,4 @@
+import { ZALO_UNSUPPORTED_THREAD_TARGET_ERROR } from "../../providers/target-normalizers.js";
 import {
   createAdminInboundRequest,
   createOpenClawCrablineProviderBridge,
@@ -68,14 +69,14 @@ export const ZALO_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablineProv
       },
       createAgentDelivery(parsed) {
         if (parsed.threadId) {
-          throw new Error("Zalo does not support thread targets.");
+          throw new Error(ZALO_UNSUPPORTED_THREAD_TARGET_ERROR);
         }
         const to = nativeId(parsed.id);
         return { channel: "zalo", replyChannel: "zalo", replyTo: to, to };
       },
       createInbound(input) {
         if (input.threadId) {
-          throw new Error("Zalo does not support thread targets.");
+          throw new Error(ZALO_UNSUPPORTED_THREAD_TARGET_ERROR);
         }
         const kind = input.conversation.kind === "direct" ? "direct" : "group";
         const chatId = nativeId(input.conversation.id);

--- a/src/providers/target-normalizers.ts
+++ b/src/providers/target-normalizers.ts
@@ -180,6 +180,8 @@ export const ZALO_ID_RULE: NativeIdRule = {
   pattern: /^\S+$/u,
 };
 
+export const ZALO_UNSUPPORTED_THREAD_TARGET_ERROR = "Zalo does not support thread targets.";
+
 function requireNativeId(value: string, rule: NativeIdRule, label: string): string {
   if (!rule.pattern.test(value)) {
     throw new CrablineError(`${label} must be a native ${rule.name} such as ${rule.example}.`, {
@@ -430,6 +432,24 @@ const MATRIX_TARGET_CODEC: LocalMockTargetCodec = {
   },
 };
 
+const ZALO_BASE_TARGET_CODEC = createNativeTargetCodec({
+  channel: ZALO_ID_RULE,
+  channelLabel: "Zalo user_id or oa_id",
+});
+
+const ZALO_TARGET_CODEC: LocalMockTargetCodec = {
+  normalize(target) {
+    if (target.threadId) {
+      throw new CrablineError(ZALO_UNSUPPORTED_THREAD_TARGET_ERROR, { kind: "config" });
+    }
+    return ZALO_BASE_TARGET_CODEC.normalize(target);
+  },
+  resolveThreadId(target) {
+    const normalized = this.normalize(target);
+    return normalized.channelId ?? normalized.id;
+  },
+};
+
 const BUILTIN_TARGET_CODECS = {
   discord: createNativeTargetCodec({
     channel: DISCORD_SNOWFLAKE_RULE,
@@ -464,10 +484,7 @@ const BUILTIN_TARGET_CODECS = {
     channel: WHATSAPP_WA_ID_RULE,
     channelLabel: "WhatsApp wa_id",
   }),
-  zalo: createNativeTargetCodec({
-    channel: ZALO_ID_RULE,
-    channelLabel: "Zalo user_id or oa_id",
-  }),
+  zalo: ZALO_TARGET_CODEC,
 } satisfies Record<BuiltinProviderAdapterId, LocalMockTargetCodec>;
 
 export function getBuiltinTargetCodec(adapter: BuiltinProviderAdapterId): LocalMockTargetCodec {

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -618,6 +618,23 @@ describe("OpenClaw local provider bridge", () => {
       },
       providerTargetKey: "group-1",
     });
+    expect(() =>
+      createOpenClawCrablineAgentDelivery({
+        manifest: zaloManifest,
+        target: "thread:group-1/message-1",
+      }),
+    ).toThrow("Zalo does not support thread targets.");
+    expect(() =>
+      createOpenClawCrablineInbound({
+        input: {
+          conversation: { id: "group-1", kind: "group" },
+          senderId: "user-1",
+          text: "hello",
+          threadId: "message-1",
+        },
+        manifest: zaloManifest,
+      }),
+    ).toThrow("Zalo does not support thread targets.");
 
     expect(
       createOpenClawCrablineOutboundFromRecorderEvent({

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -11,6 +11,7 @@ import { createRegistry } from "../src/providers/registry.js";
 import {
   normalizeBuiltinTarget,
   type BuiltinProviderAdapterId,
+  ZALO_UNSUPPORTED_THREAD_TARGET_ERROR,
 } from "../src/providers/target-normalizers.js";
 import type { ProviderContext, SendContext, WaitContext } from "../src/providers/types.js";
 import { createTempDir, disposeTempDir } from "./test-helpers.js";
@@ -231,7 +232,6 @@ describe("registry", () => {
         channelId: "user-1",
         id: "user-1",
         metadata: {},
-        threadId: "group-1",
       },
     ],
   ] satisfies Array<
@@ -262,6 +262,41 @@ describe("registry", () => {
 
     expect(registry.resolve(adapter, fixture.id).normalizeTarget(target)).toEqual(
       normalizeBuiltinTarget(adapter, target),
+    );
+  });
+
+  it("rejects unsupported Zalo thread targets through lazy adapters", () => {
+    const target = {
+      channelId: "user-1",
+      id: "user-1",
+      metadata: {},
+      threadId: "message-1",
+    };
+    const fixture = {
+      ...manifest.fixtures[0]!,
+      id: "zalo-thread-target",
+      provider: "zalo",
+      target,
+    };
+    const registry = createRegistry(
+      {
+        ...manifest,
+        fixtures: [fixture],
+        providers: {
+          zalo: {
+            adapter: "zalo",
+            capabilities: ["probe"],
+            env: [],
+            platform: "zalo",
+            status: "active",
+          },
+        },
+      },
+      "/tmp/crabline.yaml",
+    );
+
+    expect(() => registry.resolve("zalo", fixture.id).normalizeTarget(target)).toThrow(
+      ZALO_UNSUPPORTED_THREAD_TARGET_ERROR,
     );
   });
 

--- a/test/zalo-provider.test.ts
+++ b/test/zalo-provider.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { normalizeZaloWebhookPayload, ZaloProviderAdapter } from "../src/providers/builtin/zalo.js";
 import {
+  normalizeBuiltinTarget,
+  ZALO_UNSUPPORTED_THREAD_TARGET_ERROR,
+} from "../src/providers/target-normalizers.js";
+import {
   createLocalMockConfig,
   createProviderContext,
   runLocalMockProviderContract,
@@ -59,6 +63,16 @@ describe("Zalo webhook normalizer", () => {
     } finally {
       await provider.cleanup();
     }
+  });
+
+  it("rejects unsupported thread targets during normalization", () => {
+    expect(() =>
+      normalizeBuiltinTarget("zalo", {
+        id: "user-1",
+        metadata: {},
+        threadId: "message-1",
+      }),
+    ).toThrow(ZALO_UNSUPPORTED_THREAD_TARGET_ERROR);
   });
 
   it("preserves generic fallback thread payloads", () => {


### PR DESCRIPTION
## Summary

- reject Zalo thread targets during normalization
- keep normalization, lazy adapter, agent delivery, and inbound creation on one stable error contract
- preserve supported direct Zalo targets

## Validation

- 117 focused tests
- typecheck, format, lint, and `git diff --check origin/main...HEAD`
- autoreview: clean (`gpt-5.6-sol`, high, confidence 0.94)
- privacy scan: clean
- exact head: `d68a02fae0a034ca50146d6c1d11c2d7dd10bfcf`
- GitHub CI: green
- Crabbox `run_3c7986a29bb1`: `pnpm verify`, 60 files / 1144 tests passed

## Prior exact-head failure

- Crabbox `run_0f32ed9cb431` and GitHub CI caught a stale Zalo lazy-adapter parity fixture; the amended head uses a supported direct parity target and separately verifies lazy thread rejection.
