### PR TITLE
fix(telegram): preserve multipart media identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Derive Telegram multipart media identity from upload bytes while preserving filenames and file reference reuse.
 - Require valid OpenClaw readiness recorder evidence and allow unauthenticated loopback callback URLs.
 - Merge repeated WhatsApp handshake message occurrences according to protobuf semantics.
 - Close inherited credential descriptors and preserve runtime failure classification and accepted-send diagnostics.

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -612,18 +612,19 @@ function createOutboundMediaMessage(
   const height = Math.max(1, toIntegerValue(body.height) ?? 1);
   const width = Math.max(1, toIntegerValue(body.width) ?? 1);
   const chatIdentity = Buffer.from(telegramChatKey(chat.id)).toString("base64url");
-  const reusedIdentity = new RegExp(`^crabline-${mediaKind}-([A-Za-z0-9_-]{32})-`, "u").exec(
-    fileName,
-  )?.[1];
-  const fileIdentity =
-    multipartFile?.contentDigest.slice(0, 32) ??
-    reusedIdentity ??
-    createHash("sha256")
-      .update(mediaKind)
-      .update("\0")
-      .update(fileName)
-      .digest("base64url")
-      .slice(0, 32);
+  let fileIdentity: string;
+  if (multipartFile) {
+    fileIdentity = multipartFile.contentDigest.slice(0, 32);
+  } else {
+    fileIdentity =
+      new RegExp(`^crabline-${mediaKind}-([A-Za-z0-9_-]{32})-`, "u").exec(fileName)?.[1] ??
+      createHash("sha256")
+        .update(mediaKind)
+        .update("\0")
+        .update(fileName)
+        .digest("base64url")
+        .slice(0, 32);
+  }
   const fileId = `crabline-${mediaKind}-${fileIdentity}-${chatIdentity}-${messageId}`;
   const fileUniqueId = `crabline-${mediaKind}-unique-${fileIdentity}`;
   const media = {

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -162,6 +162,14 @@ type TelegramGetUpdatesState = Pick<
   "activeUpdatePoll" | "closing" | "updates"
 >;
 
+const TELEGRAM_MULTIPART_FILE = Symbol("telegramMultipartFile");
+
+type TelegramMultipartFile = {
+  [TELEGRAM_MULTIPART_FILE]: true;
+  contentDigest: string;
+  fileName: string;
+};
+
 type TelegramChat = {
   id: number;
   title?: string;
@@ -316,7 +324,16 @@ async function parseMultipartFormDataBody(
   }
   const fields: Record<string, unknown> = {};
   for (const [name, value] of form) {
-    fields[name] = typeof value === "string" ? value : value.name;
+    fields[name] =
+      typeof value === "string"
+        ? value
+        : ({
+            [TELEGRAM_MULTIPART_FILE]: true,
+            contentDigest: createHash("sha256")
+              .update(Buffer.from(await value.arrayBuffer()))
+              .digest("base64url"),
+            fileName: value.name,
+          } satisfies TelegramMultipartFile);
   }
   return fields;
 }
@@ -366,11 +383,26 @@ async function appendEvent(state: TelegramServerState, event: TelegramServerEven
   await recordServerEvent({ event, onEvent: state.onEvent, recorderPath: state.recorderPath });
 }
 
-function redactTelegramSecrets<T>(body: Record<string, T>): Record<string, T | string> {
+function isTelegramMultipartFile(value: unknown): value is TelegramMultipartFile {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    TELEGRAM_MULTIPART_FILE in value &&
+    value[TELEGRAM_MULTIPART_FILE] === true
+  );
+}
+
+function redactTelegramSecrets(body: Record<string, string>): Record<string, string>;
+function redactTelegramSecrets(body: Record<string, unknown>): Record<string, unknown>;
+function redactTelegramSecrets(body: Record<string, unknown>): Record<string, unknown> {
   return Object.fromEntries(
     Object.entries(body).map(([key, value]) => [
       key,
-      key === "secret_token" ? "<redacted>" : value,
+      key === "secret_token"
+        ? "<redacted>"
+        : isTelegramMultipartFile(value)
+          ? value.fileName
+          : value,
     ]),
   );
 }
@@ -561,7 +593,9 @@ function createOutboundMediaMessage(
   caption: string | undefined,
 ): TelegramMessage | undefined {
   const chat = resolveTelegramChat(state, body.chat_id);
-  const fileName = toStringValue(body[mediaKind]);
+  const mediaInput = body[mediaKind];
+  const multipartFile = isTelegramMultipartFile(mediaInput) ? mediaInput : undefined;
+  const fileName = multipartFile?.fileName ?? toStringValue(mediaInput);
   if (!chat || !fileName) {
     return undefined;
   }
@@ -582,6 +616,7 @@ function createOutboundMediaMessage(
     fileName,
   )?.[1];
   const fileIdentity =
+    multipartFile?.contentDigest.slice(0, 32) ??
     reusedIdentity ??
     createHash("sha256")
       .update(mediaKind)

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -2129,15 +2129,31 @@ describe("telegram local provider server", () => {
     const first = await uploadDocument(100, "first bytes");
     const different = await uploadDocument(200, "different bytes");
     const repeated = await uploadDocument(300, "first bytes");
+    const photoBody = new FormData();
+    photoBody.set("chat_id", "400");
+    photoBody.set(
+      "photo",
+      new Blob(["first bytes"], { type: "application/octet-stream" }),
+      "shared-name.bin",
+    );
+    const photoResponse = await fetch(`${apiRoot}/sendPhoto`, {
+      body: photoBody,
+      method: "POST",
+    });
+    expect(photoResponse.status).toBe(200);
+    const photo = (await photoResponse.json()) as {
+      result: { photo: Array<{ file_unique_id: string }> };
+    };
 
     expect(first.result.document.file_name).toBe("shared-name.bin");
     expect(different.result.document.file_name).toBe("shared-name.bin");
     expect(repeated.result.document.file_name).toBe("shared-name.bin");
     expect(different.result.document.file_unique_id).not.toBe(first.result.document.file_unique_id);
     expect(repeated.result.document.file_unique_id).toBe(first.result.document.file_unique_id);
+    expect(photo.result.photo[0]?.file_unique_id).not.toBe(first.result.document.file_unique_id);
 
     const collidingName = await uploadDocument(
-      400,
+      500,
       "unrelated bytes",
       first.result.document.file_id,
     );
@@ -2148,7 +2164,7 @@ describe("telegram local provider server", () => {
 
     const reused = await fetch(`${apiRoot}/sendDocument`, {
       body: JSON.stringify({
-        chat_id: 500,
+        chat_id: 600,
         document: first.result.document.file_id,
       }),
       headers: { "content-type": "application/json" },

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -2105,6 +2105,60 @@ describe("telegram local provider server", () => {
     });
   });
 
+  it("derives multipart file_unique_id from upload bytes instead of the filename", async () => {
+    const server = await startTelegramServer({ botToken: "test-token-placeholder" });
+    servers.push(server);
+    const apiRoot = `${server.manifest.baseUrl}/bottest-token-placeholder`;
+
+    const uploadDocument = async (chatId: number, bytes: string) => {
+      const body = new FormData();
+      body.set("chat_id", String(chatId));
+      body.set(
+        "document",
+        new Blob([bytes], { type: "application/octet-stream" }),
+        "shared-name.bin",
+      );
+      const response = await fetch(`${apiRoot}/sendDocument`, {
+        body,
+        method: "POST",
+      });
+      expect(response.status).toBe(200);
+      return (await response.json()) as {
+        result: {
+          document: { file_id: string; file_name: string; file_unique_id: string };
+        };
+      };
+    };
+
+    const first = await uploadDocument(100, "first bytes");
+    const different = await uploadDocument(200, "different bytes");
+    const repeated = await uploadDocument(300, "first bytes");
+
+    expect(first.result.document.file_name).toBe("shared-name.bin");
+    expect(different.result.document.file_name).toBe("shared-name.bin");
+    expect(repeated.result.document.file_name).toBe("shared-name.bin");
+    expect(different.result.document.file_unique_id).not.toBe(first.result.document.file_unique_id);
+    expect(repeated.result.document.file_unique_id).toBe(first.result.document.file_unique_id);
+
+    const reused = await fetch(`${apiRoot}/sendDocument`, {
+      body: JSON.stringify({
+        chat_id: 400,
+        document: first.result.document.file_id,
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    expect(reused.status).toBe(200);
+    await expect(reused.json()).resolves.toMatchObject({
+      result: {
+        document: {
+          file_name: first.result.document.file_id,
+          file_unique_id: first.result.document.file_unique_id,
+        },
+      },
+    });
+  });
+
   it("tracks explicit message IDs independently per chat", async () => {
     const server = await startTelegramServer({ botToken: "test-token-placeholder" });
     servers.push(server);

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -2110,14 +2110,10 @@ describe("telegram local provider server", () => {
     servers.push(server);
     const apiRoot = `${server.manifest.baseUrl}/bottest-token-placeholder`;
 
-    const uploadDocument = async (chatId: number, bytes: string) => {
+    const uploadDocument = async (chatId: number, bytes: string, fileName = "shared-name.bin") => {
       const body = new FormData();
       body.set("chat_id", String(chatId));
-      body.set(
-        "document",
-        new Blob([bytes], { type: "application/octet-stream" }),
-        "shared-name.bin",
-      );
+      body.set("document", new Blob([bytes], { type: "application/octet-stream" }), fileName);
       const response = await fetch(`${apiRoot}/sendDocument`, {
         body,
         method: "POST",
@@ -2140,9 +2136,19 @@ describe("telegram local provider server", () => {
     expect(different.result.document.file_unique_id).not.toBe(first.result.document.file_unique_id);
     expect(repeated.result.document.file_unique_id).toBe(first.result.document.file_unique_id);
 
+    const collidingName = await uploadDocument(
+      400,
+      "unrelated bytes",
+      first.result.document.file_id,
+    );
+    expect(collidingName.result.document.file_name).toBe(first.result.document.file_id);
+    expect(collidingName.result.document.file_unique_id).not.toBe(
+      first.result.document.file_unique_id,
+    );
+
     const reused = await fetch(`${apiRoot}/sendDocument`, {
       body: JSON.stringify({
-        chat_id: 400,
+        chat_id: 500,
         document: first.result.document.file_id,
       }),
       headers: { "content-type": "application/json" },


### PR DESCRIPTION
## Summary
- derive multipart media identity from uploaded bytes
- preserve filenames and string file-reference reuse
- prevent multipart filenames from aliasing existing `file_id` identities
- lock cross-media upload identity separation with a regression test

## Validation
- 54 focused Telegram tests
- `pnpm lint` and typecheck
- autoreview: clean after verified follow-up (`gpt-5.6-sol`, high, 0.91)
- Crabbox `pnpm verify`: passed, run `run_736b7cb1dfcf` (`1252` passed, `1` skipped)
- GitHub `verify` and CodeQL: passed on rebased head