### PR TITLE
fix(providers): harden chat adapter fidelity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Validate effective fixture mode overrides and stop retrying permanent provider send failures.
 - Bound watch iterator return and provider cleanup during CLI shutdown, forcing process exit after deadline failures.
 - Correct provider-native channel target examples, admin-ingress setup, and contract maintenance coverage.
+- Preserve native Slack rich text and block fallbacks, isolate Feishu replay identities, ignore non-message Google Chat interactions, and fail closed on invalid Zalo adapter inputs.
 - Randomize WhatsApp XEdDSA signatures with fresh entropy while preserving their wire encoding.
 - Suppress serve readiness output when shutdown begins during ready-file publication.
 - Treat Unicode format characters as continuations when recognizing standalone acknowledgement tokens.

--- a/src/openclaw/bridges/slack.ts
+++ b/src/openclaw/bridges/slack.ts
@@ -82,6 +82,48 @@ function structuredSlackValues(value: unknown): unknown[] {
   }
 }
 
+function slackInlineText(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value.map(slackInlineText).join("");
+  }
+  if (!isRecord(value)) {
+    return "";
+  }
+  if (value.type === "link" && typeof value.url === "string") {
+    return typeof value.text === "string" && value.text.length > 0 ? value.text : value.url;
+  }
+  if (value.type === "user" && typeof value.user_id === "string") {
+    return `<@${value.user_id}>`;
+  }
+  if (value.type === "channel" && typeof value.channel_id === "string") {
+    return `<#${value.channel_id}>`;
+  }
+  if (value.type === "usergroup" && typeof value.usergroup_id === "string") {
+    return `<!subteam^${value.usergroup_id}>`;
+  }
+  if (value.type === "emoji" && typeof value.name === "string") {
+    return `:${value.name}:`;
+  }
+  if (value.type === "broadcast" && typeof value.range === "string") {
+    return `<!${value.range}>`;
+  }
+  if (value.type === "date") {
+    if (typeof value.fallback === "string" && value.fallback.length > 0) {
+      return value.fallback;
+    }
+    if (
+      (typeof value.timestamp === "number" || typeof value.timestamp === "string") &&
+      typeof value.format === "string"
+    ) {
+      return `<!date^${value.timestamp}^${value.format}>`;
+    }
+  }
+  if (typeof value.text === "string") {
+    return value.text;
+  }
+  return slackInlineText(value.elements);
+}
+
 function collectSlackFallbackText(value: unknown, output: string[]): void {
   if (Array.isArray(value)) {
     for (const entry of value) {
@@ -90,6 +132,17 @@ function collectSlackFallbackText(value: unknown, output: string[]): void {
     return;
   }
   if (!isRecord(value)) {
+    return;
+  }
+  if (
+    value.type === "rich_text_section" ||
+    value.type === "rich_text_preformatted" ||
+    value.type === "rich_text_quote"
+  ) {
+    const text = slackInlineText(value.elements);
+    if (text.trim()) {
+      output.push(text);
+    }
     return;
   }
   for (const key of ["fallback", "title", "alt_text"] as const) {
@@ -114,15 +167,11 @@ function slackOutboundText(body: Record<string, unknown>): string | undefined {
     if (body.text.trim()) {
       return body.text;
     }
-    if (body.text.length > 0) {
-      return undefined;
-    }
   }
   const fallback: string[] = [];
   collectSlackFallbackText(structuredSlackValues(body.blocks), fallback);
   collectSlackFallbackText(structuredSlackValues(body.attachments), fallback);
-  const unique = [...new Set(fallback)];
-  return unique.length > 0 ? unique.join("\n") : undefined;
+  return fallback.length > 0 ? fallback.join("\n") : undefined;
 }
 
 export const SLACK_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablineProviderBridge({
@@ -191,8 +240,11 @@ export const SLACK_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablinePro
       },
       createAgentDelivery(parsed) {
         const to = requireSlackSendTargetId(parsed.id, "Slack target");
-        requireSlackTargetKind(parsed, to);
         const threadTs = requireSlackThreadTs(parsed.threadId, "Slack target thread");
+        if (threadTs && !SLACK_CHANNEL_ID_RULE.pattern.test(to)) {
+          throw new Error("Slack thread targets require a native parent conversation id.");
+        }
+        requireSlackTargetKind(parsed, to);
         return {
           channel: "slack",
           to,

--- a/src/openclaw/bridges/zalo.ts
+++ b/src/openclaw/bridges/zalo.ts
@@ -1,4 +1,7 @@
-import { ZALO_UNSUPPORTED_THREAD_TARGET_ERROR } from "../../providers/target-normalizers.js";
+import {
+  ZALO_ID_RULE,
+  ZALO_UNSUPPORTED_THREAD_TARGET_ERROR,
+} from "../../providers/target-normalizers.js";
 import {
   createAdminInboundRequest,
   createOpenClawCrablineProviderBridge,
@@ -13,6 +16,9 @@ function nativeId(value: string): string {
   const id = value.trim();
   if (!id) {
     throw new Error("Zalo target is required.");
+  }
+  if (!ZALO_ID_RULE.pattern.test(id)) {
+    throw new Error("Zalo target must be a native Zalo string id without whitespace.");
   }
   return id;
 }

--- a/src/providers/builtin/feishu.ts
+++ b/src/providers/builtin/feishu.ts
@@ -441,11 +441,13 @@ function readFeishuCallbackKeys(payload: unknown, encryptedEnvelope: unknown): s
   const encrypted = isRecord(encryptedEnvelope)
     ? optionalString(encryptedEnvelope, "encrypt")
     : undefined;
-  return [
-    ...(messageId ? [`message:${messageId}`] : []),
-    ...(eventId ? [`event:${eventId}`] : []),
-    ...(encrypted ? [`encrypted:${createHash("sha256").update(encrypted).digest("hex")}`] : []),
-  ];
+  if (eventId) {
+    return [`event:${eventId}`];
+  }
+  if (messageId) {
+    return [`message:${messageId}`];
+  }
+  return encrypted ? [`encrypted:${createHash("sha256").update(encrypted).digest("hex")}`] : [];
 }
 
 function reserveFeishuCallback(replayState: FeishuReplayState, callbackKeys: string[]): void {

--- a/src/providers/builtin/googlechat.ts
+++ b/src/providers/builtin/googlechat.ts
@@ -42,6 +42,7 @@ const GOOGLE_CHAT_SERVICE_ACCOUNT = "chat@system.gserviceaccount.com";
 const GOOGLE_OAUTH_CERTS_URL = "https://www.googleapis.com/oauth2/v1/certs";
 const GOOGLE_CHAT_CERTS_URL =
   "https://www.googleapis.com/service_accounts/v1/metadata/x509/chat@system.gserviceaccount.com";
+const GOOGLE_CHAT_MESSAGE_NAME_PATTERN = /^spaces\/[A-Za-z0-9_-]+\/messages\/[^/\s]+$/u;
 
 type GoogleChatAuthRuntime = {
   fetch?: typeof fetch | undefined;
@@ -278,12 +279,27 @@ export function normalizeGoogleChatWebhookPayload(payload: unknown) {
       kind: "inbound",
     });
   }
-  if (messageName && !messageName.startsWith(`${spaceName}/messages/`)) {
-    throw new CrablineError("Google Chat message.name must belong to message.space.name", {
-      kind: "inbound",
-    });
+  const validatedSpaceName = requireNativeInboundId(
+    spaceName,
+    GOOGLE_CHAT_SPACE_RULE,
+    "Google Chat space.name",
+  );
+  if (messageName) {
+    if (!GOOGLE_CHAT_MESSAGE_NAME_PATTERN.test(messageName)) {
+      throw new CrablineError("Google Chat message.name must be a valid message resource name", {
+        kind: "inbound",
+      });
+    }
+    if (!messageName.startsWith(`${validatedSpaceName}/messages/`)) {
+      throw new CrablineError("Google Chat message.name must belong to message.space.name", {
+        kind: "inbound",
+      });
+    }
   }
-  if (threadName && !threadName.startsWith(`${spaceName}/threads/`)) {
+  const validatedThreadName = threadName
+    ? requireNativeInboundId(threadName, GOOGLE_CHAT_THREAD_RULE, "Google Chat thread.name")
+    : undefined;
+  if (validatedThreadName && !validatedThreadName.startsWith(`${validatedSpaceName}/threads/`)) {
     throw new CrablineError("Google Chat thread.name must belong to message.space.name", {
       kind: "inbound",
     });
@@ -294,9 +310,7 @@ export function normalizeGoogleChatWebhookPayload(payload: unknown) {
     ...(messageName ? { id: messageName } : {}),
     raw: payload,
     text,
-    threadId: threadName
-      ? requireNativeInboundId(threadName, GOOGLE_CHAT_THREAD_RULE, "Google Chat thread.name")
-      : requireNativeInboundId(spaceName, GOOGLE_CHAT_SPACE_RULE, "Google Chat space.name"),
+    threadId: validatedThreadName ?? validatedSpaceName,
   };
 }
 
@@ -307,7 +321,7 @@ export function handleGoogleChatWebhookPayload(payload: unknown): Response | und
   } catch {
     return undefined;
   }
-  if (isRecord(event) && (event.type === "ADDED_TO_SPACE" || event.type === "REMOVED_FROM_SPACE")) {
+  if (isRecord(event) && typeof event.type === "string" && event.type !== "MESSAGE") {
     return new Response(null, { status: 200 });
   }
   return undefined;

--- a/src/providers/builtin/slack.ts
+++ b/src/providers/builtin/slack.ts
@@ -78,11 +78,37 @@ function slackInlineText(value: unknown): string {
   if (!isRecord(value)) {
     return "";
   }
+  if (value.type === "link" && typeof value.url === "string") {
+    return typeof value.text === "string" && value.text.length > 0 ? value.text : value.url;
+  }
+  if (value.type === "user" && typeof value.user_id === "string") {
+    return `<@${value.user_id}>`;
+  }
+  if (value.type === "channel" && typeof value.channel_id === "string") {
+    return `<#${value.channel_id}>`;
+  }
+  if (value.type === "usergroup" && typeof value.usergroup_id === "string") {
+    return `<!subteam^${value.usergroup_id}>`;
+  }
+  if (value.type === "emoji" && typeof value.name === "string") {
+    return `:${value.name}:`;
+  }
+  if (value.type === "broadcast" && typeof value.range === "string") {
+    return `<!${value.range}>`;
+  }
+  if (value.type === "date") {
+    if (typeof value.fallback === "string" && value.fallback.length > 0) {
+      return value.fallback;
+    }
+    if (
+      (typeof value.timestamp === "number" || typeof value.timestamp === "string") &&
+      typeof value.format === "string"
+    ) {
+      return `<!date^${value.timestamp}^${value.format}>`;
+    }
+  }
   if (typeof value.text === "string") {
     return value.text;
-  }
-  if (value.type === "link" && typeof value.url === "string") {
-    return value.url;
   }
   return slackInlineText(value.elements);
 }

--- a/src/providers/builtin/zalo.ts
+++ b/src/providers/builtin/zalo.ts
@@ -20,6 +20,13 @@ export function resolveZaloAdapterConfig(
   config: ProviderConfig,
   env: ZaloEnvironment = process.env,
 ) {
+  if (
+    config.zalo?.webhookSecret === undefined &&
+    env.ZALO_WEBHOOK_SECRET !== undefined &&
+    !env.ZALO_WEBHOOK_SECRET.trim()
+  ) {
+    throw new Error("ZALO_WEBHOOK_SECRET must not be empty or whitespace-only.");
+  }
   return {
     botToken: config.zalo?.botToken ?? env.ZALO_BOT_TOKEN ?? "local-mock-zalo-token",
     webhookSecret: config.zalo?.webhookSecret ?? env.ZALO_WEBHOOK_SECRET,

--- a/test/feishu-provider.test.ts
+++ b/test/feishu-provider.test.ts
@@ -615,6 +615,22 @@ describe("Feishu webhook normalizer", () => {
         (await readFile(config.feishu!.recorder.path!, "utf8")).trim().split("\n"),
       ).toHaveLength(1);
 
+      const relatedPayload = {
+        ...validPayload,
+        event: {
+          ...validPayload.event,
+          message: {
+            ...validPayload.event.message,
+            content: JSON.stringify({ text: "distinct related event" }),
+          },
+        },
+        header: { event_id: "event-related" },
+      };
+      expect((await send(relatedPayload)).status).toBe(200);
+      expect(
+        (await readFile(config.feishu!.recorder.path!, "utf8")).trim().split("\n"),
+      ).toHaveLength(2);
+
       const rejectedPayload = {
         event: {
           message: {

--- a/test/googlechat-provider.test.ts
+++ b/test/googlechat-provider.test.ts
@@ -225,9 +225,17 @@ describe("Google Chat webhook authentication", () => {
         iss: "https://accounts.google.com",
       });
 
-      for (const type of ["ADDED_TO_SPACE", "REMOVED_FROM_SPACE"]) {
+      for (const type of ["ADDED_TO_SPACE", "REMOVED_FROM_SPACE", "CARD_CLICKED"]) {
         const response = await fetch(endpoint, {
-          body: JSON.stringify({ space: { name: "spaces/AAAABbbbCCC" }, type }),
+          body: JSON.stringify({
+            message: {
+              name: "spaces/AAAABbbbCCC/messages/must-not-record",
+              space: { name: "spaces/AAAABbbbCCC" },
+              text: "must not record",
+            },
+            space: { name: "spaces/AAAABbbbCCC" },
+            type,
+          }),
           headers: { authorization: `Bearer ${jwt}`, "content-type": "application/json" },
           method: "POST",
         });
@@ -366,6 +374,21 @@ describe("Google Chat webhook authentication", () => {
         },
       }),
     ).toThrow(/message\.name must belong to message\.space\.name/u);
+
+    for (const name of [
+      "spaces/AAAABbbbCCC/messages/",
+      "spaces/AAAABbbbCCC/messages/msg-native/extra",
+    ]) {
+      expect(() =>
+        normalizeGoogleChatWebhookPayload({
+          message: {
+            name,
+            space: { name: "spaces/AAAABbbbCCC" },
+            text: "malformed resource",
+          },
+        }),
+      ).toThrow(/valid message resource name/u);
+    }
   });
 
   it("requires configured thread targets to belong to their space", async () => {

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -625,6 +625,12 @@ describe("OpenClaw local provider bridge", () => {
       }),
     ).toThrow("Zalo does not support thread targets.");
     expect(() =>
+      createOpenClawCrablineAgentDelivery({
+        manifest: zaloManifest,
+        target: "group:group 1",
+      }),
+    ).toThrow(/without whitespace/u);
+    expect(() =>
       createOpenClawCrablineInbound({
         input: {
           conversation: { id: "group-1", kind: "group" },
@@ -635,6 +641,16 @@ describe("OpenClaw local provider bridge", () => {
         manifest: zaloManifest,
       }),
     ).toThrow("Zalo does not support thread targets.");
+    expect(() =>
+      createOpenClawCrablineInbound({
+        input: {
+          conversation: { id: "group-1", kind: "group" },
+          senderId: "user 1",
+          text: "hello",
+        },
+        manifest: zaloManifest,
+      }),
+    ).toThrow(/without whitespace/u);
 
     expect(
       createOpenClawCrablineOutboundFromRecorderEvent({
@@ -1753,6 +1769,12 @@ describe("OpenClaw local provider bridge", () => {
     expect(() =>
       createOpenClawCrablineAgentDelivery({
         manifest: slackManifest,
+        target: "thread:U1234567890/1700000000.000100",
+      }),
+    ).toThrow("Slack thread targets require a native parent conversation id.");
+    expect(() =>
+      createOpenClawCrablineAgentDelivery({
+        manifest: slackManifest,
         target: "dm:C1234567890",
       }),
     ).toThrow("Slack target kind does not match the native conversation id.");
@@ -1880,13 +1902,38 @@ describe("OpenClaw local provider bridge", () => {
           method: "POST",
           path: "/api/chat.postMessage",
           body: {
-            blocks: [{ text: { text: "must not replace whitespace", type: "plain_text" } }],
+            blocks: [
+              {
+                elements: [
+                  {
+                    elements: [
+                      { type: "user", user_id: "U1234567890" },
+                      { text: " in ", type: "text" },
+                      { channel_id: "C1234567890", type: "channel" },
+                      { name: "wave", type: "emoji" },
+                    ],
+                    type: "rich_text_section",
+                  },
+                  {
+                    elements: [{ text: "repeat", type: "text" }],
+                    type: "rich_text_section",
+                  },
+                  {
+                    elements: [{ text: "repeat", type: "text" }],
+                    type: "rich_text_section",
+                  },
+                ],
+                type: "rich_text",
+              },
+            ],
             channel: "C1234567890",
             text: " \n\t",
           },
         },
       }),
-    ).toBeNull();
+    ).toMatchObject({
+      text: "<@U1234567890> in <#C1234567890>:wave:\nrepeat\nrepeat",
+    });
   });
 
   it("maps Signal QA targets, inbound messages, and recorder events", () => {

--- a/test/slack-provider.test.ts
+++ b/test/slack-provider.test.ts
@@ -444,6 +444,19 @@ describe("slack provider", () => {
                 {
                   elements: [
                     { text: "inline-", type: "text" },
+                    { type: "user", user_id: "U1234567890" },
+                    { text: " in ", type: "text" },
+                    { channel_id: "C1234567890", type: "channel" },
+                    { name: "wave", type: "emoji" },
+                    { range: "here", type: "broadcast" },
+                    { type: "usergroup", usergroup_id: "S1234567890" },
+                    {
+                      fallback: "Jan 1",
+                      format: "{date_short}",
+                      timestamp: 1_700_000_000,
+                      type: "date",
+                    },
+                    { text: "-", type: "text" },
                     { type: "link", url: "https://example.test/nonce" },
                     { style: { bold: true }, text: "-tail", type: "text" },
                   ],
@@ -475,7 +488,7 @@ describe("slack provider", () => {
     expect(response.status).toBe(200);
     await expect(waiting).resolves.toMatchObject({
       id: "1700000001.000202",
-      text: "inline-https://example.test/nonce-tail\nrepeat\nrepeat",
+      text: "inline-<@U1234567890> in <#C1234567890>:wave:<!here><!subteam^S1234567890>Jan 1-https://example.test/nonce-tail\nrepeat\nrepeat",
     });
   });
 

--- a/test/zalo-provider.test.ts
+++ b/test/zalo-provider.test.ts
@@ -230,6 +230,20 @@ describe("Zalo webhook normalizer", () => {
       await provider.cleanup();
     }
   });
+
+  it.each(["", " \t"])(
+    "rejects explicitly empty webhook secrets from the environment",
+    async (secret) => {
+      const config = await createLocalMockConfig("zalo", "/zalo/webhook");
+
+      expect(
+        () =>
+          new ZaloProviderAdapter("zalo", config, "crabline", {
+            env: { ZALO_WEBHOOK_SECRET: secret },
+          }),
+      ).toThrow(/ZALO_WEBHOOK_SECRET must not be empty/u);
+    },
+  );
 });
 
 runLocalMockProviderContract({


### PR DESCRIPTION
## Summary
- preserve Slack native rich-text elements, whitespace fallback, block deduplication, and threaded user targets
- filter unsupported Google Chat interactions, strengthen Feishu replay identity, and reject empty Zalo webhook secrets
- harden Slack and Zalo OpenClaw bridge translation
- record the provider-fidelity fixes in the changelog

## Validation
- 162 focused tests
- `pnpm lint`
- exact-current `gpt-5.6-sol` high autoreview, clean at 0.86 confidence

## Landing gates
- GitHub CI on the exact PR head
- Crabbox `pnpm verify` on the exact PR head