### PR TITLE
fix(ids): enforce provider numeric boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Reject provider and fixture timer durations above Node's supported ceiling.
 - Round-trip every supported WhatsApp handshake protobuf variant without dropping fields.
 - Reject unsupported Zalo thread targets during normalization, matching OpenClaw bridge execution.
+- Enforce Discord uint64 snowflakes and Telegram safe-integer chat and topic identifiers.
 - Bound shared JSON ingress, reject non-object payloads precisely, and strictly normalize loopback IP addresses.
 - Harden WhatsApp send evidence, direct-JID correlation, cursor and cleanup races, and cleartext listener exposure.
 - Revalidate npm package version, integrity, and provenance after every release publication outcome.

--- a/src/providers/builtin/native-local-mock.ts
+++ b/src/providers/builtin/native-local-mock.ts
@@ -1,6 +1,6 @@
 import { createHash, timingSafeEqual } from "node:crypto";
 import { CrablineError } from "../../core/errors.js";
-import { numericNativeId, type NativeIdRule } from "../native-ids.js";
+import { matchesNativeId, numericNativeId, type NativeIdRule } from "../native-ids.js";
 import type { InboundEnvelope } from "../types.js";
 
 export type { NativeIdRule } from "../native-ids.js";
@@ -48,7 +48,7 @@ export function normalizeAuthor(value: unknown): "assistant" | "system" | "user"
 }
 
 export function requireNativeInboundId(value: string, rule: NativeIdRule, label: string): string {
-  if (!rule.pattern.test(value)) {
+  if (!matchesNativeId(value, rule)) {
     throw new CrablineError(`${label} must be a native ${rule.name} such as ${rule.example}.`, {
       kind: "inbound",
     });
@@ -81,8 +81,8 @@ export function genericMockPayloadWithNativeThread(params: {
     };
   }
 
-  const isValidThread = params.threadRule.pattern.test(threadId);
-  const isValidChannel = params.channelRule?.pattern.test(threadId) ?? false;
+  const isValidThread = matchesNativeId(threadId, params.threadRule);
+  const isValidChannel = params.channelRule ? matchesNativeId(threadId, params.channelRule) : false;
   if (!isValidThread && !isValidChannel) {
     throw new CrablineError(
       `mock webhook threadId must be a native ${params.threadRule.name}${

--- a/src/providers/native-ids.ts
+++ b/src/providers/native-ids.ts
@@ -2,7 +2,12 @@ export type NativeIdRule = {
   example: string;
   name: string;
   pattern: RegExp;
+  validate?: ((value: string) => boolean) | undefined;
 };
+
+export function matchesNativeId(value: string, rule: NativeIdRule): boolean {
+  return rule.pattern.test(value) && (rule.validate?.(value) ?? true);
+}
 
 export function numericNativeId(value: number | bigint): string | undefined {
   if (typeof value === "number" && !Number.isSafeInteger(value)) {

--- a/src/providers/target-normalizers.ts
+++ b/src/providers/target-normalizers.ts
@@ -326,8 +326,7 @@ export function parseCanonicalTelegramTopic(
   const topicId = value.slice(separator + 1);
   if (
     !matchesNativeId(chatId, TELEGRAM_CHAT_ID_RULE) ||
-    !matchesNativeId(topicId, TELEGRAM_MESSAGE_THREAD_ID_RULE) ||
-    (!chatId.startsWith("@") && !chatId.startsWith("-"))
+    !matchesNativeId(topicId, TELEGRAM_MESSAGE_THREAD_ID_RULE)
   ) {
     return undefined;
   }

--- a/src/providers/target-normalizers.ts
+++ b/src/providers/target-normalizers.ts
@@ -2,7 +2,7 @@ import { isIP } from "node:net";
 import type { BuiltinAdapterId, FixtureDefinition, ProviderPlatform } from "../config/schema.js";
 import { CrablineError } from "../core/errors.js";
 import type { LocalMockTargetCodec } from "./local-mock.js";
-import type { NativeIdRule } from "./native-ids.js";
+import { matchesNativeId, type NativeIdRule } from "./native-ids.js";
 import { slackTargetKey, SLACK_SEND_TARGET_ID_RULE, SLACK_TS_RULE } from "./slack-ids.js";
 import type { NormalizedTarget } from "./types.js";
 
@@ -11,7 +11,8 @@ export type BuiltinProviderAdapterId = Exclude<BuiltinAdapterId, "script">;
 export const DISCORD_SNOWFLAKE_RULE: NativeIdRule = {
   example: "123456789012345678",
   name: "Discord snowflake id",
-  pattern: /^\d{17,20}$/u,
+  pattern: /^[1-9]\d{16,19}$/u,
+  validate: (value) => BigInt(value) <= 18_446_744_073_709_551_615n,
 };
 
 export const FEISHU_CHAT_ID_RULE: NativeIdRule = {
@@ -160,12 +161,15 @@ export const TELEGRAM_CHAT_ID_RULE: NativeIdRule = {
   example: "-1001234567890 or @channelusername",
   name: "Telegram chat id",
   pattern: /^(?:-?[1-9]\d*|@[A-Za-z][A-Za-z0-9_]{3,31})$/u,
+  validate: (value) =>
+    value.startsWith("@") || BigInt(value.replace(/^-/u, "")) <= BigInt(Number.MAX_SAFE_INTEGER),
 };
 
 export const TELEGRAM_MESSAGE_THREAD_ID_RULE: NativeIdRule = {
   example: "42",
   name: "Telegram message_thread_id",
   pattern: /^[1-9]\d*$/u,
+  validate: (value) => BigInt(value) <= BigInt(Number.MAX_SAFE_INTEGER),
 };
 
 export const WHATSAPP_WA_ID_RULE: NativeIdRule = {
@@ -183,7 +187,7 @@ export const ZALO_ID_RULE: NativeIdRule = {
 export const ZALO_UNSUPPORTED_THREAD_TARGET_ERROR = "Zalo does not support thread targets.";
 
 function requireNativeId(value: string, rule: NativeIdRule, label: string): string {
-  if (!rule.pattern.test(value)) {
+  if (!matchesNativeId(value, rule)) {
     throw new CrablineError(`${label} must be a native ${rule.name} such as ${rule.example}.`, {
       kind: "config",
     });
@@ -321,8 +325,9 @@ export function parseCanonicalTelegramTopic(
   const chatId = value.slice(0, separator);
   const topicId = value.slice(separator + 1);
   if (
-    !TELEGRAM_CHAT_ID_RULE.pattern.test(chatId) ||
-    !TELEGRAM_MESSAGE_THREAD_ID_RULE.pattern.test(topicId)
+    !matchesNativeId(chatId, TELEGRAM_CHAT_ID_RULE) ||
+    !matchesNativeId(topicId, TELEGRAM_MESSAGE_THREAD_ID_RULE) ||
+    (!chatId.startsWith("@") && !chatId.startsWith("-"))
   ) {
     return undefined;
   }

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -134,6 +134,54 @@ describe("registry", () => {
     }
   });
 
+  it("enforces Discord snowflake uint64 bounds", () => {
+    expect(
+      normalizeBuiltinTarget("discord", {
+        id: "18446744073709551615",
+        metadata: {},
+      }),
+    ).toMatchObject({ channelId: "18446744073709551615" });
+    for (const id of ["18446744073709551616", "99999999999999999999", "012345678901234567"]) {
+      expect(() => normalizeBuiltinTarget("discord", { id, metadata: {} })).toThrow(
+        /native Discord snowflake id/u,
+      );
+    }
+  });
+
+  it("enforces Telegram safe-integer and topic bounds", () => {
+    const maxSafeInteger = String(Number.MAX_SAFE_INTEGER);
+    expect(
+      normalizeBuiltinTarget("telegram", {
+        id: `-${maxSafeInteger}`,
+        metadata: {},
+        threadId: maxSafeInteger,
+      }),
+    ).toMatchObject({
+      channelId: `-${maxSafeInteger}`,
+      threadId: `-${maxSafeInteger}:${maxSafeInteger}`,
+    });
+
+    for (const id of ["9007199254740992", "-9007199254740992"]) {
+      expect(() => normalizeBuiltinTarget("telegram", { id, metadata: {} })).toThrow(
+        /native Telegram chat id/u,
+      );
+    }
+    expect(() =>
+      normalizeBuiltinTarget("telegram", {
+        id: "-100123",
+        metadata: {},
+        threadId: "9007199254740992",
+      }),
+    ).toThrow(/native Telegram message_thread_id/u);
+    expect(() =>
+      normalizeBuiltinTarget("telegram", {
+        id: "123",
+        metadata: {},
+        threadId: "123:42",
+      }),
+    ).toThrow(/native Telegram message_thread_id/u);
+  });
+
   it.each([
     [
       "discord",

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -173,13 +173,13 @@ describe("registry", () => {
         threadId: "9007199254740992",
       }),
     ).toThrow(/native Telegram message_thread_id/u);
-    expect(() =>
+    expect(
       normalizeBuiltinTarget("telegram", {
         id: "123",
         metadata: {},
         threadId: "123:42",
       }),
-    ).toThrow(/native Telegram message_thread_id/u);
+    ).toMatchObject({ channelId: "123", threadId: "123:42" });
   });
 
   it.each([


### PR DESCRIPTION
## Summary

- enforce Discord snowflake uint64 limits without accepting leading-zero aliases
- enforce Telegram safe-integer chat and topic boundaries across normalization and local mock ingress
- preserve canonical private-chat topic targets

## Validation

- 59 focused registry, Discord, and Telegram tests
- typecheck, format, lint, and `git diff --check origin/main...HEAD`
- autoreview: clean (`gpt-5.6-sol`, high, confidence 0.93)
- privacy scan: clean
- exact head: `71ba170650479118e39b13cc0d21a9c5146d6e34`
- GitHub CI: green
- Crabbox `run_bb9ff653c8fc`: `pnpm verify`, 60 files / 1149 tests passed
