### PR TITLE
fix(providers): harden watch cleanup and Zalo redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Reject malformed, unencodable, or non-canonical loopback v2 addresses instead of aliasing thread identities.
 - Encode generic local-mock target components without channel or thread identity collisions while preserving canonical target idempotence.
 - Keep fixture-local iMessage target IDs separate from provider-native thread aliases.
+- Keep lazy provider watches registered for cleanup after nonterminal iterator throws.
 - Randomize WhatsApp XEdDSA signatures with fresh entropy while preserving their wire encoding.
 - Suppress serve readiness output when shutdown begins during ready-file publication.
 - Treat Unicode format characters as continuations when recognizing standalone acknowledgement tokens.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Reject malformed, unencodable, or non-canonical loopback v2 addresses instead of aliasing thread identities.
 - Encode generic local-mock target components without channel or thread identity collisions while preserving canonical target idempotence.
 - Keep fixture-local iMessage target IDs separate from provider-native thread aliases.
+- Case-fold Zalo recorder credential keys and fully redact ambiguous malformed URL authorities.
 - Keep lazy provider watches registered for cleanup after nonterminal iterator throws.
 - Randomize WhatsApp XEdDSA signatures with fresh entropy while preserving their wire encoding.
 - Suppress serve readiness output when shutdown begins during ready-file publication.

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -266,11 +266,16 @@ export class LazyProviderAdapter implements ProviderAdapter {
         controller.abort();
         try {
           if (source.throw) {
-            return await source.throw(error);
+            const result = await source.throw(error);
+            if (result.done) {
+              finish();
+            }
+            return result;
           }
           throw error;
-        } finally {
+        } catch (thrownError) {
           finish();
+          throw thrownError;
         }
       },
       [Symbol.asyncIterator]() {

--- a/src/servers/zalo.ts
+++ b/src/servers/zalo.ts
@@ -194,8 +194,8 @@ function isSensitiveParam(name: string): boolean {
   const canonicalName = normalizedName.replace(/[^A-Za-z0-9]/gu, "").toLowerCase();
   return (
     SENSITIVE_PARAM_NAMES.has(canonicalName) ||
-    /[a-z0-9](?:Credential|Credentials|Key|Password|Passwd|Secret|Signature|Token)s?$/u.test(
-      normalizedName,
+    /[a-z0-9](?:credentials?|keys?|passwords?|passwds?|secrets?|signatures?|tokens?)$/u.test(
+      canonicalName,
     ) ||
     /(?:^|[_-])(?:access[_-]?token|api[_-]?key|authorization|key|password|secret|signature|token)(?:$|[_-])/iu.test(
       normalizedName,
@@ -254,6 +254,9 @@ function redactMalformedUrlCredentials(value: string): string {
     /^(\s*)((?:[a-z][a-z0-9+.-]*:)?\/\/)[^/?#]*@/iu,
     "$1$2<redacted>@",
   );
+  if (credentialRedacted === value) {
+    return "<redacted>";
+  }
   const queryStart = credentialRedacted.indexOf("?");
   const fragmentStart = credentialRedacted.indexOf("#", queryStart + 1);
   if (queryStart < 0 || (fragmentStart >= 0 && fragmentStart < queryStart)) {

--- a/test/registry-lifecycle.test.ts
+++ b/test/registry-lifecycle.test.ts
@@ -782,6 +782,71 @@ describe("lazy provider lifecycle", () => {
     }
   });
 
+  it("keeps nonterminal iterator throws tracked until cleanup closes the watch", async () => {
+    const first = {
+      author: "assistant" as const,
+      id: "first",
+      provider: "test",
+      sentAt: new Date().toISOString(),
+      text: "first",
+      threadId: "thread",
+    };
+    const recovered = { ...first, id: "recovered", text: "recovered" };
+    let watchClosed = false;
+    const concrete: ProviderAdapter = {
+      id: "test",
+      platform: "loopback",
+      status: "ready",
+      supports: ["agent"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      async probe() {
+        return { details: [], healthy: true };
+      },
+      async send() {
+        return { accepted: true, messageId: "sent", threadId: "thread" };
+      },
+      async waitForInbound() {
+        return null;
+      },
+      async *watch() {
+        try {
+          try {
+            yield first;
+          } catch {
+            yield recovered;
+            yield first;
+          }
+        } finally {
+          watchClosed = true;
+        }
+      },
+    };
+    const provider = new LazyProviderAdapter({
+      adapterName: "test",
+      factory: async () => concrete,
+      id: "test",
+      normalizeTarget: concrete.normalizeTarget.bind(concrete),
+      platform: "loopback",
+      status: "ready",
+      supports: ["agent"],
+    });
+    const { context } = createTelegramManifest("/tmp/unused.jsonl");
+    const iterator = provider.watch(context)[Symbol.asyncIterator]();
+
+    await expect(iterator.next()).resolves.toEqual({ done: false, value: first });
+    await expect(iterator.throw!(new Error("recover"))).resolves.toEqual({
+      done: false,
+      value: recovered,
+    });
+    expect(watchClosed).toBe(false);
+
+    await provider.cleanup();
+
+    expect(watchClosed).toBe(true);
+  });
+
   it("cancels an admitted watch before cleaning up a materializing provider", async () => {
     let releaseFactory: (() => void) | undefined;
     const factoryBlocked = new Promise<void>((resolve) => {

--- a/test/zalo-server.test.ts
+++ b/test/zalo-server.test.ts
@@ -209,6 +209,12 @@ describe("Zalo local provider server", () => {
                     "http://fixture-user:placeholder@example.com/hook?api_key=placeholder",
                 },
               ],
+              invalidCallbackUrl: [
+                "http://",
+                "ambiguous-user",
+                ":",
+                "ambiguous-credential-placeholder",
+              ].join(""),
             },
             secret_token: "test-auth-token",
             url: webhookUrl.href,
@@ -291,6 +297,9 @@ describe("Zalo local provider server", () => {
       expect(recorder).toContain(
         '"callbackUrl":"http://<redacted>@example.com/hook?api_key=<redacted>"',
       );
+      expect(recorder).toContain('"invalidCallbackUrl":"<redacted>"');
+      expect(recorder).not.toContain("ambiguous-user");
+      expect(recorder).not.toContain("ambiguous-credential-placeholder");
       for (const secret of ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot"]) {
         expect(recorder).not.toContain(secret);
       }
@@ -301,7 +310,7 @@ describe("Zalo local provider server", () => {
     }
   });
 
-  it("bounds recursive redaction and hides nested camel-case credentials", async () => {
+  it("bounds recursive redaction and hides nested case-folded credentials", async () => {
     const directory = await createTempDir();
     directories.push(directory);
     const recorderPath = path.join(directory, "zalo-redaction.jsonl");
@@ -315,6 +324,8 @@ describe("Zalo local provider server", () => {
     for (let depth = 0; depth < 64; depth += 1) {
       deepState = { child: deepState };
     }
+    const lowerCasePasswordKey = ["database", "password"].join("");
+    const upperCaseClientSecretKey = ["OAUTH", "CLIENT", "SECRET"].join("");
 
     const response = await fetch(
       `${server.manifest.baseUrl}/bottest-token-placeholder/sendMessage`,
@@ -323,8 +334,10 @@ describe("Zalo local provider server", () => {
           chat_id: "chat-1",
           diagnostics: {
             botToken: "test-token-placeholder",
+            [lowerCasePasswordKey]: "lowercase-credential-placeholder",
             nested: [{ databasePassword: "test-token-placeholder" }],
             oauthClientSecret: "test-token-placeholder",
+            [upperCaseClientSecretKey]: "uppercase-credential-placeholder",
           },
           state: deepState,
           text: "hello",
@@ -344,11 +357,18 @@ describe("Zalo local provider server", () => {
     const oauthClientSecretKey = ["oauth", "Client", "Secret"].join("");
     expect(recorded.body?.diagnostics).toMatchObject({
       [botTokenKey]: "<redacted>",
+      [lowerCasePasswordKey]: "<redacted>",
       nested: [{ [databasePasswordKey]: "<redacted>" }],
       [oauthClientSecretKey]: "<redacted>",
+      [upperCaseClientSecretKey]: "<redacted>",
     });
     expect(recorder).toContain('"child":"<redacted>"');
-    for (const secret of ["test-token-placeholder", "beyond-redaction-depth"]) {
+    for (const secret of [
+      "test-token-placeholder",
+      "beyond-redaction-depth",
+      "lowercase-credential-placeholder",
+      "uppercase-credential-placeholder",
+    ]) {
       expect(recorder).not.toContain(secret);
     }
   });


### PR DESCRIPTION
## What Problem This Solves

Closes two cleanup and evidence leaks: provider watch iterators that throw transiently could escape later cleanup, and Zalo recorder redaction missed mixed-case credentials and ambiguous malformed URL authorities.

## Why This Change Was Made

Nonterminal watch failures now remain registered until actual iterator completion or provider shutdown. Zalo redaction now case-folds credential keys and fails closed for malformed authority-like values.

## Evidence

- full local Vitest suite passed: 63 files, 1338 tests
- `pnpm lint` passed
- `pnpm build` passed
- exact-current gpt-5.6-sol high autoreview clean (0.95)
- GitHub CI `verify` passed; CodeQL skipped for this event
- Crabbox `pnpm verify` passed: 63 files, 1337 tests passed, 1 skipped (`run_959f4b2c8489`, lease `cbx_e897194fe1f9` auto-released)
- public-data diff scan clean
- Unreleased changelog entries included