### PR TITLE
fix(mattermost): preserve atomic thread state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Confine server recorder publication and locking to stable resolved paths across symlink retargets, start observers in durable append order without blocking later requests, snapshot observed events, classify post-commit lock cleanup failures, and preserve existing file modes.
 - Cover local GitHub Actions with ownership, CodeQL, immutable image, and test-tool runtime policies.
 - Publish Matrix direct-room account data and share strict native identifier validation across server, target, and inbound paths.
+- Materialize Mattermost thread roots, keep root posts channel-scoped, and reject oversized WebSocket post events atomically without disconnecting unrelated clients.
 - Protect pnpm install-script policy and enforce immutable action pins across reusable workflows and composite actions.
 - Stop shipping a non-runnable OpenClaw script fixture and clarify source-checkout CLI invocation.
 - Bind npm and GitHub release mutations to the revalidated tag commit and fail closed on release lookup errors.

--- a/src/servers/mattermost.ts
+++ b/src/servers/mattermost.ts
@@ -660,12 +660,17 @@ async function handleApi(params: {
     if (post.user_id !== state.botUserId) {
       return mattermostError("You do not have permission to delete this post", 403);
     }
-    state.posts.delete(post.id);
-    broadcast(
-      state,
-      postEvent("post_deleted", post, state.botUsername, state.channels.get(post.channel_id)!),
-      false,
+    const event = postEvent(
+      "post_deleted",
+      post,
+      state.botUsername,
+      state.channels.get(post.channel_id)!,
     );
+    if (webSocketEventBytes(event) > state.maxWebSocketBufferedBytes) {
+      return webSocketEventTooLargeResponse();
+    }
+    state.posts.delete(post.id);
+    broadcast(state, event, false);
     return jsonResponse({ status: "OK" });
   }
   return mattermostError("Not found", 404);

--- a/src/servers/mattermost.ts
+++ b/src/servers/mattermost.ts
@@ -449,6 +449,9 @@ function handleAdminInbound(params: {
   if (existingRoot && existingRoot.channel_id !== channelId) {
     return jsonResponse({ error: "Root post belongs to another channel", ok: false }, 400);
   }
+  if (existingRoot?.root_id) {
+    return jsonResponse({ error: "Root post is itself a reply", ok: false }, 400);
+  }
   const rootPost =
     rootId && !existingRoot
       ? buildPost({
@@ -608,6 +611,9 @@ async function handleApi(params: {
       }
       if (rootPost.channel_id !== channelId) {
         return mattermostError("Root post belongs to another channel", 400);
+      }
+      if (rootPost.root_id) {
+        return mattermostError("Root post is itself a reply", 400);
       }
     }
     const pendingPost = buildNextPost(state, {

--- a/src/servers/mattermost.ts
+++ b/src/servers/mattermost.ts
@@ -239,7 +239,7 @@ function postEvent(
 }
 
 function webSocketEventBytes(event: MattermostWebSocketEvent): number {
-  return Buffer.byteLength(JSON.stringify({ ...event, seq: 0 }), "utf8");
+  return Buffer.byteLength(JSON.stringify({ ...event, seq: Number.MAX_SAFE_INTEGER }), "utf8");
 }
 
 function sendEvent(
@@ -253,10 +253,11 @@ function sendEvent(
     return false;
   }
   const payload = JSON.stringify({ ...event, seq });
-  if (
-    client.bufferedAmount + Buffer.byteLength(payload, "utf8") >
-    state.maxWebSocketBufferedBytes
-  ) {
+  const payloadBytes = Buffer.byteLength(payload, "utf8");
+  if (payloadBytes > state.maxWebSocketBufferedBytes) {
+    return false;
+  }
+  if (client.bufferedAmount + payloadBytes > state.maxWebSocketBufferedBytes) {
     state.websocketClients.delete(client);
     client.close(1013, "client too slow");
     return false;
@@ -309,10 +310,6 @@ function broadcast(
     return true;
   }
   if (webSocketEventBytes(event) > state.maxWebSocketBufferedBytes) {
-    for (const client of state.websocketClients.keys()) {
-      state.websocketClients.delete(client);
-      client.close(1013, "client too slow");
-    }
     return false;
   }
   let delivered = false;
@@ -342,25 +339,47 @@ function pendingQueueFullResponse(state: MattermostServerState): Response {
   );
 }
 
-function createPost(params: {
+function buildPost(params: {
   channelId: string;
+  id: string;
   message: string;
   rootId?: string | undefined;
-  state: MattermostServerState;
   userId: string;
 }): MattermostPost {
-  const id = mattermostId(`post-${params.state.nextPost++}`);
-  const post = {
+  return {
     channel_id: params.channelId,
     create_at: Date.now(),
-    id,
+    id: params.id,
     message: params.message,
     root_id: params.rootId ?? "",
     type: "",
     user_id: params.userId,
   };
-  params.state.posts.set(id, post);
-  return post;
+}
+
+function buildNextPost(
+  state: MattermostServerState,
+  params: Omit<Parameters<typeof buildPost>[0], "id">,
+  reservedId?: string,
+): { nextPost: number; post: MattermostPost } {
+  let nextPost = state.nextPost;
+  let id: string;
+  do {
+    id = mattermostId(`post-${nextPost++}`);
+  } while (id === reservedId || state.posts.has(id));
+  return { nextPost, post: buildPost({ ...params, id }) };
+}
+
+function commitNextPost(
+  state: MattermostServerState,
+  pending: ReturnType<typeof buildNextPost>,
+): void {
+  state.nextPost = pending.nextPost;
+  state.posts.set(pending.post.id, pending.post);
+}
+
+function webSocketEventTooLargeResponse(): Response {
+  return mattermostError("WebSocket event is too large", 413);
 }
 
 function handleAdminInbound(params: {
@@ -420,24 +439,52 @@ function handleAdminInbound(params: {
     readMattermostString(params.body.channelDisplayName ?? params.body.channel_display_name) ??
     previousChannel?.display_name ??
     channelName;
-  const previousNextPost = params.state.nextPost;
-  params.state.users.set(senderId, { id: senderId, update_at: Date.now(), username: senderName });
-  params.state.channels.set(channelId, {
+  const channel = {
     display_name: channelDisplayName,
     id: channelId,
     name: channelName,
     type: channelType,
-  });
-  const channel = params.state.channels.get(channelId)!;
-  const post = createPost({
-    channelId,
-    message: text,
-    rootId,
-    state: params.state,
-    userId: senderId,
-  });
+  };
+  const existingRoot = rootId ? params.state.posts.get(rootId) : undefined;
+  if (existingRoot && existingRoot.channel_id !== channelId) {
+    return jsonResponse({ error: "Root post belongs to another channel", ok: false }, 400);
+  }
+  const rootPost =
+    rootId && !existingRoot
+      ? buildPost({
+          channelId,
+          id: rootId,
+          message: "",
+          userId: senderId,
+        })
+      : undefined;
+  const pendingPost = buildNextPost(
+    params.state,
+    {
+      channelId,
+      message: text,
+      rootId,
+      userId: senderId,
+    },
+    rootPost?.id,
+  );
+  const { post } = pendingPost;
+  const event = postEvent("posted", post, senderName, channel);
+  if (webSocketEventBytes(event) > params.state.maxWebSocketBufferedBytes) {
+    return jsonResponse({ error: "Inbound event is too large", ok: false }, 413);
+  }
+  const previousNextPost = params.state.nextPost;
+  params.state.users.set(senderId, { id: senderId, update_at: Date.now(), username: senderName });
+  params.state.channels.set(channelId, channel);
+  if (rootPost) {
+    params.state.posts.set(rootPost.id, rootPost);
+  }
+  commitNextPost(params.state, pendingPost);
   const rollback = () => {
     params.state.posts.delete(post.id);
+    if (rootPost) {
+      params.state.posts.delete(rootPost.id);
+    }
     params.state.nextPost = previousNextPost;
     if (previousUser) {
       params.state.users.set(senderId, previousUser);
@@ -450,11 +497,6 @@ function handleAdminInbound(params: {
       params.state.channels.delete(channelId);
     }
   };
-  const event = postEvent("posted", post, senderName, channel);
-  if (webSocketEventBytes(event) > params.state.maxWebSocketBufferedBytes) {
-    rollback();
-    return jsonResponse({ error: "Inbound event is too large", ok: false }, 413);
-  }
   if (!broadcast(params.state, event)) {
     rollback();
     return pendingQueueFullResponse(params.state);
@@ -568,14 +610,19 @@ async function handleApi(params: {
         return mattermostError("Root post belongs to another channel", 400);
       }
     }
-    const post = createPost({
+    const pendingPost = buildNextPost(state, {
       channelId,
       message,
       rootId,
-      state,
       userId: state.botUserId,
     });
-    broadcast(state, postEvent("posted", post, state.botUsername, channel), false);
+    const { post } = pendingPost;
+    const event = postEvent("posted", post, state.botUsername, channel);
+    if (webSocketEventBytes(event) > state.maxWebSocketBufferedBytes) {
+      return webSocketEventTooLargeResponse();
+    }
+    commitNextPost(state, pendingPost);
+    broadcast(state, event, false);
     return jsonResponse(post, 201);
   }
   const postMatch = /^\/posts\/([^/]+)$/u.exec(apiPath);
@@ -592,12 +639,17 @@ async function handleApi(params: {
       return mattermostError("message must be a string", 400);
     }
     const updated = { ...post, message };
-    state.posts.set(updated.id, updated);
-    broadcast(
-      state,
-      postEvent("post_edited", updated, state.botUsername, state.channels.get(updated.channel_id)!),
-      false,
+    const event = postEvent(
+      "post_edited",
+      updated,
+      state.botUsername,
+      state.channels.get(updated.channel_id)!,
     );
+    if (webSocketEventBytes(event) > state.maxWebSocketBufferedBytes) {
+      return webSocketEventTooLargeResponse();
+    }
+    state.posts.set(updated.id, updated);
+    broadcast(state, event, false);
     return jsonResponse(updated);
   }
   if (postMatch?.[1] && method === "DELETE") {

--- a/test/mattermost-provider.test.ts
+++ b/test/mattermost-provider.test.ts
@@ -54,6 +54,20 @@ describe("Mattermost webhook normalizer", () => {
     });
   });
 
+  it("normalizes root posts to the channel target instead of their post id", () => {
+    expect(
+      normalizeMattermostWebhookPayload({
+        channel_id: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+        post_id: "bbbbbbbbbbbbbbbbbbbbbbbbbb",
+        root_id: "",
+        text: "root post",
+      }),
+    ).toMatchObject({
+      id: "bbbbbbbbbbbbbbbbbbbbbbbbbb",
+      threadId: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+    });
+  });
+
   it("matches local thread replies before native channel scoping", () => {
     expect(
       matchesMattermostThread("bbbbbbbbbbbbbbbbbbbbbbbbbb", "bbbbbbbbbbbbbbbbbbbbbbbbbb", {

--- a/test/mattermost-server.test.ts
+++ b/test/mattermost-server.test.ts
@@ -1089,6 +1089,65 @@ describe("Mattermost local provider server", () => {
     second.close();
   });
 
+  it("rejects an oversized delete event before removing the post", async () => {
+    const server = await startMattermostServer({
+      adminToken: "admin",
+      botToken: "fake",
+      maxWebSocketBufferedBytes: 1024,
+    });
+    servers.push(server);
+    const registered = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({ channelId: CHANNEL_ID, senderId: USER_ID, text: "register" }),
+      headers: {
+        "content-type": "application/json",
+        "x-crabline-admin-token": "admin",
+      },
+      method: "POST",
+    });
+    expect(registered.status).toBe(200);
+
+    const created = await fetch(`${server.manifest.endpoints.apiRoot}/posts`, {
+      body: JSON.stringify({ channel_id: CHANNEL_ID, message: "small post" }),
+      headers: {
+        authorization: "Bearer fake",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+    const post = (await created.json()) as { id: string };
+    expect(created.status).toBe(201);
+
+    const boundaryEdit = await fetch(`${server.manifest.endpoints.apiRoot}/posts/${post.id}`, {
+      body: JSON.stringify({ message: "x".repeat(655) }),
+      headers: {
+        authorization: "Bearer fake",
+        "content-type": "application/json",
+      },
+      method: "PUT",
+    });
+    expect(boundaryEdit.status).toBe(200);
+
+    const rejectedDelete = await fetch(`${server.manifest.endpoints.apiRoot}/posts/${post.id}`, {
+      headers: { authorization: "Bearer fake" },
+      method: "DELETE",
+    });
+    expect(rejectedDelete.status).toBe(413);
+    await expect(rejectedDelete.json()).resolves.toMatchObject({
+      message: "WebSocket event is too large",
+      status_code: 413,
+    });
+
+    const stillPresent = await fetch(`${server.manifest.endpoints.apiRoot}/posts/${post.id}`, {
+      body: JSON.stringify({ message: "still present" }),
+      headers: {
+        authorization: "Bearer fake",
+        "content-type": "application/json",
+      },
+      method: "PUT",
+    });
+    expect(stillPresent.status).toBe(200);
+  });
+
   it("bounds unauthenticated clients and inbound WebSocket messages", async () => {
     const server = await startMattermostServer({
       botToken: "fake",

--- a/test/mattermost-server.test.ts
+++ b/test/mattermost-server.test.ts
@@ -4,6 +4,7 @@ import { Agent } from "node:http";
 import { WebSocket } from "ws";
 import { afterEach, describe, expect, it } from "vitest";
 import { startMattermostServer, type StartedMattermostServer } from "../src/index.js";
+import { mattermostId } from "../src/servers/mattermost.js";
 import { createTempDir, disposeTempDir, requestHttp } from "./test-helpers.js";
 
 const servers: StartedMattermostServer[] = [];
@@ -12,6 +13,7 @@ const CHANNEL_ID = "aaaaaaaaaaaaaaaaaaaaaaaaaa";
 const OTHER_CHANNEL_ID = "cccccccccccccccccccccccccc";
 const USER_ID = "bbbbbbbbbbbbbbbbbbbbbbbbbb";
 const OTHER_USER_ID = "dddddddddddddddddddddddddd";
+const ROOT_ID = "eeeeeeeeeeeeeeeeeeeeeeeeee";
 
 afterEach(async () => {
   await Promise.all(servers.splice(0).map((server) => server.close()));
@@ -770,6 +772,58 @@ describe("Mattermost local provider server", () => {
     }
   });
 
+  it("materializes missing roots for admin-injected thread replies", async () => {
+    const server = await startMattermostServer({ adminToken: "admin", botToken: "fake" });
+    servers.push(server);
+
+    const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({
+        channelId: CHANNEL_ID,
+        rootId: ROOT_ID,
+        senderId: USER_ID,
+        text: "user thread reply",
+      }),
+      headers: {
+        "content-type": "application/json",
+        "x-crabline-admin-token": "admin",
+      },
+      method: "POST",
+    });
+    expect(inbound.status).toBe(200);
+    await expect(inbound.json()).resolves.toMatchObject({
+      post: { channel_id: CHANNEL_ID, root_id: ROOT_ID, user_id: USER_ID },
+    });
+
+    const reply = await fetch(`${server.manifest.endpoints.apiRoot}/posts`, {
+      body: JSON.stringify({
+        channel_id: CHANNEL_ID,
+        message: "bot thread reply",
+        root_id: ROOT_ID,
+      }),
+      headers: {
+        authorization: "Bearer fake",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+    expect(reply.status).toBe(201);
+    await expect(reply.json()).resolves.toMatchObject({
+      channel_id: CHANNEL_ID,
+      root_id: ROOT_ID,
+      user_id: server.manifest.botUserId,
+    });
+
+    const rootMutation = await fetch(`${server.manifest.endpoints.apiRoot}/posts/${ROOT_ID}`, {
+      body: JSON.stringify({ message: "forbidden root edit" }),
+      headers: {
+        authorization: "Bearer fake",
+        "content-type": "application/json",
+      },
+      method: "PUT",
+    });
+    expect(rootMutation.status).toBe(403);
+  });
+
   it("keeps typing channel-scoped, omitted from the sender, and ephemeral", async () => {
     const server = await startMattermostServer({ adminToken: "admin", botToken: "fake" });
     servers.push(server);
@@ -952,6 +1006,87 @@ describe("Mattermost local provider server", () => {
 
     expect((await sendInbound("queued after oversized event")).status).toBe(200);
     expect((await sendInbound("queue is full")).status).toBe(503);
+  });
+
+  it("rejects oversized REST events atomically without disconnecting other clients", async () => {
+    const server = await startMattermostServer({
+      adminToken: "admin",
+      botToken: "fake",
+      maxWebSocketBufferedBytes: 1024,
+    });
+    servers.push(server);
+    const registered = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({ channelId: CHANNEL_ID, senderId: USER_ID, text: "register" }),
+      headers: {
+        "content-type": "application/json",
+        "x-crabline-admin-token": "admin",
+      },
+      method: "POST",
+    });
+    expect(registered.status).toBe(200);
+
+    const first = new WebSocket(server.manifest.endpoints.websocketUrl);
+    await waitForSocketOpen(first);
+    const firstAuthenticated = nextMessages(first, 3);
+    first.send(
+      JSON.stringify({
+        action: "authentication_challenge",
+        data: { token: "fake" },
+        seq: 1,
+      }),
+    );
+    await firstAuthenticated;
+
+    const second = new WebSocket(server.manifest.endpoints.websocketUrl);
+    await waitForSocketOpen(second);
+    const secondAuthenticated = nextMessages(second, 2);
+    second.send(
+      JSON.stringify({
+        action: "authentication_challenge",
+        data: { token: "fake" },
+        seq: 1,
+      }),
+    );
+    await secondAuthenticated;
+
+    const firstQuiet = expectNoSocketMessage(first);
+    const secondQuiet = expectNoSocketMessage(second);
+    const oversized = await fetch(`${server.manifest.endpoints.apiRoot}/posts`, {
+      body: JSON.stringify({ channel_id: CHANNEL_ID, message: "x".repeat(2_000) }),
+      headers: {
+        authorization: "Bearer fake",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+    expect(oversized.status).toBe(413);
+    await expect(oversized.json()).resolves.toMatchObject({
+      message: "WebSocket event is too large",
+      status_code: 413,
+    });
+    await Promise.all([firstQuiet, secondQuiet]);
+    expect(first.readyState).toBe(WebSocket.OPEN);
+    expect(second.readyState).toBe(WebSocket.OPEN);
+
+    const firstDelivered = nextMessage(first);
+    const secondDelivered = nextMessage(second);
+    const accepted = await fetch(`${server.manifest.endpoints.apiRoot}/posts`, {
+      body: JSON.stringify({ channel_id: CHANNEL_ID, message: "accepted after rejection" }),
+      headers: {
+        authorization: "Bearer fake",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+    expect(accepted.status).toBe(201);
+    await expect(accepted.json()).resolves.toMatchObject({
+      id: mattermostId("post-2"),
+      message: "accepted after rejection",
+    });
+    await expect(firstDelivered).resolves.toMatchObject({ event: "posted" });
+    await expect(secondDelivered).resolves.toMatchObject({ event: "posted" });
+    first.close();
+    second.close();
   });
 
   it("bounds unauthenticated clients and inbound WebSocket messages", async () => {

--- a/test/mattermost-server.test.ts
+++ b/test/mattermost-server.test.ts
@@ -733,11 +733,13 @@ describe("Mattermost local provider server", () => {
       method: "POST",
     });
     expect(reply.status).toBe(201);
-    await expect(reply.json()).resolves.toMatchObject({ root_id: root.id });
+    const replyPost = (await reply.json()) as { id: string; root_id: string };
+    expect(replyPost).toMatchObject({ root_id: root.id });
 
     for (const [rootId, status, message] of [
       ["missing-root", 404, "Root post not found"],
       [otherRoot.id, 400, "Root post belongs to another channel"],
+      [replyPost.id, 400, "Root post is itself a reply"],
     ] as const) {
       const response = await fetch(`${server.manifest.endpoints.apiRoot}/posts`, {
         body: JSON.stringify({
@@ -754,6 +756,25 @@ describe("Mattermost local provider server", () => {
       expect(response.status).toBe(status);
       await expect(response.json()).resolves.toMatchObject({ message });
     }
+
+    const nestedAdminReply = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({
+        channelId: root.channel_id,
+        rootId: replyPost.id,
+        senderId: USER_ID,
+        text: "invalid nested reply",
+      }),
+      headers: {
+        "content-type": "application/json",
+        "x-crabline-admin-token": "admin",
+      },
+      method: "POST",
+    });
+    expect(nestedAdminReply.status).toBe(400);
+    await expect(nestedAdminReply.json()).resolves.toEqual({
+      error: "Root post is itself a reply",
+      ok: false,
+    });
 
     for (const method of ["PUT", "DELETE"] as const) {
       const response = await fetch(`${server.manifest.endpoints.apiRoot}/posts/${root.id}`, {


### PR DESCRIPTION
## Summary

- materialize missing Mattermost thread roots without allowing cross-channel reuse
- keep root webhook targets channel-scoped
- preflight oversized create, edit, delete, and admin WebSocket events before mutating state
- isolate slow WebSocket clients instead of disconnecting unrelated clients

## Validation

- `pnpm lint`
- `pnpm exec vitest run test/mattermost-server.test.ts test/mattermost-provider.test.ts`
- public-data secret scan

## Release notes

- Added to `CHANGELOG.md`.
