### PR TITLE
fix(providers): bound key loads and stream responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Randomize WhatsApp XEdDSA signatures with fresh entropy while preserving their wire encoding.
 - Suppress serve readiness output when shutdown begins during ready-file publication.
 - Treat Unicode format characters as continuations when recognizing standalone acknowledgement tokens.
+- Stream webhook responses with backpressure and cancel unfinished bodies when clients disconnect.
 - Keep timed-out signed-JWT key loads single-flighted until their underlying loaders settle.
 - Preserve committed provider recorder errors during final identity confirmation and strictly parse quoted JWT cache lifetimes.
 - Lint repository tooling in the type-aware verification gate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Randomize WhatsApp XEdDSA signatures with fresh entropy while preserving their wire encoding.
 - Suppress serve readiness output when shutdown begins during ready-file publication.
 - Treat Unicode format characters as continuations when recognizing standalone acknowledgement tokens.
+- Keep timed-out signed-JWT key loads single-flighted until their underlying loaders settle.
 - Preserve committed provider recorder errors during final identity confirmation and strictly parse quoted JWT cache lifetimes.
 - Lint repository tooling in the type-aware verification gate.
 - Preserve WhatsApp acknowledgement races without stale pending state or false deduplication.

--- a/src/providers/signed-jwt.ts
+++ b/src/providers/signed-jwt.ts
@@ -160,7 +160,12 @@ export function createCachedJwtKeyResolver<T>(params: {
   const refreshCooldownMs = params.refreshCooldownMs ?? DEFAULT_UNKNOWN_KEY_COOLDOWN_MS;
   const timeoutMs = params.timeoutMs ?? DEFAULT_KEY_FETCH_TIMEOUT_MS;
   let cached: RemoteJwtKeySet<T> | undefined;
-  let fetchInFlight: Promise<RemoteJwtKeySet<T>> | undefined;
+  let fetchInFlight:
+    | {
+        controller: AbortController;
+        promise: Promise<RemoteJwtKeySet<T>>;
+      }
+    | undefined;
   let refreshInFlight: Promise<RemoteJwtKeySet<T>> | undefined;
   let refreshCooldownUntil = 0;
   let fetchFailureCooldownUntil = 0;
@@ -184,46 +189,58 @@ export function createCachedJwtKeyResolver<T>(params: {
   };
 
   const fetchKeys = async (): Promise<RemoteJwtKeySet<T>> => {
-    if (fetchInFlight) {
-      return await fetchInFlight;
+    let inFlight = fetchInFlight;
+    if (!inFlight) {
+      if (fetchFailureCooldownUntil > now()) {
+        throw fetchFailureError;
+      }
+      const controller = new AbortController();
+      let keyFetch!: Promise<RemoteJwtKeySet<T>>;
+      keyFetch = Promise.resolve()
+        .then(() => params.fetchKeys(controller.signal))
+        .then(
+          (keySet) => {
+            cached = keySet.expiresAt > now() ? keySet : undefined;
+            fetchFailureCooldownUntil = 0;
+            fetchFailureError = undefined;
+            for (const value of keySet.values) {
+              const keyId = params.keyId(value);
+              if (keyId) {
+                negativeKeyIds.delete(keyId);
+              }
+            }
+            return keySet;
+          },
+          (error: unknown) => {
+            fetchFailureCooldownUntil = now() + refreshCooldownMs;
+            fetchFailureError = error;
+            throw error;
+          },
+        )
+        .finally(() => {
+          if (fetchInFlight?.promise === keyFetch) {
+            fetchInFlight = undefined;
+          }
+        });
+      inFlight = { controller, promise: keyFetch };
+      fetchInFlight = inFlight;
+      void keyFetch.catch(() => {});
     }
-    if (fetchFailureCooldownUntil > now()) {
-      throw fetchFailureError;
-    }
-    const controller = new AbortController();
+
     let timeout: NodeJS.Timeout | undefined;
     const timedOut = new Promise<never>((_, reject) => {
       timeout = setTimeout(() => {
-        controller.abort();
+        inFlight.controller.abort();
         reject(new Error("JWT signing key fetch timed out."));
       }, timeoutMs);
     });
-    const keyFetch = Promise.resolve().then(() => params.fetchKeys(controller.signal));
-    fetchInFlight = Promise.race([keyFetch, timedOut])
-      .then((keySet) => {
-        cached = keySet.expiresAt > now() ? keySet : undefined;
-        fetchFailureCooldownUntil = 0;
-        fetchFailureError = undefined;
-        for (const value of keySet.values) {
-          const keyId = params.keyId(value);
-          if (keyId) {
-            negativeKeyIds.delete(keyId);
-          }
-        }
-        return keySet;
-      })
-      .catch((error: unknown) => {
-        fetchFailureCooldownUntil = now() + refreshCooldownMs;
-        fetchFailureError = error;
-        throw error;
-      })
-      .finally(() => {
-        if (timeout) {
-          clearTimeout(timeout);
-        }
-        fetchInFlight = undefined;
-      });
-    return await fetchInFlight;
+    try {
+      return await Promise.race([inFlight.promise, timedOut]);
+    } finally {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    }
   };
 
   return async (header: JwtHeader): Promise<T> => {

--- a/src/providers/webhook-server.ts
+++ b/src/providers/webhook-server.ts
@@ -12,6 +12,7 @@ const DEFAULT_BODY_TIMEOUT_MS = 5_000;
 
 class RequestBodyTooLargeError extends Error {}
 class RequestBodyTimeoutError extends Error {}
+class ResponseDeliveryClosedError extends Error {}
 
 async function readRequestBody(
   request: IncomingMessage,
@@ -111,13 +112,87 @@ async function writeFetchResponse(
     response.setHeader(name, value);
   }
 
-  if (!fetchResponse.body) {
-    response.end();
-    return;
-  }
+  const reader = fetchResponse.body?.getReader();
+  let cancellation: Promise<void> | undefined;
+  let rejectStopped!: (error: Error) => void;
+  let stoppedError: Error | undefined;
+  const stopped = new Promise<never>((_, reject) => {
+    rejectStopped = reject;
+  });
+  void stopped.catch(() => {});
 
-  const body = Buffer.from(await fetchResponse.arrayBuffer());
-  response.end(body);
+  const cancelBody = (reason: Error) => {
+    if (!reader || cancellation) {
+      return;
+    }
+    cancellation = reader.cancel(reason).catch(() => {});
+  };
+  const stop = (error: Error) => {
+    if (stoppedError) {
+      return;
+    }
+    stoppedError = error;
+    cancelBody(error);
+    rejectStopped(error);
+  };
+  const onClose = () => {
+    if (!response.writableFinished) {
+      stop(new ResponseDeliveryClosedError("Webhook response delivery closed before completion."));
+    }
+  };
+  const onError = (error: Error) => stop(error);
+  response.once("close", onClose);
+  response.once("error", onError);
+
+  try {
+    if (
+      response.destroyed ||
+      response.req?.aborted ||
+      response.req?.socket.destroyed ||
+      response.socket?.destroyed
+    ) {
+      throw new ResponseDeliveryClosedError("Webhook response delivery closed before it started.");
+    }
+
+    if (reader) {
+      while (true) {
+        const chunk = await Promise.race([reader.read(), stopped]);
+        if (chunk.done) {
+          break;
+        }
+        if (chunk.value.byteLength > 0 && !response.write(chunk.value)) {
+          let onDrain!: () => void;
+          const drained = new Promise<void>((resolve) => {
+            onDrain = resolve;
+            response.once("drain", onDrain);
+          });
+          try {
+            await Promise.race([drained, stopped]);
+          } finally {
+            response.off("drain", onDrain);
+          }
+        }
+      }
+    }
+
+    let onFinish!: () => void;
+    const finished = new Promise<void>((resolve) => {
+      onFinish = resolve;
+      response.once("finish", onFinish);
+    });
+    try {
+      response.end();
+      await Promise.race([finished, stopped]);
+    } finally {
+      response.off("finish", onFinish);
+    }
+  } catch (error) {
+    cancelBody(error instanceof Error ? error : new Error(String(error)));
+    throw error;
+  } finally {
+    response.off("close", onClose);
+    response.off("error", onError);
+  }
 }
 
 function clearUnsentResponseHeaders(response: ServerResponse<IncomingMessage>): void {
@@ -176,6 +251,10 @@ export async function startWebhookServer(params: {
       const fetchRequest = await toFetchRequest(request, url, maxBodyBytes, bodyTimeoutMs);
       await writeFetchResponse(response, await params.handle(fetchRequest));
     } catch (error) {
+      if (error instanceof ResponseDeliveryClosedError) {
+        response.destroy();
+        return;
+      }
       const status =
         error instanceof RequestBodyTooLargeError
           ? 413
@@ -189,21 +268,29 @@ export async function startWebhookServer(params: {
           // Error reporting must not change the public response.
         }
       }
+      if (response.headersSent || response.destroyed) {
+        response.destroy();
+        return;
+      }
       clearUnsentResponseHeaders(response);
-      await writeFetchResponse(
-        response,
-        new Response(
-          status === 413
-            ? "request body too large"
-            : status === 408
-              ? "request body timeout"
-              : "internal server error",
-          {
-            ...(status === 408 ? { headers: { connection: "close" } } : {}),
-            status,
-          },
-        ),
-      );
+      try {
+        await writeFetchResponse(
+          response,
+          new Response(
+            status === 413
+              ? "request body too large"
+              : status === 408
+                ? "request body timeout"
+                : "internal server error",
+            {
+              ...(status === 408 ? { headers: { connection: "close" } } : {}),
+              status,
+            },
+          ),
+        );
+      } catch {
+        response.destroy();
+      }
     }
   });
 

--- a/test/signed-jwt.test.ts
+++ b/test/signed-jwt.test.ts
@@ -388,6 +388,94 @@ describe("signed JWT remote key cache", () => {
     await expect(resolveKey({ alg: "RS256", kid: "missing" })).rejects.toThrow("timed out");
   });
 
+  it("keeps timed-out key loads shared until a late success settles", async () => {
+    vi.useFakeTimers();
+    try {
+      let fetches = 0;
+      let resolveFetch!: (keySet: { expiresAt: number; values: string[] }) => void;
+      const resolveKey = createCachedJwtKeyResolver<string>({
+        fetchKeys: async () => {
+          fetches += 1;
+          return await new Promise((resolve) => {
+            resolveFetch = resolve;
+          });
+        },
+        keyId: (value) => value,
+        now: () => 1_700_000_000_000,
+        timeoutMs: 10,
+        unknownKeyMessage: "unknown key",
+      });
+
+      const first = resolveKey({ alg: "RS256", kid: "known" }).then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+      await vi.advanceTimersByTimeAsync(10);
+      expect(await first).toEqual(
+        expect.objectContaining({ message: expect.stringMatching(/timed out/u) }),
+      );
+
+      const second = resolveKey({ alg: "RS256", kid: "known" });
+      expect(fetches).toBe(1);
+      resolveFetch({ expiresAt: 1_700_000_060_000, values: ["known"] });
+
+      await expect(second).resolves.toBe("known");
+      await expect(resolveKey({ alg: "RS256", kid: "known" })).resolves.toBe("known");
+      expect(fetches).toBe(1);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("bounds each waiter while a timed-out key load remains unsettled", async () => {
+    vi.useFakeTimers();
+    try {
+      let fetches = 0;
+      let rejectFetch!: (error: Error) => void;
+      const resolveKey = createCachedJwtKeyResolver<string>({
+        fetchKeys: async () => {
+          fetches += 1;
+          return await new Promise((_, reject) => {
+            rejectFetch = reject;
+          });
+        },
+        keyId: (value) => value,
+        now: () => 1_700_000_000_000,
+        timeoutMs: 10,
+        unknownKeyMessage: "unknown key",
+      });
+
+      const first = resolveKey({ alg: "RS256", kid: "missing" }).then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+      await vi.advanceTimersByTimeAsync(10);
+      expect(await first).toEqual(
+        expect.objectContaining({ message: expect.stringMatching(/timed out/u) }),
+      );
+
+      const secondPromise = resolveKey({ alg: "RS256", kid: "missing" });
+      const second = secondPromise.then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+      await vi.advanceTimersByTimeAsync(9);
+      expect(fetches).toBe(1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(await second).toEqual(
+        expect.objectContaining({ message: expect.stringMatching(/timed out/u) }),
+      );
+
+      rejectFetch(new Error("late loader rejection"));
+      await vi.runAllTicks();
+      expect(fetches).toBe(1);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("backs off failed key fetches", async () => {
     let now = 1_700_000_000_000;
     let fetches = 0;

--- a/test/webhook-server.test.ts
+++ b/test/webhook-server.test.ts
@@ -1,6 +1,6 @@
 import { once } from "node:events";
 import { connect } from "node:net";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { startWebhookServer } from "../src/providers/webhook-server.js";
 
 const cleanups: Array<() => Promise<void>> = [];
@@ -165,6 +165,92 @@ describe("webhook server", () => {
     expect(observedErrors).toEqual([expect.objectContaining({ message: "response body failed" })]);
   });
 
+  it("streams response chunks before the provider body completes", async () => {
+    let releaseBody!: () => void;
+    const bodyReleased = new Promise<void>((resolve) => {
+      releaseBody = resolve;
+    });
+    const server = await startWebhookServer({
+      handle: async () =>
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(Buffer.from("first"));
+            },
+            async pull(controller) {
+              await bodyReleased;
+              controller.enqueue(Buffer.from("-second"));
+              controller.close();
+            },
+          }),
+        ),
+      host: "127.0.0.1",
+      path: "/slack/events",
+      port: 0,
+    });
+    cleanups.push(() => server.close());
+
+    const response = await fetch(server.endpointUrl, { method: "POST" });
+    const reader = response.body!.getReader();
+    const first = await reader.read();
+
+    expect(Buffer.from(first.value ?? []).toString()).toBe("first");
+    expect(first.done).toBe(false);
+
+    releaseBody();
+    const second = await reader.read();
+    expect(Buffer.from(second.value ?? []).toString()).toBe("-second");
+    await expect(reader.read()).resolves.toEqual({ done: true, value: undefined });
+  });
+
+  it("applies response backpressure and cancels the body when the client disconnects", async () => {
+    const totalChunks = 512;
+    let pulls = 0;
+    let reportCancellation!: () => void;
+    const cancelled = new Promise<void>((resolve) => {
+      reportCancellation = resolve;
+    });
+    const server = await startWebhookServer({
+      handle: async () =>
+        new Response(
+          new ReadableStream({
+            cancel() {
+              reportCancellation();
+            },
+            pull(controller) {
+              pulls += 1;
+              controller.enqueue(new Uint8Array(64 * 1024));
+              if (pulls === totalChunks) {
+                controller.close();
+              }
+            },
+          }),
+        ),
+      host: "127.0.0.1",
+      path: "/slack/events",
+      port: 0,
+    });
+    cleanups.push(() => server.close());
+    const endpoint = new URL(server.endpointUrl);
+    const socket = connect(Number(endpoint.port), endpoint.hostname);
+    socket.on("error", () => {});
+    socket.pause();
+    await once(socket, "connect");
+    socket.write("POST /slack/events HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: 0\r\n\r\n");
+
+    await vi.waitFor(() => expect(pulls).toBeGreaterThan(0));
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+    expect(pulls).toBeLessThan(totalChunks);
+
+    socket.destroy();
+    await expect(
+      Promise.race([
+        cancelled.then(() => "cancelled"),
+        new Promise<string>((resolve) => setTimeout(() => resolve("timed out"), 500)),
+      ]),
+    ).resolves.toBe("cancelled");
+  });
+
   it("returns 413 for oversized request bodies without invoking the handler", async () => {
     let handlerInvoked = false;
     const server = await startWebhookServer({
@@ -309,6 +395,49 @@ describe("webhook server", () => {
     expect(response.status).toBe(202);
     await expect(response.text()).resolves.toBe("admitted response");
     await expect(closing).resolves.toBeUndefined();
+  });
+
+  it("cancels an unfinished response body after the shutdown grace period", async () => {
+    let reportCancellation!: () => void;
+    const cancelled = new Promise<void>((resolve) => {
+      reportCancellation = resolve;
+    });
+    const server = await startWebhookServer({
+      handle: async () =>
+        new Response(
+          new ReadableStream({
+            cancel() {
+              reportCancellation();
+            },
+            start(controller) {
+              controller.enqueue(Buffer.from("started"));
+            },
+          }),
+        ),
+      host: "127.0.0.1",
+      path: "/slack/events",
+      port: 0,
+      shutdownGraceMs: 30,
+    });
+    const endpoint = new URL(server.endpointUrl);
+    const socket = connect(Number(endpoint.port), endpoint.hostname);
+    socket.on("error", () => {});
+    let response = "";
+    socket.setEncoding("utf8");
+    socket.on("data", (chunk) => {
+      response += chunk;
+    });
+    await once(socket, "connect");
+    socket.write("POST /slack/events HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: 0\r\n\r\n");
+    await vi.waitFor(() => expect(response).toContain("started"));
+
+    await expect(
+      Promise.race([
+        server.close().then(() => "closed"),
+        new Promise<string>((resolve) => setTimeout(() => resolve("timed out"), 500)),
+      ]),
+    ).resolves.toBe("closed");
+    await expect(cancelled).resolves.toBeUndefined();
   });
 
   it("survives clients aborting incomplete request bodies", async () => {


### PR DESCRIPTION
## Summary
- keep timed-out signed-JWT key loads single-flighted until the underlying loader settles
- retain independent caller timeout bounds without spawning overlapping ignored-abort loads
- stream webhook responses with backpressure and cancel unfinished bodies on disconnect or shutdown

## Validation
- 41 focused signed-JWT and webhook tests
- `pnpm lint`
- autoreview: clean on rebased head (`gpt-5.6-sol`, high, 0.87)
- Crabbox `pnpm verify`: passed on rebased head, run `run_848ae365e0a1` (`1268` passed, `1` skipped)
- GitHub `verify` and Socket Security: passed on rebased head