### PR TITLE
fix(recorder): harden server append ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - Authenticate Feishu signatures before encrypted callback decryption and bound callback ciphertext work.
 - Correct Slack edited-message identity and text fallback handling, acknowledge unsupported callbacks, and fairly budget Events API address failover.
 - Preserve provider recorder cursors across parse failures, report post-commit lock cleanup failures without rejecting committed appends, and synchronize hardlink aliases.
-- Confine server recorder publication and locking to stable resolved paths across symlink retargets, and deliver observers in durable append order.
+- Confine server recorder publication and locking to stable resolved paths across symlink retargets, deliver observers in durable append order, and classify post-commit lock cleanup failures.
 - Cover local GitHub Actions with ownership, CodeQL, immutable image, and test-tool runtime policies.
 - Publish Matrix direct-room account data and share strict native identifier validation across server, target, and inbound paths.
 - Protect pnpm install-script policy and enforce immutable action pins across reusable workflows and composite actions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Authenticate Feishu signatures before encrypted callback decryption and bound callback ciphertext work.
 - Correct Slack edited-message identity and text fallback handling, acknowledge unsupported callbacks, and fairly budget Events API address failover.
 - Preserve provider recorder cursors across parse failures, report post-commit lock cleanup failures without rejecting committed appends, and synchronize hardlink aliases.
+- Confine server recorder publication and locking to stable resolved paths across symlink retargets.
 - Cover local GitHub Actions with ownership, CodeQL, immutable image, and test-tool runtime policies.
 - Publish Matrix direct-room account data and share strict native identifier validation across server, target, and inbound paths.
 - Protect pnpm install-script policy and enforce immutable action pins across reusable workflows and composite actions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - Authenticate Feishu signatures before encrypted callback decryption and bound callback ciphertext work.
 - Correct Slack edited-message identity and text fallback handling, acknowledge unsupported callbacks, and fairly budget Events API address failover.
 - Preserve provider recorder cursors across parse failures, report post-commit lock cleanup failures without rejecting committed appends, and synchronize hardlink aliases.
-- Confine server recorder publication and locking to stable resolved paths across symlink retargets.
+- Confine server recorder publication and locking to stable resolved paths across symlink retargets, and deliver observers in durable append order.
 - Cover local GitHub Actions with ownership, CodeQL, immutable image, and test-tool runtime policies.
 - Publish Matrix direct-room account data and share strict native identifier validation across server, target, and inbound paths.
 - Protect pnpm install-script policy and enforce immutable action pins across reusable workflows and composite actions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - Authenticate Feishu signatures before encrypted callback decryption and bound callback ciphertext work.
 - Correct Slack edited-message identity and text fallback handling, acknowledge unsupported callbacks, and fairly budget Events API address failover.
 - Preserve provider recorder cursors across parse failures, report post-commit lock cleanup failures without rejecting committed appends, and synchronize hardlink aliases.
-- Confine server recorder publication and locking to stable resolved paths across symlink retargets, deliver observers in durable append order, and classify post-commit lock cleanup failures.
+- Confine server recorder publication and locking to stable resolved paths across symlink retargets, deliver observers in durable append order, classify post-commit lock cleanup failures, and preserve existing file modes.
 - Cover local GitHub Actions with ownership, CodeQL, immutable image, and test-tool runtime policies.
 - Publish Matrix direct-room account data and share strict native identifier validation across server, target, and inbound paths.
 - Protect pnpm install-script policy and enforce immutable action pins across reusable workflows and composite actions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - Authenticate Feishu signatures before encrypted callback decryption and bound callback ciphertext work.
 - Correct Slack edited-message identity and text fallback handling, acknowledge unsupported callbacks, and fairly budget Events API address failover.
 - Preserve provider recorder cursors across parse failures, report post-commit lock cleanup failures without rejecting committed appends, and synchronize hardlink aliases.
-- Confine server recorder publication and locking to stable resolved paths across symlink retargets, deliver observers in durable append order, classify post-commit lock cleanup failures, and preserve existing file modes.
+- Confine server recorder publication and locking to stable resolved paths across symlink retargets, start observers in durable append order without blocking later requests, snapshot observed events, classify post-commit lock cleanup failures, and preserve existing file modes.
 - Cover local GitHub Actions with ownership, CodeQL, immutable image, and test-tool runtime policies.
 - Publish Matrix direct-room account data and share strict native identifier validation across server, target, and inbound paths.
 - Protect pnpm install-script policy and enforce immutable action pins across reusable workflows and composite actions.

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -1,4 +1,3 @@
-import { AsyncLocalStorage } from "node:async_hooks";
 import { chmod, lstat, mkdir, open, readlink, realpath, stat as statPath } from "node:fs/promises";
 import path from "node:path";
 import { lock } from "proper-lockfile";
@@ -31,23 +30,19 @@ export class ServerRecorderCommittedError extends AggregateError {
 class ServerRecorderRotationError extends Error {}
 
 type ObserverTask = {
-  completion: Promise<void> | undefined;
-  dependencies: Set<ObserverTask>;
+  markStarted: () => void;
+  started: Promise<void>;
 };
 
 type ObserverPlan = {
+  dependencies: Set<ObserverTask>;
   task: ObserverTask;
-  waitingTask: ObserverTask | undefined;
 };
 
 const pendingAppends = new Map<string, Promise<void>>();
 const pendingAdmissions = new Map<string, Promise<void>>();
 const pendingLogicalObservers = new Map<string, ObserverTask>();
 const pendingPublicationObservers = new Map<string, ObserverTask>();
-const observerContext = new AsyncLocalStorage<{
-  active: boolean;
-  task: ObserverTask;
-}>();
 const durableRecorderIdentities = new Map<string, string>();
 const MAX_DURABLE_RECORDER_IDENTITIES = 128;
 const MAX_RECOVERY_VALIDATION_BYTES = 64 * 1024 * 1024;
@@ -475,26 +470,6 @@ async function resolveRecorderPath(filePath: string): Promise<string> {
   return path.join(await resolveRecorderPath(path.dirname(filePath)), path.basename(filePath));
 }
 
-function observerTaskDependsOn(
-  task: ObserverTask,
-  target: ObserverTask,
-  visited = new Set<ObserverTask>(),
-): boolean {
-  if (task === target) {
-    return true;
-  }
-  if (visited.has(task)) {
-    return false;
-  }
-  visited.add(task);
-  for (const dependency of task.dependencies) {
-    if (observerTaskDependsOn(dependency, target, visited)) {
-      return true;
-    }
-  }
-  return false;
-}
-
 function planObserver(params: {
   key: string;
   logicalPath: string;
@@ -512,23 +487,15 @@ function planObserver(params: {
   if (previousPublication !== undefined) {
     dependencies.add(previousPublication);
   }
+  let markStarted!: () => void;
+  const started = new Promise<void>((resolve) => {
+    markStarted = resolve;
+  });
   const task: ObserverTask = {
-    completion: undefined,
-    dependencies,
+    markStarted,
+    started,
   };
-  const context = observerContext.getStore();
-  const waitingTask = context?.active === true ? context.task : undefined;
-  if (waitingTask !== undefined) {
-    if (observerTaskDependsOn(task, waitingTask)) {
-      throw new Error("Server recorder observer dependency cycle detected.");
-    }
-    waitingTask.dependencies.add(task);
-  }
-  return { task, waitingTask };
-}
-
-function cancelObserverPlan(plan: ObserverPlan | undefined): void {
-  plan?.waitingTask?.dependencies.delete(plan.task);
+  return { dependencies, task };
 }
 
 function activateObserver(params: {
@@ -541,28 +508,23 @@ function activateObserver(params: {
   if (params.onEvent === undefined || params.plan === undefined) {
     return Promise.resolve();
   }
-  const { task, waitingTask } = params.plan;
+  const { dependencies, task } = params.plan;
   const current = Promise.all(
-    [...task.dependencies].map((dependency) => dependency.completion?.catch(() => {})),
+    [...dependencies].map((dependency) => dependency.started.catch(() => {})),
   ).then(async () => {
-    const context = {
-      active: true,
-      task,
-    };
     try {
-      await observerContext.run(context, async () => await params.onEvent?.(params.event));
+      const observation = params.onEvent?.(params.event);
+      task.markStarted();
+      await observation;
     } catch (error) {
+      task.markStarted();
       throw new ServerRecorderCommittedError(params.logicalPath, error);
-    } finally {
-      context.active = false;
     }
   });
-  task.completion = current;
   pendingLogicalObservers.set(params.logicalPath, task);
   pendingPublicationObservers.set(params.key, task);
   void current.then(
     () => {
-      waitingTask?.dependencies.delete(task);
       if (pendingLogicalObservers.get(params.logicalPath) === task) {
         pendingLogicalObservers.delete(params.logicalPath);
       }
@@ -571,7 +533,6 @@ function activateObserver(params: {
       }
     },
     () => {
-      waitingTask?.dependencies.delete(task);
       if (pendingLogicalObservers.get(params.logicalPath) === task) {
         pendingLogicalObservers.delete(params.logicalPath);
       }
@@ -647,7 +608,7 @@ async function appendResolvedJsonLine(params: {
         };
       } finally {
         if (!observerActivated) {
-          cancelObserverPlan(observerPlan);
+          observerPlan?.task.markStarted();
         }
       }
     });
@@ -714,9 +675,13 @@ export async function recordServerEvent(params: {
   onEvent: ServerEventObserver | undefined;
   recorderPath: string;
 }): Promise<void> {
+  const serialized = JSON.stringify(params.event);
+  const event = JSON.parse(serialized) as ServerRequestEvent;
   await appendJsonLine({
-    ...params,
-    line: `${JSON.stringify(params.event)}\n`,
+    event,
+    line: `${serialized}\n`,
+    onEvent: params.onEvent,
+    recorderPath: params.recorderPath,
   });
 }
 
@@ -725,10 +690,14 @@ export async function recordCommittedServerEvent(params: {
   onEvent: ServerEventObserver | undefined;
   recorderPath: string;
 }): Promise<void> {
+  const serialized = JSON.stringify(params.event);
+  const event = JSON.parse(serialized) as ServerRequestEvent;
   try {
     await appendJsonLine({
-      ...params,
-      line: `${JSON.stringify(params.event)}\n`,
+      event,
+      line: `${serialized}\n`,
+      onEvent: params.onEvent,
+      recorderPath: params.recorderPath,
     });
   } catch {
     // The provider mutation already committed, so telemetry failure cannot change its response.

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -670,16 +670,28 @@ async function appendJsonLine(params: {
   await result.observation;
 }
 
+function snapshotServerEvent(event: ServerRequestEvent): {
+  event: ServerRequestEvent;
+  line: string;
+} {
+  const serialized = JSON.stringify(event);
+  if (serialized === undefined) {
+    throw new TypeError("Server recorder event is not JSON-serializable.");
+  }
+  return {
+    event: JSON.parse(serialized) as ServerRequestEvent,
+    line: `${serialized}\n`,
+  };
+}
+
 export async function recordServerEvent(params: {
   event: ServerRequestEvent;
   onEvent: ServerEventObserver | undefined;
   recorderPath: string;
 }): Promise<void> {
-  const serialized = JSON.stringify(params.event);
-  const event = JSON.parse(serialized) as ServerRequestEvent;
+  const snapshot = snapshotServerEvent(params.event);
   await appendJsonLine({
-    event,
-    line: `${serialized}\n`,
+    ...snapshot,
     onEvent: params.onEvent,
     recorderPath: params.recorderPath,
   });
@@ -690,12 +702,10 @@ export async function recordCommittedServerEvent(params: {
   onEvent: ServerEventObserver | undefined;
   recorderPath: string;
 }): Promise<void> {
-  const serialized = JSON.stringify(params.event);
-  const event = JSON.parse(serialized) as ServerRequestEvent;
   try {
+    const snapshot = snapshotServerEvent(params.event);
     await appendJsonLine({
-      event,
-      line: `${serialized}\n`,
+      ...snapshot,
       onEvent: params.onEvent,
       recorderPath: params.recorderPath,
     });

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -39,6 +39,7 @@ const RECORDER_LOCK_RETRY_MS = 100;
 const RECORDER_LOCK_STALE_MS = 30_000;
 const RECORDER_LOCK_UPDATE_MS = 10_000;
 const RECORDER_LOCK_WAIT_MARGIN_MS = 5_000;
+const RECORDER_PATH_ATTEMPTS = 3;
 const RECORDER_ROTATION_ATTEMPTS = 3;
 const TAIL_SCAN_CHUNK_BYTES = 64 * 1024;
 
@@ -317,10 +318,11 @@ async function closeRecorderAttempt(params: {
 
 async function appendRecorderAttempt(params: {
   createdDirectory: string | undefined;
-  filePath: string;
+  logicalPath: string;
   line: string;
+  publicationPath: string;
 }): Promise<"committed" | "retry"> {
-  const opened = await openRecorderFile(params.filePath);
+  const opened = await openRecorderFile(params.publicationPath);
   const { file } = opened;
   let committed = false;
   let operationFailed = false;
@@ -330,11 +332,11 @@ async function appendRecorderAttempt(params: {
     await file.chmod(0o600);
     let stats = await file.stat();
     let identity = requireRecorderIdentity(stats);
-    if (!(await recorderPathHasIdentity(params.filePath, identity))) {
+    if (!(await recorderPathHasIdentity(params.publicationPath, identity))) {
       result = "retry";
     } else {
       const needsPathDurability =
-        opened.created || durableRecorderIdentities.get(path.resolve(params.filePath)) !== identity;
+        opened.created || durableRecorderIdentities.get(params.publicationPath) !== identity;
       if (stats.size > 0) {
         const finalByte = await readBufferAt(file, 1, stats.size - 1);
         if (finalByte[0] !== 0x0a) {
@@ -360,33 +362,38 @@ async function appendRecorderAttempt(params: {
       }
       stats = await file.stat();
       identity = requireRecorderIdentity(stats);
-      if (!(await recorderPathHasIdentity(params.filePath, identity))) {
+      if (!(await recorderPathHasIdentity(params.publicationPath, identity))) {
         result = "retry";
       } else {
         try {
           await file.appendFile(params.line, { encoding: "utf8" });
           await file.sync();
-          if (!(await recorderPathHasIdentity(params.filePath, identity))) {
+          if (
+            !(await recorderPathHasIdentity(params.publicationPath, identity)) ||
+            (await resolveRecorderPath(params.logicalPath)) !== params.publicationPath
+          ) {
             throw new ServerRecorderCommittedError(
-              params.filePath,
+              params.logicalPath,
               new ServerRecorderRotationError("Server recorder rotated during append."),
             );
           } else {
             if (needsPathDurability) {
               const firstCreatedPath =
-                params.createdDirectory ??
-                (opened.created ? path.resolve(params.filePath) : undefined);
-              await syncRecorderPathAncestry(params.filePath, firstCreatedPath);
+                params.createdDirectory ?? (opened.created ? params.publicationPath : undefined);
+              await syncRecorderPathAncestry(params.publicationPath, firstCreatedPath);
             }
-            if (!(await recorderPathHasIdentity(params.filePath, identity))) {
+            if (
+              !(await recorderPathHasIdentity(params.publicationPath, identity)) ||
+              (await resolveRecorderPath(params.logicalPath)) !== params.publicationPath
+            ) {
               throw new ServerRecorderCommittedError(
-                params.filePath,
+                params.logicalPath,
                 new ServerRecorderRotationError(
                   "Server recorder rotated while syncing path ancestry.",
                 ),
               );
             } else {
-              rememberDurableRecorderIdentity(path.resolve(params.filePath), identity);
+              rememberDurableRecorderIdentity(params.publicationPath, identity);
               committed = true;
               result = "committed";
             }
@@ -395,7 +402,7 @@ async function appendRecorderAttempt(params: {
           if (error instanceof ServerRecorderCommittedError) {
             throw error;
           }
-          throw new ServerRecorderCommittedError(params.filePath, error, [], true);
+          throw new ServerRecorderCommittedError(params.logicalPath, error, [], true);
         }
       }
     }
@@ -406,7 +413,7 @@ async function appendRecorderAttempt(params: {
   await closeRecorderAttempt({
     committed,
     file,
-    filePath: params.filePath,
+    filePath: params.logicalPath,
     operationError,
     operationFailed,
   });
@@ -434,28 +441,32 @@ async function resolveRecorderPath(filePath: string): Promise<string> {
   return path.join(await resolveRecorderPath(path.dirname(filePath)), path.basename(filePath));
 }
 
-async function appendResolvedJsonLine(logicalPath: string, line: string): Promise<void> {
+async function appendResolvedJsonLine(logicalPath: string, line: string): Promise<boolean> {
   const key = await resolveRecorderPath(logicalPath);
   const previous = pendingAppends.get(key) ?? Promise.resolve();
   const current = previous
     .catch(() => {})
     .then(async () => {
-      const directory = path.dirname(logicalPath);
+      const directory = path.dirname(key);
       const createdDirectory = await mkdir(directory, { mode: 0o700, recursive: true });
       if (createdDirectory !== undefined || isManagedRecorderDirectory(directory)) {
         await chmod(directory, 0o700);
       }
       // Keep the cross-process lock through append verification.
-      await withRecorderLock(key, async () => {
+      return await withRecorderLock(key, async () => {
+        if ((await resolveRecorderPath(logicalPath)) !== key) {
+          return false;
+        }
         for (let attempt = 0; attempt < RECORDER_ROTATION_ATTEMPTS; attempt++) {
           if (
             (await appendRecorderAttempt({
               createdDirectory,
-              filePath: logicalPath,
+              logicalPath,
               line,
+              publicationPath: key,
             })) === "committed"
           ) {
-            return;
+            return true;
           }
         }
         throw new ServerRecorderRotationError(
@@ -463,12 +474,16 @@ async function appendResolvedJsonLine(logicalPath: string, line: string): Promis
         );
       });
     });
-  pendingAppends.set(key, current);
+  const tail = current.then(
+    () => undefined,
+    () => undefined,
+  );
+  pendingAppends.set(key, tail);
 
   try {
-    await current;
+    return await current;
   } finally {
-    if (pendingAppends.get(key) === current) {
+    if (pendingAppends.get(key) === tail) {
       pendingAppends.delete(key);
     }
   }
@@ -477,7 +492,18 @@ async function appendResolvedJsonLine(logicalPath: string, line: string): Promis
 async function appendJsonLine(filePath: string, line: string): Promise<void> {
   const logicalPath = path.resolve(filePath);
   const previous = pendingAdmissions.get(logicalPath) ?? Promise.resolve();
-  const current = previous.catch(() => {}).then(() => appendResolvedJsonLine(logicalPath, line));
+  const current = previous
+    .catch(() => {})
+    .then(async () => {
+      for (let attempt = 0; attempt < RECORDER_PATH_ATTEMPTS; attempt++) {
+        if (await appendResolvedJsonLine(logicalPath, line)) {
+          return;
+        }
+      }
+      throw new ServerRecorderRotationError(
+        `Server recorder path retries exhausted for "${logicalPath}".`,
+      );
+    });
   pendingAdmissions.set(logicalPath, current);
 
   try {

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -36,8 +36,6 @@ const pendingLogicalObservers = new Map<string, Promise<void>>();
 const pendingPublicationObservers = new Map<string, Promise<void>>();
 const observerContext = new AsyncLocalStorage<{
   active: boolean;
-  logicalPath: string;
-  publicationPath: string;
 }>();
 const durableRecorderIdentities = new Map<string, string>();
 const MAX_DURABLE_RECORDER_IDENTITIES = 128;
@@ -267,10 +265,11 @@ async function acquireRecorderLock(filePath: string): Promise<() => Promise<void
 }
 
 async function withRecorderLock(
-  filePath: string,
+  lockPath: string,
+  logicalPath: string,
   operation: () => Promise<boolean | undefined>,
 ): Promise<boolean | undefined> {
-  const release = await acquireRecorderLock(filePath);
+  const release = await acquireRecorderLock(lockPath);
   let operationFailed = false;
   let operationError: unknown;
   let result: boolean | undefined;
@@ -284,10 +283,10 @@ async function withRecorderLock(
     await release();
   } catch (releaseError) {
     if (operationFailed) {
-      throw recorderLockReleaseError(filePath, operationError, releaseError);
+      throw recorderLockReleaseError(logicalPath, operationError, releaseError);
     }
     if (result === true) {
-      throw new ServerRecorderCommittedError(filePath, releaseError);
+      throw new ServerRecorderCommittedError(logicalPath, releaseError);
     }
     throw releaseError;
   }
@@ -482,8 +481,6 @@ function enqueueObserver(params: {
   ]).then(async () => {
     const context = {
       active: true,
-      logicalPath: params.logicalPath,
-      publicationPath: params.key,
     };
     try {
       await observerContext.run(context, async () => await params.onEvent?.(params.event));
@@ -517,9 +514,7 @@ function enqueueObserver(params: {
 }
 
 type RecorderAppendResult = {
-  logicalPath: string;
   observation: Promise<void>;
-  publicationPath: string;
 };
 
 async function appendResolvedJsonLine(params: {
@@ -540,7 +535,7 @@ async function appendResolvedJsonLine(params: {
         await chmod(directory, 0o700);
       }
       // Keep the cross-process lock through append verification.
-      const committed = await withRecorderLock(key, async () => {
+      const committed = await withRecorderLock(key, logicalPath, async () => {
         if ((await resolveRecorderPath(logicalPath)) !== key) {
           return undefined;
         }
@@ -564,14 +559,12 @@ async function appendResolvedJsonLine(params: {
         return undefined;
       }
       return {
-        logicalPath,
         observation: enqueueObserver({
           event: params.event,
           key,
           logicalPath,
           onEvent: params.onEvent,
         }),
-        publicationPath: key,
       };
     });
   const tail = current.then(
@@ -595,6 +588,9 @@ async function appendJsonLine(params: {
   onEvent: ServerEventObserver | undefined;
   recorderPath: string;
 }): Promise<void> {
+  if (observerContext.getStore()?.active === true && params.onEvent !== undefined) {
+    throw new Error("Server recorder observers cannot register nested observers.");
+  }
   const logicalPath = path.resolve(params.recorderPath);
   const previous = pendingAdmissions.get(logicalPath) ?? Promise.resolve();
   const current = previous
@@ -628,15 +624,6 @@ async function appendJsonLine(params: {
     if (pendingAdmissions.get(logicalPath) === tail) {
       pendingAdmissions.delete(logicalPath);
     }
-  }
-  const activeObserver = observerContext.getStore();
-  if (
-    activeObserver?.active === true &&
-    (activeObserver.logicalPath === result.logicalPath ||
-      activeObserver.publicationPath === result.publicationPath)
-  ) {
-    // The callback remains queued behind the active observer; awaiting it here would deadlock.
-    return;
   }
   await result.observation;
 }

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -31,6 +31,7 @@ class ServerRecorderRotationError extends Error {}
 
 const pendingAppends = new Map<string, Promise<void>>();
 const pendingAdmissions = new Map<string, Promise<void>>();
+const pendingObservers = new Map<string, Promise<void>>();
 const durableRecorderIdentities = new Map<string, string>();
 const MAX_DURABLE_RECORDER_IDENTITIES = 128;
 const MAX_RECOVERY_VALIDATION_BYTES = 64 * 1024 * 1024;
@@ -441,7 +442,52 @@ async function resolveRecorderPath(filePath: string): Promise<string> {
   return path.join(await resolveRecorderPath(path.dirname(filePath)), path.basename(filePath));
 }
 
-async function appendResolvedJsonLine(logicalPath: string, line: string): Promise<boolean> {
+function enqueueObserver(params: {
+  event: ServerRequestEvent;
+  key: string;
+  logicalPath: string;
+  onEvent: ServerEventObserver | undefined;
+}): Promise<void> {
+  if (params.onEvent === undefined) {
+    return Promise.resolve();
+  }
+  const previous = pendingObservers.get(params.key) ?? Promise.resolve();
+  const current = previous
+    .catch(() => {})
+    .then(async () => {
+      try {
+        await params.onEvent?.(params.event);
+      } catch (error) {
+        throw new ServerRecorderCommittedError(params.logicalPath, error);
+      }
+    });
+  pendingObservers.set(params.key, current);
+  void current.then(
+    () => {
+      if (pendingObservers.get(params.key) === current) {
+        pendingObservers.delete(params.key);
+      }
+    },
+    () => {
+      if (pendingObservers.get(params.key) === current) {
+        pendingObservers.delete(params.key);
+      }
+    },
+  );
+  return current;
+}
+
+type RecorderAppendResult = {
+  observation: Promise<void>;
+};
+
+async function appendResolvedJsonLine(params: {
+  event: ServerRequestEvent;
+  line: string;
+  logicalPath: string;
+  onEvent: ServerEventObserver | undefined;
+}): Promise<RecorderAppendResult | undefined> {
+  const { logicalPath } = params;
   const key = await resolveRecorderPath(logicalPath);
   const previous = pendingAppends.get(key) ?? Promise.resolve();
   const current = previous
@@ -455,18 +501,25 @@ async function appendResolvedJsonLine(logicalPath: string, line: string): Promis
       // Keep the cross-process lock through append verification.
       return await withRecorderLock(key, async () => {
         if ((await resolveRecorderPath(logicalPath)) !== key) {
-          return false;
+          return undefined;
         }
         for (let attempt = 0; attempt < RECORDER_ROTATION_ATTEMPTS; attempt++) {
           if (
             (await appendRecorderAttempt({
               createdDirectory,
               logicalPath,
-              line,
+              line: params.line,
               publicationPath: key,
             })) === "committed"
           ) {
-            return true;
+            return {
+              observation: enqueueObserver({
+                event: params.event,
+                key,
+                logicalPath,
+                onEvent: params.onEvent,
+              }),
+            };
           }
         }
         throw new ServerRecorderRotationError(
@@ -489,30 +542,46 @@ async function appendResolvedJsonLine(logicalPath: string, line: string): Promis
   }
 }
 
-async function appendJsonLine(filePath: string, line: string): Promise<void> {
-  const logicalPath = path.resolve(filePath);
+async function appendJsonLine(params: {
+  event: ServerRequestEvent;
+  onEvent: ServerEventObserver | undefined;
+  recorderPath: string;
+}): Promise<void> {
+  const logicalPath = path.resolve(params.recorderPath);
   const previous = pendingAdmissions.get(logicalPath) ?? Promise.resolve();
   const current = previous
     .catch(() => {})
     .then(async () => {
       for (let attempt = 0; attempt < RECORDER_PATH_ATTEMPTS; attempt++) {
-        if (await appendResolvedJsonLine(logicalPath, line)) {
-          return;
+        const result = await appendResolvedJsonLine({
+          event: params.event,
+          line: `${JSON.stringify(params.event)}\n`,
+          logicalPath,
+          onEvent: params.onEvent,
+        });
+        if (result !== undefined) {
+          return result;
         }
       }
       throw new ServerRecorderRotationError(
         `Server recorder path retries exhausted for "${logicalPath}".`,
       );
     });
-  pendingAdmissions.set(logicalPath, current);
+  const tail = current.then(
+    () => undefined,
+    () => undefined,
+  );
+  pendingAdmissions.set(logicalPath, tail);
 
+  let result: RecorderAppendResult;
   try {
-    await current;
+    result = await current;
   } finally {
-    if (pendingAdmissions.get(logicalPath) === current) {
+    if (pendingAdmissions.get(logicalPath) === tail) {
       pendingAdmissions.delete(logicalPath);
     }
   }
+  await result.observation;
 }
 
 export async function recordServerEvent(params: {
@@ -520,12 +589,7 @@ export async function recordServerEvent(params: {
   onEvent: ServerEventObserver | undefined;
   recorderPath: string;
 }): Promise<void> {
-  await appendJsonLine(params.recorderPath, `${JSON.stringify(params.event)}\n`);
-  try {
-    await params.onEvent?.(params.event);
-  } catch (error) {
-    throw new ServerRecorderCommittedError(params.recorderPath, error);
-  }
+  await appendJsonLine(params);
 }
 
 export async function recordCommittedServerEvent(params: {
@@ -534,8 +598,7 @@ export async function recordCommittedServerEvent(params: {
   recorderPath: string;
 }): Promise<void> {
   try {
-    await appendJsonLine(params.recorderPath, `${JSON.stringify(params.event)}\n`);
-    await params.onEvent?.(params.event);
+    await appendJsonLine(params);
   } catch {
     // The provider mutation already committed, so telemetry failure cannot change its response.
   }

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -34,6 +34,8 @@ const pendingAppends = new Map<string, Promise<void>>();
 const pendingAdmissions = new Map<string, Promise<void>>();
 const pendingLogicalObservers = new Map<string, Promise<void>>();
 const pendingPublicationObservers = new Map<string, Promise<void>>();
+const activeLogicalObservers = new Set<string>();
+const activePublicationObservers = new Set<string>();
 const observerContext = new AsyncLocalStorage<{
   active: boolean;
 }>();
@@ -482,12 +484,16 @@ function enqueueObserver(params: {
     const context = {
       active: true,
     };
+    activeLogicalObservers.add(params.logicalPath);
+    activePublicationObservers.add(params.key);
     try {
       await observerContext.run(context, async () => await params.onEvent?.(params.event));
     } catch (error) {
       throw new ServerRecorderCommittedError(params.logicalPath, error);
     } finally {
       context.active = false;
+      activeLogicalObservers.delete(params.logicalPath);
+      activePublicationObservers.delete(params.key);
     }
   });
   pendingLogicalObservers.set(params.logicalPath, current);
@@ -525,6 +531,13 @@ async function appendResolvedJsonLine(params: {
 }): Promise<RecorderAppendResult | undefined> {
   const { logicalPath } = params;
   const key = await resolveRecorderPath(logicalPath);
+  if (
+    observerContext.getStore()?.active === true &&
+    params.onEvent !== undefined &&
+    (activeLogicalObservers.has(logicalPath) || activePublicationObservers.has(key))
+  ) {
+    throw new Error("Server recorder observers cannot depend on an active observer.");
+  }
   const previous = pendingAppends.get(key) ?? Promise.resolve();
   const current = previous
     .catch(() => {})
@@ -588,9 +601,6 @@ async function appendJsonLine(params: {
   onEvent: ServerEventObserver | undefined;
   recorderPath: string;
 }): Promise<void> {
-  if (observerContext.getStore()?.active === true && params.onEvent !== undefined) {
-    throw new Error("Server recorder observers cannot register nested observers.");
-  }
   const logicalPath = path.resolve(params.recorderPath);
   const previous = pendingAdmissions.get(logicalPath) ?? Promise.resolve();
   const current = previous

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { chmod, lstat, mkdir, open, readlink, realpath, stat as statPath } from "node:fs/promises";
 import path from "node:path";
 import { lock } from "proper-lockfile";
@@ -33,6 +34,11 @@ const pendingAppends = new Map<string, Promise<void>>();
 const pendingAdmissions = new Map<string, Promise<void>>();
 const pendingLogicalObservers = new Map<string, Promise<void>>();
 const pendingPublicationObservers = new Map<string, Promise<void>>();
+const observerContext = new AsyncLocalStorage<{
+  active: boolean;
+  logicalPath: string;
+  publicationPath: string;
+}>();
 const durableRecorderIdentities = new Map<string, string>();
 const MAX_DURABLE_RECORDER_IDENTITIES = 128;
 const MAX_RECOVERY_VALIDATION_BYTES = 64 * 1024 * 1024;
@@ -474,10 +480,17 @@ function enqueueObserver(params: {
     previousLogical.catch(() => {}),
     previousPublication.catch(() => {}),
   ]).then(async () => {
+    const context = {
+      active: true,
+      logicalPath: params.logicalPath,
+      publicationPath: params.key,
+    };
     try {
-      await params.onEvent?.(params.event);
+      await observerContext.run(context, async () => await params.onEvent?.(params.event));
     } catch (error) {
       throw new ServerRecorderCommittedError(params.logicalPath, error);
+    } finally {
+      context.active = false;
     }
   });
   pendingLogicalObservers.set(params.logicalPath, current);
@@ -504,7 +517,9 @@ function enqueueObserver(params: {
 }
 
 type RecorderAppendResult = {
+  logicalPath: string;
   observation: Promise<void>;
+  publicationPath: string;
 };
 
 async function appendResolvedJsonLine(params: {
@@ -549,12 +564,14 @@ async function appendResolvedJsonLine(params: {
         return undefined;
       }
       return {
+        logicalPath,
         observation: enqueueObserver({
           event: params.event,
           key,
           logicalPath,
           onEvent: params.onEvent,
         }),
+        publicationPath: key,
       };
     });
   const tail = current.then(
@@ -574,6 +591,7 @@ async function appendResolvedJsonLine(params: {
 
 async function appendJsonLine(params: {
   event: ServerRequestEvent;
+  line: string;
   onEvent: ServerEventObserver | undefined;
   recorderPath: string;
 }): Promise<void> {
@@ -585,7 +603,7 @@ async function appendJsonLine(params: {
       for (let attempt = 0; attempt < RECORDER_PATH_ATTEMPTS; attempt++) {
         const result = await appendResolvedJsonLine({
           event: params.event,
-          line: `${JSON.stringify(params.event)}\n`,
+          line: params.line,
           logicalPath,
           onEvent: params.onEvent,
         });
@@ -611,6 +629,15 @@ async function appendJsonLine(params: {
       pendingAdmissions.delete(logicalPath);
     }
   }
+  const activeObserver = observerContext.getStore();
+  if (
+    activeObserver?.active === true &&
+    (activeObserver.logicalPath === result.logicalPath ||
+      activeObserver.publicationPath === result.publicationPath)
+  ) {
+    // The callback remains queued behind the active observer; awaiting it here would deadlock.
+    return;
+  }
   await result.observation;
 }
 
@@ -619,7 +646,10 @@ export async function recordServerEvent(params: {
   onEvent: ServerEventObserver | undefined;
   recorderPath: string;
 }): Promise<void> {
-  await appendJsonLine(params);
+  await appendJsonLine({
+    ...params,
+    line: `${JSON.stringify(params.event)}\n`,
+  });
 }
 
 export async function recordCommittedServerEvent(params: {
@@ -628,7 +658,10 @@ export async function recordCommittedServerEvent(params: {
   recorderPath: string;
 }): Promise<void> {
   try {
-    await appendJsonLine(params);
+    await appendJsonLine({
+      ...params,
+      line: `${JSON.stringify(params.event)}\n`,
+    });
   } catch {
     // The provider mutation already committed, so telemetry failure cannot change its response.
   }

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -344,7 +344,9 @@ async function appendRecorderAttempt(params: {
   let operationError: unknown;
   let result: "committed" | "retry" | undefined;
   try {
-    await file.chmod(0o600);
+    if (opened.created) {
+      await file.chmod(0o600);
+    }
     let stats = await file.stat();
     let identity = requireRecorderIdentity(stats);
     if (!(await recorderPathHasIdentity(params.publicationPath, identity))) {

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -31,7 +31,8 @@ class ServerRecorderRotationError extends Error {}
 
 const pendingAppends = new Map<string, Promise<void>>();
 const pendingAdmissions = new Map<string, Promise<void>>();
-const pendingObservers = new Map<string, Promise<void>>();
+const pendingLogicalObservers = new Map<string, Promise<void>>();
+const pendingPublicationObservers = new Map<string, Promise<void>>();
 const durableRecorderIdentities = new Map<string, string>();
 const MAX_DURABLE_RECORDER_IDENTITIES = 128;
 const MAX_RECOVERY_VALIDATION_BYTES = 64 * 1024 * 1024;
@@ -467,26 +468,35 @@ function enqueueObserver(params: {
   if (params.onEvent === undefined) {
     return Promise.resolve();
   }
-  const previous = pendingObservers.get(params.key) ?? Promise.resolve();
-  const current = previous
-    .catch(() => {})
-    .then(async () => {
-      try {
-        await params.onEvent?.(params.event);
-      } catch (error) {
-        throw new ServerRecorderCommittedError(params.logicalPath, error);
-      }
-    });
-  pendingObservers.set(params.key, current);
+  const previousLogical = pendingLogicalObservers.get(params.logicalPath) ?? Promise.resolve();
+  const previousPublication = pendingPublicationObservers.get(params.key) ?? Promise.resolve();
+  const current = Promise.all([
+    previousLogical.catch(() => {}),
+    previousPublication.catch(() => {}),
+  ]).then(async () => {
+    try {
+      await params.onEvent?.(params.event);
+    } catch (error) {
+      throw new ServerRecorderCommittedError(params.logicalPath, error);
+    }
+  });
+  pendingLogicalObservers.set(params.logicalPath, current);
+  pendingPublicationObservers.set(params.key, current);
   void current.then(
     () => {
-      if (pendingObservers.get(params.key) === current) {
-        pendingObservers.delete(params.key);
+      if (pendingLogicalObservers.get(params.logicalPath) === current) {
+        pendingLogicalObservers.delete(params.logicalPath);
+      }
+      if (pendingPublicationObservers.get(params.key) === current) {
+        pendingPublicationObservers.delete(params.key);
       }
     },
     () => {
-      if (pendingObservers.get(params.key) === current) {
-        pendingObservers.delete(params.key);
+      if (pendingLogicalObservers.get(params.logicalPath) === current) {
+        pendingLogicalObservers.delete(params.logicalPath);
+      }
+      if (pendingPublicationObservers.get(params.key) === current) {
+        pendingPublicationObservers.delete(params.key);
       }
     },
   );

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -210,7 +210,15 @@ function recorderLockReleaseError(
   filePath: string,
   operationError: unknown,
   releaseError: unknown,
-): AggregateError {
+): AggregateError | ServerRecorderCommittedError {
+  if (operationError instanceof ServerRecorderCommittedError) {
+    return new ServerRecorderCommittedError(
+      filePath,
+      operationError,
+      [releaseError],
+      operationError.indeterminate,
+    );
+  }
   return new AggregateError(
     [operationError, releaseError],
     `Server recorder append and lock release both failed for "${filePath}".`,
@@ -251,11 +259,14 @@ async function acquireRecorderLock(filePath: string): Promise<() => Promise<void
   }
 }
 
-async function withRecorderLock<T>(filePath: string, operation: () => Promise<T>): Promise<T> {
+async function withRecorderLock(
+  filePath: string,
+  operation: () => Promise<boolean | undefined>,
+): Promise<boolean | undefined> {
   const release = await acquireRecorderLock(filePath);
   let operationFailed = false;
   let operationError: unknown;
-  let result: T | undefined;
+  let result: boolean | undefined;
   try {
     result = await operation();
   } catch (error) {
@@ -268,12 +279,15 @@ async function withRecorderLock<T>(filePath: string, operation: () => Promise<T>
     if (operationFailed) {
       throw recorderLockReleaseError(filePath, operationError, releaseError);
     }
+    if (result === true) {
+      throw new ServerRecorderCommittedError(filePath, releaseError);
+    }
     throw releaseError;
   }
   if (operationFailed) {
     throw operationError;
   }
-  return result as T;
+  return result;
 }
 
 async function closeRecorderAttempt(params: {
@@ -499,7 +513,7 @@ async function appendResolvedJsonLine(params: {
         await chmod(directory, 0o700);
       }
       // Keep the cross-process lock through append verification.
-      return await withRecorderLock(key, async () => {
+      const committed = await withRecorderLock(key, async () => {
         if ((await resolveRecorderPath(logicalPath)) !== key) {
           return undefined;
         }
@@ -512,20 +526,24 @@ async function appendResolvedJsonLine(params: {
               publicationPath: key,
             })) === "committed"
           ) {
-            return {
-              observation: enqueueObserver({
-                event: params.event,
-                key,
-                logicalPath,
-                onEvent: params.onEvent,
-              }),
-            };
+            return true;
           }
         }
         throw new ServerRecorderRotationError(
           `Server recorder rotation retries exhausted for "${logicalPath}".`,
         );
       });
+      if (committed !== true) {
+        return undefined;
+      }
+      return {
+        observation: enqueueObserver({
+          event: params.event,
+          key,
+          logicalPath,
+          onEvent: params.onEvent,
+        }),
+      };
     });
   const tail = current.then(
     () => undefined,

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -30,14 +30,23 @@ export class ServerRecorderCommittedError extends AggregateError {
 
 class ServerRecorderRotationError extends Error {}
 
+type ObserverTask = {
+  completion: Promise<void> | undefined;
+  dependencies: Set<ObserverTask>;
+};
+
+type ObserverPlan = {
+  task: ObserverTask;
+  waitingTask: ObserverTask | undefined;
+};
+
 const pendingAppends = new Map<string, Promise<void>>();
 const pendingAdmissions = new Map<string, Promise<void>>();
-const pendingLogicalObservers = new Map<string, Promise<void>>();
-const pendingPublicationObservers = new Map<string, Promise<void>>();
-const activeLogicalObservers = new Set<string>();
-const activePublicationObservers = new Set<string>();
+const pendingLogicalObservers = new Map<string, ObserverTask>();
+const pendingPublicationObservers = new Map<string, ObserverTask>();
 const observerContext = new AsyncLocalStorage<{
   active: boolean;
+  task: ObserverTask;
 }>();
 const durableRecorderIdentities = new Map<string, string>();
 const MAX_DURABLE_RECORDER_IDENTITIES = 128;
@@ -466,52 +475,107 @@ async function resolveRecorderPath(filePath: string): Promise<string> {
   return path.join(await resolveRecorderPath(path.dirname(filePath)), path.basename(filePath));
 }
 
-function enqueueObserver(params: {
+function observerTaskDependsOn(
+  task: ObserverTask,
+  target: ObserverTask,
+  visited = new Set<ObserverTask>(),
+): boolean {
+  if (task === target) {
+    return true;
+  }
+  if (visited.has(task)) {
+    return false;
+  }
+  visited.add(task);
+  for (const dependency of task.dependencies) {
+    if (observerTaskDependsOn(dependency, target, visited)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function planObserver(params: {
+  key: string;
+  logicalPath: string;
+  onEvent: ServerEventObserver | undefined;
+}): ObserverPlan | undefined {
+  if (params.onEvent === undefined) {
+    return undefined;
+  }
+  const dependencies = new Set<ObserverTask>();
+  const previousLogical = pendingLogicalObservers.get(params.logicalPath);
+  const previousPublication = pendingPublicationObservers.get(params.key);
+  if (previousLogical !== undefined) {
+    dependencies.add(previousLogical);
+  }
+  if (previousPublication !== undefined) {
+    dependencies.add(previousPublication);
+  }
+  const task: ObserverTask = {
+    completion: undefined,
+    dependencies,
+  };
+  const context = observerContext.getStore();
+  const waitingTask = context?.active === true ? context.task : undefined;
+  if (waitingTask !== undefined) {
+    if (observerTaskDependsOn(task, waitingTask)) {
+      throw new Error("Server recorder observer dependency cycle detected.");
+    }
+    waitingTask.dependencies.add(task);
+  }
+  return { task, waitingTask };
+}
+
+function cancelObserverPlan(plan: ObserverPlan | undefined): void {
+  plan?.waitingTask?.dependencies.delete(plan.task);
+}
+
+function activateObserver(params: {
   event: ServerRequestEvent;
   key: string;
   logicalPath: string;
   onEvent: ServerEventObserver | undefined;
+  plan: ObserverPlan | undefined;
 }): Promise<void> {
-  if (params.onEvent === undefined) {
+  if (params.onEvent === undefined || params.plan === undefined) {
     return Promise.resolve();
   }
-  const previousLogical = pendingLogicalObservers.get(params.logicalPath) ?? Promise.resolve();
-  const previousPublication = pendingPublicationObservers.get(params.key) ?? Promise.resolve();
-  const current = Promise.all([
-    previousLogical.catch(() => {}),
-    previousPublication.catch(() => {}),
-  ]).then(async () => {
+  const { task, waitingTask } = params.plan;
+  const current = Promise.all(
+    [...task.dependencies].map((dependency) => dependency.completion?.catch(() => {})),
+  ).then(async () => {
     const context = {
       active: true,
+      task,
     };
-    activeLogicalObservers.add(params.logicalPath);
-    activePublicationObservers.add(params.key);
     try {
       await observerContext.run(context, async () => await params.onEvent?.(params.event));
     } catch (error) {
       throw new ServerRecorderCommittedError(params.logicalPath, error);
     } finally {
       context.active = false;
-      activeLogicalObservers.delete(params.logicalPath);
-      activePublicationObservers.delete(params.key);
     }
   });
-  pendingLogicalObservers.set(params.logicalPath, current);
-  pendingPublicationObservers.set(params.key, current);
+  task.completion = current;
+  pendingLogicalObservers.set(params.logicalPath, task);
+  pendingPublicationObservers.set(params.key, task);
   void current.then(
     () => {
-      if (pendingLogicalObservers.get(params.logicalPath) === current) {
+      waitingTask?.dependencies.delete(task);
+      if (pendingLogicalObservers.get(params.logicalPath) === task) {
         pendingLogicalObservers.delete(params.logicalPath);
       }
-      if (pendingPublicationObservers.get(params.key) === current) {
+      if (pendingPublicationObservers.get(params.key) === task) {
         pendingPublicationObservers.delete(params.key);
       }
     },
     () => {
-      if (pendingLogicalObservers.get(params.logicalPath) === current) {
+      waitingTask?.dependencies.delete(task);
+      if (pendingLogicalObservers.get(params.logicalPath) === task) {
         pendingLogicalObservers.delete(params.logicalPath);
       }
-      if (pendingPublicationObservers.get(params.key) === current) {
+      if (pendingPublicationObservers.get(params.key) === task) {
         pendingPublicationObservers.delete(params.key);
       }
     },
@@ -531,54 +595,61 @@ async function appendResolvedJsonLine(params: {
 }): Promise<RecorderAppendResult | undefined> {
   const { logicalPath } = params;
   const key = await resolveRecorderPath(logicalPath);
-  if (
-    observerContext.getStore()?.active === true &&
-    params.onEvent !== undefined &&
-    (activeLogicalObservers.has(logicalPath) || activePublicationObservers.has(key))
-  ) {
-    throw new Error("Server recorder observers cannot depend on an active observer.");
-  }
   const previous = pendingAppends.get(key) ?? Promise.resolve();
   const current = previous
     .catch(() => {})
     .then(async () => {
-      const directory = path.dirname(key);
-      const createdDirectory = await mkdir(directory, { mode: 0o700, recursive: true });
-      if (createdDirectory !== undefined || isManagedRecorderDirectory(directory)) {
-        await chmod(directory, 0o700);
-      }
-      // Keep the cross-process lock through append verification.
-      const committed = await withRecorderLock(key, logicalPath, async () => {
-        if ((await resolveRecorderPath(logicalPath)) !== key) {
+      const observerPlan = planObserver({
+        key,
+        logicalPath,
+        onEvent: params.onEvent,
+      });
+      let observerActivated = false;
+      try {
+        const directory = path.dirname(key);
+        const createdDirectory = await mkdir(directory, { mode: 0o700, recursive: true });
+        if (createdDirectory !== undefined || isManagedRecorderDirectory(directory)) {
+          await chmod(directory, 0o700);
+        }
+        // Keep the cross-process lock through append verification.
+        const committed = await withRecorderLock(key, logicalPath, async () => {
+          if ((await resolveRecorderPath(logicalPath)) !== key) {
+            return undefined;
+          }
+          for (let attempt = 0; attempt < RECORDER_ROTATION_ATTEMPTS; attempt++) {
+            if (
+              (await appendRecorderAttempt({
+                createdDirectory,
+                logicalPath,
+                line: params.line,
+                publicationPath: key,
+              })) === "committed"
+            ) {
+              return true;
+            }
+          }
+          throw new ServerRecorderRotationError(
+            `Server recorder rotation retries exhausted for "${logicalPath}".`,
+          );
+        });
+        if (committed !== true) {
           return undefined;
         }
-        for (let attempt = 0; attempt < RECORDER_ROTATION_ATTEMPTS; attempt++) {
-          if (
-            (await appendRecorderAttempt({
-              createdDirectory,
-              logicalPath,
-              line: params.line,
-              publicationPath: key,
-            })) === "committed"
-          ) {
-            return true;
-          }
+        observerActivated = true;
+        return {
+          observation: activateObserver({
+            event: params.event,
+            key,
+            logicalPath,
+            onEvent: params.onEvent,
+            plan: observerPlan,
+          }),
+        };
+      } finally {
+        if (!observerActivated) {
+          cancelObserverPlan(observerPlan);
         }
-        throw new ServerRecorderRotationError(
-          `Server recorder rotation retries exhausted for "${logicalPath}".`,
-        );
-      });
-      if (committed !== true) {
-        return undefined;
       }
-      return {
-        observation: enqueueObserver({
-          event: params.event,
-          key,
-          logicalPath,
-          onEvent: params.onEvent,
-        }),
-      };
     });
   const tail = current.then(
     () => undefined,

--- a/test/recorder-concurrency.test.ts
+++ b/test/recorder-concurrency.test.ts
@@ -213,7 +213,7 @@ async function expectSerializedWrites(
 describe("recorder append serialization", () => {
   it("serializes server event appends to the same JSONL file", async () => {
     const recorderPath = path.join("/tmp", "crabline-server-recorder.jsonl");
-    fsMocks.serverDirectory = path.dirname(recorderPath);
+    fsMocks.serverDirectory = await realpath(path.dirname(recorderPath));
     const firstEvent = {
       at: "2026-07-12T10:00:00.000Z",
       method: "GET",

--- a/test/server-recorder-filesystem.test.ts
+++ b/test/server-recorder-filesystem.test.ts
@@ -148,6 +148,72 @@ it.skipIf(process.platform === "win32")(
   },
 );
 
+it.skipIf(process.platform === "win32")(
+  "does not retry a committed append after a recorder symlink is retargeted",
+  async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const recorderPath = path.join(directory, "server.jsonl");
+    const firstTarget = path.join(directory, "first.jsonl");
+    const secondTarget = path.join(directory, "second.jsonl");
+    await writeFile(firstTarget, "", "utf8");
+    await writeFile(secondTarget, "", "utf8");
+    await symlink(firstTarget, recorderPath, "file");
+
+    const probe = await open(firstTarget, "a+");
+    const prototype = Object.getPrototypeOf(probe) as {
+      appendFile(data: string, options: { encoding: "utf8" }): Promise<void>;
+    };
+    await probe.close();
+    const originalAppendFile = prototype.appendFile;
+    let releaseWrite!: () => void;
+    let reportWrite!: () => void;
+    const writeReported = new Promise<void>((resolve) => {
+      reportWrite = resolve;
+    });
+    const writeReleased = new Promise<void>((resolve) => {
+      releaseWrite = resolve;
+    });
+    let interceptAppend = true;
+    prototype.appendFile = async function (this: FileHandle, data, options) {
+      await originalAppendFile.call(this, data, options);
+      if (interceptAppend && data.includes('"path":"/retargeted-after-append"')) {
+        interceptAppend = false;
+        reportWrite();
+        await writeReleased;
+      }
+    };
+
+    const recording = recordServerEvent({
+      event: {
+        at: new Date().toISOString(),
+        method: "POST",
+        path: "/retargeted-after-append",
+        query: {},
+        type: "api",
+      },
+      onEvent: undefined,
+      recorderPath,
+    });
+    try {
+      await writeReported;
+      await rm(recorderPath);
+      await symlink(secondTarget, recorderPath, "file");
+      releaseWrite();
+      await expect(recording).rejects.toMatchObject({
+        committed: true,
+        name: "ServerRecorderCommittedError",
+      });
+    } finally {
+      releaseWrite();
+      prototype.appendFile = originalAppendFile;
+    }
+
+    expect((await readFile(firstTarget, "utf8")).trimEnd().split("\n")).toHaveLength(1);
+    expect(await readFile(secondTarget, "utf8")).toBe("");
+  },
+);
+
 it.skipIf(process.platform === "win32")("preserves an existing recorder file mode", async () => {
   const directory = await createTempDir();
   directories.push(directory);

--- a/test/server-recorder-filesystem.test.ts
+++ b/test/server-recorder-filesystem.test.ts
@@ -89,7 +89,7 @@ it.skipIf(process.platform === "win32")(
 );
 
 it.skipIf(process.platform === "win32")(
-  "preserves observer order when a recorder symlink is retargeted",
+  "preserves observer start order when a recorder symlink is retargeted",
   async () => {
     const directory = await createTempDir();
     directories.push(directory);
@@ -140,11 +140,11 @@ it.skipIf(process.platform === "win32")(
     await expect
       .poll(async () => await readFile(secondTarget, "utf8"))
       .toContain('"path":"/second"');
-    expect(order).toEqual(["first:start"]);
+    await expect.poll(() => [...order]).toEqual(["first:start", "second"]);
 
     releaseFirst?.();
     await Promise.all([first, second]);
-    expect(order).toEqual(["first:start", "first:end", "second"]);
+    expect(order).toEqual(["first:start", "second", "first:end"]);
   },
 );
 

--- a/test/server-recorder-filesystem.test.ts
+++ b/test/server-recorder-filesystem.test.ts
@@ -214,6 +214,33 @@ it.skipIf(process.platform === "win32")(
   },
 );
 
+it.skipIf(process.platform === "win32")(
+  "locks and appends through a dangling recorder symlink target",
+  async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const recorderPath = path.join(directory, "server.jsonl");
+    const targetPath = path.join(directory, "target.jsonl");
+    await symlink(targetPath, recorderPath, "file");
+
+    await recordServerEvent({
+      event: {
+        at: new Date().toISOString(),
+        method: "POST",
+        path: "/dangling",
+        query: {},
+        type: "api",
+      },
+      onEvent: undefined,
+      recorderPath,
+    });
+
+    const lines = (await readFile(targetPath, "utf8")).trimEnd().split("\n");
+    expect(lines).toHaveLength(1);
+    expect(JSON.parse(lines[0]!)).toMatchObject({ path: "/dangling" });
+  },
+);
+
 it.skipIf(process.platform === "win32")("preserves an existing recorder file mode", async () => {
   const directory = await createTempDir();
   directories.push(directory);

--- a/test/server-recorder-filesystem.test.ts
+++ b/test/server-recorder-filesystem.test.ts
@@ -238,6 +238,7 @@ it.skipIf(process.platform === "win32")(
     const lines = (await readFile(targetPath, "utf8")).trimEnd().split("\n");
     expect(lines).toHaveLength(1);
     expect(JSON.parse(lines[0]!)).toMatchObject({ path: "/dangling" });
+    expect((await stat(targetPath)).mode & 0o777).toBe(0o600);
   },
 );
 

--- a/test/server-recorder-filesystem.test.ts
+++ b/test/server-recorder-filesystem.test.ts
@@ -88,6 +88,66 @@ it.skipIf(process.platform === "win32")(
   },
 );
 
+it.skipIf(process.platform === "win32")(
+  "preserves observer order when a recorder symlink is retargeted",
+  async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const recorderPath = path.join(directory, "server.jsonl");
+    const firstTarget = path.join(directory, "first.jsonl");
+    const secondTarget = path.join(directory, "second.jsonl");
+    await writeFile(firstTarget, "", "utf8");
+    await writeFile(secondTarget, "", "utf8");
+    await symlink(firstTarget, recorderPath, "file");
+
+    const order: string[] = [];
+    let releaseFirst: (() => void) | undefined;
+    const firstBlocked = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const first = recordServerEvent({
+      event: {
+        at: new Date().toISOString(),
+        method: "POST",
+        path: "/first",
+        query: {},
+        type: "api",
+      },
+      onEvent: async () => {
+        order.push("first:start");
+        await firstBlocked;
+        order.push("first:end");
+      },
+      recorderPath,
+    });
+    await expect.poll(() => [...order]).toEqual(["first:start"]);
+
+    await rm(recorderPath);
+    await symlink(secondTarget, recorderPath, "file");
+    const second = recordServerEvent({
+      event: {
+        at: new Date().toISOString(),
+        method: "POST",
+        path: "/second",
+        query: {},
+        type: "api",
+      },
+      onEvent: () => {
+        order.push("second");
+      },
+      recorderPath,
+    });
+    await expect
+      .poll(async () => await readFile(secondTarget, "utf8"))
+      .toContain('"path":"/second"');
+    expect(order).toEqual(["first:start"]);
+
+    releaseFirst?.();
+    await Promise.all([first, second]);
+    expect(order).toEqual(["first:start", "first:end", "second"]);
+  },
+);
+
 it.skipIf(process.platform === "win32")("preserves an existing recorder file mode", async () => {
   const directory = await createTempDir();
   directories.push(directory);

--- a/test/server-recorder-filesystem.test.ts
+++ b/test/server-recorder-filesystem.test.ts
@@ -1,5 +1,15 @@
-import { appendFile, open, readFile, rename, writeFile, type FileHandle } from "node:fs/promises";
+import {
+  appendFile,
+  open,
+  readFile,
+  rename,
+  rm,
+  symlink,
+  writeFile,
+  type FileHandle,
+} from "node:fs/promises";
 import path from "node:path";
+import { lock } from "proper-lockfile";
 import { afterEach, expect, it } from "vitest";
 import { recordServerEvent } from "../src/servers/recorder.js";
 import { createTempDir, disposeTempDir } from "./test-helpers.js";
@@ -9,6 +19,72 @@ const directories: string[] = [];
 afterEach(async () => {
   await Promise.all(directories.splice(0).map(disposeTempDir));
 });
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+it.skipIf(process.platform === "win32")(
+  "reacquires the matching lock when a recorder symlink is retargeted",
+  async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const recorderPath = path.join(directory, "server.jsonl");
+    const firstTarget = path.join(directory, "first.jsonl");
+    const secondTarget = path.join(directory, "second.jsonl");
+    await writeFile(firstTarget, "", "utf8");
+    await writeFile(secondTarget, "", "utf8");
+    await symlink(firstTarget, recorderPath, "file");
+
+    let releaseFirst: (() => Promise<void>) | undefined = await lock(firstTarget, {
+      realpath: false,
+    });
+    let releaseSecond: (() => Promise<void>) | undefined = await lock(secondTarget, {
+      realpath: false,
+    });
+    let settled = false;
+    const recording = recordServerEvent({
+      event: {
+        at: new Date().toISOString(),
+        method: "POST",
+        path: "/retargeted",
+        query: {},
+        type: "api",
+      },
+      onEvent: undefined,
+      recorderPath,
+    });
+    void recording.then(
+      () => {
+        settled = true;
+      },
+      () => {
+        settled = true;
+      },
+    );
+
+    try {
+      await delay(150);
+      await rm(recorderPath);
+      await symlink(secondTarget, recorderPath, "file");
+      await releaseFirst();
+      releaseFirst = undefined;
+
+      await delay(150);
+      expect(settled).toBe(false);
+
+      await releaseSecond();
+      releaseSecond = undefined;
+      await recording;
+    } finally {
+      await releaseFirst?.();
+      await releaseSecond?.();
+    }
+
+    expect(await readFile(firstTarget, "utf8")).toBe("");
+    expect(await readFile(secondTarget, "utf8")).toContain('"path":"/retargeted"');
+  },
+);
 
 it("never truncates a rotated inode after a later writer appends", async () => {
   const directory = await createTempDir();

--- a/test/server-recorder-filesystem.test.ts
+++ b/test/server-recorder-filesystem.test.ts
@@ -1,9 +1,11 @@
 import {
   appendFile,
+  chmod,
   open,
   readFile,
   rename,
   rm,
+  stat,
   symlink,
   writeFile,
   type FileHandle,
@@ -85,6 +87,28 @@ it.skipIf(process.platform === "win32")(
     expect(await readFile(secondTarget, "utf8")).toContain('"path":"/retargeted"');
   },
 );
+
+it.skipIf(process.platform === "win32")("preserves an existing recorder file mode", async () => {
+  const directory = await createTempDir();
+  directories.push(directory);
+  const recorderPath = path.join(directory, "server.jsonl");
+  await writeFile(recorderPath, "", "utf8");
+  await chmod(recorderPath, 0o640);
+
+  await recordServerEvent({
+    event: {
+      at: new Date().toISOString(),
+      method: "POST",
+      path: "/existing-mode",
+      query: {},
+      type: "api",
+    },
+    onEvent: undefined,
+    recorderPath,
+  });
+
+  expect((await stat(recorderPath)).mode & 0o777).toBe(0o640);
+});
 
 it("never truncates a rotated inode after a later writer appends", async () => {
   const directory = await createTempDir();

--- a/test/server-recorder.test.ts
+++ b/test/server-recorder.test.ts
@@ -775,6 +775,39 @@ describe("server recorder", () => {
     });
   });
 
+  it("exposes committed status when lock release fails after a durable append", async () => {
+    const releaseFailure = new Error("simulated lock release failure");
+    const observer = vi.fn<(event: ServerRequestEvent) => void>();
+    lockMocks.release.mockRejectedValueOnce(releaseFailure).mockResolvedValue(undefined);
+    const recorderPath = path.join(
+      "/tmp",
+      "crabline-server-recorder-committed-release-failed.jsonl",
+    );
+
+    await expect(
+      recordServerEvent({
+        event: serverEvent("/release-failed-after-commit"),
+        onEvent: observer,
+        recorderPath,
+      }),
+    ).rejects.toMatchObject({
+      cause: releaseFailure,
+      committed: true,
+      indeterminate: false,
+      name: "ServerRecorderCommittedError",
+    });
+    expect(observer).not.toHaveBeenCalled();
+
+    await expect(
+      recordServerEvent({
+        event: serverEvent("/after-release-failure"),
+        onEvent: undefined,
+        recorderPath,
+      }),
+    ).resolves.toBeUndefined();
+    expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(2);
+  });
+
   it("fills short tail reads before repairing a torn final append", async () => {
     const recorderPath = path.join("/tmp", "crabline-server-recorder-torn.jsonl");
     const completed = `${JSON.stringify(serverEvent("/completed"))}\n`;

--- a/test/server-recorder.test.ts
+++ b/test/server-recorder.test.ts
@@ -1122,6 +1122,40 @@ describe("server recorder", () => {
     expect(observer).toHaveBeenCalledWith(event);
   });
 
+  it("runs observers in durable append order", async () => {
+    const recorderPath = path.join("/tmp", "crabline-server-recorder-observer-order.jsonl");
+    const order: string[] = [];
+    let releaseFirst: (() => void) | undefined;
+    const firstBlocked = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const first = recordServerEvent({
+      event: serverEvent("/first"),
+      onEvent: async () => {
+        order.push("first:start");
+        await firstBlocked;
+        order.push("first:end");
+      },
+      recorderPath,
+    });
+    await vi.waitFor(() => expect(order).toEqual(["first:start"]));
+
+    const second = recordServerEvent({
+      event: serverEvent("/second"),
+      onEvent: () => {
+        order.push("second");
+      },
+      recorderPath,
+    });
+    await vi.waitFor(() => expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(2));
+    expect(order).toEqual(["first:start"]);
+
+    releaseFirst?.();
+    await Promise.all([first, second]);
+    expect(order).toEqual(["first:start", "first:end", "second"]);
+  });
+
   it("allows observers to append reentrantly to the same recorder", async () => {
     const recorderPath = path.join("/tmp", "crabline-server-recorder-reentrant.jsonl");
 

--- a/test/server-recorder.test.ts
+++ b/test/server-recorder.test.ts
@@ -1203,29 +1203,49 @@ describe("server recorder", () => {
     expect(order).toEqual(["first:start", "first:end", "second"]);
   });
 
-  it("allows observers to append reentrantly without overtaking the active observer", async () => {
+  it("allows observers to append reentrantly to the same recorder", async () => {
     const recorderPath = path.join("/tmp", "crabline-server-recorder-reentrant.jsonl");
-    const observations: string[] = [];
 
     await recordServerEvent({
       event: serverEvent("/outer"),
       onEvent: async () => {
-        observations.push("outer:start");
         await recordServerEvent({
           event: serverEvent("/nested"),
-          onEvent: () => {
-            observations.push("nested");
-          },
+          onEvent: undefined,
           recorderPath,
         });
-        observations.push("outer:end");
       },
       recorderPath,
     });
-    await vi.waitFor(() => expect(observations).toEqual(["outer:start", "outer:end", "nested"]));
 
     expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(2);
     expect(fsMocks.file.sync).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects nested observer registration before appending the nested event", async () => {
+    const recorderPath = path.join("/tmp", "crabline-server-recorder-nested-observer.jsonl");
+
+    await expect(
+      recordServerEvent({
+        event: serverEvent("/outer"),
+        onEvent: async () => {
+          await recordServerEvent({
+            event: serverEvent("/nested"),
+            onEvent: () => undefined,
+            recorderPath,
+          });
+        },
+        recorderPath,
+      }),
+    ).rejects.toMatchObject({
+      cause: expect.objectContaining({
+        message: "Server recorder observers cannot register nested observers.",
+      }),
+      committed: true,
+      name: "ServerRecorderCommittedError",
+    });
+
+    expect(fsMocks.file.appendFile).toHaveBeenCalledOnce();
   });
 
   it("keeps later appends available after an observer failure", async () => {

--- a/test/server-recorder.test.ts
+++ b/test/server-recorder.test.ts
@@ -1239,13 +1239,78 @@ describe("server recorder", () => {
       }),
     ).rejects.toMatchObject({
       cause: expect.objectContaining({
-        message: "Server recorder observers cannot register nested observers.",
+        message: "Server recorder observers cannot depend on an active observer.",
       }),
       committed: true,
       name: "ServerRecorderCommittedError",
     });
 
     expect(fsMocks.file.appendFile).toHaveBeenCalledOnce();
+  });
+
+  it("allows nested observers for independent recorder paths", async () => {
+    const nestedObserver = vi.fn<(event: ServerRequestEvent) => void>();
+
+    await recordServerEvent({
+      event: serverEvent("/outer"),
+      onEvent: async () => {
+        await recordServerEvent({
+          event: serverEvent("/nested"),
+          onEvent: nestedObserver,
+          recorderPath: path.join("/tmp", "crabline-server-recorder-independent-nested.jsonl"),
+        });
+      },
+      recorderPath: path.join("/tmp", "crabline-server-recorder-independent-outer.jsonl"),
+    });
+
+    expect(nestedObserver).toHaveBeenCalledWith(serverEvent("/nested"));
+    expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects cross-recorder observer dependency cycles", async () => {
+    const firstPath = path.join("/tmp", "crabline-server-recorder-cycle-first.jsonl");
+    const secondPath = path.join("/tmp", "crabline-server-recorder-cycle-second.jsonl");
+    let activeObservers = 0;
+    let releaseObservers: (() => void) | undefined;
+    const observersReady = new Promise<void>((resolve) => {
+      releaseObservers = resolve;
+    });
+    const waitForBothObservers = async () => {
+      activeObservers += 1;
+      if (activeObservers === 2) {
+        releaseObservers?.();
+      }
+      await observersReady;
+    };
+
+    const first = recordServerEvent({
+      event: serverEvent("/first"),
+      onEvent: async () => {
+        await waitForBothObservers();
+        await recordServerEvent({
+          event: serverEvent("/first-to-second"),
+          onEvent: () => undefined,
+          recorderPath: secondPath,
+        });
+      },
+      recorderPath: firstPath,
+    });
+    const second = recordServerEvent({
+      event: serverEvent("/second"),
+      onEvent: async () => {
+        await waitForBothObservers();
+        await recordServerEvent({
+          event: serverEvent("/second-to-first"),
+          onEvent: () => undefined,
+          recorderPath: firstPath,
+        });
+      },
+      recorderPath: secondPath,
+    });
+
+    const results = await Promise.allSettled([first, second]);
+    expect(results.some((result) => result.status === "rejected")).toBe(true);
+    expect(fsMocks.file.appendFile.mock.calls.length).toBeLessThanOrEqual(3);
   });
 
   it("keeps later appends available after an observer failure", async () => {

--- a/test/server-recorder.test.ts
+++ b/test/server-recorder.test.ts
@@ -502,6 +502,20 @@ describe("server recorder", () => {
     );
   });
 
+  it("snapshots events before waiting for recorder admission", async () => {
+    const event = serverEvent("/original");
+    const recording = recordServerEvent({
+      event,
+      onEvent: undefined,
+      recorderPath: path.join("/tmp", "crabline-server-recorder-snapshot.jsonl"),
+    });
+    event.path = "/mutated";
+
+    await recording;
+
+    expect(JSON.parse(fsMocks.file.appendFile.mock.calls[0]![0]).path).toBe("/original");
+  });
+
   it("recovers serialization after an append failure", async () => {
     const recorderPath = path.join("/tmp", "crabline-server-recorder-recovery.jsonl");
     const appendFailure = new Error("disk unavailable");
@@ -1189,20 +1203,26 @@ describe("server recorder", () => {
     expect(order).toEqual(["first:start", "first:end", "second"]);
   });
 
-  it("allows observers to append reentrantly to the same recorder", async () => {
+  it("allows observers to append reentrantly without overtaking the active observer", async () => {
     const recorderPath = path.join("/tmp", "crabline-server-recorder-reentrant.jsonl");
+    const observations: string[] = [];
 
     await recordServerEvent({
       event: serverEvent("/outer"),
       onEvent: async () => {
+        observations.push("outer:start");
         await recordServerEvent({
           event: serverEvent("/nested"),
-          onEvent: undefined,
+          onEvent: () => {
+            observations.push("nested");
+          },
           recorderPath,
         });
+        observations.push("outer:end");
       },
       recorderPath,
     });
+    await vi.waitFor(() => expect(observations).toEqual(["outer:start", "outer:end", "nested"]));
 
     expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(2);
     expect(fsMocks.file.sync).toHaveBeenCalledTimes(2);

--- a/test/server-recorder.test.ts
+++ b/test/server-recorder.test.ts
@@ -445,7 +445,7 @@ describe("server recorder", () => {
     expect(lockMocks.release).toHaveBeenCalledOnce();
   });
 
-  it("repairs managed recorder directories without chmodding caller-owned parents", async () => {
+  it("repairs managed directories without chmodding existing recorder files or parents", async () => {
     const callerOwnedPath = path.join("/tmp", "events.jsonl");
     await recordServerEvent({
       event: serverEvent("/caller-owned"),
@@ -453,7 +453,7 @@ describe("server recorder", () => {
       recorderPath: callerOwnedPath,
     });
     expect(fsMocks.chmod).not.toHaveBeenCalled();
-    expect(fsMocks.file.chmod).toHaveBeenCalledWith(0o600);
+    expect(fsMocks.file.chmod).not.toHaveBeenCalled();
 
     const managedPath = path.resolve(".crabline", "servers", "events.jsonl");
     await recordServerEvent({

--- a/test/server-recorder.test.ts
+++ b/test/server-recorder.test.ts
@@ -1239,7 +1239,7 @@ describe("server recorder", () => {
       }),
     ).rejects.toMatchObject({
       cause: expect.objectContaining({
-        message: "Server recorder observers cannot depend on an active observer.",
+        message: "Server recorder observer dependency cycle detected.",
       }),
       committed: true,
       name: "ServerRecorderCommittedError",
@@ -1265,6 +1265,47 @@ describe("server recorder", () => {
 
     expect(nestedObserver).toHaveBeenCalledWith(serverEvent("/nested"));
     expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(2);
+  });
+
+  it("allows acyclic waits on an active observer for another recorder", async () => {
+    const firstPath = path.join("/tmp", "crabline-server-recorder-active-independent.jsonl");
+    const secondPath = path.join("/tmp", "crabline-server-recorder-waiting-independent.jsonl");
+    const nestedObserver = vi.fn<(event: ServerRequestEvent) => void>();
+    let reportFirstActive!: () => void;
+    let releaseFirst!: () => void;
+    const firstActive = new Promise<void>((resolve) => {
+      reportFirstActive = resolve;
+    });
+    const firstBlocked = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const first = recordServerEvent({
+      event: serverEvent("/first"),
+      onEvent: async () => {
+        reportFirstActive();
+        await firstBlocked;
+      },
+      recorderPath: firstPath,
+    });
+    await firstActive;
+
+    const second = recordServerEvent({
+      event: serverEvent("/second"),
+      onEvent: async () => {
+        await recordServerEvent({
+          event: serverEvent("/nested-on-first"),
+          onEvent: nestedObserver,
+          recorderPath: firstPath,
+        });
+      },
+      recorderPath: secondPath,
+    });
+    await vi.waitFor(() => expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(3));
+    expect(nestedObserver).not.toHaveBeenCalled();
+
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(nestedObserver).toHaveBeenCalledWith(serverEvent("/nested-on-first"));
   });
 
   it("rejects cross-recorder observer dependency cycles", async () => {

--- a/test/server-recorder.test.ts
+++ b/test/server-recorder.test.ts
@@ -1440,4 +1440,18 @@ describe("server recorder", () => {
       }),
     ).resolves.toBeUndefined();
   });
+
+  it("does not surface serialization failure after a committed mutation", async () => {
+    const event = serverEvent("/committed-cycle");
+    (event.query as Record<string, unknown>).cycle = event;
+
+    await expect(
+      recordCommittedServerEvent({
+        event,
+        onEvent: undefined,
+        recorderPath: path.join("/tmp", "crabline-server-recorder-committed-cycle.jsonl"),
+      }),
+    ).resolves.toBeUndefined();
+    expect(fsMocks.file.appendFile).not.toHaveBeenCalled();
+  });
 });

--- a/test/server-recorder.test.ts
+++ b/test/server-recorder.test.ts
@@ -504,9 +504,10 @@ describe("server recorder", () => {
 
   it("snapshots events before waiting for recorder admission", async () => {
     const event = serverEvent("/original");
+    const observer = vi.fn<(event: ServerRequestEvent) => void>();
     const recording = recordServerEvent({
       event,
-      onEvent: undefined,
+      onEvent: observer,
       recorderPath: path.join("/tmp", "crabline-server-recorder-snapshot.jsonl"),
     });
     event.path = "/mutated";
@@ -514,6 +515,7 @@ describe("server recorder", () => {
     await recording;
 
     expect(JSON.parse(fsMocks.file.appendFile.mock.calls[0]![0]).path).toBe("/original");
+    expect(observer).toHaveBeenCalledWith(serverEvent("/original"));
   });
 
   it("recovers serialization after an append failure", async () => {
@@ -1169,7 +1171,7 @@ describe("server recorder", () => {
     expect(observer).toHaveBeenCalledWith(event);
   });
 
-  it("runs observers in durable append order", async () => {
+  it("starts observers in durable append order without waiting for completion", async () => {
     const recorderPath = path.join("/tmp", "crabline-server-recorder-observer-order.jsonl");
     const order: string[] = [];
     let releaseFirst: (() => void) | undefined;
@@ -1196,11 +1198,39 @@ describe("server recorder", () => {
       recorderPath,
     });
     await vi.waitFor(() => expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(2));
-    expect(order).toEqual(["first:start"]);
+    await vi.waitFor(() => expect(order).toEqual(["first:start", "second"]));
 
     releaseFirst?.();
     await Promise.all([first, second]);
-    expect(order).toEqual(["first:start", "first:end", "second"]);
+    expect(order).toEqual(["first:start", "second", "first:end"]);
+  });
+
+  it("does not deadlock when an observer waits for a later externally registered event", async () => {
+    const recorderPath = path.join("/tmp", "crabline-server-recorder-external-wait.jsonl");
+    let allowFirstToWait!: () => void;
+    const secondRegistered = new Promise<void>((resolve) => {
+      allowFirstToWait = resolve;
+    });
+    let second!: Promise<void>;
+    const first = recordServerEvent({
+      event: serverEvent("/first"),
+      onEvent: async () => {
+        await secondRegistered;
+        await second;
+      },
+      recorderPath,
+    });
+    await vi.waitFor(() => expect(fsMocks.file.appendFile).toHaveBeenCalledOnce());
+
+    second = recordServerEvent({
+      event: serverEvent("/second"),
+      onEvent: () => undefined,
+      recorderPath,
+    });
+    allowFirstToWait();
+
+    await expect(Promise.all([first, second])).resolves.toEqual([undefined, undefined]);
+    expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(2);
   });
 
   it("allows observers to append reentrantly to the same recorder", async () => {
@@ -1222,30 +1252,24 @@ describe("server recorder", () => {
     expect(fsMocks.file.sync).toHaveBeenCalledTimes(2);
   });
 
-  it("rejects nested observer registration before appending the nested event", async () => {
+  it("allows nested observer registration on the same recorder", async () => {
     const recorderPath = path.join("/tmp", "crabline-server-recorder-nested-observer.jsonl");
+    const nestedObserver = vi.fn<(event: ServerRequestEvent) => void>();
 
-    await expect(
-      recordServerEvent({
-        event: serverEvent("/outer"),
-        onEvent: async () => {
-          await recordServerEvent({
-            event: serverEvent("/nested"),
-            onEvent: () => undefined,
-            recorderPath,
-          });
-        },
-        recorderPath,
-      }),
-    ).rejects.toMatchObject({
-      cause: expect.objectContaining({
-        message: "Server recorder observer dependency cycle detected.",
-      }),
-      committed: true,
-      name: "ServerRecorderCommittedError",
+    await recordServerEvent({
+      event: serverEvent("/outer"),
+      onEvent: async () => {
+        await recordServerEvent({
+          event: serverEvent("/nested"),
+          onEvent: nestedObserver,
+          recorderPath,
+        });
+      },
+      recorderPath,
     });
 
-    expect(fsMocks.file.appendFile).toHaveBeenCalledOnce();
+    expect(nestedObserver).toHaveBeenCalledWith(serverEvent("/nested"));
+    expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(2);
   });
 
   it("allows nested observers for independent recorder paths", async () => {
@@ -1267,7 +1291,7 @@ describe("server recorder", () => {
     expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(2);
   });
 
-  it("allows acyclic waits on an active observer for another recorder", async () => {
+  it("starts nested observers after prior invocation without waiting for completion", async () => {
     const firstPath = path.join("/tmp", "crabline-server-recorder-active-independent.jsonl");
     const secondPath = path.join("/tmp", "crabline-server-recorder-waiting-independent.jsonl");
     const nestedObserver = vi.fn<(event: ServerRequestEvent) => void>();
@@ -1301,14 +1325,15 @@ describe("server recorder", () => {
       recorderPath: secondPath,
     });
     await vi.waitFor(() => expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(3));
-    expect(nestedObserver).not.toHaveBeenCalled();
+    await vi.waitFor(() =>
+      expect(nestedObserver).toHaveBeenCalledWith(serverEvent("/nested-on-first")),
+    );
 
     releaseFirst();
     await Promise.all([first, second]);
-    expect(nestedObserver).toHaveBeenCalledWith(serverEvent("/nested-on-first"));
   });
 
-  it("rejects cross-recorder observer dependency cycles", async () => {
+  it("allows active observers to append across recorder paths without deadlocking", async () => {
     const firstPath = path.join("/tmp", "crabline-server-recorder-cycle-first.jsonl");
     const secondPath = path.join("/tmp", "crabline-server-recorder-cycle-second.jsonl");
     let activeObservers = 0;
@@ -1349,9 +1374,8 @@ describe("server recorder", () => {
       recorderPath: secondPath,
     });
 
-    const results = await Promise.allSettled([first, second]);
-    expect(results.some((result) => result.status === "rejected")).toBe(true);
-    expect(fsMocks.file.appendFile.mock.calls.length).toBeLessThanOrEqual(3);
+    await expect(Promise.all([first, second])).resolves.toEqual([undefined, undefined]);
+    expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(4);
   });
 
   it("keeps later appends available after an observer failure", async () => {

--- a/test/server-recorder.test.ts
+++ b/test/server-recorder.test.ts
@@ -143,6 +143,15 @@ function serverEvent(pathname: string): ServerRequestEvent {
   };
 }
 
+function directoryAncestryCount(directory: string): number {
+  let count = 1;
+  while (path.dirname(directory) !== directory) {
+    count += 1;
+    directory = path.dirname(directory);
+  }
+  return count;
+}
+
 beforeEach(() => {
   lockMocks.release.mockReset();
   lockMocks.release.mockResolvedValue();
@@ -190,8 +199,11 @@ describe("server recorder", () => {
     const firstParent = path.join("/tmp", "private");
     const finalParent = path.join(firstParent, "nested");
     const recorderPath = path.join(finalParent, "events.jsonl");
+    const canonicalFirstParent = path.join(await realpath("/tmp"), "private");
+    const canonicalFinalParent = path.join(canonicalFirstParent, "nested");
+    const canonicalRecorderPath = path.join(canonicalFinalParent, "events.jsonl");
     const observer = vi.fn<(event: ServerRequestEvent) => void>();
-    fsMocks.mkdir.mockResolvedValueOnce(firstParent);
+    fsMocks.mkdir.mockResolvedValueOnce(canonicalFirstParent);
     fsMocks.open.mockImplementation(async (_filePath, flags) =>
       flags === "r" ? fsMocks.directory : fsMocks.file,
     );
@@ -201,16 +213,16 @@ describe("server recorder", () => {
       recorderPath,
     });
 
-    expect(fsMocks.mkdir).toHaveBeenCalledWith(finalParent, {
+    expect(fsMocks.mkdir).toHaveBeenCalledWith(canonicalFinalParent, {
       mode: 0o700,
       recursive: true,
     });
-    expect(fsMocks.chmod).toHaveBeenCalledWith(finalParent, 0o700);
+    expect(fsMocks.chmod).toHaveBeenCalledWith(canonicalFinalParent, 0o700);
     expect(fsMocks.open.mock.calls).toEqual([
-      [recorderPath, "ax+", 0o600],
-      [finalParent, "r"],
-      [firstParent, "r"],
-      [path.dirname(firstParent), "r"],
+      [canonicalRecorderPath, "ax+", 0o600],
+      [canonicalFinalParent, "r"],
+      [canonicalFirstParent, "r"],
+      [path.dirname(canonicalFirstParent), "r"],
     ]);
     expect(fsMocks.file.chmod).toHaveBeenCalledWith(0o600);
     expect(fsMocks.file.appendFile).toHaveBeenCalledWith(expect.any(String), {
@@ -224,15 +236,12 @@ describe("server recorder", () => {
     expect(fsMocks.directory.sync.mock.invocationCallOrder.at(-1)).toBeLessThan(
       observer.mock.invocationCallOrder[0]!,
     );
-    expect(lockMocks.lock).toHaveBeenCalledWith(
-      path.join(await realpath("/tmp"), "private/nested/events.jsonl"),
-      {
-        realpath: false,
-        retries: 0,
-        stale: 30_000,
-        update: 10_000,
-      },
-    );
+    expect(lockMocks.lock).toHaveBeenCalledWith(canonicalRecorderPath, {
+      realpath: false,
+      retries: 0,
+      stale: 30_000,
+      update: 10_000,
+    });
     expect(lockMocks.release).toHaveBeenCalledOnce();
     expect(fsMocks.file.chmod.mock.invocationCallOrder[0]).toBeLessThan(
       fsMocks.file.appendFile.mock.invocationCallOrder[0]!,
@@ -245,16 +254,18 @@ describe("server recorder", () => {
     const firstParent = path.join("/tmp", "retry-private");
     const finalParent = path.join(firstParent, "nested");
     const recorderPath = path.join(finalParent, "events.jsonl");
+    const canonicalRoot = await realpath("/tmp");
+    const canonicalFirstParent = path.join(canonicalRoot, "retry-private");
     const ancestrySyncFailure = new Error("simulated recorder ancestry sync interruption");
     const observer = vi.fn<(event: ServerRequestEvent) => void>();
     let recorderExists = false;
-    fsMocks.mkdir.mockResolvedValueOnce(firstParent).mockResolvedValueOnce(undefined);
+    fsMocks.mkdir.mockResolvedValueOnce(canonicalFirstParent).mockResolvedValueOnce(undefined);
     fsMocks.file.stat.mockResolvedValue({ dev: 42, ino: 84, size: 0 });
     fsMocks.stat.mockResolvedValue({ dev: 42, ino: 84, size: 0 });
     fsMocks.directory.sync.mockRejectedValueOnce(ancestrySyncFailure).mockResolvedValue(undefined);
     fsMocks.open.mockImplementation(async (openedPath, flags) => {
       if (flags === "r") {
-        if (openedPath === path.dirname(firstParent)) {
+        if (openedPath === canonicalRoot) {
           throw Object.assign(new Error("execute-only ancestor"), { code: "EACCES" });
         }
         return fsMocks.directory;
@@ -303,6 +314,8 @@ describe("server recorder", () => {
   it("fails an immediate parent sync without caching durability or notifying observers", async () => {
     const finalParent = path.join("/tmp", "recorder-immediate-denied");
     const recorderPath = path.join(finalParent, "events.jsonl");
+    const canonicalRoot = await realpath("/tmp");
+    const canonicalFinalParent = path.join(canonicalRoot, "recorder-immediate-denied");
     const syncFailure = Object.assign(new Error("recorder parent denied"), { code: "EACCES" });
     const observer = vi.fn<(event: ServerRequestEvent) => void>();
     let immediateAttempts = 0;
@@ -313,10 +326,10 @@ describe("server recorder", () => {
         throw Object.assign(new Error("Recorder already exists"), { code: "EEXIST" });
       }
       if (flags === "r") {
-        if (openedPath === finalParent && immediateAttempts++ === 0) {
+        if (openedPath === canonicalFinalParent && immediateAttempts++ === 0) {
           throw syncFailure;
         }
-        if (openedPath === path.dirname(finalParent)) {
+        if (openedPath === canonicalRoot) {
           throw Object.assign(new Error("execute-only ancestor"), { code: "EACCES" });
         }
         return fsMocks.directory;
@@ -356,13 +369,15 @@ describe("server recorder", () => {
     const firstParent = path.join("/tmp", "recorder-created-denied");
     const finalParent = path.join(firstParent, "nested");
     const recorderPath = path.join(finalParent, "events.jsonl");
+    const canonicalRoot = await realpath("/tmp");
+    const canonicalFirstParent = path.join(canonicalRoot, "recorder-created-denied");
     const syncFailure = Object.assign(new Error("created recorder ancestry denied"), {
       code: "EPERM",
     });
     const observer = vi.fn<(event: ServerRequestEvent) => void>();
     let recorderExists = false;
     let denyCreatedBoundary = true;
-    fsMocks.mkdir.mockResolvedValueOnce(firstParent).mockResolvedValueOnce(undefined);
+    fsMocks.mkdir.mockResolvedValueOnce(canonicalFirstParent).mockResolvedValueOnce(undefined);
     fsMocks.file.stat.mockResolvedValue({ dev: 71, ino: 72, size: 0 });
     fsMocks.stat.mockResolvedValue({ dev: 71, ino: 72, size: 0 });
     fsMocks.open.mockImplementation(async (openedPath, flags) => {
@@ -374,7 +389,7 @@ describe("server recorder", () => {
         return fsMocks.file;
       }
       if (flags === "r") {
-        if (openedPath === path.dirname(firstParent)) {
+        if (openedPath === canonicalRoot) {
           if (denyCreatedBoundary) {
             denyCreatedBoundary = false;
             throw syncFailure;
@@ -653,7 +668,9 @@ describe("server recorder", () => {
     expect(fsMocks.file.appendFile).toHaveBeenCalledOnce();
     expect(fsMocks.file.truncate).not.toHaveBeenCalled();
     expect(fsMocks.file.sync).toHaveBeenCalledOnce();
-    expect(fsMocks.directory.sync).toHaveBeenCalledTimes(2);
+    expect(fsMocks.directory.sync).toHaveBeenCalledTimes(
+      directoryAncestryCount(await realpath("/tmp")),
+    );
     expect(fsMocks.file.close).toHaveBeenCalledOnce();
   });
 


### PR DESCRIPTION
## Summary

- confine recorder publication and locking to canonical paths across symlink retargets
- preserve existing file modes and classify committed unlock failures
- serialize durable appends while starting observers in append order without waiting for prior async completion
- snapshot observer payloads from the exact JSON persisted to disk
- keep committed-event serialization failures inside the telemetry boundary
- add filesystem, concurrency, reentrancy, external-wait, and dangling-symlink mode coverage
- add an Unreleased changelog entry

## Verification

- recorder filesystem/unit and Zalo suites: 73 tests
- `pnpm lint`
- privacy scan clean
- Crabbox Linux `pnpm verify`: `run_48ee58b201d8` (60 files, 1,189 tests)
- GitHub Actions `CI/verify` on `bcfdabee6676a8e43f541769e434729b84f34f9d`
- gpt-5.6-sol high autoreview: clean, confidence 0.87

## Audit context

Remediates confirmed server-recorder path, durability, observer-ordering, mutable-event, and committed-boundary findings from the final14 Clawpatch audit.