### PR TITLE
fix(recorder): harden provider append durability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Revalidate npm package version, integrity, and provenance after every release publication outcome.
 - Authenticate Feishu signatures before encrypted callback decryption and bound callback ciphertext work.
 - Correct Slack edited-message identity and text fallback handling, acknowledge unsupported callbacks, and fairly budget Events API address failover.
+- Preserve provider recorder cursors across parse failures, report post-commit lock cleanup failures without rejecting committed appends, and synchronize hardlink aliases.
 - Cover local GitHub Actions with ownership, CodeQL, immutable image, and test-tool runtime policies.
 - Publish Matrix direct-room account data and share strict native identifier validation across server, target, and inbound paths.
 - Protect pnpm install-script policy and enforce immutable action pins across reusable workflows and composite actions.

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -630,14 +630,8 @@ async function privateRecorderLockRoot(): Promise<string> {
     throw new Error("Provider recorder identity locking requires a current user id.");
   }
 
-  const root = path.join("/tmp", `.crabline-provider-recorder-${currentUserId}`);
-  try {
-    await mkdir(root, { mode: 0o700 });
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
-      throw error;
-    }
-  }
+  const root = path.join(homedir(), ".cache", "crabline", "locks", "provider-recorder");
+  await mkdir(root, { mode: 0o700, recursive: true });
   const handle = await open(
     root,
     fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW,
@@ -725,7 +719,7 @@ async function withRecorderLock<T>(
   try {
     releases.push(await acquireRecorderLock(filePath));
     for (let attempt = 0; attempt < RECORDER_ROTATION_ATTEMPTS; attempt += 1) {
-      lockCreatedFile = (await ensureRecorderExistsForLock(filePath)) || lockCreatedFile;
+      lockCreatedFile = await ensureRecorderExistsForLock(filePath);
       const identity = await readRecorderFileIdentity(filePath);
       if (!identity) {
         continue;

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -646,10 +646,10 @@ async function secureRecorderLockRoot(
     ) {
       throw new Error("Provider recorder lock directory is not privately owned.");
     }
-    if ((identity.mode & 0o077n) !== 0n) {
+    if ((identity.mode & 0o777n) !== 0o700n) {
       await handle.chmod(0o700);
       const secured = await handle.stat({ bigint: true });
-      if ((secured.mode & 0o077n) !== 0n) {
+      if ((secured.mode & 0o777n) !== 0o700n) {
         throw new Error("Provider recorder lock directory permissions are not private.");
       }
     }
@@ -695,7 +695,12 @@ async function privateRecorderLockRoot(
     );
   }
   return await secureRecorderLockRoot(
-    path.join(path.dirname(filePath), ".crabline-provider-recorder-locks"),
+    path.join(
+      path.dirname(filePath),
+      currentUserId === undefined
+        ? ".crabline-provider-recorder-locks"
+        : `.crabline-provider-recorder-locks-${currentUserId}`,
+    ),
     currentUserId,
   );
 }

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -1,4 +1,6 @@
+import { constants as fsConstants } from "node:fs";
 import { lstat, mkdir, open, readFile, readlink, realpath } from "node:fs/promises";
+import { homedir } from "node:os";
 import path from "node:path";
 import { lock } from "proper-lockfile";
 import type { InboundEnvelope } from "./types.js";
@@ -594,9 +596,21 @@ function reportRecorderLockReleaseFailure(filePath: string, releaseError: unknow
 }
 
 async function privateRecorderLockRoot(): Promise<string> {
+  if (process.platform === "win32") {
+    const localAppData =
+      process.env.LOCALAPPDATA?.trim() || path.join(homedir(), "AppData", "Local");
+    const root = path.join(localAppData, "Crabline", "locks", "provider-recorder");
+    await mkdir(root, { recursive: true });
+    const identity = await lstat(root);
+    if (!identity.isDirectory() || identity.isSymbolicLink()) {
+      throw new Error("Provider recorder lock directory is not a private directory.");
+    }
+    return root;
+  }
+
   const currentUserId = process.geteuid?.();
-  if (process.platform === "win32" || currentUserId === undefined) {
-    throw new Error("Hardlinked provider recorder paths are unsupported on this platform.");
+  if (currentUserId === undefined) {
+    throw new Error("Provider recorder identity locking requires a current user id.");
   }
 
   const root = path.join("/tmp", `.crabline-provider-recorder-${currentUserId}`);
@@ -607,9 +621,11 @@ async function privateRecorderLockRoot(): Promise<string> {
       throw error;
     }
   }
-  const handle = await open(root, "r");
+  const handle = await open(
+    root,
+    fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW,
+  );
   try {
-    await handle.chmod(0o700);
     const identity = await handle.stat({ bigint: true });
     const current = await lstat(root, { bigint: true });
     if (
@@ -618,9 +634,16 @@ async function privateRecorderLockRoot(): Promise<string> {
       identity.dev !== current.dev ||
       identity.ino !== current.ino ||
       identity.uid !== BigInt(currentUserId) ||
-      (identity.mode & 0o077n) !== 0n
+      current.uid !== BigInt(currentUserId)
     ) {
       throw new Error("Provider recorder lock directory is not privately owned.");
+    }
+    if ((identity.mode & 0o077n) !== 0n) {
+      await handle.chmod(0o700);
+      const secured = await handle.stat({ bigint: true });
+      if ((secured.mode & 0o077n) !== 0n) {
+        throw new Error("Provider recorder lock directory permissions are not private.");
+      }
     }
   } finally {
     await handle.close();
@@ -663,7 +686,7 @@ async function withRecorderLock<T>(filePath: string, operation: () => Promise<T>
   try {
     releases.push(await acquireRecorderLock(filePath));
     const identity = await readRecorderFileIdentity(filePath);
-    if (identity && identity.nlink > 1n) {
+    if (identity) {
       releases.push(await acquireRecorderLock(await recorderIdentityLockTarget(identity)));
     }
   } catch (error) {

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -776,13 +776,16 @@ async function withRecorderLock<T>(
       const releaseIdentityLock = await acquireRecorderLock(
         await recorderIdentityLockTarget(filePath, identity),
       );
+      releases.push(releaseIdentityLock);
       const currentIdentity = await readRecorderFileIdentity(filePath);
       if (sameRecorderFileIdentity(identity, currentIdentity)) {
-        releases.push(releaseIdentityLock);
         lockedIdentity = identity;
         break;
       }
-      const releaseErrors = await releaseRecorderLocks([releaseIdentityLock]);
+      const registeredIdentityRelease = releases.pop();
+      const releaseErrors = await releaseRecorderLocks(
+        registeredIdentityRelease ? [registeredIdentityRelease] : [],
+      );
       if (releaseErrors.length > 0) {
         throw recorderLockReleaseError(
           filePath,

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -1,4 +1,5 @@
 import { lstat, mkdir, open, readFile, readlink, realpath } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { lock } from "proper-lockfile";
 import type { InboundEnvelope } from "./types.js";
@@ -560,17 +561,24 @@ async function appendCommittedLine(
 function recorderLockReleaseError(
   filePath: string,
   operationError: unknown,
-  releaseError: unknown,
+  releaseErrors: unknown[],
 ): AggregateError {
   return new AggregateError(
-    [operationError, releaseError],
+    [operationError, ...releaseErrors],
     `Recorder append and lock release both failed for "${filePath}".`,
     { cause: operationError },
   );
 }
 
+function recorderErrorDetail(error: unknown): string {
+  if (error instanceof AggregateError) {
+    return error.errors.map(recorderErrorDetail).join("; ");
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
 function reportRecorderLockReleaseFailure(filePath: string, releaseError: unknown): void {
-  const detail = releaseError instanceof Error ? releaseError.message : String(releaseError);
+  const detail = recorderErrorDetail(releaseError);
   try {
     process.emitWarning(
       `Provider recorder append committed but lock cleanup failed for "${filePath}": ${detail}`,
@@ -584,8 +592,16 @@ function reportRecorderLockReleaseFailure(filePath: string, releaseError: unknow
   }
 }
 
-async function withRecorderLock<T>(filePath: string, operation: () => Promise<T>): Promise<T> {
-  const release = await lock(filePath, {
+function recorderIdentityLockTarget(identity: RecorderFileIdentity): string {
+  const userScope = typeof process.getuid === "function" ? process.getuid() : "user";
+  return path.join(
+    tmpdir(),
+    `.crabline-provider-recorder-${userScope}-${identity.dev}-${identity.ino}`,
+  );
+}
+
+async function acquireRecorderLock(filePath: string): Promise<() => Promise<void>> {
+  return await lock(filePath, {
     realpath: false,
     retries: {
       factor: 1,
@@ -596,6 +612,36 @@ async function withRecorderLock<T>(filePath: string, operation: () => Promise<T>
     stale: RECORDER_LOCK_STALE_MS,
     update: RECORDER_LOCK_UPDATE_MS,
   });
+}
+
+async function releaseRecorderLocks(releases: Array<() => Promise<void>>): Promise<unknown[]> {
+  const errors: unknown[] = [];
+  for (const release of releases.reverse()) {
+    try {
+      await release();
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  return errors;
+}
+
+async function withRecorderLock<T>(filePath: string, operation: () => Promise<T>): Promise<T> {
+  const releases: Array<() => Promise<void>> = [];
+  try {
+    releases.push(await acquireRecorderLock(filePath));
+    const identity = await readRecorderFileIdentity(filePath);
+    if (identity) {
+      releases.push(await acquireRecorderLock(recorderIdentityLockTarget(identity)));
+    }
+  } catch (error) {
+    const releaseErrors = await releaseRecorderLocks(releases);
+    if (releaseErrors.length > 0) {
+      throw recorderLockReleaseError(filePath, error, releaseErrors);
+    }
+    throw error;
+  }
+
   let operationFailed = false;
   let operationError: unknown;
   let result: T | undefined;
@@ -605,16 +651,20 @@ async function withRecorderLock<T>(filePath: string, operation: () => Promise<T>
     operationFailed = true;
     operationError = error;
   }
-  try {
-    await release();
-  } catch (releaseError) {
-    if (operationFailed) {
-      throw recorderLockReleaseError(filePath, operationError, releaseError);
-    }
-    reportRecorderLockReleaseFailure(filePath, releaseError);
-  }
+  const releaseErrors = await releaseRecorderLocks(releases);
   if (operationFailed) {
+    if (releaseErrors.length > 0) {
+      throw recorderLockReleaseError(filePath, operationError, releaseErrors);
+    }
     throw operationError;
+  }
+  if (releaseErrors.length > 0) {
+    reportRecorderLockReleaseFailure(
+      filePath,
+      releaseErrors.length === 1
+        ? releaseErrors[0]
+        : new AggregateError(releaseErrors, "Multiple recorder lock cleanup operations failed."),
+    );
   }
   return result as T;
 }

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -668,17 +668,24 @@ async function privateRecorderLockRoot(
   filePath: string,
   identity: RecorderFileIdentity,
 ): Promise<string> {
-  const account = userInfo();
   const currentUserId = process.platform === "win32" ? undefined : process.geteuid?.();
-  const sharedRoot =
-    process.platform === "win32"
-      ? path.join(account.homedir, "AppData", "Local", "Crabline", "locks", "provider-recorder")
-      : path.join(account.homedir, ".cache", "crabline", "locks", "provider-recorder");
+  let sharedRoot: string | undefined;
   try {
-    return await secureRecorderLockRoot(sharedRoot, currentUserId);
-  } catch (error) {
-    if (!recorderLockRootUnavailable(error)) {
-      throw error;
+    const account = userInfo();
+    sharedRoot =
+      process.platform === "win32"
+        ? path.join(account.homedir, "AppData", "Local", "Crabline", "locks", "provider-recorder")
+        : path.join(account.homedir, ".cache", "crabline", "locks", "provider-recorder");
+  } catch {
+    // Arbitrary container UIDs may not have an OS account entry.
+  }
+  if (sharedRoot) {
+    try {
+      return await secureRecorderLockRoot(sharedRoot, currentUserId);
+    } catch (error) {
+      if (!recorderLockRootUnavailable(error)) {
+        throw error;
+      }
     }
   }
 

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -569,6 +569,21 @@ function recorderLockReleaseError(
   );
 }
 
+function reportRecorderLockReleaseFailure(filePath: string, releaseError: unknown): void {
+  const detail = releaseError instanceof Error ? releaseError.message : String(releaseError);
+  try {
+    process.emitWarning(
+      `Provider recorder append committed but lock cleanup failed for "${filePath}": ${detail}`,
+      {
+        code: "CRABLINE_RECORDER_LOCK_CLEANUP",
+        type: "ProviderRecorderWarning",
+      },
+    );
+  } catch {
+    // Cleanup reporting must not change the result of a committed append.
+  }
+}
+
 async function withRecorderLock<T>(filePath: string, operation: () => Promise<T>): Promise<T> {
   const release = await lock(filePath, {
     realpath: false,
@@ -596,7 +611,7 @@ async function withRecorderLock<T>(filePath: string, operation: () => Promise<T>
     if (operationFailed) {
       throw recorderLockReleaseError(filePath, operationError, releaseError);
     }
-    throw releaseError;
+    reportRecorderLockReleaseFailure(filePath, releaseError);
   }
   if (operationFailed) {
     throw operationError;

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -661,13 +661,36 @@ async function secureRecorderLockRoot(
 
 function recorderLockRootUnavailable(error: unknown): boolean {
   const code = (error as NodeJS.ErrnoException).code;
-  return code === "EACCES" || code === "EPERM" || code === "EROFS";
+  return (
+    code === "EACCES" ||
+    code === "EDQUOT" ||
+    code === "ENOSPC" ||
+    code === "EPERM" ||
+    code === "EROFS"
+  );
 }
 
-async function privateRecorderLockRoot(
+function adjacentRecorderLockRoot(filePath: string, currentUserId: number | undefined): string {
+  return path.join(
+    path.dirname(filePath),
+    currentUserId === undefined
+      ? ".crabline-provider-recorder-locks"
+      : `.crabline-provider-recorder-locks-${currentUserId}`,
+  );
+}
+
+function recorderIdentityLockPath(root: string, identity: RecorderFileIdentity): string {
+  return path.join(root, `recorder-${identity.dev}-${identity.ino}`);
+}
+
+async function recorderIdentityLockTargets(
   filePath: string,
   identity: RecorderFileIdentity,
-): Promise<string> {
+): Promise<{
+  fallbackRoot?: string;
+  preferred: string;
+  userId: number | undefined;
+}> {
   const currentUserId = process.platform === "win32" ? undefined : process.geteuid?.();
   let sharedRoot: string | undefined;
   try {
@@ -681,7 +704,16 @@ async function privateRecorderLockRoot(
   }
   if (sharedRoot) {
     try {
-      return await secureRecorderLockRoot(sharedRoot, currentUserId);
+      return {
+        ...(identity.nlink === 1n
+          ? { fallbackRoot: adjacentRecorderLockRoot(filePath, currentUserId) }
+          : {}),
+        preferred: recorderIdentityLockPath(
+          await secureRecorderLockRoot(sharedRoot, currentUserId),
+          identity,
+        ),
+        userId: currentUserId,
+      };
     } catch (error) {
       if (!recorderLockRootUnavailable(error)) {
         throw error;
@@ -694,25 +726,30 @@ async function privateRecorderLockRoot(
       "Provider recorder hardlinks require a writable shared per-user lock directory.",
     );
   }
-  return await secureRecorderLockRoot(
-    path.join(
-      path.dirname(filePath),
-      currentUserId === undefined
-        ? ".crabline-provider-recorder-locks"
-        : `.crabline-provider-recorder-locks-${currentUserId}`,
-    ),
+  const adjacentRoot = await secureRecorderLockRoot(
+    adjacentRecorderLockRoot(filePath, currentUserId),
     currentUserId,
   );
+  return {
+    preferred: recorderIdentityLockPath(adjacentRoot, identity),
+    userId: currentUserId,
+  };
 }
 
-async function recorderIdentityLockTarget(
+async function acquireRecorderIdentityLock(
   filePath: string,
   identity: RecorderFileIdentity,
-): Promise<string> {
-  return path.join(
-    await privateRecorderLockRoot(filePath, identity),
-    `recorder-${identity.dev}-${identity.ino}`,
-  );
+): Promise<() => Promise<void>> {
+  const targets = await recorderIdentityLockTargets(filePath, identity);
+  try {
+    return await acquireRecorderLock(targets.preferred);
+  } catch (error) {
+    if (!targets.fallbackRoot || !recorderLockRootUnavailable(error)) {
+      throw error;
+    }
+    const fallbackRoot = await secureRecorderLockRoot(targets.fallbackRoot, targets.userId);
+    return await acquireRecorderLock(recorderIdentityLockPath(fallbackRoot, identity));
+  }
 }
 
 async function acquireRecorderLock(filePath: string): Promise<() => Promise<void>> {
@@ -773,9 +810,7 @@ async function withRecorderLock<T>(
       if (!identity) {
         continue;
       }
-      const releaseIdentityLock = await acquireRecorderLock(
-        await recorderIdentityLockTarget(filePath, identity),
-      );
+      const releaseIdentityLock = await acquireRecorderIdentityLock(filePath, identity);
       releases.push(releaseIdentityLock);
       const currentIdentity = await readRecorderFileIdentity(filePath);
       if (sameRecorderFileIdentity(identity, currentIdentity)) {

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -724,16 +724,21 @@ async function withRecorderLock<T>(
       if (!identity) {
         continue;
       }
-      const releaseIdentityLock = await acquireRecorderLock(
-        await recorderIdentityLockTarget(identity),
-      );
+      const releaseIdentityLock =
+        identity.nlink > 1n
+          ? await acquireRecorderLock(await recorderIdentityLockTarget(identity))
+          : undefined;
       const currentIdentity = await readRecorderFileIdentity(filePath);
       if (sameRecorderFileIdentity(identity, currentIdentity)) {
-        releases.push(releaseIdentityLock);
+        if (releaseIdentityLock) {
+          releases.push(releaseIdentityLock);
+        }
         lockedIdentity = identity;
         break;
       }
-      const releaseErrors = await releaseRecorderLocks([releaseIdentityLock]);
+      const releaseErrors = releaseIdentityLock
+        ? await releaseRecorderLocks([releaseIdentityLock])
+        : [];
       if (releaseErrors.length > 0) {
         throw recorderLockReleaseError(
           filePath,

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -1,5 +1,4 @@
 import { lstat, mkdir, open, readFile, readlink, realpath } from "node:fs/promises";
-import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 import { lock } from "proper-lockfile";
 import type { InboundEnvelope } from "./types.js";
@@ -76,6 +75,7 @@ type RecordIdentityIndex = {
 type RecorderFileIdentity = {
   dev: bigint;
   ino: bigint;
+  nlink: bigint;
 };
 
 type RecordedInboundBatchLine = {
@@ -335,6 +335,7 @@ async function readRecorderFileIdentity(
     return {
       dev: stats.dev,
       ino: stats.ino,
+      nlink: stats.nlink,
     };
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
@@ -462,7 +463,7 @@ async function prepareRecorderPathForAppend(
   const opened = await openRecorderForAppend(publicationPath);
   const { handle } = opened;
   const identity = await handle.stat({ bigint: true });
-  const recorderIdentity = { dev: identity.dev, ino: identity.ino };
+  const recorderIdentity = { dev: identity.dev, ino: identity.ino, nlink: identity.nlink };
   try {
     const changed = await prepareRecorderTailForAppend(handle);
     if (changed && durable) {
@@ -506,7 +507,7 @@ async function appendCommittedLine(
   const opened = await openRecorderForAppend(publicationPath);
   const { handle } = opened;
   const identity = await handle.stat({ bigint: true });
-  const recorderIdentity = { dev: identity.dev, ino: identity.ino };
+  const recorderIdentity = { dev: identity.dev, ino: identity.ino, nlink: identity.nlink };
   const needsParentSync =
     opened.created ||
     syncCreatedParent ||
@@ -594,22 +595,21 @@ function reportRecorderLockReleaseFailure(filePath: string, releaseError: unknow
 
 async function privateRecorderLockRoot(): Promise<string> {
   const currentUserId = process.geteuid?.();
-  let parent = tmpdir();
-  if (currentUserId !== undefined) {
-    const temporaryDirectory = await lstat(parent, { bigint: true });
-    const privateTemporaryDirectory =
-      temporaryDirectory.isDirectory() &&
-      temporaryDirectory.uid === BigInt(currentUserId) &&
-      (temporaryDirectory.mode & 0o077n) === 0n;
-    if (!privateTemporaryDirectory) {
-      parent = homedir();
-    }
+  if (process.platform === "win32" || currentUserId === undefined) {
+    throw new Error("Hardlinked provider recorder paths are unsupported on this platform.");
   }
 
-  const root = path.join(parent, ".crabline", "locks", "provider-recorder");
-  await mkdir(root, { mode: 0o700, recursive: true });
+  const root = path.join("/tmp", `.crabline-provider-recorder-${currentUserId}`);
+  try {
+    await mkdir(root, { mode: 0o700 });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+      throw error;
+    }
+  }
   const handle = await open(root, "r");
   try {
+    await handle.chmod(0o700);
     const identity = await handle.stat({ bigint: true });
     const current = await lstat(root, { bigint: true });
     if (
@@ -617,11 +617,11 @@ async function privateRecorderLockRoot(): Promise<string> {
       !current.isDirectory() ||
       identity.dev !== current.dev ||
       identity.ino !== current.ino ||
-      (currentUserId !== undefined && identity.uid !== BigInt(currentUserId))
+      identity.uid !== BigInt(currentUserId) ||
+      (identity.mode & 0o077n) !== 0n
     ) {
       throw new Error("Provider recorder lock directory is not privately owned.");
     }
-    await handle.chmod(0o700);
   } finally {
     await handle.close();
   }
@@ -663,7 +663,7 @@ async function withRecorderLock<T>(filePath: string, operation: () => Promise<T>
   try {
     releases.push(await acquireRecorderLock(filePath));
     const identity = await readRecorderFileIdentity(filePath);
-    if (identity) {
+    if (identity && identity.nlink > 1n) {
       releases.push(await acquireRecorderLock(await recorderIdentityLockTarget(identity)));
     }
   } catch (error) {

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -104,6 +104,25 @@ function createIncrementalReadState(): IncrementalReadState {
   };
 }
 
+function snapshotIncrementalReadState(state: IncrementalReadState): IncrementalReadState {
+  return {
+    ...state,
+    identity: state.identity ? { ...state.identity } : undefined,
+  };
+}
+
+function restoreIncrementalReadState(
+  state: IncrementalReadState,
+  snapshot: IncrementalReadState,
+): void {
+  state.caughtUp = snapshot.caughtUp;
+  state.continuity = snapshot.continuity;
+  state.generation = snapshot.generation;
+  state.identity = snapshot.identity;
+  state.offset = snapshot.offset;
+  state.pending = snapshot.pending;
+}
+
 export function createRecordedInboundCursor(): RecordedInboundCursor {
   return {
     buffered: [],
@@ -614,6 +633,7 @@ async function readRecordedInboundAppend(
   filePath: string,
   state: IncrementalReadState,
 ): Promise<RecordedInboundEnvelope[]> {
+  const snapshot = snapshotIncrementalReadState(state);
   let handle;
 
   try {
@@ -671,6 +691,9 @@ async function readRecordedInboundAppend(
     }
     state.caughtUp = reachedUnexpectedEof || position >= stats.size;
     return events;
+  } catch (error) {
+    restoreIncrementalReadState(state, snapshot);
+    throw error;
   } finally {
     await handle.close();
   }

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -314,16 +314,19 @@ function consumeRecordedChunk(
 async function appendJsonLine(filePath: string, line: string): Promise<void> {
   for (let attempt = 0; ; attempt++) {
     try {
-      await serializeAppend(filePath, async (publicationPath, logicalPath, lockCreatedFile) => {
-        await appendCommittedLine(
-          publicationPath,
-          logicalPath,
-          line,
-          true,
-          undefined,
-          lockCreatedFile,
-        );
-      });
+      await serializeAppend(
+        filePath,
+        async (publicationPath, logicalPath, lockCreatedFile, lockedIdentity) => {
+          await appendCommittedLine(
+            publicationPath,
+            logicalPath,
+            line,
+            true,
+            lockedIdentity,
+            lockCreatedFile,
+          );
+        },
+      );
       return;
     } catch (error) {
       if (!(error instanceof RecorderRotatedError) || attempt + 1 >= RECORDER_ROTATION_ATTEMPTS) {
@@ -468,12 +471,19 @@ async function prepareRecorderPathForAppend(
   publicationPath: string,
   logicalPath: string,
   durable: boolean,
+  expectedIdentity?: RecorderFileIdentity,
 ): Promise<{ created: boolean; identity: RecorderFileIdentity }> {
   const opened = await openRecorderForAppend(publicationPath);
   const { handle } = opened;
   const identity = await handle.stat({ bigint: true });
   const recorderIdentity = { dev: identity.dev, ino: identity.ino, nlink: identity.nlink };
   try {
+    if (
+      expectedIdentity !== undefined &&
+      !sameRecorderFileIdentity(expectedIdentity, recorderIdentity)
+    ) {
+      throw new RecorderRotatedError("Recorder rotated before preparing a committed line.");
+    }
     const changed = await prepareRecorderTailForAppend(handle);
     if (changed && durable) {
       await handle.sync();
@@ -707,10 +717,11 @@ async function releaseRecorderLocks(releases: Array<() => Promise<void>>): Promi
 
 async function withRecorderLock<T>(
   filePath: string,
-  operation: (lockCreatedFile: boolean) => Promise<T>,
+  operation: (lockCreatedFile: boolean, lockedIdentity: RecorderFileIdentity) => Promise<T>,
 ): Promise<T> {
   const releases: Array<() => Promise<void>> = [];
   let lockCreatedFile = false;
+  let lockedIdentity: RecorderFileIdentity | undefined;
   try {
     releases.push(await acquireRecorderLock(filePath));
     for (let attempt = 0; attempt < RECORDER_ROTATION_ATTEMPTS; attempt += 1) {
@@ -725,6 +736,7 @@ async function withRecorderLock<T>(
       const currentIdentity = await readRecorderFileIdentity(filePath);
       if (sameRecorderFileIdentity(identity, currentIdentity)) {
         releases.push(releaseIdentityLock);
+        lockedIdentity = identity;
         break;
       }
       const releaseErrors = await releaseRecorderLocks([releaseIdentityLock]);
@@ -739,6 +751,9 @@ async function withRecorderLock<T>(
         throw new RecorderRotatedError("Recorder kept rotating while acquiring its identity lock.");
       }
     }
+    if (!lockedIdentity) {
+      throw new RecorderRotatedError("Recorder disappeared while acquiring its identity lock.");
+    }
   } catch (error) {
     const releaseErrors = await releaseRecorderLocks(releases);
     if (releaseErrors.length > 0) {
@@ -751,7 +766,7 @@ async function withRecorderLock<T>(
   let operationError: unknown;
   let result: T | undefined;
   try {
-    result = await operation(lockCreatedFile);
+    result = await operation(lockCreatedFile, lockedIdentity);
   } catch (error) {
     operationFailed = true;
     operationError = error;
@@ -776,7 +791,12 @@ async function withRecorderLock<T>(
 
 async function serializeAppend<T>(
   filePath: string,
-  operation: (publicationPath: string, logicalPath: string, lockCreatedFile: boolean) => Promise<T>,
+  operation: (
+    publicationPath: string,
+    logicalPath: string,
+    lockCreatedFile: boolean,
+    lockedIdentity: RecorderFileIdentity,
+  ) => Promise<T>,
 ): Promise<T> {
   const logicalPath = path.resolve(filePath);
   const key = await resolveRecorderPublicationPath(logicalPath);
@@ -787,7 +807,8 @@ async function serializeAppend<T>(
     .then(async () => {
       result = await withRecorderLock(
         key,
-        async (lockCreatedFile) => await operation(key, logicalPath, lockCreatedFile),
+        async (lockCreatedFile, lockedIdentity) =>
+          await operation(key, logicalPath, lockCreatedFile, lockedIdentity),
       );
     });
   pendingAppends.set(key, current);
@@ -905,8 +926,13 @@ export async function appendRecordedInboundBatch(
     try {
       return await serializeAppend(
         filePath,
-        async (publicationPath, logicalPath, lockCreatedFile) => {
-          const generation = await prepareRecorderPathForAppend(publicationPath, logicalPath, true);
+        async (publicationPath, logicalPath, lockCreatedFile, lockedIdentity) => {
+          const generation = await prepareRecorderPathForAppend(
+            publicationPath,
+            logicalPath,
+            true,
+            lockedIdentity,
+          );
           const seen = await syncRecordIdentityIndex(publicationPath);
           const pendingIdentities = new Set<string>();
           const recorded: RecordedInboundEnvelope[] = [];

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -314,8 +314,15 @@ function consumeRecordedChunk(
 async function appendJsonLine(filePath: string, line: string): Promise<void> {
   for (let attempt = 0; ; attempt++) {
     try {
-      await serializeAppend(filePath, async (publicationPath, logicalPath) => {
-        await appendCommittedLine(publicationPath, logicalPath, line, true);
+      await serializeAppend(filePath, async (publicationPath, logicalPath, lockCreatedFile) => {
+        await appendCommittedLine(
+          publicationPath,
+          logicalPath,
+          line,
+          true,
+          undefined,
+          lockCreatedFile,
+        );
       });
       return;
     } catch (error) {
@@ -669,6 +676,23 @@ async function acquireRecorderLock(filePath: string): Promise<() => Promise<void
   });
 }
 
+async function ensureRecorderExistsForLock(filePath: string): Promise<boolean> {
+  if (await readRecorderFileIdentity(filePath)) {
+    return false;
+  }
+  let handle: Awaited<ReturnType<typeof open>>;
+  try {
+    handle = await open(filePath, "ax", 0o600);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+      return false;
+    }
+    throw error;
+  }
+  await handle.close();
+  return true;
+}
+
 async function releaseRecorderLocks(releases: Array<() => Promise<void>>): Promise<unknown[]> {
   const errors: unknown[] = [];
   for (const release of releases.reverse()) {
@@ -681,13 +705,39 @@ async function releaseRecorderLocks(releases: Array<() => Promise<void>>): Promi
   return errors;
 }
 
-async function withRecorderLock<T>(filePath: string, operation: () => Promise<T>): Promise<T> {
+async function withRecorderLock<T>(
+  filePath: string,
+  operation: (lockCreatedFile: boolean) => Promise<T>,
+): Promise<T> {
   const releases: Array<() => Promise<void>> = [];
+  let lockCreatedFile = false;
   try {
     releases.push(await acquireRecorderLock(filePath));
-    const identity = await readRecorderFileIdentity(filePath);
-    if (identity) {
-      releases.push(await acquireRecorderLock(await recorderIdentityLockTarget(identity)));
+    for (let attempt = 0; attempt < RECORDER_ROTATION_ATTEMPTS; attempt += 1) {
+      lockCreatedFile = (await ensureRecorderExistsForLock(filePath)) || lockCreatedFile;
+      const identity = await readRecorderFileIdentity(filePath);
+      if (!identity) {
+        continue;
+      }
+      const releaseIdentityLock = await acquireRecorderLock(
+        await recorderIdentityLockTarget(identity),
+      );
+      const currentIdentity = await readRecorderFileIdentity(filePath);
+      if (sameRecorderFileIdentity(identity, currentIdentity)) {
+        releases.push(releaseIdentityLock);
+        break;
+      }
+      const releaseErrors = await releaseRecorderLocks([releaseIdentityLock]);
+      if (releaseErrors.length > 0) {
+        throw recorderLockReleaseError(
+          filePath,
+          new RecorderRotatedError("Recorder rotated while acquiring its identity lock."),
+          releaseErrors,
+        );
+      }
+      if (attempt + 1 >= RECORDER_ROTATION_ATTEMPTS) {
+        throw new RecorderRotatedError("Recorder kept rotating while acquiring its identity lock.");
+      }
     }
   } catch (error) {
     const releaseErrors = await releaseRecorderLocks(releases);
@@ -701,7 +751,7 @@ async function withRecorderLock<T>(filePath: string, operation: () => Promise<T>
   let operationError: unknown;
   let result: T | undefined;
   try {
-    result = await operation();
+    result = await operation(lockCreatedFile);
   } catch (error) {
     operationFailed = true;
     operationError = error;
@@ -726,7 +776,7 @@ async function withRecorderLock<T>(filePath: string, operation: () => Promise<T>
 
 async function serializeAppend<T>(
   filePath: string,
-  operation: (publicationPath: string, logicalPath: string) => Promise<T>,
+  operation: (publicationPath: string, logicalPath: string, lockCreatedFile: boolean) => Promise<T>,
 ): Promise<T> {
   const logicalPath = path.resolve(filePath);
   const key = await resolveRecorderPublicationPath(logicalPath);
@@ -735,7 +785,10 @@ async function serializeAppend<T>(
   const current = previous
     .catch(() => {})
     .then(async () => {
-      result = await withRecorderLock(key, async () => await operation(key, logicalPath));
+      result = await withRecorderLock(
+        key,
+        async (lockCreatedFile) => await operation(key, logicalPath, lockCreatedFile),
+      );
     });
   pendingAppends.set(key, current);
 
@@ -850,53 +903,56 @@ export async function appendRecordedInboundBatch(
   await mkdir(path.dirname(filePath), { recursive: true });
   for (let attempt = 0; ; attempt++) {
     try {
-      return await serializeAppend(filePath, async (publicationPath, logicalPath) => {
-        const generation = await prepareRecorderPathForAppend(publicationPath, logicalPath, true);
-        const seen = await syncRecordIdentityIndex(publicationPath);
-        const pendingIdentities = new Set<string>();
-        const recorded: RecordedInboundEnvelope[] = [];
-        for (const event of events) {
-          const identity = recordIdentity(event);
-          if (seen.has(identity) || pendingIdentities.has(identity)) {
-            continue;
+      return await serializeAppend(
+        filePath,
+        async (publicationPath, logicalPath, lockCreatedFile) => {
+          const generation = await prepareRecorderPathForAppend(publicationPath, logicalPath, true);
+          const seen = await syncRecordIdentityIndex(publicationPath);
+          const pendingIdentities = new Set<string>();
+          const recorded: RecordedInboundEnvelope[] = [];
+          for (const event of events) {
+            const identity = recordIdentity(event);
+            if (seen.has(identity) || pendingIdentities.has(identity)) {
+              continue;
+            }
+            pendingIdentities.add(identity);
+            recorded.push({
+              ...event,
+              recordedAt: new Date().toISOString(),
+            });
           }
-          pendingIdentities.add(identity);
-          recorded.push({
-            ...event,
-            recordedAt: new Date().toISOString(),
-          });
-        }
-        if (recorded.length > 0) {
-          const batch = {
-            events: recorded,
-            recordType: "crabline.recorder.batch",
-            recorderBatchVersion: RECORDER_BATCH_VERSION,
-          } satisfies RecordedInboundBatchLine;
-          const line = `${JSON.stringify(batch)}\n`;
-          if (Buffer.byteLength(line) > MAX_PENDING_RECORD_BYTES) {
-            throw new Error(
-              `Recorder record exceeded ${MAX_PENDING_RECORD_BYTES} bytes without a newline.`,
+          if (recorded.length > 0) {
+            const batch = {
+              events: recorded,
+              recordType: "crabline.recorder.batch",
+              recorderBatchVersion: RECORDER_BATCH_VERSION,
+            } satisfies RecordedInboundBatchLine;
+            const line = `${JSON.stringify(batch)}\n`;
+            if (Buffer.byteLength(line) > MAX_PENDING_RECORD_BYTES) {
+              throw new Error(
+                `Recorder record exceeded ${MAX_PENDING_RECORD_BYTES} bytes without a newline.`,
+              );
+            }
+            await appendCommittedLine(
+              publicationPath,
+              logicalPath,
+              line,
+              true,
+              generation.identity,
+              generation.created || lockCreatedFile,
             );
+            await syncRecordIdentityIndex(publicationPath);
+          } else if (
+            !sameRecorderFileIdentity(
+              generation.identity,
+              await readRecorderFileIdentity(await resolveRecorderPublicationPath(logicalPath)),
+            )
+          ) {
+            throw new RecorderRotatedError("Recorder rotated before confirming a duplicate batch.");
           }
-          await appendCommittedLine(
-            publicationPath,
-            logicalPath,
-            line,
-            true,
-            generation.identity,
-            generation.created,
-          );
-          await syncRecordIdentityIndex(publicationPath);
-        } else if (
-          !sameRecorderFileIdentity(
-            generation.identity,
-            await readRecorderFileIdentity(await resolveRecorderPublicationPath(logicalPath)),
-          )
-        ) {
-          throw new RecorderRotatedError("Recorder rotated before confirming a duplicate batch.");
-        }
-        return recorded;
-      });
+          return recorded;
+        },
+      );
     } catch (error) {
       if (!(error instanceof RecorderRotatedError) || attempt + 1 >= RECORDER_ROTATION_ATTEMPTS) {
         throw error;

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -1,6 +1,6 @@
 import { constants as fsConstants } from "node:fs";
 import { lstat, mkdir, open, readFile, readlink, realpath } from "node:fs/promises";
-import { homedir } from "node:os";
+import { userInfo } from "node:os";
 import path from "node:path";
 import { lock } from "proper-lockfile";
 import type { InboundEnvelope } from "./types.js";
@@ -612,12 +612,12 @@ function reportRecorderLockReleaseFailure(filePath: string, releaseError: unknow
   }
 }
 
-async function privateRecorderLockRoot(): Promise<string> {
+async function secureRecorderLockRoot(
+  root: string,
+  currentUserId: number | undefined,
+): Promise<string> {
+  await mkdir(root, { mode: 0o700, recursive: true });
   if (process.platform === "win32") {
-    const localAppData =
-      process.env.LOCALAPPDATA?.trim() || path.join(homedir(), "AppData", "Local");
-    const root = path.join(localAppData, "Crabline", "locks", "provider-recorder");
-    await mkdir(root, { recursive: true });
     const identity = await lstat(root);
     if (!identity.isDirectory() || identity.isSymbolicLink()) {
       throw new Error("Provider recorder lock directory is not a private directory.");
@@ -625,13 +625,10 @@ async function privateRecorderLockRoot(): Promise<string> {
     return root;
   }
 
-  const currentUserId = process.geteuid?.();
   if (currentUserId === undefined) {
     throw new Error("Provider recorder identity locking requires a current user id.");
   }
 
-  const root = path.join(homedir(), ".cache", "crabline", "locks", "provider-recorder");
-  await mkdir(root, { mode: 0o700, recursive: true });
   const handle = await open(
     root,
     fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW,
@@ -662,8 +659,48 @@ async function privateRecorderLockRoot(): Promise<string> {
   return root;
 }
 
-async function recorderIdentityLockTarget(identity: RecorderFileIdentity): Promise<string> {
-  return path.join(await privateRecorderLockRoot(), `recorder-${identity.dev}-${identity.ino}`);
+function recorderLockRootUnavailable(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === "EACCES" || code === "EPERM" || code === "EROFS";
+}
+
+async function privateRecorderLockRoot(
+  filePath: string,
+  identity: RecorderFileIdentity,
+): Promise<string> {
+  const account = userInfo();
+  const currentUserId = process.platform === "win32" ? undefined : process.geteuid?.();
+  const sharedRoot =
+    process.platform === "win32"
+      ? path.join(account.homedir, "AppData", "Local", "Crabline", "locks", "provider-recorder")
+      : path.join(account.homedir, ".cache", "crabline", "locks", "provider-recorder");
+  try {
+    return await secureRecorderLockRoot(sharedRoot, currentUserId);
+  } catch (error) {
+    if (!recorderLockRootUnavailable(error)) {
+      throw error;
+    }
+  }
+
+  if (identity.nlink > 1n) {
+    throw new Error(
+      "Provider recorder hardlinks require a writable shared per-user lock directory.",
+    );
+  }
+  return await secureRecorderLockRoot(
+    path.join(path.dirname(filePath), ".crabline-provider-recorder-locks"),
+    currentUserId,
+  );
+}
+
+async function recorderIdentityLockTarget(
+  filePath: string,
+  identity: RecorderFileIdentity,
+): Promise<string> {
+  return path.join(
+    await privateRecorderLockRoot(filePath, identity),
+    `recorder-${identity.dev}-${identity.ino}`,
+  );
 }
 
 async function acquireRecorderLock(filePath: string): Promise<() => Promise<void>> {
@@ -724,21 +761,16 @@ async function withRecorderLock<T>(
       if (!identity) {
         continue;
       }
-      const releaseIdentityLock =
-        identity.nlink > 1n
-          ? await acquireRecorderLock(await recorderIdentityLockTarget(identity))
-          : undefined;
+      const releaseIdentityLock = await acquireRecorderLock(
+        await recorderIdentityLockTarget(filePath, identity),
+      );
       const currentIdentity = await readRecorderFileIdentity(filePath);
       if (sameRecorderFileIdentity(identity, currentIdentity)) {
-        if (releaseIdentityLock) {
-          releases.push(releaseIdentityLock);
-        }
+        releases.push(releaseIdentityLock);
         lockedIdentity = identity;
         break;
       }
-      const releaseErrors = releaseIdentityLock
-        ? await releaseRecorderLocks([releaseIdentityLock])
-        : [];
+      const releaseErrors = await releaseRecorderLocks([releaseIdentityLock]);
       if (releaseErrors.length > 0) {
         throw recorderLockReleaseError(
           filePath,

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -1,5 +1,5 @@
 import { lstat, mkdir, open, readFile, readlink, realpath } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import path from "node:path";
 import { lock } from "proper-lockfile";
 import type { InboundEnvelope } from "./types.js";
@@ -592,12 +592,44 @@ function reportRecorderLockReleaseFailure(filePath: string, releaseError: unknow
   }
 }
 
-function recorderIdentityLockTarget(identity: RecorderFileIdentity): string {
-  const userScope = typeof process.getuid === "function" ? process.getuid() : "user";
-  return path.join(
-    tmpdir(),
-    `.crabline-provider-recorder-${userScope}-${identity.dev}-${identity.ino}`,
-  );
+async function privateRecorderLockRoot(): Promise<string> {
+  const currentUserId = process.geteuid?.();
+  let parent = tmpdir();
+  if (currentUserId !== undefined) {
+    const temporaryDirectory = await lstat(parent, { bigint: true });
+    const privateTemporaryDirectory =
+      temporaryDirectory.isDirectory() &&
+      temporaryDirectory.uid === BigInt(currentUserId) &&
+      (temporaryDirectory.mode & 0o077n) === 0n;
+    if (!privateTemporaryDirectory) {
+      parent = homedir();
+    }
+  }
+
+  const root = path.join(parent, ".crabline", "locks", "provider-recorder");
+  await mkdir(root, { mode: 0o700, recursive: true });
+  const handle = await open(root, "r");
+  try {
+    const identity = await handle.stat({ bigint: true });
+    const current = await lstat(root, { bigint: true });
+    if (
+      !identity.isDirectory() ||
+      !current.isDirectory() ||
+      identity.dev !== current.dev ||
+      identity.ino !== current.ino ||
+      (currentUserId !== undefined && identity.uid !== BigInt(currentUserId))
+    ) {
+      throw new Error("Provider recorder lock directory is not privately owned.");
+    }
+    await handle.chmod(0o700);
+  } finally {
+    await handle.close();
+  }
+  return root;
+}
+
+async function recorderIdentityLockTarget(identity: RecorderFileIdentity): Promise<string> {
+  return path.join(await privateRecorderLockRoot(), `recorder-${identity.dev}-${identity.ino}`);
 }
 
 async function acquireRecorderLock(filePath: string): Promise<() => Promise<void>> {
@@ -632,7 +664,7 @@ async function withRecorderLock<T>(filePath: string, operation: () => Promise<T>
     releases.push(await acquireRecorderLock(filePath));
     const identity = await readRecorderFileIdentity(filePath);
     if (identity) {
-      releases.push(await acquireRecorderLock(recorderIdentityLockTarget(identity)));
+      releases.push(await acquireRecorderLock(await recorderIdentityLockTarget(identity)));
     }
   } catch (error) {
     const releaseErrors = await releaseRecorderLocks(releases);

--- a/test/recorder-concurrency.test.ts
+++ b/test/recorder-concurrency.test.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
-import { link, realpath, rm, stat, writeFile } from "node:fs/promises";
-import { userInfo } from "node:os";
+import { chmod, link, mkdir, mkdtemp, realpath, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir, userInfo } from "node:os";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   appendRecordedInbound,
@@ -284,14 +284,24 @@ describe("recorder append serialization", () => {
   });
 
   it.skipIf(process.platform === "win32")(
-    "falls back to a private adjacent lock namespace without an OS account entry",
+    "repairs a UID-scoped adjacent lock namespace without an OS account entry",
     async () => {
-      const recorderPath = path.join(
-        "/tmp",
-        `crabline-provider-recorder-unknown-user-${process.pid}-${Date.now()}.jsonl`,
+      const tempRoot = await mkdtemp(
+        path.join(tmpdir(), "crabline-provider-recorder-unknown-user-"),
       );
-      fsMocks.providerDirectory = await realpath(path.dirname(recorderPath));
+      const recorderPath = path.join(tempRoot, "events.jsonl");
+      fsMocks.providerDirectory = await realpath(tempRoot);
       fsMocks.providerWrite.mockResolvedValue(undefined);
+      const currentUserId = process.geteuid?.();
+      if (currentUserId === undefined) {
+        throw new Error("Expected a current user id on Unix.");
+      }
+      const fallbackRoot = path.join(
+        fsMocks.providerDirectory,
+        `.crabline-provider-recorder-locks-${currentUserId}`,
+      );
+      await mkdir(fallbackRoot, { mode: 0o700 });
+      await chmod(fallbackRoot, 0o500);
       osMocks.userInfo.mockImplementationOnce(() => {
         throw Object.assign(new Error("unknown uid"), { code: "ENOENT" });
       });
@@ -311,11 +321,10 @@ describe("recorder append serialization", () => {
           .map(([lockPath]) => String(lockPath))
           .find((lockPath) => path.basename(lockPath).startsWith("recorder-"));
         expect(identityLockPath).toBeDefined();
-        expect(path.dirname(identityLockPath!)).toBe(
-          path.join(fsMocks.providerDirectory, ".crabline-provider-recorder-locks"),
-        );
+        expect(path.dirname(identityLockPath!)).toBe(fallbackRoot);
+        expect((await stat(fallbackRoot)).mode & 0o777).toBe(0o700);
       } finally {
-        await rm(recorderPath, { force: true });
+        await rm(tempRoot, { force: true, recursive: true });
       }
     },
   );

--- a/test/recorder-concurrency.test.ts
+++ b/test/recorder-concurrency.test.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { link, realpath, rm, stat, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
+import { userInfo } from "node:os";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   appendRecordedInbound,
@@ -264,7 +264,7 @@ describe("recorder append serialization", () => {
       const identityLockPath = fsMocks.lock.mock.calls
         .map(([lockPath]) => String(lockPath))
         .find((lockPath) => path.basename(lockPath).startsWith("recorder-"));
-      expect(identityLockPath).toBeUndefined();
+      expect(identityLockPath).toBeDefined();
     } finally {
       await rm(recorderPath, { force: true });
     }
@@ -300,7 +300,7 @@ describe("recorder append serialization", () => {
           .find((lockPath) => path.basename(lockPath).startsWith("recorder-"));
         expect(identityLockPath).toBeDefined();
         expect(path.dirname(identityLockPath!)).toBe(
-          path.join(homedir(), ".cache", "crabline", "locks", "provider-recorder"),
+          path.join(userInfo().homedir, ".cache", "crabline", "locks", "provider-recorder"),
         );
         expect((await stat(path.dirname(identityLockPath!))).mode & 0o777).toBe(0o700);
       } finally {

--- a/test/recorder-concurrency.test.ts
+++ b/test/recorder-concurrency.test.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { realpath, rm, stat } from "node:fs/promises";
+import { link, realpath, rm, stat, writeFile } from "node:fs/promises";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   appendRecordedInbound,
@@ -259,15 +259,55 @@ describe("recorder append serialization", () => {
         ["ax+", 0o600],
         ["a+", 0o600],
       ]);
-      const identityLockPath = fsMocks.lock.mock.calls
-        .map(([lockPath]) => String(lockPath))
-        .find((lockPath) => path.basename(lockPath).startsWith("recorder-"));
-      expect(identityLockPath).toBeDefined();
-      expect((await stat(path.dirname(identityLockPath!))).mode & 0o777).toBe(0o700);
+      expect(
+        fsMocks.lock.mock.calls.some(([lockPath]) =>
+          path.basename(String(lockPath)).startsWith("recorder-"),
+        ),
+      ).toBe(false);
     } finally {
       await rm(recorderPath, { force: true });
     }
   });
+
+  it.skipIf(process.platform === "win32")(
+    "uses one private UID-scoped lock namespace for hardlinked provider recorders",
+    async () => {
+      const recorderPath = path.join(
+        "/tmp",
+        `crabline-provider-recorder-hardlink-${process.pid}-${Date.now()}.jsonl`,
+      );
+      const aliasPath = `${recorderPath}.alias`;
+      fsMocks.providerDirectory = await realpath(path.dirname(recorderPath));
+      fsMocks.providerWrite.mockResolvedValue(undefined);
+      await writeFile(recorderPath, "", { mode: 0o600 });
+      await link(recorderPath, aliasPath);
+      const event = {
+        author: "assistant" as const,
+        id: "hardlink-lock-root",
+        provider: "slack",
+        sentAt: "2026-07-12T10:00:00.000Z",
+        text: "hardlinked",
+        threadId: "slack:C123",
+      };
+
+      try {
+        await expect(appendRecordedInbound(aliasPath, event)).resolves.toMatchObject({
+          id: event.id,
+        });
+        const identityLockPath = fsMocks.lock.mock.calls
+          .map(([lockPath]) => String(lockPath))
+          .find((lockPath) => path.basename(lockPath).startsWith("recorder-"));
+        expect(identityLockPath).toBeDefined();
+        expect(path.dirname(identityLockPath!)).toBe(
+          path.join("/tmp", `.crabline-provider-recorder-${process.geteuid!()}`),
+        );
+        expect((await stat(path.dirname(identityLockPath!))).mode & 0o777).toBe(0o700);
+      } finally {
+        await rm(aliasPath, { force: true });
+        await rm(recorderPath, { force: true });
+      }
+    },
+  );
 
   it.skipIf(process.platform === "win32")(
     "retries parent durability for a newly created provider recorder",

--- a/test/recorder-concurrency.test.ts
+++ b/test/recorder-concurrency.test.ts
@@ -13,6 +13,9 @@ const fsMocks = vi.hoisted(() => ({
   lockRelease: vi.fn<() => Promise<void>>(),
   providerDirectory: "",
   providerDirectorySync: vi.fn<(directoryPath: string) => Promise<void>>(),
+  providerLstatFailure: undefined as Error | undefined,
+  providerLstatFailureAfterLocks: 0,
+  providerRecorderPath: "",
   providerOpen: vi.fn<(filePath: string, flags: string, mode?: number | string) => void>(),
   providerSync: vi.fn<(filePath: string) => Promise<void>>(),
   providerWrite: vi.fn<(filePath: string, data: string) => Promise<void>>(),
@@ -50,6 +53,16 @@ vi.mock("node:fs/promises", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs/promises")>();
   return {
     ...actual,
+    lstat: async (...args: Parameters<typeof actual.lstat>) => {
+      if (
+        String(args[0]) === fsMocks.providerRecorderPath &&
+        fsMocks.providerLstatFailure &&
+        fsMocks.lock.mock.calls.length >= fsMocks.providerLstatFailureAfterLocks
+      ) {
+        throw fsMocks.providerLstatFailure;
+      }
+      return await actual.lstat(...args);
+    },
     open: async (...args: Parameters<typeof actual.open>) => {
       const filePath = String(args[0]);
       if (args[1] === "r" && filePath === fsMocks.serverDirectory) {
@@ -148,6 +161,9 @@ beforeEach(() => {
   fsMocks.providerDirectory = "";
   fsMocks.providerDirectorySync.mockReset();
   fsMocks.providerDirectorySync.mockResolvedValue(undefined);
+  fsMocks.providerLstatFailure = undefined;
+  fsMocks.providerLstatFailureAfterLocks = 0;
+  fsMocks.providerRecorderPath = "";
   fsMocks.providerOpen.mockReset();
   fsMocks.providerSync.mockReset();
   fsMocks.providerSync.mockResolvedValue(undefined);
@@ -328,6 +344,38 @@ describe("recorder append serialization", () => {
       }
     },
   );
+
+  it("releases both recorder locks when identity verification fails", async () => {
+    const recorderPath = path.join(
+      "/tmp",
+      `crabline-provider-recorder-verification-${process.pid}-${Date.now()}.jsonl`,
+    );
+    fsMocks.providerDirectory = await realpath(path.dirname(recorderPath));
+    fsMocks.providerRecorderPath = path.join(
+      fsMocks.providerDirectory,
+      path.basename(recorderPath),
+    );
+    fsMocks.providerLstatFailure = Object.assign(new Error("simulated identity failure"), {
+      code: "EIO",
+    });
+    fsMocks.providerLstatFailureAfterLocks = 2;
+
+    try {
+      await expect(
+        appendRecordedInbound(recorderPath, {
+          author: "assistant",
+          id: "identity-verification-failure",
+          provider: "slack",
+          sentAt: "2026-07-12T10:00:00.000Z",
+          text: "verification",
+          threadId: "slack:C123",
+        }),
+      ).rejects.toBe(fsMocks.providerLstatFailure);
+      expect(fsMocks.lockRelease).toHaveBeenCalledTimes(2);
+    } finally {
+      await rm(recorderPath, { force: true });
+    }
+  });
 
   it.skipIf(process.platform === "win32")(
     "uses one private UID-scoped lock namespace for hardlinked provider recorders",

--- a/test/recorder-concurrency.test.ts
+++ b/test/recorder-concurrency.test.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { realpath, rm } from "node:fs/promises";
+import { realpath, rm, stat } from "node:fs/promises";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   appendRecordedInbound,
@@ -8,7 +8,7 @@ import {
 import { recordServerEvent } from "../src/servers/recorder.js";
 
 const fsMocks = vi.hoisted(() => ({
-  lock: vi.fn<() => Promise<() => Promise<void>>>(),
+  lock: vi.fn<(filePath: string, options?: unknown) => Promise<() => Promise<void>>>(),
   lockRelease: vi.fn<() => Promise<void>>(),
   providerDirectory: "",
   providerDirectorySync: vi.fn<(directoryPath: string) => Promise<void>>(),
@@ -259,6 +259,11 @@ describe("recorder append serialization", () => {
         ["ax+", 0o600],
         ["a+", 0o600],
       ]);
+      const identityLockPath = fsMocks.lock.mock.calls
+        .map(([lockPath]) => String(lockPath))
+        .find((lockPath) => path.basename(lockPath).startsWith("recorder-"));
+      expect(identityLockPath).toBeDefined();
+      expect((await stat(path.dirname(identityLockPath!))).mode & 0o777).toBe(0o700);
     } finally {
       await rm(recorderPath, { force: true });
     }

--- a/test/recorder-concurrency.test.ts
+++ b/test/recorder-concurrency.test.ts
@@ -25,11 +25,24 @@ const fsMocks = vi.hoisted(() => ({
   serverWrite: vi.fn<(filePath: string, data: string) => Promise<void>>(),
 }));
 
+const osMocks = vi.hoisted(() => ({
+  userInfo: vi.fn<typeof import("node:os").userInfo>(),
+}));
+
 vi.mock("proper-lockfile", async (importOriginal) => {
   const actual = await importOriginal<typeof import("proper-lockfile")>();
   return {
     ...actual,
     lock: fsMocks.lock,
+  };
+});
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  osMocks.userInfo.mockImplementation(actual.userInfo);
+  return {
+    ...actual,
+    userInfo: osMocks.userInfo,
   };
 });
 
@@ -269,6 +282,43 @@ describe("recorder append serialization", () => {
       await rm(recorderPath, { force: true });
     }
   });
+
+  it.skipIf(process.platform === "win32")(
+    "falls back to a private adjacent lock namespace without an OS account entry",
+    async () => {
+      const recorderPath = path.join(
+        "/tmp",
+        `crabline-provider-recorder-unknown-user-${process.pid}-${Date.now()}.jsonl`,
+      );
+      fsMocks.providerDirectory = await realpath(path.dirname(recorderPath));
+      fsMocks.providerWrite.mockResolvedValue(undefined);
+      osMocks.userInfo.mockImplementationOnce(() => {
+        throw Object.assign(new Error("unknown uid"), { code: "ENOENT" });
+      });
+
+      try {
+        await expect(
+          appendRecordedInbound(recorderPath, {
+            author: "assistant",
+            id: "unknown-user-lock-root",
+            provider: "slack",
+            sentAt: "2026-07-12T10:00:00.000Z",
+            text: "container uid",
+            threadId: "slack:C123",
+          }),
+        ).resolves.toMatchObject({ id: "unknown-user-lock-root" });
+        const identityLockPath = fsMocks.lock.mock.calls
+          .map(([lockPath]) => String(lockPath))
+          .find((lockPath) => path.basename(lockPath).startsWith("recorder-"));
+        expect(identityLockPath).toBeDefined();
+        expect(path.dirname(identityLockPath!)).toBe(
+          path.join(fsMocks.providerDirectory, ".crabline-provider-recorder-locks"),
+        );
+      } finally {
+        await rm(recorderPath, { force: true });
+      }
+    },
+  );
 
   it.skipIf(process.platform === "win32")(
     "uses one private UID-scoped lock namespace for hardlinked provider recorders",

--- a/test/recorder-concurrency.test.ts
+++ b/test/recorder-concurrency.test.ts
@@ -256,6 +256,7 @@ describe("recorder append serialization", () => {
       );
       expect(fsMocks.providerOpen.mock.calls.map(([, flags, mode]) => [flags, mode])).toEqual([
         ["ax+", 0o600],
+        ["a+", 0o600],
         ["ax+", 0o600],
         ["a+", 0o600],
       ]);

--- a/test/recorder-concurrency.test.ts
+++ b/test/recorder-concurrency.test.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { link, realpath, rm, stat, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   appendRecordedInbound,
@@ -299,7 +300,7 @@ describe("recorder append serialization", () => {
           .find((lockPath) => path.basename(lockPath).startsWith("recorder-"));
         expect(identityLockPath).toBeDefined();
         expect(path.dirname(identityLockPath!)).toBe(
-          path.join("/tmp", `.crabline-provider-recorder-${process.geteuid!()}`),
+          path.join(homedir(), ".cache", "crabline", "locks", "provider-recorder"),
         );
         expect((await stat(path.dirname(identityLockPath!))).mode & 0o777).toBe(0o700);
       } finally {

--- a/test/recorder-concurrency.test.ts
+++ b/test/recorder-concurrency.test.ts
@@ -345,6 +345,49 @@ describe("recorder append serialization", () => {
     },
   );
 
+  it.skipIf(process.platform === "win32")(
+    "falls back when shared identity lock creation exhausts its filesystem",
+    async () => {
+      const tempRoot = await mkdtemp(
+        path.join(tmpdir(), "crabline-provider-recorder-lock-fallback-"),
+      );
+      const recorderPath = path.join(tempRoot, "events.jsonl");
+      fsMocks.providerDirectory = await realpath(tempRoot);
+      fsMocks.providerWrite.mockResolvedValue(undefined);
+      const sharedFailure = Object.assign(new Error("shared lock filesystem full"), {
+        code: "ENOSPC",
+      });
+      fsMocks.lock
+        .mockResolvedValueOnce(fsMocks.lockRelease)
+        .mockRejectedValueOnce(sharedFailure)
+        .mockResolvedValueOnce(fsMocks.lockRelease);
+
+      try {
+        await expect(
+          appendRecordedInbound(recorderPath, {
+            author: "assistant",
+            id: "identity-lock-fallback",
+            provider: "slack",
+            sentAt: "2026-07-12T10:00:00.000Z",
+            text: "fallback",
+            threadId: "slack:C123",
+          }),
+        ).resolves.toMatchObject({ id: "identity-lock-fallback" });
+        expect(fsMocks.lock).toHaveBeenCalledTimes(3);
+        expect(path.dirname(String(fsMocks.lock.mock.calls[1]?.[0]))).not.toBe(tempRoot);
+        expect(path.dirname(String(fsMocks.lock.mock.calls[2]?.[0]))).toBe(
+          path.join(
+            fsMocks.providerDirectory,
+            `.crabline-provider-recorder-locks-${process.geteuid?.()}`,
+          ),
+        );
+        expect(fsMocks.lockRelease).toHaveBeenCalledTimes(2);
+      } finally {
+        await rm(tempRoot, { force: true, recursive: true });
+      }
+    },
+  );
+
   it("releases both recorder locks when identity verification fails", async () => {
     const recorderPath = path.join(
       "/tmp",

--- a/test/recorder-concurrency.test.ts
+++ b/test/recorder-concurrency.test.ts
@@ -264,7 +264,7 @@ describe("recorder append serialization", () => {
       const identityLockPath = fsMocks.lock.mock.calls
         .map(([lockPath]) => String(lockPath))
         .find((lockPath) => path.basename(lockPath).startsWith("recorder-"));
-      expect(identityLockPath).toBeDefined();
+      expect(identityLockPath).toBeUndefined();
     } finally {
       await rm(recorderPath, { force: true });
     }

--- a/test/recorder-concurrency.test.ts
+++ b/test/recorder-concurrency.test.ts
@@ -304,4 +304,40 @@ describe("recorder append serialization", () => {
       }
     },
   );
+
+  it("reports lock cleanup failure without rejecting a committed provider append", async () => {
+    const recorderPath = path.join(
+      "/tmp",
+      `crabline-provider-recorder-release-${process.pid}-${Date.now()}.jsonl`,
+    );
+    fsMocks.providerDirectory = await realpath(path.dirname(recorderPath));
+    fsMocks.providerWrite.mockResolvedValue(undefined);
+    const releaseError = new Error("simulated lock cleanup failure");
+    fsMocks.lockRelease.mockRejectedValue(releaseError);
+    const warning = vi.spyOn(process, "emitWarning").mockImplementation(() => {});
+    const event = {
+      author: "assistant" as const,
+      id: "committed-release-failure",
+      provider: "slack",
+      sentAt: "2026-07-12T10:00:00.000Z",
+      text: "committed",
+      threadId: "slack:C123",
+    };
+
+    try {
+      await expect(appendRecordedInbound(recorderPath, event)).resolves.toMatchObject({
+        id: event.id,
+      });
+      expect(warning).toHaveBeenCalledWith(
+        expect.stringContaining("Provider recorder append committed but lock cleanup failed"),
+        {
+          code: "CRABLINE_RECORDER_LOCK_CLEANUP",
+          type: "ProviderRecorderWarning",
+        },
+      );
+    } finally {
+      warning.mockRestore();
+      await rm(recorderPath, { force: true });
+    }
+  });
 });

--- a/test/recorder-concurrency.test.ts
+++ b/test/recorder-concurrency.test.ts
@@ -259,11 +259,10 @@ describe("recorder append serialization", () => {
         ["ax+", 0o600],
         ["a+", 0o600],
       ]);
-      expect(
-        fsMocks.lock.mock.calls.some(([lockPath]) =>
-          path.basename(String(lockPath)).startsWith("recorder-"),
-        ),
-      ).toBe(false);
+      const identityLockPath = fsMocks.lock.mock.calls
+        .map(([lockPath]) => String(lockPath))
+        .find((lockPath) => path.basename(lockPath).startsWith("recorder-"));
+      expect(identityLockPath).toBeDefined();
     } finally {
       await rm(recorderPath, { force: true });
     }

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -1,6 +1,7 @@
 import {
   appendFile,
   chmod,
+  link,
   open,
   readFile,
   rename,
@@ -669,6 +670,31 @@ describe("recorder", () => {
       provider: "whatsapp",
       sentAt: new Date().toISOString(),
       text: "one logical recorder",
+      threadId: "15551234567",
+    };
+
+    const results = await Promise.all([
+      appendRecordedInboundBatch(filePath, [event]),
+      appendRecordedInboundBatch(aliasPath, [event]),
+    ]);
+
+    expect(results.flat()).toHaveLength(1);
+    await expect(readRecordedInbound(filePath)).resolves.toEqual([
+      expect.objectContaining({ id: event.id }),
+    ]);
+  });
+
+  it("deduplicates concurrent batches through hardlink aliases", async () => {
+    const filePath = await createRecorderPath();
+    const aliasPath = `${filePath}.alias`;
+    await writeFile(filePath, "", "utf8");
+    await link(filePath, aliasPath);
+    const event = {
+      author: "user" as const,
+      id: "hardlink-alias-batch",
+      provider: "whatsapp",
+      sentAt: new Date().toISOString(),
+      text: "one recorder inode",
       threadId: "15551234567",
     };
 

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -15,6 +15,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   appendRecordedInbound,
   appendRecordedInboundBatch,
+  cloneRecordedInboundCursor,
   createRecordedInboundCursor,
   readRecordedInbound,
   waitForRecordedInbound,
@@ -921,6 +922,55 @@ describe("recorder", () => {
     await appendFile(filePath, '{"id":"malformed"} trailing\n   ', "utf8");
 
     await expect(readRecordedInbound(filePath)).rejects.toThrow(SyntaxError);
+  });
+
+  it("does not advance an incremental cursor past a malformed completed partial record", async () => {
+    const filePath = await createRecorderPath();
+    const cursor = createRecordedInboundCursor();
+    const partial = '{"author":"assistant"';
+    await writeFile(filePath, partial, "utf8");
+
+    await expect(
+      waitForRecordedInbound({
+        cursor,
+        filePath,
+        matches: () => false,
+        pollMs: 5,
+        timeoutMs: 15,
+      }),
+    ).resolves.toBeNull();
+    const beforeFailure = cloneRecordedInboundCursor(cursor);
+
+    const recovered = {
+      author: "assistant",
+      id: "recovered-after-malformed",
+      provider: "slack",
+      recordedAt: new Date().toISOString(),
+      sentAt: new Date().toISOString(),
+      text: "recover me",
+      threadId: "slack:C123",
+    } as const;
+    await appendFile(filePath, ` trailing\n${JSON.stringify(recovered)}\n`, "utf8");
+
+    await expect(
+      waitForRecordedInbound({
+        cursor,
+        filePath,
+        matches: () => true,
+        timeoutMs: 30,
+      }),
+    ).rejects.toThrow(SyntaxError);
+    expect(cursor).toEqual(beforeFailure);
+
+    await writeFile(filePath, `${JSON.stringify(recovered)}\n`, "utf8");
+    await expect(
+      waitForRecordedInbound({
+        cursor,
+        filePath,
+        matches: () => true,
+        timeoutMs: 30,
+      }),
+    ).resolves.toEqual(recovered);
   });
 
   it("waits for a matching inbound event", async () => {


### PR DESCRIPTION
## Summary

- preserve provider recorder cursor state when parsing an append fails
- serialize logical and inode identities across hardlink aliases and recorder rotation
- distinguish committed durability/cleanup failures from pre-publication failures
- secure per-user identity lock namespaces, including container UID and adjacent fallback paths
- fall back from unavailable shared lock filesystems for single-link recorders while keeping hardlinks fail-closed
- add focused regression coverage and an Unreleased changelog entry

## Verification

- `pnpm lint`
- focused recorder suites: 55 tests on macOS
- Crabbox Linux fallback regression: `run_30b920824c4f`
- Crabbox Linux `pnpm verify`: `run_b60ac2bdd38f` (60 files, 1,175 tests)
- GitHub Actions `CI/verify` on `98914adf83833d5c3bf3679d22876ab218d2a25b`
- gpt-5.6-sol high autoreview: clean, confidence 0.82

## Audit context

Remediates confirmed provider-recorder correctness, durability, alias synchronization, and lock-cleanup findings from the final14 Clawpatch audit.