### PR TITLE
fix(runtime): classify failures and bound watch shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Verify downloaded npm tarball integrity, retry transient provenance lookups, and revalidate release tags immediately before publication mutations.
 - Validate effective fixture mode overrides and stop retrying permanent provider send failures.
+- Bound watch iterator return and provider cleanup during CLI shutdown.
 - Randomize WhatsApp XEdDSA signatures with fresh entropy while preserving their wire encoding.
 - Suppress serve readiness output when shutdown begins during ready-file publication.
 - Treat Unicode format characters as continuations when recognizing standalone acknowledgement tokens.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Verify downloaded npm tarball integrity, retry transient provenance lookups, and revalidate release tags immediately before publication mutations.
 - Validate effective fixture mode overrides and stop retrying permanent provider send failures.
-- Bound watch iterator return and provider cleanup during CLI shutdown.
+- Bound watch iterator return and provider cleanup during CLI shutdown, forcing process exit after deadline failures.
 - Randomize WhatsApp XEdDSA signatures with fresh entropy while preserving their wire encoding.
 - Suppress serve readiness output when shutdown begins during ready-file publication.
 - Treat Unicode format characters as continuations when recognizing standalone acknowledgement tokens.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Verify downloaded npm tarball integrity, retry transient provenance lookups, and revalidate release tags immediately before publication mutations.
+- Validate effective fixture mode overrides and stop retrying permanent provider send failures.
 - Randomize WhatsApp XEdDSA signatures with fresh entropy while preserving their wire encoding.
 - Suppress serve readiness output when shutdown begins during ready-file publication.
 - Treat Unicode format characters as continuations when recognizing standalone acknowledgement tokens.

--- a/src/bin/crabline.ts
+++ b/src/bin/crabline.ts
@@ -2,7 +2,9 @@
 
 import { runCli } from "../cli/program.js";
 
-const exitCode = await runCli(process.argv);
+const exitCode = await runCli(process.argv, {
+  forceExit: (code) => process.exit(code),
+});
 if (exitCode !== 0) {
   process.exitCode = exitCode;
 }

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -82,6 +82,8 @@ type ServeParamFactory = (
 const READY_FILE_LEASE_STALE_MS = 60_000;
 const READY_FILE_LEASE_UPDATE_MS = 1_000;
 const MAX_SERVE_CREDENTIALS_BYTES = 64 * 1024;
+const WATCH_SHUTDOWN_GRACE_MS = 250;
+const WATCH_SHUTDOWN_REACHED = Symbol("watch shutdown reached");
 
 const SERVE_CREDENTIAL_ENV = [
   ["accessToken", "CRABLINE_ACCESS_TOKEN"],
@@ -206,6 +208,30 @@ async function writeOutput(stream: NodeJS.WriteStream, value: string): Promise<b
 
 async function print(value: string): Promise<boolean> {
   return await writeOutput(process.stdout, `${value}\n`);
+}
+
+async function withWatchShutdownDeadline<T>(
+  operation: PromiseLike<T>,
+  operationName: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(
+        new CrablineError(
+          `Provider ${operationName} did not settle within ${WATCH_SHUTDOWN_GRACE_MS}ms during watch shutdown.`,
+          { kind: "timeout" },
+        ),
+      );
+    }, WATCH_SHUTDOWN_GRACE_MS);
+  });
+  try {
+    return await Promise.race([Promise.resolve(operation), deadline]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
 }
 
 async function withManifest<T>(
@@ -465,9 +491,13 @@ export function createProgram(
           | undefined;
         const stopWatch = onceAsync(async () => {
           controller.abort();
-          await iterator?.return?.();
+          const returnResult = iterator?.return?.();
+          if (returnResult) {
+            await withWatchShutdownDeadline(returnResult, "watch iterator return");
+          }
         });
         const shutdown = installShutdownHandler(stopWatch);
+        const shutdownSettled = shutdown.wait().then(() => WATCH_SHUTDOWN_REACHED);
         const lifecycleErrors: unknown[] = [];
         try {
           const watchContext = {
@@ -494,7 +524,10 @@ export function createProgram(
           const watch = provider.watch(watchContext);
           iterator = watch[Symbol.asyncIterator]();
           while (true) {
-            const result = await iterator.next();
+            const result = await Promise.race([iterator.next(), shutdownSettled]);
+            if (typeof result === "symbol") {
+              break;
+            }
             if (result.done) {
               break;
             }
@@ -519,7 +552,10 @@ export function createProgram(
           }
         }
         try {
-          await provider.cleanup?.();
+          const cleanup = provider.cleanup?.();
+          if (cleanup) {
+            await withWatchShutdownDeadline(cleanup, "cleanup");
+          }
         } catch (error) {
           if (!lifecycleErrors.includes(error)) {
             lifecycleErrors.push(error);

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -51,6 +51,11 @@ type ProgramDependencies = {
   startServer?: (params: StartCrablineServerParams) => Promise<StartedCrablineServer>;
 };
 
+type RunCliOptions = {
+  dependencies?: ProgramDependencies;
+  forceExit?: (code: number) => never;
+};
+
 type ServeSharedOptions = {
   host: string;
   port: number;
@@ -210,6 +215,8 @@ async function print(value: string): Promise<boolean> {
   return await writeOutput(process.stdout, `${value}\n`);
 }
 
+class WatchShutdownDeadlineError extends CrablineError {}
+
 async function withWatchShutdownDeadline<T>(
   operation: PromiseLike<T>,
   operationName: string,
@@ -218,7 +225,7 @@ async function withWatchShutdownDeadline<T>(
   const deadline = new Promise<never>((_, reject) => {
     timer = setTimeout(() => {
       reject(
-        new CrablineError(
+        new WatchShutdownDeadlineError(
           `Provider ${operationName} did not settle within ${WATCH_SHUTDOWN_GRACE_MS}ms during watch shutdown.`,
           { kind: "timeout" },
         ),
@@ -232,6 +239,20 @@ async function withWatchShutdownDeadline<T>(
       clearTimeout(timer);
     }
   }
+}
+
+function containsWatchShutdownDeadline(error: unknown, seen = new Set<object>()): boolean {
+  if (error instanceof WatchShutdownDeadlineError) {
+    return true;
+  }
+  if (!error || typeof error !== "object" || seen.has(error)) {
+    return false;
+  }
+  seen.add(error);
+  if (error instanceof AggregateError) {
+    return error.errors.some((entry) => containsWatchShutdownDeadline(entry, seen));
+  }
+  return "cause" in error && containsWatchShutdownDeadline(error.cause, seen);
 }
 
 async function withManifest<T>(
@@ -1255,11 +1276,11 @@ function diagnose(manifest: Awaited<ReturnType<typeof loadManifest>>["manifest"]
   return findings;
 }
 
-export async function runCli(argv: string[]): Promise<number> {
+export async function runCli(argv: string[], options: RunCliOptions = {}): Promise<number> {
   let exitCode = 0;
   const program = createProgram((code) => {
     exitCode = code;
-  });
+  }, options.dependencies);
   const parserErrors: string[] = [];
   const parserOutput: string[] = [];
   const bufferParserErrors = (command: Command): void => {
@@ -1310,6 +1331,9 @@ export async function runCli(argv: string[]): Promise<number> {
       await writeOutput(process.stderr, parserErrors.join(""));
     } else {
       await writeOutput(process.stderr, `${ensureErrorMessage(error)}\n`);
+    }
+    if (options.forceExit && containsWatchShutdownDeadline(error)) {
+      options.forceExit(errorExitCode);
     }
     return errorExitCode;
   }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -62,6 +62,24 @@ export const PROVIDER_PLATFORMS = [
 
 type BuiltinAdapterName = (typeof BUILTIN_ADAPTERS)[number];
 type ProviderPlatformName = (typeof PROVIDER_PLATFORMS)[number];
+type FixtureModeConstraintInput = {
+  inboundMatch: {
+    pattern?: string | undefined;
+    strategy: (typeof INBOUND_STRATEGIES)[number];
+  };
+  mode: (typeof FIXTURE_MODES)[number];
+};
+
+export function fixtureModeValidationError(value: FixtureModeConstraintInput): string | undefined {
+  if (
+    value.mode === "agent" &&
+    value.inboundMatch.strategy === "exact" &&
+    value.inboundMatch.pattern
+  ) {
+    return "agent mode cannot use inboundMatch.strategy=exact with a static pattern because replies must include the generated ACK nonce";
+  }
+  return undefined;
+}
 
 const HttpUrlSchema = z
   .string()
@@ -706,23 +724,34 @@ export const ProviderConfigSchema = z
     platform: value.platform ?? inferProviderPlatform(value.adapter) ?? "loopback",
   }));
 
-export const FixtureSchema = z.strictObject({
-  accountId: z.string().min(1).optional(),
-  env: z.array(z.string().min(1)).default([]),
-  id: z.string().min(1).refine(isValidNonceFixtureId, NONCE_FIXTURE_ID_ERROR),
-  inboundMatch: InboundMatchSchema.default({
-    author: "assistant",
-    nonce: "contains",
-    strategy: "contains",
-  }),
-  mode: z.enum(FIXTURE_MODES),
-  notes: z.string().optional(),
-  provider: z.string().min(1),
-  retries: z.number().int().min(0).max(MAX_FIXTURE_RETRIES).default(0),
-  tags: z.array(z.string().min(1)).default([]),
-  target: TargetSchema,
-  timeoutMs: TimerMsSchema.min(100).default(30_000),
-});
+export const FixtureSchema = z
+  .strictObject({
+    accountId: z.string().min(1).optional(),
+    env: z.array(z.string().min(1)).default([]),
+    id: z.string().min(1).refine(isValidNonceFixtureId, NONCE_FIXTURE_ID_ERROR),
+    inboundMatch: InboundMatchSchema.default({
+      author: "assistant",
+      nonce: "contains",
+      strategy: "contains",
+    }),
+    mode: z.enum(FIXTURE_MODES),
+    notes: z.string().optional(),
+    provider: z.string().min(1),
+    retries: z.number().int().min(0).max(MAX_FIXTURE_RETRIES).default(0),
+    tags: z.array(z.string().min(1)).default([]),
+    target: TargetSchema,
+    timeoutMs: TimerMsSchema.min(100).default(30_000),
+  })
+  .superRefine((value, ctx) => {
+    const validationError = fixtureModeValidationError(value);
+    if (validationError) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: validationError,
+        path: ["inboundMatch", "strategy"],
+      });
+    }
+  });
 
 const MANIFEST_EXTENSION_KEY_PATTERN = /^x-[a-z0-9][a-z0-9._-]*$/u;
 

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -5,7 +5,7 @@ import { createNonce } from "./nonces.js";
 import { compileInboundRegex } from "./safe-regex.js";
 import { type FailureKind, CrablineError, ensureErrorMessage } from "./errors.js";
 import { EXIT_CODES, type ExitCode } from "./exit-codes.js";
-import type { ManifestDefinition } from "../config/schema.js";
+import { fixtureModeValidationError, type ManifestDefinition } from "../config/schema.js";
 import type { Registry } from "../providers/registry.js";
 
 export type CommandRunResult = {
@@ -285,6 +285,18 @@ export async function runFixtureCommand(params: {
   const mode = params.modeOverride ?? configuredFixture.mode;
   const fixture =
     mode === configuredFixture.mode ? configuredFixture : { ...configuredFixture, mode };
+  const validationError = fixtureModeValidationError(fixture);
+  if (validationError) {
+    return toFailure(
+      configuredFixture.id,
+      configuredFixture.provider,
+      mode,
+      new CrablineError(`Invalid effective fixture "${configuredFixture.id}": ${validationError}`, {
+        kind: "config",
+      }),
+      "config",
+    );
+  }
   const provider = params.registry.resolve(fixture.provider, fixture.id);
   const diagnostics: string[] = [];
   let abortDrainFailed = false;
@@ -420,6 +432,9 @@ export async function runFixtureCommand(params: {
             if (error instanceof UnsettledProviderOperationError) {
               abortDrainFailed = true;
               unsettledProviderOperations.push(error.operation);
+              break;
+            }
+            if (lastFailure.failureKind === "auth" || lastFailure.failureKind === "config") {
               break;
             }
             continue;

--- a/test/cli-shutdown-subprocess.test.ts
+++ b/test/cli-shutdown-subprocess.test.ts
@@ -1,0 +1,114 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createTempDir, disposeTempDir, writeText } from "./test-helpers.js";
+
+const directories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(directories.splice(0).map(disposeTempDir));
+});
+
+describe.skipIf(process.platform === "win32")("CLI shutdown subprocess", () => {
+  it("forces exit after a watch shutdown deadline with a ref'd handle", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const configPath = path.join(directory, "crabline.yaml");
+    await writeText(
+      configPath,
+      [
+        "configVersion: 1",
+        "providers:",
+        "  local:",
+        "    adapter: loopback",
+        "fixtures:",
+        "  - id: watched",
+        "    provider: local",
+        "    mode: agent",
+        "    target:",
+        "      id: echo-bot",
+      ].join("\n"),
+    );
+
+    const programUrl = new URL("../src/cli/program.ts", import.meta.url).href;
+    const script = `
+      import { runCli } from ${JSON.stringify(programUrl)};
+      setInterval(() => undefined, 1_000);
+      let announced = false;
+      const pending = () => new Promise(() => undefined);
+      const iterator = {
+        next() {
+          if (!announced) {
+            announced = true;
+            process.stdout.write("ready\\n");
+          }
+          return pending();
+        },
+        return: pending,
+      };
+      const provider = {
+        cleanup: pending,
+        watch() {
+          return {
+            [Symbol.asyncIterator]() {
+              return iterator;
+            },
+          };
+        },
+      };
+      const exitCode = await runCli(
+        ["node", "crabline", "--config", ${JSON.stringify(configPath)}, "watch", "watched"],
+        {
+          dependencies: {
+            createRegistry: () => ({
+              resolve: () => provider,
+            }),
+          },
+          forceExit: (code) => process.exit(code),
+        },
+      );
+      process.exitCode = exitCode;
+    `;
+    const child = spawn(
+      process.execPath,
+      ["--import", "tsx", "--input-type=module", "--eval", script],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+
+    let exitTimeout: NodeJS.Timeout | undefined;
+    try {
+      await expect.poll(() => stdout, { interval: 10, timeout: 2_000 }).toContain("ready\n");
+      child.kill("SIGTERM");
+      const [code, signal] = (await Promise.race([
+        once(child, "exit"),
+        new Promise<never>((_, reject) => {
+          exitTimeout = setTimeout(
+            () => reject(new Error("CLI did not exit after shutdown deadline")),
+            2_000,
+          );
+        }),
+      ])) as [number | null, NodeJS.Signals | null];
+
+      expect(signal).toBeNull();
+      expect(code).toBe(1);
+      expect(stderr).toContain("Crabline watch lifecycle failed.");
+    } finally {
+      clearTimeout(exitTimeout);
+      if (child.exitCode === null && child.signalCode === null) {
+        child.kill("SIGKILL");
+        await once(child, "exit");
+      }
+    }
+  });
+});

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1347,6 +1347,78 @@ describe("cli", () => {
     expect(process.listenerCount("SIGTERM")).toBe(baseline);
   });
 
+  it("bounds iterator return and provider cleanup during watch shutdown", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const configPath = path.join(directory, "crabline.yaml");
+    await writeText(
+      configPath,
+      [
+        "configVersion: 1",
+        "providers:",
+        "  local:",
+        "    adapter: loopback",
+        "fixtures:",
+        "  - id: watched",
+        "    provider: local",
+        "    mode: agent",
+        "    target:",
+        "      id: echo-bot",
+      ].join("\n"),
+    );
+    const iterator = {
+      next: vi.fn(async () => await new Promise<never>(() => undefined)),
+      return: vi.fn(async () => await new Promise<never>(() => undefined)),
+    };
+    const cleanup = vi.fn(async () => await new Promise<never>(() => undefined));
+    const provider = {
+      cleanup,
+      watch() {
+        return {
+          [Symbol.asyncIterator]() {
+            return iterator;
+          },
+        };
+      },
+    };
+    const program = createProgram(() => undefined, {
+      createRegistry: () =>
+        ({
+          resolve: () => provider,
+        }) as never,
+    });
+    const baseline = process.listenerCount("SIGTERM");
+    const running = program
+      .parseAsync(["node", "crabline", "--config", configPath, "watch", "watched"])
+      .catch((error: unknown) => error);
+    await vi.waitFor(() => {
+      expect(iterator.next).toHaveBeenCalledTimes(1);
+      expect(process.listenerCount("SIGTERM")).toBeGreaterThan(baseline);
+    });
+
+    process.emit("SIGTERM", "SIGTERM");
+    let hangTimer: ReturnType<typeof setTimeout> | undefined;
+    const hung = new Promise<"hung">((resolve) => {
+      hangTimer = setTimeout(() => resolve("hung"), 2_000);
+    });
+    const failure = await Promise.race([running, hung]);
+    clearTimeout(hangTimer);
+
+    expect(failure).toBeInstanceOf(AggregateError);
+    expect((failure as AggregateError).errors).toEqual([
+      expect.objectContaining({
+        message:
+          "Provider watch iterator return did not settle within 250ms during watch shutdown.",
+      }),
+      expect.objectContaining({
+        message: "Provider cleanup did not settle within 250ms during watch shutdown.",
+      }),
+    ]);
+    expect(iterator.return).toHaveBeenCalledTimes(1);
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(process.listenerCount("SIGTERM")).toBe(baseline);
+  });
+
   it("waits for stdout backpressure while watching", async () => {
     const directory = await createTempDir();
     directories.push(directory);

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -122,6 +122,28 @@ describe("manifest schema", () => {
     ).toThrow(/strategy=exact requires inboundMatch\.nonce=ignore/u);
   });
 
+  it("rejects exact static patterns for agent acknowledgements", () => {
+    expect(() =>
+      ManifestSchema.parse({
+        configVersion: 1,
+        fixtures: [
+          {
+            id: "impossible-agent-exact",
+            inboundMatch: {
+              nonce: "ignore",
+              pattern: "ACK",
+              strategy: "exact",
+            },
+            mode: "agent",
+            provider: "local",
+            target: { id: "agent-bot" },
+          },
+        ],
+        providers: { local: { adapter: "loopback" } },
+      }),
+    ).toThrow(/agent mode cannot use inboundMatch\.strategy=exact/u);
+  });
+
   it("accepts only HTTP(S) provider endpoint URLs", () => {
     for (const apiUrl of [
       "data:text/plain,hello",

--- a/test/run.behavior.test.ts
+++ b/test/run.behavior.test.ts
@@ -386,6 +386,41 @@ describe("run behavior", () => {
     expect(outboundText).toContain("crabline agent fixture");
   });
 
+  it("validates mode overrides before resolving or sending with the effective fixture", async () => {
+    const resolve = vi.fn();
+    const exactManifest = withAllCapabilities({
+      ...manifest,
+      fixtures: [
+        {
+          ...manifest.fixtures[0]!,
+          inboundMatch: {
+            author: "assistant",
+            nonce: "ignore",
+            pattern: "ACK",
+            strategy: "exact",
+          },
+        },
+      ],
+    });
+
+    const result = await runFixtureCommand({
+      fixtureId: "fixture",
+      manifest: exactManifest,
+      manifestPath: "/tmp/crabline.yaml",
+      modeOverride: "agent",
+      registry: {
+        catalog: OPENCLAW_SUPPORT_CATALOG,
+        resolve,
+      },
+    });
+
+    expect(result).toMatchObject({ failureKind: "config", mode: "agent", ok: false });
+    expect(result.diagnostics.join("\n")).toContain(
+      "agent mode cannot use inboundMatch.strategy=exact",
+    );
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
   it("requires an exact ACK and canonical nonce for agent replies", async () => {
     let waitCalls = 0;
     const provider: ProviderAdapter = {
@@ -628,6 +663,45 @@ describe("run behavior", () => {
     expect(computeExitCode(wait)).toBe(EXIT_CODES.INBOUND);
     expect(wait.diagnostics).toEqual(["accepted message sent", "wait exploded"]);
   });
+
+  it.each(["auth", "config"] as const)(
+    "does not retry permanent %s send failures",
+    async (failureKind) => {
+      let sendCalls = 0;
+      const provider: ProviderAdapter = {
+        id: "mock",
+        platform: "loopback",
+        status: "ready",
+        supports: ["roundtrip"],
+        normalizeTarget(target) {
+          return { id: target.id, metadata: target.metadata };
+        },
+        probe: async () => ({ details: [], healthy: true }),
+        send: async () => {
+          sendCalls += 1;
+          throw new CrablineError(`permanent ${failureKind} failure`, { kind: failureKind });
+        },
+        waitForInbound: async () => {
+          throw new Error("wait must not run");
+        },
+      };
+      const retryingManifest = withAllCapabilities({
+        ...manifest,
+        fixtures: [{ ...manifest.fixtures[0]!, retries: 3 }],
+      });
+
+      const result = await runFixtureCommand({
+        fixtureId: "fixture",
+        manifest: retryingManifest,
+        manifestPath: "/tmp/crabline.yaml",
+        registry: buildRegistry(provider),
+      });
+
+      expect(result).toMatchObject({ failureKind, ok: false });
+      expect(result.diagnostics).toContain(`permanent ${failureKind} failure`);
+      expect(sendCalls).toBe(1);
+    },
+  );
 
   it("retries rejected outbound results and fails when rejection persists", async () => {
     let sendCalls = 0;


### PR DESCRIPTION
## Summary
- stop retries for permanent provider authentication and configuration failures
- validate effective agent-mode overrides, including exact nonce contracts
- bound watch iterator and provider cleanup during shutdown
- document the operational changes in the changelog

## Validation
- `pnpm test` (1,274 tests)
- `pnpm lint`
- `pnpm build`
- focused Codex autoreview, clean

## Follow-up gate
- Crabbox `pnpm verify` on the exact PR head