### PR TITLE
fix(auth): harden JWT and Teams failure semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Treat Unicode format characters as continuations when recognizing standalone acknowledgement tokens.
 - Stream webhook responses with backpressure and cancel unfinished bodies when clients disconnect.
 - Keep timed-out signed-JWT key loads single-flighted during a bounded cooldown, fence late generations, and reject malformed or oversized remote key sets.
+- Distinguish Microsoft Teams signing-service failures from invalid bearer tokens and preserve invoke response status semantics.
 - Preserve committed provider recorder errors during final identity confirmation and strictly parse quoted JWT cache lifetimes.
 - Lint repository tooling in the type-aware verification gate.
 - Preserve WhatsApp acknowledgement races without stale pending state or false deduplication.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Suppress serve readiness output when shutdown begins during ready-file publication.
 - Treat Unicode format characters as continuations when recognizing standalone acknowledgement tokens.
 - Stream webhook responses with backpressure and cancel unfinished bodies when clients disconnect.
-- Keep timed-out signed-JWT key loads single-flighted until their underlying loaders settle.
+- Keep timed-out signed-JWT key loads single-flighted during a bounded cooldown, fence late generations, and reject malformed or oversized remote key sets.
 - Preserve committed provider recorder errors during final identity confirmation and strictly parse quoted JWT cache lifetimes.
 - Lint repository tooling in the type-aware verification gate.
 - Preserve WhatsApp acknowledgement races without stale pending state or false deduplication.

--- a/src/providers/builtin/msteams.ts
+++ b/src/providers/builtin/msteams.ts
@@ -6,6 +6,7 @@ import { LocalMockProviderAdapter } from "../local-mock.js";
 import type { ProviderAdapter } from "../types.js";
 import {
   createCachedJwtKeyResolver,
+  JwtKeyInfrastructureError,
   readBearerToken,
   resolveHttpCacheExpiry,
   verifySignedJwt,
@@ -62,33 +63,42 @@ export function createMsTeamsWebhookAuthenticator(
   const fetchImpl = runtime.fetch ?? fetch;
   const resolveSigningKey = createCachedJwtKeyResolver<BotConnectorKey>({
     async fetchKeys(signal) {
-      const fetchedAt = runtime.now?.() ?? Date.now();
-      const metadataResponse = await fetchImpl(BOT_CONNECTOR_OPENID_URL, { signal });
-      if (!metadataResponse.ok) {
-        throw new Error(
-          `Bot Connector metadata fetch failed with HTTP ${metadataResponse.status}.`,
-        );
+      try {
+        const fetchedAt = runtime.now?.() ?? Date.now();
+        const metadataResponse = await fetchImpl(BOT_CONNECTOR_OPENID_URL, { signal });
+        if (!metadataResponse.ok) {
+          throw new Error(
+            `Bot Connector metadata fetch failed with HTTP ${metadataResponse.status}.`,
+          );
+        }
+        const metadataExpiry = resolveHttpCacheExpiry(metadataResponse, fetchedAt);
+        const metadata = (await metadataResponse.json()) as { jwks_uri?: unknown };
+        if (typeof metadata.jwks_uri !== "string") {
+          throw new Error("Bot Connector metadata omitted jwks_uri.");
+        }
+        const keysResponse = await fetchImpl(metadata.jwks_uri, { signal });
+        if (!keysResponse.ok) {
+          throw new Error(`Bot Connector key fetch failed with HTTP ${keysResponse.status}.`);
+        }
+        const keyExpiry = resolveHttpCacheExpiry(keysResponse, fetchedAt);
+        const keys = (await keysResponse.json()) as { keys?: unknown };
+        if (!Array.isArray(keys.keys)) {
+          throw new Error("Bot Connector key response omitted keys.");
+        }
+        return {
+          expiresAt: Math.min(metadataExpiry, keyExpiry),
+          values: keys.keys as BotConnectorKey[],
+        };
+      } catch (error) {
+        throw error instanceof JwtKeyInfrastructureError
+          ? error
+          : new JwtKeyInfrastructureError(
+              error instanceof Error ? error.message : "Bot Connector key fetch failed.",
+              { cause: error },
+            );
       }
-      const metadataExpiry = resolveHttpCacheExpiry(metadataResponse, fetchedAt);
-      const metadata = (await metadataResponse.json()) as { jwks_uri?: unknown };
-      if (typeof metadata.jwks_uri !== "string") {
-        throw new Error("Bot Connector metadata omitted jwks_uri.");
-      }
-      const keysResponse = await fetchImpl(metadata.jwks_uri, { signal });
-      if (!keysResponse.ok) {
-        throw new Error(`Bot Connector key fetch failed with HTTP ${keysResponse.status}.`);
-      }
-      const keyExpiry = resolveHttpCacheExpiry(keysResponse, fetchedAt);
-      const keys = (await keysResponse.json()) as { keys?: unknown };
-      if (!Array.isArray(keys.keys)) {
-        throw new Error("Bot Connector key response omitted keys.");
-      }
-      return {
-        expiresAt: Math.min(metadataExpiry, keyExpiry),
-        values: keys.keys as BotConnectorKey[],
-      };
     },
-    keyId: (value) => value.kid,
+    keyId: (value) => (isRecord(value) && typeof value.kid === "string" ? value.kid : undefined),
     now: runtime.now,
     refreshCooldownMs: runtime.unknownKeyCooldownMs,
     timeoutMs: runtime.keyFetchTimeoutMs,
@@ -97,10 +107,7 @@ export function createMsTeamsWebhookAuthenticator(
   return async (request: Request, rawBody: string): Promise<Response | undefined> => {
     const token = readBearerToken(request);
     if (!token) {
-      return new Response("unauthorized", {
-        headers: { "www-authenticate": "Bearer" },
-        status: 401,
-      });
+      return botConnectorAuthenticationResponse(401);
     }
     try {
       const payload: unknown = JSON.parse(rawBody);
@@ -121,7 +128,13 @@ export function createMsTeamsWebhookAuthenticator(
           if (key.endorsements && !key.endorsements.includes(channelId)) {
             throw new Error("Bot Connector JWT key does not endorse the activity channel.");
           }
-          return createPublicKey({ format: "jwk", key });
+          try {
+            return createPublicKey({ format: "jwk", key });
+          } catch (error) {
+            throw new JwtKeyInfrastructureError("Bot Connector JWT signing key is invalid.", {
+              cause: error,
+            });
+          }
         },
         token,
       });
@@ -129,13 +142,22 @@ export function createMsTeamsWebhookAuthenticator(
         throw new Error("Bot Connector serviceurl claim does not match the activity.");
       }
       return undefined;
-    } catch {
-      return new Response("unauthorized", {
-        headers: { "www-authenticate": "Bearer" },
-        status: 401,
-      });
+    } catch (error) {
+      return botConnectorAuthenticationResponse(
+        error instanceof JwtKeyInfrastructureError ? 503 : 401,
+      );
     }
   };
+}
+
+function botConnectorAuthenticationResponse(status: 401 | 503): Response {
+  return new Response(status === 401 ? "unauthorized" : "service unavailable", {
+    headers: {
+      "cache-control": "no-store",
+      ...(status === 401 ? { "www-authenticate": "Bearer" } : {}),
+    },
+    status,
+  });
 }
 
 export class MsTeamsProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
@@ -226,6 +248,9 @@ export function normalizeMsTeamsWebhookPayload(payload: unknown) {
 }
 
 export function handleMsTeamsWebhookPayload(payload: unknown): Response | undefined {
+  if (isRecord(payload) && payload.type === "invoke") {
+    return new Response(null, { status: 501 });
+  }
   if (
     isRecord(payload) &&
     typeof payload.type === "string" &&

--- a/src/providers/signed-jwt.ts
+++ b/src/providers/signed-jwt.ts
@@ -12,10 +12,18 @@ export type RemoteJwtKeySet<T> = {
   values: readonly T[];
 };
 
+export class JwtKeyInfrastructureError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "JwtKeyInfrastructureError";
+  }
+}
+
 const DEFAULT_KEY_FETCH_TIMEOUT_MS = 5_000;
 const DEFAULT_UNKNOWN_KEY_COOLDOWN_MS = 30_000;
 const MAX_HTTP_CACHE_AGE_SECONDS = 24 * 60 * 60;
 const MAX_NEGATIVE_KEY_IDS = 128;
+const MAX_REMOTE_KEY_SET_SIZE = 128;
 const UTF8_DECODER = new TextDecoder("utf-8", { fatal: true });
 
 function decodeBase64UrlPart(value: string, label: string): Buffer {
@@ -148,6 +156,40 @@ export function resolveHttpCacheExpiry(response: Response, now: number): number 
     : now;
 }
 
+function validateRemoteJwtKeySet<T>(
+  keySet: RemoteJwtKeySet<T>,
+  keyId: (value: T) => string | undefined,
+): { keyIds: readonly string[]; keySet: RemoteJwtKeySet<T> } {
+  if (!Number.isFinite(keySet.expiresAt)) {
+    throw new JwtKeyInfrastructureError("JWT signing key set expiry is invalid.");
+  }
+  if (!Array.isArray(keySet.values)) {
+    throw new JwtKeyInfrastructureError("JWT signing key set values must be an array.");
+  }
+  if (keySet.values.length > MAX_REMOTE_KEY_SET_SIZE) {
+    throw new JwtKeyInfrastructureError(
+      `JWT signing key set exceeds the ${MAX_REMOTE_KEY_SET_SIZE}-key limit.`,
+    );
+  }
+  const keyIds = new Set<string>();
+  for (const value of keySet.values) {
+    let candidateKeyId: string | undefined;
+    try {
+      candidateKeyId = keyId(value);
+    } catch (error) {
+      throw new JwtKeyInfrastructureError("JWT signing key id is invalid.", { cause: error });
+    }
+    if (typeof candidateKeyId !== "string" || candidateKeyId.length === 0) {
+      throw new JwtKeyInfrastructureError("JWT signing key id is invalid.");
+    }
+    if (keyIds.has(candidateKeyId)) {
+      throw new JwtKeyInfrastructureError("JWT signing key ids must be unique.");
+    }
+    keyIds.add(candidateKeyId);
+  }
+  return { keyIds: [...keyIds], keySet };
+}
+
 export function createCachedJwtKeyResolver<T>(params: {
   fetchKeys(signal: AbortSignal): Promise<RemoteJwtKeySet<T>>;
   keyId(value: T): string | undefined;
@@ -163,9 +205,12 @@ export function createCachedJwtKeyResolver<T>(params: {
   let fetchInFlight:
     | {
         controller: AbortController;
+        generation: number;
         promise: Promise<RemoteJwtKeySet<T>>;
+        retryAt: number | undefined;
       }
     | undefined;
+  let fetchGeneration = 0;
   let refreshInFlight: Promise<RemoteJwtKeySet<T>> | undefined;
   let refreshCooldownUntil = 0;
   let fetchFailureCooldownUntil = 0;
@@ -190,39 +235,52 @@ export function createCachedJwtKeyResolver<T>(params: {
 
   const fetchKeys = async (): Promise<RemoteJwtKeySet<T>> => {
     let inFlight = fetchInFlight;
+    const currentTime = now();
+    if (inFlight?.retryAt !== undefined && inFlight.retryAt <= currentTime) {
+      if (fetchInFlight?.generation === inFlight.generation) {
+        fetchInFlight = undefined;
+      }
+      inFlight = undefined;
+    }
     if (!inFlight) {
-      if (fetchFailureCooldownUntil > now()) {
+      if (fetchFailureCooldownUntil > currentTime) {
         throw fetchFailureError;
       }
       const controller = new AbortController();
+      const generation = ++fetchGeneration;
       let keyFetch!: Promise<RemoteJwtKeySet<T>>;
       keyFetch = Promise.resolve()
         .then(() => params.fetchKeys(controller.signal))
+        .then((keySet) => validateRemoteJwtKeySet(keySet, params.keyId))
         .then(
-          (keySet) => {
+          ({ keyIds, keySet }) => {
+            if (fetchInFlight?.generation !== generation) {
+              throw new JwtKeyInfrastructureError(
+                "JWT signing key fetch completed after its generation expired.",
+              );
+            }
             cached = keySet.expiresAt > now() ? keySet : undefined;
             fetchFailureCooldownUntil = 0;
             fetchFailureError = undefined;
-            for (const value of keySet.values) {
-              const keyId = params.keyId(value);
-              if (keyId) {
-                negativeKeyIds.delete(keyId);
-              }
+            for (const keyId of keyIds) {
+              negativeKeyIds.delete(keyId);
             }
             return keySet;
           },
           (error: unknown) => {
-            fetchFailureCooldownUntil = now() + refreshCooldownMs;
-            fetchFailureError = error;
+            if (fetchInFlight?.generation === generation) {
+              fetchFailureCooldownUntil = now() + refreshCooldownMs;
+              fetchFailureError = error;
+            }
             throw error;
           },
         )
         .finally(() => {
-          if (fetchInFlight?.promise === keyFetch) {
+          if (fetchInFlight?.generation === generation) {
             fetchInFlight = undefined;
           }
         });
-      inFlight = { controller, promise: keyFetch };
+      inFlight = { controller, generation, promise: keyFetch, retryAt: undefined };
       fetchInFlight = inFlight;
       void keyFetch.catch(() => {});
     }
@@ -231,7 +289,13 @@ export function createCachedJwtKeyResolver<T>(params: {
     const timedOut = new Promise<never>((_, reject) => {
       timeout = setTimeout(() => {
         inFlight.controller.abort();
-        reject(new Error("JWT signing key fetch timed out."));
+        const timeoutError = new JwtKeyInfrastructureError("JWT signing key fetch timed out.");
+        inFlight.retryAt ??= now() + refreshCooldownMs;
+        if (fetchInFlight?.generation === inFlight.generation) {
+          fetchFailureCooldownUntil = inFlight.retryAt;
+          fetchFailureError = timeoutError;
+        }
+        reject(timeoutError);
       }, timeoutMs);
     });
     try {

--- a/test/msteams-provider.test.ts
+++ b/test/msteams-provider.test.ts
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 import {
   createMsTeamsWebhookAuthenticator,
+  handleMsTeamsWebhookPayload,
   MsTeamsProviderAdapter,
   normalizeMsTeamsWebhookPayload,
 } from "../src/providers/builtin/msteams.js";
@@ -13,6 +14,12 @@ import {
 } from "./local-mock-provider-helpers.js";
 
 const conversationId = "a:opaque-conversation-id";
+
+function jwtForKeyLookup(claims: Record<string, unknown>, kid = "test-key"): string {
+  const header = Buffer.from(JSON.stringify({ alg: "RS256", kid })).toString("base64url");
+  const payload = Buffer.from(JSON.stringify(claims)).toString("base64url");
+  return `${header}.${payload}.AA`;
+}
 
 function endpointFromDetails(details: string[]): string {
   const detail = details.find((entry) => entry.includes("http://"));
@@ -44,6 +51,19 @@ describe("Microsoft Teams webhook authentication", () => {
         type: "message",
       }),
     ).toThrow(/channelId=msteams/u);
+  });
+
+  it("returns the Bot Framework unsupported status for invoke activities", async () => {
+    const response = handleMsTeamsWebhookPayload({
+      channelId: "msteams",
+      name: "task/fetch",
+      type: "invoke",
+      value: {},
+    });
+
+    expect(response?.status).toBe(501);
+    await expect(response?.text()).resolves.toBe("");
+    expect(handleMsTeamsWebhookPayload({ type: "conversationUpdate" })?.status).toBe(200);
   });
 
   it("requires Bot Connector auth for externally reachable webhooks", async () => {
@@ -236,6 +256,76 @@ describe("Microsoft Teams webhook authentication", () => {
         body,
       ),
     ).resolves.toMatchObject({ status: 401 });
+  });
+
+  it("distinguishes Bot Connector signing infrastructure failures from invalid credentials", async () => {
+    const config = await createLocalMockConfig("msteams", "/msteams/webhook");
+    config.msteams!.appId = "teams-app-id";
+    const now = Date.now();
+    let fetches = 0;
+    const authenticate = createMsTeamsWebhookAuthenticator(config, {
+      fetch: async () => {
+        fetches += 1;
+        throw new Error("JWKS unavailable");
+      },
+      now: () => now,
+    });
+    const body = JSON.stringify({
+      channelId: "msteams",
+      serviceUrl: "https://smba.trafficmanager.net/emea/",
+      type: "message",
+    });
+    const signedRequest = jwtForKeyLookup({
+      aud: "teams-app-id",
+      exp: Math.floor(now / 1000) + 60,
+      iss: "https://api.botframework.com",
+      serviceurl: "https://smba.trafficmanager.net/emea/",
+    });
+    const request = () =>
+      new Request("https://bot.example.test/msteams/webhook", {
+        headers: { authorization: `Bearer ${signedRequest}` },
+      });
+
+    const first = await authenticate!(request(), body);
+    expect(first?.status).toBe(503);
+    expect(first?.headers.get("cache-control")).toBe("no-store");
+    expect(first?.headers.get("www-authenticate")).toBeNull();
+    await expect(first?.text()).resolves.toBe("service unavailable");
+
+    await expect(authenticate!(request(), body)).resolves.toMatchObject({ status: 503 });
+    expect(fetches).toBe(1);
+    await expect(
+      authenticate!(new Request("https://bot.example.test/msteams/webhook"), body),
+    ).resolves.toMatchObject({ status: 401 });
+  });
+
+  it("treats malformed Bot Connector key material as an infrastructure failure", async () => {
+    const config = await createLocalMockConfig("msteams", "/msteams/webhook");
+    config.msteams!.appId = "teams-app-id";
+    const now = Date.now();
+    const authenticate = createMsTeamsWebhookAuthenticator(config, {
+      fetch: async (input: string | URL | Request) =>
+        String(input).includes("openidconfiguration")
+          ? Response.json({ jwks_uri: "https://login.example.test/keys" })
+          : Response.json({ keys: [{ kty: "RSA" }] }),
+      now: () => now,
+    });
+    const serviceUrl = "https://smba.trafficmanager.net/emea/";
+    const signedRequest = jwtForKeyLookup({
+      aud: "teams-app-id",
+      exp: Math.floor(now / 1000) + 60,
+      iss: "https://api.botframework.com",
+      serviceurl: serviceUrl,
+    });
+
+    await expect(
+      authenticate!(
+        new Request("https://bot.example.test/msteams/webhook", {
+          headers: { authorization: `Bearer ${signedRequest}` },
+        }),
+        JSON.stringify({ channelId: "msteams", serviceUrl, type: "message" }),
+      ),
+    ).resolves.toMatchObject({ status: 503 });
   });
 
   it("acknowledges authenticated non-message activities without recording them", async () => {

--- a/test/signed-jwt.test.ts
+++ b/test/signed-jwt.test.ts
@@ -2,6 +2,7 @@ import { generateKeyPairSync, sign } from "node:crypto";
 import { describe, expect, it, vi } from "vitest";
 import {
   createCachedJwtKeyResolver,
+  JwtKeyInfrastructureError,
   resolveHttpCacheExpiry,
   verifySignedJwt,
 } from "../src/providers/signed-jwt.js";
@@ -474,6 +475,108 @@ describe("signed JWT remote key cache", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("replaces a permanently pending generation after cooldown and fences its late result", async () => {
+    vi.useFakeTimers();
+    try {
+      type TestKey = { generation: number; kid: string };
+      let now = 1_700_000_000_000;
+      let fetches = 0;
+      const loads: Array<{
+        resolve(keySet: { expiresAt: number; values: TestKey[] }): void;
+      }> = [];
+      const resolveKey = createCachedJwtKeyResolver<TestKey>({
+        fetchKeys: async () => {
+          fetches += 1;
+          return await new Promise((resolve) => {
+            loads.push({ resolve });
+          });
+        },
+        keyId: (value) => value.kid,
+        now: () => now,
+        refreshCooldownMs: 100,
+        timeoutMs: 10,
+        unknownKeyMessage: "unknown key",
+      });
+
+      const first = resolveKey({ alg: "RS256", kid: "known" }).then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+      await vi.advanceTimersByTimeAsync(10);
+      expect(await first).toBeInstanceOf(JwtKeyInfrastructureError);
+      expect(fetches).toBe(1);
+
+      now += 101;
+      const replacement = resolveKey({ alg: "RS256", kid: "known" });
+      await vi.runAllTicks();
+      expect(fetches).toBe(2);
+      loads[1]!.resolve({
+        expiresAt: now + 60_000,
+        values: [{ generation: 2, kid: "known" }],
+      });
+      await expect(replacement).resolves.toMatchObject({ generation: 2 });
+
+      loads[0]!.resolve({
+        expiresAt: now + 120_000,
+        values: [{ generation: 1, kid: "known" }],
+      });
+      await vi.runAllTicks();
+      await expect(resolveKey({ alg: "RS256", kid: "known" })).resolves.toMatchObject({
+        generation: 2,
+      });
+      expect(fetches).toBe(2);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("rejects a key set when any remote key id is invalid before caching valid peers", async () => {
+    let now = 1_700_000_000_000;
+    let fetches = 0;
+    const resolveKey = createCachedJwtKeyResolver<{ kid?: string }>({
+      async fetchKeys() {
+        fetches += 1;
+        return {
+          expiresAt: now + 60_000,
+          values: fetches === 1 ? [{ kid: "known" }, {}] : [{ kid: "known" }],
+        };
+      },
+      keyId: (value) => value.kid,
+      now: () => now,
+      refreshCooldownMs: 100,
+      unknownKeyMessage: "unknown key",
+    });
+
+    await expect(resolveKey({ alg: "RS256", kid: "known" })).rejects.toThrow(
+      JwtKeyInfrastructureError,
+    );
+    await expect(resolveKey({ alg: "RS256", kid: "known" })).rejects.toThrow(/key id is invalid/u);
+    expect(fetches).toBe(1);
+
+    now += 101;
+    await expect(resolveKey({ alg: "RS256", kid: "known" })).resolves.toMatchObject({
+      kid: "known",
+    });
+    expect(fetches).toBe(2);
+  });
+
+  it("rejects oversized remote key sets before positive caching", async () => {
+    const resolveKey = createCachedJwtKeyResolver<string>({
+      async fetchKeys() {
+        return {
+          expiresAt: 1_700_000_060_000,
+          values: Array.from({ length: 129 }, (_, index) => `key-${index}`),
+        };
+      },
+      keyId: (value) => value,
+      now: () => 1_700_000_000_000,
+      unknownKeyMessage: "unknown key",
+    });
+
+    await expect(resolveKey({ alg: "RS256", kid: "key-0" })).rejects.toThrow(/128-key limit/u);
   });
 
   it("backs off failed key fetches", async () => {


### PR DESCRIPTION
## Summary
- bound stalled signed-JWT key generations and validate keysets before caching
- preserve Teams authentication infrastructure failures instead of flattening them to 401
- align invoke response status/body behavior with the supported Bot Framework contract

## Validation
- 39 focused tests
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- exact-base `gpt-5.6-sol` high autoreview: clean

## Changelog
- added under Unreleased