### PR TITLE
fix(recorder): serialize hardlink aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 - Authenticate Feishu signatures before encrypted callback decryption and bound callback ciphertext work.
 - Correct Slack edited-message identity and text fallback handling, acknowledge unsupported callbacks, and fairly budget Events API address failover.
 - Preserve provider recorder cursors across parse failures, report post-commit lock cleanup failures without rejecting committed appends, and synchronize hardlink aliases.
-- Confine server recorder publication and locking to stable resolved paths across symlink retargets, start observers in durable append order without blocking later requests, snapshot observed events, classify post-commit lock cleanup failures, and preserve existing file modes.
+- Confine server recorder publication and locking to stable resolved paths and hardlink identities across symlink retargets, start observers in durable append order without blocking later requests, snapshot observed events, classify post-commit lock cleanup failures, and preserve existing file modes.
 - Cover local GitHub Actions with ownership, CodeQL, immutable image, and test-tool runtime policies.
 - Publish Matrix direct-room account data and share strict native identifier validation across server, target, and inbound paths.
 - Materialize Mattermost thread roots, keep root posts channel-scoped, and reject oversized WebSocket post events atomically without disconnecting unrelated clients.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 - Authenticate Feishu signatures before encrypted callback decryption and bound callback ciphertext work.
 - Correct Slack edited-message identity and text fallback handling, acknowledge unsupported callbacks, and fairly budget Events API address failover.
 - Preserve provider recorder cursors across parse failures, report post-commit lock cleanup failures without rejecting committed appends, and synchronize hardlink aliases.
-- Confine server recorder publication and locking to stable resolved paths and hardlink identities across symlink retargets, preserve Signal timestamp capacity after rejected queue admission, start observers in durable append order without blocking later requests, snapshot observed events, classify post-commit lock cleanup failures, and preserve existing file modes.
+- Confine server recorder publication and locking to stable resolved paths and explicitly shared hardlink identities across symlink retargets, preserve Signal timestamp capacity after rejected queue admission, start observers in durable append order without blocking later requests, snapshot observed events, classify post-commit lock cleanup failures, and preserve existing file modes.
 - Cover local GitHub Actions with ownership, CodeQL, immutable image, and test-tool runtime policies.
 - Publish Matrix direct-room account data and share strict native identifier validation across server, target, and inbound paths.
 - Materialize Mattermost thread roots, keep root posts channel-scoped, and reject oversized WebSocket post events atomically without disconnecting unrelated clients.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 - Authenticate Feishu signatures before encrypted callback decryption and bound callback ciphertext work.
 - Correct Slack edited-message identity and text fallback handling, acknowledge unsupported callbacks, and fairly budget Events API address failover.
 - Preserve provider recorder cursors across parse failures, report post-commit lock cleanup failures without rejecting committed appends, and synchronize hardlink aliases.
-- Confine server recorder publication and locking to stable resolved paths and hardlink identities across symlink retargets, start observers in durable append order without blocking later requests, snapshot observed events, classify post-commit lock cleanup failures, and preserve existing file modes.
+- Confine server recorder publication and locking to stable resolved paths and hardlink identities across symlink retargets, preserve Signal timestamp capacity after rejected queue admission, start observers in durable append order without blocking later requests, snapshot observed events, classify post-commit lock cleanup failures, and preserve existing file modes.
 - Cover local GitHub Actions with ownership, CodeQL, immutable image, and test-tool runtime policies.
 - Publish Matrix direct-room account data and share strict native identifier validation across server, target, and inbound paths.
 - Materialize Mattermost thread roots, keep root posts channel-scoped, and reject oversized WebSocket post events atomically without disconnecting unrelated clients.

--- a/README.md
+++ b/README.md
@@ -177,6 +177,13 @@ provider server, or `startOpenClawCrablineAdapter`. Crabline awaits the callback
 after appending each API/admin event to `recorderPath`, so callers can react in
 process while retaining the JSONL artifact as durable evidence.
 
+Recorder files should normally have one filesystem name. If multiple processes
+write through hardlinks to the same recorder inode, set
+`CRABLINE_RECORDER_LOCK_DIR` to the same absolute writable directory for every
+writer. Pre-create that directory with the ownership, group, or ACLs required
+by those writers. Crabline refuses hardlinked server-recorder writes without
+this shared lock namespace.
+
 Mattermost:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -182,7 +182,10 @@ write through hardlinks to the same recorder inode, set
 `CRABLINE_RECORDER_LOCK_DIR` to the same absolute writable directory for every
 writer. Pre-create that directory with the ownership, group, or ACLs required
 by those writers. Crabline refuses hardlinked server-recorder writes without
-this shared lock namespace.
+this shared lock namespace. The configured path must be canonical and contain
+no symlink components. Scope each lock directory to one recorder filesystem;
+lock identities omit device numbers so containers that mount the same inode
+under different device IDs still coordinate.
 
 Mattermost:
 

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -286,6 +286,12 @@ outcome together with the provider's exact send method and path. Rejected
 requests and lookalike route suffixes can remain diagnostic recorder entries,
 but they are never exposed as successful outbound deliveries.
 
+Use one filesystem name per recorder file. When multiple server processes must
+write through hardlinks to the same recorder inode, set
+`CRABLINE_RECORDER_LOCK_DIR` to one absolute writable directory shared by every
+writer and pre-create its ownership, group, or ACLs. Hardlinked server-recorder
+writes fail closed when this shared lock namespace is absent.
+
 Slack:
 
 ```bash

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -290,7 +290,10 @@ Use one filesystem name per recorder file. When multiple server processes must
 write through hardlinks to the same recorder inode, set
 `CRABLINE_RECORDER_LOCK_DIR` to one absolute writable directory shared by every
 writer and pre-create its ownership, group, or ACLs. Hardlinked server-recorder
-writes fail closed when this shared lock namespace is absent.
+writes fail closed when this shared lock namespace is absent. The path must be
+canonical and contain no symlink components. Use a separate lock directory per
+recorder filesystem; lock identities omit device numbers so containers that
+mount the same inode under different device IDs still coordinate.
 
 Slack:
 

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -1,4 +1,6 @@
+import { constants as fsConstants } from "node:fs";
 import { chmod, lstat, mkdir, open, readlink, realpath, stat as statPath } from "node:fs/promises";
+import { userInfo } from "node:os";
 import path from "node:path";
 import { lock } from "proper-lockfile";
 import type { ServerRequestEvent } from "./http.js";
@@ -28,6 +30,12 @@ export class ServerRecorderCommittedError extends AggregateError {
 }
 
 class ServerRecorderRotationError extends Error {}
+
+type RecorderFileIdentity = {
+  dev: bigint;
+  ino: bigint;
+  nlink: bigint;
+};
 
 type ObserverTask = {
   markStarted: () => void;
@@ -184,6 +192,21 @@ function recorderIdentity(stats: {
   return `${stats.dev}:${stats.ino}`;
 }
 
+function requireRecorderFileIdentity(stats: {
+  dev?: bigint | number;
+  ino?: bigint | number;
+  nlink?: bigint | number;
+}): RecorderFileIdentity {
+  if (stats.dev === undefined || stats.ino === undefined) {
+    throw new Error("Server recorder file identity is unavailable.");
+  }
+  return {
+    dev: BigInt(stats.dev),
+    ino: BigInt(stats.ino),
+    nlink: stats.nlink === undefined ? 1n : BigInt(stats.nlink),
+  };
+}
+
 async function recorderPathHasIdentity(
   filePath: string,
   expectedIdentity: string,
@@ -245,6 +268,73 @@ function isRecorderLockContention(error: unknown): boolean {
   );
 }
 
+async function secureRecorderLockRoot(
+  root: string,
+  currentUserId: number | undefined,
+): Promise<string> {
+  await mkdir(root, { mode: 0o700, recursive: true });
+  if (process.platform === "win32") {
+    const identity = await lstat(root);
+    if (!identity.isDirectory() || identity.isSymbolicLink()) {
+      throw new Error("Server recorder lock directory is not a private directory.");
+    }
+    return root;
+  }
+  if (currentUserId === undefined) {
+    throw new Error("Server recorder identity locking requires a current user id.");
+  }
+  const handle = await open(
+    root,
+    fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW,
+  );
+  try {
+    const identity = await handle.stat({ bigint: true });
+    const current = await lstat(root, { bigint: true });
+    if (
+      !identity.isDirectory() ||
+      !current.isDirectory() ||
+      identity.dev !== current.dev ||
+      identity.ino !== current.ino ||
+      identity.uid !== BigInt(currentUserId) ||
+      current.uid !== BigInt(currentUserId)
+    ) {
+      throw new Error("Server recorder lock directory is not privately owned.");
+    }
+    if ((identity.mode & 0o777n) !== 0o700n) {
+      await handle.chmod(0o700);
+      const secured = await handle.stat({ bigint: true });
+      if ((secured.mode & 0o777n) !== 0o700n) {
+        throw new Error("Server recorder lock directory permissions are not private.");
+      }
+    }
+  } finally {
+    await handle.close();
+  }
+  return root;
+}
+
+function recorderIdentityLockPath(root: string, identity: RecorderFileIdentity): string {
+  return path.join(root, `recorder-${identity.dev}-${identity.ino}`);
+}
+
+async function recorderIdentityLockTarget(identity: RecorderFileIdentity): Promise<string> {
+  const currentUserId = process.platform === "win32" ? undefined : process.geteuid?.();
+  let sharedRoot: string;
+  try {
+    const account = userInfo();
+    sharedRoot =
+      process.platform === "win32"
+        ? path.join(account.homedir, "AppData", "Local", "Crabline", "locks", "server-recorder")
+        : path.join(account.homedir, ".cache", "crabline", "locks", "server-recorder");
+  } catch {
+    throw new Error("Server recorder hardlinks require a writable shared per-user lock directory.");
+  }
+  return recorderIdentityLockPath(
+    await secureRecorderLockRoot(sharedRoot, currentUserId),
+    identity,
+  );
+}
+
 async function acquireRecorderLock(filePath: string): Promise<() => Promise<void>> {
   const deadline = performance.now() + RECORDER_LOCK_STALE_MS + RECORDER_LOCK_WAIT_MARGIN_MS;
   for (;;) {
@@ -268,6 +358,12 @@ async function acquireRecorderLock(filePath: string): Promise<() => Promise<void
       );
     }
   }
+}
+
+async function acquireRecorderIdentityLock(
+  identity: RecorderFileIdentity,
+): Promise<() => Promise<void>> {
+  return await acquireRecorderLock(await recorderIdentityLockTarget(identity));
 }
 
 async function withRecorderLock(
@@ -354,6 +450,7 @@ async function appendRecorderAttempt(params: {
   let committed = false;
   let operationFailed = false;
   let operationError: unknown;
+  let releaseIdentityLock: (() => Promise<void>) | undefined;
   let result: "committed" | "retry" | undefined;
   try {
     if (opened.created) {
@@ -364,80 +461,108 @@ async function appendRecorderAttempt(params: {
     if (!(await recorderPathHasIdentity(params.publicationPath, identity))) {
       result = "retry";
     } else {
-      const needsPathDurability =
-        opened.created || durableRecorderIdentities.get(params.publicationPath) !== identity;
-      if (stats.size > 0) {
-        const finalByte = await readBufferAt(file, 1, stats.size - 1);
-        if (finalByte[0] !== 0x0a) {
-          const tailStart = await findIncompleteTailStart(file, stats.size);
-          const tailLength = stats.size - tailStart;
-          if (tailLength > MAX_RECOVERY_VALIDATION_BYTES) {
-            throw recoveryValidationLimitError();
-          }
-          const tail = await readBufferAt(file, tailLength, tailStart);
-          if (tail.length !== tailLength) {
-            throw new Error("Server recorder changed while repairing its final record.");
-          }
-          try {
-            JSON.parse(tail.toString("utf8"));
-            await file.appendFile("\n", { encoding: "utf8" });
-          } catch (error) {
-            if (!(error instanceof SyntaxError)) {
-              throw error;
-            }
-            await file.truncate(tailStart);
-          }
+      const lockedIdentity = requireRecorderFileIdentity(stats);
+      if (lockedIdentity.nlink > 1n) {
+        releaseIdentityLock = await acquireRecorderIdentityLock(lockedIdentity);
+        stats = await file.stat();
+        identity = requireRecorderIdentity(stats);
+        if (
+          identity !== `${lockedIdentity.dev}:${lockedIdentity.ino}` ||
+          !(await recorderPathHasIdentity(params.publicationPath, identity))
+        ) {
+          result = "retry";
         }
       }
-      stats = await file.stat();
-      identity = requireRecorderIdentity(stats);
-      if (!(await recorderPathHasIdentity(params.publicationPath, identity))) {
-        result = "retry";
-      } else {
-        try {
-          await file.appendFile(params.line, { encoding: "utf8" });
-          await file.sync();
-          if (
-            !(await recorderPathHasIdentity(params.publicationPath, identity)) ||
-            (await resolveRecorderPath(params.logicalPath)) !== params.publicationPath
-          ) {
-            throw new ServerRecorderCommittedError(
-              params.logicalPath,
-              new ServerRecorderRotationError("Server recorder rotated during append."),
-            );
-          } else {
-            if (needsPathDurability) {
-              const firstCreatedPath =
-                params.createdDirectory ?? (opened.created ? params.publicationPath : undefined);
-              await syncRecorderPathAncestry(params.publicationPath, firstCreatedPath);
+      if (result !== "retry") {
+        const needsPathDurability =
+          opened.created || durableRecorderIdentities.get(params.publicationPath) !== identity;
+        if (stats.size > 0) {
+          const finalByte = await readBufferAt(file, 1, stats.size - 1);
+          if (finalByte[0] !== 0x0a) {
+            const tailStart = await findIncompleteTailStart(file, stats.size);
+            const tailLength = stats.size - tailStart;
+            if (tailLength > MAX_RECOVERY_VALIDATION_BYTES) {
+              throw recoveryValidationLimitError();
             }
+            const tail = await readBufferAt(file, tailLength, tailStart);
+            if (tail.length !== tailLength) {
+              throw new Error("Server recorder changed while repairing its final record.");
+            }
+            try {
+              JSON.parse(tail.toString("utf8"));
+              await file.appendFile("\n", { encoding: "utf8" });
+            } catch (error) {
+              if (!(error instanceof SyntaxError)) {
+                throw error;
+              }
+              await file.truncate(tailStart);
+            }
+          }
+        }
+        stats = await file.stat();
+        identity = requireRecorderIdentity(stats);
+        if (!(await recorderPathHasIdentity(params.publicationPath, identity))) {
+          result = "retry";
+        } else {
+          try {
+            await file.appendFile(params.line, { encoding: "utf8" });
+            await file.sync();
             if (
               !(await recorderPathHasIdentity(params.publicationPath, identity)) ||
               (await resolveRecorderPath(params.logicalPath)) !== params.publicationPath
             ) {
               throw new ServerRecorderCommittedError(
                 params.logicalPath,
-                new ServerRecorderRotationError(
-                  "Server recorder rotated while syncing path ancestry.",
-                ),
+                new ServerRecorderRotationError("Server recorder rotated during append."),
               );
             } else {
-              rememberDurableRecorderIdentity(params.publicationPath, identity);
-              committed = true;
-              result = "committed";
+              if (needsPathDurability) {
+                const firstCreatedPath =
+                  params.createdDirectory ?? (opened.created ? params.publicationPath : undefined);
+                await syncRecorderPathAncestry(params.publicationPath, firstCreatedPath);
+              }
+              if (
+                !(await recorderPathHasIdentity(params.publicationPath, identity)) ||
+                (await resolveRecorderPath(params.logicalPath)) !== params.publicationPath
+              ) {
+                throw new ServerRecorderCommittedError(
+                  params.logicalPath,
+                  new ServerRecorderRotationError(
+                    "Server recorder rotated while syncing path ancestry.",
+                  ),
+                );
+              } else {
+                rememberDurableRecorderIdentity(params.publicationPath, identity);
+                committed = true;
+                result = "committed";
+              }
             }
+          } catch (error) {
+            if (error instanceof ServerRecorderCommittedError) {
+              throw error;
+            }
+            throw new ServerRecorderCommittedError(params.logicalPath, error, [], true);
           }
-        } catch (error) {
-          if (error instanceof ServerRecorderCommittedError) {
-            throw error;
-          }
-          throw new ServerRecorderCommittedError(params.logicalPath, error, [], true);
         }
       }
     }
   } catch (error) {
     operationFailed = true;
     operationError = error;
+  }
+  if (releaseIdentityLock) {
+    try {
+      await releaseIdentityLock();
+    } catch (releaseError) {
+      if (operationFailed) {
+        operationError = recorderLockReleaseError(params.logicalPath, operationError, releaseError);
+      } else {
+        operationFailed = true;
+        operationError = committed
+          ? new ServerRecorderCommittedError(params.logicalPath, releaseError)
+          : releaseError;
+      }
+    }
   }
   await closeRecorderAttempt({
     committed,

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -317,9 +317,36 @@ function recorderIdentityLockPath(root: string, identity: RecorderFileIdentity):
   return path.join(root, `recorder-${identity.dev}-${identity.ino}`);
 }
 
-async function recorderIdentityLockTarget(identity: RecorderFileIdentity): Promise<string> {
+function recorderLockRootUnavailable(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException).code;
+  return (
+    code === "EACCES" ||
+    code === "EDQUOT" ||
+    code === "ENOSPC" ||
+    code === "EPERM" ||
+    code === "EROFS"
+  );
+}
+
+function adjacentRecorderLockRoot(filePath: string, currentUserId: number | undefined): string {
+  return path.join(
+    path.dirname(filePath),
+    currentUserId === undefined
+      ? ".crabline-server-recorder-locks"
+      : `.crabline-server-recorder-locks-${currentUserId}`,
+  );
+}
+
+async function recorderIdentityLockTargets(
+  filePath: string,
+  identity: RecorderFileIdentity,
+): Promise<{
+  fallbackRoot?: string;
+  preferred: string;
+  userId: number | undefined;
+}> {
   const currentUserId = process.platform === "win32" ? undefined : process.geteuid?.();
-  let sharedRoot: string;
+  let sharedRoot: string | undefined;
   try {
     const account = userInfo();
     sharedRoot =
@@ -327,12 +354,37 @@ async function recorderIdentityLockTarget(identity: RecorderFileIdentity): Promi
         ? path.join(account.homedir, "AppData", "Local", "Crabline", "locks", "server-recorder")
         : path.join(account.homedir, ".cache", "crabline", "locks", "server-recorder");
   } catch {
+    // Arbitrary container UIDs may not have an OS account entry.
+  }
+  if (sharedRoot) {
+    try {
+      return {
+        ...(identity.nlink === 1n
+          ? { fallbackRoot: adjacentRecorderLockRoot(filePath, currentUserId) }
+          : {}),
+        preferred: recorderIdentityLockPath(
+          await secureRecorderLockRoot(sharedRoot, currentUserId),
+          identity,
+        ),
+        userId: currentUserId,
+      };
+    } catch (error) {
+      if (!recorderLockRootUnavailable(error)) {
+        throw error;
+      }
+    }
+  }
+  if (identity.nlink > 1n) {
     throw new Error("Server recorder hardlinks require a writable shared per-user lock directory.");
   }
-  return recorderIdentityLockPath(
-    await secureRecorderLockRoot(sharedRoot, currentUserId),
-    identity,
+  const adjacentRoot = await secureRecorderLockRoot(
+    adjacentRecorderLockRoot(filePath, currentUserId),
+    currentUserId,
   );
+  return {
+    preferred: recorderIdentityLockPath(adjacentRoot, identity),
+    userId: currentUserId,
+  };
 }
 
 async function acquireRecorderLock(filePath: string): Promise<() => Promise<void>> {
@@ -361,9 +413,19 @@ async function acquireRecorderLock(filePath: string): Promise<() => Promise<void
 }
 
 async function acquireRecorderIdentityLock(
+  filePath: string,
   identity: RecorderFileIdentity,
 ): Promise<() => Promise<void>> {
-  return await acquireRecorderLock(await recorderIdentityLockTarget(identity));
+  const targets = await recorderIdentityLockTargets(filePath, identity);
+  try {
+    return await acquireRecorderLock(targets.preferred);
+  } catch (error) {
+    if (!targets.fallbackRoot || !recorderLockRootUnavailable(error)) {
+      throw error;
+    }
+    const fallbackRoot = await secureRecorderLockRoot(targets.fallbackRoot, targets.userId);
+    return await acquireRecorderLock(recorderIdentityLockPath(fallbackRoot, identity));
+  }
 }
 
 async function withRecorderLock(
@@ -462,16 +524,17 @@ async function appendRecorderAttempt(params: {
       result = "retry";
     } else {
       const lockedIdentity = requireRecorderFileIdentity(stats);
-      if (lockedIdentity.nlink > 1n) {
-        releaseIdentityLock = await acquireRecorderIdentityLock(lockedIdentity);
-        stats = await file.stat();
-        identity = requireRecorderIdentity(stats);
-        if (
-          identity !== `${lockedIdentity.dev}:${lockedIdentity.ino}` ||
-          !(await recorderPathHasIdentity(params.publicationPath, identity))
-        ) {
-          result = "retry";
-        }
+      releaseIdentityLock = await acquireRecorderIdentityLock(
+        params.publicationPath,
+        lockedIdentity,
+      );
+      stats = await file.stat();
+      identity = requireRecorderIdentity(stats);
+      if (
+        identity !== `${lockedIdentity.dev}:${lockedIdentity.ino}` ||
+        !(await recorderPathHasIdentity(params.publicationPath, identity))
+      ) {
+        result = "retry";
       }
       if (result !== "retry") {
         const needsPathDurability =

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -34,12 +34,6 @@ class ServerRecorderRotationError extends Error {}
 type RecorderFileIdentity = {
   dev: bigint;
   ino: bigint;
-  nlink: bigint;
-};
-
-type RecorderIdentityLock = {
-  hardlinkSafe: boolean;
-  release: () => Promise<void>;
 };
 
 type ObserverTask = {
@@ -200,7 +194,6 @@ function recorderIdentity(stats: {
 function requireRecorderFileIdentity(stats: {
   dev?: bigint | number;
   ino?: bigint | number;
-  nlink?: bigint | number;
 }): RecorderFileIdentity {
   if (stats.dev === undefined || stats.ino === undefined) {
     throw new Error("Server recorder file identity is unavailable.");
@@ -208,7 +201,6 @@ function requireRecorderFileIdentity(stats: {
   return {
     dev: BigInt(stats.dev),
     ino: BigInt(stats.ino),
-    nlink: stats.nlink === undefined ? 1n : BigInt(stats.nlink),
   };
 }
 
@@ -322,37 +314,9 @@ function recorderIdentityLockPath(root: string, identity: RecorderFileIdentity):
   return path.join(root, `recorder-${identity.dev}-${identity.ino}`);
 }
 
-function recorderLockRootUnavailable(error: unknown): boolean {
-  const code = (error as NodeJS.ErrnoException).code;
-  return (
-    code === "EACCES" ||
-    code === "EDQUOT" ||
-    code === "ENOSPC" ||
-    code === "EPERM" ||
-    code === "EROFS"
-  );
-}
-
-function adjacentRecorderLockRoot(filePath: string, currentUserId: number | undefined): string {
-  return path.join(
-    path.dirname(filePath),
-    currentUserId === undefined
-      ? ".crabline-server-recorder-locks"
-      : `.crabline-server-recorder-locks-${currentUserId}`,
-  );
-}
-
-async function recorderIdentityLockTargets(
-  filePath: string,
-  identity: RecorderFileIdentity,
-): Promise<{
-  fallbackRoot?: string;
-  preferred: string;
-  preferredHardlinkSafe: boolean;
-  userId: number | undefined;
-}> {
+async function recorderIdentityLockTarget(identity: RecorderFileIdentity): Promise<string> {
   const currentUserId = process.platform === "win32" ? undefined : process.geteuid?.();
-  let sharedRoot: string | undefined;
+  let sharedRoot: string;
   try {
     const account = userInfo();
     sharedRoot =
@@ -360,39 +324,12 @@ async function recorderIdentityLockTargets(
         ? path.join(account.homedir, "AppData", "Local", "Crabline", "locks", "server-recorder")
         : path.join(account.homedir, ".cache", "crabline", "locks", "server-recorder");
   } catch {
-    // Arbitrary container UIDs may not have an OS account entry.
+    throw new Error("Server recorder identity locking requires an OS account directory.");
   }
-  if (sharedRoot) {
-    try {
-      return {
-        ...(identity.nlink === 1n
-          ? { fallbackRoot: adjacentRecorderLockRoot(filePath, currentUserId) }
-          : {}),
-        preferred: recorderIdentityLockPath(
-          await secureRecorderLockRoot(sharedRoot, currentUserId),
-          identity,
-        ),
-        preferredHardlinkSafe: true,
-        userId: currentUserId,
-      };
-    } catch (error) {
-      if (!recorderLockRootUnavailable(error)) {
-        throw error;
-      }
-    }
-  }
-  if (identity.nlink > 1n) {
-    throw new Error("Server recorder hardlinks require a writable shared per-user lock directory.");
-  }
-  const adjacentRoot = await secureRecorderLockRoot(
-    adjacentRecorderLockRoot(filePath, currentUserId),
-    currentUserId,
+  return recorderIdentityLockPath(
+    await secureRecorderLockRoot(sharedRoot, currentUserId),
+    identity,
   );
-  return {
-    preferred: recorderIdentityLockPath(adjacentRoot, identity),
-    preferredHardlinkSafe: false,
-    userId: currentUserId,
-  };
 }
 
 async function acquireRecorderLock(filePath: string): Promise<() => Promise<void>> {
@@ -421,25 +358,9 @@ async function acquireRecorderLock(filePath: string): Promise<() => Promise<void
 }
 
 async function acquireRecorderIdentityLock(
-  filePath: string,
   identity: RecorderFileIdentity,
-): Promise<RecorderIdentityLock> {
-  const targets = await recorderIdentityLockTargets(filePath, identity);
-  try {
-    return {
-      hardlinkSafe: targets.preferredHardlinkSafe,
-      release: await acquireRecorderLock(targets.preferred),
-    };
-  } catch (error) {
-    if (!targets.fallbackRoot || !recorderLockRootUnavailable(error)) {
-      throw error;
-    }
-    const fallbackRoot = await secureRecorderLockRoot(targets.fallbackRoot, targets.userId);
-    return {
-      hardlinkSafe: false,
-      release: await acquireRecorderLock(recorderIdentityLockPath(fallbackRoot, identity)),
-    };
-  }
+): Promise<() => Promise<void>> {
+  return await acquireRecorderLock(await recorderIdentityLockTarget(identity));
 }
 
 async function withRecorderLock(
@@ -538,17 +459,11 @@ async function appendRecorderAttempt(params: {
       result = "retry";
     } else {
       const lockedIdentity = requireRecorderFileIdentity(stats);
-      const identityLock = await acquireRecorderIdentityLock(
-        params.publicationPath,
-        lockedIdentity,
-      );
-      releaseIdentityLock = identityLock.release;
+      releaseIdentityLock = await acquireRecorderIdentityLock(lockedIdentity);
       stats = await file.stat();
-      const refreshedIdentity = requireRecorderFileIdentity(stats);
       identity = requireRecorderIdentity(stats);
       if (
         identity !== `${lockedIdentity.dev}:${lockedIdentity.ino}` ||
-        (!identityLock.hardlinkSafe && refreshedIdentity.nlink > 1n) ||
         !(await recorderPathHasIdentity(params.publicationPath, identity))
       ) {
         result = "retry";

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -1,6 +1,5 @@
 import { constants as fsConstants } from "node:fs";
 import { chmod, lstat, mkdir, open, readlink, realpath, stat as statPath } from "node:fs/promises";
-import { userInfo } from "node:os";
 import path from "node:path";
 import { lock } from "proper-lockfile";
 import type { ServerRequestEvent } from "./http.js";
@@ -34,6 +33,7 @@ class ServerRecorderRotationError extends Error {}
 type RecorderFileIdentity = {
   dev: bigint;
   ino: bigint;
+  nlink: bigint;
 };
 
 type ObserverTask = {
@@ -58,6 +58,7 @@ const RECORDER_LOCK_RETRY_MS = 100;
 const RECORDER_LOCK_STALE_MS = 30_000;
 const RECORDER_LOCK_UPDATE_MS = 10_000;
 const RECORDER_LOCK_WAIT_MARGIN_MS = 5_000;
+const RECORDER_LOCK_DIRECTORY_ENV = "CRABLINE_RECORDER_LOCK_DIR";
 const RECORDER_PATH_ATTEMPTS = 3;
 const RECORDER_ROTATION_ATTEMPTS = 3;
 const TAIL_SCAN_CHUNK_BYTES = 64 * 1024;
@@ -194,6 +195,7 @@ function recorderIdentity(stats: {
 function requireRecorderFileIdentity(stats: {
   dev?: bigint | number;
   ino?: bigint | number;
+  nlink?: bigint | number;
 }): RecorderFileIdentity {
   if (stats.dev === undefined || stats.ino === undefined) {
     throw new Error("Server recorder file identity is unavailable.");
@@ -201,6 +203,7 @@ function requireRecorderFileIdentity(stats: {
   return {
     dev: BigInt(stats.dev),
     ino: BigInt(stats.ino),
+    nlink: BigInt(stats.nlink ?? 1),
   };
 }
 
@@ -265,10 +268,7 @@ function isRecorderLockContention(error: unknown): boolean {
   );
 }
 
-async function secureRecorderLockRoot(
-  root: string,
-  currentUserId: number | undefined,
-): Promise<string> {
+async function secureRecorderLockRoot(root: string): Promise<string> {
   await mkdir(root, { mode: 0o700, recursive: true });
   if (process.platform === "win32") {
     const identity = await lstat(root);
@@ -276,9 +276,6 @@ async function secureRecorderLockRoot(
       throw new Error("Server recorder lock directory is not a private directory.");
     }
     return root;
-  }
-  if (currentUserId === undefined) {
-    throw new Error("Server recorder identity locking requires a current user id.");
   }
   const handle = await open(
     root,
@@ -291,18 +288,9 @@ async function secureRecorderLockRoot(
       !identity.isDirectory() ||
       !current.isDirectory() ||
       identity.dev !== current.dev ||
-      identity.ino !== current.ino ||
-      identity.uid !== BigInt(currentUserId) ||
-      current.uid !== BigInt(currentUserId)
+      identity.ino !== current.ino
     ) {
-      throw new Error("Server recorder lock directory is not privately owned.");
-    }
-    if ((identity.mode & 0o777n) !== 0o700n) {
-      await handle.chmod(0o700);
-      const secured = await handle.stat({ bigint: true });
-      if ((secured.mode & 0o777n) !== 0o700n) {
-        throw new Error("Server recorder lock directory permissions are not private.");
-      }
+      throw new Error("Server recorder lock directory changed while opening it.");
     }
   } finally {
     await handle.close();
@@ -311,25 +299,26 @@ async function secureRecorderLockRoot(
 }
 
 function recorderIdentityLockPath(root: string, identity: RecorderFileIdentity): string {
-  return path.join(root, `recorder-${identity.dev}-${identity.ino}`);
+  return path.join(root, `recorder-${identity.ino}`);
 }
 
-async function recorderIdentityLockTarget(identity: RecorderFileIdentity): Promise<string> {
-  const currentUserId = process.platform === "win32" ? undefined : process.geteuid?.();
-  let sharedRoot: string;
-  try {
-    const account = userInfo();
-    sharedRoot =
-      process.platform === "win32"
-        ? path.join(account.homedir, "AppData", "Local", "Crabline", "locks", "server-recorder")
-        : path.join(account.homedir, ".cache", "crabline", "locks", "server-recorder");
-  } catch {
-    throw new Error("Server recorder identity locking requires an OS account directory.");
+async function recorderIdentityLockTarget(
+  identity: RecorderFileIdentity,
+): Promise<string | undefined> {
+  const configuredRoot = process.env[RECORDER_LOCK_DIRECTORY_ENV]?.trim();
+  if (!configuredRoot) {
+    if (identity.nlink > 1n) {
+      throw new Error(
+        `Server recorder hardlinks require ${RECORDER_LOCK_DIRECTORY_ENV} to name one shared writable lock directory for every writer.`,
+      );
+    }
+    return undefined;
   }
-  return recorderIdentityLockPath(
-    await secureRecorderLockRoot(sharedRoot, currentUserId),
-    identity,
-  );
+  if (!path.isAbsolute(configuredRoot)) {
+    throw new Error(`${RECORDER_LOCK_DIRECTORY_ENV} must be an absolute path.`);
+  }
+  const sharedRoot = await secureRecorderLockRoot(configuredRoot);
+  return recorderIdentityLockPath(sharedRoot, identity);
 }
 
 async function acquireRecorderLock(filePath: string): Promise<() => Promise<void>> {
@@ -359,8 +348,9 @@ async function acquireRecorderLock(filePath: string): Promise<() => Promise<void
 
 async function acquireRecorderIdentityLock(
   identity: RecorderFileIdentity,
-): Promise<() => Promise<void>> {
-  return await acquireRecorderLock(await recorderIdentityLockTarget(identity));
+): Promise<(() => Promise<void>) | undefined> {
+  const target = await recorderIdentityLockTarget(identity);
+  return target === undefined ? undefined : await acquireRecorderLock(target);
 }
 
 async function withRecorderLock(
@@ -453,15 +443,15 @@ async function appendRecorderAttempt(params: {
     if (opened.created) {
       await file.chmod(0o600);
     }
-    let stats = await file.stat();
-    let identity = requireRecorderIdentity(stats);
+    const openedStats = await file.stat();
+    let identity = requireRecorderIdentity(openedStats);
     if (!(await recorderPathHasIdentity(params.publicationPath, identity))) {
       result = "retry";
     } else {
-      const lockedIdentity = requireRecorderFileIdentity(stats);
+      const lockedIdentity = requireRecorderFileIdentity(openedStats);
       releaseIdentityLock = await acquireRecorderIdentityLock(lockedIdentity);
-      // The identity lock may have blocked while another alias repaired or appended.
-      stats = await file.stat();
+      // Lock acquisition may have blocked while another writer repaired or appended.
+      let stats = await file.stat();
       identity = requireRecorderIdentity(stats);
       if (
         identity !== `${lockedIdentity.dev}:${lockedIdentity.ino}` ||

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -37,6 +37,11 @@ type RecorderFileIdentity = {
   nlink: bigint;
 };
 
+type RecorderIdentityLock = {
+  hardlinkSafe: boolean;
+  release: () => Promise<void>;
+};
+
 type ObserverTask = {
   markStarted: () => void;
   started: Promise<void>;
@@ -343,6 +348,7 @@ async function recorderIdentityLockTargets(
 ): Promise<{
   fallbackRoot?: string;
   preferred: string;
+  preferredHardlinkSafe: boolean;
   userId: number | undefined;
 }> {
   const currentUserId = process.platform === "win32" ? undefined : process.geteuid?.();
@@ -366,6 +372,7 @@ async function recorderIdentityLockTargets(
           await secureRecorderLockRoot(sharedRoot, currentUserId),
           identity,
         ),
+        preferredHardlinkSafe: true,
         userId: currentUserId,
       };
     } catch (error) {
@@ -383,6 +390,7 @@ async function recorderIdentityLockTargets(
   );
   return {
     preferred: recorderIdentityLockPath(adjacentRoot, identity),
+    preferredHardlinkSafe: false,
     userId: currentUserId,
   };
 }
@@ -415,16 +423,22 @@ async function acquireRecorderLock(filePath: string): Promise<() => Promise<void
 async function acquireRecorderIdentityLock(
   filePath: string,
   identity: RecorderFileIdentity,
-): Promise<() => Promise<void>> {
+): Promise<RecorderIdentityLock> {
   const targets = await recorderIdentityLockTargets(filePath, identity);
   try {
-    return await acquireRecorderLock(targets.preferred);
+    return {
+      hardlinkSafe: targets.preferredHardlinkSafe,
+      release: await acquireRecorderLock(targets.preferred),
+    };
   } catch (error) {
     if (!targets.fallbackRoot || !recorderLockRootUnavailable(error)) {
       throw error;
     }
     const fallbackRoot = await secureRecorderLockRoot(targets.fallbackRoot, targets.userId);
-    return await acquireRecorderLock(recorderIdentityLockPath(fallbackRoot, identity));
+    return {
+      hardlinkSafe: false,
+      release: await acquireRecorderLock(recorderIdentityLockPath(fallbackRoot, identity)),
+    };
   }
 }
 
@@ -524,14 +538,17 @@ async function appendRecorderAttempt(params: {
       result = "retry";
     } else {
       const lockedIdentity = requireRecorderFileIdentity(stats);
-      releaseIdentityLock = await acquireRecorderIdentityLock(
+      const identityLock = await acquireRecorderIdentityLock(
         params.publicationPath,
         lockedIdentity,
       );
+      releaseIdentityLock = identityLock.release;
       stats = await file.stat();
+      const refreshedIdentity = requireRecorderFileIdentity(stats);
       identity = requireRecorderIdentity(stats);
       if (
         identity !== `${lockedIdentity.dev}:${lockedIdentity.ino}` ||
+        (!identityLock.hardlinkSafe && refreshedIdentity.nlink > 1n) ||
         !(await recorderPathHasIdentity(params.publicationPath, identity))
       ) {
         result = "retry";

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -441,14 +441,14 @@ async function appendRecorderAttempt(params: {
   logicalPath: string;
   line: string;
   publicationPath: string;
-}): Promise<"committed" | "retry"> {
+}): Promise<"committed" | "retargeted" | "retry"> {
   const opened = await openRecorderFile(params.publicationPath);
   const { file } = opened;
   let committed = false;
   let operationFailed = false;
   let operationError: unknown;
   let releaseIdentityLock: (() => Promise<void>) | undefined;
-  let result: "committed" | "retry" | undefined;
+  let result: "committed" | "retargeted" | "retry" | undefined;
   try {
     if (opened.created) {
       await file.chmod(0o600);
@@ -460,6 +460,7 @@ async function appendRecorderAttempt(params: {
     } else {
       const lockedIdentity = requireRecorderFileIdentity(stats);
       releaseIdentityLock = await acquireRecorderIdentityLock(lockedIdentity);
+      // The identity lock may have blocked while another alias repaired or appended.
       stats = await file.stat();
       identity = requireRecorderIdentity(stats);
       if (
@@ -467,8 +468,10 @@ async function appendRecorderAttempt(params: {
         !(await recorderPathHasIdentity(params.publicationPath, identity))
       ) {
         result = "retry";
+      } else if ((await resolveRecorderPath(params.logicalPath)) !== params.publicationPath) {
+        result = "retargeted";
       }
-      if (result !== "retry") {
+      if (result === undefined) {
         const needsPathDurability =
           opened.created || durableRecorderIdentities.get(params.publicationPath) !== identity;
         if (stats.size > 0) {
@@ -698,15 +701,17 @@ async function appendResolvedJsonLine(params: {
             return undefined;
           }
           for (let attempt = 0; attempt < RECORDER_ROTATION_ATTEMPTS; attempt++) {
-            if (
-              (await appendRecorderAttempt({
-                createdDirectory,
-                logicalPath,
-                line: params.line,
-                publicationPath: key,
-              })) === "committed"
-            ) {
+            const result = await appendRecorderAttempt({
+              createdDirectory,
+              logicalPath,
+              line: params.line,
+              publicationPath: key,
+            });
+            if (result === "committed") {
               return true;
+            }
+            if (result === "retargeted") {
+              return undefined;
             }
           }
           throw new ServerRecorderRotationError(

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -200,10 +200,13 @@ function requireRecorderFileIdentity(stats: {
   if (stats.dev === undefined || stats.ino === undefined) {
     throw new Error("Server recorder file identity is unavailable.");
   }
+  if (stats.nlink === undefined) {
+    throw new Error("Server recorder file link count is unavailable.");
+  }
   return {
     dev: BigInt(stats.dev),
     ino: BigInt(stats.ino),
-    nlink: BigInt(stats.nlink ?? 1),
+    nlink: BigInt(stats.nlink),
   };
 }
 
@@ -269,7 +272,6 @@ function isRecorderLockContention(error: unknown): boolean {
 }
 
 async function secureRecorderLockRoot(root: string): Promise<string> {
-  await mkdir(root, { mode: 0o700, recursive: true });
   if (process.platform === "win32") {
     const identity = await lstat(root);
     if (!identity.isDirectory() || identity.isSymbolicLink()) {

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -272,20 +272,26 @@ function isRecorderLockContention(error: unknown): boolean {
 }
 
 async function secureRecorderLockRoot(root: string): Promise<string> {
+  const canonicalRoot = await realpath(root);
+  if (path.relative(root, canonicalRoot) !== "") {
+    throw new Error(
+      `${RECORDER_LOCK_DIRECTORY_ENV} must name a canonical directory without symlink components.`,
+    );
+  }
   if (process.platform === "win32") {
-    const identity = await lstat(root);
+    const identity = await lstat(canonicalRoot);
     if (!identity.isDirectory() || identity.isSymbolicLink()) {
       throw new Error("Server recorder lock directory is not a private directory.");
     }
-    return root;
+    return canonicalRoot;
   }
   const handle = await open(
-    root,
+    canonicalRoot,
     fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW,
   );
   try {
     const identity = await handle.stat({ bigint: true });
-    const current = await lstat(root, { bigint: true });
+    const current = await lstat(canonicalRoot, { bigint: true });
     if (
       !identity.isDirectory() ||
       !current.isDirectory() ||
@@ -297,10 +303,12 @@ async function secureRecorderLockRoot(root: string): Promise<string> {
   } finally {
     await handle.close();
   }
-  return root;
+  return canonicalRoot;
 }
 
 function recorderIdentityLockPath(root: string, identity: RecorderFileIdentity): string {
+  // st_dev can differ for one shared inode across container mount namespaces.
+  // Scope each configured root to one recorder filesystem to avoid false inode collisions.
   return path.join(root, `recorder-${identity.ino}`);
 }
 

--- a/src/servers/signal.ts
+++ b/src/servers/signal.ts
@@ -434,7 +434,6 @@ async function handleAdminInbound(params: {
   if (timestamp >= Number.MAX_SAFE_INTEGER) {
     return jsonResponse({ error: "timestamp capacity exhausted", ok: false }, 503);
   }
-  params.state.nextTimestamp = Math.max(params.state.nextTimestamp, timestamp + 1);
   const groupId = readTrimmedString(params.body.groupId);
   const payload = {
     envelope: {
@@ -458,6 +457,7 @@ async function handleAdminInbound(params: {
       503,
     );
   }
+  params.state.nextTimestamp = Math.max(params.state.nextTimestamp, timestamp + 1);
   return jsonResponse({ event: payload, ok: true });
 }
 

--- a/test/recorder-concurrency.test.ts
+++ b/test/recorder-concurrency.test.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { chmod, link, mkdir, mkdtemp, realpath, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir, userInfo } from "node:os";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   appendRecordedInbound,
   ProviderRecorderCommittedError,
@@ -22,6 +22,8 @@ const fsMocks = vi.hoisted(() => ({
   serverDirectory: "",
   serverDirectorySync: vi.fn<(directoryPath: string) => Promise<void>>(),
   serverFileExists: false,
+  serverFileStat:
+    vi.fn<() => Promise<{ dev: number; ino: number; nlink?: number; size: number }>>(),
   serverOpen: vi.fn<(filePath: string, flags: string) => void>(),
   serverStat: vi.fn<(filePath: string) => Promise<{ dev: number; ino: number; size: number }>>(),
   serverSync: vi.fn<(filePath: string) => Promise<void>>(),
@@ -91,7 +93,7 @@ vi.mock("node:fs/promises", async (importOriginal) => {
           chmod: async () => {},
           close: async () => {},
           read: async (buffer: Buffer) => ({ buffer, bytesRead: 0 }),
-          stat: async () => ({ dev: 1, ino: 1, size: 0 }),
+          stat: async () => await fsMocks.serverFileStat(),
           sync: async () => await fsMocks.serverSync(filePath),
           truncate: async () => {},
         } as unknown as Awaited<ReturnType<typeof actual.open>>;
@@ -172,6 +174,8 @@ beforeEach(() => {
   fsMocks.serverDirectorySync.mockReset();
   fsMocks.serverDirectorySync.mockResolvedValue(undefined);
   fsMocks.serverFileExists = false;
+  fsMocks.serverFileStat.mockReset();
+  fsMocks.serverFileStat.mockResolvedValue({ dev: 1, ino: 1, size: 0 });
   fsMocks.serverOpen.mockReset();
   fsMocks.serverStat.mockReset();
   fsMocks.serverStat.mockResolvedValue({ dev: 1, ino: 1, size: 0 });
@@ -190,6 +194,10 @@ beforeEach(() => {
         addPendingWrite(data, resolve);
       }),
   );
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
 });
 
 async function expectSerializedWrites(
@@ -246,7 +254,7 @@ describe("recorder append serialization", () => {
     ]);
     expect(fsMocks.serverSync).toHaveBeenCalledTimes(2);
     expect(fsMocks.serverDirectorySync).toHaveBeenCalledOnce();
-    expect(fsMocks.lock).toHaveBeenCalledTimes(4);
+    expect(fsMocks.lock).toHaveBeenCalledTimes(2);
     expect(fsMocks.serverOpen.mock.calls.map(([, flags]) => flags)).toEqual(["ax+", "ax+", "a+"]);
   });
 
@@ -259,6 +267,8 @@ describe("recorder append serialization", () => {
       );
       fsMocks.serverDirectory = await realpath(path.dirname(recorderPath));
       fsMocks.serverWrite.mockResolvedValue(undefined);
+      fsMocks.serverFileStat.mockResolvedValue({ dev: 1, ino: 1, nlink: 2, size: 0 });
+      vi.stubEnv("CRABLINE_RECORDER_LOCK_DIR", tmpdir());
       const pathRelease = vi.fn(async () => {});
       const releaseFailure = new Error("identity lock cleanup failed");
       const identityRelease = vi.fn(async () => {
@@ -305,6 +315,8 @@ describe("recorder append serialization", () => {
       );
       fsMocks.serverDirectory = await realpath(path.dirname(recorderPath));
       fsMocks.serverWrite.mockResolvedValue(undefined);
+      fsMocks.serverFileStat.mockResolvedValue({ dev: 1, ino: 1, nlink: 2, size: 0 });
+      vi.stubEnv("CRABLINE_RECORDER_LOCK_DIR", tmpdir());
       const sharedFailure = Object.assign(new Error("shared lock filesystem full"), {
         code: "ENOSPC",
       });
@@ -328,6 +340,36 @@ describe("recorder append serialization", () => {
       expect(pathRelease).toHaveBeenCalledOnce();
     },
   );
+
+  it("rejects hardlinked server recorders without a shared lock namespace", async () => {
+    const recorderPath = path.join(
+      "/tmp",
+      `crabline-server-recorder-hardlink-unconfigured-${process.pid}-${Date.now()}.jsonl`,
+    );
+    fsMocks.serverDirectory = await realpath(path.dirname(recorderPath));
+    fsMocks.serverWrite.mockResolvedValue(undefined);
+    fsMocks.serverFileStat.mockResolvedValue({ dev: 1, ino: 1, nlink: 2, size: 0 });
+    const pathRelease = vi.fn(async () => {});
+    fsMocks.lock.mockResolvedValueOnce(pathRelease);
+
+    await expect(
+      recordServerEvent({
+        event: {
+          at: "2026-07-12T10:00:00.000Z",
+          method: "POST",
+          path: "/hardlink-unconfigured",
+          query: {},
+          type: "api",
+        },
+        onEvent: undefined,
+        recorderPath,
+      }),
+    ).rejects.toThrow(
+      "Server recorder hardlinks require CRABLINE_RECORDER_LOCK_DIR to name one shared writable lock directory for every writer.",
+    );
+    expect(fsMocks.serverWrite).not.toHaveBeenCalled();
+    expect(pathRelease).toHaveBeenCalledOnce();
+  });
 
   it("serializes provider inbound appends to the same JSONL file", async () => {
     const recorderPath = path.join(

--- a/test/recorder-concurrency.test.ts
+++ b/test/recorder-concurrency.test.ts
@@ -175,7 +175,7 @@ beforeEach(() => {
   fsMocks.serverDirectorySync.mockResolvedValue(undefined);
   fsMocks.serverFileExists = false;
   fsMocks.serverFileStat.mockReset();
-  fsMocks.serverFileStat.mockResolvedValue({ dev: 1, ino: 1, size: 0 });
+  fsMocks.serverFileStat.mockResolvedValue({ dev: 1, ino: 1, nlink: 1, size: 0 });
   fsMocks.serverOpen.mockReset();
   fsMocks.serverStat.mockReset();
   fsMocks.serverStat.mockResolvedValue({ dev: 1, ino: 1, size: 0 });
@@ -369,6 +369,41 @@ describe("recorder append serialization", () => {
     );
     expect(fsMocks.serverWrite).not.toHaveBeenCalled();
     expect(pathRelease).toHaveBeenCalledOnce();
+  });
+
+  it("requires the configured server recorder lock directory to be pre-created", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "crabline-server-lock-root-"));
+    const lockRoot = path.join(directory, "missing");
+    const recorderPath = path.join(
+      "/tmp",
+      `crabline-server-recorder-lock-root-${process.pid}-${Date.now()}.jsonl`,
+    );
+    fsMocks.serverDirectory = await realpath(path.dirname(recorderPath));
+    fsMocks.serverWrite.mockResolvedValue(undefined);
+    vi.stubEnv("CRABLINE_RECORDER_LOCK_DIR", lockRoot);
+    const pathRelease = vi.fn(async () => {});
+    fsMocks.lock.mockResolvedValueOnce(pathRelease);
+
+    try {
+      await expect(
+        recordServerEvent({
+          event: {
+            at: "2026-07-12T10:00:00.000Z",
+            method: "POST",
+            path: "/missing-lock-root",
+            query: {},
+            type: "api",
+          },
+          onEvent: undefined,
+          recorderPath,
+        }),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(stat(lockRoot)).rejects.toMatchObject({ code: "ENOENT" });
+      expect(fsMocks.serverWrite).not.toHaveBeenCalled();
+      expect(pathRelease).toHaveBeenCalledOnce();
+    } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
   });
 
   it("serializes provider inbound appends to the same JSONL file", async () => {

--- a/test/recorder-concurrency.test.ts
+++ b/test/recorder-concurrency.test.ts
@@ -22,7 +22,6 @@ const fsMocks = vi.hoisted(() => ({
   serverDirectory: "",
   serverDirectorySync: vi.fn<(directoryPath: string) => Promise<void>>(),
   serverFileExists: false,
-  serverFileNlink: 1,
   serverOpen: vi.fn<(filePath: string, flags: string) => void>(),
   serverStat: vi.fn<(filePath: string) => Promise<{ dev: number; ino: number; size: number }>>(),
   serverSync: vi.fn<(filePath: string) => Promise<void>>(),
@@ -92,7 +91,7 @@ vi.mock("node:fs/promises", async (importOriginal) => {
           chmod: async () => {},
           close: async () => {},
           read: async (buffer: Buffer) => ({ buffer, bytesRead: 0 }),
-          stat: async () => ({ dev: 1, ino: 1, nlink: fsMocks.serverFileNlink, size: 0 }),
+          stat: async () => ({ dev: 1, ino: 1, size: 0 }),
           sync: async () => await fsMocks.serverSync(filePath),
           truncate: async () => {},
         } as unknown as Awaited<ReturnType<typeof actual.open>>;
@@ -173,7 +172,6 @@ beforeEach(() => {
   fsMocks.serverDirectorySync.mockReset();
   fsMocks.serverDirectorySync.mockResolvedValue(undefined);
   fsMocks.serverFileExists = false;
-  fsMocks.serverFileNlink = 1;
   fsMocks.serverOpen.mockReset();
   fsMocks.serverStat.mockReset();
   fsMocks.serverStat.mockResolvedValue({ dev: 1, ino: 1, size: 0 });
@@ -253,14 +251,13 @@ describe("recorder append serialization", () => {
   });
 
   it.skipIf(process.platform === "win32")(
-    "preserves committed status when a hardlink identity lock release fails",
+    "preserves committed status when an identity lock release fails",
     async () => {
       const recorderPath = path.join(
         "/tmp",
         `crabline-server-recorder-hardlink-release-${process.pid}-${Date.now()}.jsonl`,
       );
       fsMocks.serverDirectory = await realpath(path.dirname(recorderPath));
-      fsMocks.serverFileNlink = 2;
       fsMocks.serverWrite.mockResolvedValue(undefined);
       const pathRelease = vi.fn(async () => {});
       const releaseFailure = new Error("identity lock cleanup failed");
@@ -300,57 +297,35 @@ describe("recorder append serialization", () => {
   );
 
   it.skipIf(process.platform === "win32")(
-    "abandons an adjacent identity lock when the recorder becomes hardlinked",
+    "fails closed when the shared identity lock is unavailable",
     async () => {
       const recorderPath = path.join(
         "/tmp",
-        `crabline-server-recorder-fallback-race-${process.pid}-${Date.now()}.jsonl`,
-      );
-      const currentUserId = process.geteuid?.();
-      if (currentUserId === undefined) {
-        throw new Error("Expected a current user id on Unix.");
-      }
-      const fallbackRoot = path.join(
-        path.dirname(recorderPath),
-        `.crabline-server-recorder-locks-${currentUserId}`,
+        `crabline-server-recorder-shared-lock-${process.pid}-${Date.now()}.jsonl`,
       );
       fsMocks.serverDirectory = await realpath(path.dirname(recorderPath));
-      fsMocks.serverFileNlink = 1;
       fsMocks.serverWrite.mockResolvedValue(undefined);
       const sharedFailure = Object.assign(new Error("shared lock filesystem full"), {
         code: "ENOSPC",
       });
       const pathRelease = vi.fn(async () => {});
-      const fallbackRelease = vi.fn(async () => {});
-      fsMocks.lock
-        .mockResolvedValueOnce(pathRelease)
-        .mockImplementationOnce(async () => {
-          fsMocks.serverFileNlink = 2;
-          throw sharedFailure;
-        })
-        .mockResolvedValueOnce(fallbackRelease)
-        .mockRejectedValueOnce(sharedFailure);
+      fsMocks.lock.mockResolvedValueOnce(pathRelease).mockRejectedValueOnce(sharedFailure);
 
-      try {
-        await expect(
-          recordServerEvent({
-            event: {
-              at: "2026-07-12T10:00:00.000Z",
-              method: "POST",
-              path: "/fallback-hardlink-race",
-              query: {},
-              type: "api",
-            },
-            onEvent: undefined,
-            recorderPath,
-          }),
-        ).rejects.toBe(sharedFailure);
-        expect(fsMocks.serverWrite).not.toHaveBeenCalled();
-        expect(fallbackRelease).toHaveBeenCalledOnce();
-        expect(pathRelease).toHaveBeenCalledOnce();
-      } finally {
-        await rm(fallbackRoot, { force: true, recursive: true });
-      }
+      await expect(
+        recordServerEvent({
+          event: {
+            at: "2026-07-12T10:00:00.000Z",
+            method: "POST",
+            path: "/shared-lock-unavailable",
+            query: {},
+            type: "api",
+          },
+          onEvent: undefined,
+          recorderPath,
+        }),
+      ).rejects.toBe(sharedFailure);
+      expect(fsMocks.serverWrite).not.toHaveBeenCalled();
+      expect(pathRelease).toHaveBeenCalledOnce();
     },
   );
 

--- a/test/recorder-concurrency.test.ts
+++ b/test/recorder-concurrency.test.ts
@@ -299,6 +299,61 @@ describe("recorder append serialization", () => {
     },
   );
 
+  it.skipIf(process.platform === "win32")(
+    "abandons an adjacent identity lock when the recorder becomes hardlinked",
+    async () => {
+      const recorderPath = path.join(
+        "/tmp",
+        `crabline-server-recorder-fallback-race-${process.pid}-${Date.now()}.jsonl`,
+      );
+      const currentUserId = process.geteuid?.();
+      if (currentUserId === undefined) {
+        throw new Error("Expected a current user id on Unix.");
+      }
+      const fallbackRoot = path.join(
+        path.dirname(recorderPath),
+        `.crabline-server-recorder-locks-${currentUserId}`,
+      );
+      fsMocks.serverDirectory = await realpath(path.dirname(recorderPath));
+      fsMocks.serverFileNlink = 1;
+      fsMocks.serverWrite.mockResolvedValue(undefined);
+      const sharedFailure = Object.assign(new Error("shared lock filesystem full"), {
+        code: "ENOSPC",
+      });
+      const pathRelease = vi.fn(async () => {});
+      const fallbackRelease = vi.fn(async () => {});
+      fsMocks.lock
+        .mockResolvedValueOnce(pathRelease)
+        .mockImplementationOnce(async () => {
+          fsMocks.serverFileNlink = 2;
+          throw sharedFailure;
+        })
+        .mockResolvedValueOnce(fallbackRelease)
+        .mockRejectedValueOnce(sharedFailure);
+
+      try {
+        await expect(
+          recordServerEvent({
+            event: {
+              at: "2026-07-12T10:00:00.000Z",
+              method: "POST",
+              path: "/fallback-hardlink-race",
+              query: {},
+              type: "api",
+            },
+            onEvent: undefined,
+            recorderPath,
+          }),
+        ).rejects.toBe(sharedFailure);
+        expect(fsMocks.serverWrite).not.toHaveBeenCalled();
+        expect(fallbackRelease).toHaveBeenCalledOnce();
+        expect(pathRelease).toHaveBeenCalledOnce();
+      } finally {
+        await rm(fallbackRoot, { force: true, recursive: true });
+      }
+    },
+  );
+
   it("serializes provider inbound appends to the same JSONL file", async () => {
     const recorderPath = path.join(
       "/tmp",

--- a/test/recorder-concurrency.test.ts
+++ b/test/recorder-concurrency.test.ts
@@ -1,5 +1,15 @@
 import path from "node:path";
-import { chmod, link, mkdir, mkdtemp, realpath, rm, stat, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  link,
+  mkdir,
+  mkdtemp,
+  realpath,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir, userInfo } from "node:os";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -268,7 +278,7 @@ describe("recorder append serialization", () => {
       fsMocks.serverDirectory = await realpath(path.dirname(recorderPath));
       fsMocks.serverWrite.mockResolvedValue(undefined);
       fsMocks.serverFileStat.mockResolvedValue({ dev: 1, ino: 1, nlink: 2, size: 0 });
-      vi.stubEnv("CRABLINE_RECORDER_LOCK_DIR", tmpdir());
+      vi.stubEnv("CRABLINE_RECORDER_LOCK_DIR", await realpath(tmpdir()));
       const pathRelease = vi.fn(async () => {});
       const releaseFailure = new Error("identity lock cleanup failed");
       const identityRelease = vi.fn(async () => {
@@ -316,7 +326,7 @@ describe("recorder append serialization", () => {
       fsMocks.serverDirectory = await realpath(path.dirname(recorderPath));
       fsMocks.serverWrite.mockResolvedValue(undefined);
       fsMocks.serverFileStat.mockResolvedValue({ dev: 1, ino: 1, nlink: 2, size: 0 });
-      vi.stubEnv("CRABLINE_RECORDER_LOCK_DIR", tmpdir());
+      vi.stubEnv("CRABLINE_RECORDER_LOCK_DIR", await realpath(tmpdir()));
       const sharedFailure = Object.assign(new Error("shared lock filesystem full"), {
         code: "ENOSPC",
       });
@@ -405,6 +415,48 @@ describe("recorder append serialization", () => {
       await rm(directory, { force: true, recursive: true });
     }
   });
+
+  it.skipIf(process.platform === "win32")(
+    "rejects configured server recorder lock paths with symlink components",
+    async () => {
+      const directory = await mkdtemp(path.join(tmpdir(), "crabline-server-lock-symlink-"));
+      const canonicalRoot = path.join(directory, "canonical");
+      const symlinkRoot = path.join(directory, "current");
+      const recorderPath = path.join(
+        "/tmp",
+        `crabline-server-recorder-lock-symlink-${process.pid}-${Date.now()}.jsonl`,
+      );
+      await mkdir(canonicalRoot, { mode: 0o700 });
+      await symlink(canonicalRoot, symlinkRoot, "dir");
+      fsMocks.serverDirectory = await realpath(path.dirname(recorderPath));
+      fsMocks.serverWrite.mockResolvedValue(undefined);
+      vi.stubEnv("CRABLINE_RECORDER_LOCK_DIR", symlinkRoot);
+      const pathRelease = vi.fn(async () => {});
+      fsMocks.lock.mockResolvedValueOnce(pathRelease);
+
+      try {
+        await expect(
+          recordServerEvent({
+            event: {
+              at: "2026-07-12T10:00:00.000Z",
+              method: "POST",
+              path: "/symlinked-lock-root",
+              query: {},
+              type: "api",
+            },
+            onEvent: undefined,
+            recorderPath,
+          }),
+        ).rejects.toThrow(
+          "CRABLINE_RECORDER_LOCK_DIR must name a canonical directory without symlink components.",
+        );
+        expect(fsMocks.serverWrite).not.toHaveBeenCalled();
+        expect(pathRelease).toHaveBeenCalledOnce();
+      } finally {
+        await rm(directory, { force: true, recursive: true });
+      }
+    },
+  );
 
   it("serializes provider inbound appends to the same JSONL file", async () => {
     const recorderPath = path.join(

--- a/test/recorder-concurrency.test.ts
+++ b/test/recorder-concurrency.test.ts
@@ -248,7 +248,7 @@ describe("recorder append serialization", () => {
     ]);
     expect(fsMocks.serverSync).toHaveBeenCalledTimes(2);
     expect(fsMocks.serverDirectorySync).toHaveBeenCalledOnce();
-    expect(fsMocks.lock).toHaveBeenCalledTimes(2);
+    expect(fsMocks.lock).toHaveBeenCalledTimes(4);
     expect(fsMocks.serverOpen.mock.calls.map(([, flags]) => flags)).toEqual(["ax+", "ax+", "a+"]);
   });
 

--- a/test/recorder-concurrency.test.ts
+++ b/test/recorder-concurrency.test.ts
@@ -22,6 +22,7 @@ const fsMocks = vi.hoisted(() => ({
   serverDirectory: "",
   serverDirectorySync: vi.fn<(directoryPath: string) => Promise<void>>(),
   serverFileExists: false,
+  serverFileNlink: 1,
   serverOpen: vi.fn<(filePath: string, flags: string) => void>(),
   serverStat: vi.fn<(filePath: string) => Promise<{ dev: number; ino: number; size: number }>>(),
   serverSync: vi.fn<(filePath: string) => Promise<void>>(),
@@ -91,7 +92,7 @@ vi.mock("node:fs/promises", async (importOriginal) => {
           chmod: async () => {},
           close: async () => {},
           read: async (buffer: Buffer) => ({ buffer, bytesRead: 0 }),
-          stat: async () => ({ dev: 1, ino: 1, size: 0 }),
+          stat: async () => ({ dev: 1, ino: 1, nlink: fsMocks.serverFileNlink, size: 0 }),
           sync: async () => await fsMocks.serverSync(filePath),
           truncate: async () => {},
         } as unknown as Awaited<ReturnType<typeof actual.open>>;
@@ -172,6 +173,7 @@ beforeEach(() => {
   fsMocks.serverDirectorySync.mockReset();
   fsMocks.serverDirectorySync.mockResolvedValue(undefined);
   fsMocks.serverFileExists = false;
+  fsMocks.serverFileNlink = 1;
   fsMocks.serverOpen.mockReset();
   fsMocks.serverStat.mockReset();
   fsMocks.serverStat.mockResolvedValue({ dev: 1, ino: 1, size: 0 });
@@ -249,6 +251,53 @@ describe("recorder append serialization", () => {
     expect(fsMocks.lock).toHaveBeenCalledTimes(2);
     expect(fsMocks.serverOpen.mock.calls.map(([, flags]) => flags)).toEqual(["ax+", "ax+", "a+"]);
   });
+
+  it.skipIf(process.platform === "win32")(
+    "preserves committed status when a hardlink identity lock release fails",
+    async () => {
+      const recorderPath = path.join(
+        "/tmp",
+        `crabline-server-recorder-hardlink-release-${process.pid}-${Date.now()}.jsonl`,
+      );
+      fsMocks.serverDirectory = await realpath(path.dirname(recorderPath));
+      fsMocks.serverFileNlink = 2;
+      fsMocks.serverWrite.mockResolvedValue(undefined);
+      const pathRelease = vi.fn(async () => {});
+      const releaseFailure = new Error("identity lock cleanup failed");
+      const identityRelease = vi.fn(async () => {
+        throw releaseFailure;
+      });
+      fsMocks.lock.mockResolvedValueOnce(pathRelease).mockResolvedValueOnce(identityRelease);
+      const observer = vi.fn();
+
+      await expect(
+        recordServerEvent({
+          event: {
+            at: "2026-07-12T10:00:00.000Z",
+            method: "POST",
+            path: "/committed-hardlink-release",
+            query: {},
+            type: "api",
+          },
+          onEvent: observer,
+          recorderPath,
+        }),
+      ).rejects.toMatchObject({
+        cause: releaseFailure,
+        committed: true,
+        indeterminate: false,
+        name: "ServerRecorderCommittedError",
+      });
+      expect(observer).not.toHaveBeenCalled();
+      expect(pathRelease).toHaveBeenCalledOnce();
+      expect(identityRelease).toHaveBeenCalledOnce();
+      expect(
+        fsMocks.lock.mock.calls.some(([lockPath]) =>
+          path.basename(String(lockPath)).startsWith("recorder-"),
+        ),
+      ).toBe(true);
+    },
+  );
 
   it("serializes provider inbound appends to the same JSONL file", async () => {
     const recorderPath = path.join(

--- a/test/server-recorder-filesystem.test.ts
+++ b/test/server-recorder-filesystem.test.ts
@@ -11,16 +11,16 @@ import {
   writeFile,
   type FileHandle,
 } from "node:fs/promises";
-import { userInfo } from "node:os";
 import path from "node:path";
 import { lock } from "proper-lockfile";
-import { afterEach, expect, it } from "vitest";
+import { afterEach, expect, it, vi } from "vitest";
 import { recordServerEvent } from "../src/servers/recorder.js";
 import { createTempDir, disposeTempDir } from "./test-helpers.js";
 
 const directories: string[] = [];
 
 afterEach(async () => {
+  vi.unstubAllEnvs();
   await Promise.all(directories.splice(0).map(disposeTempDir));
 });
 
@@ -102,18 +102,13 @@ it.skipIf(process.platform === "win32")(
     await writeFile(secondTarget, "", "utf8");
     await symlink(firstTarget, recorderPath, "file");
     const identity = await stat(firstTarget, { bigint: true });
-    const lockRoot = path.join(
-      userInfo().homedir,
-      ".cache",
-      "crabline",
-      "locks",
-      "server-recorder",
-    );
+    const lockRoot = path.join(directory, "shared-locks");
     await mkdir(lockRoot, { mode: 0o700, recursive: true });
     await chmod(lockRoot, 0o700);
+    vi.stubEnv("CRABLINE_RECORDER_LOCK_DIR", lockRoot);
 
     let releaseIdentity: (() => Promise<void>) | undefined = await lock(
-      path.join(lockRoot, `recorder-${identity.dev}-${identity.ino}`),
+      path.join(lockRoot, `recorder-${identity.ino}`),
       { realpath: false },
     );
     const recording = recordServerEvent({

--- a/test/server-recorder-filesystem.test.ts
+++ b/test/server-recorder-filesystem.test.ts
@@ -4,6 +4,7 @@ import {
   mkdir,
   open,
   readFile,
+  realpath,
   rename,
   rm,
   stat,
@@ -105,10 +106,11 @@ it.skipIf(process.platform === "win32")(
     const lockRoot = path.join(directory, "shared-locks");
     await mkdir(lockRoot, { mode: 0o700, recursive: true });
     await chmod(lockRoot, 0o700);
-    vi.stubEnv("CRABLINE_RECORDER_LOCK_DIR", lockRoot);
+    const canonicalLockRoot = await realpath(lockRoot);
+    vi.stubEnv("CRABLINE_RECORDER_LOCK_DIR", canonicalLockRoot);
 
     let releaseIdentity: (() => Promise<void>) | undefined = await lock(
-      path.join(lockRoot, `recorder-${identity.ino}`),
+      path.join(canonicalLockRoot, `recorder-${identity.ino}`),
       { realpath: false },
     );
     const recording = recordServerEvent({

--- a/test/server-recorder-filesystem.test.ts
+++ b/test/server-recorder-filesystem.test.ts
@@ -1,6 +1,7 @@
 import {
   appendFile,
   chmod,
+  mkdir,
   open,
   readFile,
   rename,
@@ -10,6 +11,7 @@ import {
   writeFile,
   type FileHandle,
 } from "node:fs/promises";
+import { userInfo } from "node:os";
 import path from "node:path";
 import { lock } from "proper-lockfile";
 import { afterEach, expect, it } from "vitest";
@@ -85,6 +87,70 @@ it.skipIf(process.platform === "win32")(
 
     expect(await readFile(firstTarget, "utf8")).toBe("");
     expect(await readFile(secondTarget, "utf8")).toContain('"path":"/retargeted"');
+  },
+);
+
+it.skipIf(process.platform === "win32")(
+  "revalidates a recorder symlink after waiting for its identity lock",
+  async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const recorderPath = path.join(directory, "server.jsonl");
+    const firstTarget = path.join(directory, "first.jsonl");
+    const secondTarget = path.join(directory, "second.jsonl");
+    await writeFile(firstTarget, "", "utf8");
+    await writeFile(secondTarget, "", "utf8");
+    await symlink(firstTarget, recorderPath, "file");
+    const identity = await stat(firstTarget, { bigint: true });
+    const lockRoot = path.join(
+      userInfo().homedir,
+      ".cache",
+      "crabline",
+      "locks",
+      "server-recorder",
+    );
+    await mkdir(lockRoot, { mode: 0o700, recursive: true });
+    await chmod(lockRoot, 0o700);
+
+    let releaseIdentity: (() => Promise<void>) | undefined = await lock(
+      path.join(lockRoot, `recorder-${identity.dev}-${identity.ino}`),
+      { realpath: false },
+    );
+    const recording = recordServerEvent({
+      event: {
+        at: new Date().toISOString(),
+        method: "POST",
+        path: "/retargeted-during-identity-wait",
+        query: {},
+        type: "api",
+      },
+      onEvent: undefined,
+      recorderPath,
+    });
+    try {
+      await expect
+        .poll(async () => {
+          try {
+            await stat(`${firstTarget}.lock`);
+            return true;
+          } catch {
+            return false;
+          }
+        })
+        .toBe(true);
+      await rm(recorderPath);
+      await symlink(secondTarget, recorderPath, "file");
+      await releaseIdentity();
+      releaseIdentity = undefined;
+      await recording;
+    } finally {
+      await releaseIdentity?.();
+    }
+
+    expect(await readFile(firstTarget, "utf8")).toBe("");
+    expect(await readFile(secondTarget, "utf8")).toContain(
+      '"path":"/retargeted-during-identity-wait"',
+    );
   },
 );
 

--- a/test/server-recorder.test.ts
+++ b/test/server-recorder.test.ts
@@ -1209,12 +1209,16 @@ describe("server recorder", () => {
         const lockRoot = path.join(directory, "shared-locks");
         await actualFs.mkdir(lockRoot, { mode: 0o700, recursive: true });
         await actualFs.chmod(lockRoot, 0o700);
-        releaseGate = await actualLockfile.lock(path.join(lockRoot, `recorder-${identity.ino}`), {
-          realpath: false,
-          stale: 30_000,
-          update: 10_000,
-        });
-        const first = startRecorderProcess(recorderPath, "/process-a", lockRoot);
+        const canonicalLockRoot = await actualFs.realpath(lockRoot);
+        releaseGate = await actualLockfile.lock(
+          path.join(canonicalLockRoot, `recorder-${identity.ino}`),
+          {
+            realpath: false,
+            stale: 30_000,
+            update: 10_000,
+          },
+        );
+        const first = startRecorderProcess(recorderPath, "/process-a", canonicalLockRoot);
         processes.push(first);
 
         await vi.waitFor(
@@ -1228,7 +1232,7 @@ describe("server recorder", () => {
           await expect(actualFs.stat(`${recorderPath}.lock`)).resolves.toBeDefined();
         });
         await actualFs.link(recorderPath, aliasPath);
-        const second = startRecorderProcess(aliasPath, "/process-b", lockRoot);
+        const second = startRecorderProcess(aliasPath, "/process-b", canonicalLockRoot);
         processes.push(second);
         await vi.waitFor(
           () => {

--- a/test/server-recorder.test.ts
+++ b/test/server-recorder.test.ts
@@ -111,7 +111,11 @@ type RecorderProcess = {
   stdout: () => string;
 };
 
-function startRecorderProcess(recorderPath: string, pathname: string): RecorderProcess {
+function startRecorderProcess(
+  recorderPath: string,
+  pathname: string,
+  recorderLockDirectory?: string,
+): RecorderProcess {
   const recorderModuleUrl = new URL("../src/servers/recorder.ts", import.meta.url).href;
   const script = `
     import { recordServerEvent } from ${JSON.stringify(recorderModuleUrl)};
@@ -140,7 +144,13 @@ function startRecorderProcess(recorderPath: string, pathname: string): RecorderP
   const child = spawn(
     process.execPath,
     ["--import", "tsx", "--input-type=module", "--eval", script, recorderPath, pathname],
-    { stdio: ["pipe", "pipe", "pipe"] },
+    {
+      env:
+        recorderLockDirectory === undefined
+          ? process.env
+          : { ...process.env, CRABLINE_RECORDER_LOCK_DIR: recorderLockDirectory },
+      stdio: ["pipe", "pipe", "pipe"],
+    },
   );
   let stdout = "";
   let stderr = "";
@@ -286,12 +296,12 @@ describe("server recorder", () => {
       stale: 30_000,
       update: 10_000,
     });
-    expect(lockMocks.release).toHaveBeenCalledTimes(2);
+    expect(lockMocks.release).toHaveBeenCalledOnce();
     expect(fsMocks.file.chmod.mock.invocationCallOrder[0]).toBeLessThan(
       fsMocks.file.appendFile.mock.invocationCallOrder[0]!,
     );
     expect(fsMocks.file.close).toHaveBeenCalledOnce();
-    expect(fsMocks.directory.close).toHaveBeenCalledTimes(4);
+    expect(fsMocks.directory.close).toHaveBeenCalledTimes(3);
   });
 
   it("resyncs recorder ancestry after an interrupted first-append attempt", async () => {
@@ -493,9 +503,9 @@ describe("server recorder", () => {
       recorderPath: path.join("/tmp", "crabline-server-recorder-contention.jsonl"),
     });
 
-    expect(lockMocks.lock).toHaveBeenCalledTimes(3);
+    expect(lockMocks.lock).toHaveBeenCalledTimes(2);
     expect(fsMocks.file.appendFile).toHaveBeenCalledOnce();
-    expect(lockMocks.release).toHaveBeenCalledTimes(2);
+    expect(lockMocks.release).toHaveBeenCalledOnce();
   });
 
   it("repairs managed directories without chmodding existing recorder files or parents", async () => {
@@ -1179,24 +1189,15 @@ describe("server recorder", () => {
       try {
         await actualFs.writeFile(recorderPath, initialContents, { mode: 0o600 });
         const identity = await actualFs.stat(recorderPath, { bigint: true });
-        const lockRoot = path.join(
-          os.userInfo().homedir,
-          ".cache",
-          "crabline",
-          "locks",
-          "server-recorder",
-        );
+        const lockRoot = path.join(directory, "shared-locks");
         await actualFs.mkdir(lockRoot, { mode: 0o700, recursive: true });
         await actualFs.chmod(lockRoot, 0o700);
-        releaseGate = await actualLockfile.lock(
-          path.join(lockRoot, `recorder-${identity.dev}-${identity.ino}`),
-          {
-            realpath: false,
-            stale: 30_000,
-            update: 10_000,
-          },
-        );
-        const first = startRecorderProcess(recorderPath, "/process-a");
+        releaseGate = await actualLockfile.lock(path.join(lockRoot, `recorder-${identity.ino}`), {
+          realpath: false,
+          stale: 30_000,
+          update: 10_000,
+        });
+        const first = startRecorderProcess(recorderPath, "/process-a", lockRoot);
         processes.push(first);
 
         await vi.waitFor(
@@ -1210,7 +1211,7 @@ describe("server recorder", () => {
           await expect(actualFs.stat(`${recorderPath}.lock`)).resolves.toBeDefined();
         });
         await actualFs.link(recorderPath, aliasPath);
-        const second = startRecorderProcess(aliasPath, "/process-b");
+        const second = startRecorderProcess(aliasPath, "/process-b", lockRoot);
         processes.push(second);
         await vi.waitFor(
           () => {

--- a/test/server-recorder.test.ts
+++ b/test/server-recorder.test.ts
@@ -1089,6 +1089,92 @@ describe("server recorder", () => {
     }
   });
 
+  it.skipIf(process.platform === "win32")(
+    "serializes hardlink aliases across recorder processes",
+    async () => {
+      const actualFs = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+      const actualLockfile =
+        await vi.importActual<typeof import("proper-lockfile")>("proper-lockfile");
+      const directory = await actualFs.mkdtemp(
+        path.join(os.tmpdir(), "crabline-server-recorder-hardlink-"),
+      );
+      const recorderPath = path.join(directory, "events.jsonl");
+      const aliasPath = path.join(directory, "events-alias.jsonl");
+      const initialContents = `${JSON.stringify(serverEvent("/completed"))}\n{"path":"/torn"`;
+      let releaseGate: (() => Promise<void>) | undefined;
+      const processes: RecorderProcess[] = [];
+      try {
+        await actualFs.writeFile(recorderPath, initialContents, { mode: 0o600 });
+        await actualFs.link(recorderPath, aliasPath);
+        const identity = await actualFs.stat(recorderPath, { bigint: true });
+        const lockRoot = path.join(
+          os.userInfo().homedir,
+          ".cache",
+          "crabline",
+          "locks",
+          "server-recorder",
+        );
+        await actualFs.mkdir(lockRoot, { mode: 0o700, recursive: true });
+        await actualFs.chmod(lockRoot, 0o700);
+        releaseGate = await actualLockfile.lock(
+          path.join(lockRoot, `recorder-${identity.dev}-${identity.ino}`),
+          {
+            realpath: false,
+            stale: 30_000,
+            update: 10_000,
+          },
+        );
+        const first = startRecorderProcess(recorderPath, "/process-a");
+        const second = startRecorderProcess(aliasPath, "/process-b");
+        processes.push(first, second);
+
+        await vi.waitFor(
+          () => {
+            expect(first.stdout()).toContain("ready\n");
+            expect(second.stdout()).toContain("ready\n");
+          },
+          { timeout: 5_000 },
+        );
+        first.child.stdin.end("go\n");
+        second.child.stdin.end("go\n");
+        await new Promise((resolve) => setTimeout(resolve, 100));
+
+        expect(first.stdout()).not.toContain("done\n");
+        expect(second.stdout()).not.toContain("done\n");
+        await expect(actualFs.readFile(recorderPath, "utf8")).resolves.toBe(initialContents);
+
+        await releaseGate();
+        releaseGate = undefined;
+        await vi.waitFor(
+          () => {
+            expect(first.stdout()).toContain("done\n");
+            expect(second.stdout()).toContain("done\n");
+          },
+          { timeout: 5_000 },
+        );
+        await expect(Promise.all(processes.map((process) => process.exited))).resolves.toEqual([
+          0, 0,
+        ]);
+
+        const recordedPaths = (await actualFs.readFile(recorderPath, "utf8"))
+          .trimEnd()
+          .split("\n")
+          .map((line) => (JSON.parse(line) as ServerRequestEvent).path)
+          .sort();
+        expect(recordedPaths).toEqual(["/completed", "/process-a", "/process-b"]);
+      } finally {
+        await releaseGate?.();
+        for (const process of processes) {
+          if (process.child.exitCode === null) {
+            process.child.kill();
+          }
+        }
+        await Promise.all(processes.map((process) => process.exited));
+        await actualFs.rm(directory, { force: true, recursive: true });
+      }
+    },
+  );
+
   it("waits beyond five seconds for a live recorder owner", async () => {
     const actualFs = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
     const actualLockfile =

--- a/test/server-recorder.test.ts
+++ b/test/server-recorder.test.ts
@@ -48,7 +48,7 @@ const fsMocks = vi.hoisted(() => {
         position: number,
       ) => Promise<{ bytesRead: number; buffer: Buffer }>
     >(),
-    stat: vi.fn<() => Promise<{ dev?: number; ino?: number; size: number }>>(),
+    stat: vi.fn<() => Promise<{ dev?: number; ino?: number; nlink?: number; size: number }>>(),
     sync: vi.fn<() => Promise<void>>(),
     truncate: vi.fn<(length: number) => Promise<void>>(),
   };
@@ -80,7 +80,9 @@ const fsMocks = vi.hoisted(() => {
         mode?: number,
       ) => Promise<typeof directory | typeof file>
     >(),
-    stat: vi.fn<(filePath: string) => Promise<{ dev?: number; ino?: number; size: number }>>(),
+    stat: vi.fn<
+      (filePath: string) => Promise<{ dev?: number; ino?: number; nlink?: number; size: number }>
+    >(),
   };
 });
 
@@ -217,7 +219,7 @@ beforeEach(() => {
   fsMocks.file.read.mockReset();
   fsMocks.file.read.mockResolvedValue({ buffer: Buffer.alloc(0), bytesRead: 0 });
   fsMocks.file.stat.mockReset();
-  fsMocks.file.stat.mockResolvedValue({ dev: 1, ino: 1, size: 0 });
+  fsMocks.file.stat.mockResolvedValue({ dev: 1, ino: 1, nlink: 1, size: 0 });
   fsMocks.file.sync.mockReset();
   fsMocks.file.sync.mockResolvedValue();
   fsMocks.file.truncate.mockReset();
@@ -241,7 +243,7 @@ beforeEach(() => {
     return typeof flags === "number" || flags === "r" ? fsMocks.directory : fsMocks.file;
   });
   fsMocks.stat.mockReset();
-  fsMocks.stat.mockResolvedValue({ dev: 1, ino: 1, size: 0 });
+  fsMocks.stat.mockResolvedValue({ dev: 1, ino: 1, nlink: 1, size: 0 });
 });
 
 afterEach(() => {
@@ -314,8 +316,8 @@ describe("server recorder", () => {
     const observer = vi.fn<(event: ServerRequestEvent) => void>();
     let recorderExists = false;
     fsMocks.mkdir.mockResolvedValueOnce(canonicalFirstParent).mockResolvedValueOnce(undefined);
-    fsMocks.file.stat.mockResolvedValue({ dev: 42, ino: 84, size: 0 });
-    fsMocks.stat.mockResolvedValue({ dev: 42, ino: 84, size: 0 });
+    fsMocks.file.stat.mockResolvedValue({ dev: 42, ino: 84, nlink: 1, size: 0 });
+    fsMocks.stat.mockResolvedValue({ dev: 42, ino: 84, nlink: 1, size: 0 });
     fsMocks.directory.sync.mockRejectedValueOnce(ancestrySyncFailure).mockResolvedValue(undefined);
     fsMocks.open.mockImplementation(async (openedPath, flags) => {
       if (typeof flags === "number") {
@@ -376,8 +378,8 @@ describe("server recorder", () => {
     const syncFailure = Object.assign(new Error("recorder parent denied"), { code: "EACCES" });
     const observer = vi.fn<(event: ServerRequestEvent) => void>();
     let immediateAttempts = 0;
-    fsMocks.file.stat.mockResolvedValue({ dev: 61, ino: 62, size: 0 });
-    fsMocks.stat.mockResolvedValue({ dev: 61, ino: 62, size: 0 });
+    fsMocks.file.stat.mockResolvedValue({ dev: 61, ino: 62, nlink: 1, size: 0 });
+    fsMocks.stat.mockResolvedValue({ dev: 61, ino: 62, nlink: 1, size: 0 });
     fsMocks.open.mockImplementation(async (openedPath, flags) => {
       if (typeof flags === "number") {
         return fsMocks.directory;
@@ -438,8 +440,8 @@ describe("server recorder", () => {
     let recorderExists = false;
     let denyCreatedBoundary = true;
     fsMocks.mkdir.mockResolvedValueOnce(canonicalFirstParent).mockResolvedValueOnce(undefined);
-    fsMocks.file.stat.mockResolvedValue({ dev: 71, ino: 72, size: 0 });
-    fsMocks.stat.mockResolvedValue({ dev: 71, ino: 72, size: 0 });
+    fsMocks.file.stat.mockResolvedValue({ dev: 71, ino: 72, nlink: 1, size: 0 });
+    fsMocks.stat.mockResolvedValue({ dev: 71, ino: 72, nlink: 1, size: 0 });
     fsMocks.open.mockImplementation(async (openedPath, flags) => {
       if (typeof flags === "number") {
         return fsMocks.directory;
@@ -675,9 +677,9 @@ describe("server recorder", () => {
   it("reopens the recorder when rotation happens before append", async () => {
     const recorderPath = path.join("/tmp", "crabline-server-recorder-rotated-before.jsonl");
     fsMocks.file.stat
-      .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
-      .mockResolvedValue({ dev: 1, ino: 2, size: 0 });
-    fsMocks.stat.mockResolvedValue({ dev: 1, ino: 2, size: 0 });
+      .mockResolvedValueOnce({ dev: 1, ino: 1, nlink: 1, size: 0 })
+      .mockResolvedValue({ dev: 1, ino: 2, nlink: 1, size: 0 });
+    fsMocks.stat.mockResolvedValue({ dev: 1, ino: 2, nlink: 1, size: 0 });
 
     await recordServerEvent({
       event: serverEvent("/after-rotation"),
@@ -705,18 +707,33 @@ describe("server recorder", () => {
     expect(fsMocks.file.close).toHaveBeenCalledOnce();
   });
 
+  it("fails when recorder link count cannot be verified", async () => {
+    fsMocks.file.stat.mockResolvedValue({ dev: 1, ino: 1, size: 0 });
+
+    await expect(
+      recordServerEvent({
+        event: serverEvent("/link-count-unavailable"),
+        onEvent: undefined,
+        recorderPath: path.join("/tmp", "crabline-server-recorder-no-link-count.jsonl"),
+      }),
+    ).rejects.toThrow("Server recorder file link count is unavailable.");
+
+    expect(fsMocks.file.appendFile).not.toHaveBeenCalled();
+    expect(fsMocks.file.close).toHaveBeenCalledOnce();
+  });
+
   it("reports a committed append without truncating a rotated inode", async () => {
     const recorderPath = path.join("/tmp", "crabline-server-recorder-rotated-after.jsonl");
     fsMocks.file.stat
-      .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
-      .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
-      .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
-      .mockResolvedValue({ dev: 1, ino: 2, size: 0 });
+      .mockResolvedValueOnce({ dev: 1, ino: 1, nlink: 1, size: 0 })
+      .mockResolvedValueOnce({ dev: 1, ino: 1, nlink: 1, size: 0 })
+      .mockResolvedValueOnce({ dev: 1, ino: 1, nlink: 1, size: 0 })
+      .mockResolvedValue({ dev: 1, ino: 2, nlink: 1, size: 0 });
     fsMocks.stat
-      .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
-      .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
-      .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
-      .mockResolvedValue({ dev: 1, ino: 2, size: 0 });
+      .mockResolvedValueOnce({ dev: 1, ino: 1, nlink: 1, size: 0 })
+      .mockResolvedValueOnce({ dev: 1, ino: 1, nlink: 1, size: 0 })
+      .mockResolvedValueOnce({ dev: 1, ino: 1, nlink: 1, size: 0 })
+      .mockResolvedValue({ dev: 1, ino: 2, nlink: 1, size: 0 });
 
     await expect(
       recordServerEvent({
@@ -735,16 +752,16 @@ describe("server recorder", () => {
   it("does not roll back a committed append when rotation happens during ancestry sync", async () => {
     const recorderPath = path.join("/tmp", "crabline-server-recorder-rotated-during-sync.jsonl");
     fsMocks.file.stat
-      .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
-      .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
-      .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
-      .mockResolvedValue({ dev: 1, ino: 2, size: 0 });
+      .mockResolvedValueOnce({ dev: 1, ino: 1, nlink: 1, size: 0 })
+      .mockResolvedValueOnce({ dev: 1, ino: 1, nlink: 1, size: 0 })
+      .mockResolvedValueOnce({ dev: 1, ino: 1, nlink: 1, size: 0 })
+      .mockResolvedValue({ dev: 1, ino: 2, nlink: 1, size: 0 });
     fsMocks.stat
-      .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
-      .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
-      .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
-      .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
-      .mockResolvedValue({ dev: 1, ino: 2, size: 0 });
+      .mockResolvedValueOnce({ dev: 1, ino: 1, nlink: 1, size: 0 })
+      .mockResolvedValueOnce({ dev: 1, ino: 1, nlink: 1, size: 0 })
+      .mockResolvedValueOnce({ dev: 1, ino: 1, nlink: 1, size: 0 })
+      .mockResolvedValueOnce({ dev: 1, ino: 1, nlink: 1, size: 0 })
+      .mockResolvedValue({ dev: 1, ino: 2, nlink: 1, size: 0 });
 
     await expect(
       recordServerEvent({
@@ -766,13 +783,13 @@ describe("server recorder", () => {
   it("preserves committed rotation status when close also fails", async () => {
     const recorderPath = path.join("/tmp", "crabline-server-recorder-rotation-retry.jsonl");
     fsMocks.file.stat
-      .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
-      .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
-      .mockResolvedValue({ dev: 1, ino: 2, size: 0 });
+      .mockResolvedValueOnce({ dev: 1, ino: 1, nlink: 1, size: 0 })
+      .mockResolvedValueOnce({ dev: 1, ino: 1, nlink: 1, size: 0 })
+      .mockResolvedValue({ dev: 1, ino: 2, nlink: 1, size: 0 });
     fsMocks.stat
-      .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
-      .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
-      .mockResolvedValue({ dev: 1, ino: 2, size: 0 });
+      .mockResolvedValueOnce({ dev: 1, ino: 1, nlink: 1, size: 0 })
+      .mockResolvedValueOnce({ dev: 1, ino: 1, nlink: 1, size: 0 })
+      .mockResolvedValue({ dev: 1, ino: 2, nlink: 1, size: 0 });
     fsMocks.file.close.mockRejectedValueOnce(new Error("simulated close failure"));
 
     await expect(
@@ -903,8 +920,8 @@ describe("server recorder", () => {
     const torn = '{"type":"api","path":"/torn"';
     const contents = Buffer.from(completed + torn);
     fsMocks.file.stat
-      .mockResolvedValueOnce({ dev: 1, ino: 1, size: contents.length })
-      .mockResolvedValueOnce({ dev: 1, ino: 1, size: contents.length });
+      .mockResolvedValueOnce({ dev: 1, ino: 1, nlink: 1, size: contents.length })
+      .mockResolvedValueOnce({ dev: 1, ino: 1, nlink: 1, size: contents.length });
     fsMocks.file.read.mockImplementation(async (buffer, offset, length, position) => {
       const source = contents.subarray(position, position + Math.min(length, 3));
       source.copy(buffer, offset);
@@ -955,8 +972,8 @@ describe("server recorder", () => {
     });
     const contents = Buffer.from(completed + legacyEvent);
     fsMocks.file.stat
-      .mockResolvedValueOnce({ dev: 1, ino: 1, size: contents.length })
-      .mockResolvedValueOnce({ dev: 1, ino: 1, size: contents.length });
+      .mockResolvedValueOnce({ dev: 1, ino: 1, nlink: 1, size: contents.length })
+      .mockResolvedValueOnce({ dev: 1, ino: 1, nlink: 1, size: contents.length });
     fsMocks.file.read.mockImplementation(async (buffer, offset, length, position) => {
       const source = contents.subarray(position, position + length);
       source.copy(buffer, offset);
@@ -986,8 +1003,8 @@ describe("server recorder", () => {
     const tailStart = completedBuffer.length;
     const fileSize = tailStart + validationBudget;
     fsMocks.file.stat
-      .mockResolvedValueOnce({ dev: 1, ino: 1, size: fileSize })
-      .mockResolvedValueOnce({ dev: 1, ino: 1, size: fileSize });
+      .mockResolvedValueOnce({ dev: 1, ino: 1, nlink: 1, size: fileSize })
+      .mockResolvedValueOnce({ dev: 1, ino: 1, nlink: 1, size: fileSize });
     fsMocks.file.read.mockImplementation(async (buffer, offset, length, position) => {
       const bytesRead = Math.max(0, Math.min(length, fileSize - position));
       if (bytesRead === 0) {
@@ -1038,8 +1055,8 @@ describe("server recorder", () => {
     const completed = `${JSON.stringify(serverEvent("/completed"))}\n`;
     const contents = Buffer.from(`${completed}{"payload":"${"x".repeat(4 * 1024 * 1024)}"`);
     fsMocks.file.stat
-      .mockResolvedValueOnce({ dev: 1, ino: 1, size: contents.length })
-      .mockResolvedValueOnce({ dev: 1, ino: 1, size: contents.length });
+      .mockResolvedValueOnce({ dev: 1, ino: 1, nlink: 1, size: contents.length })
+      .mockResolvedValueOnce({ dev: 1, ino: 1, nlink: 1, size: contents.length });
     fsMocks.file.read.mockImplementation(async (buffer, offset, length, position) => {
       const source = contents.subarray(position, position + length);
       source.copy(buffer, offset);
@@ -1066,8 +1083,8 @@ describe("server recorder", () => {
     const fileSize = 8 * 1024 * 1024 * 1024;
     const validationBudget = 64 * 1024 * 1024;
     fsMocks.file.stat
-      .mockResolvedValueOnce({ dev: 1, ino: 1, size: fileSize })
-      .mockResolvedValueOnce({ dev: 1, ino: 1, size: fileSize });
+      .mockResolvedValueOnce({ dev: 1, ino: 1, nlink: 1, size: fileSize })
+      .mockResolvedValueOnce({ dev: 1, ino: 1, nlink: 1, size: fileSize });
     fsMocks.file.read.mockImplementation(async (buffer, offset, length, position) => {
       if (length === 1 && position === fileSize - 1) {
         buffer[offset] = 0x7d;

--- a/test/server-recorder.test.ts
+++ b/test/server-recorder.test.ts
@@ -23,7 +23,17 @@ const lockMocks = vi.hoisted(() => {
 
 const fsMocks = vi.hoisted(() => {
   const directory = {
+    chmod: vi.fn<(mode: number) => Promise<void>>(),
     close: vi.fn<() => Promise<void>>(),
+    stat: vi.fn<
+      () => Promise<{
+        dev: bigint;
+        ino: bigint;
+        isDirectory(): boolean;
+        mode: bigint;
+        uid: bigint;
+      }>
+    >(),
     sync: vi.fn<() => Promise<void>>(),
   };
   const file = {
@@ -46,6 +56,16 @@ const fsMocks = vi.hoisted(() => {
     chmod: vi.fn<(filePath: string, mode: number) => Promise<void>>(),
     directory,
     file,
+    lstat: vi.fn<
+      () => Promise<{
+        dev: bigint;
+        ino: bigint;
+        isDirectory(): boolean;
+        isSymbolicLink(): boolean;
+        mode: bigint;
+        uid: bigint;
+      }>
+    >(),
     mkdir:
       vi.fn<
         (
@@ -54,7 +74,11 @@ const fsMocks = vi.hoisted(() => {
         ) => Promise<string | undefined>
       >(),
     open: vi.fn<
-      (filePath: string, flags: string, mode?: number) => Promise<typeof directory | typeof file>
+      (
+        filePath: string,
+        flags: number | string,
+        mode?: number,
+      ) => Promise<typeof directory | typeof file>
     >(),
     stat: vi.fn<(filePath: string) => Promise<{ dev?: number; ino?: number; size: number }>>(),
   };
@@ -73,6 +97,7 @@ vi.mock("node:fs/promises", async (importOriginal) => {
   return {
     ...actual,
     chmod: fsMocks.chmod,
+    lstat: fsMocks.lstat,
     mkdir: fsMocks.mkdir,
     open: fsMocks.open,
     stat: fsMocks.stat,
@@ -159,8 +184,18 @@ beforeEach(() => {
   lockMocks.lock.mockResolvedValue(lockMocks.release);
   fsMocks.chmod.mockReset();
   fsMocks.chmod.mockResolvedValue();
+  fsMocks.directory.chmod.mockReset();
+  fsMocks.directory.chmod.mockResolvedValue();
   fsMocks.directory.close.mockReset();
   fsMocks.directory.close.mockResolvedValue();
+  fsMocks.directory.stat.mockReset();
+  fsMocks.directory.stat.mockResolvedValue({
+    dev: 10n,
+    ino: 20n,
+    isDirectory: () => true,
+    mode: 0o700n,
+    uid: BigInt(process.geteuid?.() ?? 0),
+  });
   fsMocks.directory.sync.mockReset();
   fsMocks.directory.sync.mockResolvedValue();
   fsMocks.file.appendFile.mockReset();
@@ -177,6 +212,15 @@ beforeEach(() => {
   fsMocks.file.sync.mockResolvedValue();
   fsMocks.file.truncate.mockReset();
   fsMocks.file.truncate.mockResolvedValue();
+  fsMocks.lstat.mockReset();
+  fsMocks.lstat.mockResolvedValue({
+    dev: 10n,
+    ino: 20n,
+    isDirectory: () => true,
+    isSymbolicLink: () => false,
+    mode: 0o700n,
+    uid: BigInt(process.geteuid?.() ?? 0),
+  });
   fsMocks.mkdir.mockReset();
   fsMocks.mkdir.mockResolvedValue(undefined);
   fsMocks.open.mockReset();
@@ -184,7 +228,7 @@ beforeEach(() => {
     if (flags === "ax+") {
       throw Object.assign(new Error("Recorder already exists"), { code: "EEXIST" });
     }
-    return flags === "r" ? fsMocks.directory : fsMocks.file;
+    return typeof flags === "number" || flags === "r" ? fsMocks.directory : fsMocks.file;
   });
   fsMocks.stat.mockReset();
   fsMocks.stat.mockResolvedValue({ dev: 1, ino: 1, size: 0 });
@@ -205,7 +249,7 @@ describe("server recorder", () => {
     const observer = vi.fn<(event: ServerRequestEvent) => void>();
     fsMocks.mkdir.mockResolvedValueOnce(canonicalFirstParent);
     fsMocks.open.mockImplementation(async (_filePath, flags) =>
-      flags === "r" ? fsMocks.directory : fsMocks.file,
+      typeof flags === "number" || flags === "r" ? fsMocks.directory : fsMocks.file,
     );
     await recordServerEvent({
       event: serverEvent("/private"),
@@ -218,7 +262,7 @@ describe("server recorder", () => {
       recursive: true,
     });
     expect(fsMocks.chmod).toHaveBeenCalledWith(canonicalFinalParent, 0o700);
-    expect(fsMocks.open.mock.calls).toEqual([
+    expect(fsMocks.open.mock.calls.filter(([, flags]) => typeof flags === "string")).toEqual([
       [canonicalRecorderPath, "ax+", 0o600],
       [canonicalFinalParent, "r"],
       [canonicalFirstParent, "r"],
@@ -242,12 +286,12 @@ describe("server recorder", () => {
       stale: 30_000,
       update: 10_000,
     });
-    expect(lockMocks.release).toHaveBeenCalledOnce();
+    expect(lockMocks.release).toHaveBeenCalledTimes(2);
     expect(fsMocks.file.chmod.mock.invocationCallOrder[0]).toBeLessThan(
       fsMocks.file.appendFile.mock.invocationCallOrder[0]!,
     );
     expect(fsMocks.file.close).toHaveBeenCalledOnce();
-    expect(fsMocks.directory.close).toHaveBeenCalledTimes(3);
+    expect(fsMocks.directory.close).toHaveBeenCalledTimes(4);
   });
 
   it("resyncs recorder ancestry after an interrupted first-append attempt", async () => {
@@ -264,6 +308,9 @@ describe("server recorder", () => {
     fsMocks.stat.mockResolvedValue({ dev: 42, ino: 84, size: 0 });
     fsMocks.directory.sync.mockRejectedValueOnce(ancestrySyncFailure).mockResolvedValue(undefined);
     fsMocks.open.mockImplementation(async (openedPath, flags) => {
+      if (typeof flags === "number") {
+        return fsMocks.directory;
+      }
       if (flags === "r") {
         if (openedPath === canonicalRoot) {
           throw Object.assign(new Error("execute-only ancestor"), { code: "EACCES" });
@@ -322,6 +369,9 @@ describe("server recorder", () => {
     fsMocks.file.stat.mockResolvedValue({ dev: 61, ino: 62, size: 0 });
     fsMocks.stat.mockResolvedValue({ dev: 61, ino: 62, size: 0 });
     fsMocks.open.mockImplementation(async (openedPath, flags) => {
+      if (typeof flags === "number") {
+        return fsMocks.directory;
+      }
       if (flags === "ax+") {
         throw Object.assign(new Error("Recorder already exists"), { code: "EEXIST" });
       }
@@ -381,6 +431,9 @@ describe("server recorder", () => {
     fsMocks.file.stat.mockResolvedValue({ dev: 71, ino: 72, size: 0 });
     fsMocks.stat.mockResolvedValue({ dev: 71, ino: 72, size: 0 });
     fsMocks.open.mockImplementation(async (openedPath, flags) => {
+      if (typeof flags === "number") {
+        return fsMocks.directory;
+      }
       if (flags === "ax+") {
         if (recorderExists) {
           throw Object.assign(new Error("Recorder already exists"), { code: "EEXIST" });
@@ -440,9 +493,9 @@ describe("server recorder", () => {
       recorderPath: path.join("/tmp", "crabline-server-recorder-contention.jsonl"),
     });
 
-    expect(lockMocks.lock).toHaveBeenCalledTimes(2);
+    expect(lockMocks.lock).toHaveBeenCalledTimes(3);
     expect(fsMocks.file.appendFile).toHaveBeenCalledOnce();
-    expect(lockMocks.release).toHaveBeenCalledOnce();
+    expect(lockMocks.release).toHaveBeenCalledTimes(2);
   });
 
   it("repairs managed directories without chmodding existing recorder files or parents", async () => {
@@ -474,6 +527,9 @@ describe("server recorder", () => {
       )
       .mockResolvedValueOnce(undefined);
     const recorderPath = path.join("/tmp", "crabline-server-recorder-admission.jsonl");
+    const recorderDirectory = await realpath(path.dirname(recorderPath));
+    const recorderMkdirCalls = () =>
+      fsMocks.mkdir.mock.calls.filter(([directory]) => directory === recorderDirectory);
 
     const first = recordServerEvent({
       event: serverEvent("/first"),
@@ -486,20 +542,23 @@ describe("server recorder", () => {
       recorderPath,
     });
 
-    await vi.waitFor(() => expect(fsMocks.mkdir).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(recorderMkdirCalls()).toHaveLength(1));
     expect(fsMocks.file.appendFile).not.toHaveBeenCalled();
 
     releaseFirstMkdir?.();
     await Promise.all([first, second]);
 
-    expect(fsMocks.mkdir).toHaveBeenCalledTimes(2);
+    expect(recorderMkdirCalls()).toHaveLength(2);
     expect(fsMocks.file.appendFile.mock.calls.map(([line]) => JSON.parse(line).path)).toEqual([
       "/first",
       "/second",
     ]);
-    expect(fsMocks.mkdir.mock.invocationCallOrder[1]).toBeGreaterThan(
-      fsMocks.file.appendFile.mock.invocationCallOrder[0]!,
-    );
+    expect(recorderMkdirCalls()[1]).toBeDefined();
+    expect(
+      fsMocks.mkdir.mock.invocationCallOrder[
+        fsMocks.mkdir.mock.calls.indexOf(recorderMkdirCalls()[1]!)
+      ],
+    ).toBeGreaterThan(fsMocks.file.appendFile.mock.invocationCallOrder[0]!);
   });
 
   it("snapshots events before waiting for recorder admission", async () => {
@@ -641,8 +700,10 @@ describe("server recorder", () => {
     fsMocks.file.stat
       .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
       .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
+      .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
       .mockResolvedValue({ dev: 1, ino: 2, size: 0 });
     fsMocks.stat
+      .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
       .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
       .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
       .mockResolvedValue({ dev: 1, ino: 2, size: 0 });
@@ -666,8 +727,10 @@ describe("server recorder", () => {
     fsMocks.file.stat
       .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
       .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
+      .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
       .mockResolvedValue({ dev: 1, ino: 2, size: 0 });
     fsMocks.stat
+      .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
       .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
       .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
       .mockResolvedValueOnce({ dev: 1, ino: 1, size: 0 })
@@ -829,7 +892,9 @@ describe("server recorder", () => {
     const completed = `${JSON.stringify(serverEvent("/completed"))}\n`;
     const torn = '{"type":"api","path":"/torn"';
     const contents = Buffer.from(completed + torn);
-    fsMocks.file.stat.mockResolvedValueOnce({ dev: 1, ino: 1, size: contents.length });
+    fsMocks.file.stat
+      .mockResolvedValueOnce({ dev: 1, ino: 1, size: contents.length })
+      .mockResolvedValueOnce({ dev: 1, ino: 1, size: contents.length });
     fsMocks.file.read.mockImplementation(async (buffer, offset, length, position) => {
       const source = contents.subarray(position, position + Math.min(length, 3));
       source.copy(buffer, offset);
@@ -879,7 +944,9 @@ describe("server recorder", () => {
       query: { payload: "x".repeat(4 * 1024 * 1024) },
     });
     const contents = Buffer.from(completed + legacyEvent);
-    fsMocks.file.stat.mockResolvedValueOnce({ dev: 1, ino: 1, size: contents.length });
+    fsMocks.file.stat
+      .mockResolvedValueOnce({ dev: 1, ino: 1, size: contents.length })
+      .mockResolvedValueOnce({ dev: 1, ino: 1, size: contents.length });
     fsMocks.file.read.mockImplementation(async (buffer, offset, length, position) => {
       const source = contents.subarray(position, position + length);
       source.copy(buffer, offset);
@@ -908,7 +975,9 @@ describe("server recorder", () => {
     const validationBudget = 64 * 1024 * 1024;
     const tailStart = completedBuffer.length;
     const fileSize = tailStart + validationBudget;
-    fsMocks.file.stat.mockResolvedValueOnce({ dev: 1, ino: 1, size: fileSize });
+    fsMocks.file.stat
+      .mockResolvedValueOnce({ dev: 1, ino: 1, size: fileSize })
+      .mockResolvedValueOnce({ dev: 1, ino: 1, size: fileSize });
     fsMocks.file.read.mockImplementation(async (buffer, offset, length, position) => {
       const bytesRead = Math.max(0, Math.min(length, fileSize - position));
       if (bytesRead === 0) {
@@ -958,7 +1027,9 @@ describe("server recorder", () => {
     const recorderPath = path.join("/tmp", "crabline-server-recorder-oversized-tail.jsonl");
     const completed = `${JSON.stringify(serverEvent("/completed"))}\n`;
     const contents = Buffer.from(`${completed}{"payload":"${"x".repeat(4 * 1024 * 1024)}"`);
-    fsMocks.file.stat.mockResolvedValueOnce({ dev: 1, ino: 1, size: contents.length });
+    fsMocks.file.stat
+      .mockResolvedValueOnce({ dev: 1, ino: 1, size: contents.length })
+      .mockResolvedValueOnce({ dev: 1, ino: 1, size: contents.length });
     fsMocks.file.read.mockImplementation(async (buffer, offset, length, position) => {
       const source = contents.subarray(position, position + length);
       source.copy(buffer, offset);
@@ -984,7 +1055,9 @@ describe("server recorder", () => {
     const recorderPath = path.join("/tmp", "crabline-server-recorder-unvalidated-tail.jsonl");
     const fileSize = 8 * 1024 * 1024 * 1024;
     const validationBudget = 64 * 1024 * 1024;
-    fsMocks.file.stat.mockResolvedValueOnce({ dev: 1, ino: 1, size: fileSize });
+    fsMocks.file.stat
+      .mockResolvedValueOnce({ dev: 1, ino: 1, size: fileSize })
+      .mockResolvedValueOnce({ dev: 1, ino: 1, size: fileSize });
     fsMocks.file.read.mockImplementation(async (buffer, offset, length, position) => {
       if (length === 1 && position === fileSize - 1) {
         buffer[offset] = 0x7d;
@@ -1105,7 +1178,6 @@ describe("server recorder", () => {
       const processes: RecorderProcess[] = [];
       try {
         await actualFs.writeFile(recorderPath, initialContents, { mode: 0o600 });
-        await actualFs.link(recorderPath, aliasPath);
         const identity = await actualFs.stat(recorderPath, { bigint: true });
         const lockRoot = path.join(
           os.userInfo().homedir,
@@ -1125,17 +1197,27 @@ describe("server recorder", () => {
           },
         );
         const first = startRecorderProcess(recorderPath, "/process-a");
-        const second = startRecorderProcess(aliasPath, "/process-b");
-        processes.push(first, second);
+        processes.push(first);
 
         await vi.waitFor(
           () => {
             expect(first.stdout()).toContain("ready\n");
-            expect(second.stdout()).toContain("ready\n");
           },
           { timeout: 5_000 },
         );
         first.child.stdin.end("go\n");
+        await vi.waitFor(async () => {
+          await expect(actualFs.stat(`${recorderPath}.lock`)).resolves.toBeDefined();
+        });
+        await actualFs.link(recorderPath, aliasPath);
+        const second = startRecorderProcess(aliasPath, "/process-b");
+        processes.push(second);
+        await vi.waitFor(
+          () => {
+            expect(second.stdout()).toContain("ready\n");
+          },
+          { timeout: 5_000 },
+        );
         second.child.stdin.end("go\n");
         await new Promise((resolve) => setTimeout(resolve, 100));
 

--- a/test/signal-server.test.ts
+++ b/test/signal-server.test.ts
@@ -867,6 +867,60 @@ describe("signal local provider server", () => {
     });
   });
 
+  it("does not consume the final timestamp when queue admission fails", async () => {
+    const server = await startSignalServer({
+      adminToken: "admin",
+      maxPendingInboundEvents: 1,
+    });
+    servers.push(server);
+    const sendInbound = (body: Record<string, unknown>) =>
+      fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({ sourceNumber: "+15557654321", ...body }),
+        headers: {
+          "content-type": "application/json",
+          "x-crabline-admin-token": "admin",
+        },
+        method: "POST",
+      });
+    const finalTimestamp = Number.MAX_SAFE_INTEGER - 1;
+
+    expect(
+      (
+        await sendInbound({
+          text: "fill queue",
+          timestamp: finalTimestamp - 1,
+        })
+      ).status,
+    ).toBe(200);
+    const rejected = await sendInbound({ text: "rejected candidate" });
+    expect(rejected.status).toBe(503);
+    await expect(rejected.json()).resolves.toEqual({
+      error: "Pending inbound queue is full (1 events)",
+      ok: false,
+    });
+
+    const controller = new AbortController();
+    try {
+      const events = await fetch(server.manifest.endpoints.eventsUrl, {
+        signal: controller.signal,
+      });
+      expect(events.status).toBe(200);
+      const accepted = await sendInbound({ text: "reuse candidate" });
+      expect(accepted.status).toBe(200);
+      await expect(accepted.json()).resolves.toMatchObject({
+        event: {
+          envelope: {
+            dataMessage: { timestamp: finalTimestamp },
+            timestamp: finalTimestamp,
+          },
+        },
+        ok: true,
+      });
+    } finally {
+      controller.abort();
+    }
+  });
+
   it("bounds the disconnected event queue by encoded bytes", async () => {
     const server = await startSignalServer({
       adminToken: "admin",


### PR DESCRIPTION
## Summary

- serialize server-recorder recovery and appends across hardlink aliases with an explicit shared lock namespace
- reject unstable or unavailable lock metadata, retry symlink retargets before append, and preserve committed-error classification
- preserve Signal timestamp capacity when pending inbound queue admission fails
- document the shared hardlink lock-directory contract and changelog the behavior

## Validation

- `pnpm test --run test/recorder-concurrency.test.ts test/server-recorder.test.ts test/server-recorder-filesystem.test.ts test/signal-server.test.ts` (98 tests)
- `pnpm lint`
- Codex autoreview: `gpt-5.6-sol`, high reasoning, clean (0.87 confidence)
- Crabbox `run_f279f5ad0736`: full `pnpm verify`, 61 files, 1,242 passed, 1 skipped, exit 0