### PR TITLE
fix(whatsapp): preserve acknowledgement acceptance races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Preserve WhatsApp acknowledgement races without stale pending state or false deduplication.
 - Derive Telegram multipart media identity from upload bytes while preserving filenames and file reference reuse.
 - Require valid OpenClaw readiness recorder evidence and allow unauthenticated loopback callback URLs.
 - Merge repeated WhatsApp handshake message occurrences according to protobuf semantics.

--- a/src/servers/whatsapp-baileys-websocket.ts
+++ b/src/servers/whatsapp-baileys-websocket.ts
@@ -120,12 +120,17 @@ export type WhatsAppSignalDecryptResult<T> =
   | { status: "unavailable" }
   | { status: "rejected" };
 
+type PendingWhatsAppAcknowledgement = {
+  acceptedAt: number | undefined;
+  acknowledged: boolean;
+};
+
 export class WhatsAppSignalBundleStore {
   readonly #acknowledgedMessageIds = new Map<string, true>();
   readonly #bundles = new Map<string, MockSignalBundle>();
   readonly #lidByPhoneNumber = new Map<string, string>();
   readonly #pendingMessageAcceptances = new Map<string, Promise<void>>();
-  readonly #pendingAcknowledgements = new Map<string, number>();
+  readonly #pendingAcknowledgements = new Map<string, PendingWhatsAppAcknowledgement>();
   readonly #pendingTransactions = new Map<string, Promise<void>>();
   readonly #sessions = new Map<string, Map<string, SessionRecord>>();
 
@@ -176,12 +181,28 @@ export class WhatsAppSignalBundleStore {
           `WhatsApp pending acknowledgement limit exceeded (${this.maxPendingAcknowledgements}).`,
         );
       }
-      const accepted = await operation();
-      if (!accepted) {
-        return false;
+      const pendingAcknowledgement: PendingWhatsAppAcknowledgement = {
+        acceptedAt: undefined,
+        acknowledged: false,
+      };
+      this.#pendingAcknowledgements.set(messageKey, pendingAcknowledgement);
+      try {
+        const accepted = await operation();
+        if (!accepted) {
+          this.#pendingAcknowledgements.delete(messageKey);
+          return false;
+        }
+        if (pendingAcknowledgement.acknowledged) {
+          this.#pendingAcknowledgements.delete(messageKey);
+          this.#rememberAcknowledgedMessage(messageKey);
+        } else {
+          pendingAcknowledgement.acceptedAt = this.now();
+        }
+        return true;
+      } catch (error) {
+        this.#pendingAcknowledgements.delete(messageKey);
+        throw error;
       }
-      this.#pendingAcknowledgements.set(messageKey, this.now());
-      return true;
     });
   }
 
@@ -190,9 +211,15 @@ export class WhatsAppSignalBundleStore {
     if (peer && messageId) {
       const messageKey = `${peer}\0${messageId}`;
       this.#recoverExpiredPendingAcknowledgements();
-      if (!this.#pendingAcknowledgements.delete(messageKey)) {
+      const pendingAcknowledgement = this.#pendingAcknowledgements.get(messageKey);
+      if (!pendingAcknowledgement) {
         return;
       }
+      if (pendingAcknowledgement.acceptedAt === undefined) {
+        pendingAcknowledgement.acknowledged = true;
+        return;
+      }
+      this.#pendingAcknowledgements.delete(messageKey);
       this.#rememberAcknowledgedMessage(messageKey);
     }
   }
@@ -363,7 +390,11 @@ export class WhatsAppSignalBundleStore {
 
   #recoverExpiredPendingAcknowledgements(): void {
     const now = this.now();
-    for (const [messageKey, acceptedAt] of this.#pendingAcknowledgements) {
+    for (const [messageKey, pendingAcknowledgement] of this.#pendingAcknowledgements) {
+      const { acceptedAt } = pendingAcknowledgement;
+      if (acceptedAt === undefined) {
+        continue;
+      }
       if (now - acceptedAt < this.maxPendingAcknowledgementAgeMs) {
         continue;
       }

--- a/src/servers/whatsapp-baileys-websocket.ts
+++ b/src/servers/whatsapp-baileys-websocket.ts
@@ -128,6 +128,7 @@ type PendingWhatsAppAcknowledgement = {
 export class WhatsAppSignalBundleStore {
   readonly #acknowledgedMessageIds = new Map<string, true>();
   readonly #bundles = new Map<string, MockSignalBundle>();
+  readonly #inFlightMessageAcceptances = new Map<string, Promise<boolean>>();
   readonly #lidByPhoneNumber = new Map<string, string>();
   readonly #pendingMessageAcceptances = new Map<string, Promise<void>>();
   readonly #pendingAcknowledgements = new Map<string, PendingWhatsAppAcknowledgement>();
@@ -167,43 +168,59 @@ export class WhatsAppSignalBundleStore {
   }
 
   async acceptMessageOnce(messageKey: string, operation: () => Promise<boolean>): Promise<boolean> {
-    return await this.#runSerialized(this.#pendingMessageAcceptances, "messages", async () => {
-      this.#recoverExpiredPendingAcknowledgements();
-      if (this.#pendingAcknowledgements.has(messageKey)) {
-        return true;
-      }
-      if (this.#acknowledgedMessageIds.delete(messageKey)) {
-        this.#acknowledgedMessageIds.set(messageKey, true);
-        return true;
-      }
-      if (this.#pendingAcknowledgements.size >= this.maxPendingAcknowledgements) {
-        throw new Error(
-          `WhatsApp pending acknowledgement limit exceeded (${this.maxPendingAcknowledgements}).`,
-        );
-      }
-      const pendingAcknowledgement: PendingWhatsAppAcknowledgement = {
-        acceptedAt: undefined,
-        acknowledged: false,
-      };
-      this.#pendingAcknowledgements.set(messageKey, pendingAcknowledgement);
-      try {
-        const accepted = await operation();
-        if (!accepted) {
-          this.#pendingAcknowledgements.delete(messageKey);
-          return false;
+    const inFlightAcceptance = this.#inFlightMessageAcceptances.get(messageKey);
+    if (inFlightAcceptance) {
+      return await inFlightAcceptance;
+    }
+    const acceptance = this.#runSerialized(
+      this.#pendingMessageAcceptances,
+      "messages",
+      async () => {
+        this.#recoverExpiredPendingAcknowledgements();
+        if (this.#pendingAcknowledgements.has(messageKey)) {
+          return true;
         }
-        if (pendingAcknowledgement.acknowledged) {
-          this.#pendingAcknowledgements.delete(messageKey);
-          this.#rememberAcknowledgedMessage(messageKey);
-        } else {
-          pendingAcknowledgement.acceptedAt = this.now();
+        if (this.#acknowledgedMessageIds.delete(messageKey)) {
+          this.#acknowledgedMessageIds.set(messageKey, true);
+          return true;
         }
-        return true;
-      } catch (error) {
-        this.#pendingAcknowledgements.delete(messageKey);
-        throw error;
+        if (this.#pendingAcknowledgements.size >= this.maxPendingAcknowledgements) {
+          throw new Error(
+            `WhatsApp pending acknowledgement limit exceeded (${this.maxPendingAcknowledgements}).`,
+          );
+        }
+        const pendingAcknowledgement: PendingWhatsAppAcknowledgement = {
+          acceptedAt: undefined,
+          acknowledged: false,
+        };
+        this.#pendingAcknowledgements.set(messageKey, pendingAcknowledgement);
+        try {
+          const accepted = await operation();
+          if (!accepted) {
+            this.#pendingAcknowledgements.delete(messageKey);
+            return false;
+          }
+          if (pendingAcknowledgement.acknowledged) {
+            this.#pendingAcknowledgements.delete(messageKey);
+            this.#rememberAcknowledgedMessage(messageKey);
+          } else {
+            pendingAcknowledgement.acceptedAt = this.now();
+          }
+          return true;
+        } catch (error) {
+          this.#pendingAcknowledgements.delete(messageKey);
+          throw error;
+        }
+      },
+    );
+    this.#inFlightMessageAcceptances.set(messageKey, acceptance);
+    try {
+      return await acceptance;
+    } finally {
+      if (this.#inFlightMessageAcceptances.get(messageKey) === acceptance) {
+        this.#inFlightMessageAcceptances.delete(messageKey);
       }
-    });
+    }
   }
 
   markMessageAcknowledged(peerJid: string, messageId: string): void {

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -980,6 +980,66 @@ describe("whatsapp local provider server", () => {
     expect(events).toHaveLength(1);
   });
 
+  it("commits acknowledgements received while message acceptance is pending", async () => {
+    const receiver = new WhatsAppSignalBundleStore(1, 1);
+    let markAcceptanceStarted!: () => void;
+    const acceptanceStarted = new Promise<void>((resolve) => {
+      markAcceptanceStarted = resolve;
+    });
+    let releaseAcceptance!: (accepted: boolean) => void;
+    const acceptanceBlocked = new Promise<boolean>((resolve) => {
+      releaseAcceptance = resolve;
+    });
+    const acceptance = receiver.acceptMessageOnce("15557654321@s.whatsapp.net\0pending-ack", () => {
+      markAcceptanceStarted();
+      return acceptanceBlocked;
+    });
+    await acceptanceStarted;
+
+    receiver.markMessageAcknowledged("15557654321@s.whatsapp.net", "pending-ack");
+    releaseAcceptance(true);
+    await expect(acceptance).resolves.toBe(true);
+
+    const duplicateOperation = vi.fn(async () => true);
+    await expect(
+      receiver.acceptMessageOnce("15557654321@s.whatsapp.net\0pending-ack", duplicateOperation),
+    ).resolves.toBe(true);
+    expect(duplicateOperation).not.toHaveBeenCalled();
+    await expect(
+      receiver.acceptMessageOnce("15557654321@s.whatsapp.net\0next", async () => true),
+    ).resolves.toBe(true);
+  });
+
+  it("rolls back an early acknowledgement when message acceptance rejects", async () => {
+    const receiver = new WhatsAppSignalBundleStore(1, 1);
+    let markAcceptanceStarted!: () => void;
+    const acceptanceStarted = new Promise<void>((resolve) => {
+      markAcceptanceStarted = resolve;
+    });
+    let rejectAcceptance!: (error: Error) => void;
+    const acceptanceBlocked = new Promise<boolean>((_resolve, reject) => {
+      rejectAcceptance = reject;
+    });
+    const acceptance = receiver.acceptMessageOnce(
+      "15557654321@s.whatsapp.net\0rejected-ack",
+      () => {
+        markAcceptanceStarted();
+        return acceptanceBlocked;
+      },
+    );
+    await acceptanceStarted;
+
+    receiver.markMessageAcknowledged("15557654321@s.whatsapp.net", "rejected-ack");
+    rejectAcceptance(new Error("simulated acceptance failure"));
+    await expect(acceptance).rejects.toThrow("simulated acceptance failure");
+
+    const retryOperation = vi.fn(async () => true);
+    await expect(
+      receiver.acceptMessageOnce("15557654321@s.whatsapp.net\0rejected-ack", retryOperation),
+    ).resolves.toBe(true);
+    expect(retryOperation).toHaveBeenCalledOnce();
+  });
+
   it("recovers expired pending acknowledgement capacity without duplicate delivery", async () => {
     let now = 0;
     const receiver = new WhatsAppSignalBundleStore(1, 1, 2, 100, () => now);

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -1010,7 +1010,42 @@ describe("whatsapp local provider server", () => {
     ).resolves.toBe(true);
   });
 
-  it("rolls back an early acknowledgement when message acceptance rejects", async () => {
+  it("shares a pending false acceptance with concurrent duplicates", async () => {
+    const receiver = new WhatsAppSignalBundleStore(1, 1);
+    let markAcceptanceStarted!: () => void;
+    const acceptanceStarted = new Promise<void>((resolve) => {
+      markAcceptanceStarted = resolve;
+    });
+    let releaseAcceptance!: (accepted: boolean) => void;
+    const acceptanceBlocked = new Promise<boolean>((resolve) => {
+      releaseAcceptance = resolve;
+    });
+    const acceptance = receiver.acceptMessageOnce("15557654321@s.whatsapp.net\0false-ack", () => {
+      markAcceptanceStarted();
+      return acceptanceBlocked;
+    });
+    await acceptanceStarted;
+
+    receiver.markMessageAcknowledged("15557654321@s.whatsapp.net", "false-ack");
+    const duplicateOperation = vi.fn(async () => true);
+    const duplicate = receiver.acceptMessageOnce(
+      "15557654321@s.whatsapp.net\0false-ack",
+      duplicateOperation,
+    );
+    releaseAcceptance(false);
+
+    await expect(acceptance).resolves.toBe(false);
+    await expect(duplicate).resolves.toBe(false);
+    expect(duplicateOperation).not.toHaveBeenCalled();
+
+    const retryOperation = vi.fn(async () => true);
+    await expect(
+      receiver.acceptMessageOnce("15557654321@s.whatsapp.net\0false-ack", retryOperation),
+    ).resolves.toBe(true);
+    expect(retryOperation).toHaveBeenCalledOnce();
+  });
+
+  it("shares a pending rejection with concurrent duplicates", async () => {
     const receiver = new WhatsAppSignalBundleStore(1, 1);
     let markAcceptanceStarted!: () => void;
     const acceptanceStarted = new Promise<void>((resolve) => {
@@ -1030,8 +1065,24 @@ describe("whatsapp local provider server", () => {
     await acceptanceStarted;
 
     receiver.markMessageAcknowledged("15557654321@s.whatsapp.net", "rejected-ack");
+    const duplicateOperation = vi.fn(async () => true);
+    const duplicate = receiver.acceptMessageOnce(
+      "15557654321@s.whatsapp.net\0rejected-ack",
+      duplicateOperation,
+    );
+    const outcomes = Promise.allSettled([acceptance, duplicate]);
     rejectAcceptance(new Error("simulated acceptance failure"));
-    await expect(acceptance).rejects.toThrow("simulated acceptance failure");
+    await expect(outcomes).resolves.toEqual([
+      {
+        reason: expect.objectContaining({ message: "simulated acceptance failure" }),
+        status: "rejected",
+      },
+      {
+        reason: expect.objectContaining({ message: "simulated acceptance failure" }),
+        status: "rejected",
+      },
+    ]);
+    expect(duplicateOperation).not.toHaveBeenCalled();
 
     const retryOperation = vi.fn(async () => true);
     await expect(


### PR DESCRIPTION
## Summary
- retain acknowledgements arriving while message acceptance is pending
- share in-flight acceptance results with concurrent duplicates
- roll back failed acceptance state without false deduplication

## Validation
- 30 focused WhatsApp tests
- `pnpm lint` and typecheck
- autoreview: clean (`gpt-5.6-sol`, high, 0.87)
- Crabbox `pnpm verify`: passed, run `run_cbfb6d124f98` (`1255` passed, `1` skipped)
- GitHub `verify`, CodeQL, and Socket Security: passed on rebased head