### PR TITLE
fix(core): bound inbound candidate processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Reject unsupported Zalo thread targets during normalization, matching OpenClaw bridge execution.
 - Enforce Discord uint64 snowflakes and Telegram safe-integer chat and topic identifiers.
 - Reject credential-bearing CLI arguments and add bounded stdin or inherited-fd ingress for `serve` secrets.
+- Bound fixture inbound candidate tracking, reuse compiled regex matchers, and keep deadlines monotonic across wall-clock changes.
 - Bound shared JSON ingress, reject non-object payloads precisely, and strictly normalize loopback IP addresses.
 - Commit Signal sends only after recorder publication, emit canonical native source numbers, and canonicalize OpenClaw outbound recipient identity.
 - Harden WhatsApp send evidence, direct-JID correlation, cursor and cleanup races, and cleartext listener exposure.

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -1,7 +1,7 @@
 import { matchesInbound } from "./matcher.js";
 import { createOutboundText } from "./message-template.js";
 import { createNonce } from "./nonces.js";
-import { inboundRegexSafetyError } from "./safe-regex.js";
+import { compileInboundRegex } from "./safe-regex.js";
 import { type FailureKind, CrablineError, ensureErrorMessage } from "./errors.js";
 import { EXIT_CODES, type ExitCode } from "./exit-codes.js";
 import type { ManifestDefinition } from "../config/schema.js";
@@ -357,13 +357,11 @@ export async function runFixtureCommand(params: {
         return (result = toFailure(fixture.id, fixture.provider, mode, error, "connectivity"));
       }
     } else {
+      let compiledInboundRegex: ReturnType<typeof compileInboundRegex> | undefined;
       if (fixture.inboundMatch.strategy === "regex" && fixture.inboundMatch.pattern) {
         try {
           RegExp(fixture.inboundMatch.pattern, "u");
-          const safetyError = inboundRegexSafetyError(fixture.inboundMatch.pattern);
-          if (safetyError) {
-            throw new Error(safetyError);
-          }
+          compiledInboundRegex = compileInboundRegex(fixture.inboundMatch.pattern);
         } catch (error) {
           return (result = toFailure(
             fixture.id,
@@ -377,6 +375,9 @@ export async function runFixtureCommand(params: {
           ));
         }
       }
+      const preparedInboundMatch = compiledInboundRegex
+        ? { ...fixture.inboundMatch, pattern: undefined }
+        : fixture.inboundMatch;
 
       let attempts = 0;
       const maxAttempts = fixture.retries + 1;
@@ -505,9 +506,10 @@ export async function runFixtureCommand(params: {
               seenInbound.add(key);
 
               if (
-                matchesInbound(candidate, fixture.inboundMatch, nonce, {
+                matchesInbound(candidate, preparedInboundMatch, nonce, {
                   requireAcknowledgement: mode === "agent",
-                })
+                }) &&
+                (!compiledInboundRegex || compiledInboundRegex.test(candidate.text))
               ) {
                 inbound = candidate;
                 break;

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -520,9 +520,11 @@ export async function runFixtureCommand(params: {
                 break;
               }
               if (seenInbound.size >= MAX_EXCLUDED_INBOUND_IDS) {
-                const diagnostic = excludedInboundIds.has(candidate.id)
-                  ? `Provider returned more than ${MAX_EXCLUDED_INBOUND_IDS} distinct unmatched inbound envelopes.`
-                  : `Provider returned more than ${MAX_EXCLUDED_INBOUND_IDS} unmatched inbound message IDs.`;
+                const diagnostic =
+                  excludedInboundIds.size >= MAX_EXCLUDED_INBOUND_IDS &&
+                  !excludedInboundIds.has(candidate.id)
+                    ? `Provider returned more than ${MAX_EXCLUDED_INBOUND_IDS} unmatched inbound message IDs.`
+                    : `Provider returned more than ${MAX_EXCLUDED_INBOUND_IDS} distinct unmatched inbound envelopes.`;
                 throw new CrablineError(diagnostic, { kind: "inbound" });
               }
               seenInbound.add(key);

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -1,3 +1,4 @@
+import { performance } from "node:perf_hooks";
 import { matchesInbound } from "./matcher.js";
 import { createOutboundText } from "./message-template.js";
 import { createNonce } from "./nonces.js";
@@ -449,13 +450,16 @@ export async function runFixtureCommand(params: {
             });
           }
 
-          const inboundDeadline = Date.now() + fixture.timeoutMs;
+          const inboundDeadline = performance.now() + fixture.timeoutMs;
           const seenInbound = new Set<string>();
           const excludedInboundIds = new Set<string>();
           let inbound;
           try {
-            while (Date.now() < inboundDeadline) {
-              const timeoutMs = inboundDeadline - Date.now();
+            while (true) {
+              const timeoutMs = Math.max(0, Math.ceil(inboundDeadline - performance.now()));
+              if (timeoutMs === 0) {
+                break;
+              }
               const controller = new AbortController();
               const excludeIds = [...excludedInboundIds];
               const waitContext = {
@@ -500,7 +504,9 @@ export async function runFixtureCommand(params: {
 
               const key = JSON.stringify([candidate.provider, candidate.threadId, candidate.id]);
               if (seenInbound.has(key)) {
-                await sleep(Math.min(10, Math.max(0, inboundDeadline - Date.now())));
+                await sleep(
+                  Math.min(10, Math.max(0, Math.ceil(inboundDeadline - performance.now()))),
+                );
                 continue;
               }
 

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -503,7 +503,6 @@ export async function runFixtureCommand(params: {
                 await sleep(Math.min(10, Math.max(0, inboundDeadline - Date.now())));
                 continue;
               }
-              seenInbound.add(key);
 
               if (
                 matchesInbound(candidate, preparedInboundMatch, nonce, {
@@ -514,13 +513,14 @@ export async function runFixtureCommand(params: {
                 inbound = candidate;
                 break;
               }
+              if (seenInbound.size >= MAX_EXCLUDED_INBOUND_IDS) {
+                const diagnostic = excludedInboundIds.has(candidate.id)
+                  ? `Provider returned more than ${MAX_EXCLUDED_INBOUND_IDS} distinct unmatched inbound envelopes.`
+                  : `Provider returned more than ${MAX_EXCLUDED_INBOUND_IDS} unmatched inbound message IDs.`;
+                throw new CrablineError(diagnostic, { kind: "inbound" });
+              }
+              seenInbound.add(key);
               if (!excludedInboundIds.has(candidate.id)) {
-                if (excludedInboundIds.size >= MAX_EXCLUDED_INBOUND_IDS) {
-                  throw new CrablineError(
-                    `Provider returned more than ${MAX_EXCLUDED_INBOUND_IDS} unmatched inbound message IDs.`,
-                    { kind: "inbound" },
-                  );
-                }
                 excludedInboundIds.add(candidate.id);
               }
             }

--- a/test/run.behavior.test.ts
+++ b/test/run.behavior.test.ts
@@ -934,6 +934,49 @@ describe("run behavior", () => {
     expect(maxExcludedIds).toBe(1);
   });
 
+  it("reports composite overflow after mixed reused and new inbound IDs", async () => {
+    let waitCalls = 0;
+    const provider: ProviderAdapter = {
+      id: "mock",
+      platform: "loopback",
+      status: "ready",
+      supports: ["roundtrip"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      probe: async () => ({ details: [], healthy: true }),
+      send: async () => ({ accepted: true, messageId: "sent", threadId: "thread" }),
+      waitForInbound: async () => {
+        waitCalls += 1;
+        return {
+          author: "assistant",
+          id: waitCalls > 1024 ? "new" : "reused",
+          provider: "mock",
+          sentAt: new Date().toISOString(),
+          text: "not the requested nonce",
+          threadId: `thread-${waitCalls}`,
+        };
+      },
+    };
+    const boundedManifest = withAllCapabilities({
+      ...manifest,
+      fixtures: [{ ...manifest.fixtures[0]!, timeoutMs: 5_000 }],
+    });
+
+    const result = await runFixtureCommand({
+      fixtureId: "fixture",
+      manifest: boundedManifest,
+      manifestPath: "/tmp/crabline.yaml",
+      registry: buildRegistry(provider),
+    });
+
+    expect(result.failureKind).toBe("inbound");
+    expect(result.diagnostics).toContain(
+      "Provider returned more than 1024 distinct unmatched inbound envelopes.",
+    );
+    expect(waitCalls).toBe(1025);
+  });
+
   it("bounds a hung inbound provider by the core deadline", async () => {
     let rejectWait: ((error: Error) => void) | undefined;
     const provider: ProviderAdapter = {

--- a/test/run.behavior.test.ts
+++ b/test/run.behavior.test.ts
@@ -888,6 +888,52 @@ describe("run behavior", () => {
     expect(waitCalls).toBe(1025);
   });
 
+  it("bounds reused inbound IDs across changing threads", async () => {
+    let waitCalls = 0;
+    let maxExcludedIds = 0;
+    const provider: ProviderAdapter = {
+      id: "mock",
+      platform: "loopback",
+      status: "ready",
+      supports: ["roundtrip"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      probe: async () => ({ details: [], healthy: true }),
+      send: async () => ({ accepted: true, messageId: "sent", threadId: "thread" }),
+      waitForInbound: async (context) => {
+        waitCalls += 1;
+        maxExcludedIds = Math.max(maxExcludedIds, context.excludeIds?.length ?? 0);
+        return {
+          author: "assistant",
+          id: "reused",
+          provider: "mock",
+          sentAt: new Date().toISOString(),
+          text: "not the requested nonce",
+          threadId: `thread-${waitCalls}`,
+        };
+      },
+    };
+    const boundedManifest = withAllCapabilities({
+      ...manifest,
+      fixtures: [{ ...manifest.fixtures[0]!, timeoutMs: 5_000 }],
+    });
+
+    const result = await runFixtureCommand({
+      fixtureId: "fixture",
+      manifest: boundedManifest,
+      manifestPath: "/tmp/crabline.yaml",
+      registry: buildRegistry(provider),
+    });
+
+    expect(result.failureKind).toBe("inbound");
+    expect(result.diagnostics).toContain(
+      "Provider returned more than 1024 distinct unmatched inbound envelopes.",
+    );
+    expect(waitCalls).toBe(1025);
+    expect(maxExcludedIds).toBe(1);
+  });
+
   it("bounds a hung inbound provider by the core deadline", async () => {
     let rejectWait: ((error: Error) => void) | undefined;
     const provider: ProviderAdapter = {

--- a/test/run.behavior.test.ts
+++ b/test/run.behavior.test.ts
@@ -270,6 +270,64 @@ describe("run behavior", () => {
     }
   });
 
+  it("preserves agent author, acknowledgement, and nonce gates with a compiled regex", async () => {
+    let waitCalls = 0;
+    const provider: ProviderAdapter = {
+      id: "mock",
+      platform: "loopback",
+      status: "ready",
+      supports: ["agent"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      probe: async () => ({ details: [], healthy: true }),
+      send: async () => ({ accepted: true, messageId: "sent", threadId: "thread" }),
+      waitForInbound: async (context) => {
+        waitCalls += 1;
+        const candidates = [
+          { author: "user" as const, text: `ACK ${context.nonce} expected reply` },
+          { author: "assistant" as const, text: "ACK wrong-nonce expected reply" },
+          { author: "assistant" as const, text: `${context.nonce} expected reply` },
+          { author: "assistant" as const, text: `ACK ${context.nonce} expected reply` },
+        ];
+        const candidate = candidates[waitCalls - 1]!;
+        return {
+          ...candidate,
+          id: `inbound-${waitCalls}`,
+          provider: "mock",
+          sentAt: new Date().toISOString(),
+          threadId: "thread",
+        };
+      },
+    };
+    const regexManifest = withAllCapabilities({
+      ...manifest,
+      fixtures: [
+        {
+          ...manifest.fixtures[0]!,
+          inboundMatch: {
+            author: "assistant",
+            nonce: "exact",
+            pattern: "^.*expected reply$",
+            strategy: "regex",
+          },
+          mode: "agent",
+          timeoutMs: 100,
+        },
+      ],
+    });
+
+    const result = await runFixtureCommand({
+      fixtureId: "fixture",
+      manifest: regexManifest,
+      manifestPath: "/tmp/crabline.yaml",
+      registry: buildRegistry(provider),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(waitCalls).toBe(4);
+  });
+
   it("uses one effective fixture for mode overrides in provider contexts", async () => {
     const contextFixtures: ManifestDefinition["fixtures"] = [];
     let outboundText = "";
@@ -975,6 +1033,56 @@ describe("run behavior", () => {
       "Provider returned more than 1024 distinct unmatched inbound envelopes.",
     );
     expect(waitCalls).toBe(1025);
+  });
+
+  it("checks duplicates and matching candidates before enforcing the envelope cap", async () => {
+    let waitCalls = 0;
+    const provider: ProviderAdapter = {
+      id: "mock",
+      platform: "loopback",
+      status: "ready",
+      supports: ["roundtrip"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      probe: async () => ({ details: [], healthy: true }),
+      send: async () => ({ accepted: true, messageId: "sent", threadId: "thread" }),
+      waitForInbound: async (context) => {
+        waitCalls += 1;
+        if (waitCalls === 1025) {
+          return {
+            author: "assistant",
+            id: "unmatched-1",
+            provider: "mock",
+            sentAt: new Date().toISOString(),
+            text: "still not the requested nonce",
+            threadId: "thread",
+          };
+        }
+        return {
+          author: "assistant",
+          id: waitCalls === 1026 ? "matching" : `unmatched-${waitCalls}`,
+          provider: "mock",
+          sentAt: new Date().toISOString(),
+          text: waitCalls === 1026 ? context.nonce : "not the requested nonce",
+          threadId: "thread",
+        };
+      },
+    };
+    const boundedManifest = withAllCapabilities({
+      ...manifest,
+      fixtures: [{ ...manifest.fixtures[0]!, timeoutMs: 5_000 }],
+    });
+
+    const result = await runFixtureCommand({
+      fixtureId: "fixture",
+      manifest: boundedManifest,
+      manifestPath: "/tmp/crabline.yaml",
+      registry: buildRegistry(provider),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(waitCalls).toBe(1026);
   });
 
   it("bounds a hung inbound provider by the core deadline", async () => {

--- a/test/run.behavior.test.ts
+++ b/test/run.behavior.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { RE2JS } from "re2js";
 import { CrablineError } from "../src/core/errors.js";
 import { EXIT_CODES } from "../src/core/exit-codes.js";
 import { computeExitCode, runFixtureCommand, runSuite } from "../src/core/run.js";
@@ -210,6 +211,63 @@ describe("run behavior", () => {
     expect(result.failureKind).toBe("config");
     expect(result.diagnostics.join("\n")).toContain("Invalid inbound regex");
     expect(sendCalls).toBe(0);
+  });
+
+  it("compiles an inbound regex once while checking multiple candidates", async () => {
+    let waitCalls = 0;
+    const compileSpy = vi.spyOn(RE2JS, "compile");
+    const provider: ProviderAdapter = {
+      id: "mock",
+      platform: "loopback",
+      status: "ready",
+      supports: ["roundtrip"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      probe: async () => ({ details: [], healthy: true }),
+      send: async () => ({ accepted: true, messageId: "sent", threadId: "thread" }),
+      waitForInbound: async () => {
+        waitCalls += 1;
+        return {
+          author: "assistant",
+          id: `inbound-${waitCalls}`,
+          provider: "mock",
+          sentAt: new Date().toISOString(),
+          text: waitCalls === 3 ? "expected reply" : "unrelated reply",
+          threadId: "thread",
+        };
+      },
+    };
+    const regexManifest = withAllCapabilities({
+      ...manifest,
+      fixtures: [
+        {
+          ...manifest.fixtures[0]!,
+          inboundMatch: {
+            author: "assistant",
+            nonce: "ignore",
+            pattern: "^expected reply$",
+            strategy: "regex",
+          },
+          timeoutMs: 100,
+        },
+      ],
+    });
+
+    try {
+      const result = await runFixtureCommand({
+        fixtureId: "fixture",
+        manifest: regexManifest,
+        manifestPath: "/tmp/crabline.yaml",
+        registry: buildRegistry(provider),
+      });
+
+      expect(result.ok).toBe(true);
+      expect(waitCalls).toBe(3);
+      expect(compileSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      compileSpy.mockRestore();
+    }
   });
 
   it("uses one effective fixture for mode overrides in provider contexts", async () => {

--- a/test/run.retry-timeout.test.ts
+++ b/test/run.retry-timeout.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { runFixtureCommand } from "../src/core/run.js";
 import type { ManifestDefinition } from "../src/config/schema.js";
 import { OPENCLAW_SUPPORT_CATALOG } from "../src/providers/catalog.js";
@@ -33,6 +33,67 @@ const manifest: ManifestDefinition = {
 };
 
 describe("runFixtureCommand retries", () => {
+  it("keeps inbound deadlines monotonic when the wall clock moves backward", async () => {
+    let wallNow = 10_000;
+    let waitCalls = 0;
+    const dateNowSpy = vi.spyOn(Date, "now").mockImplementation(() => wallNow);
+    const provider: ProviderAdapter = {
+      id: "mock",
+      platform: "loopback",
+      status: "ready",
+      supports: ["roundtrip"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      async probe() {
+        return { details: [], healthy: true };
+      },
+      async send() {
+        return { accepted: true, messageId: "sent-1", threadId: "thread-1" };
+      },
+      async waitForInbound(context) {
+        waitCalls += 1;
+        expect(context.timeoutMs).toBeLessThanOrEqual(30);
+        if (waitCalls === 1) {
+          wallNow -= 60_000;
+        }
+        return {
+          author: "assistant",
+          id: "repeated",
+          provider: "mock",
+          sentAt: new Date(wallNow).toISOString(),
+          text: "not the requested nonce",
+          threadId: "thread-1",
+        };
+      },
+    };
+    const registry: Registry = {
+      catalog: OPENCLAW_SUPPORT_CATALOG,
+      resolve() {
+        return provider;
+      },
+    };
+    const boundedManifest: ManifestDefinition = {
+      ...manifest,
+      fixtures: [{ ...manifest.fixtures[0]!, retries: 0, timeoutMs: 30 }],
+    };
+
+    try {
+      const result = await runFixtureCommand({
+        fixtureId: "fixture",
+        manifest: boundedManifest,
+        manifestPath: "/tmp/crabline.yaml",
+        registry,
+      });
+
+      expect(result).toMatchObject({ failureKind: "timeout", ok: false });
+      expect(waitCalls).toBeGreaterThan(1);
+      expect(waitCalls).toBeLessThan(10);
+    } finally {
+      dateNowSpy.mockRestore();
+    }
+  });
+
   it("retries after a timeout and succeeds", async () => {
     let waitCalls = 0;
     const provider: ProviderAdapter = {

--- a/test/run.retry-timeout.test.ts
+++ b/test/run.retry-timeout.test.ts
@@ -33,66 +33,72 @@ const manifest: ManifestDefinition = {
 };
 
 describe("runFixtureCommand retries", () => {
-  it("keeps inbound deadlines monotonic when the wall clock moves backward", async () => {
-    let wallNow = 10_000;
-    let waitCalls = 0;
-    const dateNowSpy = vi.spyOn(Date, "now").mockImplementation(() => wallNow);
-    const provider: ProviderAdapter = {
-      id: "mock",
-      platform: "loopback",
-      status: "ready",
-      supports: ["roundtrip"],
-      normalizeTarget(target) {
-        return { id: target.id, metadata: target.metadata };
-      },
-      async probe() {
-        return { details: [], healthy: true };
-      },
-      async send() {
-        return { accepted: true, messageId: "sent-1", threadId: "thread-1" };
-      },
-      async waitForInbound(context) {
-        waitCalls += 1;
-        expect(context.timeoutMs).toBeLessThanOrEqual(30);
-        if (waitCalls === 1) {
-          wallNow -= 60_000;
-        }
-        return {
-          author: "assistant",
-          id: "repeated",
-          provider: "mock",
-          sentAt: new Date(wallNow).toISOString(),
-          text: "not the requested nonce",
-          threadId: "thread-1",
-        };
-      },
-    };
-    const registry: Registry = {
-      catalog: OPENCLAW_SUPPORT_CATALOG,
-      resolve() {
-        return provider;
-      },
-    };
-    const boundedManifest: ManifestDefinition = {
-      ...manifest,
-      fixtures: [{ ...manifest.fixtures[0]!, retries: 0, timeoutMs: 30 }],
-    };
+  it.each([
+    ["backward", -60_000],
+    ["forward", 60_000],
+  ] as const)(
+    "keeps inbound deadlines monotonic when the wall clock moves %s",
+    async (_direction, wallShift) => {
+      let wallNow = 10_000;
+      let waitCalls = 0;
+      const dateNowSpy = vi.spyOn(Date, "now").mockImplementation(() => wallNow);
+      const provider: ProviderAdapter = {
+        id: "mock",
+        platform: "loopback",
+        status: "ready",
+        supports: ["roundtrip"],
+        normalizeTarget(target) {
+          return { id: target.id, metadata: target.metadata };
+        },
+        async probe() {
+          return { details: [], healthy: true };
+        },
+        async send() {
+          return { accepted: true, messageId: "sent-1", threadId: "thread-1" };
+        },
+        async waitForInbound(context) {
+          waitCalls += 1;
+          expect(context.timeoutMs).toBeLessThanOrEqual(30);
+          if (waitCalls === 1) {
+            wallNow += wallShift;
+          }
+          return {
+            author: "assistant",
+            id: "repeated",
+            provider: "mock",
+            sentAt: new Date(wallNow).toISOString(),
+            text: "not the requested nonce",
+            threadId: "thread-1",
+          };
+        },
+      };
+      const registry: Registry = {
+        catalog: OPENCLAW_SUPPORT_CATALOG,
+        resolve() {
+          return provider;
+        },
+      };
+      const boundedManifest: ManifestDefinition = {
+        ...manifest,
+        fixtures: [{ ...manifest.fixtures[0]!, retries: 0, timeoutMs: 30 }],
+      };
 
-    try {
-      const result = await runFixtureCommand({
-        fixtureId: "fixture",
-        manifest: boundedManifest,
-        manifestPath: "/tmp/crabline.yaml",
-        registry,
-      });
+      try {
+        const result = await runFixtureCommand({
+          fixtureId: "fixture",
+          manifest: boundedManifest,
+          manifestPath: "/tmp/crabline.yaml",
+          registry,
+        });
 
-      expect(result).toMatchObject({ failureKind: "timeout", ok: false });
-      expect(waitCalls).toBeGreaterThan(1);
-      expect(waitCalls).toBeLessThan(10);
-    } finally {
-      dateNowSpy.mockRestore();
-    }
-  });
+        expect(result).toMatchObject({ failureKind: "timeout", ok: false });
+        expect(waitCalls).toBeGreaterThan(1);
+        expect(waitCalls).toBeLessThan(10);
+      } finally {
+        dateNowSpy.mockRestore();
+      }
+    },
+  );
 
   it("retries after a timeout and succeeds", async () => {
     let waitCalls = 0;


### PR DESCRIPTION
## Summary

- compile configured inbound regexes once per fixture run
- bound unmatched inbound envelope tracking even when providers reuse message IDs
- use monotonic deadlines for inbound waits
- classify distinct-ID and composite-envelope overflow precisely

## Validation

- `pnpm lint`
- `pnpm exec vitest run test/run.behavior.test.ts test/run.retry-timeout.test.ts`
- public-data secret scan

## Release notes

- Added to `CHANGELOG.md`.
