### PR TITLE
fix(providers): validate and drain webhook ingress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fail OpenClaw provider readiness when a successful probe produces no recorder evidence.
 - Merge repeated WhatsApp handshake message occurrences according to protobuf semantics.
 - Close inherited credential descriptors and preserve runtime failure classification and accepted-send diagnostics.
+- Validate every configured webhook callback independently and gracefully drain admitted provider responses before bounded connection teardown.
 - Confine generated local-mock recorder paths by rejecting absolute and parent-traversal provider IDs.
 - Accept native Zalo image callbacks, honor injected webhook auth environments, and bound recursive credential redaction.
 - Use one case-insensitive numeric identity for Telegram username chats across provider sends, OpenClaw inbound injection, and recorder correlation.

--- a/src/providers/builtin/external-webhook-auth.ts
+++ b/src/providers/builtin/external-webhook-auth.ts
@@ -8,15 +8,18 @@ type WebhookConfig = {
 
 export function requireExternalWebhookAuthentication(params: {
   authenticated: boolean;
-  authenticatedIngressUrl?: string | undefined;
+  authenticatedIngressUrls?: readonly string[] | undefined;
   provider: string;
   requirement: string;
   webhook: WebhookConfig | undefined;
 }): void {
   const host = params.webhook?.host ?? "127.0.0.1";
   const hostIsLoopback = isLoopbackHost(host);
-  const publicUrl = params.authenticatedIngressUrl ?? params.webhook?.publicUrl;
-  const externallyReachable = Boolean(publicUrl) || !hostIsLoopback;
+  const publicUrls = [
+    ...(params.authenticatedIngressUrls ?? []),
+    ...(params.webhook?.publicUrl ? [params.webhook.publicUrl] : []),
+  ];
+  const externallyReachable = publicUrls.length > 0 || !hostIsLoopback;
   if (externallyReachable && !params.authenticated) {
     throw new CrablineError(
       `${params.provider} externally reachable webhooks require ${params.requirement}.`,
@@ -26,28 +29,30 @@ export function requireExternalWebhookAuthentication(params: {
   if (!externallyReachable) {
     return;
   }
-  if (!publicUrl) {
+  if (publicUrls.length === 0) {
     throw new CrablineError(
       `${params.provider} authenticated external webhooks require a public callback URL with HTTPS.`,
       { kind: "config" },
     );
   }
 
-  let url: URL;
-  try {
-    url = new URL(publicUrl);
-  } catch (error) {
-    throw new CrablineError(`${params.provider} public callback URL is invalid.`, {
-      cause: error,
-      kind: "config",
-    });
-  }
-  const safeLoopbackHttp =
-    url.protocol === "http:" && hostIsLoopback && isLoopbackHost(url.hostname);
-  if (url.protocol !== "https:" && !safeLoopbackHttp) {
-    throw new CrablineError(
-      `${params.provider} authenticated external webhooks require HTTPS; plain HTTP is allowed only for loopback-local ingress.`,
-      { kind: "config" },
-    );
+  for (const publicUrl of publicUrls) {
+    let url: URL;
+    try {
+      url = new URL(publicUrl);
+    } catch (error) {
+      throw new CrablineError(`${params.provider} public callback URL is invalid.`, {
+        cause: error,
+        kind: "config",
+      });
+    }
+    const safeLoopbackHttp =
+      url.protocol === "http:" && hostIsLoopback && isLoopbackHost(url.hostname);
+    if (url.protocol !== "https:" && !safeLoopbackHttp) {
+      throw new CrablineError(
+        `${params.provider} authenticated external webhooks require HTTPS; plain HTTP is allowed only for loopback-local ingress.`,
+        { kind: "config" },
+      );
+    }
   }
 }

--- a/src/providers/builtin/googlechat.ts
+++ b/src/providers/builtin/googlechat.ts
@@ -207,7 +207,9 @@ export class GoogleChatProviderAdapter extends LocalMockProviderAdapter implemen
       );
     requireExternalWebhookAuthentication({
       authenticated: authenticationConfigured,
-      authenticatedIngressUrl: endpointAudience,
+      authenticatedIngressUrls: config.googlechat?.endpointUrl
+        ? [config.googlechat.endpointUrl]
+        : undefined,
       provider: "Google Chat",
       requirement:
         "googlechat.endpointUrl, googlechat.googleChatProjectNumber, or googlechat.pubsubAudience with a Pub/Sub service-account identity and signature verification enabled",

--- a/src/providers/local-mock.ts
+++ b/src/providers/local-mock.ts
@@ -268,6 +268,7 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
   #cleanupBegun = false;
   #cleanupPromise: Promise<void> | null = null;
   #server: StartedWebhookServer | null = null;
+  #serverClosing: Promise<void> | null = null;
   #serverStarting: Promise<StartedWebhookServer> | null = null;
 
   constructor(params: {
@@ -463,6 +464,8 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
     this.#cleanupBegun = true;
     this.#cleanupController.abort(this.#cleanedUpError());
     this.#waitCursors.clear();
+    this.#serverClosing = this.#closeWebhookServer();
+    void this.#serverClosing.catch(() => undefined);
   }
 
   #installCleanupFence(): void {
@@ -481,7 +484,7 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
       const sends = [...this.#activeSends];
       const webhookHandlers = [...this.#activeWebhookHandlers];
       const [serverResult] = await Promise.allSettled([
-        this.#closeWebhookServer(),
+        this.#serverClosing,
         ...sends,
         ...webhookHandlers,
       ]);

--- a/src/providers/webhook-server.ts
+++ b/src/providers/webhook-server.ts
@@ -1,5 +1,6 @@
-import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { isCanonicalHttpPath } from "../core/http-path.js";
+import { closeServer } from "../servers/http.js";
 
 export type StartedWebhookServer = {
   close(): Promise<void>;
@@ -128,19 +129,6 @@ function clearUnsentResponseHeaders(response: ServerResponse<IncomingMessage>): 
   }
 }
 
-function closeServer(server: Server): Promise<void> {
-  return new Promise((resolve, reject) => {
-    server.close((error) => {
-      if (error) {
-        reject(error);
-        return;
-      }
-      resolve();
-    });
-    server.closeAllConnections();
-  });
-}
-
 function formatUrlHost(host: string): string {
   return host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
 }
@@ -154,6 +142,7 @@ export async function startWebhookServer(params: {
   onError?: ((error: unknown) => void) | undefined;
   path: string;
   port: number;
+  shutdownGraceMs?: number | undefined;
 }): Promise<StartedWebhookServer> {
   if (!isCanonicalHttpPath(params.path)) {
     throw new Error("Webhook path must be a canonical URL pathname.");
@@ -161,8 +150,20 @@ export async function startWebhookServer(params: {
   const methods = new Set(params.methods ?? ["POST"]);
   const maxBodyBytes = params.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES;
   const bodyTimeoutMs = params.bodyTimeoutMs ?? DEFAULT_BODY_TIMEOUT_MS;
+  let closing = false;
   const server = createServer(async (request, response) => {
     try {
+      if (closing) {
+        request.resume();
+        await writeFetchResponse(
+          response,
+          new Response("provider is shutting down", {
+            headers: { connection: "close" },
+            status: 503,
+          }),
+        );
+        return;
+      }
       const method = request.method ?? "GET";
       const host = request.headers.host ?? "127.0.0.1";
       const url = new URL(request.url ?? "/", `http://${host}`);
@@ -219,9 +220,12 @@ export async function startWebhookServer(params: {
     throw new Error("Unable to resolve webhook server address.");
   }
 
+  let closingPromise: Promise<void> | null = null;
   return {
     async close() {
-      await closeServer(server);
+      closing = true;
+      closingPromise ??= closeServer(server, params.shutdownGraceMs);
+      await closingPromise;
     },
     endpointUrl: `http://${formatUrlHost(params.host)}:${address.port}${params.path}`,
   };

--- a/test/external-webhook-auth.test.ts
+++ b/test/external-webhook-auth.test.ts
@@ -31,8 +31,20 @@ describe("external webhook authentication policy", () => {
       requireExternalWebhookAuthentication({
         ...base,
         authenticated: true,
-        authenticatedIngressUrl: "http://hooks.example.test/events",
+        authenticatedIngressUrls: ["http://hooks.example.test/events"],
         webhook: { host: "0.0.0.0" },
+      }),
+    ).toThrow(/require HTTPS/u);
+
+    expect(() =>
+      requireExternalWebhookAuthentication({
+        ...base,
+        authenticated: true,
+        authenticatedIngressUrls: ["https://hooks.example.test/events"],
+        webhook: {
+          host: "127.0.0.1",
+          publicUrl: "http://hooks.example.test/secondary",
+        },
       }),
     ).toThrow(/require HTTPS/u);
 
@@ -83,7 +95,7 @@ describe("external webhook authentication policy", () => {
       requireExternalWebhookAuthentication({
         ...base,
         authenticated: true,
-        authenticatedIngressUrl: "https://hooks.example.test/events",
+        authenticatedIngressUrls: ["https://hooks.example.test/events"],
         webhook: { host: "0.0.0.0" },
       }),
     ).not.toThrow();
@@ -101,6 +113,18 @@ describe("external webhook authentication policy", () => {
         }),
       ).not.toThrow();
     }
+
+    expect(() =>
+      requireExternalWebhookAuthentication({
+        ...base,
+        authenticated: true,
+        authenticatedIngressUrls: ["http://localhost:8787/primary"],
+        webhook: {
+          host: "127.0.0.1",
+          publicUrl: "http://127.0.0.1:8787/secondary",
+        },
+      }),
+    ).not.toThrow();
   });
 
   it("allows unauthenticated ingress only when it stays on loopback", () => {

--- a/test/googlechat-provider.test.ts
+++ b/test/googlechat-provider.test.ts
@@ -55,6 +55,13 @@ describe("Google Chat webhook authentication", () => {
 
     config.googlechat!.disableSignatureVerification = false;
     expect(() => new GoogleChatProviderAdapter("googlechat", config, "crabline")).not.toThrow();
+
+    config.googlechat!.webhook.publicUrl = "http://chat.example.test/googlechat/webhook";
+    expect(() => new GoogleChatProviderAdapter("googlechat", config, "crabline")).toThrow(
+      /require HTTPS/u,
+    );
+    config.googlechat!.webhook.publicUrl = "https://chat.example.test/googlechat/webhook";
+    expect(() => new GoogleChatProviderAdapter("googlechat", config, "crabline")).not.toThrow();
   });
 
   it("verifies HTTP endpoint audience ID tokens", async () => {

--- a/test/local-mock-provider.test.ts
+++ b/test/local-mock-provider.test.ts
@@ -700,7 +700,7 @@ describe("local mock provider", () => {
     expect((await readFile(recorderPath, "utf8")).trim().split("\n")).toHaveLength(2);
   });
 
-  it("drains webhook handlers admitted before cleanup", async () => {
+  it("closes ingress at the cleanup fence and drains admitted webhook handlers", async () => {
     let handleRequest: ((request: Request) => Promise<Response>) | undefined;
     let releaseHandler!: () => void;
     const handlerReleased = new Promise<void>((resolve) => {
@@ -745,12 +745,13 @@ describe("local mock provider", () => {
       }),
     );
     await admitted;
+    (provider as ProviderAdapter).beginCleanup?.();
+    await vi.waitFor(() => expect(close).toHaveBeenCalledOnce());
     let cleanupResolved = false;
     const cleanup = provider.cleanup().then(() => {
       cleanupResolved = true;
     });
 
-    await vi.waitFor(() => expect(close).toHaveBeenCalledOnce());
     expect(cleanupResolved).toBe(false);
     await expect(
       handleRequest!(

--- a/test/webhook-server.test.ts
+++ b/test/webhook-server.test.ts
@@ -252,6 +252,7 @@ describe("webhook server", () => {
       host: "127.0.0.1",
       path: "/slack/events",
       port: 0,
+      shutdownGraceMs: 50,
     });
     const endpoint = new URL(server.endpointUrl);
     const socket = connect(Number(endpoint.port), endpoint.hostname);
@@ -259,14 +260,55 @@ describe("webhook server", () => {
     socket.write("POST /slack/events HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: 5\r\n\r\n1");
     socket.on("error", () => {});
     const closed = new Promise<void>((resolve) => socket.once("close", () => resolve()));
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
 
+    const closingStartedAt = Date.now();
     await expect(
       Promise.race([
         server.close().then(() => "closed"),
-        new Promise<string>((resolve) => setTimeout(() => resolve("timed out"), 250)),
+        new Promise<string>((resolve) => setTimeout(() => resolve("timed out"), 500)),
       ]),
     ).resolves.toBe("closed");
+    expect(Date.now() - closingStartedAt).toBeGreaterThanOrEqual(30);
     await closed;
+  });
+
+  it("drains an admitted HTTP response before closing its connection", async () => {
+    let reportAdmission!: () => void;
+    const admitted = new Promise<void>((resolve) => {
+      reportAdmission = resolve;
+    });
+    let releaseHandler!: () => void;
+    const handlerReleased = new Promise<void>((resolve) => {
+      releaseHandler = resolve;
+    });
+    const server = await startWebhookServer({
+      async handle() {
+        reportAdmission();
+        await handlerReleased;
+        return new Response("admitted response", { status: 202 });
+      },
+      host: "127.0.0.1",
+      path: "/slack/events",
+      port: 0,
+      shutdownGraceMs: 500,
+    });
+    cleanups.push(() => server.close());
+    const responsePromise = fetch(server.endpointUrl, { body: "{}", method: "POST" });
+    await admitted;
+
+    let closeResolved = false;
+    const closing = server.close().then(() => {
+      closeResolved = true;
+    });
+    await Promise.resolve();
+    expect(closeResolved).toBe(false);
+
+    releaseHandler();
+    const response = await responsePromise;
+    expect(response.status).toBe(202);
+    await expect(response.text()).resolves.toBe("admitted response");
+    await expect(closing).resolves.toBeUndefined();
   });
 
   it("survives clients aborting incomplete request bodies", async () => {


### PR DESCRIPTION
## Summary
- validate every configured authenticated callback URL independently
- reject Google Chat configurations with a separate insecure public URL
- drain admitted webhook responses before bounded connection teardown

## Validation
- focused tests: 67 passed
- pnpm lint
- gpt-5.6-sol high autoreview: clean