### PR TITLE
fix(openclaw): validate readiness evidence and local callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fail OpenClaw provider readiness when a successful probe produces no recorder evidence.
+- Require valid OpenClaw readiness recorder evidence and allow unauthenticated loopback callback URLs.
 - Merge repeated WhatsApp handshake message occurrences according to protobuf semantics.
 - Close inherited credential descriptors and preserve runtime failure classification and accepted-send diagnostics.
 - Validate every configured webhook callback independently and gracefully drain admitted provider responses before bounded connection teardown.

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -82,7 +82,8 @@ header before JSON parsing or recorder writes:
   Google Chat may use its HTTPS `endpointUrl` as the signed public callback
   instead. A non-loopback bind without a public HTTPS endpoint is rejected even
   when request credentials are configured. Plain HTTP is reserved for local
-  tests where both the listener host and advertised URL host are loopback.
+  tests where both the listener host and advertised URL host are loopback; that
+  loopback-only case does not require provider callback authentication.
 - Discord `publicKey` or `DISCORD_PUBLIC_KEY` verifies
   `X-Signature-Ed25519` over `X-Signature-Timestamp` plus the raw request body.
 - Google Chat `endpointUrl` verifies Google ID tokens for the configured HTTP
@@ -98,14 +99,13 @@ header before JSON parsing or recorder writes:
   identity.
 - Microsoft Teams `appId` or `TEAMS_APP_ID` verifies Bot Connector bearer
   tokens, including the activity channel and exact `serviceUrl`. An `appId` is
-  required when the webhook host is non-loopback or `publicUrl` is set; an
-  unauthenticated webhook remains available only on loopback.
+  required when the webhook host or advertised callback is non-loopback.
 - Matrix webhook ingress currently has no provider-native authentication mode,
-  so it is restricted to loopback hosts and cannot set `publicUrl`.
+  so its listener and any advertised callback must remain loopback-only.
 - Mattermost and iMessage webhook ingress currently have no provider-native
-  authentication mode, so those adapter webhooks are restricted to loopback
-  hosts and cannot set `publicUrl`. Their API credentials do not authenticate
-  inbound callbacks.
+  authentication mode, so their listeners and any advertised callbacks must
+  remain loopback-only. Their API credentials do not authenticate inbound
+  callbacks.
 - Feishu `verificationToken` or `FEISHU_VERIFICATION_TOKEN` verifies plaintext
   callback tokens on loopback and remains an additional check when configured
   with encryption. Externally reachable webhooks require `encryptKey` or
@@ -117,7 +117,7 @@ header before JSON parsing or recorder writes:
   `text` field; malformed JSON is rejected instead of treated as plaintext.
 - Slack `signingSecret` or `SLACK_SIGNING_SECRET` verifies
   `X-Slack-Request-Timestamp` and `X-Slack-Signature`; it is required when the
-  webhook host is non-loopback or `publicUrl` is set.
+  webhook host or advertised callback is non-loopback.
 - Telegram `secretToken` or `TELEGRAM_WEBHOOK_SECRET_TOKEN` verifies
   `X-Telegram-Bot-Api-Secret-Token`. The value must contain 1-256 letters,
   digits, underscores, or hyphens; control characters are rejected.
@@ -591,7 +591,9 @@ inside one owner-only generation directory under the legacy
 directory, and then atomically switches the single `current.json` pointer.
 Readers therefore see either the prior complete generation or the next complete
 generation, never per-file mixtures. Setup, probe, cleanup, staging, or
-ownership failures leave the prior pointer unchanged. Crash-leftover staging
+ownership failures leave the prior pointer unchanged. A successful probe must
+also produce at least one valid JSONL recorder evidence record before
+publication. Crash-leftover staging
 directories and installed-but-uncommitted generations remain owner-only.
 Publication rollback removes them when possible, and the next lock-owning
 publisher prunes any leftovers before staging a new generation. Post-commit

--- a/src/openclaw.ts
+++ b/src/openclaw.ts
@@ -24,6 +24,7 @@ import {
   OPENCLAW_CRABLINE_ARTIFACT_POINTER_PATH,
   OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY,
   OPENCLAW_CRABLINE_MANIFEST_PATH,
+  isRecord,
   parseQaTarget,
   runOpenClawCrablineProviderProbe,
   type OpenClawCrablineAgentDelivery,
@@ -93,6 +94,19 @@ const RECORDER_LOCK_REMOVAL_TOMBSTONE_PATTERN =
 function isOpenClawCrablineRecorderTemporary(name: string): boolean {
   const channel = RECORDER_TEMP_NAME_PATTERN.exec(name)?.[1]?.toLowerCase();
   return channel !== undefined && isCrablineServerChannel(channel);
+}
+
+function hasOpenClawCrablineRecorderEvidence(contents: string): boolean {
+  return contents.split(/\r?\n/u).some((line) => {
+    if (!line.trim()) {
+      return false;
+    }
+    try {
+      return isRecord(JSON.parse(line));
+    } catch {
+      return false;
+    }
+  });
 }
 
 function isOpenClawCrablineRecorderTemporaryLock(name: string): boolean {
@@ -415,6 +429,11 @@ export async function runOpenClawCrablineProviderReadiness(
       throw probeFailure;
     }
     const recorderSnapshotContents = await fs.readFile(recorderPath, "utf8");
+    if (!hasOpenClawCrablineRecorderEvidence(recorderSnapshotContents)) {
+      throw new Error(
+        "OpenClaw Crabline provider probe produced no valid JSONL recorder evidence.",
+      );
+    }
 
     const capabilityReport = {
       result: {

--- a/src/providers/builtin/external-webhook-auth.ts
+++ b/src/providers/builtin/external-webhook-auth.ts
@@ -19,7 +19,22 @@ export function requireExternalWebhookAuthentication(params: {
     ...(params.authenticatedIngressUrls ?? []),
     ...(params.webhook?.publicUrl ? [params.webhook.publicUrl] : []),
   ];
-  const externallyReachable = publicUrls.length > 0 || !hostIsLoopback;
+  const callbackUrls = publicUrls.map((publicUrl) => {
+    try {
+      const url = new URL(publicUrl);
+      return {
+        isLoopback: hostIsLoopback && isLoopbackHost(url.hostname),
+        url,
+      };
+    } catch (error) {
+      throw new CrablineError(`${params.provider} public callback URL is invalid.`, {
+        cause: error,
+        kind: "config",
+      });
+    }
+  });
+  const externallyReachable =
+    !hostIsLoopback || callbackUrls.some((callbackUrl) => !callbackUrl.isLoopback);
   if (externallyReachable && !params.authenticated) {
     throw new CrablineError(
       `${params.provider} externally reachable webhooks require ${params.requirement}.`,
@@ -36,19 +51,9 @@ export function requireExternalWebhookAuthentication(params: {
     );
   }
 
-  for (const publicUrl of publicUrls) {
-    let url: URL;
-    try {
-      url = new URL(publicUrl);
-    } catch (error) {
-      throw new CrablineError(`${params.provider} public callback URL is invalid.`, {
-        cause: error,
-        kind: "config",
-      });
-    }
-    const safeLoopbackHttp =
-      url.protocol === "http:" && hostIsLoopback && isLoopbackHost(url.hostname);
-    if (url.protocol !== "https:" && !safeLoopbackHttp) {
+  for (const callbackUrl of callbackUrls) {
+    const safeLoopbackHttp = callbackUrl.url.protocol === "http:" && callbackUrl.isLoopback;
+    if (callbackUrl.url.protocol !== "https:" && !safeLoopbackHttp) {
       throw new CrablineError(
         `${params.provider} authenticated external webhooks require HTTPS; plain HTTP is allowed only for loopback-local ingress.`,
         { kind: "config" },

--- a/test/external-webhook-auth.test.ts
+++ b/test/external-webhook-auth.test.ts
@@ -60,24 +60,27 @@ describe("external webhook authentication policy", () => {
     ).toThrow(/require HTTPS/u);
   });
 
-  it("classifies malformed public callback URLs as configuration errors", () => {
-    let failure: unknown;
-    try {
-      requireExternalWebhookAuthentication({
-        ...base,
-        authenticated: true,
-        webhook: { host: "0.0.0.0", publicUrl: "not a URL" },
-      });
-    } catch (error) {
-      failure = error;
-    }
+  it.each([true, false])(
+    "classifies malformed public callback URLs as configuration errors when authenticated=%s",
+    (authenticated) => {
+      let failure: unknown;
+      try {
+        requireExternalWebhookAuthentication({
+          ...base,
+          authenticated,
+          webhook: { host: "127.0.0.1", publicUrl: "not a URL" },
+        });
+      } catch (error) {
+        failure = error;
+      }
 
-    expect(failure).toBeInstanceOf(CrablineError);
-    expect(failure).toMatchObject({
-      kind: "config",
-      message: "Example public callback URL is invalid.",
-    });
-  });
+      expect(failure).toBeInstanceOf(CrablineError);
+      expect(failure).toMatchObject({
+        kind: "config",
+        message: "Example public callback URL is invalid.",
+      });
+    },
+  );
 
   it("allows HTTPS frontends and loopback-local HTTP", () => {
     expect(() =>
@@ -127,13 +130,30 @@ describe("external webhook authentication policy", () => {
     ).not.toThrow();
   });
 
-  it("allows unauthenticated ingress only when it stays on loopback", () => {
+  it.each([
+    ["127.0.0.1", "http://127.0.0.1:8787/events"],
+    ["localhost", "http://localhost:8787/events"],
+    ["::1", "http://[::1]:8787/events"],
+  ])("allows unauthenticated loopback ingress on %s", (host, publicUrl) => {
     expect(() =>
       requireExternalWebhookAuthentication({
         ...base,
         authenticated: false,
-        webhook: { host: "localhost" },
+        webhook: { host, publicUrl },
       }),
     ).not.toThrow();
+  });
+
+  it.each([
+    ["external callback", "127.0.0.1", "https://hooks.example.test/events"],
+    ["external bind", "0.0.0.0", "http://127.0.0.1:8787/events"],
+  ])("requires authentication for %s", (_label, host, publicUrl) => {
+    expect(() =>
+      requireExternalWebhookAuthentication({
+        ...base,
+        authenticated: false,
+        webhook: { host, publicUrl },
+      }),
+    ).toThrow(/externally reachable webhooks require example\.signingSecret/u);
   });
 });

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -3039,13 +3039,62 @@ describe("OpenClaw local provider bridge", () => {
     }
   });
 
+  it.each([
+    ["empty", ""],
+    ["whitespace-only", " \n\t\r\n"],
+    ["malformed", "not-json\n"],
+    ["non-record JSON", "null\n42\n[]\n"],
+  ])("fails closed on %s readiness recorder evidence", async (_label, recorderContents) => {
+    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-recorder-invalid-"));
+    const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
+    const close = vi.fn(async () => undefined);
+    const publishGeneration = vi.fn<typeof publishOpenClawCrablineArtifactGeneration>();
+    const releaseLock = vi.fn(async (lock: { release(): Promise<void> }) => await lock.release());
+    const syncParent = vi.fn(async (unlinkedPath: string) => {
+      await expect(fs.stat(unlinkedPath)).rejects.toMatchObject({ code: "ENOENT" });
+    });
+    try {
+      await expect(
+        runProviderReadinessWithDependencies(
+          { outputDir, selection },
+          {
+            publishGeneration,
+            releaseLock,
+            startAdapter: async (params) => {
+              await fs.writeFile(params.recorderPath!, recorderContents);
+              return {
+                close,
+                manifest: { ...manifest, recorderPath: params.recorderPath! },
+                probe: async () => ({ ok: true }),
+              } as unknown as Awaited<ReturnType<typeof startOpenClawCrablineAdapter>>;
+            },
+            syncParent,
+          },
+        ),
+      ).rejects.toThrow(
+        "OpenClaw Crabline provider probe produced no valid JSONL recorder evidence.",
+      );
+
+      expect(close).toHaveBeenCalledTimes(1);
+      expect(publishGeneration).not.toHaveBeenCalled();
+      expect(syncParent).toHaveBeenCalledTimes(1);
+      expect(releaseLock).toHaveBeenCalledTimes(1);
+      await expect(readOpenClawCrablineArtifactPointer(outputDir)).resolves.toBeNull();
+    } finally {
+      await fs.rm(outputDir, { recursive: true, force: true });
+    }
+  });
+
   it("keeps readiness recorder snapshots immutable across later generations", async () => {
     const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-recorder-snapshots-"));
     const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
     let run = 0;
     const startAdapter = async (params: Parameters<typeof startOpenClawCrablineAdapter>[0]) => {
       const currentRun = ++run;
-      await fs.writeFile(params.recorderPath!, `run-${currentRun}\n`);
+      await fs.writeFile(
+        params.recorderPath!,
+        `${JSON.stringify({ event: "probe", run: currentRun })}\n`,
+      );
       return {
         close: async () => undefined,
         manifest: {
@@ -3063,7 +3112,7 @@ describe("OpenClaw local provider bridge", () => {
       const firstRecorderPath = (first.providerReadiness as { result: { recorderPath: string } })
         .result.recorderPath;
       await expect(fs.readFile(path.join(outputDir, firstRecorderPath), "utf8")).resolves.toBe(
-        "run-1\n",
+        '{"event":"probe","run":1}\n',
       );
 
       const second = await runProviderReadinessWithDependencies(
@@ -3075,10 +3124,10 @@ describe("OpenClaw local provider bridge", () => {
 
       expect(secondRecorderPath).not.toBe(firstRecorderPath);
       await expect(fs.readFile(path.join(outputDir, firstRecorderPath), "utf8")).resolves.toBe(
-        "run-1\n",
+        '{"event":"probe","run":1}\n',
       );
       await expect(fs.readFile(path.join(outputDir, secondRecorderPath), "utf8")).resolves.toBe(
-        "run-2\n",
+        '{"event":"probe","run":2}\n',
       );
     } finally {
       await fs.rm(outputDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- require valid JSONL recorder evidence before publishing provider readiness
- classify loopback callback URLs before enforcing external authentication
- align channel setup documentation with loopback-only callback behavior

## Validation
- 94 focused tests
- `pnpm lint`
- autoreview: clean (`gpt-5.6-sol`, high, 0.92)
- Crabbox `pnpm verify`: passed, run `run_a6cc950795d2` (`1243` passed, `1` skipped)
- GitHub `verify`: passed