### PR TITLE
fix(cli): remove credentials from argv ingress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Round-trip every supported WhatsApp handshake protobuf variant without dropping fields.
 - Reject unsupported Zalo thread targets during normalization, matching OpenClaw bridge execution.
 - Enforce Discord uint64 snowflakes and Telegram safe-integer chat and topic identifiers.
+- Reject credential-bearing CLI arguments and add bounded stdin or inherited-fd ingress for `serve` secrets.
 - Bound shared JSON ingress, reject non-object payloads precisely, and strictly normalize loopback IP addresses.
 - Commit Signal sends only after recorder publication, emit canonical native source numbers, and canonicalize OpenClaw outbound recipient identity.
 - Harden WhatsApp send evidence, direct-JID correlation, cursor and cleanup races, and cleartext listener exposure.

--- a/README.md
+++ b/README.md
@@ -152,18 +152,25 @@ replace `crabline` with `pnpm dev`.
 
 `serve` never accepts credential values in command-line arguments. Set
 `CRABLINE_ACCESS_TOKEN`, `CRABLINE_ADMIN_TOKEN`, `CRABLINE_BOT_TOKEN`, or
-`CRABLINE_SIGNING_SECRET`, or pass a bounded JSON object through stdin or an
-inherited file descriptor:
+`CRABLINE_SIGNING_SECRET`, or pass a bounded JSON object through a file
+descriptor. Package runners should use stdin:
 
 ```bash
-crabline --json serve slack --credentials-fd 0 < .crabline/serve-credentials.json
+pnpm dev --json serve slack --credentials-fd 0 < .crabline/serve-credentials.json
+```
+
+The installed CLI can also use an inherited descriptor when its launcher
+preserves descriptors above 2:
+
+```bash
 crabline --json serve slack --credentials-fd 3 3< .crabline/serve-credentials.json
 ```
 
 The JSON fields are `accessToken`, `adminToken`, `botToken`, and
-`signingSecret`. File-descriptor values override environment fallbacks. Keep
-credential files owner-readable or pipe the JSON directly from a secret
-manager.
+`signingSecret`. File-descriptor values override environment fallbacks. Do not
+pass descriptors above 2 through package runners such as `pnpm`; use fd 0
+instead. Keep credential files owner-readable or pipe the JSON directly from a
+secret manager.
 
 Library callers can pass `onEvent` to `startCrablineServer`, an individual
 provider server, or `startOpenClawCrablineAdapter`. Crabline awaits the callback

--- a/README.md
+++ b/README.md
@@ -150,6 +150,21 @@ but the provider endpoint is local and deterministic.
 Commands in this section use the installed-package form. In a source checkout,
 replace `crabline` with `pnpm dev`.
 
+`serve` never accepts credential values in command-line arguments. Set
+`CRABLINE_ACCESS_TOKEN`, `CRABLINE_ADMIN_TOKEN`, `CRABLINE_BOT_TOKEN`, or
+`CRABLINE_SIGNING_SECRET`, or pass a bounded JSON object through stdin or an
+inherited file descriptor:
+
+```bash
+crabline --json serve slack --credentials-fd 0 < .crabline/serve-credentials.json
+crabline --json serve slack --credentials-fd 3 3< .crabline/serve-credentials.json
+```
+
+The JSON fields are `accessToken`, `adminToken`, `botToken`, and
+`signingSecret`. File-descriptor values override environment fallbacks. Keep
+credential files owner-readable or pipe the JSON directly from a secret
+manager.
+
 Library callers can pass `onEvent` to `startCrablineServer`, an individual
 provider server, or `startOpenClawCrablineAdapter`. Crabline awaits the callback
 after appending each API/admin event to `recorderPath`, so callers can react in
@@ -223,8 +238,8 @@ The JSON manifest contains:
 - `endpoints.eventsUrl`: local Slack Events API endpoint
 - `recorderPath`: JSONL file of local provider API/admin traffic
 
-The admin token is generated randomly unless `--admin-token <token>` is
-provided. Implemented Slack Web API endpoints include `auth.test`,
+The admin token is generated randomly unless `adminToken` is supplied through
+the credential ingress above. Implemented Slack Web API endpoints include `auth.test`,
 `chat.postMessage`, `conversations.open`, `conversations.info`,
 `conversations.history`, and `conversations.replies`.
 
@@ -266,9 +281,9 @@ The JSON manifest contains:
   messages; OpenClaw reads them through Telegram `getUpdates`
 - `recorderPath`: JSONL file of local provider API/admin traffic
 
-The admin token is generated randomly unless `--admin-token <token>` is
-provided. The inbound endpoint rejects requests without the matching admin
-header (or `Authorization: Bearer <token>`).
+The admin token is generated randomly unless `adminToken` is supplied through
+the credential ingress above. The inbound endpoint rejects requests without
+the matching admin header (or `Authorization: Bearer <token>`).
 
 Implemented Telegram Bot API endpoints include `getMe`, `sendMessage`,
 `sendPhoto`, `sendDocument`, `sendVideo`, `sendAudio`, `sendAnimation`, `editMessageText`,
@@ -319,7 +334,8 @@ Group outbound uses sender-key `skmsg` encryption and is outside this supported
 subset, so OpenClaw Crabline outbound targets are direct users only. Group
 inbound injection remains supported. The WebSocket endpoint rejects clients
 that do not present the access token embedded in the manifest URL. The admin
-token is generated randomly unless `--admin-token <token>` is provided.
+token is generated randomly unless `adminToken` is supplied through the
+credential ingress above.
 
 OpenClaw bridge callers should post injected user messages with the
 `providerUrl`, `providerHeaders`, and `providerBody` returned by

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -203,17 +203,25 @@ replace `crabline` with `pnpm dev`; `pnpm exec crabline` is not available.
 shell history are not secret-safe. Use the `CRABLINE_ADMIN_TOKEN`,
 `CRABLINE_ACCESS_TOKEN`, `CRABLINE_BOT_TOKEN`, and
 `CRABLINE_SIGNING_SECRET` environment fallbacks, or pass a JSON object through
-stdin or an inherited file descriptor:
+a file descriptor. Package runners should use stdin:
 
 ```bash
-crabline --json serve slack --credentials-fd 0 < .crabline/serve-credentials.json
+pnpm dev --json serve slack --credentials-fd 0 < .crabline/serve-credentials.json
+```
+
+The installed CLI can also use an inherited descriptor when its launcher
+preserves descriptors above 2:
+
+```bash
 crabline --json serve slack --credentials-fd 3 3< .crabline/serve-credentials.json
 ```
 
 The accepted JSON fields are `adminToken`, `accessToken`, `botToken`, and
 `signingSecret`. The input is bounded to 64 KiB, must contain only string
-values, and overrides environment fallbacks field by field. Keep credential
-files owner-readable or pipe the JSON directly from a secret manager.
+values, and overrides environment fallbacks field by field. Do not pass
+descriptors above 2 through package runners such as `pnpm`; use fd 0 instead.
+Keep credential files owner-readable or pipe the JSON directly from a secret
+manager.
 
 ### Mattermost
 

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -192,17 +192,28 @@ watch commands are terminated when cancellation fires.
 Server-backed channels currently include Mattermost, Matrix, Signal, Slack,
 Telegram, WhatsApp, and Zalo. Loopback binds retain stable local credentials for
 fixture compatibility. Non-loopback binds generate fresh provider-shaped
-credentials unless the corresponding token or secret option is supplied.
+credentials unless the corresponding credential is supplied.
 WhatsApp is loopback-only because its HTTP and WebSocket endpoints carry bearer
 credentials over cleartext and the built-in server does not terminate TLS.
 
 Commands in this section use the installed-package form. In a source checkout,
 replace `crabline` with `pnpm dev`; `pnpm exec crabline` is not available.
 
-Serve credential flags take precedence over their optional environment
-fallbacks: `--admin-token` over `CRABLINE_ADMIN_TOKEN`, `--access-token` over
-`CRABLINE_ACCESS_TOKEN`, `--bot-token` over `CRABLINE_BOT_TOKEN`, and
-`--signing-secret` over `CRABLINE_SIGNING_SECRET`.
+`serve` rejects credential values in command-line arguments because argv and
+shell history are not secret-safe. Use the `CRABLINE_ADMIN_TOKEN`,
+`CRABLINE_ACCESS_TOKEN`, `CRABLINE_BOT_TOKEN`, and
+`CRABLINE_SIGNING_SECRET` environment fallbacks, or pass a JSON object through
+stdin or an inherited file descriptor:
+
+```bash
+crabline --json serve slack --credentials-fd 0 < .crabline/serve-credentials.json
+crabline --json serve slack --credentials-fd 3 3< .crabline/serve-credentials.json
+```
+
+The accepted JSON fields are `adminToken`, `accessToken`, `botToken`, and
+`signingSecret`. The input is bounded to 64 KiB, must contain only string
+values, and overrides environment fallbacks field by field. Keep credential
+files owner-readable or pipe the JSON directly from a secret manager.
 
 ### Mattermost
 
@@ -343,8 +354,9 @@ Manifest fields:
 - `endpoints.adminInboundUrl`: authenticated admin ingress for test user messages
 - `recorderPath`: JSONL provider traffic recorder
 
-The admin token is generated randomly unless `--admin-token <token>` is
-provided. Requests may also use `Authorization: Bearer <token>`.
+The admin token is generated randomly unless `adminToken` is supplied through
+the credential ingress above. Requests may also use
+`Authorization: Bearer <token>`.
 
 The admin ingress accepts JSON like:
 
@@ -410,7 +422,8 @@ Group outbound uses sender-key `skmsg` encryption and is outside this supported
 subset, so OpenClaw Crabline outbound targets are direct users only. Group
 inbound injection remains supported. The WebSocket endpoint rejects clients
 that do not present the access token embedded in the manifest URL. The admin
-token is generated randomly unless `--admin-token <token>` is provided.
+token is generated randomly unless `adminToken` is supplied through the
+credential ingress above.
 
 OpenClaw bridge callers should post injected user messages with the
 `providerUrl`, `providerHeaders`, and `providerBody` returned by

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -1,6 +1,6 @@
-import { Command, CommanderError } from "commander";
+import { Command, CommanderError, Option } from "commander";
 import { randomUUID } from "node:crypto";
-import { constants as fsConstants } from "node:fs";
+import { constants as fsConstants, createReadStream } from "node:fs";
 import fs from "node:fs/promises";
 import nodePath from "node:path";
 import { lock } from "proper-lockfile";
@@ -62,6 +62,7 @@ type ServeCommandOptions = {
   adminToken?: string | undefined;
   botToken?: string | undefined;
   botUsername?: string | undefined;
+  credentialsFd?: string | undefined;
   host: string;
   once?: boolean | undefined;
   port: string;
@@ -79,6 +80,17 @@ type ServeParamFactory = (
 
 const READY_FILE_LEASE_STALE_MS = 60_000;
 const READY_FILE_LEASE_UPDATE_MS = 1_000;
+const MAX_SERVE_CREDENTIALS_BYTES = 64 * 1024;
+
+const SERVE_CREDENTIAL_ENV = [
+  ["accessToken", "CRABLINE_ACCESS_TOKEN"],
+  ["adminToken", "CRABLINE_ADMIN_TOKEN"],
+  ["botToken", "CRABLINE_BOT_TOKEN"],
+  ["signingSecret", "CRABLINE_SIGNING_SECRET"],
+] as const;
+
+type ServeCredentialName = (typeof SERVE_CREDENTIAL_ENV)[number][0];
+type ServeCredentials = Partial<Record<ServeCredentialName, string>>;
 
 const SERVE_PARAM_FACTORIES = {
   mattermost: (shared, commandOptions) => ({
@@ -200,6 +212,108 @@ async function withManifest<T>(
   action: (context: Awaited<ReturnType<typeof loadManifest>>) => Promise<T>,
 ): Promise<T> {
   return action(await loadManifest(options.config));
+}
+
+function rejectedSecretOption(flags: string, optionName: string, envName: string): Option {
+  return new Option(flags).hideHelp().argParser(() => {
+    throw new CrablineError(
+      `${optionName} no longer accepts credential values in command-line arguments. Use ${envName} or --credentials-fd.`,
+      { kind: "config" },
+    );
+  });
+}
+
+function parseCredentialsFd(value: string): number {
+  if (!/^[0-9]+$/u.test(value)) {
+    throw new CrablineError(
+      "Serve credentials file descriptor must be 0 or an integer greater than 2.",
+      { kind: "config" },
+    );
+  }
+  const fd = Number(value);
+  if (!Number.isSafeInteger(fd) || fd === 1 || fd === 2 || fd > 2_147_483_647) {
+    throw new CrablineError(
+      "Serve credentials file descriptor must be 0 or an integer greater than 2.",
+      { kind: "config" },
+    );
+  }
+  return fd;
+}
+
+async function readBoundedFileDescriptor(fd: number): Promise<string> {
+  const stream = createReadStream("", { autoClose: false, fd });
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+  try {
+    for await (const chunk of stream) {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      totalBytes += buffer.byteLength;
+      if (totalBytes > MAX_SERVE_CREDENTIALS_BYTES) {
+        throw new CrablineError(
+          `Serve credentials JSON exceeds ${MAX_SERVE_CREDENTIALS_BYTES} bytes.`,
+          { kind: "config" },
+        );
+      }
+      chunks.push(buffer);
+    }
+  } catch (error) {
+    stream.destroy();
+    if (error instanceof CrablineError) {
+      throw error;
+    }
+    throw new CrablineError(`Unable to read serve credentials from file descriptor ${fd}.`, {
+      cause: error,
+      kind: "config",
+    });
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+function parseServeCredentialsJson(input: string): ServeCredentials {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(input);
+  } catch (error) {
+    throw new CrablineError("Serve credentials input must be valid JSON.", {
+      cause: error,
+      kind: "config",
+    });
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new CrablineError("Serve credentials JSON must be an object.", { kind: "config" });
+  }
+
+  const values: ServeCredentials = {};
+  for (const [key, value] of Object.entries(parsed)) {
+    if (!SERVE_CREDENTIAL_ENV.some(([name]) => name === key)) {
+      throw new CrablineError("Serve credentials JSON contains unsupported fields.", {
+        kind: "config",
+      });
+    }
+    if (typeof value !== "string") {
+      throw new CrablineError("Serve credentials JSON values must be strings.", {
+        kind: "config",
+      });
+    }
+    values[key as ServeCredentialName] = value;
+  }
+  return values;
+}
+
+async function resolveServeCredentials(credentialsFd?: string): Promise<ServeCredentials> {
+  const overrides =
+    credentialsFd === undefined
+      ? {}
+      : parseServeCredentialsJson(
+          await readBoundedFileDescriptor(parseCredentialsFd(credentialsFd)),
+        );
+  return Object.fromEntries(
+    SERVE_CREDENTIAL_ENV.flatMap(([name, envName]) => {
+      const override = overrides[name];
+      const value = override ?? process.env[envName];
+      return value === undefined ? [] : [[name, value]];
+    }),
+  ) as ServeCredentials;
 }
 
 export function createProgram(
@@ -418,27 +532,44 @@ export function createProgram(
     .description("Start a local provider server that OpenClaw live adapters can target")
     .option("--host <host>", "Bind host", "127.0.0.1")
     .option("--port <port>", "Bind port", "0")
-    .option(
-      "--admin-token <token>",
-      "Admin token for inbound test messages (or CRABLINE_ADMIN_TOKEN)",
-    )
     .option("--account <number>", "Signal account number")
-    .option("--access-token <token>", "Matrix or WhatsApp access token (or CRABLINE_ACCESS_TOKEN)")
-    .option(
-      "--bot-token <token>",
-      "Mattermost, Slack, Telegram, or Zalo bot token (or CRABLINE_BOT_TOKEN)",
-    )
     .option(
       "--bot-username <username>",
       "Mattermost, Telegram, or Zalo bot username",
       "crabline_bot",
     )
+    .option(
+      "--credentials-fd <fd>",
+      "Read JSON credentials from fd 0 or an inherited fd; values override CRABLINE_* env",
+    )
     .option("--recorder <path>", "JSONL recorder path")
     .option("--ready-file <path>", "Write the server runtime manifest to this path")
     .option("--self-jid <jid>", "WhatsApp self JID")
     .option("--show-secrets", "Print provider credentials in text output", false)
-    .option("--signing-secret <secret>", "Slack signing secret (or CRABLINE_SIGNING_SECRET)")
     .option("--once", "Start, print the runtime manifest, and stop immediately", false)
+    .addOption(
+      rejectedSecretOption("--access-token <token>", "--access-token", "CRABLINE_ACCESS_TOKEN"),
+    )
+    .addOption(
+      rejectedSecretOption("--admin-token <token>", "--admin-token", "CRABLINE_ADMIN_TOKEN"),
+    )
+    .addOption(rejectedSecretOption("--bot-token <token>", "--bot-token", "CRABLINE_BOT_TOKEN"))
+    .addOption(
+      rejectedSecretOption(
+        "--signing-secret <secret>",
+        "--signing-secret",
+        "CRABLINE_SIGNING_SECRET",
+      ),
+    )
+    .addHelpText(
+      "after",
+      [
+        "",
+        "Credential JSON fields: accessToken, adminToken, botToken, signingSecret",
+        "Environment fallbacks: CRABLINE_ACCESS_TOKEN, CRABLINE_ADMIN_TOKEN,",
+        "  CRABLINE_BOT_TOKEN, CRABLINE_SIGNING_SECRET",
+      ].join("\n"),
+    )
     .action(async (provider, commandOptions: ServeCommandOptions) => {
       const options = program.opts() as GlobalOptions;
       if (!isCrablineServerChannel(provider)) {
@@ -446,10 +577,11 @@ export function createProgram(
           kind: "config",
         });
       }
-      commandOptions.accessToken ??= process.env.CRABLINE_ACCESS_TOKEN;
-      commandOptions.adminToken ??= process.env.CRABLINE_ADMIN_TOKEN;
-      commandOptions.botToken ??= process.env.CRABLINE_BOT_TOKEN;
-      commandOptions.signingSecret ??= process.env.CRABLINE_SIGNING_SECRET;
+      const credentials = await resolveServeCredentials(commandOptions.credentialsFd);
+      commandOptions.accessToken = credentials.accessToken;
+      commandOptions.adminToken = credentials.adminToken;
+      commandOptions.botToken = credentials.botToken;
+      commandOptions.signingSecret = credentials.signingSecret;
       if (!/^[0-9]+$/u.test(commandOptions.port)) {
         throw new CrablineError(`Invalid local server port: ${commandOptions.port}`, {
           kind: "config",

--- a/test/cli-credential-subprocess.test.ts
+++ b/test/cli-credential-subprocess.test.ts
@@ -1,0 +1,129 @@
+import { spawnSync, type SpawnSyncOptionsWithStringEncoding } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createTempDir, disposeTempDir, writeText } from "./test-helpers.js";
+
+const directories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(directories.splice(0).map(disposeTempDir));
+});
+
+const parseManifest = (output: string): Record<string, unknown> => {
+  return JSON.parse(output.trim()) as Record<string, unknown>;
+};
+
+const spawnChecked = (
+  command: string,
+  args: string[],
+  options: SpawnSyncOptionsWithStringEncoding,
+): string => {
+  const result = spawnSync(command, args, { ...options, timeout: 10_000 });
+  expect(result.error).toBeUndefined();
+  expect(result.signal).toBeNull();
+  if (result.status !== 0) {
+    throw new Error(`Subprocess exited with status ${String(result.status)}:\n${result.stderr}`);
+  }
+  return result.stdout;
+};
+
+const spawnPnpmChecked = (args: string[], options: SpawnSyncOptionsWithStringEncoding): string => {
+  if (process.platform !== "win32") {
+    return spawnChecked("pnpm", args, options);
+  }
+  const command = `"${["pnpm.cmd", ...args]
+    .map((value) => `"${value.replaceAll("%", "%%").replaceAll('"', '""')}"`)
+    .join(" ")}"`;
+  return spawnChecked(process.env.ComSpec ?? "cmd.exe", ["/d", "/s", "/c", command], {
+    ...options,
+    windowsVerbatimArguments: true,
+  });
+};
+
+describe("CLI credential subprocess ingress", () => {
+  it("reads package-runner credentials from stdin fd 0", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const recorderPath = path.join(directory, "package-runner.jsonl");
+    const output = spawnPnpmChecked(
+      [
+        "--silent",
+        "dev",
+        "--json",
+        "serve",
+        "slack",
+        "--once",
+        "--recorder",
+        recorderPath,
+        "--credentials-fd",
+        "0",
+      ],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: { ...process.env, NO_COLOR: "1" },
+        input: JSON.stringify({
+          adminToken: "fake",
+          botToken: "sample",
+          signingSecret: "fake",
+        }),
+      },
+    );
+
+    expect(parseManifest(output)).toMatchObject({
+      adminToken: "fake",
+      botToken: "sample",
+      signingSecret: "fake",
+    });
+  });
+
+  it("reads an inherited descriptor through direct Node execution", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const credentialsPath = path.join(directory, "credentials.json");
+    const recorderPath = path.join(directory, "direct-node.jsonl");
+    await writeText(
+      credentialsPath,
+      JSON.stringify({
+        adminToken: "admin",
+        botToken: "sample",
+        signingSecret: "fake",
+      }),
+    );
+    const credentialsHandle = await fs.open(credentialsPath, "r");
+
+    try {
+      const output = spawnChecked(
+        process.execPath,
+        [
+          "--import",
+          "tsx",
+          "src/bin/crabline.ts",
+          "--json",
+          "serve",
+          "slack",
+          "--once",
+          "--recorder",
+          recorderPath,
+          "--credentials-fd",
+          "3",
+        ],
+        {
+          cwd: process.cwd(),
+          encoding: "utf8",
+          env: { ...process.env, NO_COLOR: "1" },
+          stdio: ["ignore", "pipe", "pipe", credentialsHandle.fd],
+        },
+      );
+
+      expect(parseManifest(output)).toMatchObject({
+        adminToken: "admin",
+        botToken: "sample",
+        signingSecret: "fake",
+      });
+    } finally {
+      await credentialsHandle.close();
+    }
+  });
+});

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -362,18 +362,84 @@ describe("cli", () => {
     expect(startServer).not.toHaveBeenCalled();
   });
 
-  it("loads serve secrets from env while keeping flags authoritative", async () => {
+  it("documents safe serve credential ingress without advertising secret flags", async () => {
+    const captured = await captureWrites(async () => {
+      expect(await runCli(["node", "crabline", "serve", "--help"])).toBe(0);
+    });
+
+    const help = captured.stdout.join("");
+    expect(help).toContain("--credentials-fd <fd>");
+    expect(help).toContain("accessToken, adminToken, botToken, signingSecret");
+    expect(help).toContain("CRABLINE_ACCESS_TOKEN");
+    expect(help).not.toContain("--access-token");
+    expect(help).not.toContain("--admin-token");
+    expect(help).not.toContain("--bot-token");
+    expect(help).not.toContain("--signing-secret");
+  });
+
+  it("rejects command-line credential values without echoing them", async () => {
+    const unsafeArguments = [
+      ["--access-token", "access-value"],
+      [["--access-token", "access-equals-value"].join("=")],
+      ["--admin-token", "admin-value"],
+      [["--admin-token", "admin-equals-value"].join("=")],
+      ["--bot-token", "bot-value"],
+      [["--bot-token", "bot-equals-value"].join("=")],
+      ["--signing-secret", "signing-value"],
+      [["--signing-secret", "signing-equals-value"].join("=")],
+    ];
+
+    const captured = await captureWrites(async () => {
+      for (const args of unsafeArguments) {
+        expect(await runCli(["node", "crabline", "serve", "slack", "--once", ...args])).toBe(10);
+      }
+    });
+
+    const stderr = captured.stderr.join("");
+    expect(stderr).toContain("no longer accepts credential values in command-line arguments");
+    for (const sentinel of [
+      "access-value",
+      "access-equals-value",
+      "admin-value",
+      "admin-equals-value",
+      "bot-value",
+      "bot-equals-value",
+      "signing-value",
+      "signing-equals-value",
+    ]) {
+      expect(stderr).not.toContain(sentinel);
+    }
+  });
+
+  it("loads serve secrets from a bounded file descriptor over env", async () => {
     vi.stubEnv("CRABLINE_ACCESS_TOKEN", "example");
     vi.stubEnv("CRABLINE_ADMIN_TOKEN", "fake");
     vi.stubEnv("CRABLINE_BOT_TOKEN", "sample");
     vi.stubEnv("CRABLINE_SIGNING_SECRET", "test-token-placeholder");
+    const directory = await createTempDir();
+    directories.push(directory);
+    const credentialsPath = path.join(directory, "credentials.json");
+    const fdAccess = ["fd", "access"].join("-");
+    const fdAdmin = ["fd", "admin"].join("-");
+    const fdBot = ["fd", "bot"].join("-");
+    const fdSigning = ["fd", "signing"].join("-");
+    await writeText(
+      credentialsPath,
+      JSON.stringify({
+        accessToken: fdAccess,
+        adminToken: fdAdmin,
+        botToken: fdBot,
+        signingSecret: fdSigning,
+      }),
+    );
+    const credentialsHandle = await fs.open(credentialsPath, "r");
     const startServer = vi.fn(
       async (_params: StartCrablineServerParams): Promise<StartedCrablineServer> => ({
         async close() {},
         manifest: {
-          adminToken: "fake",
+          adminToken: fdAdmin,
           baseUrl: "http://127.0.0.1:12345",
-          botToken: "placeholder",
+          botToken: fdBot,
           endpoints: {
             adminInboundUrl: "http://127.0.0.1:12345/crabline/slack/inbound",
             apiRoot: "http://127.0.0.1:12345/api/",
@@ -381,38 +447,90 @@ describe("cli", () => {
           },
           env: {
             SLACK_API_URL: "http://127.0.0.1:12345/api/",
-            SLACK_BOT_TOKEN: "placeholder",
-            SLACK_SIGNING_SECRET: "test-token-placeholder",
+            SLACK_BOT_TOKEN: fdBot,
+            SLACK_SIGNING_SECRET: fdSigning,
           },
           provider: "slack" as const,
           recorderPath: "/tmp/slack.jsonl",
-          signingSecret: "test-token-placeholder",
+          signingSecret: fdSigning,
           version: 1 as const,
         },
       }),
     );
     const program = createProgram(() => undefined, { startServer });
-    await captureWrites(async () => {
-      await program.parseAsync([
-        "node",
-        "crabline",
-        "--json",
-        "serve",
-        "slack",
-        "--bot-token",
-        "placeholder",
-        "--once",
-      ]);
-    });
+    try {
+      await captureWrites(async () => {
+        await program.parseAsync([
+          "node",
+          "crabline",
+          "--json",
+          "serve",
+          "slack",
+          "--credentials-fd",
+          String(credentialsHandle.fd),
+          "--once",
+        ]);
+      });
+    } finally {
+      await credentialsHandle.close();
+    }
 
     expect(startServer).toHaveBeenCalledWith(
       expect.objectContaining({
-        adminToken: "fake",
-        botToken: "placeholder",
+        adminToken: fdAdmin,
+        botToken: fdBot,
         channel: "slack",
-        signingSecret: "test-token-placeholder",
+        signingSecret: fdSigning,
       }),
     );
+  });
+
+  it("rejects malformed credential streams without echoing their contents", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const credentialsPath = path.join(directory, "credentials.json");
+    const sentinel = "credential-stream-secret";
+    await writeText(credentialsPath, `{"adminToken":"${sentinel}"`);
+    const credentialsHandle = await fs.open(credentialsPath, "r");
+    const captured = await captureWrites(async () => {
+      expect(
+        await runCli([
+          "node",
+          "crabline",
+          "serve",
+          "slack",
+          "--once",
+          "--credentials-fd",
+          String(credentialsHandle.fd),
+        ]),
+      ).toBe(10);
+    }).finally(async () => await credentialsHandle.close());
+
+    expect(captured.stderr.join("")).toContain("Serve credentials input must be valid JSON.");
+    expect(captured.stderr.join("")).not.toContain(sentinel);
+  });
+
+  it("bounds credential streams before parsing them", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const credentialsPath = path.join(directory, "credentials.json");
+    await writeText(credentialsPath, JSON.stringify({ adminToken: "x".repeat(64 * 1024) }));
+    const credentialsHandle = await fs.open(credentialsPath, "r");
+    const captured = await captureWrites(async () => {
+      expect(
+        await runCli([
+          "node",
+          "crabline",
+          "serve",
+          "slack",
+          "--once",
+          "--credentials-fd",
+          String(credentialsHandle.fd),
+        ]),
+      ).toBe(10);
+    }).finally(async () => await credentialsHandle.close());
+
+    expect(captured.stderr.join("")).toContain("Serve credentials JSON exceeds 65536 bytes.");
   });
 
   it("isolates exit codes across repeated invocations", async () => {
@@ -1439,6 +1557,8 @@ describe("cli", () => {
     const directory = await createTempDir();
     directories.push(directory);
     const captured = await captureWrites(async () => {
+      vi.stubEnv("CRABLINE_ADMIN_TOKEN", "fake");
+      vi.stubEnv("CRABLINE_BOT_TOKEN", "sample");
       expect(
         await runCli([
           "node",
@@ -1446,14 +1566,12 @@ describe("cli", () => {
           "serve",
           "telegram",
           "--once",
-          "--admin-token",
-          "fake",
-          "--bot-token",
-          "sample",
           "--recorder",
           path.join(directory, "redacted.jsonl"),
         ]),
       ).toBe(0);
+      vi.stubEnv("CRABLINE_ADMIN_TOKEN", "example");
+      vi.stubEnv("CRABLINE_ACCESS_TOKEN", "placeholder");
       expect(
         await runCli([
           "node",
@@ -1461,14 +1579,11 @@ describe("cli", () => {
           "serve",
           "whatsapp",
           "--once",
-          "--admin-token",
-          "example",
-          "--access-token",
-          "placeholder",
           "--recorder",
           path.join(directory, "whatsapp-redacted.jsonl"),
         ]),
       ).toBe(0);
+      vi.stubEnv("CRABLINE_BOT_TOKEN", "placeholder");
       expect(
         await runCli([
           "node",
@@ -1477,10 +1592,6 @@ describe("cli", () => {
           "telegram",
           "--once",
           "--show-secrets",
-          "--admin-token",
-          "example",
-          "--bot-token",
-          "placeholder",
           "--recorder",
           path.join(directory, "visible.jsonl"),
         ]),
@@ -1501,6 +1612,7 @@ describe("cli", () => {
   it("prints a Telegram server runtime manifest", async () => {
     const directory = await createTempDir();
     directories.push(directory);
+    vi.stubEnv("CRABLINE_ADMIN_TOKEN", "test-admin-token");
     const readyFile = path.join(directory, ".crabline", "telegram-server.json");
     await fs.mkdir(path.dirname(readyFile), { recursive: true });
     await fs.writeFile(readyFile, "stale\n", { mode: 0o644 });
@@ -1515,8 +1627,6 @@ describe("cli", () => {
           "--once",
           "--ready-file",
           readyFile,
-          "--admin-token",
-          "test-admin-token",
           "--recorder",
           path.join(directory, "telegram.jsonl"),
         ]),
@@ -1543,6 +1653,8 @@ describe("cli", () => {
   it("prints a Zalo server runtime manifest", async () => {
     const directory = await createTempDir();
     directories.push(directory);
+    vi.stubEnv("CRABLINE_ADMIN_TOKEN", "test-admin-token");
+    vi.stubEnv("CRABLINE_BOT_TOKEN", "test-token-placeholder");
     const readyFile = path.join(directory, ".crabline", "zalo-server.json");
     const captured = await captureWrites(async () => {
       expect(
@@ -1555,10 +1667,6 @@ describe("cli", () => {
           "--once",
           "--ready-file",
           readyFile,
-          "--admin-token",
-          "test-admin-token",
-          "--bot-token",
-          "test-token-placeholder",
           "--recorder",
           path.join(directory, "zalo.jsonl"),
         ]),
@@ -1589,6 +1697,9 @@ describe("cli", () => {
   it("prints a Slack server runtime manifest", async () => {
     const directory = await createTempDir();
     directories.push(directory);
+    vi.stubEnv("CRABLINE_ADMIN_TOKEN", "test-admin-token");
+    vi.stubEnv("CRABLINE_BOT_TOKEN", "xoxb-test");
+    vi.stubEnv("CRABLINE_SIGNING_SECRET", "test-signing-secret");
     const readyFile = path.join(directory, ".crabline", "slack-server.json");
     const captured = await captureWrites(async () => {
       expect(
@@ -1601,12 +1712,6 @@ describe("cli", () => {
           "--once",
           "--ready-file",
           readyFile,
-          "--admin-token",
-          "test-admin-token",
-          "--bot-token",
-          "xoxb-test",
-          "--signing-secret",
-          "test-signing-secret",
           "--recorder",
           path.join(directory, "slack.jsonl"),
         ]),
@@ -1635,6 +1740,8 @@ describe("cli", () => {
   it("prints a WhatsApp server runtime manifest", async () => {
     const directory = await createTempDir();
     directories.push(directory);
+    vi.stubEnv("CRABLINE_ADMIN_TOKEN", "test-whatsapp-admin-token");
+    vi.stubEnv("CRABLINE_ACCESS_TOKEN", "test-whatsapp-access-token");
     const readyFile = path.join(directory, ".crabline", "whatsapp-server.json");
     const captured = await captureWrites(async () => {
       expect(
@@ -1647,10 +1754,6 @@ describe("cli", () => {
           "--once",
           "--ready-file",
           readyFile,
-          "--admin-token",
-          "test-whatsapp-admin-token",
-          "--access-token",
-          "test-whatsapp-access-token",
           "--recorder",
           path.join(directory, "whatsapp.jsonl"),
         ]),

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -411,7 +411,7 @@ describe("cli", () => {
     }
   });
 
-  it("loads serve secrets from a bounded file descriptor over env", async () => {
+  it("loads partial serve secrets from a bounded file descriptor over env", async () => {
     vi.stubEnv("CRABLINE_ACCESS_TOKEN", "example");
     vi.stubEnv("CRABLINE_ADMIN_TOKEN", "fake");
     vi.stubEnv("CRABLINE_BOT_TOKEN", "sample");
@@ -419,25 +419,14 @@ describe("cli", () => {
     const directory = await createTempDir();
     directories.push(directory);
     const credentialsPath = path.join(directory, "credentials.json");
-    const fdAccess = ["fd", "access"].join("-");
-    const fdAdmin = ["fd", "admin"].join("-");
     const fdBot = ["fd", "bot"].join("-");
-    const fdSigning = ["fd", "signing"].join("-");
-    await writeText(
-      credentialsPath,
-      JSON.stringify({
-        accessToken: fdAccess,
-        adminToken: fdAdmin,
-        botToken: fdBot,
-        signingSecret: fdSigning,
-      }),
-    );
+    await writeText(credentialsPath, JSON.stringify({ botToken: fdBot }));
     const credentialsHandle = await fs.open(credentialsPath, "r");
     const startServer = vi.fn(
       async (_params: StartCrablineServerParams): Promise<StartedCrablineServer> => ({
         async close() {},
         manifest: {
-          adminToken: fdAdmin,
+          adminToken: "fake",
           baseUrl: "http://127.0.0.1:12345",
           botToken: fdBot,
           endpoints: {
@@ -448,11 +437,11 @@ describe("cli", () => {
           env: {
             SLACK_API_URL: "http://127.0.0.1:12345/api/",
             SLACK_BOT_TOKEN: fdBot,
-            SLACK_SIGNING_SECRET: fdSigning,
+            SLACK_SIGNING_SECRET: "test-token-placeholder",
           },
           provider: "slack" as const,
           recorderPath: "/tmp/slack.jsonl",
-          signingSecret: fdSigning,
+          signingSecret: "test-token-placeholder",
           version: 1 as const,
         },
       }),
@@ -477,12 +466,99 @@ describe("cli", () => {
 
     expect(startServer).toHaveBeenCalledWith(
       expect.objectContaining({
-        adminToken: fdAdmin,
+        adminToken: "fake",
         botToken: fdBot,
         channel: "slack",
-        signingSecret: fdSigning,
+        signingSecret: "test-token-placeholder",
       }),
     );
+  });
+
+  it("accepts credential JSON at the exact byte limit", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const credentialsPath = path.join(directory, "credentials.json");
+    const emptyDocumentBytes = Buffer.byteLength(JSON.stringify({ botToken: "" }));
+    const botToken = "x".repeat(64 * 1024 - emptyDocumentBytes);
+    const document = JSON.stringify({ botToken });
+    expect(Buffer.byteLength(document)).toBe(64 * 1024);
+    await writeText(credentialsPath, document);
+    const credentialsHandle = await fs.open(credentialsPath, "r");
+    const startServer = vi.fn(
+      async (): Promise<StartedCrablineServer> => ({
+        async close() {},
+        manifest: {
+          adminToken: "fake",
+          baseUrl: "http://127.0.0.1:12345",
+          botToken,
+          endpoints: {
+            adminInboundUrl: "http://127.0.0.1:12345/crabline/slack/inbound",
+            apiRoot: "http://127.0.0.1:12345/api/",
+            eventsUrl: "http://127.0.0.1:12345/slack/events",
+          },
+          env: {
+            SLACK_API_URL: "http://127.0.0.1:12345/api/",
+            SLACK_BOT_TOKEN: botToken,
+            SLACK_SIGNING_SECRET: "fake",
+          },
+          provider: "slack" as const,
+          recorderPath: "/tmp/slack.jsonl",
+          signingSecret: "fake",
+          version: 1 as const,
+        },
+      }),
+    );
+    const program = createProgram(() => undefined, { startServer });
+
+    try {
+      await captureWrites(async () => {
+        await program.parseAsync([
+          "node",
+          "crabline",
+          "serve",
+          "slack",
+          "--credentials-fd",
+          String(credentialsHandle.fd),
+          "--once",
+        ]);
+      });
+    } finally {
+      await credentialsHandle.close();
+    }
+
+    expect(startServer).toHaveBeenCalledWith(expect.objectContaining({ botToken }));
+  });
+
+  it("rejects unsupported or non-string credential fields", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+
+    for (const [index, [document, message]] of (
+      [
+        [JSON.stringify({ password: "hidden" }), "contains unsupported fields"],
+        [JSON.stringify({ botToken: 42 }), "values must be strings"],
+      ] as const
+    ).entries()) {
+      const credentialsPath = path.join(directory, `${index}.json`);
+      await writeText(credentialsPath, document);
+      const credentialsHandle = await fs.open(credentialsPath, "r");
+      const captured = await captureWrites(async () => {
+        expect(
+          await runCli([
+            "node",
+            "crabline",
+            "serve",
+            "slack",
+            "--once",
+            "--credentials-fd",
+            String(credentialsHandle.fd),
+          ]),
+        ).toBe(10);
+      }).finally(async () => await credentialsHandle.close());
+
+      expect(captured.stderr.join("")).toContain(message);
+      expect(captured.stderr.join("")).not.toContain(document);
+    }
   });
 
   it("rejects malformed credential streams without echoing their contents", async () => {


### PR DESCRIPTION
## Summary

- reject credential-bearing `serve` arguments so secrets do not enter argv or shell history
- add bounded JSON credential ingress through stdin or a preserved inherited descriptor
- document package-runner fd 0 behavior and direct CLI fd >2 behavior
- add parser boundary and real subprocess coverage

## Validation

- `pnpm lint`
- `pnpm exec vitest run test/cli.test.ts test/cli-credential-subprocess.test.ts test/package-production.test.ts`
- public-data secret scan

## Release notes

- Added to `CHANGELOG.md`.
