### PR TITLE
fix(providers): harden Mattermost, Matrix, and Signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Correlate complete NAT64 discovery pairs and retain DNS capacity until abandoned lookups settle.
 - Verify loopback bindings by their listening address, sanitize framing and connection-nominated Fetch response headers, and advertise usable endpoints for every wildcard address spelling.
 - Route local-mock GET hooks through the real server and parse structured JSON media types as JSON.
-- Bound Matrix and Mattermost committed state, enforce native Mattermost transport, webhook, post lifecycle, and direct-channel identity semantics, and serialize Signal timestamps, SSE cleanup, JSON-RPC strings, and username identity.
+- Bound Matrix and Mattermost committed state, authenticate and redact native Mattermost outgoing webhooks, enforce native transport, post lifecycle, and direct-channel identity semantics, and serialize Signal timestamps, SSE cleanup, JSON-RPC strings, and username identity.
 - Randomize WhatsApp XEdDSA signatures with fresh entropy while preserving their wire encoding.
 - Suppress serve readiness output when shutdown begins during ready-file publication.
 - Treat Unicode format characters as continuations when recognizing standalone acknowledgement tokens.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Correlate complete NAT64 discovery pairs and retain DNS capacity until abandoned lookups settle.
 - Verify loopback bindings by their listening address, sanitize framing and connection-nominated Fetch response headers, and advertise usable endpoints for every wildcard address spelling.
 - Route local-mock GET hooks through the real server and parse structured JSON media types as JSON.
+- Bound Matrix and Mattermost committed state, enforce native Mattermost transport, webhook, post lifecycle, and direct-channel identity semantics, and serialize Signal timestamps, SSE cleanup, JSON-RPC strings, and username identity.
 - Randomize WhatsApp XEdDSA signatures with fresh entropy while preserving their wire encoding.
 - Suppress serve readiness output when shutdown begins during ready-file publication.
 - Treat Unicode format characters as continuations when recognizing standalone acknowledgement tokens.

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ The JSON manifest contains:
 
 - `baseUrl`: OpenClaw `channels.mattermost.baseUrl` / `MATTERMOST_URL`
 - `botToken`: OpenClaw `channels.mattermost.botToken` / `MATTERMOST_BOT_TOKEN`
+- `webhookToken` / `MATTERMOST_TOKEN`: verifies native outgoing webhook posts
 - `endpoints.websocketUrl`: native Mattermost WebSocket endpoint
 - `adminToken`: send this as the `X-Crabline-Admin-Token` header when posting
   test user messages

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -102,10 +102,12 @@ header before JSON parsing or recorder writes:
   required when the webhook host or advertised callback is non-loopback.
 - Matrix webhook ingress currently has no provider-native authentication mode,
   so its listener and any advertised callback must remain loopback-only.
-- Mattermost and iMessage webhook ingress currently have no provider-native
-  authentication mode, so their listeners and any advertised callbacks must
-  remain loopback-only. Their API credentials do not authenticate inbound
-  callbacks.
+- Mattermost `webhookToken` or `MATTERMOST_TOKEN` verifies the `token` field in
+  outgoing webhook form or JSON bodies. The token is removed before recorder
+  persistence. Externally reachable callbacks require this token and an HTTPS
+  `webhook.publicUrl`.
+- iMessage webhook ingress currently has no provider-native authentication
+  mode, so its listener and any advertised callback must remain loopback-only.
 - Feishu `verificationToken` or `FEISHU_VERIFICATION_TOKEN` verifies plaintext
   callback tokens on loopback and remains an additional check when configured
   with encryption. Externally reachable webhooks require `encryptKey` or

--- a/fixtures/examples/crabline.example.yaml
+++ b/fixtures/examples/crabline.example.yaml
@@ -89,6 +89,7 @@ providers:
   mattermost:
     adapter: mattermost
     mattermost:
+      # webhookToken: sample
       recorder:
         path: ./.crabline/recorders/mattermost.jsonl
       webhook:

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -462,6 +462,11 @@ const MattermostConfigSchema = z.strictObject({
     path: "/mattermost/webhook",
     port: 8793,
   }),
+  webhookToken: z
+    .string()
+    .min(1)
+    .refine((value) => value.trim().length > 0, "webhookToken must not be blank")
+    .optional(),
   websocket: MattermostWebsocketSchema.optional(),
 });
 

--- a/src/openclaw/bridges/signal.ts
+++ b/src/openclaw/bridges/signal.ts
@@ -54,8 +54,8 @@ function signalOutboundTargets(params: Record<string, unknown>, account: string)
     ...signalRecipientValues(params.groupIds).map((id) => `group:${id}`),
     ...signalDirectRecipientValues(params.recipient),
     ...signalDirectRecipientValues(params.recipients),
-    ...signalRecipientValues(params.username),
-    ...signalRecipientValues(params.usernames),
+    ...signalDirectRecipientValues(params.username),
+    ...signalDirectRecipientValues(params.usernames),
     ...(params.noteToSelf === true ? [signalDirectIdentity(account).recipient] : []),
   ];
   return [...new Set(targets)];

--- a/src/providers/builtin/mattermost.ts
+++ b/src/providers/builtin/mattermost.ts
@@ -8,6 +8,7 @@ import type { ProviderAdapter } from "../types.js";
 import { getBuiltinTargetCodec, MATTERMOST_ID_RULE } from "../target-normalizers.js";
 import {
   authorFromBotFlag,
+  createSecretVerifier,
   genericMockPayloadWithNativeThread,
   isRecord,
   optionalRecord,
@@ -16,9 +17,16 @@ import {
 } from "./native-local-mock.js";
 import { requireExternalWebhookAuthentication } from "./external-webhook-auth.js";
 
+type MattermostEnvironment = Partial<
+  Pick<
+    NodeJS.ProcessEnv,
+    "MATTERMOST_BASE_URL" | "MATTERMOST_BOT_TOKEN" | "MATTERMOST_TOKEN" | "MATTERMOST_URL"
+  >
+>;
+
 export function resolveMattermostAdapterConfig(
   config: ProviderConfig,
-  env: NodeJS.ProcessEnv = process.env,
+  env: MattermostEnvironment = process.env,
 ) {
   const baseUrl =
     config.mattermost?.baseUrl ??
@@ -43,21 +51,32 @@ export function resolveMattermostAdapterConfig(
       { kind: "config" },
     );
   }
+  if (
+    config.mattermost?.webhookToken === undefined &&
+    env.MATTERMOST_TOKEN !== undefined &&
+    !env.MATTERMOST_TOKEN.trim()
+  ) {
+    throw new Error("MATTERMOST_TOKEN must not be empty or whitespace-only.");
+  }
   return {
     baseUrl,
     botToken: config.mattermost?.botToken ?? env.MATTERMOST_BOT_TOKEN ?? "local-mock-token",
     userName: config.mattermost?.userName,
+    webhookToken: config.mattermost?.webhookToken ?? env.MATTERMOST_TOKEN,
   };
 }
 
 export class MattermostProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
-  constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
-    resolveMattermostAdapterConfig(config);
+  constructor(id: string, config: ProviderConfig, _userName: string, runtime?: unknown) {
+    const env = (runtime as { env?: MattermostEnvironment } | undefined)?.env ?? process.env;
+    const resolvedConfig = resolveMattermostAdapterConfig(config, env);
+    const authenticateWebhook = resolvedConfig.webhookToken
+      ? createSecretVerifier(resolvedConfig.webhookToken)
+      : undefined;
     requireExternalWebhookAuthentication({
-      authenticated: false,
+      authenticated: Boolean(authenticateWebhook),
       provider: "Mattermost",
-      requirement:
-        "a provider-native authenticated ingress mode, which this adapter does not support",
+      requirement: "webhookToken or MATTERMOST_TOKEN",
       webhook: config.mattermost?.webhook,
     });
     const recorderPath = config.mattermost?.recorder.path
@@ -68,6 +87,15 @@ export class MattermostProviderAdapter extends LocalMockProviderAdapter implemen
       config,
       id,
       options: {
+        ...(authenticateWebhook
+          ? {
+              authenticateWebhookRequest(request: Request, rawBody: string) {
+                return authenticateWebhook(readMattermostWebhookToken(request, rawBody))
+                  ? undefined
+                  : new Response("unauthorized", { status: 401 });
+              },
+            }
+          : {}),
         defaultWebhook: { host: "127.0.0.1", path: "/mattermost/webhook", port: 8793 },
         endpointLabel: "webhook endpoint",
         matchesThread: matchesMattermostThread,
@@ -144,6 +172,27 @@ export function matchesMattermostThread(
   );
 }
 
+function readMattermostWebhookToken(request: Request, rawBody: string): string | null {
+  const mediaType = request.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase();
+  if (mediaType === "application/x-www-form-urlencoded") {
+    return new URLSearchParams(rawBody).get("token");
+  }
+  if (mediaType !== "application/json") {
+    return null;
+  }
+  try {
+    const payload = JSON.parse(rawBody) as unknown;
+    return isRecord(payload) && typeof payload.token === "string" ? payload.token : null;
+  } catch {
+    return null;
+  }
+}
+
+function withoutMattermostWebhookToken(payload: Record<string, unknown>): Record<string, unknown> {
+  const { token: _token, ...safePayload } = payload;
+  return safePayload;
+}
+
 type NormalizedMattermostWebhookPayload = {
   author: "assistant" | "system" | "user";
   id?: string | undefined;
@@ -159,18 +208,19 @@ export function normalizeMattermostWebhookPayload(
     throw new CrablineError("Mattermost webhook payload must be an object", { kind: "inbound" });
   }
 
-  if (optionalRecord(payload, "message")) {
+  const safePayload = withoutMattermostWebhookToken(payload);
+  if (optionalRecord(safePayload, "message")) {
     return genericMockPayloadWithNativeThread({
       channelRule: MATTERMOST_ID_RULE,
-      payload,
+      payload: safePayload,
       threadRule: MATTERMOST_ID_RULE,
     }) as NormalizedMattermostWebhookPayload;
   }
 
-  const channelId = optionalString(payload, "channel_id");
-  const postId = optionalString(payload, "post_id");
-  const rootId = optionalString(payload, "root_id");
-  const text = optionalString(payload, "text");
+  const channelId = optionalString(safePayload, "channel_id");
+  const postId = optionalString(safePayload, "post_id");
+  const rootId = optionalString(safePayload, "root_id");
+  const text = optionalString(safePayload, "text");
   if (!channelId || !text) {
     throw new CrablineError("Mattermost webhook payload requires channel_id and text", {
       kind: "inbound",
@@ -182,7 +232,7 @@ export function normalizeMattermostWebhookPayload(
     ...(postId
       ? { id: requireNativeInboundId(postId, MATTERMOST_ID_RULE, "Mattermost post_id") }
       : {}),
-    raw: payload,
+    raw: safePayload,
     text,
     threadId: rootId
       ? mattermostThreadKey(

--- a/src/providers/builtin/mattermost.ts
+++ b/src/providers/builtin/mattermost.ts
@@ -1,7 +1,9 @@
 import path from "node:path";
 import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
-import { LocalMockProviderAdapter } from "../local-mock.js";
+import { isLoopbackHost } from "../../servers/http.js";
+import { LocalMockProviderAdapter, resolveGeneratedLocalMockRecorderPath } from "../local-mock.js";
+import { appendRecordedInbound } from "../recorder.js";
 import type { ProviderAdapter } from "../types.js";
 import { getBuiltinTargetCodec, MATTERMOST_ID_RULE } from "../target-normalizers.js";
 import {
@@ -18,12 +20,31 @@ export function resolveMattermostAdapterConfig(
   config: ProviderConfig,
   env: NodeJS.ProcessEnv = process.env,
 ) {
+  const baseUrl =
+    config.mattermost?.baseUrl ??
+    env.MATTERMOST_URL ??
+    env.MATTERMOST_BASE_URL ??
+    "http://127.0.0.1";
+  let parsedBaseUrl: URL;
+  try {
+    parsedBaseUrl = new URL(baseUrl);
+  } catch (error) {
+    throw new CrablineError("Mattermost base URL is invalid.", {
+      cause: error,
+      kind: "config",
+    });
+  }
+  if (
+    parsedBaseUrl.protocol !== "https:" &&
+    !(parsedBaseUrl.protocol === "http:" && isLoopbackHost(parsedBaseUrl.hostname))
+  ) {
+    throw new CrablineError(
+      "Mattermost bearer authentication requires HTTPS; plain HTTP is allowed only for loopback-local servers.",
+      { kind: "config" },
+    );
+  }
   return {
-    baseUrl:
-      config.mattermost?.baseUrl ??
-      env.MATTERMOST_URL ??
-      env.MATTERMOST_BASE_URL ??
-      "http://mattermost.local",
+    baseUrl,
     botToken: config.mattermost?.botToken ?? env.MATTERMOST_BOT_TOKEN ?? "local-mock-token",
     userName: config.mattermost?.userName,
   };
@@ -31,6 +52,7 @@ export function resolveMattermostAdapterConfig(
 
 export class MattermostProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
+    resolveMattermostAdapterConfig(config);
     requireExternalWebhookAuthentication({
       authenticated: false,
       provider: "Mattermost",
@@ -38,6 +60,9 @@ export class MattermostProviderAdapter extends LocalMockProviderAdapter implemen
         "a provider-native authenticated ingress mode, which this adapter does not support",
       webhook: config.mattermost?.webhook,
     });
+    const recorderPath = config.mattermost?.recorder.path
+      ? path.resolve(config.mattermost.recorder.path)
+      : resolveGeneratedLocalMockRecorderPath(id);
     super({
       codec: getBuiltinTargetCodec("mattermost"),
       config,
@@ -46,12 +71,47 @@ export class MattermostProviderAdapter extends LocalMockProviderAdapter implemen
         defaultWebhook: { host: "127.0.0.1", path: "/mattermost/webhook", port: 8793 },
         endpointLabel: "webhook endpoint",
         matchesThread: matchesMattermostThread,
+        handleWebhookPayload: async (payload, request) => {
+          const mediaType = request.headers
+            .get("content-type")
+            ?.split(";", 1)[0]
+            ?.trim()
+            .toLowerCase();
+          if (mediaType !== "application/x-www-form-urlencoded" || typeof payload !== "string") {
+            return undefined;
+          }
+          let normalized: ReturnType<typeof normalizeMattermostWebhookPayload>;
+          try {
+            normalized = normalizeMattermostWebhookPayload(
+              Object.fromEntries(new URLSearchParams(payload).entries()),
+            );
+          } catch (error) {
+            if (error instanceof CrablineError && error.kind === "inbound") {
+              return new Response(error.message, { status: 400 });
+            }
+            throw error;
+          }
+          const messageId =
+            normalized.id ??
+            `mattermost-mock-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+          await appendRecordedInbound(recorderPath, {
+            author: normalized.author,
+            id: messageId,
+            provider: id,
+            raw: normalized.raw,
+            recordedDirection: "inbound",
+            sentAt: new Date().toISOString(),
+            text: normalized.text,
+            threadId: normalized.threadId,
+          });
+          return new Response(JSON.stringify({ id: messageId, ok: true }), {
+            headers: { "content-type": "application/json" },
+          });
+        },
         normalizeWebhookPayload: normalizeMattermostWebhookPayload,
         platform: "mattermost",
         publicUrl: config.mattermost?.webhook.publicUrl,
-        recorderPath: config.mattermost?.recorder.path
-          ? path.resolve(config.mattermost.recorder.path)
-          : undefined,
+        recorderPath,
         webhook: config.mattermost?.webhook,
       },
     });
@@ -84,7 +144,17 @@ export function matchesMattermostThread(
   );
 }
 
-export function normalizeMattermostWebhookPayload(payload: unknown) {
+type NormalizedMattermostWebhookPayload = {
+  author: "assistant" | "system" | "user";
+  id?: string | undefined;
+  raw: unknown;
+  text: string;
+  threadId: string;
+};
+
+export function normalizeMattermostWebhookPayload(
+  payload: unknown,
+): NormalizedMattermostWebhookPayload {
   if (!isRecord(payload)) {
     throw new CrablineError("Mattermost webhook payload must be an object", { kind: "inbound" });
   }
@@ -94,7 +164,7 @@ export function normalizeMattermostWebhookPayload(payload: unknown) {
       channelRule: MATTERMOST_ID_RULE,
       payload,
       threadRule: MATTERMOST_ID_RULE,
-    });
+    }) as NormalizedMattermostWebhookPayload;
   }
 
   const channelId = optionalString(payload, "channel_id");

--- a/src/providers/catalog.ts
+++ b/src/providers/catalog.ts
@@ -63,7 +63,7 @@ export const OPENCLAW_SUPPORT_CATALOG = [
     supports: COMMON_BRIDGE_SUPPORT,
   },
   {
-    notes: "Built-in local Mattermost mock.",
+    notes: "Built-in local Mattermost mock with authenticated outgoing webhook ingress.",
     platform: "mattermost",
     status: "ready",
     supports: COMMON_BRIDGE_SUPPORT,

--- a/src/servers/matrix.ts
+++ b/src/servers/matrix.ts
@@ -65,6 +65,8 @@ type MatrixServerState = {
   directRoomsSequence: number | undefined;
   filterBytes: number;
   filters: Map<string, { body: Record<string, unknown>; bytes: number }>;
+  maxCommittedRooms: number;
+  maxCommittedUsers: number;
   nextEvent: number;
   nextFilter: number;
   nextSequence: number;
@@ -87,6 +89,8 @@ const MAX_MATRIX_TIMELINE_EVENTS = 1_000;
 const MAX_MATRIX_TRANSACTION_RESPONSES = 1_000;
 const MATRIX_TRANSACTION_RETENTION_MS = 10 * 60_000;
 const MAX_NODE_TIMER_DELAY_MS = 2_147_483_647;
+const DEFAULT_MAX_MATRIX_COMMITTED_ROOMS = 1_000;
+const DEFAULT_MAX_MATRIX_COMMITTED_USERS = 1_000;
 
 class InvalidMatrixPathEncodingError extends Error {
   constructor() {
@@ -127,6 +131,8 @@ export type StartMatrixServerParams = {
   botUserId?: string | undefined;
   deviceId?: string | undefined;
   host?: string | undefined;
+  maxCommittedRooms?: number | undefined;
+  maxCommittedUsers?: number | undefined;
   onEvent?: ServerEventObserver | undefined;
   port?: number | undefined;
   recorderPath?: string | undefined;
@@ -166,6 +172,16 @@ function matrixResourceLimitError(error: string): Response {
     },
     503,
   );
+}
+
+function resolvePositiveLimit(value: number | undefined, name: string, fallback: number): number {
+  if (value === undefined) {
+    return fallback;
+  }
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new Error(`${name} must be a positive safe integer.`);
+  }
+  return value;
 }
 
 function decodeMatrixPathSegment(value: string): string {
@@ -523,8 +539,25 @@ async function handleAdminInbound(params: {
     return jsonResponse({ error: "Invalid Matrix identifier", ok: false }, 400);
   }
   const direct = params.body.direct === true;
+  const existingRoom = params.state.rooms.get(roomId);
+  if (!existingRoom && params.state.rooms.size >= params.state.maxCommittedRooms) {
+    return jsonResponse({ error: "Committed Matrix rooms limit reached", ok: false }, 503);
+  }
+  if (
+    !params.state.profiles.has(sender) &&
+    params.state.profiles.size >= params.state.maxCommittedUsers
+  ) {
+    return jsonResponse({ error: "Committed Matrix users limit reached", ok: false }, 503);
+  }
+  const roomHasSender = existingRoom
+    ? existingRoom.users.has(sender)
+    : sender === params.state.botUserId;
+  const roomUserCount = existingRoom?.users.size ?? 1;
+  if (!roomHasSender && roomUserCount >= params.state.maxCommittedUsers) {
+    return jsonResponse({ error: "Committed Matrix users limit reached", ok: false }, 503);
+  }
   const room =
-    params.state.rooms.get(roomId) ??
+    existingRoom ??
     createRoom({
       botUserId: params.state.botUserId,
       createdSequence: params.state.nextSequence++,
@@ -865,6 +898,16 @@ export async function startMatrixServer(
     directRoomsSequence: undefined,
     filterBytes: 0,
     filters: new Map(),
+    maxCommittedRooms: resolvePositiveLimit(
+      params.maxCommittedRooms,
+      "maxCommittedRooms",
+      DEFAULT_MAX_MATRIX_COMMITTED_ROOMS,
+    ),
+    maxCommittedUsers: resolvePositiveLimit(
+      params.maxCommittedUsers,
+      "maxCommittedUsers",
+      DEFAULT_MAX_MATRIX_COMMITTED_USERS,
+    ),
     nextEvent: 1,
     nextFilter: 1,
     nextSequence: 1,

--- a/src/servers/mattermost.ts
+++ b/src/servers/mattermost.ts
@@ -484,6 +484,7 @@ function handleAdminInbound(params: {
   if (!previousChannel && params.state.channels.size >= params.state.maxCommittedChannels) {
     return committedStateFullResponse("channels");
   }
+  // buildNextPost always allocates a fresh ID, including against a synthesized root.
   const requiredPostSlots = 1 + (rootId && !existingRoot ? 1 : 0);
   if (params.state.posts.size + requiredPostSlots > params.state.maxCommittedPosts) {
     return committedStateFullResponse("posts");

--- a/src/servers/mattermost.ts
+++ b/src/servers/mattermost.ts
@@ -30,6 +30,9 @@ const DEFAULT_WEBSOCKET_AUTHENTICATION_TIMEOUT_MS = 5_000;
 const DEFAULT_MAX_WEBSOCKET_BUFFERED_BYTES = 1024 * 1024;
 const DEFAULT_MAX_WEBSOCKET_MESSAGE_BYTES = 64 * 1024;
 const DEFAULT_MAX_UNAUTHENTICATED_WEBSOCKET_CLIENTS = 32;
+const DEFAULT_MAX_COMMITTED_CHANNELS = 1_000;
+const DEFAULT_MAX_COMMITTED_POSTS = 1_000;
+const DEFAULT_MAX_COMMITTED_USERS = 1_000;
 const MATTERMOST_ID_PATTERN = /^[a-z0-9]{26}(?![\s\S])/u;
 
 function resolvePositiveLimit(value: number | undefined, name: string, fallback: number): number {
@@ -45,10 +48,13 @@ function resolvePositiveLimit(value: number | undefined, name: string, fallback:
 type MattermostPost = {
   channel_id: string;
   create_at: number;
+  delete_at: number;
+  edit_at: number;
   id: string;
   message: string;
   root_id: string;
   type: string;
+  update_at: number;
   user_id: string;
 };
 
@@ -79,6 +85,9 @@ type MattermostServerState = {
   botUserId: string;
   botUsername: string;
   channels: Map<string, MattermostChannel>;
+  maxCommittedChannels: number;
+  maxCommittedPosts: number;
+  maxCommittedUsers: number;
   maxPendingInboundEvents: number;
   maxWebSocketBufferedBytes: number;
   nextPost: number;
@@ -123,6 +132,9 @@ export type StartMattermostServerParams = {
   onEvent?: ServerEventObserver | undefined;
   port?: number | undefined;
   recorderPath?: string | undefined;
+  maxCommittedChannels?: number | undefined;
+  maxCommittedPosts?: number | undefined;
+  maxCommittedUsers?: number | undefined;
   maxPendingInboundEvents?: number | undefined;
   maxWebSocketBufferedBytes?: number | undefined;
   maxWebSocketMessageBytes?: number | undefined;
@@ -339,6 +351,16 @@ function pendingQueueFullResponse(state: MattermostServerState): Response {
   );
 }
 
+function committedStateFullResponse(resource: "channels" | "posts" | "users"): Response {
+  return jsonResponse(
+    {
+      error: `Committed Mattermost ${resource} limit reached`,
+      ok: false,
+    },
+    503,
+  );
+}
+
 function buildPost(params: {
   channelId: string;
   id: string;
@@ -346,13 +368,17 @@ function buildPost(params: {
   rootId?: string | undefined;
   userId: string;
 }): MattermostPost {
+  const now = Date.now();
   return {
     channel_id: params.channelId,
-    create_at: Date.now(),
+    create_at: now,
+    delete_at: 0,
+    edit_at: 0,
     id: params.id,
     message: params.message,
     root_id: params.rootId ?? "",
     type: "",
+    update_at: now,
     user_id: params.userId,
   };
 }
@@ -451,6 +477,16 @@ function handleAdminInbound(params: {
   }
   if (existingRoot?.root_id) {
     return jsonResponse({ error: "Root post is itself a reply", ok: false }, 400);
+  }
+  if (!previousUser && params.state.users.size >= params.state.maxCommittedUsers) {
+    return committedStateFullResponse("users");
+  }
+  if (!previousChannel && params.state.channels.size >= params.state.maxCommittedChannels) {
+    return committedStateFullResponse("channels");
+  }
+  const requiredPostSlots = 1 + (rootId && !existingRoot ? 1 : 0);
+  if (params.state.posts.size + requiredPostSlots > params.state.maxCommittedPosts) {
+    return committedStateFullResponse("posts");
   }
   const rootPost =
     rootId && !existingRoot
@@ -551,8 +587,13 @@ async function handleApi(params: {
     if (firstUserId !== state.botUserId && secondUserId !== state.botUserId) {
       return mattermostError("Authenticated user must belong to the direct channel", 403);
     }
-    const channelId = mattermostId(`dm:${userIds.sort().join(":")}`);
-    const channel = { display_name: "", id: channelId, name: channelId, type: "D" };
+    const participantIds = [...userIds].sort();
+    const channelName = participantIds.join("__");
+    const channelId = mattermostId(`dm:${participantIds.join(":")}`);
+    if (!state.channels.has(channelId) && state.channels.size >= state.maxCommittedChannels) {
+      return mattermostError("Too many retained channels", 503);
+    }
+    const channel = { display_name: "", id: channelId, name: channelName, type: "D" };
     state.channels.set(channelId, channel);
     return jsonResponse(channel, 201);
   }
@@ -616,6 +657,9 @@ async function handleApi(params: {
         return mattermostError("Root post is itself a reply", 400);
       }
     }
+    if (state.posts.size >= state.maxCommittedPosts) {
+      return mattermostError("Too many retained posts", 503);
+    }
     const pendingPost = buildNextPost(state, {
       channelId,
       message,
@@ -644,7 +688,8 @@ async function handleApi(params: {
     if (!message) {
       return mattermostError("message must be a string", 400);
     }
-    const updated = { ...post, message };
+    const editedAt = Math.max(Date.now(), post.update_at + 1);
+    const updated = { ...post, edit_at: editedAt, message, update_at: editedAt };
     const event = postEvent(
       "post_edited",
       updated,
@@ -666,11 +711,13 @@ async function handleApi(params: {
     if (post.user_id !== state.botUserId) {
       return mattermostError("You do not have permission to delete this post", 403);
     }
+    const deletedAt = Math.max(Date.now(), post.update_at + 1);
+    const deletedPost = { ...post, delete_at: deletedAt, update_at: deletedAt };
     const event = postEvent(
       "post_deleted",
-      post,
+      deletedPost,
       state.botUsername,
-      state.channels.get(post.channel_id)!,
+      state.channels.get(deletedPost.channel_id)!,
     );
     if (webSocketEventBytes(event) > state.maxWebSocketBufferedBytes) {
       return webSocketEventTooLargeResponse();
@@ -936,6 +983,21 @@ export async function startMattermostServer(
     botUserId,
     botUsername,
     channels: new Map(),
+    maxCommittedChannels: resolvePositiveLimit(
+      params.maxCommittedChannels,
+      "maxCommittedChannels",
+      DEFAULT_MAX_COMMITTED_CHANNELS,
+    ),
+    maxCommittedPosts: resolvePositiveLimit(
+      params.maxCommittedPosts,
+      "maxCommittedPosts",
+      DEFAULT_MAX_COMMITTED_POSTS,
+    ),
+    maxCommittedUsers: resolvePositiveLimit(
+      params.maxCommittedUsers,
+      "maxCommittedUsers",
+      DEFAULT_MAX_COMMITTED_USERS,
+    ),
     maxPendingInboundEvents: resolveMaxPendingInboundEvents(params.maxPendingInboundEvents),
     maxWebSocketBufferedBytes: resolvePositiveLimit(
       params.maxWebSocketBufferedBytes,

--- a/src/servers/signal.ts
+++ b/src/servers/signal.ts
@@ -34,12 +34,13 @@ type SignalServerState = {
   clientBuffers: Map<ServerResponse, SignalClientBuffer>;
   maxPendingInboundEvents: number;
   maxSseClients: number;
+  lastCommittedTimestamp: number | undefined;
   nextEventSequence: number;
   nextTimestamp: number;
   onEvent: ServerEventObserver | undefined;
   pendingEventBytes: number;
   pendingEvents: SignalSseChunk[];
-  pendingRpcRequests: Promise<void>;
+  pendingTimestampCommits: Promise<void>;
   pendingSseClients: number;
   recorderPath: string;
 };
@@ -142,13 +143,20 @@ function removeSignalClient(
   const buffer = state.clientBuffers.get(client);
   state.clients.delete(client);
   state.clientBuffers.delete(client);
+  const bufferedEvents = new Set<SignalSseChunk>([
+    ...state.pendingEvents,
+    ...[...state.clientBuffers.values()].flatMap((entry) => [...entry.inFlight, ...entry.events]),
+    ...(buffer ? [...buffer.inFlight, ...buffer.events] : []),
+  ]);
+  for (const event of bufferedEvents) {
+    event.recipients?.delete(client);
+  }
   if (buffer) {
-    const undeliveredEvents = [...buffer.inFlight, ...buffer.events].filter((event) => {
-      event.recipients?.delete(client);
-      return event.sequence !== undefined && event.recipients?.size === 0;
-    });
-    const restoredEvents = undeliveredEvents.filter(
-      (event) => !state.pendingEvents.includes(event),
+    const restoredEvents = [...new Set([...buffer.inFlight, ...buffer.events])].filter(
+      (event) =>
+        event.sequence !== undefined &&
+        event.recipients?.size === 0 &&
+        !isSignalEventBuffered(state, event),
     );
     if (restoredEvents.length > 0) {
       state.pendingEvents.push(...restoredEvents);
@@ -390,6 +398,15 @@ function normalizeSignalPhoneNumber(value: unknown): string | undefined {
   return number && SIGNAL_PHONE_NUMBER_RE.test(number) ? number : undefined;
 }
 
+function nextSignalTimestamp(state: SignalServerState): number {
+  return Math.max(state.nextTimestamp, (state.lastCommittedTimestamp ?? -1) + 1);
+}
+
+function commitSignalTimestamp(state: SignalServerState, timestamp: number): void {
+  state.lastCommittedTimestamp = timestamp;
+  state.nextTimestamp = Math.max(state.nextTimestamp, timestamp + 1);
+}
+
 async function handleAdminInbound(params: {
   body: Record<string, unknown>;
   state: SignalServerState;
@@ -430,7 +447,17 @@ async function handleAdminInbound(params: {
       400,
     );
   }
-  const timestamp = suppliedTimestamp ?? params.state.nextTimestamp;
+  if (
+    suppliedTimestamp !== undefined &&
+    params.state.lastCommittedTimestamp !== undefined &&
+    suppliedTimestamp <= params.state.lastCommittedTimestamp
+  ) {
+    return jsonResponse(
+      { error: "timestamp must be greater than the last committed timestamp", ok: false },
+      409,
+    );
+  }
+  const timestamp = suppliedTimestamp ?? nextSignalTimestamp(params.state);
   if (timestamp >= Number.MAX_SAFE_INTEGER) {
     return jsonResponse({ error: "timestamp capacity exhausted", ok: false }, 503);
   }
@@ -457,7 +484,7 @@ async function handleAdminInbound(params: {
       503,
     );
   }
-  params.state.nextTimestamp = Math.max(params.state.nextTimestamp, timestamp + 1);
+  commitSignalTimestamp(params.state, timestamp);
   return jsonResponse({ event: payload, ok: true });
 }
 
@@ -518,7 +545,7 @@ async function handleRpc(params: {
           : rpcError(-32602, "Invalid params", id),
       };
     }
-    const timestamp = params.state.nextTimestamp;
+    const timestamp = nextSignalTimestamp(params.state);
     if (timestamp >= Number.MAX_SAFE_INTEGER) {
       return {
         accepted: false,
@@ -601,23 +628,58 @@ function hasStringArray(value: unknown): boolean {
   );
 }
 
+function readSignalRpcString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function hasValidSignalRecipientFieldTypes(params: Record<string, unknown>): boolean {
+  return ["recipient", "recipients", "groupId", "groupIds", "username", "usernames"].every(
+    (field) => {
+      const value = params[field];
+      return (
+        value === undefined ||
+        (typeof value === "string" && value.trim().length > 0) ||
+        hasStringArray(value)
+      );
+    },
+  );
+}
+
+function hasValidOptionalSignalString(params: Record<string, unknown>, field: string): boolean {
+  return params[field] === undefined || readSignalRpcString(params[field]) !== undefined;
+}
+
 function validSignalRpcParams(method: string, value: unknown): boolean {
-  if (!isJsonObject(value)) {
+  if (
+    !isJsonObject(value) ||
+    !hasValidSignalRecipientFieldTypes(value) ||
+    !hasValidOptionalSignalString(value, "account") ||
+    (value.noteToSelf !== undefined && typeof value.noteToSelf !== "boolean")
+  ) {
     return false;
   }
   if (method === "send") {
     return (
+      hasValidOptionalSignalString(value, "message") &&
+      hasValidOptionalSignalString(value, "attachment") &&
+      (value.attachments === undefined || hasStringArray(value.attachments)) &&
       hasRecipients(value) &&
-      (readTrimmedString(value.message) !== undefined ||
-        readTrimmedString(value.attachment) !== undefined ||
+      (readSignalRpcString(value.message) !== undefined ||
+        readSignalRpcString(value.attachment) !== undefined ||
         hasStringArray(value.attachments))
     );
   }
   if (method === "sendReaction") {
     return (
+      hasValidOptionalSignalString(value, "emoji") &&
+      hasValidOptionalSignalString(value, "targetAuthor") &&
       hasRecipients(value) &&
-      readTrimmedString(value.emoji) !== undefined &&
-      readTrimmedString(value.targetAuthor) !== undefined &&
+      readSignalRpcString(value.emoji) !== undefined &&
+      readSignalRpcString(value.targetAuthor) !== undefined &&
       validTimestamp(value.targetTimestamp)
     );
   }
@@ -625,8 +687,9 @@ function validSignalRpcParams(method: string, value: unknown): boolean {
     const targetTimestamps = value.targetTimestamps ?? value.targetTimestamp;
     const timestamps = Array.isArray(targetTimestamps) ? targetTimestamps : [targetTimestamps];
     return (
-      (readTrimmedString(value.recipient) !== undefined ||
-        readTrimmedString(value.username) !== undefined ||
+      hasValidOptionalSignalString(value, "type") &&
+      (readSignalRpcString(value.recipient) !== undefined ||
+        readSignalRpcString(value.username) !== undefined ||
         hasStringArray(value.usernames)) &&
       timestamps.length > 0 &&
       timestamps.every(validTimestamp) &&
@@ -636,45 +699,57 @@ function validSignalRpcParams(method: string, value: unknown): boolean {
   return method === "sendTyping" && hasTypingRecipients(value);
 }
 
+function serializeSignalTimestampCommit<T>(
+  state: SignalServerState,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const run = state.pendingTimestampCommits.catch(() => {}).then(operation);
+  state.pendingTimestampCommits = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
+}
+
+function processSignalAdminInbound(params: {
+  body: Record<string, unknown>;
+  state: SignalServerState;
+}): Promise<Response> {
+  return serializeSignalTimestampCommit(params.state, () => handleAdminInbound(params));
+}
+
 async function processSignalRpc(params: {
   body: Record<string, unknown>;
   state: SignalServerState;
   url: URL;
 }): Promise<Response> {
-  const run = params.state.pendingRpcRequests
-    .catch(() => {})
-    .then(async () => {
-      const rpc = await handleRpc({ body: params.body, state: params.state });
-      if (rpc.record) {
-        const event: SignalRecorderEvent = {
-          accepted: rpc.accepted,
-          at: new Date().toISOString(),
-          body: params.body,
-          method: "POST",
-          path: params.url.pathname,
-          query: queryRecord(params.url),
-          type: "api",
-        };
-        if (rpc.accepted) {
-          try {
-            await appendEvent(params.state, event);
-          } catch (error) {
-            if (!(error instanceof ServerRecorderCommittedError)) {
-              throw error;
-            }
+  return serializeSignalTimestampCommit(params.state, async () => {
+    const rpc = await handleRpc({ body: params.body, state: params.state });
+    if (rpc.record) {
+      const event: SignalRecorderEvent = {
+        accepted: rpc.accepted,
+        at: new Date().toISOString(),
+        body: params.body,
+        method: "POST",
+        path: params.url.pathname,
+        query: queryRecord(params.url),
+        type: "api",
+      };
+      if (rpc.accepted) {
+        try {
+          await appendEvent(params.state, event);
+        } catch (error) {
+          if (!(error instanceof ServerRecorderCommittedError)) {
+            throw error;
           }
-          params.state.nextTimestamp = Math.max(params.state.nextTimestamp, rpc.timestamp + 1);
-        } else {
-          await appendEvent(params.state, event, rpc.response.status === 204);
         }
+        commitSignalTimestamp(params.state, rpc.timestamp);
+      } else {
+        await appendEvent(params.state, event, rpc.response.status === 204);
       }
-      return rpc.response;
-    });
-  params.state.pendingRpcRequests = run.then(
-    () => undefined,
-    () => undefined,
-  );
-  return run;
+    }
+    return rpc.response;
+  });
 }
 
 function hasSignalJsonContentType(request: IncomingMessage): boolean {
@@ -760,7 +835,7 @@ async function handleRequest(params: {
         query: queryRecord(url),
         type: "admin",
       });
-      fetchResponse = await handleAdminInbound({ body, state: params.state });
+      fetchResponse = await processSignalAdminInbound({ body, state: params.state });
     }
   } else if (url.pathname === "/api/v1/check" && params.request.method === "GET") {
     await appendEvent(params.state, {
@@ -862,6 +937,7 @@ export async function startSignalServer(
     adminToken: params.adminToken ?? randomBytes(24).toString("base64url"),
     clients: new Set(),
     clientBuffers: new Map(),
+    lastCommittedTimestamp: undefined,
     maxPendingInboundEvents: resolveMaxPendingInboundEvents(params.maxPendingInboundEvents),
     maxSseClients:
       Number.isSafeInteger(params.maxSseClients) && (params.maxSseClients ?? 0) > 0
@@ -872,7 +948,7 @@ export async function startSignalServer(
     onEvent: params.onEvent,
     pendingEventBytes: 0,
     pendingEvents: [],
-    pendingRpcRequests: Promise.resolve(),
+    pendingTimestampCommits: Promise.resolve(),
     pendingSseClients: 0,
     recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "signal.jsonl"),
   };

--- a/src/servers/signal.ts
+++ b/src/servers/signal.ts
@@ -650,7 +650,7 @@ function hasValidSignalRecipientFieldTypes(params: Record<string, unknown>): boo
 }
 
 function hasValidOptionalSignalString(params: Record<string, unknown>, field: string): boolean {
-  return params[field] === undefined || readSignalRpcString(params[field]) !== undefined;
+  return params[field] === undefined || typeof params[field] === "string";
 }
 
 function validSignalRpcParams(method: string, value: unknown): boolean {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -999,6 +999,7 @@ describe("manifest schema", () => {
           adapter: "mattermost",
           mattermost: {
             baseUrl: "https://mattermost.example.com",
+            webhookToken: "sample",
           },
         },
         msteams: {
@@ -1037,6 +1038,7 @@ describe("manifest schema", () => {
     expect(manifest.providers["googlechat"]?.googlechat?.webhook.port).toBe(8792);
     expect(manifest.providers["googlechat"]?.platform).toBe("googlechat");
     expect(manifest.providers["mattermost"]?.mattermost?.webhook.path).toBe("/mattermost/webhook");
+    expect(manifest.providers["mattermost"]?.mattermost?.webhookToken).toBe("sample");
     expect(manifest.providers["mattermost"]?.platform).toBe("mattermost");
     expect(manifest.providers["msteams"]?.msteams?.webhook.path).toBe("/msteams/webhook");
     expect(manifest.providers["msteams"]?.platform).toBe("msteams");

--- a/test/matrix-server.test.ts
+++ b/test/matrix-server.test.ts
@@ -308,7 +308,7 @@ describe("Matrix local provider server", () => {
 
   it("bounds committed room and user state before mutation", async () => {
     const server = await startMatrixServer({
-      accessToken: "test-token",
+      accessToken: "fake",
       adminToken: "admin",
       maxCommittedRooms: 2,
       maxCommittedUsers: 2,
@@ -358,19 +358,19 @@ describe("Matrix local provider server", () => {
     });
 
     const rooms = await fetch(`${server.manifest.endpoints.clientApiRoot}/joined_rooms`, {
-      headers: auth("test-token"),
+      headers: auth("fake"),
     });
     await expect(rooms.json()).resolves.toEqual({
       joined_rooms: ["!default:matrix.test", "!dynamic:matrix.test"],
     });
     const bobProfile = await fetch(
       `${server.manifest.endpoints.clientApiRoot}/profile/${encodeURIComponent("@bob:matrix.test")}`,
-      { headers: auth("test-token") },
+      { headers: auth("fake") },
     );
     expect(bobProfile.status).toBe(404);
     const members = await fetch(
       `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!dynamic:matrix.test")}/joined_members`,
-      { headers: auth("test-token") },
+      { headers: auth("fake") },
     );
     await expect(members.json()).resolves.toEqual({
       joined: {

--- a/test/matrix-server.test.ts
+++ b/test/matrix-server.test.ts
@@ -306,6 +306,89 @@ describe("Matrix local provider server", () => {
     expect(overCount.status).toBe(503);
   });
 
+  it("bounds committed room and user state before mutation", async () => {
+    const server = await startMatrixServer({
+      accessToken: "test-token",
+      adminToken: "admin",
+      maxCommittedRooms: 2,
+      maxCommittedUsers: 2,
+      roomId: "!default:matrix.test",
+    });
+    servers.push(server);
+    const sendInbound = (body: Record<string, unknown>) =>
+      fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify(body),
+        headers: {
+          "content-type": "application/json",
+          [ADMIN_TOKEN_HEADER]: "admin",
+        },
+        method: "POST",
+      });
+
+    expect(
+      (
+        await sendInbound({
+          roomId: "!dynamic:matrix.test",
+          senderId: "@alice:matrix.test",
+          text: "fills committed state",
+        })
+      ).status,
+    ).toBe(200);
+
+    const roomLimit = await sendInbound({
+      roomId: "!overflow:matrix.test",
+      senderId: "@alice:matrix.test",
+      text: "new room",
+    });
+    expect(roomLimit.status).toBe(503);
+    await expect(roomLimit.json()).resolves.toEqual({
+      error: "Committed Matrix rooms limit reached",
+      ok: false,
+    });
+
+    const userLimit = await sendInbound({
+      roomId: "!dynamic:matrix.test",
+      senderId: "@bob:matrix.test",
+      text: "new user",
+    });
+    expect(userLimit.status).toBe(503);
+    await expect(userLimit.json()).resolves.toEqual({
+      error: "Committed Matrix users limit reached",
+      ok: false,
+    });
+
+    const rooms = await fetch(`${server.manifest.endpoints.clientApiRoot}/joined_rooms`, {
+      headers: auth("test-token"),
+    });
+    await expect(rooms.json()).resolves.toEqual({
+      joined_rooms: ["!default:matrix.test", "!dynamic:matrix.test"],
+    });
+    const bobProfile = await fetch(
+      `${server.manifest.endpoints.clientApiRoot}/profile/${encodeURIComponent("@bob:matrix.test")}`,
+      { headers: auth("test-token") },
+    );
+    expect(bobProfile.status).toBe(404);
+    const members = await fetch(
+      `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!dynamic:matrix.test")}/joined_members`,
+      { headers: auth("test-token") },
+    );
+    await expect(members.json()).resolves.toEqual({
+      joined: {
+        "@alice:matrix.test": {},
+        [server.manifest.botUserId]: { display_name: "OpenClaw QA" },
+      },
+    });
+  });
+
+  it("validates committed Matrix state limits", async () => {
+    await expect(startMatrixServer({ maxCommittedRooms: 0 })).rejects.toThrow(
+      "maxCommittedRooms must be a positive safe integer.",
+    );
+    await expect(startMatrixServer({ maxCommittedUsers: 0 })).rejects.toThrow(
+      "maxCommittedUsers must be a positive safe integer.",
+    );
+  });
+
   it("rejects malformed native identifiers before mutating room state", async () => {
     const server = await startMatrixServer();
     servers.push(server);

--- a/test/mattermost-provider.test.ts
+++ b/test/mattermost-provider.test.ts
@@ -25,8 +25,15 @@ describe("Mattermost webhook normalizer", () => {
     expect(
       resolveMattermostAdapterConfig(config, {
         MATTERMOST_BASE_URL: "https://legacy.example.test",
+        MATTERMOST_TOKEN: "sample",
       }),
-    ).toMatchObject({ baseUrl: "https://legacy.example.test" });
+    ).toMatchObject({
+      baseUrl: "https://legacy.example.test",
+      webhookToken: "sample",
+    });
+    expect(() => resolveMattermostAdapterConfig(config, { MATTERMOST_TOKEN: " \t" })).toThrow(
+      "MATTERMOST_TOKEN must not be empty or whitespace-only.",
+    );
   });
 
   it("rejects bearer credentials over non-loopback cleartext transport", async () => {
@@ -60,6 +67,76 @@ describe("Mattermost webhook normalizer", () => {
 
   it("accepts provider-native form-encoded outgoing webhooks", async () => {
     const config = await createLocalMockConfig("mattermost", "/mattermost/webhook");
+    config.mattermost!.webhookToken = "sample";
+    const provider = new MattermostProviderAdapter("mattermost", config, "crabline");
+    const context = createProviderContext("mattermost", config, {
+      id: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+      metadata: {},
+    });
+    context.fixture.inboundMatch = {
+      author: "user",
+      nonce: "contains",
+      strategy: "contains",
+    };
+    try {
+      const probe = await provider.probe(context);
+      const endpoint = probe.details
+        .find((detail) => detail.includes("webhook endpoint"))!
+        .replace(/^.*?(https?:\/\/\S+)$/u, "$1");
+      const since = new Date(Date.now() - 1_000).toISOString();
+      for (const token of [undefined, "wrong-token"]) {
+        const rejected = await fetch(endpoint, {
+          body: new URLSearchParams({
+            channel_id: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+            post_id: "cccccccccccccccccccccccccc",
+            root_id: "bbbbbbbbbbbbbbbbbbbbbbbbbb",
+            text: "rejected form webhook",
+            ...(token ? { token } : {}),
+          }),
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+          method: "POST",
+        });
+        expect(rejected.status).toBe(401);
+      }
+      const response = await fetch(endpoint, {
+        body: new URLSearchParams({
+          channel_id: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+          post_id: "cccccccccccccccccccccccccc",
+          root_id: "bbbbbbbbbbbbbbbbbbbbbbbbbb",
+          text: "form webhook nonce",
+          token: "sample",
+        }),
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        method: "POST",
+      });
+      expect(response.status).toBe(200);
+      await expect(
+        provider.waitForInbound({
+          ...context,
+          nonce: "form webhook nonce",
+          since,
+          threadId: "aaaaaaaaaaaaaaaaaaaaaaaaaa:thread:bbbbbbbbbbbbbbbbbbbbbbbbbb",
+          timeoutMs: 500,
+        }),
+      ).resolves.toMatchObject({
+        author: "user",
+        id: "cccccccccccccccccccccccccc",
+        raw: {
+          channel_id: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+          post_id: "cccccccccccccccccccccccccc",
+          root_id: "bbbbbbbbbbbbbbbbbbbbbbbbbb",
+          text: "form webhook nonce",
+        },
+        text: "form webhook nonce",
+      });
+    } finally {
+      await provider.cleanup();
+    }
+  });
+
+  it("authenticates provider-native JSON outgoing webhooks", async () => {
+    const config = await createLocalMockConfig("mattermost", "/mattermost/webhook");
+    config.mattermost!.webhookToken = "sample";
     const provider = new MattermostProviderAdapter("mattermost", config, "crabline");
     const context = createProviderContext("mattermost", config, {
       id: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -77,46 +154,68 @@ describe("Mattermost webhook normalizer", () => {
         .replace(/^.*?(https?:\/\/\S+)$/u, "$1");
       const since = new Date(Date.now() - 1_000).toISOString();
       const response = await fetch(endpoint, {
-        body: new URLSearchParams({
+        body: JSON.stringify({
           channel_id: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
           post_id: "cccccccccccccccccccccccccc",
-          root_id: "bbbbbbbbbbbbbbbbbbbbbbbbbb",
-          text: "form webhook nonce",
+          text: "json webhook nonce",
+          token: "sample",
         }),
-        headers: { "content-type": "application/x-www-form-urlencoded" },
+        headers: { "content-type": "application/json" },
         method: "POST",
       });
       expect(response.status).toBe(200);
       await expect(
         provider.waitForInbound({
           ...context,
-          nonce: "form webhook nonce",
+          nonce: "json webhook nonce",
           since,
-          threadId: "aaaaaaaaaaaaaaaaaaaaaaaaaa:thread:bbbbbbbbbbbbbbbbbbbbbbbbbb",
+          threadId: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
           timeoutMs: 500,
         }),
       ).resolves.toMatchObject({
-        author: "user",
-        id: "cccccccccccccccccccccccccc",
-        text: "form webhook nonce",
+        raw: {
+          channel_id: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+          post_id: "cccccccccccccccccccccccccc",
+          text: "json webhook nonce",
+        },
       });
     } finally {
       await provider.cleanup();
     }
   });
 
-  it("rejects externally reachable webhooks without provider-native authentication", async () => {
+  it("requires provider-native authentication for externally reachable webhooks", async () => {
     const config = await createLocalMockConfig("mattermost", "/mattermost/webhook");
     config.mattermost!.webhook.host = "0.0.0.0";
     expect(() => new MattermostProviderAdapter("mattermost", config, "crabline")).toThrow(
-      /provider-native authenticated ingress mode/u,
+      /webhookToken or MATTERMOST_TOKEN/u,
     );
 
     config.mattermost!.webhook.host = "127.0.0.1";
     config.mattermost!.webhook.publicUrl = "https://mattermost.example.test/webhook";
     expect(() => new MattermostProviderAdapter("mattermost", config, "crabline")).toThrow(
-      /provider-native authenticated ingress mode/u,
+      /webhookToken or MATTERMOST_TOKEN/u,
     );
+
+    config.mattermost!.webhookToken = "sample";
+    expect(() => new MattermostProviderAdapter("mattermost", config, "crabline")).not.toThrow();
+  });
+
+  it("redacts outgoing webhook tokens from normalized evidence", () => {
+    expect(
+      normalizeMattermostWebhookPayload({
+        channel_id: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+        post_id: "bbbbbbbbbbbbbbbbbbbbbbbbbb",
+        text: "authenticated webhook",
+        token: "sample",
+      }),
+    ).toMatchObject({
+      raw: {
+        channel_id: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+        post_id: "bbbbbbbbbbbbbbbbbbbbbbbbbb",
+        text: "authenticated webhook",
+      },
+    });
   });
 
   it("preserves the channel when normalizing thread replies", () => {

--- a/test/mattermost-provider.test.ts
+++ b/test/mattermost-provider.test.ts
@@ -8,6 +8,7 @@ import {
 import { optionalStringish } from "../src/providers/builtin/native-local-mock.js";
 import {
   createLocalMockConfig,
+  createProviderContext,
   runLocalMockProviderContract,
 } from "./local-mock-provider-helpers.js";
 
@@ -26,6 +27,82 @@ describe("Mattermost webhook normalizer", () => {
         MATTERMOST_BASE_URL: "https://legacy.example.test",
       }),
     ).toMatchObject({ baseUrl: "https://legacy.example.test" });
+  });
+
+  it("rejects bearer credentials over non-loopback cleartext transport", async () => {
+    const config = await createLocalMockConfig("mattermost", "/mattermost/webhook");
+
+    expect(() =>
+      resolveMattermostAdapterConfig(config, {
+        MATTERMOST_URL: "http://mattermost.example.test",
+      }),
+    ).toThrow(/requires HTTPS/u);
+    expect(
+      () =>
+        new MattermostProviderAdapter(
+          "mattermost",
+          {
+            ...config,
+            mattermost: {
+              ...config.mattermost!,
+              baseUrl: "http://192.0.2.1",
+            },
+          },
+          "crabline",
+        ),
+    ).toThrow(/requires HTTPS/u);
+    expect(
+      resolveMattermostAdapterConfig(config, {
+        MATTERMOST_URL: "http://127.0.0.1:8065",
+      }),
+    ).toMatchObject({ baseUrl: "http://127.0.0.1:8065" });
+  });
+
+  it("accepts provider-native form-encoded outgoing webhooks", async () => {
+    const config = await createLocalMockConfig("mattermost", "/mattermost/webhook");
+    const provider = new MattermostProviderAdapter("mattermost", config, "crabline");
+    const context = createProviderContext("mattermost", config, {
+      id: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+      metadata: {},
+    });
+    context.fixture.inboundMatch = {
+      author: "user",
+      nonce: "contains",
+      strategy: "contains",
+    };
+    try {
+      const probe = await provider.probe(context);
+      const endpoint = probe.details
+        .find((detail) => detail.includes("webhook endpoint"))!
+        .replace(/^.*?(https?:\/\/\S+)$/u, "$1");
+      const since = new Date(Date.now() - 1_000).toISOString();
+      const response = await fetch(endpoint, {
+        body: new URLSearchParams({
+          channel_id: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+          post_id: "cccccccccccccccccccccccccc",
+          root_id: "bbbbbbbbbbbbbbbbbbbbbbbbbb",
+          text: "form webhook nonce",
+        }),
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        method: "POST",
+      });
+      expect(response.status).toBe(200);
+      await expect(
+        provider.waitForInbound({
+          ...context,
+          nonce: "form webhook nonce",
+          since,
+          threadId: "aaaaaaaaaaaaaaaaaaaaaaaaaa:thread:bbbbbbbbbbbbbbbbbbbbbbbbbb",
+          timeoutMs: 500,
+        }),
+      ).resolves.toMatchObject({
+        author: "user",
+        id: "cccccccccccccccccccccccccc",
+        text: "form webhook nonce",
+      });
+    } finally {
+      await provider.cleanup();
+    }
   });
 
   it("rejects externally reachable webhooks without provider-native authentication", async () => {

--- a/test/mattermost-server.test.ts
+++ b/test/mattermost-server.test.ts
@@ -15,6 +15,12 @@ const USER_ID = "bbbbbbbbbbbbbbbbbbbbbbbbbb";
 const OTHER_USER_ID = "dddddddddddddddddddddddddd";
 const ROOT_ID = "eeeeeeeeeeeeeeeeeeeeeeeeee";
 
+type MattermostLifecyclePost = {
+  delete_at: number;
+  edit_at: number;
+  update_at: number;
+};
+
 afterEach(async () => {
   await Promise.all(servers.splice(0).map((server) => server.close()));
   await Promise.all(directories.splice(0).map(disposeTempDir));
@@ -390,7 +396,11 @@ describe("Mattermost local provider server", () => {
     const sentPost = (await send.json()) as Record<string, unknown>;
     expect(sentPost).toMatchObject({
       channel_id: CHANNEL_ID,
+      create_at: expect.any(Number),
+      delete_at: 0,
+      edit_at: 0,
       message: "assistant nonce-1",
+      update_at: expect.any(Number),
       user_id: server.manifest.botUserId,
     });
     await expect(outboundEvent).resolves.toMatchObject({
@@ -413,7 +423,10 @@ describe("Mattermost local provider server", () => {
       method: "POST",
     });
     expect(direct.status).toBe(201);
-    await expect(direct.json()).resolves.toMatchObject({ type: "D" });
+    await expect(direct.json()).resolves.toMatchObject({
+      name: [server.manifest.botUserId, USER_ID].sort().join("__"),
+      type: "D",
+    });
 
     const postId = sentPost.id;
     expect(postId).toMatch(/^[a-z0-9]{26}$/u);
@@ -427,10 +440,25 @@ describe("Mattermost local provider server", () => {
       method: "PUT",
     });
     expect(edited.status).toBe(200);
-    await expect(editedEvent).resolves.toMatchObject({
+    const editedPost = (await edited.json()) as {
+      edit_at: number;
+      update_at: number;
+    };
+    expect(editedPost.edit_at).toBeGreaterThan(Number(sentPost.update_at));
+    expect(editedPost.update_at).toBe(editedPost.edit_at);
+    const editedMessage = await editedEvent;
+    expect(editedMessage).toMatchObject({
       broadcast: { channel_id: CHANNEL_ID, user_id: "" },
       event: "post_edited",
       seq: 3,
+    });
+    const editedEventPost = JSON.parse(
+      (editedMessage.data as { post: string }).post,
+    ) as MattermostLifecyclePost;
+    expect(editedEventPost).toMatchObject({
+      delete_at: 0,
+      edit_at: editedPost.edit_at,
+      update_at: editedPost.update_at,
     });
 
     const deletedEvent = nextMessage(socket);
@@ -440,11 +468,17 @@ describe("Mattermost local provider server", () => {
     });
     expect(deleted.status).toBe(200);
     await expect(deleted.json()).resolves.toEqual({ status: "OK" });
-    await expect(deletedEvent).resolves.toMatchObject({
+    const deletedMessage = await deletedEvent;
+    expect(deletedMessage).toMatchObject({
       broadcast: { channel_id: CHANNEL_ID, user_id: "" },
       event: "post_deleted",
       seq: 4,
     });
+    const deletedEventPost = JSON.parse(
+      (deletedMessage.data as { post: string }).post,
+    ) as MattermostLifecyclePost;
+    expect(deletedEventPost.delete_at).toBeGreaterThan(editedPost.update_at);
+    expect(deletedEventPost.update_at).toBe(deletedEventPost.delete_at);
     socket.close();
 
     const recorded = await fs.readFile(recorderPath, "utf8");
@@ -1139,7 +1173,7 @@ describe("Mattermost local provider server", () => {
     expect(created.status).toBe(201);
 
     const boundaryEdit = await fetch(`${server.manifest.endpoints.apiRoot}/posts/${post.id}`, {
-      body: JSON.stringify({ message: "x".repeat(655) }),
+      body: JSON.stringify({ message: "x".repeat(573) }),
       headers: {
         authorization: "Bearer fake",
         "content-type": "application/json",
@@ -1213,6 +1247,15 @@ describe("Mattermost local provider server", () => {
   });
 
   it("validates WebSocket resource limits", async () => {
+    await expect(startMattermostServer({ maxCommittedChannels: 0 })).rejects.toThrow(
+      "maxCommittedChannels must be a positive safe integer.",
+    );
+    await expect(startMattermostServer({ maxCommittedPosts: 0 })).rejects.toThrow(
+      "maxCommittedPosts must be a positive safe integer.",
+    );
+    await expect(startMattermostServer({ maxCommittedUsers: 0 })).rejects.toThrow(
+      "maxCommittedUsers must be a positive safe integer.",
+    );
     await expect(startMattermostServer({ maxWebSocketBufferedBytes: 0 })).rejects.toThrow(
       "maxWebSocketBufferedBytes must be a positive safe integer.",
     );
@@ -1222,6 +1265,59 @@ describe("Mattermost local provider server", () => {
     await expect(startMattermostServer({ maxUnauthenticatedWebSocketClients: 0 })).rejects.toThrow(
       "maxUnauthenticatedWebSocketClients must be a positive safe integer.",
     );
+  });
+
+  it("bounds committed users, channels, and posts before mutation", async () => {
+    const server = await startMattermostServer({
+      adminToken: "admin",
+      botToken: "fake",
+      maxCommittedChannels: 1,
+      maxCommittedPosts: 1,
+      maxCommittedUsers: 2,
+    });
+    servers.push(server);
+    const sendInbound = (body: Record<string, unknown>) =>
+      fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify(body),
+        headers: {
+          "content-type": "application/json",
+          "x-crabline-admin-token": "admin",
+        },
+        method: "POST",
+      });
+
+    expect(
+      (
+        await sendInbound({
+          channelId: CHANNEL_ID,
+          senderId: USER_ID,
+          text: "fills committed state",
+        })
+      ).status,
+    ).toBe(200);
+
+    for (const [body, resource] of [
+      [{ channelId: OTHER_CHANNEL_ID, senderId: USER_ID, text: "new channel" }, "channels"],
+      [{ channelId: CHANNEL_ID, senderId: OTHER_USER_ID, text: "new user" }, "users"],
+      [{ channelId: CHANNEL_ID, senderId: USER_ID, text: "new post" }, "posts"],
+    ] as const) {
+      const response = await sendInbound(body);
+      expect(response.status).toBe(503);
+      await expect(response.json()).resolves.toEqual({
+        error: `Committed Mattermost ${resource} limit reached`,
+        ok: false,
+      });
+    }
+
+    const missingUser = await fetch(`${server.manifest.endpoints.apiRoot}/users/${OTHER_USER_ID}`, {
+      headers: { authorization: "Bearer fake" },
+    });
+    expect(missingUser.status).toBe(404);
+    const missingChannel = await fetch(
+      `${server.manifest.endpoints.apiRoot}/channels/${OTHER_CHANNEL_ID}`,
+      { headers: { authorization: "Bearer fake" } },
+    );
+    expect(missingChannel.status).toBe(404);
   });
 
   it("drains authorized GET and DELETE request bodies", async () => {

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -2047,8 +2047,8 @@ describe("OpenClaw local provider bridge", () => {
         providerTarget: "+15551234567",
       },
       { params: { groupIds: ["group-1"] }, providerTarget: "group:group-1" },
-      { params: { username: "alice.01" }, providerTarget: "alice.01" },
-      { params: { usernames: ["alice.01"] }, providerTarget: "alice.01" },
+      { params: { username: "qa-operator" }, providerTarget: directDelivery.to },
+      { params: { usernames: ["qa-operator"] }, providerTarget: directDelivery.to },
       { params: { noteToSelf: true }, providerTarget: signalManifest.account },
     ]) {
       expect(

--- a/test/signal-server.test.ts
+++ b/test/signal-server.test.ts
@@ -246,7 +246,14 @@ describe("signal local provider server", () => {
       result: { timestamp: expect.any(Number) },
     });
     for (const [method, params] of [
-      ["send", { attachment: "/tmp/test-attachment-placeholder", recipients: ["+15551234567"] }],
+      [
+        "send",
+        {
+          attachment: "/tmp/test-attachment-placeholder",
+          message: "",
+          recipients: ["+15551234567"],
+        },
+      ],
       ["sendReceipt", { targetTimestamps: [1_700_000_000_000], usernames: ["alice"] }],
       [
         "sendReaction",

--- a/test/signal-server.test.ts
+++ b/test/signal-server.test.ts
@@ -278,10 +278,28 @@ describe("signal local provider server", () => {
 
     for (const [method, params] of [
       ["send", {}],
+      ["send", { message: "invalid optional account", recipient: "+15551234567", account: 42 }],
+      ["send", { message: "invalid optional username", recipient: "+15551234567", username: 42 }],
+      ["send", { message: "invalid attachment", recipient: "+15551234567", attachment: 42 }],
       ["sendReaction", { emoji: "👍", recipient: ["+15551234567"] }],
+      [
+        "sendReaction",
+        {
+          emoji: "👍",
+          groupId: 42,
+          recipient: "+15551234567",
+          targetAuthor: "+15557654321",
+          targetTimestamp: 1_700_000_000_000,
+        },
+      ],
       ["sendReceipt", { recipient: "+15551234567", targetTimestamp: [] }],
+      [
+        "sendReceipt",
+        { recipient: "+15551234567", targetTimestamp: 1_700_000_000_000, username: 42 },
+      ],
       ["sendTyping", { username: ["alice"] }],
       ["sendTyping", { noteToSelf: true }],
+      ["sendTyping", { groupId: 42, recipient: "+15551234567" }],
       ["sendTyping", { recipient: ["+15551234567"], stop: "yes" }],
     ] as const) {
       const invalid = await fetch(server.manifest.endpoints.rpcUrl, {
@@ -324,7 +342,6 @@ describe("signal local provider server", () => {
         sourceName: "Alice",
         sourceNumber: "+15557654321",
         text: "user nonce-1",
-        timestamp: 1_700_000_000_000,
       }),
       headers: {
         "content-type": "application/json",
@@ -333,6 +350,9 @@ describe("signal local provider server", () => {
       method: "POST",
     });
     expect(accepted.status).toBe(200);
+    const acceptedBody = (await accepted.json()) as {
+      event: { envelope: { timestamp: number } };
+    };
 
     const controller = new AbortController();
     const events = await fetch(server.manifest.endpoints.eventsUrl, { signal: controller.signal });
@@ -340,7 +360,7 @@ describe("signal local provider server", () => {
     const chunk = await reader?.read();
     controller.abort();
     expect(new TextDecoder().decode(chunk?.value)).toContain(
-      'event:receive\ndata:{"envelope":{"sourceName":"Alice","sourceNumber":"+15557654321","timestamp":1700000000000,"dataMessage":{"message":"user nonce-1","timestamp":1700000000000,"groupInfo":{"groupId":"signal-group-1"}}}}',
+      `event:receive\ndata:{"envelope":{"sourceName":"Alice","sourceNumber":"+15557654321","timestamp":${acceptedBody.event.envelope.timestamp},"dataMessage":{"message":"user nonce-1","timestamp":${acceptedBody.event.envelope.timestamp},"groupInfo":{"groupId":"signal-group-1"}}}}`,
     );
 
     const recorded = await fs.readFile(recorderPath, "utf8");
@@ -634,6 +654,58 @@ describe("signal local provider server", () => {
       event: { envelope: { timestamp: number } };
     };
     expect(generatedBody.event.envelope.timestamp).toBeGreaterThan(rpcBody.result.timestamp);
+  });
+
+  it("serializes admin and RPC timestamps and rejects stale explicit commits", async () => {
+    const now = 1_700_000_000_000;
+    const dateNow = vi.spyOn(Date, "now").mockReturnValue(now);
+    const server = await startSignalServer({ adminToken: "admin" });
+    dateNow.mockRestore();
+    servers.push(server);
+    const sendRpc = (id: string) =>
+      fetch(server.manifest.endpoints.rpcUrl, {
+        body: JSON.stringify({
+          id,
+          jsonrpc: "2.0",
+          method: "send",
+          params: { message: id, recipient: "+15551234567" },
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      }).then((response) => response.json() as Promise<{ result: { timestamp: number } }>);
+    const sendAdmin = (body: Record<string, unknown>) =>
+      fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({
+          sourceNumber: "+15557654321",
+          text: "admin inbound",
+          ...body,
+        }),
+        headers: {
+          "content-type": "application/json",
+          "x-crabline-admin-token": "admin",
+        },
+        method: "POST",
+      });
+
+    const firstRpc = await sendRpc("first");
+    expect(firstRpc.result.timestamp).toBe(now);
+
+    const stale = await sendAdmin({ timestamp: now });
+    expect(stale.status).toBe(409);
+    await expect(stale.json()).resolves.toEqual({
+      error: "timestamp must be greater than the last committed timestamp",
+      ok: false,
+    });
+
+    const [adminResponse, rpcResponse] = await Promise.all([sendAdmin({}), sendRpc("concurrent")]);
+    const adminBody = (await adminResponse.json()) as {
+      event: { envelope: { timestamp: number } };
+    };
+    expect(
+      [adminBody.event.envelope.timestamp, rpcResponse.result.timestamp].sort(
+        (left, right) => left - right,
+      ),
+    ).toEqual([now + 1, now + 2]);
   });
 
   it("does not commit or consume a send timestamp on definite recorder failure", async () => {
@@ -1198,6 +1270,73 @@ describe("signal local provider server", () => {
       }
     } finally {
       firstController.abort();
+      write.mockRestore();
+    }
+  });
+
+  it("removes disconnected clients from events buffered by other SSE clients", async () => {
+    const server = await startSignalServer({ adminToken: "admin" });
+    servers.push(server);
+    const originalWrite = ServerResponse.prototype.write;
+    let matchingWrites = 0;
+    let backpressuredResponse: ServerResponse | undefined;
+    const write = vi.spyOn(ServerResponse.prototype, "write").mockImplementation(function (
+      this: ServerResponse,
+      ...args: Parameters<typeof originalWrite>
+    ) {
+      const accepted = Reflect.apply(originalWrite, this, args) as boolean;
+      if (typeof args[0] === "string" && args[0].includes("shared buffered event")) {
+        matchingWrites += 1;
+        if (matchingWrites === 2) {
+          backpressuredResponse = this;
+          return false;
+        }
+      }
+      return accepted;
+    });
+    const firstController = new AbortController();
+    const secondController = new AbortController();
+    const thirdController = new AbortController();
+    try {
+      const firstEvents = await fetch(server.manifest.endpoints.eventsUrl, {
+        signal: firstController.signal,
+      });
+      await fetch(server.manifest.endpoints.eventsUrl, {
+        signal: secondController.signal,
+      });
+      const sent = await fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({
+          sourceNumber: "+15557654321",
+          text: "shared buffered event",
+        }),
+        headers: {
+          "content-type": "application/json",
+          "x-crabline-admin-token": "admin",
+        },
+        method: "POST",
+      });
+      expect(sent.status).toBe(200);
+      await vi.waitFor(() => expect(backpressuredResponse).toBeDefined());
+
+      firstController.abort();
+      await firstEvents.body?.cancel().catch(() => undefined);
+      await new Promise((resolve) => setImmediate(resolve));
+
+      const thirdEvents = await fetch(server.manifest.endpoints.eventsUrl, {
+        signal: thirdController.signal,
+      });
+      const reader = thirdEvents.body!.getReader();
+      const chunk = await Promise.race([
+        reader.read(),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error("timed out waiting for replay")), 500),
+        ),
+      ]);
+      expect(new TextDecoder().decode(chunk.value)).toContain("shared buffered event");
+    } finally {
+      firstController.abort();
+      secondController.abort();
+      thirdController.abort();
       write.mockRestore();
     }
   });


### PR DESCRIPTION
## Summary
- harden Mattermost transport, lifecycle, webhook authentication, token redaction, and retained state behavior
- bound committed Matrix state and preserve synthetic credential fixtures
- serialize Signal identities, timestamps, SSE state, and JSON-RPC behavior

## Validation
- 246 focused tests passed
- lint and build passed
- exact-current gpt-5.6-sol high autoreview clean (0.87) after remediating webhook authentication and recorder-token findings
- public-data diff scan clean
- includes an Unreleased changelog entry

## Remote proof
- GitHub CI/verify passed
- Crabbox `run_82a96b7c5700` / `cbx_7a917af036e1`: `pnpm verify` passed, 1,320 tests passed and 1 skipped
- one-shot Crabbox lease auto-released