### PR TITLE
fix(core): preserve runtime failure fidelity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fail OpenClaw provider readiness when a successful probe produces no recorder evidence.
 - Merge repeated WhatsApp handshake message occurrences according to protobuf semantics.
+- Close inherited credential descriptors and preserve runtime failure classification and accepted-send diagnostics.
 - Confine generated local-mock recorder paths by rejecting absolute and parent-traversal provider IDs.
 - Accept native Zalo image callbacks, honor injected webhook auth environments, and bound recursive credential redaction.
 - Use one case-insensitive numeric identity for Telegram username chats across provider sends, OpenClaw inbound injection, and recorder correlation.

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { constants as fsConstants, createReadStream } from "node:fs";
 import fs from "node:fs/promises";
 import nodePath from "node:path";
+import { finished } from "node:stream/promises";
 import { lock } from "proper-lockfile";
 import { loadManifest } from "../config/load.js";
 import { createRegistry } from "../providers/registry.js";
@@ -241,7 +242,7 @@ function parseCredentialsFd(value: string): number {
 }
 
 async function readBoundedFileDescriptor(fd: number): Promise<string> {
-  const stream = createReadStream("", { autoClose: false, fd });
+  const stream = createReadStream("", { autoClose: fd !== 0, fd });
   const chunks: Buffer[] = [];
   let totalBytes = 0;
   try {
@@ -265,6 +266,11 @@ async function readBoundedFileDescriptor(fd: number): Promise<string> {
       cause: error,
       kind: "config",
     });
+  } finally {
+    if (fd !== 0 && !stream.closed) {
+      stream.destroy();
+      await finished(stream).catch(() => undefined);
+    }
   }
   return Buffer.concat(chunks).toString("utf8");
 }

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -21,6 +21,7 @@ const KIND_TO_EXIT: Record<FailureKind, ExitCode> = {
 
 export class CrablineError extends Error {
   readonly exitCode: ExitCode;
+  readonly hasExplicitExitCode: boolean;
   readonly kind: FailureKind | undefined;
 
   constructor(
@@ -29,6 +30,7 @@ export class CrablineError extends Error {
   ) {
     super(message, options);
     this.name = "CrablineError";
+    this.hasExplicitExitCode = options?.exitCode !== undefined;
     this.kind = options?.kind;
     this.exitCode =
       options?.exitCode === EXIT_CODES.SUCCESS

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -533,7 +533,15 @@ export async function runFixtureCommand(params: {
               }
             }
           } catch (error) {
-            lastFailure = toFailure(fixture.id, fixture.provider, mode, error, "inbound", nonce);
+            lastFailure = toFailure(
+              fixture.id,
+              fixture.provider,
+              mode,
+              error,
+              "inbound",
+              nonce,
+              diagnostics,
+            );
             if (abortDrainFailed) {
               break;
             }
@@ -567,7 +575,15 @@ export async function runFixtureCommand(params: {
             providerId: fixture.provider,
           });
         } catch (error) {
-          lastFailure = toFailure(fixture.id, fixture.provider, mode, error, "assertion", nonce);
+          lastFailure = toFailure(
+            fixture.id,
+            fixture.provider,
+            mode,
+            error,
+            "assertion",
+            nonce,
+            diagnostics,
+          );
         }
       }
 
@@ -742,13 +758,14 @@ function toFailure(
   error: unknown,
   fallbackKind: FailureKind,
   nonce?: string,
+  priorDiagnostics: readonly string[] = [],
 ): CommandRunResult {
-  const diagnostics = [ensureErrorMessage(error)];
+  const diagnostics = [...priorDiagnostics, ensureErrorMessage(error)];
   if (error instanceof CrablineError) {
     return {
       diagnostics,
-      exitCode: error.exitCode,
-      failureKind: error.kind,
+      ...(error.hasExplicitExitCode || error.kind ? { exitCode: error.exitCode } : {}),
+      failureKind: error.kind ?? fallbackKind,
       fixtureId,
       mode,
       nonce,

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import { closeSync, fstatSync, openSync, type Stats } from "node:fs";
 import path from "node:path";
 import fs from "node:fs/promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -44,6 +45,26 @@ const directories: string[] = [];
 const ansiPattern = new RegExp(String.raw`\u001B\[[0-?]*[ -/]*[@-~]`, "g");
 
 const stripAnsi = (value: string): string => value.replace(ansiPattern, "");
+
+const expectDescriptorReleased = (fd: number, original: Stats): void => {
+  try {
+    const current = fstatSync(fd);
+    expect([current.dev, current.ino]).not.toEqual([original.dev, original.ino]);
+  } catch (error) {
+    expect(error).toMatchObject({ code: "EBADF" });
+  }
+};
+
+const closeIfStillOwned = (fd: number, original: Stats): void => {
+  try {
+    const current = fstatSync(fd);
+    if (current.dev === original.dev && current.ino === original.ino) {
+      closeSync(fd);
+    }
+  } catch {
+    // The descriptor was already closed or reassigned.
+  }
+};
 
 afterEach(async () => {
   process.exitCode = 0;
@@ -421,7 +442,8 @@ describe("cli", () => {
     const credentialsPath = path.join(directory, "credentials.json");
     const fdBot = ["fd", "bot"].join("-");
     await writeText(credentialsPath, JSON.stringify({ botToken: fdBot }));
-    const credentialsHandle = await fs.open(credentialsPath, "r");
+    const credentialsFd = openSync(credentialsPath, "r");
+    const credentialsIdentity = fstatSync(credentialsFd);
     const startServer = vi.fn(
       async (_params: StartCrablineServerParams): Promise<StartedCrablineServer> => ({
         async close() {},
@@ -456,12 +478,13 @@ describe("cli", () => {
           "serve",
           "slack",
           "--credentials-fd",
-          String(credentialsHandle.fd),
+          String(credentialsFd),
           "--once",
         ]);
       });
+      expectDescriptorReleased(credentialsFd, credentialsIdentity);
     } finally {
-      await credentialsHandle.close();
+      closeIfStillOwned(credentialsFd, credentialsIdentity);
     }
 
     expect(startServer).toHaveBeenCalledWith(
@@ -483,7 +506,8 @@ describe("cli", () => {
     const document = JSON.stringify({ botToken });
     expect(Buffer.byteLength(document)).toBe(64 * 1024);
     await writeText(credentialsPath, document);
-    const credentialsHandle = await fs.open(credentialsPath, "r");
+    const credentialsFd = openSync(credentialsPath, "r");
+    const credentialsIdentity = fstatSync(credentialsFd);
     const startServer = vi.fn(
       async (): Promise<StartedCrablineServer> => ({
         async close() {},
@@ -518,12 +542,13 @@ describe("cli", () => {
           "serve",
           "slack",
           "--credentials-fd",
-          String(credentialsHandle.fd),
+          String(credentialsFd),
           "--once",
         ]);
       });
+      expectDescriptorReleased(credentialsFd, credentialsIdentity);
     } finally {
-      await credentialsHandle.close();
+      closeIfStillOwned(credentialsFd, credentialsIdentity);
     }
 
     expect(startServer).toHaveBeenCalledWith(expect.objectContaining({ botToken }));
@@ -541,23 +566,28 @@ describe("cli", () => {
     ).entries()) {
       const credentialsPath = path.join(directory, `${index}.json`);
       await writeText(credentialsPath, document);
-      const credentialsHandle = await fs.open(credentialsPath, "r");
-      const captured = await captureWrites(async () => {
-        expect(
-          await runCli([
-            "node",
-            "crabline",
-            "serve",
-            "slack",
-            "--once",
-            "--credentials-fd",
-            String(credentialsHandle.fd),
-          ]),
-        ).toBe(10);
-      }).finally(async () => await credentialsHandle.close());
-
-      expect(captured.stderr.join("")).toContain(message);
-      expect(captured.stderr.join("")).not.toContain(document);
+      const credentialsFd = openSync(credentialsPath, "r");
+      const credentialsIdentity = fstatSync(credentialsFd);
+      try {
+        const captured = await captureWrites(async () => {
+          expect(
+            await runCli([
+              "node",
+              "crabline",
+              "serve",
+              "slack",
+              "--once",
+              "--credentials-fd",
+              String(credentialsFd),
+            ]),
+          ).toBe(10);
+        });
+        expectDescriptorReleased(credentialsFd, credentialsIdentity);
+        expect(captured.stderr.join("")).toContain(message);
+        expect(captured.stderr.join("")).not.toContain(document);
+      } finally {
+        closeIfStillOwned(credentialsFd, credentialsIdentity);
+      }
     }
   });
 
@@ -567,23 +597,28 @@ describe("cli", () => {
     const credentialsPath = path.join(directory, "credentials.json");
     const sentinel = "credential-stream-secret";
     await writeText(credentialsPath, `{"adminToken":"${sentinel}"`);
-    const credentialsHandle = await fs.open(credentialsPath, "r");
-    const captured = await captureWrites(async () => {
-      expect(
-        await runCli([
-          "node",
-          "crabline",
-          "serve",
-          "slack",
-          "--once",
-          "--credentials-fd",
-          String(credentialsHandle.fd),
-        ]),
-      ).toBe(10);
-    }).finally(async () => await credentialsHandle.close());
-
-    expect(captured.stderr.join("")).toContain("Serve credentials input must be valid JSON.");
-    expect(captured.stderr.join("")).not.toContain(sentinel);
+    const credentialsFd = openSync(credentialsPath, "r");
+    const credentialsIdentity = fstatSync(credentialsFd);
+    try {
+      const captured = await captureWrites(async () => {
+        expect(
+          await runCli([
+            "node",
+            "crabline",
+            "serve",
+            "slack",
+            "--once",
+            "--credentials-fd",
+            String(credentialsFd),
+          ]),
+        ).toBe(10);
+      });
+      expectDescriptorReleased(credentialsFd, credentialsIdentity);
+      expect(captured.stderr.join("")).toContain("Serve credentials input must be valid JSON.");
+      expect(captured.stderr.join("")).not.toContain(sentinel);
+    } finally {
+      closeIfStillOwned(credentialsFd, credentialsIdentity);
+    }
   });
 
   it("bounds credential streams before parsing them", async () => {
@@ -591,22 +626,27 @@ describe("cli", () => {
     directories.push(directory);
     const credentialsPath = path.join(directory, "credentials.json");
     await writeText(credentialsPath, JSON.stringify({ adminToken: "x".repeat(64 * 1024) }));
-    const credentialsHandle = await fs.open(credentialsPath, "r");
-    const captured = await captureWrites(async () => {
-      expect(
-        await runCli([
-          "node",
-          "crabline",
-          "serve",
-          "slack",
-          "--once",
-          "--credentials-fd",
-          String(credentialsHandle.fd),
-        ]),
-      ).toBe(10);
-    }).finally(async () => await credentialsHandle.close());
-
-    expect(captured.stderr.join("")).toContain("Serve credentials JSON exceeds 65536 bytes.");
+    const credentialsFd = openSync(credentialsPath, "r");
+    const credentialsIdentity = fstatSync(credentialsFd);
+    try {
+      const captured = await captureWrites(async () => {
+        expect(
+          await runCli([
+            "node",
+            "crabline",
+            "serve",
+            "slack",
+            "--once",
+            "--credentials-fd",
+            String(credentialsFd),
+          ]),
+        ).toBe(10);
+      });
+      expectDescriptorReleased(credentialsFd, credentialsIdentity);
+      expect(captured.stderr.join("")).toContain("Serve credentials JSON exceeds 65536 bytes.");
+    } finally {
+      closeIfStillOwned(credentialsFd, credentialsIdentity);
+    }
   });
 
   it("isolates exit codes across repeated invocations", async () => {

--- a/test/reporters-errors.test.ts
+++ b/test/reporters-errors.test.ts
@@ -11,11 +11,12 @@ describe("errors and reporters", () => {
   it("maps failure kinds to exit codes", () => {
     const error = new CrablineError("boom", { kind: "auth" });
     expect(error.exitCode).toBe(EXIT_CODES.AUTH);
+    expect(error.hasExplicitExitCode).toBe(false);
     expect(ensureErrorMessage(error)).toBe("boom");
     expect(ensureErrorMessage("plain")).toBe("plain");
-    expect(new CrablineError("failed", { exitCode: EXIT_CODES.SUCCESS }).exitCode).toBe(
-      EXIT_CODES.FAILURE,
-    );
+    const normalizedExit = new CrablineError("failed", { exitCode: EXIT_CODES.SUCCESS });
+    expect(normalizedExit.exitCode).toBe(EXIT_CODES.FAILURE);
+    expect(normalizedExit.hasExplicitExitCode).toBe(true);
     expect(ensureErrorMessage(Object.create(null))).toBe("Unknown error");
     const numericMessage = new Error("hidden");
     Object.defineProperty(numericMessage, "message", { value: 42 });

--- a/test/run.behavior.test.ts
+++ b/test/run.behavior.test.ts
@@ -573,7 +573,60 @@ describe("run behavior", () => {
     stage = "send";
     expect((await run()).failureKind).toBe("outbound");
     stage = "wait";
-    expect((await run()).failureKind).toBe("inbound");
+    const waitFailure = await run();
+    expect(waitFailure.failureKind).toBe("inbound");
+    expect(waitFailure.diagnostics).toEqual(["accepted message sent", "wait exploded"]);
+  });
+
+  it("classifies untyped CrablineError failures by execution stage", async () => {
+    let stage: "probe" | "send" | "wait" = "probe";
+    const provider: ProviderAdapter = {
+      id: "mock",
+      platform: "loopback",
+      status: "ready",
+      supports: ["probe", "send", "roundtrip", "agent"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      probe: async () => {
+        throw new CrablineError("probe exploded");
+      },
+      send: async () => {
+        if (stage === "send") {
+          throw new CrablineError("send exploded");
+        }
+        return { accepted: true, messageId: "sent", threadId: "thread" };
+      },
+      waitForInbound: async () => {
+        throw new CrablineError("wait exploded");
+      },
+    };
+    const run = (modeOverride?: "probe") =>
+      runFixtureCommand({
+        fixtureId: "fixture",
+        manifest: withAllCapabilities(manifest),
+        manifestPath: "/tmp/crabline.yaml",
+        ...(modeOverride ? { modeOverride } : {}),
+        registry: buildRegistry(provider),
+      });
+
+    const probe = await run("probe");
+    expect(probe).toMatchObject({ failureKind: "connectivity", ok: false });
+    expect(probe.exitCode).toBeUndefined();
+    expect(computeExitCode(probe)).toBe(EXIT_CODES.CONNECTIVITY);
+
+    stage = "send";
+    const send = await run();
+    expect(send).toMatchObject({ failureKind: "outbound", ok: false });
+    expect(send.exitCode).toBeUndefined();
+    expect(computeExitCode(send)).toBe(EXIT_CODES.OUTBOUND);
+
+    stage = "wait";
+    const wait = await run();
+    expect(wait).toMatchObject({ failureKind: "inbound", ok: false });
+    expect(wait.exitCode).toBeUndefined();
+    expect(computeExitCode(wait)).toBe(EXIT_CODES.INBOUND);
+    expect(wait.diagnostics).toEqual(["accepted message sent", "wait exploded"]);
   });
 
   it("retries rejected outbound results and fails when rejection persists", async () => {


### PR DESCRIPTION
## Summary
- close inherited credential descriptors while preserving stdin ownership
- derive untyped CrablineError exit codes from the failing operation
- retain accepted-send diagnostics when inbound handling later fails

## Validation
- focused tests: 94 passed
- pnpm lint
- gpt-5.6-sol high autoreview: clean, 0.90 confidence