### PR TITLE
fix(http): harden network and response boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Preserve native Slack rich text and block fallbacks, isolate Feishu replay identities, ignore non-message Google Chat interactions, and fail closed on invalid Zalo adapter inputs.
 - Discover network-specific NAT64 prefixes and safely recycle aborted DNS lookup capacity without accepting stale results.
 - Verify loopback bindings by their listening address, sanitize Fetch response headers, and advertise usable wildcard-bound webhook endpoints.
+- Route local-mock GET hooks through the real server and parse structured JSON media types as JSON.
 - Randomize WhatsApp XEdDSA signatures with fresh entropy while preserving their wire encoding.
 - Suppress serve readiness output when shutdown begins during ready-file publication.
 - Treat Unicode format characters as continuations when recognizing standalone acknowledgement tokens.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Bound watch iterator return and provider cleanup during CLI shutdown, forcing process exit after deadline failures.
 - Correct provider-native channel target examples, admin-ingress setup, and contract maintenance coverage.
 - Preserve native Slack rich text and block fallbacks, isolate Feishu replay identities, ignore non-message Google Chat interactions, and fail closed on invalid Zalo adapter inputs.
-- Correlate complete NAT64 discovery pairs and safely recycle aborted DNS lookup capacity without accepting stale results.
+- Correlate complete NAT64 discovery pairs and retain DNS capacity until abandoned lookups settle.
 - Verify loopback bindings by their listening address, sanitize framing and connection-nominated Fetch response headers, and advertise usable endpoints for every wildcard address spelling.
 - Route local-mock GET hooks through the real server and parse structured JSON media types as JSON.
 - Randomize WhatsApp XEdDSA signatures with fresh entropy while preserving their wire encoding.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Correct provider-native channel target examples, admin-ingress setup, and contract maintenance coverage.
 - Preserve native Slack rich text and block fallbacks, isolate Feishu replay identities, ignore non-message Google Chat interactions, and fail closed on invalid Zalo adapter inputs.
 - Discover network-specific NAT64 prefixes and safely recycle aborted DNS lookup capacity without accepting stale results.
+- Verify loopback bindings by their listening address, sanitize Fetch response headers, and advertise usable wildcard-bound webhook endpoints.
 - Randomize WhatsApp XEdDSA signatures with fresh entropy while preserving their wire encoding.
 - Suppress serve readiness output when shutdown begins during ready-file publication.
 - Treat Unicode format characters as continuations when recognizing standalone acknowledgement tokens.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Bound watch iterator return and provider cleanup during CLI shutdown, forcing process exit after deadline failures.
 - Correct provider-native channel target examples, admin-ingress setup, and contract maintenance coverage.
 - Preserve native Slack rich text and block fallbacks, isolate Feishu replay identities, ignore non-message Google Chat interactions, and fail closed on invalid Zalo adapter inputs.
-- Discover network-specific NAT64 prefixes and safely recycle aborted DNS lookup capacity without accepting stale results.
+- Correlate complete NAT64 discovery pairs and safely recycle aborted DNS lookup capacity without accepting stale results.
 - Verify loopback bindings by their listening address, sanitize Fetch response headers, and advertise usable endpoints for every wildcard address spelling.
 - Route local-mock GET hooks through the real server and parse structured JSON media types as JSON.
 - Randomize WhatsApp XEdDSA signatures with fresh entropy while preserving their wire encoding.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Correct provider-native channel target examples, admin-ingress setup, and contract maintenance coverage.
 - Preserve native Slack rich text and block fallbacks, isolate Feishu replay identities, ignore non-message Google Chat interactions, and fail closed on invalid Zalo adapter inputs.
 - Correlate complete NAT64 discovery pairs and safely recycle aborted DNS lookup capacity without accepting stale results.
-- Verify loopback bindings by their listening address, sanitize Fetch response headers, and advertise usable endpoints for every wildcard address spelling.
+- Verify loopback bindings by their listening address, sanitize framing and connection-nominated Fetch response headers, and advertise usable endpoints for every wildcard address spelling.
 - Route local-mock GET hooks through the real server and parse structured JSON media types as JSON.
 - Randomize WhatsApp XEdDSA signatures with fresh entropy while preserving their wire encoding.
 - Suppress serve readiness output when shutdown begins during ready-file publication.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Bound watch iterator return and provider cleanup during CLI shutdown, forcing process exit after deadline failures.
 - Correct provider-native channel target examples, admin-ingress setup, and contract maintenance coverage.
 - Preserve native Slack rich text and block fallbacks, isolate Feishu replay identities, ignore non-message Google Chat interactions, and fail closed on invalid Zalo adapter inputs.
+- Discover network-specific NAT64 prefixes and safely recycle aborted DNS lookup capacity without accepting stale results.
 - Randomize WhatsApp XEdDSA signatures with fresh entropy while preserving their wire encoding.
 - Suppress serve readiness output when shutdown begins during ready-file publication.
 - Treat Unicode format characters as continuations when recognizing standalone acknowledgement tokens.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Correct provider-native channel target examples, admin-ingress setup, and contract maintenance coverage.
 - Preserve native Slack rich text and block fallbacks, isolate Feishu replay identities, ignore non-message Google Chat interactions, and fail closed on invalid Zalo adapter inputs.
 - Discover network-specific NAT64 prefixes and safely recycle aborted DNS lookup capacity without accepting stale results.
-- Verify loopback bindings by their listening address, sanitize Fetch response headers, and advertise usable wildcard-bound webhook endpoints.
+- Verify loopback bindings by their listening address, sanitize Fetch response headers, and advertise usable endpoints for every wildcard address spelling.
 - Route local-mock GET hooks through the real server and parse structured JSON media types as JSON.
 - Randomize WhatsApp XEdDSA signatures with fresh entropy while preserving their wire encoding.
 - Suppress serve readiness output when shutdown begins during ready-file publication.

--- a/src/providers/local-mock.ts
+++ b/src/providers/local-mock.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { CrablineError, ensureErrorMessage } from "../core/errors.js";
 import type { ProviderConfig, ProviderPlatform } from "../config/schema.js";
+import { isJsonMediaType } from "../servers/http.js";
 import {
   appendRecordedInbound,
   cloneRecordedInboundCursor,
@@ -517,9 +518,9 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
     if (authenticationFailure) {
       return authenticationFailure;
     }
-    const mediaType = request.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase();
+    const isJson = isJsonMediaType(request.headers.get("content-type") ?? "");
     let rawPayload: unknown;
-    if (mediaType === "application/json") {
+    if (isJson) {
       try {
         rawPayload = JSON.parse(rawBody) as unknown;
       } catch {
@@ -554,7 +555,7 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
       if (directResponse) {
         return respond(directResponse);
       }
-      if (mediaType !== "application/json") {
+      if (!isJson) {
         return respond(new Response("expected application/json", { status: 415 }));
       }
       let payload: MockWebhookPayload;
@@ -622,6 +623,7 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
         return await startWebhookServer({
           handle: (request) => this.#handleWebhook(request),
           host,
+          methods: this.#options.handleWebhookPayload ? ["GET", "POST"] : ["POST"],
           path: webhookPath,
           port,
         });

--- a/src/providers/webhook-server.ts
+++ b/src/providers/webhook-server.ts
@@ -1,6 +1,11 @@
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { isCanonicalHttpPath } from "../core/http-path.js";
-import { closeServer } from "../servers/http.js";
+import {
+  advertisedHostForBindAddress,
+  closeServer,
+  formatUrlHost,
+  writeFetchResponseHeaders,
+} from "../servers/http.js";
 
 export type StartedWebhookServer = {
   close(): Promise<void>;
@@ -107,10 +112,7 @@ async function writeFetchResponse(
   fetchResponse: Response,
 ): Promise<void> {
   response.statusCode = fetchResponse.status;
-
-  for (const [name, value] of fetchResponse.headers) {
-    response.setHeader(name, value);
-  }
+  writeFetchResponseHeaders(response, fetchResponse);
 
   const reader = fetchResponse.body?.getReader();
   let cancellation: Promise<void> | undefined;
@@ -202,10 +204,6 @@ function clearUnsentResponseHeaders(response: ServerResponse<IncomingMessage>): 
   for (const name of response.getHeaderNames()) {
     response.removeHeader(name);
   }
-}
-
-function formatUrlHost(host: string): string {
-  return host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
 }
 
 export async function startWebhookServer(params: {
@@ -306,6 +304,7 @@ export async function startWebhookServer(params: {
   if (!address || typeof address === "string") {
     throw new Error("Unable to resolve webhook server address.");
   }
+  const advertisedHost = advertisedHostForBindAddress(params.host, address.address);
 
   let closingPromise: Promise<void> | null = null;
   return {
@@ -314,6 +313,6 @@ export async function startWebhookServer(params: {
       closingPromise ??= closeServer(server, params.shutdownGraceMs);
       await closingPromise;
     },
-    endpointUrl: `http://${formatUrlHost(params.host)}:${address.port}${params.path}`,
+    endpointUrl: `http://${formatUrlHost(advertisedHost)}:${address.port}${params.path}`,
   };
 }

--- a/src/servers/http.ts
+++ b/src/servers/http.ts
@@ -27,6 +27,9 @@ const LOOPBACK_ADDRESSES = new BlockList();
 LOOPBACK_ADDRESSES.addSubnet("127.0.0.0", 8, "ipv4");
 LOOPBACK_ADDRESSES.addAddress("::1", "ipv6");
 LOOPBACK_ADDRESSES.addSubnet("::ffff:127.0.0.0", 104, "ipv6");
+const UNSPECIFIED_ADDRESSES = new BlockList();
+UNSPECIFIED_ADDRESSES.addAddress("0.0.0.0", "ipv4");
+UNSPECIFIED_ADDRESSES.addAddress("::", "ipv6");
 const HOP_BY_HOP_RESPONSE_HEADERS = new Set([
   "connection",
   "keep-alive",
@@ -215,10 +218,12 @@ export function isLoopbackHost(host: string): boolean {
 }
 
 export function advertisedHostForBindAddress(host: string, boundAddress: string): string {
-  if (host === "0.0.0.0") {
+  const normalizedBoundAddress = normalizeHost(boundAddress);
+  const boundFamily = isIP(normalizedBoundAddress);
+  if (boundFamily === 4 && UNSPECIFIED_ADDRESSES.check(normalizedBoundAddress, "ipv4")) {
     return "127.0.0.1";
   }
-  if (host === "::") {
+  if (boundFamily === 6 && UNSPECIFIED_ADDRESSES.check(normalizedBoundAddress, "ipv6")) {
     return "::1";
   }
   return isLoopbackHost(host) && isLoopbackAddress(boundAddress) ? boundAddress : host;

--- a/src/servers/http.ts
+++ b/src/servers/http.ts
@@ -27,6 +27,17 @@ const LOOPBACK_ADDRESSES = new BlockList();
 LOOPBACK_ADDRESSES.addSubnet("127.0.0.0", 8, "ipv4");
 LOOPBACK_ADDRESSES.addAddress("::1", "ipv6");
 LOOPBACK_ADDRESSES.addSubnet("::ffff:127.0.0.0", 104, "ipv6");
+const HOP_BY_HOP_RESPONSE_HEADERS = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "proxy-connection",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
 
 export class InvalidJsonBodyError extends Error {
   constructor(cause: unknown, message = "Request body is not valid JSON.") {
@@ -177,15 +188,16 @@ export function formatUrlHost(host: string): string {
   return host.includes(":") ? `[${host}]` : host;
 }
 
-export function isLoopbackHost(host: string): boolean {
-  const normalized = host
+function normalizeHost(host: string): string {
+  return host
     .trim()
     .replace(/^\[(.*)\]$/u, "$1")
     .toLowerCase()
     .replace(/\.$/u, "");
-  if (normalized === "localhost" || normalized.endsWith(".localhost")) {
-    return true;
-  }
+}
+
+export function isLoopbackAddress(address: string): boolean {
+  const normalized = normalizeHost(address);
   const family = isIP(normalized);
   return family === 4
     ? LOOPBACK_ADDRESSES.check(normalized, "ipv4")
@@ -194,30 +206,63 @@ export function isLoopbackHost(host: string): boolean {
       : false;
 }
 
-export async function writeResponse(
-  response: ServerResponse,
-  fetchResponse: Response,
-): Promise<void> {
-  const body = Buffer.from(await fetchResponse.arrayBuffer());
+export function isLoopbackHost(host: string): boolean {
+  const normalized = normalizeHost(host);
+  if (normalized === "localhost" || normalized.endsWith(".localhost")) {
+    return true;
+  }
+  return isLoopbackAddress(normalized);
+}
+
+export function advertisedHostForBindAddress(host: string, boundAddress: string): string {
+  if (host === "0.0.0.0") {
+    return "127.0.0.1";
+  }
+  if (host === "::") {
+    return "::1";
+  }
+  return isLoopbackHost(host) && isLoopbackAddress(boundAddress) ? boundAddress : host;
+}
+
+export function writeFetchResponseHeaders(response: ServerResponse, fetchResponse: Response): void {
   const preserveRepresentationLength =
     response.req?.method === "HEAD" || fetchResponse.status === 304;
-  response.statusCode = fetchResponse.status;
+  const connectionHeaders = new Set(
+    (fetchResponse.headers.get("connection") ?? "")
+      .split(",")
+      .map((name) => name.trim().toLowerCase())
+      .filter(Boolean),
+  );
+  if (connectionHeaders.has("close")) {
+    response.shouldKeepAlive = false;
+  }
+
   for (const [name, value] of fetchResponse.headers) {
     const normalizedName = name.toLowerCase();
     if (
-      (normalizedName === "content-length" && !preserveRepresentationLength) ||
       normalizedName === "set-cookie" ||
-      normalizedName === "trailer" ||
-      normalizedName === "transfer-encoding"
+      HOP_BY_HOP_RESPONSE_HEADERS.has(normalizedName) ||
+      connectionHeaders.has(normalizedName) ||
+      (normalizedName === "content-length" && !preserveRepresentationLength)
     ) {
       continue;
     }
     response.setHeader(name, value);
   }
+
   const setCookies = fetchResponse.headers.getSetCookie();
   if (setCookies.length > 0) {
     response.setHeader("set-cookie", setCookies);
   }
+}
+
+export async function writeResponse(
+  response: ServerResponse,
+  fetchResponse: Response,
+): Promise<void> {
+  const body = Buffer.from(await fetchResponse.arrayBuffer());
+  response.statusCode = fetchResponse.status;
+  writeFetchResponseHeaders(response, fetchResponse);
   await new Promise<void>((resolve, reject) => {
     if (
       response.destroyed ||
@@ -348,8 +393,14 @@ export async function startHttpJsonServer(params: {
       kind: "connectivity",
     });
   }
-  const advertisedHost =
-    params.host === "0.0.0.0" ? "127.0.0.1" : params.host === "::" ? "::1" : params.host;
+  if (isLoopbackHost(params.host) && !isLoopbackAddress(address.address)) {
+    await closeServer(server);
+    throw new CrablineError(
+      `${params.serverName} resolved a loopback hostname to non-loopback address ${address.address}.`,
+      { kind: "connectivity" },
+    );
+  }
+  const advertisedHost = advertisedHostForBindAddress(params.host, address.address);
   return {
     baseUrl: `http://${formatUrlHost(advertisedHost)}:${address.port}`,
     async close() {

--- a/src/servers/http.ts
+++ b/src/servers/http.ts
@@ -256,7 +256,7 @@ export function writeFetchResponseHeaders(response: ServerResponse, fetchRespons
   }
 
   const setCookies = fetchResponse.headers.getSetCookie();
-  if (setCookies.length > 0) {
+  if (setCookies.length > 0 && !connectionHeaders.has("set-cookie")) {
     response.setHeader("set-cookie", setCookies);
   }
 }

--- a/src/servers/webhook-target.ts
+++ b/src/servers/webhook-target.ts
@@ -82,10 +82,6 @@ export class WebhookDnsLookupPool {
             if (index >= 0) {
               this.#pending.splice(index, 1);
             }
-          } else {
-            // The OS lookup may ignore cancellation; release only this caller's slot.
-            // slotHeld keeps a late completion from releasing a successor's capacity.
-            this.#releaseSlot(pending);
           }
           signal?.removeEventListener("abort", pending.onAbort);
           reject(abortSignalError(signal));

--- a/src/servers/webhook-target.ts
+++ b/src/servers/webhook-target.ts
@@ -380,20 +380,21 @@ const WELL_KNOWN_NAT64_PREFIX: Nat64Prefix = {
   length: 96,
 };
 
-function embeddedNat64Ipv4(
+function embeddedNat64Ipv4Addresses(
   address: string,
   nat64Prefixes: readonly Nat64Prefix[],
-): string | undefined {
+): string[] {
   const bytes = ipv6Bytes(address);
   if (!bytes) {
-    return undefined;
+    return [];
   }
+  const addresses: string[] = [];
   for (const prefix of [WELL_KNOWN_NAT64_PREFIX, ...nat64Prefixes]) {
     if (prefixMatches(bytes, prefix)) {
-      return extractRfc6052Ipv4(bytes, prefix.length);
+      addresses.push(extractRfc6052Ipv4(bytes, prefix.length));
     }
   }
-  return undefined;
+  return addresses;
 }
 
 function isBlockedWebhookAddress(
@@ -409,8 +410,11 @@ function isBlockedWebhookAddress(
     );
   }
   if (family === 6) {
-    const embeddedIpv4 = embeddedNat64Ipv4(normalized, nat64Prefixes);
-    if (embeddedIpv4 && isBlockedWebhookAddress(embeddedIpv4)) {
+    if (
+      embeddedNat64Ipv4Addresses(normalized, nat64Prefixes).some((embeddedIpv4) =>
+        isBlockedWebhookAddress(embeddedIpv4),
+      )
+    ) {
       return true;
     }
     if (GLOBAL_IPV6_EXCEPTIONS.check(normalized, "ipv6")) {

--- a/src/servers/webhook-target.ts
+++ b/src/servers/webhook-target.ts
@@ -83,6 +83,8 @@ export class WebhookDnsLookupPool {
               this.#pending.splice(index, 1);
             }
           } else {
+            // The OS lookup may ignore cancellation; release only this caller's slot.
+            // slotHeld keeps a late completion from releasing a successor's capacity.
             this.#releaseSlot(pending);
           }
           signal?.removeEventListener("abort", pending.onAbort);

--- a/src/servers/webhook-target.ts
+++ b/src/servers/webhook-target.ts
@@ -32,9 +32,16 @@ const BLOCKED_IPV6_ADDRESSES = createBlockedIpv6Addresses();
 const GLOBAL_IPV4_EXCEPTIONS = createGlobalIpv4Exceptions();
 const GLOBAL_IPV6_EXCEPTIONS = createGlobalIpv6Exceptions();
 const ALLOCATED_GLOBAL_IPV6_RANGES = createAllocatedGlobalIpv6Ranges();
+const RFC6052_PREFIX_LENGTHS = [32, 40, 48, 56, 64, 96] as const;
+const IPV4ONLY_ADDRESSES = new Set(["192.0.0.170", "192.0.0.171"]);
 
 type WebhookDnsLookupResult = ReadonlyArray<{ address: string; family: number }>;
 type WebhookDnsLookup = (hostname: string) => Promise<WebhookDnsLookupResult>;
+type Nat64PrefixLength = (typeof RFC6052_PREFIX_LENGTHS)[number];
+type Nat64Prefix = {
+  bytes: readonly number[];
+  length: Nat64PrefixLength;
+};
 
 type PendingWebhookDnsLookup = {
   hostname: string;
@@ -43,6 +50,7 @@ type PendingWebhookDnsLookup = {
   resolve(addresses: WebhookDnsLookupResult): void;
   settled: boolean;
   signal: AbortSignal | undefined;
+  slotHeld: boolean;
   started: boolean;
 };
 
@@ -74,6 +82,8 @@ export class WebhookDnsLookupPool {
             if (index >= 0) {
               this.#pending.splice(index, 1);
             }
+          } else {
+            this.#releaseSlot(pending);
           }
           signal?.removeEventListener("abort", pending.onAbort);
           reject(abortSignalError(signal));
@@ -83,6 +93,7 @@ export class WebhookDnsLookupPool {
         resolve,
         settled: false,
         signal,
+        slotHeld: false,
         started: false,
       };
       if (signal?.aborted) {
@@ -105,8 +116,15 @@ export class WebhookDnsLookupPool {
         continue;
       }
       pending.started = true;
+      pending.slotHeld = true;
       this.#active += 1;
-      void this.lookupHostname(pending.hostname)
+      let lookupPromise: Promise<WebhookDnsLookupResult>;
+      try {
+        lookupPromise = this.lookupHostname(pending.hostname);
+      } catch (error) {
+        lookupPromise = Promise.reject(error);
+      }
+      void lookupPromise
         .then(
           (addresses) => {
             if (!pending.settled) {
@@ -123,10 +141,18 @@ export class WebhookDnsLookupPool {
         )
         .finally(() => {
           pending.signal?.removeEventListener("abort", pending.onAbort);
-          this.#active -= 1;
-          this.#pump();
+          this.#releaseSlot(pending);
         });
     }
+  }
+
+  #releaseSlot(pending: PendingWebhookDnsLookup): void {
+    if (!pending.slotHeld) {
+      return;
+    }
+    pending.slotHeld = false;
+    this.#active -= 1;
+    this.#pump();
   }
 }
 
@@ -281,20 +307,84 @@ function parseIpv6Hextets(address: string): number[] | undefined {
   return hextets.length === 8 ? hextets : undefined;
 }
 
-function embeddedNat64Ipv4(address: string): string | undefined {
-  const hextets = parseIpv6Hextets(address);
-  if (
-    !hextets ||
-    hextets[0] !== 0x64 ||
-    hextets[1] !== 0xff9b ||
-    hextets.slice(2, 6).some((value) => value !== 0)
-  ) {
+function ipv6Bytes(address: string): number[] | undefined {
+  if (isIP(address) !== 6) {
     return undefined;
   }
-  return [hextets[6]! >> 8, hextets[6]! & 0xff, hextets[7]! >> 8, hextets[7]! & 0xff].join(".");
+  const hextets = parseIpv6Hextets(address);
+  if (!hextets) {
+    return undefined;
+  }
+  return hextets.flatMap((value) => [value >> 8, value & 0xff]);
 }
 
-function isBlockedWebhookAddress(address: string): boolean {
+function extractRfc6052Ipv4(bytes: readonly number[], prefixLength: Nat64PrefixLength): string {
+  if (prefixLength === 96) {
+    return bytes.slice(12, 16).join(".");
+  }
+  const prefixBytes = prefixLength / 8;
+  const leadingIpv4Bytes = 8 - prefixBytes;
+  return [...bytes.slice(prefixBytes, 8), ...bytes.slice(9, 9 + (4 - leadingIpv4Bytes))].join(".");
+}
+
+function prefixMatches(bytes: readonly number[], prefix: Nat64Prefix): boolean {
+  const prefixBytes = prefix.length / 8;
+  return prefix.bytes.slice(0, prefixBytes).every((value, index) => bytes[index] === value);
+}
+
+function nat64PrefixKey(prefix: Nat64Prefix): string {
+  return `${prefix.length}:${prefix.bytes.slice(0, prefix.length / 8).join(".")}`;
+}
+
+function discoverNat64Prefixes(addresses: WebhookDnsLookupResult): Nat64Prefix[] {
+  const prefixes = new Map<string, Nat64Prefix>();
+  for (const entry of addresses) {
+    if (entry.family !== 6) {
+      continue;
+    }
+    const bytes = ipv6Bytes(normalizeHostname(entry.address));
+    if (!bytes) {
+      continue;
+    }
+    for (const length of RFC6052_PREFIX_LENGTHS) {
+      if (length !== 96 && bytes[8] !== 0) {
+        continue;
+      }
+      if (!IPV4ONLY_ADDRESSES.has(extractRfc6052Ipv4(bytes, length))) {
+        continue;
+      }
+      const prefix = { bytes, length };
+      prefixes.set(nat64PrefixKey(prefix), prefix);
+    }
+  }
+  return [...prefixes.values()];
+}
+
+const WELL_KNOWN_NAT64_PREFIX: Nat64Prefix = {
+  bytes: ipv6Bytes("64:ff9b::")!,
+  length: 96,
+};
+
+function embeddedNat64Ipv4(
+  address: string,
+  nat64Prefixes: readonly Nat64Prefix[],
+): string | undefined {
+  const bytes = ipv6Bytes(address);
+  if (!bytes) {
+    return undefined;
+  }
+  for (const prefix of [WELL_KNOWN_NAT64_PREFIX, ...nat64Prefixes]) {
+    if (prefixMatches(bytes, prefix)) {
+      return extractRfc6052Ipv4(bytes, prefix.length);
+    }
+  }
+  return undefined;
+}
+
+function isBlockedWebhookAddress(
+  address: string,
+  nat64Prefixes: readonly Nat64Prefix[] = [],
+): boolean {
   const normalized = normalizeHostname(address);
   const family = isIP(normalized);
   if (family === 4) {
@@ -304,7 +394,7 @@ function isBlockedWebhookAddress(address: string): boolean {
     );
   }
   if (family === 6) {
-    const embeddedIpv4 = embeddedNat64Ipv4(normalized);
+    const embeddedIpv4 = embeddedNat64Ipv4(normalized, nat64Prefixes);
     if (embeddedIpv4 && isBlockedWebhookAddress(embeddedIpv4)) {
       return true;
     }
@@ -377,6 +467,25 @@ export async function validateWebhookTarget(params: {
   }
   if (addresses.some((entry) => isBlockedWebhookAddress(entry.address))) {
     return { error: "private-address" };
+  }
+  if (addresses.some((entry) => entry.family === 6)) {
+    let nat64Prefixes: Nat64Prefix[];
+    try {
+      nat64Prefixes = discoverNat64Prefixes(
+        await (params.dnsLookupPool ?? webhookDnsLookupPool).resolve(
+          "ipv4only.arpa",
+          params.signal,
+        ),
+      );
+    } catch (error) {
+      if (params.signal?.aborted) {
+        throw error;
+      }
+      return { error: "private-address" };
+    }
+    if (addresses.some((entry) => isBlockedWebhookAddress(entry.address, nat64Prefixes))) {
+      return { error: "private-address" };
+    }
   }
   return { addresses };
 }

--- a/src/servers/webhook-target.ts
+++ b/src/servers/webhook-target.ts
@@ -338,12 +338,14 @@ function nat64PrefixKey(prefix: Nat64Prefix): string {
   return `${prefix.length}:${prefix.bytes.slice(0, prefix.length / 8).join(".")}`;
 }
 
-function discoverNat64Prefixes(addresses: WebhookDnsLookupResult): Nat64Prefix[] {
-  const prefixes = new Map<string, Nat64Prefix>();
+function discoverNat64Prefixes(addresses: WebhookDnsLookupResult): Nat64Prefix[] | undefined {
+  const candidates = new Map<string, { addresses: Set<string>; prefix: Nat64Prefix }>();
+  let ipv6Answers = 0;
   for (const entry of addresses) {
     if (entry.family !== 6) {
       continue;
     }
+    ipv6Answers++;
     const bytes = ipv6Bytes(normalizeHostname(entry.address));
     if (!bytes) {
       continue;
@@ -356,10 +358,21 @@ function discoverNat64Prefixes(addresses: WebhookDnsLookupResult): Nat64Prefix[]
         continue;
       }
       const prefix = { bytes, length };
-      prefixes.set(nat64PrefixKey(prefix), prefix);
+      const key = nat64PrefixKey(prefix);
+      const candidate = candidates.get(key) ?? { addresses: new Set(), prefix };
+      candidate.addresses.add(extractRfc6052Ipv4(bytes, length));
+      candidates.set(key, candidate);
     }
   }
-  return [...prefixes.values()];
+  if (ipv6Answers === 0) {
+    return [];
+  }
+  const prefixes = [...candidates.values()]
+    .filter((candidate) =>
+      [...IPV4ONLY_ADDRESSES].every((address) => candidate.addresses.has(address)),
+    )
+    .map((candidate) => candidate.prefix);
+  return prefixes.length > 0 ? prefixes : undefined;
 }
 
 const WELL_KNOWN_NAT64_PREFIX: Nat64Prefix = {
@@ -471,7 +484,7 @@ export async function validateWebhookTarget(params: {
     return { error: "private-address" };
   }
   if (addresses.some((entry) => entry.family === 6)) {
-    let nat64Prefixes: Nat64Prefix[];
+    let nat64Prefixes: Nat64Prefix[] | undefined;
     try {
       nat64Prefixes = discoverNat64Prefixes(
         await (params.dnsLookupPool ?? webhookDnsLookupPool).resolve(
@@ -483,6 +496,9 @@ export async function validateWebhookTarget(params: {
       if (params.signal?.aborted) {
         throw error;
       }
+      return { error: "private-address" };
+    }
+    if (!nat64Prefixes) {
       return { error: "private-address" };
     }
     if (addresses.some((entry) => isBlockedWebhookAddress(entry.address, nat64Prefixes))) {

--- a/test/http-server.test.ts
+++ b/test/http-server.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_MAX_REQUEST_BODY_BYTES,
   drainRequestBody,
   InvalidJsonBodyError,
+  isLoopbackAddress,
   isLoopbackHost,
   parseRequestBody,
   parseUnknownRequestBody,
@@ -130,6 +131,14 @@ describe("server HTTP body reader", () => {
     expect(isLoopbackHost(host)).toBe(expected);
   });
 
+  it("distinguishes loopback-looking hostnames from actual loopback addresses", () => {
+    expect(isLoopbackHost("service.localhost")).toBe(true);
+    expect(isLoopbackAddress("service.localhost")).toBe(false);
+    expect(isLoopbackAddress("127.0.0.1")).toBe(true);
+    expect(isLoopbackAddress("[::1]")).toBe(true);
+    expect(isLoopbackAddress("192.0.2.1")).toBe(false);
+  });
+
   it.each([
     ["0.0.0.0", "127.0.0.1"],
     ["::", "[::1]"],
@@ -199,6 +208,32 @@ describe("server HTTP body reader", () => {
       const response = await fetch(server.baseUrl);
       expect(response.headers.get("trailer")).toBeNull();
       expect(response.headers.get("content-length")).toBe("8");
+      await expect(response.text()).resolves.toBe("complete");
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("removes connection-scoped response headers named by Connection", async () => {
+    const server = await startHttpJsonServer({
+      async handle() {
+        return new Response("complete", {
+          headers: {
+            connection: "x-internal",
+            "x-internal": "secret",
+            "x-safe": "visible",
+          },
+        });
+      },
+      host: "127.0.0.1",
+      port: 0,
+      serverName: "test",
+    });
+
+    try {
+      const response = await fetch(server.baseUrl);
+      expect(response.headers.get("x-internal")).toBeNull();
+      expect(response.headers.get("x-safe")).toBe("visible");
       await expect(response.text()).resolves.toBe("complete");
     } finally {
       await server.close();

--- a/test/http-server.test.ts
+++ b/test/http-server.test.ts
@@ -140,33 +140,37 @@ describe("server HTTP body reader", () => {
   });
 
   it.each([
-    ["0.0.0.0", "127.0.0.1"],
-    ["::", "[::1]"],
-  ])("advertises loopback while preserving the %s wildcard bind", async (host, advertisedHost) => {
-    const server = await startHttpJsonServer({
-      async handle() {
-        return Response.json({ ok: true });
-      },
-      host,
-      port: 0,
-      serverName: "test",
-    });
-
-    try {
-      expect(new URL(server.baseUrl).hostname).toBe(advertisedHost);
-      const address = server.server.address();
-      expect(address).not.toBeNull();
-      expect(typeof address).not.toBe("string");
-      expect(typeof address === "string" || address === null ? undefined : address.address).toBe(
+    ["0.0.0.0", "127.0.0.1", "0.0.0.0"],
+    ["::", "[::1]", "::"],
+    ["0:0:0:0:0:0:0:0", "[::1]", "::"],
+  ])(
+    "advertises loopback while preserving the %s wildcard bind",
+    async (host, advertisedHost, boundAddress) => {
+      const server = await startHttpJsonServer({
+        async handle() {
+          return Response.json({ ok: true });
+        },
         host,
-      );
-      await expect(fetch(server.baseUrl).then((response) => response.json())).resolves.toEqual({
-        ok: true,
+        port: 0,
+        serverName: "test",
       });
-    } finally {
-      await server.close();
-    }
-  });
+
+      try {
+        expect(new URL(server.baseUrl).hostname).toBe(advertisedHost);
+        const address = server.server.address();
+        expect(address).not.toBeNull();
+        expect(typeof address).not.toBe("string");
+        expect(typeof address === "string" || address === null ? undefined : address.address).toBe(
+          boundAddress,
+        );
+        await expect(fetch(server.baseUrl).then((response) => response.json())).resolves.toEqual({
+          ok: true,
+        });
+      } finally {
+        await server.close();
+      }
+    },
+  );
 
   it("owns buffered response framing instead of trusting caller Content-Length", async () => {
     const server = await startHttpJsonServer({

--- a/test/local-mock-provider.test.ts
+++ b/test/local-mock-provider.test.ts
@@ -461,6 +461,85 @@ describe("local mock provider", () => {
     );
   });
 
+  it("routes GET challenge hooks through the real webhook server", async () => {
+    const actualWebhookServer = await vi.importActual<
+      typeof import("../src/providers/webhook-server.js")
+    >("../src/providers/webhook-server.js");
+    let endpointUrl: string | undefined;
+    webhookMocks.startWebhookServer.mockImplementationOnce(async (params) => {
+      const server = await actualWebhookServer.startWebhookServer(params);
+      endpointUrl = server.endpointUrl;
+      return server;
+    });
+    const config = createConfig();
+    const provider = new LocalMockProviderAdapter({
+      codec: createGenericLocalMockTargetCodec("slack"),
+      config,
+      id: "provider-a",
+      options: {
+        defaultWebhook: { host: "127.0.0.1", path: "/slack/events", port: 0 },
+        endpointLabel: "events endpoint",
+        handleWebhookPayload(_payload, request) {
+          return new Response(new URL(request.url).searchParams.get("challenge") ?? "", {
+            status: 202,
+          });
+        },
+        platform: "slack",
+      },
+    });
+    providers.push(provider);
+    await provider.probe(createContext(config));
+
+    const response = await fetch(`${endpointUrl}?challenge=provider-ok`, { method: "GET" });
+
+    expect(response.status).toBe(202);
+    await expect(response.text()).resolves.toBe("provider-ok");
+    expect(webhookMocks.startWebhookServer).toHaveBeenCalledWith(
+      expect.objectContaining({ methods: ["GET", "POST"] }),
+    );
+  });
+
+  it("parses structured JSON request bodies before provider hooks", async () => {
+    let handleRequest: ((request: Request) => Promise<Response>) | undefined;
+    webhookMocks.startWebhookServer.mockImplementationOnce(async (params) => {
+      handleRequest = params.handle;
+      return {
+        async close() {},
+        endpointUrl: "http://127.0.0.1:43210/slack/events",
+      };
+    });
+    const handlePayload = vi.fn(() => new Response("accepted", { status: 202 }));
+    const config = createConfig();
+    const provider = new LocalMockProviderAdapter({
+      codec: createGenericLocalMockTargetCodec("slack"),
+      config,
+      id: "provider-a",
+      options: {
+        defaultWebhook: { host: "127.0.0.1", path: "/slack/events", port: 0 },
+        endpointLabel: "events endpoint",
+        handleWebhookPayload: handlePayload,
+        platform: "slack",
+      },
+    });
+    providers.push(provider);
+    await provider.probe(createContext(config));
+
+    const response = await handleRequest!(
+      new Request("http://127.0.0.1:43210/slack/events", {
+        body: '{"type":"challenge"}',
+        headers: { "content-type": "application/problem+json; charset=utf-8" },
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(202);
+    expect(handlePayload).toHaveBeenCalledWith(
+      { type: "challenge" },
+      expect.any(Request),
+      '{"type":"challenge"}',
+    );
+  });
+
   it("rejects malformed normalized webhook envelopes", async () => {
     let handleRequest: ((request: Request) => Promise<Response>) | undefined;
     webhookMocks.startWebhookServer.mockImplementationOnce(async (params) => {

--- a/test/server-credentials.test.ts
+++ b/test/server-credentials.test.ts
@@ -8,6 +8,7 @@ import {
   startZaloServer,
   type StartedCrablineServer,
 } from "../src/index.js";
+import { isLoopbackAddress } from "../src/servers/http.js";
 
 const servers: StartedCrablineServer[] = [];
 
@@ -51,6 +52,14 @@ describe("externally bound provider server credentials", () => {
     await expect(startWhatsAppServer({ host: "0.0.0.0" })).rejects.toThrow(
       /requires a loopback host/u,
     );
+  });
+
+  it("advertises the resolved loopback address for a loopback hostname", async () => {
+    const server = await startWhatsAppServer({ host: "localhost" });
+    servers.push(server);
+
+    expect(isLoopbackAddress(new URL(server.manifest.baseUrl).hostname)).toBe(true);
+    expect(new URL(server.manifest.baseUrl).hostname).not.toBe("localhost");
   });
 });
 

--- a/test/webhook-server.test.ts
+++ b/test/webhook-server.test.ts
@@ -24,6 +24,23 @@ describe("webhook server", () => {
     expect(response.status).toBe(200);
   });
 
+  it.each([
+    ["0.0.0.0", "127.0.0.1"],
+    ["::", "[::1]"],
+  ])("advertises loopback instead of the %s wildcard bind", async (host, advertisedHost) => {
+    const server = await startWebhookServer({
+      handle: async () => new Response("ok"),
+      host,
+      path: "/slack/events",
+      port: 0,
+    });
+    cleanups.push(() => server.close());
+
+    expect(new URL(server.endpointUrl).hostname).toBe(advertisedHost);
+    const response = await fetch(server.endpointUrl, { method: "POST" });
+    expect(response.status).toBe(200);
+  });
+
   it("serves the configured POST path", async () => {
     const server = await startWebhookServer({
       async handle(request) {
@@ -163,6 +180,41 @@ describe("webhook server", () => {
     expect(response.headers.get("x-response-kind")).toBeNull();
     await expect(response.text()).resolves.toBe("internal server error");
     expect(observedErrors).toEqual([expect.objectContaining({ message: "response body failed" })]);
+  });
+
+  it("filters response framing and hop-by-hop headers while preserving distinct cookies", async () => {
+    const server = await startWebhookServer({
+      async handle() {
+        const headers = new Headers({
+          connection: "close, x-internal",
+          "content-length": "999",
+          trailer: "x-checksum",
+          "transfer-encoding": "chunked",
+          "x-internal": "secret",
+          "x-safe": "visible",
+        });
+        headers.append("set-cookie", "first=1; Path=/");
+        headers.append("set-cookie", "second=2; Path=/");
+        return new Response("ok", { headers });
+      },
+      host: "127.0.0.1",
+      path: "/slack/events",
+      port: 0,
+    });
+    cleanups.push(() => server.close());
+
+    const response = await fetch(server.endpointUrl, {
+      method: "POST",
+      signal: AbortSignal.timeout(1_000),
+    });
+
+    expect(response.headers.get("content-length")).not.toBe("999");
+    expect(response.headers.get("connection")).toBe("close");
+    expect(response.headers.get("trailer")).toBeNull();
+    expect(response.headers.get("x-internal")).toBeNull();
+    expect(response.headers.get("x-safe")).toBe("visible");
+    expect(response.headers.getSetCookie()).toEqual(["first=1; Path=/", "second=2; Path=/"]);
+    await expect(response.text()).resolves.toBe("ok");
   });
 
   it("streams response chunks before the provider body completes", async () => {

--- a/test/webhook-server.test.ts
+++ b/test/webhook-server.test.ts
@@ -218,6 +218,28 @@ describe("webhook server", () => {
     await expect(response.text()).resolves.toBe("ok");
   });
 
+  it("does not restore cookies nominated by the Connection header", async () => {
+    const server = await startWebhookServer({
+      async handle() {
+        return new Response("ok", {
+          headers: {
+            connection: "set-cookie",
+            "set-cookie": "session=secret; Path=/",
+          },
+        });
+      },
+      host: "127.0.0.1",
+      path: "/slack/events",
+      port: 0,
+    });
+    cleanups.push(() => server.close());
+
+    const response = await fetch(server.endpointUrl, { method: "POST" });
+
+    expect(response.headers.getSetCookie()).toEqual([]);
+    await expect(response.text()).resolves.toBe("ok");
+  });
+
   it("streams response chunks before the provider body completes", async () => {
     let releaseBody!: () => void;
     const bodyReleased = new Promise<void>((resolve) => {

--- a/test/webhook-server.test.ts
+++ b/test/webhook-server.test.ts
@@ -27,6 +27,7 @@ describe("webhook server", () => {
   it.each([
     ["0.0.0.0", "127.0.0.1"],
     ["::", "[::1]"],
+    ["0:0:0:0:0:0:0:0", "[::1]"],
   ])("advertises loopback instead of the %s wildcard bind", async (host, advertisedHost) => {
     const server = await startWebhookServer({
       handle: async () => new Response("ok"),

--- a/test/webhook-target.test.ts
+++ b/test/webhook-target.test.ts
@@ -221,6 +221,28 @@ describe("webhook target validation", () => {
     ).resolves.toEqual({ error: "private-address" });
   });
 
+  it("blocks private IPv4 embeddings under overlapping discovered NAT64 prefixes", async () => {
+    const dnsLookupPool = new WebhookDnsLookupPool(1, async (hostname) =>
+      hostname === "ipv4only.arpa"
+        ? [
+            { address: rfc6052Address(32, "192.0.0.170"), family: 6 },
+            { address: rfc6052Address(32, "192.0.0.171"), family: 6 },
+            { address: rfc6052Address(96, "192.0.0.170"), family: 6 },
+            { address: rfc6052Address(96, "192.0.0.171"), family: 6 },
+          ]
+        : [],
+    );
+
+    await expect(
+      validateWebhookTarget({
+        allowLoopbackHttp: false,
+        dnsLookupPool,
+        restrictPrivateAddresses: true,
+        url: new URL(`https://[${rfc6052Address(96, "127.0.0.1")}]/webhook`),
+      }),
+    ).resolves.toEqual({ error: "private-address" });
+  });
+
   it("skips address resolution when private-target restriction is disabled", async () => {
     const resolve = vi.fn(async () => {
       throw new Error("resolution should not run");

--- a/test/webhook-target.test.ts
+++ b/test/webhook-target.test.ts
@@ -1,5 +1,5 @@
 import { createServer } from "node:http";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   postWebhookRequest,
   postWebhookRequestWithResponse,
@@ -202,6 +202,39 @@ describe("webhook target validation", () => {
         url: new URL("https://[2001:4860:4860::8888]/webhook"),
       }),
     ).resolves.toEqual({ error: "private-address" });
+  });
+
+  it("fails closed when NAT64 discovery does not return the complete reserved pair", async () => {
+    const dnsLookupPool = new WebhookDnsLookupPool(1, async (hostname) =>
+      hostname === "ipv4only.arpa"
+        ? [{ address: rfc6052Address(96, "192.0.0.170"), family: 6 }]
+        : [],
+    );
+
+    await expect(
+      validateWebhookTarget({
+        allowLoopbackHttp: false,
+        dnsLookupPool,
+        restrictPrivateAddresses: true,
+        url: new URL("https://[2001:4860:4860::8888]/webhook"),
+      }),
+    ).resolves.toEqual({ error: "private-address" });
+  });
+
+  it("skips address resolution when private-target restriction is disabled", async () => {
+    const resolve = vi.fn(async () => {
+      throw new Error("resolution should not run");
+    });
+
+    await expect(
+      validateWebhookTarget({
+        allowLoopbackHttp: false,
+        dnsLookupPool: { resolve },
+        restrictPrivateAddresses: false,
+        url: new URL("https://[2001:4860:4860::8888]/webhook"),
+      }),
+    ).resolves.toEqual({ addresses: undefined });
+    expect(resolve).not.toHaveBeenCalled();
   });
 
   it("bounds DNS lookup concurrency and cancels queued registrations", async () => {

--- a/test/webhook-target.test.ts
+++ b/test/webhook-target.test.ts
@@ -10,9 +10,31 @@ import {
 async function validate(address: string) {
   return await validateWebhookTarget({
     allowLoopbackHttp: false,
+    dnsLookupPool: new WebhookDnsLookupPool(1, async (hostname) =>
+      hostname === "ipv4only.arpa" ? [{ address: "192.0.0.170", family: 4 }] : [],
+    ),
     restrictPrivateAddresses: true,
     url: new URL(`https://${address}/webhook`),
   });
+}
+
+function rfc6052Address(prefixLength: 32 | 40 | 48 | 56 | 64 | 96, ipv4: string): string {
+  const prefix = [0x20, 0x01, 0x48, 0x60, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x11, 0x22];
+  const ipv4Bytes = ipv4.split(".").map(Number);
+  const bytes = Array.from({ length: 16 }, () => 0);
+  const prefixBytes = prefixLength / 8;
+  bytes.splice(0, prefixBytes, ...prefix.slice(0, prefixBytes));
+  if (prefixLength === 96) {
+    bytes.splice(12, 4, ...ipv4Bytes);
+  } else {
+    const leadingIpv4Bytes = 8 - prefixBytes;
+    bytes.splice(prefixBytes, leadingIpv4Bytes, ...ipv4Bytes.slice(0, leadingIpv4Bytes));
+    bytes[8] = 0;
+    bytes.splice(9, 4 - leadingIpv4Bytes, ...ipv4Bytes.slice(leadingIpv4Bytes));
+  }
+  return Array.from({ length: 8 }, (_, index) =>
+    ((bytes[index * 2]! << 8) | bytes[index * 2 + 1]!).toString(16),
+  ).join(":");
 }
 
 describe("webhook target validation", () => {
@@ -129,6 +151,59 @@ describe("webhook target validation", () => {
     ).resolves.toEqual({ error: "private-address" });
   });
 
+  it.each([32, 40, 48, 56, 64, 96] as const)(
+    "blocks private IPv4 targets embedded under a network-specific /%i NAT64 prefix",
+    async (prefixLength) => {
+      const dnsLookupPool = new WebhookDnsLookupPool(1, async (hostname) =>
+        hostname === "ipv4only.arpa"
+          ? [
+              { address: rfc6052Address(prefixLength, "192.0.0.170"), family: 6 },
+              { address: rfc6052Address(prefixLength, "192.0.0.171"), family: 6 },
+            ]
+          : [],
+      );
+      const privateAddress = rfc6052Address(prefixLength, "127.0.0.1");
+      const publicAddress = rfc6052Address(prefixLength, "93.184.216.34");
+      const normalizedPublicAddress = new URL(
+        `https://[${publicAddress}]/webhook`,
+      ).hostname.replace(/^\[(.*)\]$/u, "$1");
+
+      await expect(
+        validateWebhookTarget({
+          allowLoopbackHttp: false,
+          dnsLookupPool,
+          restrictPrivateAddresses: true,
+          url: new URL(`https://[${privateAddress}]/webhook`),
+        }),
+      ).resolves.toEqual({ error: "private-address" });
+      await expect(
+        validateWebhookTarget({
+          allowLoopbackHttp: false,
+          dnsLookupPool,
+          restrictPrivateAddresses: true,
+          url: new URL(`https://[${publicAddress}]/webhook`),
+        }),
+      ).resolves.toEqual({
+        addresses: [{ address: normalizedPublicAddress, family: 6 }],
+      });
+    },
+  );
+
+  it("fails closed for IPv6 targets when NAT64 prefix discovery fails", async () => {
+    const dnsLookupPool = new WebhookDnsLookupPool(1, async () => {
+      throw new Error("resolver unavailable");
+    });
+
+    await expect(
+      validateWebhookTarget({
+        allowLoopbackHttp: false,
+        dnsLookupPool,
+        restrictPrivateAddresses: true,
+        url: new URL("https://[2001:4860:4860::8888]/webhook"),
+      }),
+    ).resolves.toEqual({ error: "private-address" });
+  });
+
   it("bounds DNS lookup concurrency and cancels queued registrations", async () => {
     const started: string[] = [];
     const releases = new Map<
@@ -157,6 +232,43 @@ describe("webhook target validation", () => {
     releases.get("second.test")?.([{ address: "93.184.216.35", family: 4 }]);
     await expect(first).resolves.toEqual([{ address: "93.184.216.34", family: 4 }]);
     await expect(second).resolves.toEqual([{ address: "93.184.216.35", family: 4 }]);
+  });
+
+  it("releases an aborted active lookup without letting its late result release a newer slot", async () => {
+    const started: string[] = [];
+    const releases = new Map<
+      string,
+      (addresses: Array<{ address: string; family: number }>) => void
+    >();
+    const pool = new WebhookDnsLookupPool(
+      1,
+      async (hostname) =>
+        await new Promise((resolve) => {
+          started.push(hostname);
+          releases.set(hostname, resolve);
+        }),
+    );
+    const controller = new AbortController();
+    const first = pool.resolve("first.test", controller.signal);
+    const second = pool.resolve("second.test");
+    const third = pool.resolve("third.test");
+
+    expect(started).toEqual(["first.test"]);
+    controller.abort();
+    await expect(first).rejects.toMatchObject({ name: "AbortError" });
+    expect(started).toEqual(["first.test", "second.test"]);
+
+    releases.get("first.test")?.([{ address: "93.184.216.34", family: 4 }]);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(started).toEqual(["first.test", "second.test"]);
+
+    releases.get("second.test")?.([{ address: "93.184.216.35", family: 4 }]);
+    await expect(second).resolves.toEqual([{ address: "93.184.216.35", family: 4 }]);
+    expect(started).toEqual(["first.test", "second.test", "third.test"]);
+
+    releases.get("third.test")?.([{ address: "93.184.216.36", family: 4 }]);
+    await expect(third).resolves.toEqual([{ address: "93.184.216.36", family: 4 }]);
   });
 
   it("does not reuse sockets for DNS-pinned webhook delivery", async () => {

--- a/test/webhook-target.test.ts
+++ b/test/webhook-target.test.ts
@@ -289,41 +289,58 @@ describe("webhook target validation", () => {
     await expect(second).resolves.toEqual([{ address: "93.184.216.35", family: 4 }]);
   });
 
-  it("releases an aborted active lookup without letting its late result release a newer slot", async () => {
+  it("keeps actual DNS concurrency bounded while active callers abort", async () => {
     const started: string[] = [];
+    let active = 0;
+    let maximumActive = 0;
     const releases = new Map<
       string,
       (addresses: Array<{ address: string; family: number }>) => void
     >();
     const pool = new WebhookDnsLookupPool(
-      1,
+      2,
       async (hostname) =>
         await new Promise((resolve) => {
+          active += 1;
+          maximumActive = Math.max(maximumActive, active);
           started.push(hostname);
-          releases.set(hostname, resolve);
+          releases.set(hostname, (addresses) => {
+            active -= 1;
+            resolve(addresses);
+          });
         }),
     );
-    const controller = new AbortController();
-    const first = pool.resolve("first.test", controller.signal);
-    const second = pool.resolve("second.test");
+    const firstController = new AbortController();
+    const secondController = new AbortController();
+    const first = pool.resolve("first.test", firstController.signal);
+    const second = pool.resolve("second.test", secondController.signal);
     const third = pool.resolve("third.test");
+    const fourth = pool.resolve("fourth.test");
 
-    expect(started).toEqual(["first.test"]);
-    controller.abort();
-    await expect(first).rejects.toMatchObject({ name: "AbortError" });
     expect(started).toEqual(["first.test", "second.test"]);
+    firstController.abort();
+    secondController.abort();
+    await Promise.all([
+      expect(first).rejects.toMatchObject({ name: "AbortError" }),
+      expect(second).rejects.toMatchObject({ name: "AbortError" }),
+    ]);
+    expect(started).toEqual(["first.test", "second.test"]);
+    expect(maximumActive).toBe(2);
 
     releases.get("first.test")?.([{ address: "93.184.216.34", family: 4 }]);
-    await Promise.resolve();
-    await Promise.resolve();
-    expect(started).toEqual(["first.test", "second.test"]);
+    await vi.waitFor(() => expect(started).toEqual(["first.test", "second.test", "third.test"]));
+    expect(maximumActive).toBe(2);
 
     releases.get("second.test")?.([{ address: "93.184.216.35", family: 4 }]);
-    await expect(second).resolves.toEqual([{ address: "93.184.216.35", family: 4 }]);
-    expect(started).toEqual(["first.test", "second.test", "third.test"]);
+    await vi.waitFor(() =>
+      expect(started).toEqual(["first.test", "second.test", "third.test", "fourth.test"]),
+    );
+    expect(maximumActive).toBe(2);
 
     releases.get("third.test")?.([{ address: "93.184.216.36", family: 4 }]);
+    releases.get("fourth.test")?.([{ address: "93.184.216.37", family: 4 }]);
     await expect(third).resolves.toEqual([{ address: "93.184.216.36", family: 4 }]);
+    await expect(fourth).resolves.toEqual([{ address: "93.184.216.37", family: 4 }]);
   });
 
   it("does not reuse sockets for DNS-pinned webhook delivery", async () => {


### PR DESCRIPTION
## Summary
- validate DNS and NAT64 resolution without cross-request state corruption
- hold DNS capacity until uncancellable abandoned lookups actually settle
- canonicalize wildcard listener addresses and sanitize provider response headers
- expose local webhook hooks while preserving GET and JSON media semantics
- record the network and response-boundary fixes in the changelog

## Validation
- 153 focused tests
- `pnpm lint`
- exact-current `gpt-5.6-sol` high autoreview, clean at 0.91 confidence

## Landing gates
- GitHub CI on the exact PR head
- Crabbox `pnpm verify` on the exact PR head