### PR TITLE
fix(openclaw): harden smoke lock staging and identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Honor injected WhatsApp runtime credentials during delayed webhook startup.
 - Generate Signal bundle public keys with the provider-required type prefix while preserving raw WhatsApp wire encoding.
 - Reject nonce fixture IDs outside the extractor alphabet and share one validation boundary.
+- Keep smoke-lock staging claim-local, confine commit paths, and add backward-compatible sub-second Darwin process identities.
 - Reject provider and fixture timer durations above Node's supported ceiling.
 - Round-trip every supported WhatsApp handshake protobuf variant without dropping fields.
 - Reject unsupported Zalo thread targets during normalization, matching OpenClaw bridge execution.

--- a/src/openclaw/smoke-lock.ts
+++ b/src/openclaw/smoke-lock.ts
@@ -74,6 +74,19 @@ type DirectoryIdentity = {
   device: bigint;
   inode: bigint;
 };
+type FileIdentity = DirectoryIdentity;
+type SerializedIdentity = {
+  device: string;
+  inode: string;
+};
+type CommitStageRecord = {
+  directoryIdentity: SerializedIdentity;
+  directoryPath: string;
+  fileIdentity: SerializedIdentity;
+  fileName: string;
+  token: string;
+  version: 1;
+};
 
 type SmokeLockRuntime = {
   currentProcessIdentity: string | null;
@@ -110,31 +123,79 @@ export function processStartedAtMsFromTimeOrigin(timeOrigin: number): number {
   return Math.trunc(timeOrigin);
 }
 
-function parseCommitStagePath(contents: string, token: string): string {
-  let value: { path?: unknown; token?: unknown };
+function parseSerializedIdentity(value: unknown): SerializedIdentity | null {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("device" in value) ||
+    !("inode" in value) ||
+    typeof value.device !== "string" ||
+    typeof value.inode !== "string" ||
+    !/^\d+$/u.test(value.device) ||
+    !/^[1-9]\d*$/u.test(value.inode)
+  ) {
+    return null;
+  }
+  return {
+    device: value.device,
+    inode: value.inode,
+  };
+}
+
+function parseCommitStageRecord(contents: string, token: string): CommitStageRecord | null {
+  let value: {
+    directoryIdentity?: unknown;
+    directoryPath?: unknown;
+    fileIdentity?: unknown;
+    fileName?: unknown;
+    path?: unknown;
+    token?: unknown;
+    version?: unknown;
+  };
   try {
-    value = JSON.parse(contents) as { path?: unknown; token?: unknown };
+    value = JSON.parse(contents) as typeof value;
   } catch (error) {
     throw new Error("OpenClaw Crabline smoke lock commit stage metadata is malformed.", {
       cause: error,
     });
   }
+  if (value.version === undefined && value.token === token && typeof value.path === "string") {
+    return null;
+  }
   const expectedPrefix = `.commit-file.${token}.`;
+  const directoryIdentity = parseSerializedIdentity(value.directoryIdentity);
+  const fileIdentity = parseSerializedIdentity(value.fileIdentity);
   if (
+    value.version !== 1 ||
     value.token !== token ||
-    typeof value.path !== "string" ||
-    !path.isAbsolute(value.path) ||
-    !path.basename(value.path).startsWith(expectedPrefix) ||
-    !path.basename(value.path).endsWith(".tmp")
+    typeof value.directoryPath !== "string" ||
+    !path.isAbsolute(value.directoryPath) ||
+    path.resolve(value.directoryPath) !== value.directoryPath ||
+    typeof value.fileName !== "string" ||
+    path.basename(value.fileName) !== value.fileName ||
+    !value.fileName.startsWith(expectedPrefix) ||
+    !value.fileName.endsWith(".tmp") ||
+    directoryIdentity === null ||
+    fileIdentity === null
   ) {
     throw new Error("OpenClaw Crabline smoke lock commit stage metadata is malformed.");
   }
-  return value.path;
+  return {
+    directoryIdentity,
+    directoryPath: value.directoryPath,
+    fileIdentity,
+    fileName: value.fileName,
+    token,
+    version: 1,
+  };
 }
 
-async function readCommitStagePath(lockDirectory: string, token: string): Promise<string | null> {
+async function readCommitStageRecord(
+  lockDirectory: string,
+  token: string,
+): Promise<CommitStageRecord | null> {
   try {
-    return parseCommitStagePath(
+    return parseCommitStageRecord(
       await fs.readFile(path.join(lockDirectory, commitStageFileName(token)), "utf8"),
       token,
     );
@@ -152,7 +213,7 @@ function commitStageFileName(token: string): string {
 
 async function writeCommitStagePath(
   lockDirectory: string,
-  stagedFilePath: string,
+  record: CommitStageRecord,
   token: string,
 ): Promise<void> {
   const temporaryPath = path.join(
@@ -160,7 +221,7 @@ async function writeCommitStagePath(
     `.${commitStageFileName(token)}.${randomUUID()}.tmp`,
   );
   try {
-    await fs.writeFile(temporaryPath, `${JSON.stringify({ path: stagedFilePath, token })}\n`, {
+    await fs.writeFile(temporaryPath, `${JSON.stringify(record)}\n`, {
       encoding: "utf8",
       flag: "wx",
       mode: 0o600,
@@ -242,6 +303,24 @@ async function readDirectoryIdentity(directoryPath: string): Promise<DirectoryId
     const stats = await fs.lstat(directoryPath, { bigint: true });
     if (!stats.isDirectory() || stats.ino <= 0n) {
       throw new Error("OpenClaw Crabline smoke lock claim is not a directory.");
+    }
+    return {
+      device: stats.dev,
+      inode: stats.ino,
+    };
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function readFileIdentity(filePath: string): Promise<FileIdentity | null> {
+  try {
+    const stats = await fs.lstat(filePath, { bigint: true });
+    if (!stats.isFile() || stats.nlink !== 1n || stats.ino <= 0n) {
+      return null;
     }
     return {
       device: stats.dev,
@@ -578,6 +657,91 @@ function activeRunError(params: {
   );
 }
 
+function serializeIdentity(identity: DirectoryIdentity): SerializedIdentity {
+  return {
+    device: identity.device.toString(),
+    inode: identity.inode.toString(),
+  };
+}
+
+function hasSerializedIdentity(
+  actual: DirectoryIdentity | null,
+  expected: SerializedIdentity,
+): actual is DirectoryIdentity {
+  return (
+    actual !== null &&
+    actual.device === BigInt(expected.device) &&
+    actual.inode === BigInt(expected.inode)
+  );
+}
+
+function isPathConfinedTo(rootPath: string, candidatePath: string): boolean {
+  const relative = path.relative(rootPath, candidatePath);
+  return (
+    relative === "" ||
+    (!path.isAbsolute(relative) && relative !== ".." && !relative.startsWith(`..${path.sep}`))
+  );
+}
+
+function resolveConfinedPath(rootPath: string, candidatePath: string, description: string): string {
+  const resolvedPath = path.resolve(candidatePath);
+  if (resolvedPath !== candidatePath || !isPathConfinedTo(rootPath, resolvedPath)) {
+    throw new Error(`OpenClaw Crabline smoke lock ${description} escapes its output directory.`);
+  }
+  return resolvedPath;
+}
+
+async function resolveValidatedCommitStagePath(
+  outputDir: string,
+  record: CommitStageRecord,
+): Promise<{ fileIdentity: FileIdentity; filePath: string } | null> {
+  let directoryPath: string;
+  try {
+    directoryPath = resolveConfinedPath(outputDir, record.directoryPath, "commit stage directory");
+  } catch {
+    return null;
+  }
+  if (
+    !hasSerializedIdentity(await readDirectoryIdentity(directoryPath), record.directoryIdentity)
+  ) {
+    return null;
+  }
+  const filePath = path.join(directoryPath, record.fileName);
+  if (
+    !isPathConfinedTo(directoryPath, filePath) ||
+    !hasSerializedIdentity(await readFileIdentity(filePath), record.fileIdentity)
+  ) {
+    return null;
+  }
+  return {
+    fileIdentity: {
+      device: BigInt(record.fileIdentity.device),
+      inode: BigInt(record.fileIdentity.inode),
+    },
+    filePath,
+  };
+}
+
+async function removeValidatedCommitStageFile(params: {
+  outputDir: string;
+  record: CommitStageRecord;
+  token: string;
+}): Promise<void> {
+  const validated = await resolveValidatedCommitStagePath(params.outputDir, params.record);
+  if (!validated) {
+    return;
+  }
+  const revokedStagePath = path.join(
+    path.dirname(validated.filePath),
+    `.revoked-commit-file.${params.token}.${randomUUID()}.tmp`,
+  );
+  await fs.rename(validated.filePath, revokedStagePath);
+  if (!hasSameDirectoryIdentity(validated.fileIdentity, await readFileIdentity(revokedStagePath))) {
+    throw new Error("OpenClaw Crabline smoke lock commit stage identity changed during cleanup.");
+  }
+  await fs.rm(revokedStagePath, { force: true });
+}
+
 async function removeOwnedLock(params: {
   beforeClaim?: () => Promise<void>;
   beforeRename?: () => Promise<void>;
@@ -641,15 +805,14 @@ async function removeOwnedLock(params: {
     return false;
   }
 
-  const stagedFilePath = await readCommitStagePath(releaseClaim, params.token);
-  if (stagedFilePath) {
-    const revokedStagePath = path.join(
-      path.dirname(stagedFilePath),
-      `.revoked-commit-file.${params.token}.${randomUUID()}.tmp`,
-    );
+  const stageRecord = await readCommitStageRecord(releaseClaim, params.token);
+  if (stageRecord) {
     try {
-      await fs.rename(stagedFilePath, revokedStagePath);
-      await fs.rm(revokedStagePath, { force: true });
+      await removeValidatedCommitStageFile({
+        outputDir: path.dirname(params.lockDirectory),
+        record: stageRecord,
+        token: params.token,
+      });
     } catch (error) {
       if (!isMissingPathError(error)) {
         throw error;
@@ -1400,13 +1563,60 @@ export async function acquireOpenClawCrablineSmokeRunLock(
         await renew();
         heartbeat.assertHealthy();
 
+        const resolvedDestinationPath = resolveConfinedPath(
+          outputDir,
+          destinationPath,
+          "commit destination",
+        );
+        const resolvedStageDirectory = stageDirectory
+          ? resolveConfinedPath(outputDir, stageDirectory, "commit stage directory")
+          : ownerDirectory;
+        let stageDirectoryIdentity: DirectoryIdentity | null = null;
+        if (stageDirectory) {
+          try {
+            stageDirectoryIdentity = await readDirectoryIdentity(resolvedStageDirectory);
+          } catch (error) {
+            throw new Error("OpenClaw Crabline smoke lock commit stage directory is invalid.", {
+              cause: error,
+            });
+          }
+        }
+        if (stageDirectory && stageDirectoryIdentity === null) {
+          throw new Error("OpenClaw Crabline smoke lock commit stage directory is invalid.");
+        }
         const stagedFileName = `.commit-file.${token}.${randomUUID()}.tmp`;
-        const stagedFilePath = path.join(stageDirectory ?? ownerDirectory, stagedFileName);
+        const stagedFilePath = path.join(resolvedStageDirectory, stagedFileName);
+        let stagedFileIdentity: FileIdentity | null = null;
         let committed = false;
         try {
           await stageFile(stagedFilePath, contents);
           if (stageDirectory) {
-            await writeCommitStagePath(ownerDirectory, stagedFilePath, token);
+            if (
+              !hasSameDirectoryIdentity(
+                stageDirectoryIdentity,
+                await readDirectoryIdentity(resolvedStageDirectory),
+              )
+            ) {
+              throw new Error(
+                "OpenClaw Crabline smoke lock commit stage directory identity changed.",
+              );
+            }
+            stagedFileIdentity = await readFileIdentity(stagedFilePath);
+            if (stagedFileIdentity === null) {
+              throw new Error("OpenClaw Crabline smoke lock commit stage file is invalid.");
+            }
+            await writeCommitStagePath(
+              ownerDirectory,
+              {
+                directoryIdentity: serializeIdentity(stageDirectoryIdentity!),
+                directoryPath: resolvedStageDirectory,
+                fileIdentity: serializeIdentity(stagedFileIdentity),
+                fileName: stagedFileName,
+                token,
+                version: 1,
+              },
+              token,
+            );
           }
           heartbeat.assertHealthy();
           await renew();
@@ -1474,14 +1684,36 @@ export async function acquireOpenClawCrablineSmokeRunLock(
             securedDirectory,
             token,
           });
+          if (
+            stageDirectory &&
+            (!hasSameDirectoryIdentity(
+              stageDirectoryIdentity,
+              await readDirectoryIdentity(resolvedStageDirectory),
+            ) ||
+              !hasSameDirectoryIdentity(stagedFileIdentity, await readFileIdentity(stagedFilePath)))
+          ) {
+            throw new Error("OpenClaw Crabline smoke lock commit stage identity changed.");
+          }
           await fs.rename(
             stageDirectory ? stagedFilePath : path.join(commitClaim, stagedFileName),
-            destinationPath,
+            resolvedDestinationPath,
           );
           committed = true;
         } finally {
-          if (!committed && stageDirectory) {
-            await fs.rm(stagedFilePath, { force: true }).catch(() => undefined);
+          if (!committed && stageDirectory && stageDirectoryIdentity && stagedFileIdentity) {
+            const cleanupRecord: CommitStageRecord = {
+              directoryIdentity: serializeIdentity(stageDirectoryIdentity),
+              directoryPath: resolvedStageDirectory,
+              fileIdentity: serializeIdentity(stagedFileIdentity),
+              fileName: stagedFileName,
+              token,
+              version: 1,
+            };
+            await removeValidatedCommitStageFile({
+              outputDir,
+              record: cleanupRecord,
+              token,
+            }).catch(() => undefined);
           }
         }
       },

--- a/src/openclaw/smoke-lock.ts
+++ b/src/openclaw/smoke-lock.ts
@@ -17,6 +17,7 @@ type LegacySmokeLockOwner = {
 type ProcessIdentifiedSmokeLockOwner = LegacySmokeLockOwner & {
   createdAtMs: number;
   processIdentity?: string;
+  processIdentityV2?: string;
   processStartedAtMs: number;
 };
 
@@ -39,6 +40,7 @@ export type OpenClawCrablineSmokeRunLock = {
   commitFileAtomically(params: {
     contents: string;
     destinationPath: string;
+    // The directory is an identity fence; temporary contents remain lock-claim-local.
     stageDirectory?: string;
     stageFile(filePath: string, contents: string): Promise<void>;
   }): Promise<void>;
@@ -75,24 +77,14 @@ type DirectoryIdentity = {
   inode: bigint;
 };
 type FileIdentity = DirectoryIdentity;
-type SerializedIdentity = {
-  device: string;
-  inode: string;
-};
-type CommitStageRecord = {
-  directoryIdentity: SerializedIdentity;
-  directoryPath: string;
-  fileIdentity: SerializedIdentity;
-  fileName: string;
-  token: string;
-  version: 1;
-};
 
 type SmokeLockRuntime = {
   currentProcessIdentity: string | null;
+  currentProcessIdentityV2: string | null;
   currentPid: number;
   currentProcessStartedAtMs: number;
   getProcessIdentity: GetProcessIdentity;
+  getProcessIdentityV2: GetProcessIdentity;
   isProcessAlive: IsProcessAlive;
   leaseMs: number;
   now: () => number;
@@ -100,7 +92,6 @@ type SmokeLockRuntime = {
 };
 
 const LOCK_OWNER_FILE = "owner.json";
-const LOCK_COMMIT_STAGE_FILE_PREFIX = "commit-stage";
 const LOCK_LEASE_FILE_PREFIX = "lease.";
 const LEGACY_RECOVERY_SUFFIX = ".recovering";
 const COMMIT_CLAIM_SUFFIX = ".commit";
@@ -121,116 +112,6 @@ export function processStartedAtMsFromTimeOrigin(timeOrigin: number): number {
     throw new Error("Process time origin is invalid.");
   }
   return Math.trunc(timeOrigin);
-}
-
-function parseSerializedIdentity(value: unknown): SerializedIdentity | null {
-  if (
-    typeof value !== "object" ||
-    value === null ||
-    !("device" in value) ||
-    !("inode" in value) ||
-    typeof value.device !== "string" ||
-    typeof value.inode !== "string" ||
-    !/^\d+$/u.test(value.device) ||
-    !/^[1-9]\d*$/u.test(value.inode)
-  ) {
-    return null;
-  }
-  return {
-    device: value.device,
-    inode: value.inode,
-  };
-}
-
-function parseCommitStageRecord(contents: string, token: string): CommitStageRecord | null {
-  let value: {
-    directoryIdentity?: unknown;
-    directoryPath?: unknown;
-    fileIdentity?: unknown;
-    fileName?: unknown;
-    path?: unknown;
-    token?: unknown;
-    version?: unknown;
-  };
-  try {
-    value = JSON.parse(contents) as typeof value;
-  } catch (error) {
-    throw new Error("OpenClaw Crabline smoke lock commit stage metadata is malformed.", {
-      cause: error,
-    });
-  }
-  if (value.version === undefined && value.token === token && typeof value.path === "string") {
-    return null;
-  }
-  const expectedPrefix = `.commit-file.${token}.`;
-  const directoryIdentity = parseSerializedIdentity(value.directoryIdentity);
-  const fileIdentity = parseSerializedIdentity(value.fileIdentity);
-  if (
-    value.version !== 1 ||
-    value.token !== token ||
-    typeof value.directoryPath !== "string" ||
-    !path.isAbsolute(value.directoryPath) ||
-    path.resolve(value.directoryPath) !== value.directoryPath ||
-    typeof value.fileName !== "string" ||
-    path.basename(value.fileName) !== value.fileName ||
-    !value.fileName.startsWith(expectedPrefix) ||
-    !value.fileName.endsWith(".tmp") ||
-    directoryIdentity === null ||
-    fileIdentity === null
-  ) {
-    throw new Error("OpenClaw Crabline smoke lock commit stage metadata is malformed.");
-  }
-  return {
-    directoryIdentity,
-    directoryPath: value.directoryPath,
-    fileIdentity,
-    fileName: value.fileName,
-    token,
-    version: 1,
-  };
-}
-
-async function readCommitStageRecord(
-  lockDirectory: string,
-  token: string,
-): Promise<CommitStageRecord | null> {
-  try {
-    return parseCommitStageRecord(
-      await fs.readFile(path.join(lockDirectory, commitStageFileName(token)), "utf8"),
-      token,
-    );
-  } catch (error) {
-    if (isMissingPathError(error)) {
-      return null;
-    }
-    throw error;
-  }
-}
-
-function commitStageFileName(token: string): string {
-  return `${LOCK_COMMIT_STAGE_FILE_PREFIX}.${token}.json`;
-}
-
-async function writeCommitStagePath(
-  lockDirectory: string,
-  record: CommitStageRecord,
-  token: string,
-): Promise<void> {
-  const temporaryPath = path.join(
-    lockDirectory,
-    `.${commitStageFileName(token)}.${randomUUID()}.tmp`,
-  );
-  try {
-    await fs.writeFile(temporaryPath, `${JSON.stringify(record)}\n`, {
-      encoding: "utf8",
-      flag: "wx",
-      mode: 0o600,
-    });
-    await fs.chmod(temporaryPath, 0o600);
-    await fs.rename(temporaryPath, path.join(lockDirectory, commitStageFileName(token)));
-  } finally {
-    await fs.rm(temporaryPath, { force: true }).catch(() => undefined);
-  }
 }
 
 const removeLockDirectory: RemoveLockDirectory = async (lockDirectory) => {
@@ -387,7 +268,11 @@ function parseLockOwner(contents: string): SmokeLockOwner {
     (owner.processIdentity !== undefined &&
       (typeof owner.processIdentity !== "string" ||
         owner.processIdentity.length === 0 ||
-        owner.processIdentity.length > 256))
+        owner.processIdentity.length > 256)) ||
+    (owner.processIdentityV2 !== undefined &&
+      (typeof owner.processIdentityV2 !== "string" ||
+        owner.processIdentityV2.length === 0 ||
+        owner.processIdentityV2.length > 256))
   ) {
     throw new Error("OpenClaw Crabline smoke lock owner metadata is malformed.");
   }
@@ -397,6 +282,7 @@ function parseLockOwner(contents: string): SmokeLockOwner {
       createdAtMs: owner.createdAtMs,
       pid: owner.pid,
       ...(owner.processIdentity ? { processIdentity: owner.processIdentity } : {}),
+      ...(owner.processIdentityV2 ? { processIdentityV2: owner.processIdentityV2 } : {}),
       processStartedAtMs: owner.processStartedAtMs,
       token: owner.token,
     };
@@ -410,6 +296,7 @@ function parseLockOwner(contents: string): SmokeLockOwner {
     leaseVersion: owner.leaseVersion,
     pid: owner.pid,
     ...(owner.processIdentity ? { processIdentity: owner.processIdentity } : {}),
+    ...(owner.processIdentityV2 ? { processIdentityV2: owner.processIdentityV2 } : {}),
     processStartedAtMs: owner.processStartedAtMs,
     token: owner.token,
   };
@@ -511,6 +398,32 @@ export function processIdentityFromDarwin(
   bootTime: string,
 ): string | null {
   const bootMatch = /\bsec = (\d+), usec = (\d+)\b/u.exec(bootTime);
+  const launchMatch =
+    /^Launch Time:\s*(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})\.(\d{3,6}) ([+-])(\d{2})(\d{2})$/mu.exec(
+      processStartedAt,
+    );
+  if (bootMatch && launchMatch) {
+    const [, year, month, day, hour, minute, second, fraction, sign, offsetHour, offsetMinute] =
+      launchMatch as RegExpExecArray &
+        [string, string, string, string, string, string, string, string, string, string, string];
+    const offsetMs =
+      (Number(offsetHour) * 60 + Number(offsetMinute)) * 60_000 * (sign === "+" ? 1 : -1);
+    const fractionMicros = Number(fraction.padEnd(6, "0"));
+    const utcMilliseconds =
+      Date.UTC(
+        Number(year),
+        Number(month) - 1,
+        Number(day),
+        Number(hour),
+        Number(minute),
+        Number(second),
+        Math.floor(fractionMicros / 1_000),
+      ) - offsetMs;
+    if (Number.isSafeInteger(utcMilliseconds) && utcMilliseconds > 0) {
+      const startedAtMicros = BigInt(utcMilliseconds) * 1_000n + BigInt(fractionMicros % 1_000);
+      return `darwin:${bootMatch[1]}.${bootMatch[2]}:us:${startedAtMicros}`;
+    }
+  }
   const normalizedStartedAt = processStartedAt.trim().replace(/\s+/gu, " ");
   if (!bootMatch || normalizedStartedAt.length === 0 || normalizedStartedAt.length > 64) {
     return null;
@@ -539,11 +452,15 @@ const getProcessIdentity: GetProcessIdentity = (pid) => {
     const options = {
       encoding: "utf8" as const,
       env: darwinProcessIdentityEnvironment(process.env),
+      maxBuffer: 512 * 1024,
       timeout: 1_000,
     };
-    const startedAt = spawnSync("ps", ["-o", "lstart=", "-p", String(pid)], options);
-    const bootTime = spawnSync("sysctl", ["-n", "kern.boottime"], options);
-    return startedAt.status === 0 && bootTime.status === 0
+    const bootTime = spawnSync("/usr/sbin/sysctl", ["-n", "kern.boottime"], options);
+    if (bootTime.status !== 0) {
+      return null;
+    }
+    const startedAt = spawnSync("/bin/ps", ["-o", "lstart=", "-p", String(pid)], options);
+    return startedAt.status === 0
       ? processIdentityFromDarwin(startedAt.stdout, bootTime.stdout)
       : null;
   }
@@ -570,6 +487,25 @@ const getProcessIdentity: GetProcessIdentity = (pid) => {
   return /^\d+$/u.test(ticks) ? `windows:${ticks}` : null;
 };
 
+const getProcessIdentityV2: GetProcessIdentity = (pid) => {
+  if (process.platform !== "darwin") {
+    return null;
+  }
+  const options = {
+    encoding: "utf8" as const,
+    env: darwinProcessIdentityEnvironment(process.env),
+    maxBuffer: 512 * 1024,
+    timeout: 3_000,
+  };
+  const bootTime = spawnSync("/usr/sbin/sysctl", ["-n", "kern.boottime"], options);
+  const processDetails = spawnSync("/usr/bin/vmmap", ["-summary", String(pid)], options);
+  if (bootTime.status !== 0 || processDetails.status !== 0) {
+    return null;
+  }
+  const identity = processIdentityFromDarwin(processDetails.stdout, bootTime.stdout);
+  return identity?.includes(":us:") ? identity : null;
+};
+
 function hasExactProcessIdentity(owner: SmokeLockOwner): owner is (
   | ProcessIdentifiedSmokeLockOwner
   | RenewableSmokeLockOwner
@@ -579,22 +515,55 @@ function hasExactProcessIdentity(owner: SmokeLockOwner): owner is (
   return hasProcessIdentity(owner) && typeof owner.processIdentity === "string";
 }
 
-function hasProcessIdentityMismatch(owner: SmokeLockOwner, runtime: SmokeLockRuntime): boolean {
+function hasCoarseDarwinProcessIdentity(owner: SmokeLockOwner): owner is (
+  | ProcessIdentifiedSmokeLockOwner
+  | RenewableSmokeLockOwner
+) & {
+  processIdentity: string;
+} {
+  if (!hasExactProcessIdentity(owner)) {
+    return false;
+  }
+  return /^darwin:\d+\.\d+:(?!us:).+$/u.test(owner.processIdentity);
+}
+
+type ProcessIdentityMatch = "legacy" | "mismatch" | "unknown" | "v2";
+
+function compareProcessIdentity(
+  owner: SmokeLockOwner,
+  runtime: SmokeLockRuntime,
+): ProcessIdentityMatch {
   if (
     hasProcessIdentity(owner) &&
     owner.pid === runtime.currentPid &&
     owner.processStartedAtMs !== runtime.currentProcessStartedAtMs
   ) {
-    return true;
+    return "mismatch";
   }
   if (!hasExactProcessIdentity(owner)) {
-    return false;
+    return "unknown";
+  }
+  if (hasProcessIdentity(owner) && typeof owner.processIdentityV2 === "string") {
+    const actualProcessIdentityV2 =
+      owner.pid === runtime.currentPid
+        ? runtime.currentProcessIdentityV2
+        : runtime.getProcessIdentityV2(owner.pid);
+    if (actualProcessIdentityV2 !== null) {
+      return owner.processIdentityV2 === actualProcessIdentityV2 ? "v2" : "mismatch";
+    }
   }
   const actualProcessIdentity =
     owner.pid === runtime.currentPid
       ? runtime.currentProcessIdentity
       : runtime.getProcessIdentity(owner.pid);
-  return actualProcessIdentity !== null && owner.processIdentity !== actualProcessIdentity;
+  if (actualProcessIdentity === null) {
+    return "unknown";
+  }
+  return owner.processIdentity === actualProcessIdentity ? "legacy" : "mismatch";
+}
+
+function hasProcessIdentityMismatch(owner: SmokeLockOwner, runtime: SmokeLockRuntime): boolean {
+  return compareProcessIdentity(owner, runtime) === "mismatch";
 }
 
 function isLockOwnerActive(record: SmokeLockRecord, runtime: SmokeLockRuntime): boolean {
@@ -602,10 +571,19 @@ function isLockOwnerActive(record: SmokeLockRecord, runtime: SmokeLockRuntime): 
   if (!runtime.isProcessAlive(owner.pid)) {
     return false;
   }
-  if (hasProcessIdentityMismatch(owner, runtime)) {
+  const identityMatch = compareProcessIdentity(owner, runtime);
+  if (identityMatch === "mismatch") {
     return false;
   }
   if (!isRenewableOwner(owner)) {
+    if (
+      owner.pid !== runtime.currentPid &&
+      hasCoarseDarwinProcessIdentity(owner) &&
+      identityMatch !== "v2"
+    ) {
+      const ageMs = runtime.now() - Math.max(owner.createdAtMs, record.renewedAtMs);
+      return ageMs >= -runtime.leaseMs && ageMs <= runtime.leaseMs;
+    }
     return true;
   }
   const ageMs = runtime.now() - Math.max(owner.createdAtMs, record.renewedAtMs);
@@ -657,24 +635,6 @@ function activeRunError(params: {
   );
 }
 
-function serializeIdentity(identity: DirectoryIdentity): SerializedIdentity {
-  return {
-    device: identity.device.toString(),
-    inode: identity.inode.toString(),
-  };
-}
-
-function hasSerializedIdentity(
-  actual: DirectoryIdentity | null,
-  expected: SerializedIdentity,
-): actual is DirectoryIdentity {
-  return (
-    actual !== null &&
-    actual.device === BigInt(expected.device) &&
-    actual.inode === BigInt(expected.inode)
-  );
-}
-
 function isPathConfinedTo(rootPath: string, candidatePath: string): boolean {
   const relative = path.relative(rootPath, candidatePath);
   return (
@@ -683,63 +643,29 @@ function isPathConfinedTo(rootPath: string, candidatePath: string): boolean {
   );
 }
 
-function resolveConfinedPath(rootPath: string, candidatePath: string, description: string): string {
+async function resolveConfinedPath(
+  rootPath: string,
+  candidatePath: string,
+  description: string,
+  candidateKind: "directory" | "file",
+): Promise<string> {
   const resolvedPath = path.resolve(candidatePath);
-  if (resolvedPath !== candidatePath || !isPathConfinedTo(rootPath, resolvedPath)) {
+  if (resolvedPath !== candidatePath) {
     throw new Error(`OpenClaw Crabline smoke lock ${description} escapes its output directory.`);
   }
-  return resolvedPath;
-}
-
-async function resolveValidatedCommitStagePath(
-  outputDir: string,
-  record: CommitStageRecord,
-): Promise<{ fileIdentity: FileIdentity; filePath: string } | null> {
-  let directoryPath: string;
+  const parentPath = candidateKind === "directory" ? resolvedPath : path.dirname(resolvedPath);
+  let realParentPath: string;
   try {
-    directoryPath = resolveConfinedPath(outputDir, record.directoryPath, "commit stage directory");
+    realParentPath = await fs.realpath(parentPath);
   } catch {
-    return null;
+    throw new Error(`OpenClaw Crabline smoke lock ${description} is invalid.`);
   }
-  if (
-    !hasSerializedIdentity(await readDirectoryIdentity(directoryPath), record.directoryIdentity)
-  ) {
-    return null;
+  if (!isPathConfinedTo(rootPath, realParentPath)) {
+    throw new Error(`OpenClaw Crabline smoke lock ${description} escapes its output directory.`);
   }
-  const filePath = path.join(directoryPath, record.fileName);
-  if (
-    !isPathConfinedTo(directoryPath, filePath) ||
-    !hasSerializedIdentity(await readFileIdentity(filePath), record.fileIdentity)
-  ) {
-    return null;
-  }
-  return {
-    fileIdentity: {
-      device: BigInt(record.fileIdentity.device),
-      inode: BigInt(record.fileIdentity.inode),
-    },
-    filePath,
-  };
-}
-
-async function removeValidatedCommitStageFile(params: {
-  outputDir: string;
-  record: CommitStageRecord;
-  token: string;
-}): Promise<void> {
-  const validated = await resolveValidatedCommitStagePath(params.outputDir, params.record);
-  if (!validated) {
-    return;
-  }
-  const revokedStagePath = path.join(
-    path.dirname(validated.filePath),
-    `.revoked-commit-file.${params.token}.${randomUUID()}.tmp`,
-  );
-  await fs.rename(validated.filePath, revokedStagePath);
-  if (!hasSameDirectoryIdentity(validated.fileIdentity, await readFileIdentity(revokedStagePath))) {
-    throw new Error("OpenClaw Crabline smoke lock commit stage identity changed during cleanup.");
-  }
-  await fs.rm(revokedStagePath, { force: true });
+  return candidateKind === "directory"
+    ? realParentPath
+    : path.join(realParentPath, path.basename(resolvedPath));
 }
 
 async function removeOwnedLock(params: {
@@ -805,21 +731,6 @@ async function removeOwnedLock(params: {
     return false;
   }
 
-  const stageRecord = await readCommitStageRecord(releaseClaim, params.token);
-  if (stageRecord) {
-    try {
-      await removeValidatedCommitStageFile({
-        outputDir: path.dirname(params.lockDirectory),
-        record: stageRecord,
-        token: params.token,
-      });
-    } catch (error) {
-      if (!isMissingPathError(error)) {
-        throw error;
-      }
-    }
-  }
-
   await (params.removeDirectory ?? removeLockDirectory)(releaseClaim);
   return true;
 }
@@ -865,6 +776,7 @@ async function retireCompatibilityMarker(
     createdAtMs: 1,
     pid: MAX_PROCESS_ID,
     ...(owner.processIdentity ? { processIdentity: "retired" } : {}),
+    ...(owner.processIdentityV2 ? { processIdentityV2: "retired" } : {}),
     processStartedAtMs: 1,
   };
   const originalBytes = Buffer.byteLength(`${JSON.stringify(owner)}\n`, "utf8");
@@ -1221,11 +1133,13 @@ export async function acquireOpenClawCrablineSmokeRunLock(
     afterLockOwnerClaimInstall?: AfterLockDirectoryWrite;
     afterLockOwnerWrite?: AfterLockDirectoryWrite;
     getProcessIdentity?: GetProcessIdentity;
+    getProcessIdentityV2?: GetProcessIdentity;
     isProcessAlive?: IsProcessAlive;
     leaseMs?: number;
     now?: () => number;
     pid?: number;
     processIdentity?: string | null;
+    processIdentityV2?: string | null;
     processStartedAtMs?: number;
     platform?: NodeJS.Platform;
     secureWindowsDirectory?: SecureWindowsDirectory;
@@ -1242,19 +1156,39 @@ export async function acquireOpenClawCrablineSmokeRunLock(
     startHeartbeat?: StartHeartbeat;
   } = {},
 ): Promise<OpenClawCrablineSmokeRunLock> {
-  const outputDir = path.resolve(params.outputDir);
+  const requestedOutputDir = path.resolve(params.outputDir);
+  await fs.mkdir(requestedOutputDir, { recursive: true });
+  const outputDir = await fs.realpath(requestedOutputDir);
+  const privateDirectoryOptions = {
+    ...(dependencies.platform ? { platform: dependencies.platform } : {}),
+    ...(dependencies.secureWindowsDirectory
+      ? { secureWindowsDirectory: dependencies.secureWindowsDirectory }
+      : {}),
+  };
+  const securedOutputDirectory = await securePrivateDirectory(outputDir, privateDirectoryOptions);
+  await securedOutputDirectory.assertIdentityAt(outputDir);
+  const outputDirectoryIdentity = await readDirectoryIdentity(outputDir);
+  if (outputDirectoryIdentity === null) {
+    throw new Error("OpenClaw Crabline smoke lock output directory is invalid.");
+  }
   const lockDirectory = path.join(outputDir, `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`);
   const token = randomUUID();
   const currentPid = dependencies.pid ?? process.pid;
   const getRuntimeProcessIdentity = dependencies.getProcessIdentity ?? getProcessIdentity;
+  const getRuntimeProcessIdentityV2 = dependencies.getProcessIdentityV2 ?? getProcessIdentityV2;
   const runtime: SmokeLockRuntime = {
     currentPid,
     currentProcessIdentity:
       dependencies.processIdentity === undefined
         ? getRuntimeProcessIdentity(currentPid)
         : dependencies.processIdentity,
+    currentProcessIdentityV2:
+      dependencies.processIdentityV2 === undefined
+        ? getRuntimeProcessIdentityV2(currentPid)
+        : dependencies.processIdentityV2,
     currentProcessStartedAtMs: dependencies.processStartedAtMs ?? CURRENT_PROCESS_STARTED_AT_MS,
     getProcessIdentity: getRuntimeProcessIdentity,
+    getProcessIdentityV2: getRuntimeProcessIdentityV2,
     isProcessAlive: dependencies.isProcessAlive ?? isProcessAlive,
     leaseMs: dependencies.leaseMs ?? LOCK_LEASE_MS,
     now: dependencies.now ?? Date.now,
@@ -1266,6 +1200,9 @@ export async function acquireOpenClawCrablineSmokeRunLock(
     (runtime.currentProcessIdentity !== null &&
       (runtime.currentProcessIdentity.length === 0 ||
         runtime.currentProcessIdentity.length > 256)) ||
+    (runtime.currentProcessIdentityV2 !== null &&
+      (runtime.currentProcessIdentityV2.length === 0 ||
+        runtime.currentProcessIdentityV2.length > 256)) ||
     !isPositiveSafeInteger(runtime.currentProcessStartedAtMs) ||
     !isPositiveSafeInteger(runtime.leaseMs) ||
     !isPositiveSafeInteger(createdAtMs)
@@ -1278,6 +1215,9 @@ export async function acquireOpenClawCrablineSmokeRunLock(
     leaseVersion: 1,
     pid: runtime.currentPid,
     ...(runtime.currentProcessIdentity ? { processIdentity: runtime.currentProcessIdentity } : {}),
+    ...(runtime.currentProcessIdentityV2
+      ? { processIdentityV2: runtime.currentProcessIdentityV2 }
+      : {}),
     processStartedAtMs: runtime.currentProcessStartedAtMs,
     token,
   };
@@ -1286,7 +1226,6 @@ export async function acquireOpenClawCrablineSmokeRunLock(
     createdAtMs: 1,
   };
 
-  await fs.mkdir(outputDir, { recursive: true });
   for (;;) {
     const lockClaims = await listLockClaims(lockDirectory);
     if (lockClaims.length > 0 || (await pathExists(`${lockDirectory}${LEGACY_RECOVERY_SUFFIX}`))) {
@@ -1294,7 +1233,7 @@ export async function acquireOpenClawCrablineSmokeRunLock(
         beforeRecoveryDeleteClaim:
           dependencies.beforeRecoveryDeleteClaim ?? (async () => undefined),
         lockDirectory,
-        outputDir,
+        outputDir: requestedOutputDir,
         requestedChannel: params.channel,
         runtime,
       });
@@ -1367,7 +1306,7 @@ export async function acquireOpenClawCrablineSmokeRunLock(
           dependencies.beforeRecoveryDeleteClaim ?? (async () => undefined),
         cause: error,
         lockDirectory,
-        outputDir,
+        outputDir: requestedOutputDir,
         requestedChannel: params.channel,
         runtime,
         beforeRecoveryClaim: dependencies.beforeRecoveryClaim ?? (async () => undefined),
@@ -1452,7 +1391,7 @@ export async function acquireOpenClawCrablineSmokeRunLock(
         beforeRecoveryDeleteClaim:
           dependencies.beforeRecoveryDeleteClaim ?? (async () => undefined),
         lockDirectory,
-        outputDir,
+        outputDir: requestedOutputDir,
         requestedChannel: params.channel,
         runtime,
       });
@@ -1563,13 +1502,34 @@ export async function acquireOpenClawCrablineSmokeRunLock(
         await renew();
         heartbeat.assertHealthy();
 
-        const resolvedDestinationPath = resolveConfinedPath(
+        const resolvedDestinationPath = await resolveConfinedPath(
           outputDir,
           destinationPath,
           "commit destination",
+          "file",
         );
+        const destinationDirectory = path.dirname(resolvedDestinationPath);
+        const securedDestinationDirectory =
+          destinationDirectory === outputDir
+            ? securedOutputDirectory
+            : await securePrivateDirectory(destinationDirectory, privateDirectoryOptions);
+        await securedDestinationDirectory.assertIdentityAt(destinationDirectory);
+        const destinationDirectoryIdentity = await readDirectoryIdentity(destinationDirectory);
+        if (destinationDirectoryIdentity === null) {
+          throw new Error("OpenClaw Crabline smoke lock commit destination is invalid.");
+        }
+        if (destinationDirectoryIdentity.device !== outputDirectoryIdentity.device) {
+          throw new Error(
+            "OpenClaw Crabline smoke lock commit destination is on another filesystem.",
+          );
+        }
         const resolvedStageDirectory = stageDirectory
-          ? resolveConfinedPath(outputDir, stageDirectory, "commit stage directory")
+          ? await resolveConfinedPath(
+              outputDir,
+              stageDirectory,
+              "commit stage directory",
+              "directory",
+            )
           : ownerDirectory;
         let stageDirectoryIdentity: DirectoryIdentity | null = null;
         if (stageDirectory) {
@@ -1584,138 +1544,152 @@ export async function acquireOpenClawCrablineSmokeRunLock(
         if (stageDirectory && stageDirectoryIdentity === null) {
           throw new Error("OpenClaw Crabline smoke lock commit stage directory is invalid.");
         }
+        if (
+          stageDirectoryIdentity !== null &&
+          stageDirectoryIdentity.device !== outputDirectoryIdentity.device
+        ) {
+          throw new Error(
+            "OpenClaw Crabline smoke lock commit stage directory is on another filesystem.",
+          );
+        }
         const stagedFileName = `.commit-file.${token}.${randomUUID()}.tmp`;
-        const stagedFilePath = path.join(resolvedStageDirectory, stagedFileName);
-        let stagedFileIdentity: FileIdentity | null = null;
-        let committed = false;
-        try {
-          await stageFile(stagedFilePath, contents);
-          if (stageDirectory) {
-            if (
-              !hasSameDirectoryIdentity(
-                stageDirectoryIdentity,
-                await readDirectoryIdentity(resolvedStageDirectory),
-              )
-            ) {
-              throw new Error(
-                "OpenClaw Crabline smoke lock commit stage directory identity changed.",
-              );
-            }
-            stagedFileIdentity = await readFileIdentity(stagedFilePath);
-            if (stagedFileIdentity === null) {
-              throw new Error("OpenClaw Crabline smoke lock commit stage file is invalid.");
-            }
-            await writeCommitStagePath(
-              ownerDirectory,
-              {
-                directoryIdentity: serializeIdentity(stageDirectoryIdentity!),
-                directoryPath: resolvedStageDirectory,
-                fileIdentity: serializeIdentity(stagedFileIdentity),
-                fileName: stagedFileName,
-                token,
-                version: 1,
-              },
-              token,
-            );
-          }
-          heartbeat.assertHealthy();
-          await renew();
-          heartbeat.assertHealthy();
-
-          await dependencies.beforeCommitClaim?.();
-          await assertCompatibilityMarkerOwned({
-            lockDirectory,
-            securedDirectory,
-            token,
-          });
-          const commitClaim = `${lockDirectory}${COMMIT_CLAIM_SUFFIX}.${token}.${randomUUID()}`;
-          const observedIdentity = await readDirectoryIdentity(ownerDirectory);
-          const observed = await readLockRecord(ownerDirectory);
+        const stagedFilePath = path.join(ownerDirectory, stagedFileName);
+        await stageFile(stagedFilePath, contents);
+        if (stageDirectory) {
           if (
-            observedIdentity === null ||
-            observed.kind === "missing" ||
-            observed.record.owner.token !== token
-          ) {
-            throw new Error("OpenClaw Crabline smoke lock ownership was lost.");
-          }
-
-          try {
-            await fs.rename(ownerDirectory, commitClaim);
-          } catch (error) {
-            if (isMissingPathError(error)) {
-              throw new Error("OpenClaw Crabline smoke lock ownership was lost.", {
-                cause: error,
-              });
-            }
-            throw error;
-          }
-          ownedDirectory = commitClaim;
-          commitFenceConsumed = true;
-
-          const claimed = await readLockRecord(commitClaim);
-          const claimedIdentity = await readDirectoryIdentity(commitClaim);
-          if (
-            claimed.kind === "missing" ||
-            claimed.record.owner.token !== token ||
-            !hasSameDirectoryIdentity(observedIdentity, claimedIdentity)
-          ) {
-            if (!(await pathExists(ownerDirectory))) {
-              try {
-                await fs.rename(commitClaim, ownerDirectory);
-                ownedDirectory = ownerDirectory;
-              } catch (error) {
-                if (!isMissingPathError(error)) {
-                  throw error;
-                }
-              }
-            }
-            throw new Error("OpenClaw Crabline smoke lock commit fence was lost.");
-          }
-
-          await dependencies.beforeCommitFileRename?.();
-          heartbeat.assertHealthy();
-          await renew();
-          heartbeat.assertHealthy();
-          await heartbeat.settle();
-          heartbeat.assertHealthy();
-          await dependencies.beforeCommitRename?.();
-          await assertCompatibilityMarkerOwned({
-            lockDirectory,
-            securedDirectory,
-            token,
-          });
-          if (
-            stageDirectory &&
-            (!hasSameDirectoryIdentity(
+            !hasSameDirectoryIdentity(
               stageDirectoryIdentity,
               await readDirectoryIdentity(resolvedStageDirectory),
-            ) ||
-              !hasSameDirectoryIdentity(stagedFileIdentity, await readFileIdentity(stagedFilePath)))
+            )
           ) {
-            throw new Error("OpenClaw Crabline smoke lock commit stage identity changed.");
-          }
-          await fs.rename(
-            stageDirectory ? stagedFilePath : path.join(commitClaim, stagedFileName),
-            resolvedDestinationPath,
-          );
-          committed = true;
-        } finally {
-          if (!committed && stageDirectory && stageDirectoryIdentity && stagedFileIdentity) {
-            const cleanupRecord: CommitStageRecord = {
-              directoryIdentity: serializeIdentity(stageDirectoryIdentity),
-              directoryPath: resolvedStageDirectory,
-              fileIdentity: serializeIdentity(stagedFileIdentity),
-              fileName: stagedFileName,
-              token,
-              version: 1,
-            };
-            await removeValidatedCommitStageFile({
-              outputDir,
-              record: cleanupRecord,
-              token,
-            }).catch(() => undefined);
+            throw new Error(
+              "OpenClaw Crabline smoke lock commit stage directory identity changed.",
+            );
           }
         }
+        const stagedFileIdentity = await readFileIdentity(stagedFilePath);
+        if (stagedFileIdentity === null) {
+          throw new Error("OpenClaw Crabline smoke lock commit stage file is invalid.");
+        }
+        heartbeat.assertHealthy();
+        await renew();
+        heartbeat.assertHealthy();
+
+        await dependencies.beforeCommitClaim?.();
+        await assertCompatibilityMarkerOwned({
+          lockDirectory,
+          securedDirectory,
+          token,
+        });
+        const commitClaim = `${lockDirectory}${COMMIT_CLAIM_SUFFIX}.${token}.${randomUUID()}`;
+        const observedIdentity = await readDirectoryIdentity(ownerDirectory);
+        const observed = await readLockRecord(ownerDirectory);
+        if (
+          observedIdentity === null ||
+          observed.kind === "missing" ||
+          observed.record.owner.token !== token
+        ) {
+          throw new Error("OpenClaw Crabline smoke lock ownership was lost.");
+        }
+
+        try {
+          await fs.rename(ownerDirectory, commitClaim);
+        } catch (error) {
+          if (isMissingPathError(error)) {
+            throw new Error("OpenClaw Crabline smoke lock ownership was lost.", {
+              cause: error,
+            });
+          }
+          throw error;
+        }
+        ownedDirectory = commitClaim;
+        commitFenceConsumed = true;
+
+        const claimed = await readLockRecord(commitClaim);
+        const claimedIdentity = await readDirectoryIdentity(commitClaim);
+        if (
+          claimed.kind === "missing" ||
+          claimed.record.owner.token !== token ||
+          !hasSameDirectoryIdentity(observedIdentity, claimedIdentity)
+        ) {
+          if (!(await pathExists(ownerDirectory))) {
+            try {
+              await fs.rename(commitClaim, ownerDirectory);
+              ownedDirectory = ownerDirectory;
+            } catch (error) {
+              if (!isMissingPathError(error)) {
+                throw error;
+              }
+            }
+          }
+          throw new Error("OpenClaw Crabline smoke lock commit fence was lost.");
+        }
+
+        await dependencies.beforeCommitFileRename?.();
+        heartbeat.assertHealthy();
+        await renew();
+        heartbeat.assertHealthy();
+        await heartbeat.settle();
+        heartbeat.assertHealthy();
+        await dependencies.beforeCommitRename?.();
+        await assertCompatibilityMarkerOwned({
+          lockDirectory,
+          securedDirectory,
+          token,
+        });
+        const claimedStagedFilePath = path.join(commitClaim, stagedFileName);
+        if (stageDirectory) {
+          const currentDirectoryIdentity = await readDirectoryIdentity(resolvedStageDirectory);
+          const currentFileIdentity = await readFileIdentity(claimedStagedFilePath);
+          if (
+            !hasSameDirectoryIdentity(stageDirectoryIdentity, currentDirectoryIdentity) ||
+            !hasSameDirectoryIdentity(stagedFileIdentity, currentFileIdentity)
+          ) {
+            const error = new Error("OpenClaw Crabline smoke lock commit stage identity changed.");
+            Object.assign(error, { code: "ENOENT", path: claimedStagedFilePath });
+            throw error;
+          }
+        } else if (
+          !hasSameDirectoryIdentity(
+            stagedFileIdentity,
+            await readFileIdentity(claimedStagedFilePath),
+          )
+        ) {
+          throw new Error("OpenClaw Crabline smoke lock commit stage identity changed.");
+        }
+        if (
+          !hasSameDirectoryIdentity(outputDirectoryIdentity, await readDirectoryIdentity(outputDir))
+        ) {
+          throw new Error("OpenClaw Crabline smoke lock output directory identity changed.");
+        }
+        await securedOutputDirectory.assertIdentityAt(outputDir);
+        let currentDestinationDirectoryIdentity: DirectoryIdentity | null = null;
+        try {
+          currentDestinationDirectoryIdentity = await readDirectoryIdentity(destinationDirectory);
+        } catch {
+          // A replaced directory or symlink is an identity mismatch.
+        }
+        if (
+          !hasSameDirectoryIdentity(
+            destinationDirectoryIdentity,
+            currentDestinationDirectoryIdentity,
+          )
+        ) {
+          throw new Error(
+            "OpenClaw Crabline smoke lock commit destination directory identity changed.",
+          );
+        }
+        await securedDestinationDirectory.assertIdentityAt(destinationDirectory);
+        const revalidatedDestinationPath = await resolveConfinedPath(
+          outputDir,
+          resolvedDestinationPath,
+          "commit destination",
+          "file",
+        );
+        if (revalidatedDestinationPath !== resolvedDestinationPath) {
+          throw new Error("OpenClaw Crabline smoke lock commit destination path identity changed.");
+        }
+        await fs.rename(claimedStagedFilePath, revalidatedDestinationPath);
       },
       async release() {
         if (released) {

--- a/src/openclaw/smoke-lock.ts
+++ b/src/openclaw/smoke-lock.ts
@@ -506,6 +506,17 @@ const getProcessIdentityV2: GetProcessIdentity = (pid) => {
   return identity?.includes(":us:") ? identity : null;
 };
 
+let cachedCurrentProcessIdentity: string | null = null;
+let cachedCurrentProcessIdentityV2: string | null = null;
+
+function getCachedCurrentProcessIdentity(): string | null {
+  return (cachedCurrentProcessIdentity ??= getProcessIdentity(process.pid));
+}
+
+function getCachedCurrentProcessIdentityV2(): string | null {
+  return (cachedCurrentProcessIdentityV2 ??= getProcessIdentityV2(process.pid));
+}
+
 function hasExactProcessIdentity(owner: SmokeLockOwner): owner is (
   | ProcessIdentifiedSmokeLockOwner
   | RenewableSmokeLockOwner
@@ -1174,8 +1185,13 @@ export async function acquireOpenClawCrablineSmokeRunLock(
   const lockDirectory = path.join(outputDir, `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`);
   const token = randomUUID();
   const currentPid = dependencies.pid ?? process.pid;
-  const getRuntimeProcessIdentity = dependencies.getProcessIdentity ?? getProcessIdentity;
-  const getRuntimeProcessIdentityV2 = dependencies.getProcessIdentityV2 ?? getProcessIdentityV2;
+  const getRuntimeProcessIdentity =
+    dependencies.getProcessIdentity ??
+    ((pid) => (pid === process.pid ? getCachedCurrentProcessIdentity() : getProcessIdentity(pid)));
+  const getRuntimeProcessIdentityV2 =
+    dependencies.getProcessIdentityV2 ??
+    ((pid) =>
+      pid === process.pid ? getCachedCurrentProcessIdentityV2() : getProcessIdentityV2(pid));
   const runtime: SmokeLockRuntime = {
     currentPid,
     currentProcessIdentity:

--- a/src/openclaw/smoke-lock.ts
+++ b/src/openclaw/smoke-lock.ts
@@ -1705,6 +1705,8 @@ export async function acquireOpenClawCrablineSmokeRunLock(
         if (revalidatedDestinationPath !== resolvedDestinationPath) {
           throw new Error("OpenClaw Crabline smoke lock commit destination path identity changed.");
         }
+        // The owner-only output tree and smoke lock serialize supported writers; confinement does
+        // not treat another process running as the same OS user as a lower-privilege adversary.
         await fs.rename(claimedStagedFilePath, revalidatedDestinationPath);
       },
       async release() {

--- a/test/openclaw-smoke-lock.test.ts
+++ b/test/openclaw-smoke-lock.test.ts
@@ -120,6 +120,198 @@ describe("OpenClaw smoke lock cleanup", () => {
     }
   });
 
+  it("rejects commit paths outside the lock output before staging", async () => {
+    const outputDir = await createTempDir();
+    const outsideDir = await createTempDir();
+    const stageFile = vi.fn(async () => undefined);
+    try {
+      const lock = await acquireOpenClawCrablineSmokeRunLock(
+        { channel: "telegram", outputDir },
+        { startHeartbeat: disableHeartbeat },
+      );
+
+      await expect(
+        lock.commitFileAtomically({
+          contents: "private\n",
+          destinationPath: path.join(outputDir, "current.json"),
+          stageDirectory: outsideDir,
+          stageFile,
+        }),
+      ).rejects.toThrow("commit stage directory escapes its output directory");
+      expect(stageFile).not.toHaveBeenCalled();
+
+      await expect(
+        lock.commitFileAtomically({
+          contents: "private\n",
+          destinationPath: path.join(outsideDir, "current.json"),
+          stageFile,
+        }),
+      ).rejects.toThrow("commit destination escapes its output directory");
+      expect(stageFile).not.toHaveBeenCalled();
+      await lock.release();
+    } finally {
+      await disposeTempDir(outsideDir);
+      await disposeTempDir(outputDir);
+    }
+  });
+
+  it("rejects a symlinked commit stage before writing through it", async () => {
+    const outputDir = await createTempDir();
+    const outsideDir = await createTempDir();
+    const stageDirectory = path.join(outputDir, "stage");
+    const stageFile = vi.fn(async () => undefined);
+    try {
+      await fs.symlink(outsideDir, stageDirectory, "dir");
+      const lock = await acquireOpenClawCrablineSmokeRunLock(
+        { channel: "telegram", outputDir },
+        { startHeartbeat: disableHeartbeat },
+      );
+
+      await expect(
+        lock.commitFileAtomically({
+          contents: "private\n",
+          destinationPath: path.join(outputDir, "current.json"),
+          stageDirectory,
+          stageFile,
+        }),
+      ).rejects.toThrow("commit stage directory is invalid");
+      expect(stageFile).not.toHaveBeenCalled();
+      await lock.release();
+    } finally {
+      await disposeTempDir(outsideDir);
+      await disposeTempDir(outputDir);
+    }
+  });
+
+  it("does not delete an escaped file named by persisted commit metadata", async () => {
+    const outputDir = await createTempDir();
+    const outsideDir = await createTempDir();
+    let now = 1_000;
+    try {
+      const expiredLock = await acquireOpenClawCrablineSmokeRunLock(
+        { channel: "telegram", outputDir },
+        {
+          isProcessAlive: () => true,
+          leaseMs: 1_000,
+          now: () => now,
+          pid: 4_242,
+          processStartedAtMs: 100,
+          startHeartbeat: disableHeartbeat,
+        },
+      );
+      const ownedDirectory = await findOwnedLockDirectory(outputDir);
+      const owner = JSON.parse(await fs.readFile(path.join(ownedDirectory, "owner.json"), "utf8"));
+      const fileName = `.commit-file.${owner.token}.sentinel.tmp`;
+      const escapedPath = path.join(outsideDir, fileName);
+      await fs.writeFile(escapedPath, "unrelated\n");
+      const directoryStats = await fs.lstat(outsideDir, { bigint: true });
+      const fileStats = await fs.lstat(escapedPath, { bigint: true });
+      await fs.writeFile(
+        path.join(ownedDirectory, `commit-stage.${owner.token}.json`),
+        `${JSON.stringify({
+          directoryIdentity: {
+            device: directoryStats.dev.toString(),
+            inode: directoryStats.ino.toString(),
+          },
+          directoryPath: outsideDir,
+          fileIdentity: {
+            device: fileStats.dev.toString(),
+            inode: fileStats.ino.toString(),
+          },
+          fileName,
+          token: owner.token,
+          version: 1,
+        })}\n`,
+      );
+
+      now = 2_001;
+      const successorLock = await acquireOpenClawCrablineSmokeRunLock(
+        { channel: "telegram", outputDir },
+        {
+          isProcessAlive: () => true,
+          leaseMs: 1_000,
+          now: () => now,
+          pid: 5_252,
+          processStartedAtMs: 200,
+          startHeartbeat: disableHeartbeat,
+        },
+      );
+
+      await expect(fs.readFile(escapedPath, "utf8")).resolves.toBe("unrelated\n");
+      await successorLock.release();
+      await expiredLock.release();
+    } finally {
+      await disposeTempDir(outsideDir);
+      await disposeTempDir(outputDir);
+    }
+  });
+
+  it("does not delete a replacement file after the recorded stage directory changes", async () => {
+    const outputDir = await createTempDir();
+    const stageDirectory = path.join(outputDir, "stage");
+    const displacedDirectory = path.join(outputDir, "displaced-stage");
+    let now = 1_000;
+    try {
+      await fs.mkdir(stageDirectory);
+      const expiredLock = await acquireOpenClawCrablineSmokeRunLock(
+        { channel: "telegram", outputDir },
+        {
+          isProcessAlive: () => true,
+          leaseMs: 1_000,
+          now: () => now,
+          pid: 4_242,
+          processStartedAtMs: 100,
+          startHeartbeat: disableHeartbeat,
+        },
+      );
+      const ownedDirectory = await findOwnedLockDirectory(outputDir);
+      const owner = JSON.parse(await fs.readFile(path.join(ownedDirectory, "owner.json"), "utf8"));
+      const originalDirectoryStats = await fs.lstat(stageDirectory, { bigint: true });
+      await fs.rename(stageDirectory, displacedDirectory);
+      await fs.mkdir(stageDirectory);
+      const fileName = `.commit-file.${owner.token}.replacement.tmp`;
+      const replacementPath = path.join(stageDirectory, fileName);
+      await fs.writeFile(replacementPath, "replacement\n");
+      const replacementStats = await fs.lstat(replacementPath, { bigint: true });
+      await fs.writeFile(
+        path.join(ownedDirectory, `commit-stage.${owner.token}.json`),
+        `${JSON.stringify({
+          directoryIdentity: {
+            device: originalDirectoryStats.dev.toString(),
+            inode: originalDirectoryStats.ino.toString(),
+          },
+          directoryPath: stageDirectory,
+          fileIdentity: {
+            device: replacementStats.dev.toString(),
+            inode: replacementStats.ino.toString(),
+          },
+          fileName,
+          token: owner.token,
+          version: 1,
+        })}\n`,
+      );
+
+      now = 2_001;
+      const successorLock = await acquireOpenClawCrablineSmokeRunLock(
+        { channel: "telegram", outputDir },
+        {
+          isProcessAlive: () => true,
+          leaseMs: 1_000,
+          now: () => now,
+          pid: 5_252,
+          processStartedAtMs: 200,
+          startHeartbeat: disableHeartbeat,
+        },
+      );
+
+      await expect(fs.readFile(replacementPath, "utf8")).resolves.toBe("replacement\n");
+      await successorLock.release();
+      await expiredLock.release();
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
   it("secures an empty Windows lock directory before writing sensitive contents", async () => {
     const outputDir = await createTempDir();
     const destinationPath = path.join(outputDir, "current.json");

--- a/test/openclaw-smoke-lock.test.ts
+++ b/test/openclaw-smoke-lock.test.ts
@@ -49,6 +49,17 @@ describe("OpenClaw smoke lock cleanup", () => {
     expect(processIdentityFromDarwin("", "{ sec = 1, usec = 2 }")).toBeNull();
   });
 
+  it("preserves sub-second Darwin launch identity from native process details", () => {
+    expect(
+      processIdentityFromDarwin(
+        ["Process:         node [4242]", "Launch Time:     2026-07-13 12:27:31.230 +0000"].join(
+          "\n",
+        ),
+        "{ sec = 1783864000, usec = 123456 } Sun Jul 12 15:46:40 2026",
+      ),
+    ).toBe("darwin:1783864000.123456:us:1783945651230000");
+  });
+
   it("preserves sub-second process start identity from the runtime time origin", () => {
     expect(processStartedAtMsFromTimeOrigin(1_783_864_000_123.875)).toBe(1_783_864_000_123);
     expect(() => processStartedAtMsFromTimeOrigin(Number.NaN)).toThrow(
@@ -70,6 +81,31 @@ describe("OpenClaw smoke lock cleanup", () => {
       UNRELATED: "preserved",
     });
   });
+
+  it.runIf(process.platform === "darwin")(
+    "records a sub-second native Darwin process identity",
+    async () => {
+      const outputDir = await createTempDir();
+      try {
+        const lock = await acquireOpenClawCrablineSmokeRunLock(
+          { channel: "telegram", outputDir },
+          { startHeartbeat: disableHeartbeat },
+        );
+        const owner = JSON.parse(
+          await fs.readFile(
+            path.join(await findOwnedLockDirectory(outputDir), "owner.json"),
+            "utf8",
+          ),
+        );
+
+        expect(owner.processIdentity).toMatch(/^darwin:\d+\.\d+:[A-Z][a-z]{2} [A-Z][a-z]{2} /u);
+        expect(owner.processIdentityV2).toMatch(/^darwin:\d+\.\d+:us:\d+$/u);
+        await lock.release();
+      } finally {
+        await disposeTempDir(outputDir);
+      }
+    },
+  );
 
   it("rejects oversized PIDs and non-liveness process errors", () => {
     const kill = vi.spyOn(process, "kill");
@@ -125,6 +161,7 @@ describe("OpenClaw smoke lock cleanup", () => {
     const outsideDir = await createTempDir();
     const stageFile = vi.fn(async () => undefined);
     try {
+      await fs.mkdir(path.join(outputDir, "nested"));
       const lock = await acquireOpenClawCrablineSmokeRunLock(
         { channel: "telegram", outputDir },
         { startHeartbeat: disableHeartbeat },
@@ -148,6 +185,16 @@ describe("OpenClaw smoke lock cleanup", () => {
         }),
       ).rejects.toThrow("commit destination escapes its output directory");
       expect(stageFile).not.toHaveBeenCalled();
+      await lock.commitFileAtomically({
+        contents: "private\n",
+        destinationPath: path.join(outputDir, "nested", "current.json"),
+        stageFile: async (filePath, contents) => {
+          await fs.writeFile(filePath, contents);
+        },
+      });
+      await expect(
+        fs.readFile(path.join(outputDir, "nested", "current.json"), "utf8"),
+      ).resolves.toBe("private\n");
       await lock.release();
     } finally {
       await disposeTempDir(outsideDir);
@@ -174,8 +221,120 @@ describe("OpenClaw smoke lock cleanup", () => {
           stageDirectory,
           stageFile,
         }),
-      ).rejects.toThrow("commit stage directory is invalid");
+      ).rejects.toThrow("commit stage directory escapes its output directory");
       expect(stageFile).not.toHaveBeenCalled();
+      await lock.release();
+    } finally {
+      await disposeTempDir(outsideDir);
+      await disposeTempDir(outputDir);
+    }
+  });
+
+  it("rejects symlinked ancestors that resolve commit paths outside the output", async () => {
+    const outputDir = await createTempDir();
+    const outsideDir = await createTempDir();
+    const outsideStage = path.join(outsideDir, "stage");
+    const linkedAncestor = path.join(outputDir, "linked");
+    const stageFile = vi.fn(async () => undefined);
+    try {
+      await fs.mkdir(outsideStage);
+      await fs.symlink(outsideDir, linkedAncestor, "dir");
+      const lock = await acquireOpenClawCrablineSmokeRunLock(
+        { channel: "telegram", outputDir },
+        { startHeartbeat: disableHeartbeat },
+      );
+
+      await expect(
+        lock.commitFileAtomically({
+          contents: "private\n",
+          destinationPath: path.join(outputDir, "current.json"),
+          stageDirectory: path.join(linkedAncestor, "stage"),
+          stageFile,
+        }),
+      ).rejects.toThrow("commit stage directory escapes its output directory");
+      await expect(
+        lock.commitFileAtomically({
+          contents: "private\n",
+          destinationPath: path.join(linkedAncestor, "current.json"),
+          stageFile,
+        }),
+      ).rejects.toThrow("commit destination escapes its output directory");
+      expect(stageFile).not.toHaveBeenCalled();
+      await lock.release();
+    } finally {
+      await disposeTempDir(outsideDir);
+      await disposeTempDir(outputDir);
+    }
+  });
+
+  it("rejects a destination parent replaced after confinement validation", async () => {
+    const outputDir = await createTempDir();
+    const outsideDir = await createTempDir();
+    const destinationDirectory = path.join(outputDir, "nested");
+    const displacedDirectory = path.join(outputDir, "displaced-nested");
+    try {
+      await fs.mkdir(destinationDirectory);
+      const lock = await acquireOpenClawCrablineSmokeRunLock(
+        { channel: "telegram", outputDir },
+        {
+          beforeCommitRename: async () => {
+            await fs.rename(destinationDirectory, displacedDirectory);
+            await fs.symlink(outsideDir, destinationDirectory, "dir");
+          },
+          startHeartbeat: disableHeartbeat,
+        },
+      );
+
+      await expect(
+        lock.commitFileAtomically({
+          contents: "private\n",
+          destinationPath: path.join(destinationDirectory, "current.json"),
+          stageFile: async (filePath, contents) => {
+            await fs.writeFile(filePath, contents);
+          },
+        }),
+      ).rejects.toThrow("commit destination directory identity changed");
+      await expect(fs.access(path.join(outsideDir, "current.json"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      await lock.release();
+    } finally {
+      await disposeTempDir(outsideDir);
+      await disposeTempDir(outputDir);
+    }
+  });
+
+  it("rejects a destination ancestor moved outside after confinement validation", async () => {
+    const outputDir = await createTempDir();
+    const outsideDir = await createTempDir();
+    const ancestorDirectory = path.join(outputDir, "ancestor");
+    const destinationDirectory = path.join(ancestorDirectory, "nested");
+    const displacedAncestor = path.join(outsideDir, "ancestor");
+    try {
+      await fs.mkdir(destinationDirectory, { recursive: true });
+      const lock = await acquireOpenClawCrablineSmokeRunLock(
+        { channel: "telegram", outputDir },
+        {
+          beforeCommitRename: async () => {
+            await fs.rename(ancestorDirectory, displacedAncestor);
+            await fs.symlink(displacedAncestor, ancestorDirectory, "dir");
+          },
+          startHeartbeat: disableHeartbeat,
+        },
+      );
+
+      await expect(
+        lock.commitFileAtomically({
+          contents: "private\n",
+          destinationPath: path.join(destinationDirectory, "current.json"),
+          stageFile: async (filePath, contents) => {
+            await fs.writeFile(filePath, contents);
+          },
+        }),
+      ).rejects.toThrow("commit destination escapes its output directory");
+      await expect(
+        fs.access(path.join(displacedAncestor, "nested", "current.json")),
+      ).rejects.toMatchObject({ code: "ENOENT" });
       await lock.release();
     } finally {
       await disposeTempDir(outsideDir);
@@ -200,14 +359,16 @@ describe("OpenClaw smoke lock cleanup", () => {
         },
       );
       const ownedDirectory = await findOwnedLockDirectory(outputDir);
-      const owner = JSON.parse(await fs.readFile(path.join(ownedDirectory, "owner.json"), "utf8"));
-      const fileName = `.commit-file.${owner.token}.sentinel.tmp`;
+      const { token } = JSON.parse(
+        await fs.readFile(path.join(ownedDirectory, "owner.json"), "utf8"),
+      );
+      const fileName = `.commit-file.${token}.sentinel.tmp`;
       const escapedPath = path.join(outsideDir, fileName);
       await fs.writeFile(escapedPath, "unrelated\n");
       const directoryStats = await fs.lstat(outsideDir, { bigint: true });
       const fileStats = await fs.lstat(escapedPath, { bigint: true });
       await fs.writeFile(
-        path.join(ownedDirectory, `commit-stage.${owner.token}.json`),
+        path.join(ownedDirectory, `commit-stage.${token}.json`),
         `${JSON.stringify({
           directoryIdentity: {
             device: directoryStats.dev.toString(),
@@ -219,7 +380,7 @@ describe("OpenClaw smoke lock cleanup", () => {
             inode: fileStats.ino.toString(),
           },
           fileName,
-          token: owner.token,
+          token,
           version: 1,
         })}\n`,
       );
@@ -265,16 +426,18 @@ describe("OpenClaw smoke lock cleanup", () => {
         },
       );
       const ownedDirectory = await findOwnedLockDirectory(outputDir);
-      const owner = JSON.parse(await fs.readFile(path.join(ownedDirectory, "owner.json"), "utf8"));
+      const { token } = JSON.parse(
+        await fs.readFile(path.join(ownedDirectory, "owner.json"), "utf8"),
+      );
       const originalDirectoryStats = await fs.lstat(stageDirectory, { bigint: true });
       await fs.rename(stageDirectory, displacedDirectory);
       await fs.mkdir(stageDirectory);
-      const fileName = `.commit-file.${owner.token}.replacement.tmp`;
+      const fileName = `.commit-file.${token}.replacement.tmp`;
       const replacementPath = path.join(stageDirectory, fileName);
       await fs.writeFile(replacementPath, "replacement\n");
       const replacementStats = await fs.lstat(replacementPath, { bigint: true });
       await fs.writeFile(
-        path.join(ownedDirectory, `commit-stage.${owner.token}.json`),
+        path.join(ownedDirectory, `commit-stage.${token}.json`),
         `${JSON.stringify({
           directoryIdentity: {
             device: originalDirectoryStats.dev.toString(),
@@ -286,7 +449,7 @@ describe("OpenClaw smoke lock cleanup", () => {
             inode: replacementStats.ino.toString(),
           },
           fileName,
-          token: owner.token,
+          token,
           version: 1,
         })}\n`,
       );
@@ -307,6 +470,40 @@ describe("OpenClaw smoke lock cleanup", () => {
       await expect(fs.readFile(replacementPath, "utf8")).resolves.toBe("replacement\n");
       await successorLock.release();
       await expiredLock.release();
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
+  it("preserves a missing-stage error when the stage directory is replaced before commit", async () => {
+    const outputDir = await createTempDir();
+    const stageDirectory = path.join(outputDir, "stage");
+    const displacedDirectory = path.join(outputDir, "displaced-stage");
+    try {
+      await fs.mkdir(stageDirectory);
+      const lock = await acquireOpenClawCrablineSmokeRunLock(
+        { channel: "telegram", outputDir },
+        {
+          beforeCommitFileRename: async () => {
+            await fs.rename(stageDirectory, displacedDirectory);
+            await fs.mkdir(stageDirectory);
+          },
+          startHeartbeat: disableHeartbeat,
+        },
+      );
+
+      await expect(
+        lock.commitFileAtomically({
+          contents: "private\n",
+          destinationPath: path.join(outputDir, "current.json"),
+          stageDirectory,
+          stageFile: async (filePath, contents) => {
+            await fs.writeFile(filePath, contents);
+          },
+        }),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.readdir(stageDirectory)).resolves.toEqual([]);
+      await lock.release();
     } finally {
       await disposeTempDir(outputDir);
     }
@@ -348,13 +545,13 @@ describe("OpenClaw smoke lock cleanup", () => {
         destinationPath,
         stageFile: async (filePath, contents) => {
           events.push("stage");
-          expect(events).toEqual(["secure", "secure", "stage"]);
+          expect(events).toEqual(["secure", "secure", "secure", "stage"]);
           await fs.writeFile(filePath, contents);
         },
       });
 
-      expect(secureWindowsDirectory).toHaveBeenCalledTimes(2);
-      expect(events).toEqual(["secure", "secure", "stage"]);
+      expect(secureWindowsDirectory).toHaveBeenCalledTimes(3);
+      expect(events).toEqual(["secure", "secure", "secure", "stage"]);
       await expect(fs.readFile(destinationPath, "utf8")).resolves.toBe("private\n");
       await lock.release();
     } finally {
@@ -756,6 +953,172 @@ describe("OpenClaw smoke lock cleanup", () => {
           processStartedAtMs: 200,
         }),
       ).rejects.toThrow("OpenClaw Crabline smoke is already running");
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
+  it("matches a recent legacy Darwin owner using its stable coarse identity", async () => {
+    const outputDir = await createTempDir();
+    const params = { channel: "telegram" as const, outputDir };
+    const lockDirectory = path.join(
+      path.resolve(outputDir),
+      `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`,
+    );
+    const coarseIdentity = "darwin:1783864000.123456:Sun Jul 12 16:04:00 2026";
+    try {
+      await fs.mkdir(lockDirectory, { mode: 0o700 });
+      const ownerPath = path.join(lockDirectory, "owner.json");
+      await fs.writeFile(
+        ownerPath,
+        `${JSON.stringify({
+          channel: "telegram",
+          createdAtMs: 1_000,
+          pid: 4_242,
+          processIdentity: coarseIdentity,
+          processStartedAtMs: 100,
+          token: "prior",
+        })}\n`,
+        { mode: 0o600 },
+      );
+      await fs.utimes(ownerPath, new Date(1_000), new Date(1_000));
+
+      await expect(
+        acquireOpenClawCrablineSmokeRunLock(params, {
+          getProcessIdentity: () => coarseIdentity,
+          isProcessAlive: () => true,
+          leaseMs: 1_000,
+          now: () => 1_500,
+          pid: 5_252,
+          processStartedAtMs: 200,
+        }),
+      ).rejects.toThrow("OpenClaw Crabline smoke is already running");
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
+  it("bounds trust in a stale remote owner with a coarse Darwin identity", async () => {
+    const outputDir = await createTempDir();
+    const params = { channel: "telegram" as const, outputDir };
+    const lockDirectory = path.join(
+      path.resolve(outputDir),
+      `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`,
+    );
+    const coarseIdentity = "darwin:1783864000.123456:Sun Jul 12 16:04:00 2026";
+    try {
+      await fs.mkdir(lockDirectory, { mode: 0o700 });
+      const ownerPath = path.join(lockDirectory, "owner.json");
+      await fs.writeFile(
+        ownerPath,
+        `${JSON.stringify({
+          channel: "telegram",
+          createdAtMs: 1_000,
+          pid: 4_242,
+          processIdentity: coarseIdentity,
+          processStartedAtMs: 100,
+          token: "prior",
+        })}\n`,
+        { mode: 0o600 },
+      );
+      await fs.utimes(ownerPath, new Date(1_000), new Date(1_000));
+
+      const replacementLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+        getProcessIdentity: () => coarseIdentity,
+        isProcessAlive: () => true,
+        leaseMs: 1_000,
+        now: () => 2_001,
+        pid: 5_252,
+        processStartedAtMs: 200,
+        startHeartbeat: disableHeartbeat,
+      });
+
+      await expect(replacementLock.assertOwned()).resolves.toBeUndefined();
+      await replacementLock.release();
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
+  it("keeps a stale remote owner when its precise Darwin identity is verified", async () => {
+    const outputDir = await createTempDir();
+    const params = { channel: "telegram" as const, outputDir };
+    const lockDirectory = path.join(
+      path.resolve(outputDir),
+      `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`,
+    );
+    const coarseIdentity = "darwin:1783864000.123456:Sun Jul 12 16:04:00 2026";
+    const preciseIdentity = "darwin:1783864000.123456:us:1783872240500000";
+    try {
+      await fs.mkdir(lockDirectory, { mode: 0o700 });
+      const ownerPath = path.join(lockDirectory, "owner.json");
+      await fs.writeFile(
+        ownerPath,
+        `${JSON.stringify({
+          channel: "telegram",
+          createdAtMs: 1_000,
+          pid: 4_242,
+          processIdentity: coarseIdentity,
+          processIdentityV2: preciseIdentity,
+          processStartedAtMs: 100,
+          token: "prior",
+        })}\n`,
+        { mode: 0o600 },
+      );
+      await fs.utimes(ownerPath, new Date(1_000), new Date(1_000));
+
+      await expect(
+        acquireOpenClawCrablineSmokeRunLock(params, {
+          getProcessIdentity: () => coarseIdentity,
+          getProcessIdentityV2: () => preciseIdentity,
+          isProcessAlive: () => true,
+          leaseMs: 1_000,
+          now: () => 10_000,
+          pid: 5_252,
+          processStartedAtMs: 200,
+        }),
+      ).rejects.toThrow("OpenClaw Crabline smoke is already running");
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
+  it("reclaims a same-second Darwin PID reuse when precise identities differ", async () => {
+    const outputDir = await createTempDir();
+    const params = { channel: "telegram" as const, outputDir };
+    const lockDirectory = path.join(
+      path.resolve(outputDir),
+      `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`,
+    );
+    try {
+      await fs.mkdir(lockDirectory, { mode: 0o700 });
+      await fs.writeFile(
+        path.join(lockDirectory, "owner.json"),
+        `${JSON.stringify({
+          channel: "telegram",
+          createdAtMs: 1_000,
+          pid: 4_242,
+          processIdentity: "darwin:1783864000.123456:Sun Jul 12 16:04:00 2026",
+          processIdentityV2: "darwin:1783864000.123456:us:1783872240100000",
+          processStartedAtMs: 100,
+          token: "prior",
+        })}\n`,
+        { mode: 0o600 },
+      );
+
+      const replacementLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+        getProcessIdentity: () => "darwin:1783864000.123456:Sun Jul 12 16:04:00 2026",
+        getProcessIdentityV2: () => "darwin:1783864000.123456:us:1783872240900000",
+        isProcessAlive: () => true,
+        leaseMs: 1_000,
+        now: () => 1_100,
+        pid: 5_252,
+        processStartedAtMs: 200,
+        startHeartbeat: disableHeartbeat,
+      });
+
+      await expect(replacementLock.assertOwned()).resolves.toBeUndefined();
+      await replacementLock.release();
     } finally {
       await disposeTempDir(outputDir);
     }


### PR DESCRIPTION
## Summary

- keep smoke-lock commit staging claim-local and reject escaped or replaced commit paths
- add backward-compatible sub-second Darwin process identities and cache successful local identity reads
- preserve owner-only trust boundaries and expand smoke-lock race and cleanup coverage

## Validation

- `pnpm test test/openclaw-smoke-lock.test.ts test/openclaw.test.ts` (2 files, 132 tests)
- `pnpm lint`
- `git diff --check`
- privacy scan: clean
- autoreview: `gpt-5.6-sol`, high reasoning, clean (0.86 confidence)

## Release note

- added under `CHANGELOG.md` Unreleased

## Review state

Exact reviewed pair: base `fd19dfdeedf9f33840cf38797a331c135122442a`, head `d169d633dbcccacf810e02c517312ab299b81e21`.