### PR TITLE
fix(providers): preserve recorder and cache semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Preserve committed provider recorder errors during final identity confirmation and strictly parse quoted JWT cache lifetimes.
 - Lint repository tooling in the type-aware verification gate.
 - Preserve WhatsApp acknowledgement races without stale pending state or false deduplication.
 - Derive Telegram multipart media identity from upload bytes while preserving filenames and file reference reuse.

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -568,12 +568,15 @@ async function appendCommittedLine(
     throw operationError;
   }
 
-  if (
-    !sameRecorderFileIdentity(
-      recorderIdentity,
-      await readRecorderFileIdentity(await resolveRecorderPublicationPath(logicalPath)),
-    )
-  ) {
+  let publishedIdentity: RecorderFileIdentity | undefined;
+  try {
+    publishedIdentity = await readRecorderFileIdentity(
+      await resolveRecorderPublicationPath(logicalPath),
+    );
+  } catch (error) {
+    throw new ProviderRecorderCommittedError(logicalPath, error);
+  }
+  if (!sameRecorderFileIdentity(recorderIdentity, publishedIdentity)) {
     throw new RecorderRotatedError("Recorder rotated while appending a committed line.");
   }
 }

--- a/src/providers/signed-jwt.ts
+++ b/src/providers/signed-jwt.ts
@@ -73,6 +73,32 @@ export function readBearerToken(request: Request): string | undefined {
   return match?.[1];
 }
 
+function splitCacheControlDirectives(value: string): string[] {
+  const directives: string[] = [];
+  let start = 0;
+  let quoted = false;
+  let escaped = false;
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    if (quoted) {
+      if (escaped) {
+        escaped = false;
+      } else if (character === "\\") {
+        escaped = true;
+      } else if (character === '"') {
+        quoted = false;
+      }
+    } else if (character === '"') {
+      quoted = true;
+    } else if (character === ",") {
+      directives.push(value.slice(start, index));
+      start = index + 1;
+    }
+  }
+  directives.push(value.slice(start));
+  return directives;
+}
+
 export function resolveHttpCacheExpiry(response: Response, now: number): number {
   const cacheControl = response.headers.get("cache-control");
   if (/(?:^|,)\s*(?:no-cache|no-store)(?:\s*(?:=|,|$))/iu.test(cacheControl ?? "")) {
@@ -80,9 +106,20 @@ export function resolveHttpCacheExpiry(response: Response, now: number): number 
   }
   const ageHeader = response.headers.get("age");
   const ageSeconds = ageHeader && /^\d+$/u.test(ageHeader) ? Number.parseInt(ageHeader, 10) : 0;
-  const maxAge = /(?:^|,)\s*max-age=(\d+)/iu.exec(cacheControl ?? "");
-  if (maxAge) {
-    const maxAgeSeconds = Number(maxAge[1]);
+  const maxAgeDirectives = splitCacheControlDirectives(cacheControl ?? "").filter((directive) =>
+    /^[ \t]*max-age\b/iu.test(directive),
+  );
+  if (maxAgeDirectives.length > 0) {
+    if (maxAgeDirectives.length !== 1) {
+      return now;
+    }
+    const maxAge = /^[ \t]*max-age[ \t]*=[ \t]*(?:"(\d+)"|(\d+))[ \t]*$/iu.exec(
+      maxAgeDirectives[0]!,
+    );
+    if (!maxAge) {
+      return now;
+    }
+    const maxAgeSeconds = Number(maxAge[1] ?? maxAge[2]);
     if (!Number.isSafeInteger(maxAgeSeconds)) {
       return now;
     }

--- a/src/providers/signed-jwt.ts
+++ b/src/providers/signed-jwt.ts
@@ -73,7 +73,7 @@ export function readBearerToken(request: Request): string | undefined {
   return match?.[1];
 }
 
-function splitCacheControlDirectives(value: string): string[] {
+function splitCacheControlDirectives(value: string): string[] | undefined {
   const directives: string[] = [];
   let start = 0;
   let quoted = false;
@@ -95,6 +95,9 @@ function splitCacheControlDirectives(value: string): string[] {
       start = index + 1;
     }
   }
+  if (quoted || escaped) {
+    return undefined;
+  }
   directives.push(value.slice(start));
   return directives;
 }
@@ -105,12 +108,16 @@ function cacheControlDirectiveName(value: string): string | undefined {
 
 export function resolveHttpCacheExpiry(response: Response, now: number): number {
   const cacheControl = response.headers.get("cache-control");
+  const cacheControlDirectives = splitCacheControlDirectives(cacheControl ?? "");
+  if (!cacheControlDirectives) {
+    return now;
+  }
   if (/(?:^|,)\s*(?:no-cache|no-store)(?:\s*(?:=|,|$))/iu.test(cacheControl ?? "")) {
     return now;
   }
   const ageHeader = response.headers.get("age");
   const ageSeconds = ageHeader && /^\d+$/u.test(ageHeader) ? Number.parseInt(ageHeader, 10) : 0;
-  const maxAgeDirectives = splitCacheControlDirectives(cacheControl ?? "").filter(
+  const maxAgeDirectives = cacheControlDirectives.filter(
     (directive) => cacheControlDirectiveName(directive) === "max-age",
   );
   if (maxAgeDirectives.length > 0) {

--- a/src/providers/signed-jwt.ts
+++ b/src/providers/signed-jwt.ts
@@ -99,6 +99,10 @@ function splitCacheControlDirectives(value: string): string[] {
   return directives;
 }
 
+function cacheControlDirectiveName(value: string): string | undefined {
+  return /^[ \t]*([!#$%&'*+\-.^_`|~0-9A-Za-z]+)/u.exec(value)?.[1]?.toLowerCase();
+}
+
 export function resolveHttpCacheExpiry(response: Response, now: number): number {
   const cacheControl = response.headers.get("cache-control");
   if (/(?:^|,)\s*(?:no-cache|no-store)(?:\s*(?:=|,|$))/iu.test(cacheControl ?? "")) {
@@ -106,8 +110,8 @@ export function resolveHttpCacheExpiry(response: Response, now: number): number 
   }
   const ageHeader = response.headers.get("age");
   const ageSeconds = ageHeader && /^\d+$/u.test(ageHeader) ? Number.parseInt(ageHeader, 10) : 0;
-  const maxAgeDirectives = splitCacheControlDirectives(cacheControl ?? "").filter((directive) =>
-    /^[ \t]*max-age\b/iu.test(directive),
+  const maxAgeDirectives = splitCacheControlDirectives(cacheControl ?? "").filter(
+    (directive) => cacheControlDirectiveName(directive) === "max-age",
   );
   if (maxAgeDirectives.length > 0) {
     if (maxAgeDirectives.length !== 1) {

--- a/test/recorder-concurrency.test.ts
+++ b/test/recorder-concurrency.test.ts
@@ -25,6 +25,10 @@ const fsMocks = vi.hoisted(() => ({
   providerDirectorySync: vi.fn<(directoryPath: string) => Promise<void>>(),
   providerLstatFailure: undefined as Error | undefined,
   providerLstatFailureAfterLocks: 0,
+  providerLstatFailureAfterWrites: 0,
+  providerLogicalPath: "",
+  providerRealpathFailure: undefined as Error | undefined,
+  providerRealpathFailureAfterWrites: 0,
   providerRecorderPath: "",
   providerOpen: vi.fn<(filePath: string, flags: string, mode?: number | string) => void>(),
   providerSync: vi.fn<(filePath: string) => Promise<void>>(),
@@ -69,7 +73,8 @@ vi.mock("node:fs/promises", async (importOriginal) => {
       if (
         String(args[0]) === fsMocks.providerRecorderPath &&
         fsMocks.providerLstatFailure &&
-        fsMocks.lock.mock.calls.length >= fsMocks.providerLstatFailureAfterLocks
+        fsMocks.lock.mock.calls.length >= fsMocks.providerLstatFailureAfterLocks &&
+        fsMocks.providerWrite.mock.calls.length >= fsMocks.providerLstatFailureAfterWrites
       ) {
         throw fsMocks.providerLstatFailure;
       }
@@ -128,6 +133,16 @@ vi.mock("node:fs/promises", async (importOriginal) => {
       }
       return handle;
     },
+    realpath: async (...args: Parameters<typeof actual.realpath>) => {
+      if (
+        String(args[0]) === fsMocks.providerLogicalPath &&
+        fsMocks.providerRealpathFailure &&
+        fsMocks.providerWrite.mock.calls.length >= fsMocks.providerRealpathFailureAfterWrites
+      ) {
+        throw fsMocks.providerRealpathFailure;
+      }
+      return await actual.realpath(...args);
+    },
     stat: async (filePath: Parameters<typeof actual.stat>[0]) => {
       if (String(filePath).includes("crabline-server-recorder")) {
         return await fsMocks.serverStat(String(filePath));
@@ -175,6 +190,10 @@ beforeEach(() => {
   fsMocks.providerDirectorySync.mockResolvedValue(undefined);
   fsMocks.providerLstatFailure = undefined;
   fsMocks.providerLstatFailureAfterLocks = 0;
+  fsMocks.providerLstatFailureAfterWrites = 0;
+  fsMocks.providerLogicalPath = "";
+  fsMocks.providerRealpathFailure = undefined;
+  fsMocks.providerRealpathFailureAfterWrites = 0;
   fsMocks.providerRecorderPath = "";
   fsMocks.providerOpen.mockReset();
   fsMocks.providerSync.mockReset();
@@ -627,6 +646,65 @@ describe("recorder append serialization", () => {
       await rm(recorderPath, { force: true });
     }
   });
+
+  it.each([
+    {
+      configureFailure(failure: Error) {
+        fsMocks.providerRealpathFailure = failure;
+        fsMocks.providerRealpathFailureAfterWrites = 1;
+      },
+      name: "publication path resolution",
+    },
+    {
+      configureFailure(failure: Error) {
+        fsMocks.providerLstatFailure = failure;
+        fsMocks.providerLstatFailureAfterLocks = 2;
+        fsMocks.providerLstatFailureAfterWrites = 1;
+      },
+      name: "identity confirmation",
+    },
+  ])(
+    "classifies final $name failure as a committed provider append",
+    async ({ configureFailure }) => {
+      const recorderPath = path.join(
+        "/tmp",
+        `crabline-provider-recorder-committed-confirmation-${process.pid}-${Date.now()}.jsonl`,
+      );
+      fsMocks.providerDirectory = await realpath(path.dirname(recorderPath));
+      fsMocks.providerLogicalPath = path.resolve(recorderPath);
+      fsMocks.providerRecorderPath = path.join(
+        fsMocks.providerDirectory,
+        path.basename(recorderPath),
+      );
+      fsMocks.providerWrite.mockResolvedValue(undefined);
+      const confirmationFailure = Object.assign(new Error("simulated final confirmation failure"), {
+        code: "EIO",
+      });
+      configureFailure(confirmationFailure);
+
+      try {
+        const append = appendRecordedInbound(recorderPath, {
+          author: "assistant",
+          id: "committed-confirmation-failure",
+          provider: "slack",
+          sentAt: "2026-07-12T10:00:00.000Z",
+          text: "committed",
+          threadId: "slack:C123",
+        });
+        await expect(append).rejects.toMatchObject({
+          cause: confirmationFailure,
+          committed: true,
+          indeterminate: true,
+          name: "ProviderRecorderCommittedError",
+        });
+        await expect(append).rejects.toBeInstanceOf(ProviderRecorderCommittedError);
+        expect(fsMocks.providerWrite).toHaveBeenCalledOnce();
+        expect(fsMocks.lockRelease).toHaveBeenCalledTimes(2);
+      } finally {
+        await rm(recorderPath, { force: true });
+      }
+    },
+  );
 
   it.skipIf(process.platform === "win32")(
     "uses one private UID-scoped lock namespace for hardlinked provider recorders",

--- a/test/signed-jwt.test.ts
+++ b/test/signed-jwt.test.ts
@@ -218,6 +218,32 @@ describe("signed JWT remote key cache", () => {
     }
   });
 
+  it("ignores extension directives whose HTTP token names start with max-age", () => {
+    const now = 1_700_000_000_000;
+    const expires = new Date(now + 30 * 60 * 1_000).toUTCString();
+
+    for (const directive of [
+      "max-age-fallback=3600",
+      "max-age.fallback=3600",
+      "max-age*fallback=3600",
+    ]) {
+      expect(
+        resolveHttpCacheExpiry(
+          new Response(null, { headers: { "cache-control": `public, ${directive}` } }),
+          now,
+        ),
+      ).toBe(now + 3_600_000);
+      expect(
+        resolveHttpCacheExpiry(
+          new Response(null, {
+            headers: { "cache-control": `public, ${directive}`, expires },
+          }),
+          now,
+        ),
+      ).toBe(now + 1_800_000);
+    }
+  });
+
   it("distinguishes absent Expires from invalid or stale values", () => {
     const now = 1_700_000_000_000;
 

--- a/test/signed-jwt.test.ts
+++ b/test/signed-jwt.test.ts
@@ -244,6 +244,26 @@ describe("signed JWT remote key cache", () => {
     }
   });
 
+  it("fails closed on unterminated Cache-Control quotes and dangling escapes", () => {
+    const now = 1_700_000_000_000;
+    const expires = new Date(now + 60 * 60 * 1_000).toUTCString();
+
+    for (const cacheControl of ['private="unterminated, max-age=0', 'private="dangling\\']) {
+      expect(
+        resolveHttpCacheExpiry(
+          new Response(null, { headers: { "cache-control": cacheControl } }),
+          now,
+        ),
+      ).toBe(now);
+      expect(
+        resolveHttpCacheExpiry(
+          new Response(null, { headers: { "cache-control": cacheControl, expires } }),
+          now,
+        ),
+      ).toBe(now);
+    }
+  });
+
   it("distinguishes absent Expires from invalid or stale values", () => {
     const now = 1_700_000_000_000;
 

--- a/test/signed-jwt.test.ts
+++ b/test/signed-jwt.test.ts
@@ -181,6 +181,43 @@ describe("signed JWT remote key cache", () => {
     ).toBe(now);
   });
 
+  it("accepts quoted max-age delta-seconds with optional whitespace", () => {
+    const now = 1_700_000_000_000;
+
+    for (const cacheControl of [
+      'public, max-age="3600"',
+      'public, max-age = "3600"',
+      'public,\tmax-age\t=\t"3600"\t',
+    ]) {
+      expect(
+        resolveHttpCacheExpiry(
+          new Response(null, { headers: { "cache-control": cacheControl } }),
+          now,
+        ),
+      ).toBe(now + 3_600_000);
+    }
+  });
+
+  it("fails closed on malformed max-age instead of using fallback freshness", () => {
+    const now = 1_700_000_000_000;
+    const expires = new Date(now + 60 * 60 * 1_000).toUTCString();
+
+    for (const cacheControl of [
+      "public, max-age",
+      "public, max-age=invalid",
+      'public, max-age="3600',
+      'public, max-age=" 3600 "',
+      "public, max-age=3600, max-age=7200",
+    ]) {
+      expect(
+        resolveHttpCacheExpiry(
+          new Response(null, { headers: { "cache-control": cacheControl, expires } }),
+          now,
+        ),
+      ).toBe(now);
+    }
+  });
+
   it("distinguishes absent Expires from invalid or stale values", () => {
     const now = 1_700_000_000_000;
 


### PR DESCRIPTION
## Summary
- preserve committed recorder errors when final publication identity checks fail
- parse quoted `Cache-Control` directives without accepting prefix aliases
- fail closed on malformed quoted cache directives

## Validation
- 37 focused recorder and signed-JWT tests
- `pnpm lint` and typecheck
- autoreview: clean after two accepted fixes (`gpt-5.6-sol`, high, 0.93)
- Crabbox `pnpm verify`: passed, run `run_4eebdb1c1ca9` (`1262` passed, `1` skipped)
- GitHub `verify`, CodeQL, and Socket Security: passed on rebased head