### PR TITLE
fix(whatsapp): merge repeated handshake messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fail OpenClaw provider readiness when a successful probe produces no recorder evidence.
+- Merge repeated WhatsApp handshake message occurrences according to protobuf semantics.
 - Confine generated local-mock recorder paths by rejecting absolute and parent-traversal provider IDs.
 - Accept native Zalo image callbacks, honor injected webhook auth environments, and bound recursive credential redaction.
 - Use one case-insensitive numeric identity for Telegram username chats across provider sends, OpenClaw inbound injection, and recorder correlation.

--- a/src/servers/whatsapp-wire/handshake.ts
+++ b/src/servers/whatsapp-wire/handshake.ts
@@ -31,13 +31,22 @@ export function decodeHandshakeMessage(data: Uint8Array): HandshakeMessage {
     const field = tag >>> 3;
     if (field === 2) {
       requireBytesWireType(tag, field);
-      message.clientHello = decodeClientHello(reader.bytes());
+      message.clientHello = {
+        ...message.clientHello,
+        ...decodeClientHello(reader.bytes()),
+      };
     } else if (field === 3) {
       requireBytesWireType(tag, field);
-      message.serverHello = decodeServerHello(reader.bytes());
+      message.serverHello = {
+        ...message.serverHello,
+        ...decodeServerHello(reader.bytes()),
+      };
     } else if (field === 4) {
       requireBytesWireType(tag, field);
-      message.clientFinish = decodeClientFinish(reader.bytes());
+      message.clientFinish = {
+        ...message.clientFinish,
+        ...decodeClientFinish(reader.bytes()),
+      };
     } else {
       reader.skip(tag & 7);
     }

--- a/test/whatsapp-wire.test.ts
+++ b/test/whatsapp-wire.test.ts
@@ -474,6 +474,86 @@ describe("WhatsApp handshake protobufs", () => {
     expect(decodeHandshakeMessage(encoded)).toEqual(message);
   });
 
+  it.each([
+    {
+      expected: {
+        clientHello: {
+          ephemeral: Buffer.from([1]),
+          staticKey: Buffer.from([2]),
+        },
+      },
+      occurrences: [
+        { clientHello: { ephemeral: Buffer.from([1]) } },
+        { clientHello: { static: Buffer.from([2]) } },
+      ],
+      variant: "client hello",
+    },
+    {
+      expected: {
+        serverHello: {
+          extendedStatic: Buffer.from([4]),
+          payload: Buffer.from([3]),
+        },
+      },
+      occurrences: [
+        { serverHello: { payload: Buffer.from([3]) } },
+        { serverHello: { extendedStatic: Buffer.from([4]) } },
+      ],
+      variant: "server hello",
+    },
+    {
+      expected: {
+        clientFinish: {
+          extendedCiphertext: Buffer.from([3]),
+          staticKey: Buffer.from([1]),
+        },
+      },
+      occurrences: [
+        { clientFinish: { static: Buffer.from([1]) } },
+        { clientFinish: { extendedCiphertext: Buffer.from([3]) } },
+      ],
+      variant: "client finish",
+    },
+  ] satisfies Array<{
+    expected: HandshakeMessage;
+    occurrences: proto.IHandshakeMessage[];
+    variant: string;
+  }>)("merges repeated $variant occurrences", ({ expected, occurrences }) => {
+    const encoded = Buffer.concat(
+      occurrences.map((occurrence) =>
+        Buffer.from(proto.HandshakeMessage.encode(occurrence).finish()),
+      ),
+    );
+
+    expect(decodeHandshakeMessage(encoded)).toEqual(expected);
+  });
+
+  it("merges optional fields and ignores unknown-only repeated occurrences", () => {
+    const first = Buffer.from(
+      proto.HandshakeMessage.encode({
+        clientHello: {
+          ephemeral: Buffer.from([1]),
+          useExtended: true,
+        },
+      }).finish(),
+    );
+    const second = Buffer.from(
+      proto.HandshakeMessage.encode({
+        clientHello: {
+          useExtended: false,
+        },
+      }).finish(),
+    );
+    const unknownOnlyClientHello = Buffer.from([0x12, 0x02, 0x30, 0x01]);
+
+    expect(decodeHandshakeMessage(Buffer.concat([first, second, unknownOnlyClientHello]))).toEqual({
+      clientHello: {
+        ephemeral: Buffer.from([1]),
+        useExtended: false,
+      },
+    });
+  });
+
   it("skips unknown ten-byte uint64 varints", () => {
     const message = decodeHandshakeMessage(
       Buffer.from([


### PR DESCRIPTION
## Summary
- merge repeated protobuf handshake submessages instead of replacing prior fields
- preserve later-field overwrite semantics
- cover all handshake variants and unknown-only occurrences

## Validation
- focused WhatsApp wire tests: 46 passed
- pnpm lint
- gpt-5.6-sol high autoreview: clean