### PR TITLE
fix(core): preserve shutdown and acknowledgement boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Randomize WhatsApp XEdDSA signatures with fresh entropy while preserving their wire encoding.
+- Treat Unicode format characters as continuations when recognizing standalone acknowledgement tokens.
 - Preserve committed provider recorder errors during final identity confirmation and strictly parse quoted JWT cache lifetimes.
 - Lint repository tooling in the type-aware verification gate.
 - Preserve WhatsApp acknowledgement races without stale pending state or false deduplication.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Randomize WhatsApp XEdDSA signatures with fresh entropy while preserving their wire encoding.
+- Suppress serve readiness output when shutdown begins during ready-file publication.
 - Treat Unicode format characters as continuations when recognizing standalone acknowledgement tokens.
 - Preserve committed provider recorder errors during final identity confirmation and strictly parse quoted JWT cache lifetimes.
 - Lint repository tooling in the type-aware verification gate.

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -703,16 +703,20 @@ export function createProgram(
                   identity: await publish(commandOptions.readyFile, readyContents),
                 };
               }
-              outputWritten = await print(
-                options.json
-                  ? payload
-                  : renderServeText(server.manifest, commandOptions.showSecrets === true),
-              );
-              if (!outputWritten) {
+              if (shutdown.requested()) {
+                outputWritten = false;
                 finishPublication();
-              }
-              if (!outputWritten) {
-                await close();
+                await shutdown.wait();
+              } else {
+                outputWritten = await print(
+                  options.json
+                    ? payload
+                    : renderServeText(server.manifest, commandOptions.showSecrets === true),
+                );
+                if (!outputWritten) {
+                  finishPublication();
+                  await close();
+                }
               }
             } finally {
               finishPublication();

--- a/src/core/matcher.ts
+++ b/src/core/matcher.ts
@@ -3,7 +3,7 @@ import { compileInboundRegex } from "./safe-regex.js";
 import type { InboundEnvelope, InboundMatchConfig } from "../providers/types.js";
 
 const EXACT_ACK_TOKEN =
-  /(?<![\p{ID_Continue}\p{Mark}\u200c\u200d])ACK(?![\p{ID_Continue}\p{Mark}\u200c\u200d])/u;
+  /(?<![\p{ID_Continue}\p{Mark}\p{Cf}])ACK(?![\p{ID_Continue}\p{Mark}\p{Cf}])/u;
 
 export function matchesInbound(
   envelope: InboundEnvelope,

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -969,10 +969,11 @@ describe("cli", () => {
     await expect(fs.readFile(readyFile, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  it("keeps the server live until shutdown-time publication settles", async () => {
+  it("does not announce readiness when shutdown starts during publication", async () => {
     const directory = await createTempDir();
     directories.push(directory);
     const readyFile = path.join(directory, "server.json");
+    const lifecycle: string[] = [];
     let releasePublish: (() => void) | undefined;
     let markPublishStarted: (() => void) | undefined;
     const publishStarted = new Promise<void>((resolve) => {
@@ -981,10 +982,17 @@ describe("cli", () => {
     const publishBlocked = new Promise<void>((resolve) => {
       releasePublish = resolve;
     });
-    const close = vi.fn(async () => undefined);
-    const removeReadyFileMock = vi.fn(async () => undefined);
+    const close = vi.fn(async () => {
+      lifecycle.push("close");
+    });
+    const releaseReadyLease = vi.fn(async () => {
+      lifecycle.push("release");
+    });
+    const removeReadyFileMock = vi.fn(async () => {
+      lifecycle.push("remove");
+    });
     const program = createProgram(() => undefined, {
-      acquireReadyFileLease: async () => async () => undefined,
+      acquireReadyFileLease: async () => releaseReadyLease,
       publishReadyFile: async () => {
         markPublishStarted?.();
         await publishBlocked;
@@ -1016,25 +1024,30 @@ describe("cli", () => {
         },
       }),
     });
-    const running = program.parseAsync([
-      "node",
-      "crabline",
-      "--json",
-      "serve",
-      "telegram",
-      "--ready-file",
-      readyFile,
-    ]);
-    await publishStarted;
+    const captured = await captureWrites(async () => {
+      const running = program.parseAsync([
+        "node",
+        "crabline",
+        "--json",
+        "serve",
+        "telegram",
+        "--ready-file",
+        readyFile,
+      ]);
+      await publishStarted;
 
-    process.emit("SIGTERM", "SIGTERM");
-    await Promise.resolve();
-    expect(close).not.toHaveBeenCalled();
-    releasePublish?.();
-    await vi.waitFor(() => expect(close).toHaveBeenCalledTimes(1));
-    await running;
+      process.emit("SIGTERM", "SIGTERM");
+      await Promise.resolve();
+      expect(close).not.toHaveBeenCalled();
+      releasePublish?.();
+      await vi.waitFor(() => expect(close).toHaveBeenCalledTimes(1));
+      await running;
+    });
 
+    expect(captured.stdout).toEqual([]);
     expect(removeReadyFileMock).toHaveBeenCalledTimes(1);
+    expect(releaseReadyLease).toHaveBeenCalledTimes(1);
+    expect(lifecycle).toEqual(["remove", "close", "release"]);
   });
 
   it("uses one heartbeat lease policy for ready-file ownership", async () => {

--- a/test/matcher.test.ts
+++ b/test/matcher.test.ts
@@ -113,6 +113,11 @@ describe("nonce + matcher", () => {
     expect(matchesReply(`ACK\u200c ${nonce}`)).toBe(false);
     expect(matchesReply(`H\u00b7ACK ${nonce}`)).toBe(false);
     expect(matchesReply(`ACK\u0387NOW ${nonce}`)).toBe(false);
+    for (const formatCharacter of ["\u00ad", "\u200b", "\u2060", "\ufeff"]) {
+      const codePoint = `U+${formatCharacter.codePointAt(0)!.toString(16).padStart(4, "0")}`;
+      expect(matchesReply(`${formatCharacter}ACK ${nonce}`), `${codePoint} before ACK`).toBe(false);
+      expect(matchesReply(`ACK${formatCharacter} ${nonce}`), `${codePoint} after ACK`).toBe(false);
+    }
   });
 
   it("covers exact, regex, and ignore-nonce branches", () => {


### PR DESCRIPTION
## Summary
- treat Unicode format characters as continuations around standalone `ACK` tokens
- suppress serve readiness output when shutdown begins during ready-file publication
- preserve ready-file withdrawal and server cleanup ordering

## Validation
- 64 focused matcher and CLI tests
- `pnpm typecheck` and `pnpm lint`
- autoreview: clean on rebased head (`gpt-5.6-sol`, high, 0.93)
- Crabbox `pnpm verify`: passed on rebased head, run `run_fac45f405a36` (`1263` passed, `1` skipped)
- GitHub `verify`: passed on rebased head