### PR TITLE
chore(lint): cover repository tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Lint repository tooling in the type-aware verification gate.
 - Preserve WhatsApp acknowledgement races without stale pending state or false deduplication.
 - Derive Telegram multipart media identity from upload bytes while preserving filenames and file reference reuse.
 - Require valid OpenClaw readiness recorder evidence and allow unauthenticated loopback callback URLs.

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "fixtures": "tsx src/bin/crabline.ts fixtures",
     "format": "oxfmt --write .",
     "format:check": "oxfmt --check .",
-    "lint": "pnpm format:check && pnpm typecheck && oxlint --deny-warnings --allow vitest/require-mock-type-parameters --type-aware --tsconfig tsconfig.test.json src test",
+    "lint": "pnpm format:check && pnpm typecheck && oxlint --deny-warnings --allow vitest/require-mock-type-parameters --type-aware --tsconfig tsconfig.test.json src test tools",
     "prepare": "npm run build",
     "run": "tsx src/bin/crabline.ts run",
     "test": "vitest run",

--- a/test/package-production.test.ts
+++ b/test/package-production.test.ts
@@ -419,6 +419,23 @@ describe("production package", () => {
     expect(launcher).toContain("Python 3.10 or newer is required");
   });
 
+  it("lints repository tooling with the type-aware gate", async () => {
+    const [pkgContents, launcher] = await Promise.all([
+      fs.readFile("package.json", "utf8"),
+      fs.readFile("tools/run-autoreview-tests.mjs", "utf8"),
+    ]);
+    const pkg = JSON.parse(pkgContents) as { scripts?: Record<string, string> };
+
+    expect(pkg.scripts?.lint).toBe(
+      "pnpm format:check && pnpm typecheck && oxlint --deny-warnings " +
+        "--allow vitest/require-mock-type-parameters --type-aware " +
+        "--tsconfig tsconfig.test.json src test tools",
+    );
+    expect(launcher).toContain(
+      "oxlint-disable-next-line no-console -- This CLI failure must be visible on stderr.",
+    );
+  });
+
   it("documents source-checkout and user-supplied script bridge commands", async () => {
     const root = process.cwd();
     const [readme, channelSetup] = await Promise.all([

--- a/tools/run-autoreview-tests.mjs
+++ b/tools/run-autoreview-tests.mjs
@@ -29,6 +29,7 @@ const python = candidates.find(([command, launcherArgs]) => {
 });
 
 if (!python) {
+  // oxlint-disable-next-line no-console -- This CLI failure must be visible on stderr.
   console.error("Python 3.10 or newer is required to run the autoreview tests.");
   process.exit(127);
 }


### PR DESCRIPTION
## Summary
- include `tools/` in the type-aware lint gate
- scope the required stderr console use to the autoreview launcher
- lock the tooling lint contract with a package test

## Validation
- `pnpm lint`
- 198 autoreview harness tests and 9 package-production tests
- autoreview: clean (`gpt-5.6-sol`, high, 0.94)
- Crabbox `pnpm verify`: passed, run `run_93b07865ee7e` (`1256` passed, `1` skipped)
- GitHub `verify`, CodeQL, and dependency review: passed on rebased head