### PR TITLE
fix(whatsapp): randomize XEdDSA signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Randomize WhatsApp XEdDSA signatures with fresh entropy while preserving their wire encoding.
 - Preserve committed provider recorder errors during final identity confirmation and strictly parse quoted JWT cache lifetimes.
 - Lint repository tooling in the type-aware verification gate.
 - Preserve WhatsApp acknowledgement races without stale pending state or false deduplication.

--- a/src/servers/whatsapp-wire/crypto.ts
+++ b/src/servers/whatsapp-wire/crypto.ts
@@ -17,7 +17,7 @@ const require = createRequire(import.meta.url);
 type Curve25519Module = {
   generateKeyPair(seed: Uint8Array): { private: Uint8Array; public: Uint8Array };
   sharedKey(privateKey: Uint8Array, publicKey: Uint8Array): Uint8Array;
-  sign(privateKey: Uint8Array, message: Uint8Array): Uint8Array;
+  sign(privateKey: Uint8Array, message: Uint8Array, random: Uint8Array): Uint8Array;
 };
 
 const curve25519 = require("curve25519-js") as Curve25519Module;
@@ -135,7 +135,9 @@ export function createCurve(nativeBackend: NativeCurveBackend = nativeCurveBacke
     },
 
     sign(privateKey: Uint8Array, message: Uint8Array): Buffer {
-      return Buffer.from(curve25519.sign(Buffer.from(privateKey), Buffer.from(message)));
+      return Buffer.from(
+        curve25519.sign(Buffer.from(privateKey), Buffer.from(message), randomBytes(64)),
+      );
     },
   };
 }

--- a/test/whatsapp-wire.test.ts
+++ b/test/whatsapp-wire.test.ts
@@ -88,6 +88,19 @@ describe("WhatsApp X25519 agreement", () => {
     );
   });
 
+  it("creates randomized XEdDSA signatures that retain the WhatsApp wire format", () => {
+    const identityKeyPair = generateSignalKeyPair();
+    const message = Buffer.from("signed pre-key");
+    const firstSignature = Curve.sign(identityKeyPair.private, message);
+    const secondSignature = Curve.sign(identityKeyPair.private, message);
+
+    expect(firstSignature).toHaveLength(64);
+    expect(secondSignature).toHaveLength(64);
+    expect(firstSignature).not.toEqual(secondSignature);
+    expect(BaileysCurve.verify(identityKeyPair.public, message, firstSignature)).toBe(true);
+    expect(BaileysCurve.verify(identityKeyPair.public, message, secondSignature)).toBe(true);
+  });
+
   it("rejects invalid peer key lengths", () => {
     expect(() => Curve.sharedKey(RFC_7748_ALICE_PRIVATE, Buffer.alloc(31))).toThrow(
       "Invalid Signal public key length: 31.",


### PR DESCRIPTION
## Summary
- supply fresh 64-byte randomness to XEdDSA signing
- preserve interoperable 64-byte signatures while preventing deterministic reuse
- add regression coverage proving repeated signatures differ and still verify

## Validation
- 47 focused WhatsApp wire tests
- full local suite: 1264 tests
- `pnpm lint`
- autoreview: clean (`gpt-5.6-sol`, high, 0.96)
- Crabbox `pnpm verify`: passed, run `run_792d2d7c9ce6` (`1263` passed, `1` skipped)