### PR TITLE
fix(whatsapp): bound Signal sessions per bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Validate signed-JWT registered claims, clock skew, and synchronous key-loader failure cleanup.
 - Reject stale or far-future signed Discord interactions before payload handling.
 - Normalize malformed callback URLs, artifact pointers, and loopback thread addresses into stable domain errors.
+- Bound retained WhatsApp Signal sessions per bundle without evicting active ratchets or committing rejected staged state.
 - Bound shared JSON ingress, reject non-object payloads precisely, and strictly normalize loopback IP addresses.
 - Harden WhatsApp send evidence, direct-JID correlation, cursor and cleanup races, and cleartext listener exposure.
 - Revalidate npm package version, integrity, and provenance after every release publication outcome.

--- a/src/servers/whatsapp-baileys-websocket.ts
+++ b/src/servers/whatsapp-baileys-websocket.ts
@@ -46,6 +46,7 @@ const MAX_WHATSAPP_PENDING_ACKNOWLEDGEMENT_AGE_MS = 5 * 60 * 1_000;
 const MAX_WHATSAPP_RECENT_ACKNOWLEDGEMENTS = 10_000;
 export const MAX_WHATSAPP_WEBSOCKET_FRAGMENTS = 1_024;
 export const MAX_WHATSAPP_SIGNAL_BUNDLES = 1_024;
+export const MAX_WHATSAPP_SIGNAL_SESSIONS_PER_BUNDLE = 32;
 export const MAX_WHATSAPP_WEBSOCKET_CLOSE_REASON_BYTES = 123;
 type NodeBuffer = Buffer<ArrayBufferLike>;
 type WhatsAppWebSocketRawData = NodeBuffer | ArrayBuffer | NodeBuffer[];
@@ -117,10 +118,15 @@ export type WhatsAppSignalDecryptResult<T> =
   | { status: "unavailable" }
   | { status: "rejected" };
 
+export type WhatsAppSignalBundleStoreOptions = {
+  maxSessionsPerBundle?: number | undefined;
+};
+
 export class WhatsAppSignalBundleStore {
   readonly #acknowledgedMessageIds = new Map<string, true>();
   readonly #bundles = new Map<string, MockSignalBundle>();
   readonly #lidByPhoneNumber = new Map<string, string>();
+  readonly #maxSessionsPerBundle: number;
   readonly #pendingMessageAcceptances = new Map<string, Promise<void>>();
   readonly #pendingAcknowledgements = new Map<string, number>();
   readonly #pendingTransactions = new Map<string, Promise<void>>();
@@ -132,9 +138,15 @@ export class WhatsAppSignalBundleStore {
     private readonly maxRecentAcknowledgements = MAX_WHATSAPP_RECENT_ACKNOWLEDGEMENTS,
     private readonly maxPendingAcknowledgementAgeMs = MAX_WHATSAPP_PENDING_ACKNOWLEDGEMENT_AGE_MS,
     private readonly now: () => number = Date.now,
+    options: WhatsAppSignalBundleStoreOptions = {},
   ) {
+    const maxSessionsPerBundle =
+      options.maxSessionsPerBundle ?? MAX_WHATSAPP_SIGNAL_SESSIONS_PER_BUNDLE;
     if (!Number.isSafeInteger(maxBundles) || maxBundles < 1) {
       throw new Error("WhatsApp maxSignalBundles must be a positive safe integer.");
+    }
+    if (!Number.isSafeInteger(maxSessionsPerBundle) || maxSessionsPerBundle < 1) {
+      throw new Error("WhatsApp maxSignalSessionsPerBundle must be a positive safe integer.");
     }
     if (!Number.isSafeInteger(maxPendingAcknowledgements) || maxPendingAcknowledgements < 1) {
       throw new Error("WhatsApp maxPendingAcknowledgements must be a positive safe integer.");
@@ -148,6 +160,7 @@ export class WhatsAppSignalBundleStore {
     ) {
       throw new Error("WhatsApp maxPendingAcknowledgementAgeMs must be a positive safe integer.");
     }
+    this.#maxSessionsPerBundle = maxSessionsPerBundle;
   }
 
   get size(): number {
@@ -156,6 +169,14 @@ export class WhatsAppSignalBundleStore {
 
   get lidMappingSize(): number {
     return this.#lidByPhoneNumber.size;
+  }
+
+  get sessionCount(): number {
+    let count = 0;
+    for (const sessions of this.#sessions.values()) {
+      count += sessions.size;
+    }
+    return count;
   }
 
   async acceptMessageOnce(messageKey: string, operation: () => Promise<boolean>): Promise<boolean> {
@@ -281,16 +302,29 @@ export class WhatsAppSignalBundleStore {
       return { status: "unavailable" };
     }
     const address = new ProtocolAddress(remoteAddress.name, remoteAddress.deviceId);
+    // Capacity checks, staged writes, and commits stay atomic per recipient bundle.
     return await this.#runTransaction(identityKey, async () => {
       const sessions = this.#sessions.get(identityKey) ?? new Map<string, SessionRecord>();
+      if (!sessions.has(address.toString()) && sessions.size >= this.#maxSessionsPerBundle) {
+        return { status: "rejected" };
+      }
       const stagedPreKeyRemovals = new Set<number>();
       const stagedSessions = new Map<string, SessionRecord>();
+      const sessionLimitError = new Error("WhatsApp Signal session limit exceeded.");
+      const maxSessionsPerBundle = this.#maxSessionsPerBundle;
+      let stagedNewSessionCount = 0;
       const storage: SignalStorage = {
         async loadSession(id) {
           const session = stagedSessions.get(id) ?? sessions.get(id);
           return session ? cloneSignalSession(session) : undefined;
         },
         async storeSession(id, session) {
+          if (!sessions.has(id) && !stagedSessions.has(id)) {
+            if (sessions.size + stagedNewSessionCount >= maxSessionsPerBundle) {
+              throw sessionLimitError;
+            }
+            stagedNewSessionCount += 1;
+          }
           stagedSessions.set(id, cloneSignalSession(session));
         },
         isTrustedIdentity: () => true,
@@ -315,6 +349,9 @@ export class WhatsAppSignalBundleStore {
             ? await cipher.decryptPreKeyWhisperMessage(params.ciphertext)
             : await cipher.decryptWhisperMessage(params.ciphertext);
       } catch (error) {
+        if (error === sessionLimitError) {
+          return { status: "rejected" };
+        }
         return { error, status: "decrypt-failed" };
       }
       const replacementPreKey = stagedPreKeyRemovals.has(bundle.preKeyId)

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -758,6 +758,95 @@ describe("whatsapp local provider server", () => {
     ).resolves.toEqual(Buffer.from("second direct message"));
   });
 
+  it("bounds Signal sessions per bundle without evicting active ratchets", async () => {
+    const recipientJid = "15551234567@s.whatsapp.net";
+    const receiver = new WhatsAppSignalBundleStore(1, undefined, undefined, undefined, undefined, {
+      maxSessionsPerBundle: 2,
+    });
+    const bundle = receiver.resolveMany([recipientJid])[0]!;
+    const createSender = async (senderJid: string, registrationId: number, message: string) => {
+      const identity = Curve.generateKeyPair();
+      const storage = createSignalTestStorage(identity, registrationId);
+      const address = new ProtocolAddress("15551234567", 0);
+      await new SessionBuilder(storage, address).initOutgoing({
+        identityKey: signalTestKeyPair(bundle.identityKey).pubKey,
+        preKey: {
+          keyId: bundle.preKeyId,
+          publicKey: signalTestKeyPair(bundle.preKey).pubKey,
+        },
+        registrationId: bundle.registrationId,
+        signedPreKey: {
+          keyId: bundle.signedPreKey.keyId,
+          publicKey: signalTestKeyPair(bundle.signedPreKey.keyPair).pubKey,
+          signature: bundle.signedPreKey.signature,
+        },
+      });
+      const cipher = new SessionCipher(storage, address);
+      const encrypted = await cipher.encrypt(Buffer.from(message));
+      return { cipher, ciphertext: signalCiphertext(encrypted.body), senderJid };
+    };
+    const accept = async (plaintext: Buffer) => plaintext;
+
+    const first = await createSender("15550000001@s.whatsapp.net", 2, "first sender");
+    await expect(
+      receiver.transactDirectMessage({
+        accept,
+        ciphertext: first.ciphertext,
+        recipientJid,
+        remoteJid: first.senderJid,
+        type: "pkmsg",
+      }),
+    ).resolves.toEqual({ status: "accepted", value: Buffer.from("first sender") });
+
+    const second = await createSender("15550000002@s.whatsapp.net", 3, "second sender");
+    await expect(
+      receiver.transactDirectMessage({
+        accept,
+        ciphertext: second.ciphertext,
+        recipientJid,
+        remoteJid: second.senderJid,
+        type: "pkmsg",
+      }),
+    ).resolves.toEqual({ status: "accepted", value: Buffer.from("second sender") });
+    expect(receiver.sessionCount).toBe(2);
+
+    const third = await createSender("15550000003@s.whatsapp.net", 4, "excess sender");
+    const retainedPreKey = bundle.preKey;
+    const retainedPreKeyId = bundle.preKeyId;
+    let acceptedExcess = false;
+    await expect(
+      receiver.transactDirectMessage({
+        accept: async () => {
+          acceptedExcess = true;
+          return true;
+        },
+        ciphertext: third.ciphertext,
+        recipientJid,
+        remoteJid: third.senderJid,
+        type: "pkmsg",
+      }),
+    ).resolves.toEqual({ status: "rejected" });
+    expect(acceptedExcess).toBe(false);
+    expect(receiver.sessionCount).toBe(2);
+    expect(bundle.preKey).toBe(retainedPreKey);
+    expect(bundle.preKeyId).toBe(retainedPreKeyId);
+
+    const followUp = await first.cipher.encrypt(Buffer.from("first sender follow-up"));
+    await expect(
+      receiver.transactDirectMessage({
+        accept,
+        ciphertext: signalCiphertext(followUp.body),
+        recipientJid,
+        remoteJid: first.senderJid,
+        type: followUp.type === 3 ? "pkmsg" : "msg",
+      }),
+    ).resolves.toEqual({
+      status: "accepted",
+      value: Buffer.from("first sender follow-up"),
+    });
+    expect(receiver.sessionCount).toBe(2);
+  });
+
   it("commits Signal ratchets and prekey replacement only after accepted evidence persists", async () => {
     const recipientJid = "15551234567@s.whatsapp.net";
     const senderJid = "15550000001@s.whatsapp.net";


### PR DESCRIPTION
## Summary

- cap retained Signal sessions per recipient bundle
- reject excess sessions without evicting active ratchets or committing staged prekey/session state
- cover the limit and retained-session behavior with a regression test

## Validation

- `pnpm exec vitest run test/whatsapp-server.test.ts` (1 file, 28 tests)
- `pnpm lint`
- `git diff --check origin/main...HEAD`
- privacy scan of added lines; only synthetic WhatsApp test JIDs matched contact-like patterns
- exact branch autoreview against `origin/main`: clean, no actionable findings (0.86 confidence)

## Exact refs

- base: `308bcc4d23f43ad9a52855dae5cc686b657f4cc1`
- head: `b85b8ac976bdd44a07a63f0d6af856a25bfc8feb`