### PR TITLE
fix(providers): disambiguate target identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Bound Matrix and Mattermost committed state, authenticate and redact native Mattermost outgoing webhooks, enforce native transport, post lifecycle, and direct-channel identity semantics, and serialize Signal timestamps, SSE cleanup, JSON-RPC strings, and username identity.
 - Enforce Telegram native identity and UTF-16 entity boundaries without synthetic chat collisions, while accepting four-character collectible chat usernames and scheduled zero message IDs.
 - Randomize WhatsApp server credentials, canonicalize direct delivery JIDs, restrict read receipts to accepted inbound messages, and bound queued, session, and binary-node resources without evicting live Signal sessions.
-- Reject malformed or non-canonical loopback v2 addresses instead of aliasing thread identities.
+- Reject malformed, unencodable, or non-canonical loopback v2 addresses instead of aliasing thread identities.
 - Encode generic local-mock target components without channel or thread identity collisions.
 - Keep fixture-local iMessage target IDs separate from provider-native thread aliases.
 - Randomize WhatsApp XEdDSA signatures with fresh entropy while preserving their wire encoding.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Bound Matrix and Mattermost committed state, authenticate and redact native Mattermost outgoing webhooks, enforce native transport, post lifecycle, and direct-channel identity semantics, and serialize Signal timestamps, SSE cleanup, JSON-RPC strings, and username identity.
 - Enforce Telegram native identity and UTF-16 entity boundaries without synthetic chat collisions, while accepting four-character collectible chat usernames and scheduled zero message IDs.
 - Randomize WhatsApp server credentials, canonicalize direct delivery JIDs, restrict read receipts to accepted inbound messages, and bound queued, session, and binary-node resources without evicting live Signal sessions.
+- Encode generic local-mock target components without channel or thread identity collisions.
 - Keep fixture-local iMessage target IDs separate from provider-native thread aliases.
 - Randomize WhatsApp XEdDSA signatures with fresh entropy while preserving their wire encoding.
 - Suppress serve readiness output when shutdown begins during ready-file publication.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Enforce Telegram native identity and UTF-16 entity boundaries without synthetic chat collisions, while accepting four-character collectible chat usernames and scheduled zero message IDs.
 - Randomize WhatsApp server credentials, canonicalize direct delivery JIDs, restrict read receipts to accepted inbound messages, and bound queued, session, and binary-node resources without evicting live Signal sessions.
 - Reject malformed, unencodable, or non-canonical loopback v2 addresses instead of aliasing thread identities.
-- Encode generic local-mock target components without channel or thread identity collisions.
+- Encode generic local-mock target components without channel or thread identity collisions while preserving canonical target idempotence.
 - Keep fixture-local iMessage target IDs separate from provider-native thread aliases.
 - Randomize WhatsApp XEdDSA signatures with fresh entropy while preserving their wire encoding.
 - Suppress serve readiness output when shutdown begins during ready-file publication.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Bound Matrix and Mattermost committed state, authenticate and redact native Mattermost outgoing webhooks, enforce native transport, post lifecycle, and direct-channel identity semantics, and serialize Signal timestamps, SSE cleanup, JSON-RPC strings, and username identity.
 - Enforce Telegram native identity and UTF-16 entity boundaries without synthetic chat collisions, while accepting four-character collectible chat usernames and scheduled zero message IDs.
 - Randomize WhatsApp server credentials, canonicalize direct delivery JIDs, restrict read receipts to accepted inbound messages, and bound queued, session, and binary-node resources without evicting live Signal sessions.
+- Keep fixture-local iMessage target IDs separate from provider-native thread aliases.
 - Randomize WhatsApp XEdDSA signatures with fresh entropy while preserving their wire encoding.
 - Suppress serve readiness output when shutdown begins during ready-file publication.
 - Treat Unicode format characters as continuations when recognizing standalone acknowledgement tokens.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Bound Matrix and Mattermost committed state, authenticate and redact native Mattermost outgoing webhooks, enforce native transport, post lifecycle, and direct-channel identity semantics, and serialize Signal timestamps, SSE cleanup, JSON-RPC strings, and username identity.
 - Enforce Telegram native identity and UTF-16 entity boundaries without synthetic chat collisions, while accepting four-character collectible chat usernames and scheduled zero message IDs.
 - Randomize WhatsApp server credentials, canonicalize direct delivery JIDs, restrict read receipts to accepted inbound messages, and bound queued, session, and binary-node resources without evicting live Signal sessions.
+- Reject malformed or non-canonical loopback v2 addresses instead of aliasing thread identities.
 - Encode generic local-mock target components without channel or thread identity collisions.
 - Keep fixture-local iMessage target IDs separate from provider-native thread aliases.
 - Randomize WhatsApp XEdDSA signatures with fresh entropy while preserving their wire encoding.

--- a/src/providers/builtin/imessage.ts
+++ b/src/providers/builtin/imessage.ts
@@ -66,10 +66,7 @@ export function matchesIMessageThread(
   if (expectedThreadId === undefined) {
     return true;
   }
-  const expectedIdentifiers = new Set([expectedThreadId, target.id]);
-  if (target.channelId) {
-    expectedIdentifiers.add(target.channelId);
-  }
+  const expectedIdentifiers = new Set([expectedThreadId, target.channelId ?? target.id]);
   return (
     expectedIdentifiers.has(candidateThreadId) ||
     (recipientAlias !== undefined && expectedIdentifiers.has(recipientAlias))

--- a/src/providers/builtin/loopback.ts
+++ b/src/providers/builtin/loopback.ts
@@ -67,12 +67,14 @@ function malformedThreadAddress(cause?: unknown): CrablineError {
 
 function decodeThreadAddressComponent(value: string): string {
   let decoded: string;
+  let canonical: string;
   try {
     decoded = decodeURIComponent(value);
+    canonical = encodeURIComponent(decoded);
   } catch (error) {
     throw malformedThreadAddress(error);
   }
-  if (!decoded || encodeURIComponent(decoded) !== value) {
+  if (!decoded || canonical !== value) {
     throw malformedThreadAddress();
   }
   return decoded;

--- a/src/providers/builtin/loopback.ts
+++ b/src/providers/builtin/loopback.ts
@@ -22,6 +22,8 @@ type StoredLoopbackMessage = {
   sequence: number;
 };
 
+const LOOPBACK_V2_PREFIX = "loopback+v2:";
+
 function createMessageId(): string {
   return `loopback-mock-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 }
@@ -56,15 +58,24 @@ function toPostableText(message: PostableMessage): string {
   return message.fallbackText ?? "[card]";
 }
 
+function malformedThreadAddress(cause?: unknown): CrablineError {
+  return new CrablineError("Loopback v2 thread address is malformed.", {
+    ...(cause === undefined ? {} : { cause }),
+    kind: "inbound",
+  });
+}
+
 function decodeThreadAddressComponent(value: string): string {
+  let decoded: string;
   try {
-    return decodeURIComponent(value);
+    decoded = decodeURIComponent(value);
   } catch (error) {
-    throw new CrablineError("Loopback v2 thread address is malformed.", {
-      cause: error,
-      kind: "inbound",
-    });
+    throw malformedThreadAddress(error);
   }
+  if (!decoded || encodeURIComponent(decoded) !== value) {
+    throw malformedThreadAddress();
+  }
+  return decoded;
 }
 
 export class LoopbackChatAdapter {
@@ -85,35 +96,48 @@ export class LoopbackChatAdapter {
 
   channelIdFromThreadId(threadId: string): string {
     const [address = threadId] = threadId.split("::");
-    if (!address.startsWith("loopback+v2:")) {
+    if (!threadId.startsWith(LOOPBACK_V2_PREFIX)) {
       return address;
     }
     return this.decodeThreadId(threadId).channelId ?? address;
   }
 
   decodeThreadId(threadId: string): ThreadAddress {
-    const [address = threadId, rawThreadId] = threadId.split("::");
-    const [platform, rawChannelOrId, rawId] = address.split(":");
-    if (platform !== "loopback+v2" || !rawChannelOrId) {
-      const [, channelId = address, id = address] = address.split(":");
-      const decoded: ThreadAddress = { id };
-      if (channelId) {
-        decoded.channelId = channelId;
+    if (threadId.startsWith(LOOPBACK_V2_PREFIX)) {
+      const threadParts = threadId.split("::");
+      if (threadParts.length > 2) {
+        throw malformedThreadAddress();
       }
-      if (rawThreadId) {
-        decoded.threadId = rawThreadId;
+      const [address = "", rawThreadId] = threadParts;
+      const addressParts = address.slice(LOOPBACK_V2_PREFIX.length).split(":");
+      if (
+        (addressParts.length !== 1 && addressParts.length !== 2) ||
+        addressParts.some((part) => part.length === 0) ||
+        rawThreadId === ""
+      ) {
+        throw malformedThreadAddress();
+      }
+      const [rawChannelOrId = "", rawId] = addressParts;
+      const decoded: ThreadAddress = {
+        id: decodeThreadAddressComponent(rawId ?? rawChannelOrId),
+      };
+      if (rawId !== undefined) {
+        decoded.channelId = decodeThreadAddressComponent(rawChannelOrId);
+      }
+      if (rawThreadId !== undefined) {
+        decoded.threadId = decodeThreadAddressComponent(rawThreadId);
       }
       return decoded;
     }
 
-    const decoded: ThreadAddress = {
-      id: decodeThreadAddressComponent(rawId ?? rawChannelOrId),
-    };
-    if (rawId) {
-      decoded.channelId = decodeThreadAddressComponent(rawChannelOrId);
+    const [address = threadId, rawThreadId] = threadId.split("::");
+    const [, channelId = address, id = address] = address.split(":");
+    const decoded: ThreadAddress = { id };
+    if (channelId) {
+      decoded.channelId = channelId;
     }
     if (rawThreadId) {
-      decoded.threadId = decodeThreadAddressComponent(rawThreadId);
+      decoded.threadId = rawThreadId;
     }
     return decoded;
   }
@@ -150,8 +174,8 @@ export class LoopbackChatAdapter {
 
   encodeThreadId(platformData: ThreadAddress): string {
     const address = platformData.channelId
-      ? `loopback+v2:${encodeURIComponent(platformData.channelId)}:${encodeURIComponent(platformData.id)}`
-      : `loopback+v2:${encodeURIComponent(platformData.id)}`;
+      ? `${LOOPBACK_V2_PREFIX}${encodeURIComponent(platformData.channelId)}:${encodeURIComponent(platformData.id)}`
+      : `${LOOPBACK_V2_PREFIX}${encodeURIComponent(platformData.id)}`;
     return platformData.threadId
       ? `${address}::${encodeURIComponent(platformData.threadId)}`
       : address;

--- a/src/providers/target-normalizers.ts
+++ b/src/providers/target-normalizers.ts
@@ -166,23 +166,57 @@ export function createGenericLocalMockTargetCodec(
       });
     }
   };
-  const encodeChannel = (value: string) => `${prefix}${encodeComponent(value, "channelId")}`;
+  const requireCanonicalComponent = (value: string, label: string) => {
+    try {
+      if (
+        !value ||
+        value.includes(":") ||
+        encodeURIComponent(decodeURIComponent(value)) !== value
+      ) {
+        throw new Error("non-canonical component");
+      }
+    } catch (error) {
+      throw new CrablineError(`${platform} canonical ${label} is malformed.`, {
+        cause: error,
+        kind: "config",
+      });
+    }
+  };
+  const normalizeChannel = (value: string) => {
+    if (!value.startsWith(prefix)) {
+      return `${prefix}${encodeComponent(value, "channelId")}`;
+    }
+    requireCanonicalComponent(value.slice(prefix.length), "channelId");
+    return value;
+  };
   return {
     normalize(target): NormalizedTarget {
-      const channelId = encodeChannel(target.channelId ?? target.id);
+      const channelId = normalizeChannel(target.channelId ?? target.id);
       const normalized: NormalizedTarget = {
         channelId,
         id: target.id,
         metadata: target.metadata,
       };
       if (target.threadId) {
-        normalized.threadId = `${channelId}:${encodeComponent(target.threadId, "threadId")}`;
+        if (target.threadId.startsWith(prefix)) {
+          const canonicalPrefix = `${channelId}:`;
+          if (!target.threadId.startsWith(canonicalPrefix)) {
+            throw new CrablineError(
+              `${platform} canonical thread parent must match the target channel.`,
+              { kind: "config" },
+            );
+          }
+          requireCanonicalComponent(target.threadId.slice(canonicalPrefix.length), "threadId");
+          normalized.threadId = target.threadId;
+        } else {
+          normalized.threadId = `${channelId}:${encodeComponent(target.threadId, "threadId")}`;
+        }
       }
       return normalized;
     },
     resolveThreadId(target) {
       const normalized = this.normalize(target);
-      return normalized.threadId ?? normalized.channelId ?? encodeChannel(normalized.id);
+      return normalized.threadId ?? normalized.channelId ?? normalizeChannel(normalized.id);
     },
   };
 }

--- a/src/providers/target-normalizers.ts
+++ b/src/providers/target-normalizers.ts
@@ -183,6 +183,9 @@ export function createGenericLocalMockTargetCodec(
     }
   };
   const normalizeChannel = (value: string) => {
+    if (!value) {
+      throw new CrablineError(`${platform} channelId must not be empty.`, { kind: "config" });
+    }
     if (!value.startsWith(prefix)) {
       return `${prefix}${encodeComponent(value, "channelId")}`;
     }

--- a/src/providers/target-normalizers.ts
+++ b/src/providers/target-normalizers.ts
@@ -156,38 +156,33 @@ export function createGenericLocalMockTargetCodec(
   platform: ProviderPlatform,
 ): LocalMockTargetCodec {
   const prefix = `${platform}:`;
-  const encode = (value: string) => (value.startsWith(prefix) ? value : `${prefix}${value}`);
+  const encodeComponent = (value: string, label: string) => {
+    try {
+      return encodeURIComponent(value);
+    } catch (error) {
+      throw new CrablineError(`${platform} ${label} cannot be encoded.`, {
+        cause: error,
+        kind: "config",
+      });
+    }
+  };
+  const encodeChannel = (value: string) => `${prefix}${encodeComponent(value, "channelId")}`;
   return {
     normalize(target): NormalizedTarget {
+      const channelId = encodeChannel(target.channelId ?? target.id);
       const normalized: NormalizedTarget = {
+        channelId,
         id: target.id,
         metadata: target.metadata,
       };
-      if (target.channelId) {
-        normalized.channelId = encode(target.channelId);
-      } else if (!target.threadId) {
-        normalized.channelId = encode(target.id);
-      }
       if (target.threadId) {
-        normalized.channelId ??= encode(target.id);
-        if (
-          target.threadId.startsWith(prefix) &&
-          !target.threadId.startsWith(`${normalized.channelId}:`)
-        ) {
-          throw new CrablineError(
-            `${platform} canonical thread parent must match the target channel.`,
-            { kind: "config" },
-          );
-        }
-        normalized.threadId = target.threadId.startsWith(prefix)
-          ? target.threadId
-          : `${normalized.channelId}:${target.threadId}`;
+        normalized.threadId = `${channelId}:${encodeComponent(target.threadId, "threadId")}`;
       }
       return normalized;
     },
     resolveThreadId(target) {
       const normalized = this.normalize(target);
-      return normalized.threadId ?? normalized.channelId ?? encode(normalized.id);
+      return normalized.threadId ?? normalized.channelId ?? encodeChannel(normalized.id);
     },
   };
 }

--- a/test/imessage-provider.test.ts
+++ b/test/imessage-provider.test.ts
@@ -56,6 +56,23 @@ describe("iMessage thread matching", () => {
     ).toBe(false);
   });
 
+  it("does not treat fixture-local ids as provider thread aliases", () => {
+    expect(
+      matchesIMessageThread(
+        "fixture-contact",
+        "iMessage;-;old-guid",
+        {
+          channelId: "+15551234567",
+          id: "fixture-contact",
+        },
+        {
+          chatGuid: "fixture-contact",
+          chatIdentifier: "+15557654321",
+        },
+      ),
+    ).toBe(false);
+  });
+
   it("matches recipient targets while preserving the native chat GUID", async () => {
     const config = await createLocalMockConfig("imessage", "/imessage/webhook");
     const provider = new IMessageProviderAdapter("imessage", config, "crabline");

--- a/test/local-mock-provider.test.ts
+++ b/test/local-mock-provider.test.ts
@@ -1229,9 +1229,9 @@ describe("local mock provider", () => {
     expect(
       new Set([channelDelimiter.threadId, threadDelimiter.threadId, encodedLooking.threadId]).size,
     ).toBe(3);
-    expect(codec.normalize({ id: "loopback:room", metadata: {} }).channelId).toBe(
-      "loopback:loopback%3Aroom",
-    );
+    expect(codec.normalize({ id: "loopback:room", metadata: {} }).channelId).toBe("loopback:room");
+    expect(codec.normalize(channelDelimiter)).toEqual(channelDelimiter);
+    expect(codec.resolveThreadId(channelDelimiter)).toBe(channelDelimiter.threadId);
   });
 
   it("classifies unencodable generic target components as config errors", () => {
@@ -1239,6 +1239,9 @@ describe("local mock provider", () => {
 
     expect(() => codec.normalize({ id: "\uD800", metadata: {} })).toThrow(
       /loopback channelId cannot be encoded/u,
+    );
+    expect(() => codec.normalize({ id: "loopback:room%2f", metadata: {} })).toThrow(
+      /loopback canonical channelId is malformed/u,
     );
   });
 

--- a/test/local-mock-provider.test.ts
+++ b/test/local-mock-provider.test.ts
@@ -1240,6 +1240,9 @@ describe("local mock provider", () => {
     expect(() => codec.normalize({ id: "\uD800", metadata: {} })).toThrow(
       /loopback channelId cannot be encoded/u,
     );
+    expect(() => codec.normalize({ channelId: "", id: "room", metadata: {} })).toThrow(
+      /loopback channelId must not be empty/u,
+    );
     expect(() => codec.normalize({ id: "loopback:room%2f", metadata: {} })).toThrow(
       /loopback canonical channelId is malformed/u,
     );

--- a/test/local-mock-provider.test.ts
+++ b/test/local-mock-provider.test.ts
@@ -1198,17 +1198,48 @@ describe("local mock provider", () => {
     }
   });
 
-  it("rejects canonical generic threads whose parent differs from the target channel", () => {
+  it("keeps generic channel and thread components collision-free", () => {
     const codec = createGenericLocalMockTargetCodec("loopback");
 
-    expect(() =>
-      codec.normalize({
-        channelId: "room-a",
-        id: "room-a",
-        metadata: {},
-        threadId: "loopback:room-b:topic",
-      }),
-    ).toThrow(/thread parent must match the target channel/u);
+    const channelDelimiter = codec.normalize({
+      channelId: "room:a",
+      id: "fixture-a",
+      metadata: {},
+      threadId: "topic",
+    });
+    const threadDelimiter = codec.normalize({
+      channelId: "room",
+      id: "fixture-b",
+      metadata: {},
+      threadId: "a:topic",
+    });
+    const encodedLooking = codec.normalize({
+      channelId: "room%3Aa",
+      id: "fixture-c",
+      metadata: {},
+      threadId: "topic",
+    });
+
+    expect(channelDelimiter).toMatchObject({
+      channelId: "loopback:room%3Aa",
+      threadId: "loopback:room%3Aa:topic",
+    });
+    expect(threadDelimiter.threadId).toBe("loopback:room:a%3Atopic");
+    expect(encodedLooking.channelId).toBe("loopback:room%253Aa");
+    expect(
+      new Set([channelDelimiter.threadId, threadDelimiter.threadId, encodedLooking.threadId]).size,
+    ).toBe(3);
+    expect(codec.normalize({ id: "loopback:room", metadata: {} }).channelId).toBe(
+      "loopback:loopback%3Aroom",
+    );
+  });
+
+  it("classifies unencodable generic target components as config errors", () => {
+    const codec = createGenericLocalMockTargetCodec("loopback");
+
+    expect(() => codec.normalize({ id: "\uD800", metadata: {} })).toThrow(
+      /loopback channelId cannot be encoded/u,
+    );
   });
 
   it("bounds successful wait cursors while retaining recent progress", async () => {

--- a/test/loopback-adapter.test.ts
+++ b/test/loopback-adapter.test.ts
@@ -58,6 +58,7 @@ describe("loopback chat adapter", () => {
     "loopback+v2:user::",
     "loopback+v2:%75ser",
     "loopback+v2:user%2f",
+    "loopback+v2:\uD800",
   ])("classifies malformed v2 thread addresses: %s", (threadId) => {
     adapter = new LoopbackChatAdapter("crabline");
 

--- a/test/loopback-adapter.test.ts
+++ b/test/loopback-adapter.test.ts
@@ -47,25 +47,33 @@ describe("loopback chat adapter", () => {
     });
   });
 
-  it.each(["loopback+v2:%", "loopback+v2:channel:%", "loopback+v2:user::%"])(
-    "classifies malformed v2 thread addresses: %s",
-    (threadId) => {
-      adapter = new LoopbackChatAdapter("crabline");
+  it.each([
+    "loopback+v2:%",
+    "loopback+v2:channel:%",
+    "loopback+v2:user::%",
+    "loopback+v2:channel:user:ignored",
+    "loopback+v2:user::topic::ignored",
+    "loopback+v2:channel:",
+    "loopback+v2::user",
+    "loopback+v2:user::",
+    "loopback+v2:%75ser",
+    "loopback+v2:user%2f",
+  ])("classifies malformed v2 thread addresses: %s", (threadId) => {
+    adapter = new LoopbackChatAdapter("crabline");
 
-      let failure: unknown;
-      try {
-        adapter.decodeThreadId(threadId);
-      } catch (error) {
-        failure = error;
-      }
+    let failure: unknown;
+    try {
+      adapter.decodeThreadId(threadId);
+    } catch (error) {
+      failure = error;
+    }
 
-      expect(failure).toBeInstanceOf(CrablineError);
-      expect(failure).toMatchObject({
-        kind: "inbound",
-        message: "Loopback v2 thread address is malformed.",
-      });
-    },
-  );
+    expect(failure).toBeInstanceOf(CrablineError);
+    expect(failure).toMatchObject({
+      kind: "inbound",
+      message: "Loopback v2 thread address is malformed.",
+    });
+  });
 
   it("returns a cursor with the initial limited page", async () => {
     adapter = new LoopbackChatAdapter("crabline");


### PR DESCRIPTION
## What Problem This Solves

Fixes target identity collisions and malformed-address handling across generic local mocks, loopback v2 addresses, and iMessage thread aliases.

## Why This Change Was Made

Generic target components are encoded independently while canonical values remain idempotent, loopback v2 parsing rejects malformed and unencodable components as inbound errors, and fixture-local iMessage IDs remain separate from provider-native aliases.

## User Impact

Repeated target normalization no longer changes routing identity, delimiter-containing targets remain collision-free, and malformed addresses fail with stable domain errors instead of native exceptions.

## Evidence

- 100 focused tests passed
- `pnpm lint` passed
- `pnpm build` passed
- exact-current gpt-5.6-sol high autoreview clean (0.89) after remediating unwrapped surrogate re-encoding, canonical target drift, and empty-channel idempotence
- GitHub CI `verify` passed; CodeQL correctly skipped for this event
- Crabbox `pnpm verify` passed: 63 files, 1336 tests passed, 1 skipped (`run_4f171d286e10`; replacement lease `cbx_9011942a8888` auto-released after initial sync lease loss)
- public-data diff scan clean
- Unreleased changelog entries included