### PR TITLE
fix(providers): preserve Telegram and WhatsApp message fidelity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Verify loopback bindings by their listening address, sanitize framing and connection-nominated Fetch response headers, and advertise usable endpoints for every wildcard address spelling.
 - Route local-mock GET hooks through the real server and parse structured JSON media types as JSON.
 - Bound Matrix and Mattermost committed state, authenticate and redact native Mattermost outgoing webhooks, enforce native transport, post lifecycle, and direct-channel identity semantics, and serialize Signal timestamps, SSE cleanup, JSON-RPC strings, and username identity.
-- Enforce Telegram native identity, username, and UTF-16 entity boundaries without synthetic chat collisions.
+- Enforce Telegram native identity and UTF-16 entity boundaries without synthetic chat collisions, while accepting four-character collectible chat usernames.
 - Randomize WhatsApp server credentials, canonicalize direct delivery JIDs, restrict read receipts to accepted inbound messages, and bound queued, session, and binary-node resources.
 - Randomize WhatsApp XEdDSA signatures with fresh entropy while preserving their wire encoding.
 - Suppress serve readiness output when shutdown begins during ready-file publication.
@@ -21,7 +21,7 @@
 - Distinguish Microsoft Teams signing-service failures from invalid bearer tokens and preserve invoke response status semantics.
 - Preserve committed provider recorder errors during final identity confirmation and strictly parse quoted JWT cache lifetimes.
 - Lint repository tooling in the type-aware verification gate.
-- Preserve WhatsApp acknowledgement races without stale pending state or false deduplication.
+- Preserve WhatsApp acknowledgement races by sharing in-flight acceptance results without stale pending state or false deduplication.
 - Derive Telegram multipart media identity from upload bytes while preserving filenames and file reference reuse.
 - Require valid OpenClaw readiness recorder evidence and allow unauthenticated loopback callback URLs.
 - Merge repeated WhatsApp handshake message occurrences according to protobuf semantics.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Verify loopback bindings by their listening address, sanitize framing and connection-nominated Fetch response headers, and advertise usable endpoints for every wildcard address spelling.
 - Route local-mock GET hooks through the real server and parse structured JSON media types as JSON.
 - Bound Matrix and Mattermost committed state, authenticate and redact native Mattermost outgoing webhooks, enforce native transport, post lifecycle, and direct-channel identity semantics, and serialize Signal timestamps, SSE cleanup, JSON-RPC strings, and username identity.
+- Enforce Telegram native identity, username, and UTF-16 entity boundaries without synthetic chat collisions.
+- Randomize WhatsApp server credentials, canonicalize direct delivery JIDs, restrict read receipts to accepted inbound messages, and bound queued, session, and binary-node resources.
 - Randomize WhatsApp XEdDSA signatures with fresh entropy while preserving their wire encoding.
 - Suppress serve readiness output when shutdown begins during ready-file publication.
 - Treat Unicode format characters as continuations when recognizing standalone acknowledgement tokens.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Verify loopback bindings by their listening address, sanitize framing and connection-nominated Fetch response headers, and advertise usable endpoints for every wildcard address spelling.
 - Route local-mock GET hooks through the real server and parse structured JSON media types as JSON.
 - Bound Matrix and Mattermost committed state, authenticate and redact native Mattermost outgoing webhooks, enforce native transport, post lifecycle, and direct-channel identity semantics, and serialize Signal timestamps, SSE cleanup, JSON-RPC strings, and username identity.
-- Enforce Telegram native identity and UTF-16 entity boundaries without synthetic chat collisions, while accepting four-character collectible chat usernames.
+- Enforce Telegram native identity and UTF-16 entity boundaries without synthetic chat collisions, while accepting four-character collectible chat usernames and scheduled zero message IDs.
 - Randomize WhatsApp server credentials, canonicalize direct delivery JIDs, restrict read receipts to accepted inbound messages, and bound queued, session, and binary-node resources without evicting live Signal sessions.
 - Randomize WhatsApp XEdDSA signatures with fresh entropy while preserving their wire encoding.
 - Suppress serve readiness output when shutdown begins during ready-file publication.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Route local-mock GET hooks through the real server and parse structured JSON media types as JSON.
 - Bound Matrix and Mattermost committed state, authenticate and redact native Mattermost outgoing webhooks, enforce native transport, post lifecycle, and direct-channel identity semantics, and serialize Signal timestamps, SSE cleanup, JSON-RPC strings, and username identity.
 - Enforce Telegram native identity and UTF-16 entity boundaries without synthetic chat collisions, while accepting four-character collectible chat usernames.
-- Randomize WhatsApp server credentials, canonicalize direct delivery JIDs, restrict read receipts to accepted inbound messages, and bound queued, session, and binary-node resources.
+- Randomize WhatsApp server credentials, canonicalize direct delivery JIDs, restrict read receipts to accepted inbound messages, and bound queued, session, and binary-node resources without evicting live Signal sessions.
 - Randomize WhatsApp XEdDSA signatures with fresh entropy while preserving their wire encoding.
 - Suppress serve readiness output when shutdown begins during ready-file publication.
 - Treat Unicode format characters as continuations when recognizing standalone acknowledgement tokens.

--- a/src/openclaw/bridges/telegram.ts
+++ b/src/openclaw/bridges/telegram.ts
@@ -10,9 +10,10 @@ import {
 } from "../shared.js";
 import {
   canonicalizeTelegramUsername,
+  TELEGRAM_BOT_USERNAME_PATTERN,
+  TELEGRAM_CHAT_USERNAME_PATTERN,
   TELEGRAM_NATIVE_CHAT_ID_MAX,
   telegramUsernameChatId,
-  TELEGRAM_USERNAME_PATTERN,
 } from "../../servers/telegram-identity.js";
 
 const TELEGRAM_SYMBOLIC_ID_BASE = TELEGRAM_NATIVE_CHAT_ID_MAX + 1n;
@@ -47,7 +48,7 @@ function normalizeTelegramChatId(
   if (value.startsWith("@")) {
     const username = canonicalizeTelegramUsername(value);
     if (!username) {
-      throw new Error("Telegram usernames must contain 5-32 letters, digits, or underscores.");
+      throw new Error("Telegram usernames must contain 4-32 letters, digits, or underscores.");
     }
     if (kind === "group" && options.preserveGroupUsername) {
       return username;
@@ -160,7 +161,7 @@ export const TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
           !readNonBlankString(result.first_name) ||
           (result.username !== undefined &&
             (typeof result.username !== "string" ||
-              !TELEGRAM_USERNAME_PATTERN.test(`@${result.username}`)))
+              !TELEGRAM_BOT_USERNAME_PATTERN.test(`@${result.username}`)))
         ) {
           throw new Error("Crabline Telegram getMe probe failed: invalid response.");
         }
@@ -220,7 +221,8 @@ export const TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
       createAgentDelivery(parsed) {
         const kind =
           parsed.native &&
-          (/^-\d+$/u.test(parsed.id.trim()) || TELEGRAM_USERNAME_PATTERN.test(parsed.id.trim()))
+          (/^-\d+$/u.test(parsed.id.trim()) ||
+            TELEGRAM_CHAT_USERNAME_PATTERN.test(parsed.id.trim()))
             ? "group"
             : parsed.kind;
         const chatId = normalizeTelegramChatId(kind, parsed.id, {

--- a/src/openclaw/bridges/telegram.ts
+++ b/src/openclaw/bridges/telegram.ts
@@ -10,14 +10,13 @@ import {
 } from "../shared.js";
 import {
   canonicalizeTelegramUsername,
+  TELEGRAM_NATIVE_CHAT_ID_MAX,
   telegramUsernameChatId,
   TELEGRAM_USERNAME_PATTERN,
 } from "../../servers/telegram-identity.js";
 
-const TELEGRAM_SYMBOLIC_DIRECT_ID_BASE = 1n << 51n;
-const TELEGRAM_SYMBOLIC_DIRECT_ID_MASK = TELEGRAM_SYMBOLIC_DIRECT_ID_BASE - 1n;
-const TELEGRAM_SYMBOLIC_GROUP_ID_BASE = 1_000_000_000_000n;
-const TELEGRAM_SYMBOLIC_GROUP_ID_RANGE = 10_000_000_000n;
+const TELEGRAM_SYMBOLIC_ID_BASE = TELEGRAM_NATIVE_CHAT_ID_MAX + 1n;
+const TELEGRAM_SYMBOLIC_ID_RANGE = 1n << 50n;
 const TELEGRAM_OUTBOUND_METHOD_RE =
   /\/(sendAnimation|sendAudio|sendDocument|sendMessage|sendPhoto|sendVideo)$/iu;
 function normalizeTelegramChatId(
@@ -40,12 +39,15 @@ function normalizeTelegramChatId(
     ) {
       throw new Error("Telegram numeric target must be a safe integer.");
     }
+    if (numericId < -TELEGRAM_NATIVE_CHAT_ID_MAX || numericId > TELEGRAM_NATIVE_CHAT_ID_MAX) {
+      throw new Error("Telegram native numeric targets must fit within 52 significant bits.");
+    }
     return numericId.toString();
   }
   if (value.startsWith("@")) {
     const username = canonicalizeTelegramUsername(value);
     if (!username) {
-      throw new Error("Telegram usernames must contain 4-32 letters, digits, or underscores.");
+      throw new Error("Telegram usernames must contain 5-32 letters, digits, or underscores.");
     }
     if (kind === "group" && options.preserveGroupUsername) {
       return username;
@@ -61,9 +63,9 @@ function normalizeTelegramChatId(
 function syntheticTelegramChatId(kind: "direct" | "group", value: string): string {
   const hash = createHash("sha256").update(`${kind}:${value}`).digest().readBigUInt64BE();
   if (kind === "group") {
-    return String(-(TELEGRAM_SYMBOLIC_GROUP_ID_BASE + (hash % TELEGRAM_SYMBOLIC_GROUP_ID_RANGE)));
+    return String(-(TELEGRAM_SYMBOLIC_ID_BASE + (hash % TELEGRAM_SYMBOLIC_ID_RANGE)));
   }
-  return String(TELEGRAM_SYMBOLIC_DIRECT_ID_BASE + (hash & TELEGRAM_SYMBOLIC_DIRECT_ID_MASK));
+  return String(TELEGRAM_SYMBOLIC_ID_BASE + (hash % TELEGRAM_SYMBOLIC_ID_RANGE));
 }
 
 function telegramTargetKey(chatId: string, threadId?: number) {

--- a/src/providers/builtin/telegram.ts
+++ b/src/providers/builtin/telegram.ts
@@ -4,8 +4,8 @@ import type { ProviderConfig } from "../../config/schema.js";
 import { LocalMockProviderAdapter } from "../local-mock.js";
 import {
   getBuiltinTargetCodec,
-  parseCanonicalTelegramTopic,
-  TELEGRAM_CHAT_ID_RULE,
+  parseCanonicalTelegramInboundTopic,
+  TELEGRAM_INBOUND_CHAT_ID_RULE,
   TELEGRAM_MESSAGE_THREAD_ID_RULE,
 } from "../target-normalizers.js";
 import type { ProviderAdapter } from "../types.js";
@@ -60,7 +60,7 @@ function normalizeGenericTelegramPayload(payload: Record<string, unknown>) {
   const threadId =
     (message ? optionalString(message, "threadId") : undefined) ??
     optionalString(payload, "threadId");
-  const canonicalTopic = threadId ? parseCanonicalTelegramTopic(threadId) : undefined;
+  const canonicalTopic = threadId ? parseCanonicalTelegramInboundTopic(threadId) : undefined;
   const channelIds = [
     optionalString(payload, "channelId"),
     ...(message ? [optionalString(message, "channelId")] : []),
@@ -68,7 +68,7 @@ function normalizeGenericTelegramPayload(payload: Record<string, unknown>) {
   if (canonicalTopic) {
     for (const channelId of channelIds) {
       if (
-        requireNativeInboundId(channelId, TELEGRAM_CHAT_ID_RULE, "Telegram channelId") !==
+        requireNativeInboundId(channelId, TELEGRAM_INBOUND_CHAT_ID_RULE, "Telegram channelId") !==
         canonicalTopic.chatId
       ) {
         throw new CrablineError(
@@ -95,7 +95,7 @@ function normalizeGenericTelegramPayload(payload: Record<string, unknown>) {
         }
     : payload;
   const normalized = genericMockPayloadWithNativeThread({
-    channelRule: TELEGRAM_CHAT_ID_RULE,
+    channelRule: TELEGRAM_INBOUND_CHAT_ID_RULE,
     payload: genericPayload,
     threadRule: TELEGRAM_MESSAGE_THREAD_ID_RULE,
   });
@@ -147,7 +147,7 @@ export function normalizeTelegramWebhookPayload(payload: unknown) {
   const topicId = optionalStringish(message, "message_thread_id");
   const normalizedChatId = requireNativeInboundId(
     chatId,
-    TELEGRAM_CHAT_ID_RULE,
+    TELEGRAM_INBOUND_CHAT_ID_RULE,
     "Telegram message.chat.id",
   );
   const from = optionalRecord(message, "from");

--- a/src/providers/target-normalizers.ts
+++ b/src/providers/target-normalizers.ts
@@ -1,6 +1,7 @@
 import type { BuiltinAdapterId, FixtureDefinition, ProviderPlatform } from "../config/schema.js";
 import { CrablineError } from "../core/errors.js";
 import { isMatrixEventId, isMatrixRoomId } from "../matrix-ids.js";
+import { TELEGRAM_NATIVE_CHAT_ID_MAX } from "../servers/telegram-identity.js";
 import type { LocalMockTargetCodec } from "./local-mock.js";
 import { matchesNativeId, type NativeIdRule } from "./native-ids.js";
 import { slackTargetKey, SLACK_SEND_TARGET_ID_RULE, SLACK_TS_RULE } from "./slack-ids.js";
@@ -75,9 +76,16 @@ export const MSTEAMS_CONVERSATION_ID_RULE: NativeIdRule = {
 export const TELEGRAM_CHAT_ID_RULE: NativeIdRule = {
   example: "-1001234567890 or @channelusername",
   name: "Telegram chat id",
-  pattern: /^(?:-?[1-9]\d*|@[A-Za-z][A-Za-z0-9_]{3,31})$/u,
+  pattern: /^(?:-?[1-9]\d*|@[A-Za-z][A-Za-z0-9_]{4,31})$/u,
   validate: (value) =>
-    value.startsWith("@") || BigInt(value.replace(/^-/u, "")) <= BigInt(Number.MAX_SAFE_INTEGER),
+    value.startsWith("@") || BigInt(value.replace(/^-/u, "")) <= TELEGRAM_NATIVE_CHAT_ID_MAX,
+};
+
+export const TELEGRAM_INBOUND_CHAT_ID_RULE: NativeIdRule = {
+  example: "-1001234567890",
+  name: "Telegram inbound chat id",
+  pattern: /^-?[1-9]\d*$/u,
+  validate: (value) => BigInt(value.replace(/^-/u, "")) <= TELEGRAM_NATIVE_CHAT_ID_MAX,
 };
 
 export const TELEGRAM_MESSAGE_THREAD_ID_RULE: NativeIdRule = {
@@ -233,6 +241,19 @@ const TELEGRAM_BASE_CODEC = createNativeTargetCodec({
 export function parseCanonicalTelegramTopic(
   value: string,
 ): { chatId: string; topicId: string } | undefined {
+  return parseCanonicalTelegramTopicWithRule(value, TELEGRAM_CHAT_ID_RULE);
+}
+
+export function parseCanonicalTelegramInboundTopic(
+  value: string,
+): { chatId: string; topicId: string } | undefined {
+  return parseCanonicalTelegramTopicWithRule(value, TELEGRAM_INBOUND_CHAT_ID_RULE);
+}
+
+function parseCanonicalTelegramTopicWithRule(
+  value: string,
+  chatRule: NativeIdRule,
+): { chatId: string; topicId: string } | undefined {
   const separator = value.lastIndexOf(":");
   if (separator <= 0) {
     return undefined;
@@ -240,7 +261,7 @@ export function parseCanonicalTelegramTopic(
   const chatId = value.slice(0, separator);
   const topicId = value.slice(separator + 1);
   if (
-    !matchesNativeId(chatId, TELEGRAM_CHAT_ID_RULE) ||
+    !matchesNativeId(chatId, chatRule) ||
     !matchesNativeId(topicId, TELEGRAM_MESSAGE_THREAD_ID_RULE)
   ) {
     return undefined;

--- a/src/providers/target-normalizers.ts
+++ b/src/providers/target-normalizers.ts
@@ -76,7 +76,7 @@ export const MSTEAMS_CONVERSATION_ID_RULE: NativeIdRule = {
 export const TELEGRAM_CHAT_ID_RULE: NativeIdRule = {
   example: "-1001234567890 or @channelusername",
   name: "Telegram chat id",
-  pattern: /^(?:-?[1-9]\d*|@[A-Za-z][A-Za-z0-9_]{4,31})$/u,
+  pattern: /^(?:-?[1-9]\d*|@[A-Za-z][A-Za-z0-9_]{3,31})$/u,
   validate: (value) =>
     value.startsWith("@") || BigInt(value.replace(/^-/u, "")) <= TELEGRAM_NATIVE_CHAT_ID_MAX,
 };

--- a/src/servers/telegram-identity.ts
+++ b/src/servers/telegram-identity.ts
@@ -1,6 +1,10 @@
 import { createHash } from "node:crypto";
 
-export const TELEGRAM_USERNAME_PATTERN = /^@[A-Za-z][A-Za-z0-9_]{3,31}$/u;
+export const TELEGRAM_NATIVE_CHAT_ID_MAX = (1n << 52n) - 1n;
+export const TELEGRAM_USERNAME_PATTERN = /^@[A-Za-z][A-Za-z0-9_]{4,31}$/u;
+
+const TELEGRAM_SYNTHETIC_ID_RANGE = 1n << 50n;
+const TELEGRAM_USERNAME_ID_BASE = (1n << 52n) + TELEGRAM_SYNTHETIC_ID_RANGE;
 
 export function canonicalizeTelegramUsername(value: string): string | undefined {
   const username = value.trim();
@@ -13,5 +17,7 @@ export function telegramUsernameChatId(value: string): number | undefined {
     return undefined;
   }
   const hash = createHash("sha256").update(username).digest();
-  return -1_000_000_000_000 - (hash.readUIntBE(0, 6) % 10_000_000_000);
+  return Number(
+    -(TELEGRAM_USERNAME_ID_BASE + (hash.readBigUInt64BE() % TELEGRAM_SYNTHETIC_ID_RANGE)),
+  );
 }

--- a/src/servers/telegram-identity.ts
+++ b/src/servers/telegram-identity.ts
@@ -1,14 +1,15 @@
 import { createHash } from "node:crypto";
 
 export const TELEGRAM_NATIVE_CHAT_ID_MAX = (1n << 52n) - 1n;
-export const TELEGRAM_USERNAME_PATTERN = /^@[A-Za-z][A-Za-z0-9_]{4,31}$/u;
+export const TELEGRAM_BOT_USERNAME_PATTERN = /^@[A-Za-z][A-Za-z0-9_]{4,31}$/u;
+export const TELEGRAM_CHAT_USERNAME_PATTERN = /^@[A-Za-z][A-Za-z0-9_]{3,31}$/u;
 
 const TELEGRAM_SYNTHETIC_ID_RANGE = 1n << 50n;
 const TELEGRAM_USERNAME_ID_BASE = (1n << 52n) + TELEGRAM_SYNTHETIC_ID_RANGE;
 
 export function canonicalizeTelegramUsername(value: string): string | undefined {
   const username = value.trim();
-  return TELEGRAM_USERNAME_PATTERN.test(username) ? username.toLowerCase() : undefined;
+  return TELEGRAM_CHAT_USERNAME_PATTERN.test(username) ? username.toLowerCase() : undefined;
 }
 
 export function telegramUsernameChatId(value: string): number | undefined {

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -28,6 +28,7 @@ import {
 } from "./webhook-target.js";
 import {
   canonicalizeTelegramUsername,
+  TELEGRAM_BOT_USERNAME_PATTERN,
   TELEGRAM_NATIVE_CHAT_ID_MAX,
   telegramUsernameChatId,
 } from "./telegram-identity.js";
@@ -1946,8 +1947,9 @@ export async function startTelegramServer(
   if (!Number.isSafeInteger(botId) || botId < 1) {
     throw new Error("botId must be a positive safe integer.");
   }
-  const botUsername = telegramChatUsername(params.botUsername ?? "crabline_bot")?.slice(1);
-  if (!botUsername) {
+  const botUsernameValue = params.botUsername ?? "crabline_bot";
+  const botUsername = botUsernameValue.trim().replace(/^@/u, "").toLowerCase();
+  if (!TELEGRAM_BOT_USERNAME_PATTERN.test(`@${botUsername}`)) {
     throw new Error("botUsername must be a valid 5-32 character Telegram username.");
   }
   const state: TelegramServerState = {

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -26,7 +26,11 @@ import {
   validateWebhookTarget,
   type WebhookAddress,
 } from "./webhook-target.js";
-import { canonicalizeTelegramUsername, telegramUsernameChatId } from "./telegram-identity.js";
+import {
+  canonicalizeTelegramUsername,
+  TELEGRAM_NATIVE_CHAT_ID_MAX,
+  telegramUsernameChatId,
+} from "./telegram-identity.js";
 
 const TELEGRAM_MAX_REQUEST_BODY_BYTES = 50 * 1024 * 1024;
 const TELEGRAM_WEBHOOK_MAX_BACKOFF_EXPONENT = 5;
@@ -373,10 +377,18 @@ function telegramChatId(value: unknown): number | undefined {
     return undefined;
   }
   if (/^-?\d+$/u.test(stringValue)) {
-    const integerValue = toIntegerValue(stringValue);
-    return integerValue === 0 ? undefined : integerValue;
+    return telegramNumericChatId(stringValue);
   }
   return telegramUsernameChatId(stringValue);
+}
+
+function telegramNumericChatId(value: unknown): number | undefined {
+  const stringValue = toStringValue(value);
+  if (!stringValue || !/^-?\d+$/u.test(stringValue)) {
+    return undefined;
+  }
+  const integerValue = toIntegerValue(stringValue);
+  return integerValue === 0 ? undefined : integerValue;
 }
 
 async function appendEvent(state: TelegramServerState, event: TelegramServerEvent) {
@@ -421,7 +433,11 @@ function createBotUser(state: TelegramServerState) {
 }
 
 function inferTelegramChatType(chatId: number): TelegramChat["type"] {
-  return chatId >= 0 ? "private" : String(chatId).startsWith("-100") ? "supergroup" : "group";
+  return chatId >= 0
+    ? "private"
+    : String(chatId).startsWith("-100") || BigInt(chatId) < -TELEGRAM_NATIVE_CHAT_ID_MAX
+      ? "supergroup"
+      : "group";
 }
 
 function createChat(chatId: number): TelegramChat {
@@ -432,7 +448,7 @@ function createChat(chatId: number): TelegramChat {
 }
 
 function telegramChatUsername(value: unknown): string | undefined {
-  const username = toStringValue(value);
+  const username = toStringValue(value)?.trim();
   if (!username) {
     return undefined;
   }
@@ -493,21 +509,18 @@ function telegramChatFromRecord(value: unknown): TelegramChat | undefined {
   if (!isJsonObject(value)) {
     return undefined;
   }
-  const id = telegramChatId(value.id);
+  const id = telegramNumericChatId(value.id);
   const type = telegramChatType(value.type);
   if (id === undefined || !type) {
     return undefined;
   }
-  const rawUsername = toStringValue(value.username);
-  const username = telegramChatUsername(rawUsername);
+  const username = telegramChatUsername(value.username);
   const title = toStringValue(value.title);
   return {
     id,
     ...(title ? { title } : {}),
     type,
-    ...(username && rawUsername
-      ? { username: rawUsername.startsWith("@") ? rawUsername.slice(1) : rawUsername }
-      : {}),
+    ...(username ? { username: username.slice(1) } : {}),
   };
 }
 
@@ -668,7 +681,7 @@ function createEditedMessage(
 ): TelegramMessage | undefined {
   const chat = resolveTelegramChat(state, body.chat_id);
   const messageId = toIntegerValue(body.message_id);
-  if (!chat || messageId === undefined) {
+  if (!chat || messageId === undefined || messageId < 1) {
     return undefined;
   }
   const parsedThreadId = toIntegerValue(body.message_thread_id);
@@ -707,16 +720,18 @@ function createInboundUpdate(
   const fromId = toIntegerValue(fromIdValue);
   const parsedThreadId = toIntegerValue(threadIdValue);
   const threadId = parsedThreadId !== undefined && parsedThreadId > 0 ? parsedThreadId : undefined;
-  const fromUsername = toStringValue(body.fromUsername ?? body.from_username);
+  const fromUsernameValue = body.fromUsername ?? body.from_username;
+  const fromUsername = telegramChatUsername(fromUsernameValue);
   const messageId = toIntegerValue(messageIdValue);
   const updateId = toIntegerValue(updateIdValue);
   const explicitChatType = telegramChatType(body.chatType ?? body.chat_type);
   if (
     ((body.chatType !== undefined || body.chat_type !== undefined) && !explicitChatType) ||
-    (fromIdValue !== undefined && fromId === undefined) ||
+    (fromIdValue !== undefined && (fromId === undefined || fromId < 1)) ||
+    (fromUsernameValue !== undefined && !fromUsername) ||
     (threadIdValue !== undefined && parsedThreadId === undefined) ||
-    (messageIdValue !== undefined && messageId === undefined) ||
-    (updateIdValue !== undefined && updateId === undefined)
+    (messageIdValue !== undefined && (messageId === undefined || messageId < 1)) ||
+    (updateIdValue !== undefined && (updateId === undefined || updateId < 1))
   ) {
     return undefined;
   }
@@ -732,7 +747,7 @@ function createInboundUpdate(
         first_name: toStringValue(body.fromName ?? body.from_name) ?? "QA User",
         id: fromId ?? 100001,
         is_bot: false,
-        ...(fromUsername ? { username: fromUsername } : {}),
+        ...(fromUsername ? { username: fromUsername.slice(1) } : {}),
       },
       message_id: messageId ?? nextTelegramMessageId(state, chat.id),
       ...(entities && entities.length > 0 ? { entities } : {}),
@@ -771,6 +786,8 @@ function parseTelegramEntities(
       offset === undefined ||
       offset < 0 ||
       offset + length > text.length ||
+      !isTelegramUtf16Boundary(text, offset) ||
+      !isTelegramUtf16Boundary(text, offset + length) ||
       !type ||
       (customEmojiId !== undefined &&
         (typeof customEmojiId !== "string" || customEmojiId.length === 0)) ||
@@ -793,6 +810,15 @@ function parseTelegramEntities(
   return entities;
 }
 
+function isTelegramUtf16Boundary(text: string, index: number): boolean {
+  if (index <= 0 || index >= text.length) {
+    return true;
+  }
+  const previous = text.charCodeAt(index - 1);
+  const next = text.charCodeAt(index);
+  return !(previous >= 0xd800 && previous <= 0xdbff && next >= 0xdc00 && next <= 0xdfff);
+}
+
 function hasTelegramMedia(value: Record<string, unknown>): boolean {
   return TELEGRAM_MEDIA_FIELDS.some((field) => value[field] !== undefined);
 }
@@ -801,7 +827,6 @@ function explicitTelegramId(
   body: Record<string, unknown>,
   names: readonly string[],
   additionalValues: readonly unknown[] = [],
-  options: { allowZero?: boolean } = {},
 ): { present: false } | { present: true; value: number } | undefined {
   const values = [
     ...names.flatMap((name) => (body[name] === undefined ? [] : [body[name]])),
@@ -811,11 +836,8 @@ function explicitTelegramId(
     return { present: false };
   }
   const parsed = values.map(toIntegerValue);
-  const minimum = options.allowZero ? 0 : 1;
   if (
-    parsed.some(
-      (value) => value === undefined || value < minimum || value >= Number.MAX_SAFE_INTEGER,
-    ) ||
+    parsed.some((value) => value === undefined || value < 1 || value >= Number.MAX_SAFE_INTEGER) ||
     new Set(parsed).size !== 1
   ) {
     return undefined;
@@ -856,7 +878,7 @@ function explicitTelegramMessageChatId(body: Record<string, unknown>): number | 
       continue;
     }
     const chat = isJsonObject(message.chat) ? message.chat : undefined;
-    const chatId = telegramChatId(chat?.id);
+    const chatId = telegramNumericChatId(chat?.id);
     if (chatId === undefined) {
       return false;
     }
@@ -867,7 +889,7 @@ function explicitTelegramMessageChatId(body: Record<string, unknown>): number | 
     callbackQuery && isJsonObject(callbackQuery.message) ? callbackQuery.message : undefined;
   if (callbackMessage?.message_id !== undefined) {
     const chat = isJsonObject(callbackMessage.chat) ? callbackMessage.chat : undefined;
-    const chatId = telegramChatId(chat?.id);
+    const chatId = telegramNumericChatId(chat?.id);
     if (chatId === undefined) {
       return false;
     }
@@ -1032,11 +1054,12 @@ function isValidIgnoredTelegramUpdate(body: Record<string, unknown>): boolean {
     const chat = isJsonObject(message.chat) ? message.chat : undefined;
     if (
       updateId === undefined ||
+      updateId < 1 ||
       !chat ||
-      telegramChatId(chat.id) === undefined ||
-      toIntegerValue(message.message_id) === undefined ||
+      telegramNumericChatId(chat.id) === undefined ||
+      (toIntegerValue(message.message_id) ?? 0) < 1 ||
       (message.from !== undefined &&
-        (!isJsonObject(message.from) || toIntegerValue(message.from.id) === undefined)) ||
+        (!isJsonObject(message.from) || (toIntegerValue(message.from.id) ?? 0) < 1)) ||
       (message.message_thread_id !== undefined &&
         toIntegerValue(message.message_thread_id) === undefined)
     ) {
@@ -1079,7 +1102,6 @@ async function handleTelegramAdminInbound(params: {
       params.body,
       ["messageId", "message_id"],
       explicitTelegramMessageIdValues(params.body),
-      { allowZero: true },
     );
     const explicitMessageChatId = explicitTelegramMessageChatId(params.body);
     const explicitUpdateId = explicitTelegramId(params.body, ["updateId", "update_id"]);
@@ -1087,7 +1109,6 @@ async function handleTelegramAdminInbound(params: {
       {},
       [],
       referencedTelegramMessageIdValues(params.body),
-      { allowZero: true },
     );
     const topLevelChatId = resolveTelegramChat(
       params.state,
@@ -1925,6 +1946,10 @@ export async function startTelegramServer(
   if (!Number.isSafeInteger(botId) || botId < 1) {
     throw new Error("botId must be a positive safe integer.");
   }
+  const botUsername = telegramChatUsername(params.botUsername ?? "crabline_bot")?.slice(1);
+  if (!botUsername) {
+    throw new Error("botUsername must be a valid 5-32 character Telegram username.");
+  }
   const state: TelegramServerState = {
     activeUpdatePoll: undefined,
     activeWebhookDeliveries: new Set(),
@@ -1937,7 +1962,7 @@ export async function startTelegramServer(
       (isLoopbackHost(host)
         ? "424242:crabline-telegram-token"
         : `${botId}:${randomBytes(26).toString("base64url")}`),
-    botUsername: params.botUsername ?? "crabline_bot",
+    botUsername,
     chatsById: new Map(),
     chatsByUsername: new Map(),
     inboundAdmission: Promise.resolve(),

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -731,7 +731,7 @@ function createInboundUpdate(
     (fromIdValue !== undefined && (fromId === undefined || fromId < 1)) ||
     (fromUsernameValue !== undefined && !fromUsername) ||
     (threadIdValue !== undefined && parsedThreadId === undefined) ||
-    (messageIdValue !== undefined && (messageId === undefined || messageId < 1)) ||
+    (messageIdValue !== undefined && (messageId === undefined || messageId < 0)) ||
     (updateIdValue !== undefined && (updateId === undefined || updateId < 1))
   ) {
     return undefined;
@@ -828,6 +828,7 @@ function explicitTelegramId(
   body: Record<string, unknown>,
   names: readonly string[],
   additionalValues: readonly unknown[] = [],
+  options: { allowZero?: boolean } = {},
 ): { present: false } | { present: true; value: number } | undefined {
   const values = [
     ...names.flatMap((name) => (body[name] === undefined ? [] : [body[name]])),
@@ -837,8 +838,11 @@ function explicitTelegramId(
     return { present: false };
   }
   const parsed = values.map(toIntegerValue);
+  const minimum = options.allowZero ? 0 : 1;
   if (
-    parsed.some((value) => value === undefined || value < 1 || value >= Number.MAX_SAFE_INTEGER) ||
+    parsed.some(
+      (value) => value === undefined || value < minimum || value >= Number.MAX_SAFE_INTEGER,
+    ) ||
     new Set(parsed).size !== 1
   ) {
     return undefined;
@@ -1053,12 +1057,14 @@ function isValidIgnoredTelegramUpdate(body: Record<string, unknown>): boolean {
   if (isJsonObject(body.message)) {
     const message = body.message;
     const chat = isJsonObject(message.chat) ? message.chat : undefined;
+    const messageId = toIntegerValue(message.message_id);
     if (
       updateId === undefined ||
       updateId < 1 ||
       !chat ||
       telegramNumericChatId(chat.id) === undefined ||
-      (toIntegerValue(message.message_id) ?? 0) < 1 ||
+      messageId === undefined ||
+      messageId < 0 ||
       (message.from !== undefined &&
         (!isJsonObject(message.from) || (toIntegerValue(message.from.id) ?? 0) < 1)) ||
       (message.message_thread_id !== undefined &&
@@ -1103,6 +1109,7 @@ async function handleTelegramAdminInbound(params: {
       params.body,
       ["messageId", "message_id"],
       explicitTelegramMessageIdValues(params.body),
+      { allowZero: true },
     );
     const explicitMessageChatId = explicitTelegramMessageChatId(params.body);
     const explicitUpdateId = explicitTelegramId(params.body, ["updateId", "update_id"]);

--- a/src/servers/whatsapp-baileys-websocket.ts
+++ b/src/servers/whatsapp-baileys-websocket.ts
@@ -194,6 +194,7 @@ export class WhatsAppSignalBundleStore {
     }
     this.#recoverExpiredPendingAcknowledgements();
     if (this.#pendingAcknowledgements.has(messageKey)) {
+      // Unsettled operations remain in #inFlightMessageAcceptances; this state is accepted and awaiting ack.
       return true;
     }
     if (this.#acknowledgedMessageIds.delete(messageKey)) {

--- a/src/servers/whatsapp-baileys-websocket.ts
+++ b/src/servers/whatsapp-baileys-websocket.ts
@@ -126,6 +126,7 @@ export type WhatsAppSignalBundleStoreOptions = {
 };
 
 type PendingWhatsAppAcknowledgement = {
+  acceptance: Promise<boolean>;
   acceptedAt: number | undefined;
   acknowledged: boolean;
 };
@@ -133,7 +134,6 @@ type PendingWhatsAppAcknowledgement = {
 export class WhatsAppSignalBundleStore {
   readonly #acknowledgedMessageIds = new Map<string, true>();
   readonly #bundles = new Map<string, MockSignalBundle>();
-  readonly #inFlightMessageAcceptances = new Map<string, Promise<boolean>>();
   readonly #lidByPhoneNumber = new Map<string, string>();
   readonly #maxSessionsPerBundle: number;
   readonly #pendingAcknowledgements = new Map<string, PendingWhatsAppAcknowledgement>();
@@ -188,14 +188,10 @@ export class WhatsAppSignalBundleStore {
   }
 
   async acceptMessageOnce(messageKey: string, operation: () => Promise<boolean>): Promise<boolean> {
-    const inFlightAcceptance = this.#inFlightMessageAcceptances.get(messageKey);
-    if (inFlightAcceptance) {
-      return await inFlightAcceptance;
-    }
     this.#recoverExpiredPendingAcknowledgements();
-    if (this.#pendingAcknowledgements.has(messageKey)) {
-      // Unsettled operations remain in #inFlightMessageAcceptances; this state is accepted and awaiting ack.
-      return true;
+    const pendingAcceptance = this.#pendingAcknowledgements.get(messageKey);
+    if (pendingAcceptance) {
+      return await pendingAcceptance.acceptance;
     }
     if (this.#acknowledgedMessageIds.delete(messageKey)) {
       this.#acknowledgedMessageIds.set(messageKey, true);
@@ -206,11 +202,7 @@ export class WhatsAppSignalBundleStore {
         `WhatsApp pending acknowledgement limit exceeded (${this.maxPendingAcknowledgements}).`,
       );
     }
-    const pendingAcknowledgement: PendingWhatsAppAcknowledgement = {
-      acceptedAt: undefined,
-      acknowledged: false,
-    };
-    this.#pendingAcknowledgements.set(messageKey, pendingAcknowledgement);
+    let pendingAcknowledgement: PendingWhatsAppAcknowledgement;
     const acceptance = Promise.resolve().then(async () => {
       try {
         const accepted = await operation();
@@ -230,14 +222,13 @@ export class WhatsAppSignalBundleStore {
         throw error;
       }
     });
-    this.#inFlightMessageAcceptances.set(messageKey, acceptance);
-    try {
-      return await acceptance;
-    } finally {
-      if (this.#inFlightMessageAcceptances.get(messageKey) === acceptance) {
-        this.#inFlightMessageAcceptances.delete(messageKey);
-      }
-    }
+    pendingAcknowledgement = {
+      acceptance,
+      acceptedAt: undefined,
+      acknowledged: false,
+    };
+    this.#pendingAcknowledgements.set(messageKey, pendingAcknowledgement);
+    return await acceptance;
   }
 
   markMessageAcknowledged(peerJid: string, messageId: string): void {

--- a/src/servers/whatsapp-baileys-websocket.ts
+++ b/src/servers/whatsapp-baileys-websocket.ts
@@ -49,6 +49,7 @@ const MAX_WHATSAPP_PENDING_ACKNOWLEDGEMENT_AGE_MS = 5 * 60 * 1_000;
 const MAX_WHATSAPP_RECENT_ACKNOWLEDGEMENTS = 10_000;
 export const MAX_WHATSAPP_WEBSOCKET_FRAGMENTS = 1_024;
 export const MAX_WHATSAPP_SIGNAL_BUNDLES = 1_024;
+export const MAX_WHATSAPP_SIGNAL_SESSIONS_PER_BUNDLE = 32;
 export const MAX_WHATSAPP_WEBSOCKET_CLOSE_REASON_BYTES = 123;
 type NodeBuffer = Buffer<ArrayBufferLike>;
 type WhatsAppWebSocketRawData = NodeBuffer | ArrayBuffer | NodeBuffer[];
@@ -120,6 +121,10 @@ export type WhatsAppSignalDecryptResult<T> =
   | { status: "unavailable" }
   | { status: "rejected" };
 
+export type WhatsAppSignalBundleStoreOptions = {
+  maxSessionsPerBundle?: number | undefined;
+};
+
 type PendingWhatsAppAcknowledgement = {
   acceptedAt: number | undefined;
   acknowledged: boolean;
@@ -130,7 +135,7 @@ export class WhatsAppSignalBundleStore {
   readonly #bundles = new Map<string, MockSignalBundle>();
   readonly #inFlightMessageAcceptances = new Map<string, Promise<boolean>>();
   readonly #lidByPhoneNumber = new Map<string, string>();
-  readonly #pendingMessageAcceptances = new Map<string, Promise<void>>();
+  readonly #maxSessionsPerBundle: number;
   readonly #pendingAcknowledgements = new Map<string, PendingWhatsAppAcknowledgement>();
   readonly #pendingTransactions = new Map<string, Promise<void>>();
   readonly #sessions = new Map<string, Map<string, SessionRecord>>();
@@ -141,9 +146,15 @@ export class WhatsAppSignalBundleStore {
     private readonly maxRecentAcknowledgements = MAX_WHATSAPP_RECENT_ACKNOWLEDGEMENTS,
     private readonly maxPendingAcknowledgementAgeMs = MAX_WHATSAPP_PENDING_ACKNOWLEDGEMENT_AGE_MS,
     private readonly now: () => number = Date.now,
+    options: WhatsAppSignalBundleStoreOptions = {},
   ) {
+    const maxSessionsPerBundle =
+      options.maxSessionsPerBundle ?? MAX_WHATSAPP_SIGNAL_SESSIONS_PER_BUNDLE;
     if (!Number.isSafeInteger(maxBundles) || maxBundles < 1) {
       throw new Error("WhatsApp maxSignalBundles must be a positive safe integer.");
+    }
+    if (!Number.isSafeInteger(maxSessionsPerBundle) || maxSessionsPerBundle < 1) {
+      throw new Error("WhatsApp maxSignalSessionsPerBundle must be a positive safe integer.");
     }
     if (!Number.isSafeInteger(maxPendingAcknowledgements) || maxPendingAcknowledgements < 1) {
       throw new Error("WhatsApp maxPendingAcknowledgements must be a positive safe integer.");
@@ -157,6 +168,7 @@ export class WhatsAppSignalBundleStore {
     ) {
       throw new Error("WhatsApp maxPendingAcknowledgementAgeMs must be a positive safe integer.");
     }
+    this.#maxSessionsPerBundle = maxSessionsPerBundle;
   }
 
   get size(): number {
@@ -167,52 +179,56 @@ export class WhatsAppSignalBundleStore {
     return this.#lidByPhoneNumber.size;
   }
 
+  get sessionCount(): number {
+    let count = 0;
+    for (const sessions of this.#sessions.values()) {
+      count += sessions.size;
+    }
+    return count;
+  }
+
   async acceptMessageOnce(messageKey: string, operation: () => Promise<boolean>): Promise<boolean> {
     const inFlightAcceptance = this.#inFlightMessageAcceptances.get(messageKey);
     if (inFlightAcceptance) {
       return await inFlightAcceptance;
     }
-    const acceptance = this.#runSerialized(
-      this.#pendingMessageAcceptances,
-      "messages",
-      async () => {
-        this.#recoverExpiredPendingAcknowledgements();
-        if (this.#pendingAcknowledgements.has(messageKey)) {
-          return true;
-        }
-        if (this.#acknowledgedMessageIds.delete(messageKey)) {
-          this.#acknowledgedMessageIds.set(messageKey, true);
-          return true;
-        }
-        if (this.#pendingAcknowledgements.size >= this.maxPendingAcknowledgements) {
-          throw new Error(
-            `WhatsApp pending acknowledgement limit exceeded (${this.maxPendingAcknowledgements}).`,
-          );
-        }
-        const pendingAcknowledgement: PendingWhatsAppAcknowledgement = {
-          acceptedAt: undefined,
-          acknowledged: false,
-        };
-        this.#pendingAcknowledgements.set(messageKey, pendingAcknowledgement);
-        try {
-          const accepted = await operation();
-          if (!accepted) {
-            this.#pendingAcknowledgements.delete(messageKey);
-            return false;
-          }
-          if (pendingAcknowledgement.acknowledged) {
-            this.#pendingAcknowledgements.delete(messageKey);
-            this.#rememberAcknowledgedMessage(messageKey);
-          } else {
-            pendingAcknowledgement.acceptedAt = this.now();
-          }
-          return true;
-        } catch (error) {
+    this.#recoverExpiredPendingAcknowledgements();
+    if (this.#pendingAcknowledgements.has(messageKey)) {
+      return true;
+    }
+    if (this.#acknowledgedMessageIds.delete(messageKey)) {
+      this.#acknowledgedMessageIds.set(messageKey, true);
+      return true;
+    }
+    if (this.#pendingAcknowledgements.size >= this.maxPendingAcknowledgements) {
+      throw new Error(
+        `WhatsApp pending acknowledgement limit exceeded (${this.maxPendingAcknowledgements}).`,
+      );
+    }
+    const pendingAcknowledgement: PendingWhatsAppAcknowledgement = {
+      acceptedAt: undefined,
+      acknowledged: false,
+    };
+    this.#pendingAcknowledgements.set(messageKey, pendingAcknowledgement);
+    const acceptance = Promise.resolve().then(async () => {
+      try {
+        const accepted = await operation();
+        if (!accepted) {
           this.#pendingAcknowledgements.delete(messageKey);
-          throw error;
+          return false;
         }
-      },
-    );
+        if (pendingAcknowledgement.acknowledged) {
+          this.#pendingAcknowledgements.delete(messageKey);
+          this.#rememberAcknowledgedMessage(messageKey);
+        } else {
+          pendingAcknowledgement.acceptedAt = this.now();
+        }
+        return true;
+      } catch (error) {
+        this.#pendingAcknowledgements.delete(messageKey);
+        throw error;
+      }
+    });
     this.#inFlightMessageAcceptances.set(messageKey, acceptance);
     try {
       return await acceptance;
@@ -328,8 +344,12 @@ export class WhatsAppSignalBundleStore {
       return { status: "unavailable" };
     }
     const address = new ProtocolAddress(remoteAddress.name, remoteAddress.deviceId);
+    // Capacity checks, staged writes, and commits stay atomic per recipient bundle.
     return await this.#runTransaction(identityKey, async () => {
       const sessions = this.#sessions.get(identityKey) ?? new Map<string, SessionRecord>();
+      const sessionLimitError = new Error("WhatsApp Signal session limit exceeded.");
+      const maxSessionsPerBundle = this.#maxSessionsPerBundle;
+      let stagedNewSessionCount = 0;
       const stagedPreKeyRemovals = new Set<number>();
       const stagedSessions = new Map<string, SessionRecord>();
       const storage: SignalStorage = {
@@ -338,6 +358,12 @@ export class WhatsAppSignalBundleStore {
           return session ? cloneSignalSession(session) : undefined;
         },
         async storeSession(id, session) {
+          if (!sessions.has(id) && !stagedSessions.has(id)) {
+            if (stagedNewSessionCount >= maxSessionsPerBundle) {
+              throw sessionLimitError;
+            }
+            stagedNewSessionCount += 1;
+          }
           stagedSessions.set(id, cloneSignalSession(session));
         },
         isTrustedIdentity: () => true,
@@ -362,6 +388,9 @@ export class WhatsAppSignalBundleStore {
             ? await cipher.decryptPreKeyWhisperMessage(params.ciphertext)
             : await cipher.decryptWhisperMessage(params.ciphertext);
       } catch (error) {
+        if (error === sessionLimitError) {
+          return { status: "rejected" };
+        }
         return { error, status: "decrypt-failed" };
       }
       const replacementPreKey = stagedPreKeyRemovals.has(bundle.preKeyId)
@@ -374,7 +403,28 @@ export class WhatsAppSignalBundleStore {
       if (accepted === undefined) {
         return { status: "rejected" };
       }
+      const sessionsToEvict: string[] = [];
+      const evictionCount = Math.max(
+        0,
+        sessions.size + stagedNewSessionCount - maxSessionsPerBundle,
+      );
+      for (const id of sessions.keys()) {
+        if (sessionsToEvict.length >= evictionCount) {
+          break;
+        }
+        if (!stagedSessions.has(id)) {
+          sessionsToEvict.push(id);
+        }
+      }
+      if (sessionsToEvict.length < evictionCount) {
+        return { status: "rejected" };
+      }
+      for (const id of sessionsToEvict) {
+        sessions.delete(id);
+      }
       for (const [id, session] of stagedSessions) {
+        // Refresh insertion order so future reclamation evicts the least-recently used session.
+        sessions.delete(id);
         sessions.set(id, session);
       }
       if (stagedSessions.size > 0) {

--- a/src/servers/whatsapp-baileys-websocket.ts
+++ b/src/servers/whatsapp-baileys-websocket.ts
@@ -351,7 +351,7 @@ export class WhatsAppSignalBundleStore {
         },
         async storeSession(id, session) {
           if (!sessions.has(id) && !stagedSessions.has(id)) {
-            if (stagedNewSessionCount >= maxSessionsPerBundle) {
+            if (sessions.size + stagedNewSessionCount >= maxSessionsPerBundle) {
               throw sessionLimitError;
             }
             stagedNewSessionCount += 1;
@@ -395,28 +395,7 @@ export class WhatsAppSignalBundleStore {
       if (accepted === undefined) {
         return { status: "rejected" };
       }
-      const sessionsToEvict: string[] = [];
-      const evictionCount = Math.max(
-        0,
-        sessions.size + stagedNewSessionCount - maxSessionsPerBundle,
-      );
-      for (const id of sessions.keys()) {
-        if (sessionsToEvict.length >= evictionCount) {
-          break;
-        }
-        if (!stagedSessions.has(id)) {
-          sessionsToEvict.push(id);
-        }
-      }
-      if (sessionsToEvict.length < evictionCount) {
-        return { status: "rejected" };
-      }
-      for (const id of sessionsToEvict) {
-        sessions.delete(id);
-      }
       for (const [id, session] of stagedSessions) {
-        // Refresh insertion order so future reclamation evicts the least-recently used session.
-        sessions.delete(id);
         sessions.set(id, session);
       }
       if (stagedSessions.size > 0) {

--- a/src/servers/whatsapp-wire/binary-node.ts
+++ b/src/servers/whatsapp-wire/binary-node.ts
@@ -13,7 +13,7 @@ export const WHATSAPP_BINARY_NODE_MAX_DEPTH = 128;
 export const WHATSAPP_BINARY_NODE_MAX_NODES = 32_768;
 export const WHATSAPP_BINARY_NODE_MAX_LIST_ITEMS = 131_072;
 
-type DecodeBudget = {
+type BinaryNodeBudget = {
   listItems: number;
   nodes: number;
 };
@@ -158,7 +158,12 @@ export async function decodeBinaryNode(frame: Buffer): Promise<BinaryNode> {
 }
 
 export function encodeBinaryNode(node: BinaryNode): Buffer {
-  return Buffer.from(encodeBinaryNodeInner(node, [0], 1));
+  return Buffer.from(
+    encodeBinaryNodeInner(node, [0], 1, {
+      listItems: 0,
+      nodes: 0,
+    }),
+  );
 }
 
 async function decompressIfRequired(buffer: Buffer): Promise<Buffer> {
@@ -201,7 +206,7 @@ function decodeDecompressedBinaryNode(
   buffer: Buffer,
   indexRef: { index: number },
   depth: number,
-  budget: DecodeBudget,
+  budget: BinaryNodeBudget,
 ): BinaryNode {
   if (depth > WHATSAPP_BINARY_NODE_MAX_DEPTH) {
     throw new Error(`WhatsApp binary node nesting exceeds ${WHATSAPP_BINARY_NODE_MAX_DEPTH}.`);
@@ -437,9 +442,18 @@ function decodeDecompressedBinaryNode(
   return content === undefined ? { attrs, tag } : { attrs, content, tag };
 }
 
-function encodeBinaryNodeInner(node: BinaryNode, buffer: number[], depth: number): number[] {
+function encodeBinaryNodeInner(
+  node: BinaryNode,
+  buffer: number[],
+  depth: number,
+  budget: BinaryNodeBudget,
+): number[] {
   if (depth > WHATSAPP_BINARY_NODE_MAX_DEPTH) {
     throw new Error(`WhatsApp binary node nesting exceeds ${WHATSAPP_BINARY_NODE_MAX_DEPTH}.`);
+  }
+  budget.nodes += 1;
+  if (budget.nodes > WHATSAPP_BINARY_NODE_MAX_NODES) {
+    throw new Error(`WhatsApp binary node count exceeds ${WHATSAPP_BINARY_NODE_MAX_NODES}.`);
   }
   if (!node.tag) {
     throw new Error("Invalid WhatsApp binary node: tag is required.");
@@ -448,7 +462,11 @@ function encodeBinaryNodeInner(node: BinaryNode, buffer: number[], depth: number
     const value = node.attrs[key];
     return value !== undefined && value !== null;
   });
-  writeListStart(buffer, 2 * validAttributes.length + 1 + (node.content !== undefined ? 1 : 0));
+  writeBudgetedListStart(
+    buffer,
+    2 * validAttributes.length + 1 + (node.content !== undefined ? 1 : 0),
+    budget,
+  );
   writeString(buffer, node.tag);
   for (const key of validAttributes) {
     writeString(buffer, key);
@@ -460,14 +478,24 @@ function encodeBinaryNodeInner(node: BinaryNode, buffer: number[], depth: number
     writeByteLength(buffer, node.content.length);
     pushBytes(buffer, node.content);
   } else if (Array.isArray(node.content)) {
-    writeListStart(buffer, node.content.length);
+    writeBudgetedListStart(buffer, node.content.length, budget);
     for (const child of node.content) {
-      encodeBinaryNodeInner(child, buffer, depth + 1);
+      encodeBinaryNodeInner(child, buffer, depth + 1, budget);
     }
   } else if (node.content !== undefined) {
     throw new Error(`Invalid WhatsApp binary node content for <${node.tag}>.`);
   }
   return buffer;
+}
+
+function writeBudgetedListStart(buffer: number[], size: number, budget: BinaryNodeBudget): void {
+  budget.listItems += size;
+  if (budget.listItems > WHATSAPP_BINARY_NODE_MAX_LIST_ITEMS) {
+    throw new Error(
+      `WhatsApp binary node list items exceed ${WHATSAPP_BINARY_NODE_MAX_LIST_ITEMS}.`,
+    );
+  }
+  writeListStart(buffer, size);
 }
 
 function pushByte(buffer: number[], value: number): void {

--- a/src/servers/whatsapp.ts
+++ b/src/servers/whatsapp.ts
@@ -35,6 +35,10 @@ const WHATSAPP_GRAPH_VERSION_RE = /^v\d+\.\d+$/u;
 const DEFAULT_GRAPH_VERSION = "v25.0";
 const MAX_WHATSAPP_READABLE_MESSAGE_IDS = 10_000;
 
+function createDefaultAccessToken(): string {
+  return `EAA${randomBytes(24).toString("base64url")}`;
+}
+
 type WhatsAppServerState = {
   accessToken: string;
   adminToken: string;
@@ -600,7 +604,7 @@ export async function startWhatsAppServer(
     throw new Error("WhatsApp selfJid must be a WhatsApp user JID.");
   }
   const state: WhatsAppServerState = {
-    accessToken: params.accessToken ?? `EAA${randomBytes(24).toString("base64url")}`,
+    accessToken: params.accessToken ?? createDefaultAccessToken(),
     adminToken: params.adminToken ?? randomBytes(24).toString("hex"),
     prepareInboundMessage: () => undefined,
     displayPhoneNumber: params.displayPhoneNumber ?? "15550000000",

--- a/src/servers/whatsapp.ts
+++ b/src/servers/whatsapp.ts
@@ -33,6 +33,7 @@ import {
 const WHATSAPP_CLOUD_RECIPIENT_RE = /^\d{7,15}$/u;
 const WHATSAPP_GRAPH_VERSION_RE = /^v\d+\.\d+$/u;
 const DEFAULT_GRAPH_VERSION = "v25.0";
+const MAX_WHATSAPP_READABLE_MESSAGE_IDS = 10_000;
 
 type WhatsAppServerState = {
   accessToken: string;
@@ -42,6 +43,7 @@ type WhatsAppServerState = {
     message: WhatsAppBaileysInboundMessage,
   ): PreparedWhatsAppBaileysInboundDelivery | undefined;
   graphVersion: string;
+  inboundMessageIds: Set<string>;
   nextMessageId: number;
   onEvent: ServerEventObserver | undefined;
   phoneNumberId: string;
@@ -322,7 +324,7 @@ function prepareSendMessage(params: {
   };
 }
 
-function handleMessageStatus(body: Record<string, unknown>): Response {
+function handleMessageStatus(state: WhatsAppServerState, body: Record<string, unknown>): Response {
   const productError = requireMessagingProduct(body);
   if (productError) {
     return productError;
@@ -333,13 +335,31 @@ function handleMessageStatus(body: Record<string, unknown>): Response {
       'status must be "read" for message status updates.',
     );
   }
-  if (!readTrimmedString(body.message_id)) {
+  const messageId = readTrimmedString(body.message_id);
+  if (!messageId) {
     return graphParameterError(
       "(#100) Missing required parameter: message_id",
       "A message status update requires message_id.",
     );
   }
+  if (!state.inboundMessageIds.has(messageId)) {
+    return graphParameterError(
+      "(#100) Invalid parameter: message_id",
+      "message_id must reference an accepted inbound message.",
+    );
+  }
   return jsonResponse({ success: true });
+}
+
+function rememberInboundMessageId(state: WhatsAppServerState, messageId: string): void {
+  state.inboundMessageIds.delete(messageId);
+  state.inboundMessageIds.add(messageId);
+  if (state.inboundMessageIds.size > MAX_WHATSAPP_READABLE_MESSAGE_IDS) {
+    const oldest = state.inboundMessageIds.values().next().value;
+    if (oldest !== undefined) {
+      state.inboundMessageIds.delete(oldest);
+    }
+  }
 }
 
 async function handleAdminInbound(params: {
@@ -376,7 +396,7 @@ async function handleAdminInbound(params: {
     fromMe: false,
     id: readTrimmedString(params.body.messageId) ?? nextMessageId(params.state),
     pushName: readTrimmedString(params.body.pushName) ?? "Test User",
-    remoteJid: chatJid,
+    remoteJid: isGroupChat ? chatJid : directPeerIdentity(chatJid),
     senderJid: isGroupChat ? senderJid : undefined,
     text,
   });
@@ -473,6 +493,7 @@ async function handleRequest(params: { request: IncomingMessage; state: WhatsApp
     }
     if (result.message && preparedDelivery) {
       const delivery = await preparedDelivery.commit();
+      rememberInboundMessageId(params.state, result.message.key.id);
       return whatsappOk({ delivery, message: result.message, webhook: result.webhook });
     }
     return graphParameterError("(#100) Invalid inbound WhatsApp event");
@@ -522,7 +543,7 @@ async function handleRequest(params: { request: IncomingMessage; state: WhatsApp
         "The request body must be a JSON object.",
       );
     } else if ("status" in body || "message_id" in body) {
-      response = handleMessageStatus(body);
+      response = handleMessageStatus(params.state, body);
       event.accepted = response.ok;
     } else {
       const prepared = prepareSendMessage({ body, state: params.state });
@@ -579,15 +600,12 @@ export async function startWhatsAppServer(
     throw new Error("WhatsApp selfJid must be a WhatsApp user JID.");
   }
   const state: WhatsAppServerState = {
-    accessToken:
-      params.accessToken ??
-      (isLoopbackHost(host)
-        ? "crabline-whatsapp-access-token"
-        : `EAA${randomBytes(24).toString("base64url")}`),
+    accessToken: params.accessToken ?? `EAA${randomBytes(24).toString("base64url")}`,
     adminToken: params.adminToken ?? randomBytes(24).toString("hex"),
     prepareInboundMessage: () => undefined,
     displayPhoneNumber: params.displayPhoneNumber ?? "15550000000",
     graphVersion,
+    inboundMessageIds: new Set(),
     nextMessageId: 1,
     onEvent: params.onEvent,
     phoneNumberId,

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -962,8 +962,8 @@ describe("OpenClaw local provider bridge", () => {
     expect(createOpenClawCrablineAgentDelivery({ manifest, target: "thread:-100123/42" }).to).toBe(
       "-100123:topic:42",
     );
-    expect(createOpenClawCrablineAgentDelivery({ manifest, target: "channel:@valid" }).to).toBe(
-      "@valid",
+    expect(createOpenClawCrablineAgentDelivery({ manifest, target: "channel:@abcd" }).to).toBe(
+      "@abcd",
     );
     expect(
       createOpenClawCrablineAgentDelivery({ manifest, target: "channel:@ChannelUserName" }).to,
@@ -972,9 +972,9 @@ describe("OpenClaw local provider bridge", () => {
     expect(
       createOpenClawCrablineAgentDelivery({ manifest, target: `channel:${maxUsername}` }).to,
     ).toBe(maxUsername);
-    for (const target of ["channel:@tiny", "channel:@abc", `channel:@${"a".repeat(33)}`]) {
+    for (const target of ["channel:@abc", `channel:@${"a".repeat(33)}`]) {
       expect(() => createOpenClawCrablineAgentDelivery({ manifest, target })).toThrow(
-        "Telegram usernames must contain 5-32 letters, digits, or underscores.",
+        "Telegram usernames must contain 4-32 letters, digits, or underscores.",
       );
     }
 

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -915,7 +915,13 @@ describe("OpenClaw local provider bridge", () => {
       replyChannel: "telegram",
       replyTo: symbolicDelivery.to,
     });
-    expect(BigInt(symbolicDelivery.to)).toBeLessThan(1n << 52n);
+    expect(BigInt(symbolicDelivery.to)).toBeGreaterThanOrEqual(1n << 52n);
+    expect(() =>
+      createOpenClawCrablineAgentDelivery({
+        manifest,
+        target: `dm:${1n << 52n}`,
+      }),
+    ).toThrow("Telegram native numeric targets must fit within 52 significant bits.");
     expect(createOpenClawCrablineAgentDelivery({ manifest, target: "dm:alice" }).to).toBe(
       symbolicDelivery.to,
     );
@@ -926,7 +932,7 @@ describe("OpenClaw local provider bridge", () => {
       manifest,
       target: "group:alice",
     });
-    expect(symbolicGroupDelivery.to).toMatch(/^-100\d+$/u);
+    expect(BigInt(symbolicGroupDelivery.to)).toBeLessThanOrEqual(-(1n << 52n));
     expect(Number.isSafeInteger(Number(symbolicGroupDelivery.to))).toBe(true);
     expect(
       createOpenClawCrablineAgentDelivery({
@@ -966,12 +972,9 @@ describe("OpenClaw local provider bridge", () => {
     expect(
       createOpenClawCrablineAgentDelivery({ manifest, target: `channel:${maxUsername}` }).to,
     ).toBe(maxUsername);
-    expect(createOpenClawCrablineAgentDelivery({ manifest, target: "channel:@tiny" }).to).toBe(
-      "@tiny",
-    );
-    for (const target of ["channel:@abc", `channel:@${"a".repeat(33)}`]) {
+    for (const target of ["channel:@tiny", "channel:@abc", `channel:@${"a".repeat(33)}`]) {
       expect(() => createOpenClawCrablineAgentDelivery({ manifest, target })).toThrow(
-        "Telegram usernames must contain 4-32 letters, digits, or underscores.",
+        "Telegram usernames must contain 5-32 letters, digits, or underscores.",
       );
     }
 
@@ -1083,6 +1086,10 @@ describe("OpenClaw local provider bridge", () => {
       },
     });
     expect(usernameGroupInbound.providerBody.chatId).not.toBe("@channelusername");
+    expect(BigInt(String(usernameGroupInbound.providerBody.chatId))).toBeLessThan(
+      -((1n << 52n) + (1n << 50n)),
+    );
+    expect(usernameGroupInbound.providerBody.chatId).not.toBe(symbolicGroupDelivery.to);
     expect(
       createOpenClawCrablineInbound({
         manifest,
@@ -1167,7 +1174,7 @@ describe("OpenClaw local provider bridge", () => {
         },
       }).providerBody,
     ).toMatchObject({
-      chatId: expect.stringMatching(/^-100\d+$/u),
+      chatId: expect.stringMatching(/^-\d+$/u),
       messageThreadId: 42,
     });
     const normalizedTopicInbound = createOpenClawCrablineInbound({

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -119,15 +119,15 @@ describe("registry", () => {
   });
 
   it("enforces Telegram's native username length in shared target normalization", () => {
-    expect(normalizeBuiltinTarget("telegram", { id: "@abcd", metadata: {} })).toMatchObject({
-      channelId: "@abcd",
+    expect(normalizeBuiltinTarget("telegram", { id: "@abcde", metadata: {} })).toMatchObject({
+      channelId: "@abcde",
     });
     expect(
       normalizeBuiltinTarget("telegram", { id: `@${"a".repeat(32)}`, metadata: {} }),
     ).toMatchObject({
       channelId: `@${"a".repeat(32)}`,
     });
-    for (const id of ["@abc", `@${"a".repeat(33)}`]) {
+    for (const id of ["@abcd", "@abc", `@${"a".repeat(33)}`]) {
       expect(() => normalizeBuiltinTarget("telegram", { id, metadata: {} })).toThrow(
         /native Telegram chat id/u,
       );
@@ -148,20 +148,21 @@ describe("registry", () => {
     }
   });
 
-  it("enforces Telegram safe-integer and topic bounds", () => {
+  it("enforces Telegram native 52-bit chat and safe-integer topic bounds", () => {
+    const maxNativeChatId = String((1n << 52n) - 1n);
     const maxSafeInteger = String(Number.MAX_SAFE_INTEGER);
     expect(
       normalizeBuiltinTarget("telegram", {
-        id: `-${maxSafeInteger}`,
+        id: `-${maxNativeChatId}`,
         metadata: {},
         threadId: maxSafeInteger,
       }),
     ).toMatchObject({
-      channelId: `-${maxSafeInteger}`,
-      threadId: `-${maxSafeInteger}:${maxSafeInteger}`,
+      channelId: `-${maxNativeChatId}`,
+      threadId: `-${maxNativeChatId}:${maxSafeInteger}`,
     });
 
-    for (const id of ["9007199254740992", "-9007199254740992"]) {
+    for (const id of [String(1n << 52n), String(-(1n << 52n))]) {
       expect(() => normalizeBuiltinTarget("telegram", { id, metadata: {} })).toThrow(
         /native Telegram chat id/u,
       );

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -119,15 +119,15 @@ describe("registry", () => {
   });
 
   it("enforces Telegram's native username length in shared target normalization", () => {
-    expect(normalizeBuiltinTarget("telegram", { id: "@abcde", metadata: {} })).toMatchObject({
-      channelId: "@abcde",
+    expect(normalizeBuiltinTarget("telegram", { id: "@abcd", metadata: {} })).toMatchObject({
+      channelId: "@abcd",
     });
     expect(
       normalizeBuiltinTarget("telegram", { id: `@${"a".repeat(32)}`, metadata: {} }),
     ).toMatchObject({
       channelId: `@${"a".repeat(32)}`,
     });
-    for (const id of ["@abcd", "@abc", `@${"a".repeat(33)}`]) {
+    for (const id of ["@abc", `@${"a".repeat(33)}`]) {
       expect(() => normalizeBuiltinTarget("telegram", { id, metadata: {} })).toThrow(
         /native Telegram chat id/u,
       );

--- a/test/telegram-provider.test.ts
+++ b/test/telegram-provider.test.ts
@@ -141,6 +141,9 @@ describe("telegram provider", () => {
     expect(() => provider.normalizeTarget({ id: "telegram:-100123", metadata: {} })).toThrow(
       /Telegram chat_id/u,
     );
+    expect(() => provider.normalizeTarget({ id: String(1n << 52n), metadata: {} })).toThrow(
+      /Telegram chat_id/u,
+    );
   });
 
   it("isolates identical topic ids across Telegram chats", () => {
@@ -164,6 +167,19 @@ describe("telegram provider", () => {
     expect(firstThreadId).toBe("-1001:42");
     expect(secondThreadId).toBe("-1002:42");
     expect(firstThreadId).not.toBe(secondThreadId);
+  });
+
+  it("rejects outbound-only usernames in native inbound chat identities", () => {
+    expect(() =>
+      normalizeTelegramWebhookPayload({
+        message: {
+          chat: { id: "@channelusername" },
+          message_id: 1,
+          text: "invalid inbound username",
+        },
+        update_id: 1,
+      }),
+    ).toThrow(/Telegram inbound chat id/u);
   });
 
   it("round-trips canonical topic ids through generic ingress", () => {

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -75,6 +75,23 @@ describe("telegram local provider server", () => {
     });
   });
 
+  it("rejects non-positive message identifiers in edits", async () => {
+    const server = await startTelegramServer({ botToken: "test-token-placeholder" });
+    servers.push(server);
+
+    for (const messageId of [0, -1]) {
+      const response = await fetch(
+        `${server.manifest.baseUrl}/bottest-token-placeholder/editMessageText`,
+        {
+          body: JSON.stringify({ chat_id: 42, message_id: messageId, text: "invalid edit" }),
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        },
+      );
+      expect(response.status).toBe(400);
+    }
+  });
+
   it("advertises valid URLs when bound to IPv6", async () => {
     const directory = await createTempDir();
     directories.push(directory);
@@ -139,34 +156,36 @@ describe("telegram local provider server", () => {
     });
     expect(usernameTopicBody.result.chat.id).toBeLessThan(-1_000_000_000_000);
 
-    const shortUsername = await fetch(
+    const minimumUsername = await fetch(
       `${server.manifest.baseUrl}/bot123456:fake-token/sendMessage`,
       {
         body: JSON.stringify({
-          chat_id: "@tiny",
-          text: "collectible username",
+          chat_id: "@valid",
+          text: "minimum username",
         }),
         headers: { "content-type": "application/json" },
         method: "POST",
       },
     );
-    expect(shortUsername.status).toBe(200);
-    await expect(shortUsername.json()).resolves.toMatchObject({
+    expect(minimumUsername.status).toBe(200);
+    await expect(minimumUsername.json()).resolves.toMatchObject({
       result: { chat: { id: expect.any(Number), type: "supergroup" } },
     });
 
-    const shorterUsername = await fetch(
-      `${server.manifest.baseUrl}/bot123456:fake-token/sendMessage`,
-      {
-        body: JSON.stringify({
-          chat_id: "@abc",
-          text: "invalid short username",
-        }),
-        headers: { "content-type": "application/json" },
-        method: "POST",
-      },
-    );
-    expect(shorterUsername.status).toBe(400);
+    for (const chatId of ["@tiny", "@abc"]) {
+      const shortUsername = await fetch(
+        `${server.manifest.baseUrl}/bot123456:fake-token/sendMessage`,
+        {
+          body: JSON.stringify({
+            chat_id: chatId,
+            text: "invalid short username",
+          }),
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        },
+      );
+      expect(shortUsername.status).toBe(400);
+    }
   });
 
   it("resolves username chats case-insensitively to one message sequence", async () => {
@@ -213,7 +232,7 @@ describe("telegram local provider server", () => {
               id: -1001111111111,
               title: "Announcements",
               type: "channel",
-              username: "Crabline_News",
+              username: "  @Crabline_News  ",
             },
           },
           update_id: 1,
@@ -256,7 +275,7 @@ describe("telegram local provider server", () => {
           id: -1001111111111,
           title: "Announcements",
           type: "channel",
-          username: "Crabline_News",
+          username: "crabline_news",
         },
       },
     });
@@ -266,7 +285,7 @@ describe("telegram local provider server", () => {
           id: -1002222222222,
           title: "Discussion",
           type: "supergroup",
-          username: "Crabline_Group",
+          username: "crabline_group",
         },
       },
     });
@@ -279,7 +298,7 @@ describe("telegram local provider server", () => {
               id: -1001111111111,
               title: "Announcements",
               type: "channel",
-              username: "Crabline_Updates",
+              username: "  Crabline_Updates  ",
             },
           },
           update_id: 3,
@@ -291,7 +310,7 @@ describe("telegram local provider server", () => {
         chat: {
           id: -1001111111111,
           type: "channel",
-          username: "Crabline_Updates",
+          username: "crabline_updates",
         },
       },
     });
@@ -623,6 +642,8 @@ describe("telegram local provider server", () => {
     for (const entities of [
       [{ length: 1.5, offset: 0, type: "bold" }],
       [{ length: 1, offset: -1, type: "bold" }],
+      [{ length: 1, offset: 0, type: "bold" }],
+      [{ length: 1, offset: 1, type: "bold" }],
       [{ length: 2, offset: 2, type: "bold" }],
     ]) {
       const invalidEntity = await injectUpdate(server, {
@@ -635,6 +656,7 @@ describe("telegram local provider server", () => {
     const utf16Entity = await injectUpdate(server, {
       chatId: 42,
       entities: [{ length: 2, offset: 0, type: "custom_emoji" }],
+      fromUsername: "  @Alice_User  ",
       text: "😀",
     });
     await expect(utf16Entity.json()).resolves.toMatchObject({
@@ -642,6 +664,7 @@ describe("telegram local provider server", () => {
       update: {
         message: {
           entities: [{ length: 2, offset: 0, type: "custom_emoji" }],
+          from: { username: "alice_user" },
         },
       },
     });
@@ -1916,6 +1939,7 @@ describe("telegram local provider server", () => {
       { chatId: 123, messageId: 11, text: "duplicate update", updateId: 20 },
       { chatId: 123, messageId: 9, text: "decreasing message", updateId: 21 },
       { chatId: 123, messageId: 11, text: "decreasing update", updateId: 19 },
+      { chatId: 123, messageId: 0, text: "zero message", updateId: 21 },
       { chatId: 123, messageId: 11, text: "negative update", updateId: -1 },
       {
         chatId: 123,
@@ -1941,20 +1965,9 @@ describe("telegram local provider server", () => {
       expect(response.status).toBe(400);
     }
 
-    const scheduled = await injectUpdate(server, {
-      chatId: 123,
-      messageId: 0,
-      text: "automatically scheduled",
-      updateId: 21,
-    });
-    expect(scheduled.status).toBe(200);
-    await expect(scheduled.json()).resolves.toMatchObject({
-      update: { message: { message_id: 0 }, update_id: 21 },
-    });
-
     const generated = await injectUpdate(server, { chatId: 123, text: "generated" });
     await expect(generated.json()).resolves.toMatchObject({
-      update: { message: { message_id: 11 }, update_id: 22 },
+      update: { message: { message_id: 11 }, update_id: 21 },
     });
 
     const ignored = await injectUpdate(server, {
@@ -1963,13 +1976,13 @@ describe("telegram local provider server", () => {
         message_id: 12,
         photo: [{ file_id: "photo", file_unique_id: "unique", height: 1, width: 1 }],
       },
-      update_id: 23,
+      update_id: 22,
     });
     expect(ignored.status).toBe(200);
 
     const afterIgnored = await injectUpdate(server, { chatId: 123, text: "after ignored" });
     await expect(afterIgnored.json()).resolves.toMatchObject({
-      update: { message: { message_id: 13 }, update_id: 24 },
+      update: { message: { message_id: 13 }, update_id: 23 },
     });
 
     const channelPost = await injectUpdate(server, {

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -160,7 +160,7 @@ describe("telegram local provider server", () => {
       `${server.manifest.baseUrl}/bot123456:fake-token/sendMessage`,
       {
         body: JSON.stringify({
-          chat_id: "@valid",
+          chat_id: "@abcd",
           text: "minimum username",
         }),
         headers: { "content-type": "application/json" },
@@ -172,7 +172,7 @@ describe("telegram local provider server", () => {
       result: { chat: { id: expect.any(Number), type: "supergroup" } },
     });
 
-    for (const chatId of ["@tiny", "@abc"]) {
+    for (const chatId of ["@abc"]) {
       const shortUsername = await fetch(
         `${server.manifest.baseUrl}/bot123456:fake-token/sendMessage`,
         {
@@ -2380,6 +2380,9 @@ describe("telegram local provider server", () => {
 
     await expect(startTelegramServer({ botId: Number.MAX_SAFE_INTEGER + 1 })).rejects.toThrow(
       "botId must be a positive safe integer.",
+    );
+    await expect(startTelegramServer({ botUsername: "abcd" })).rejects.toThrow(
+      "botUsername must be a valid 5-32 character Telegram username.",
     );
   });
 

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -1939,7 +1939,7 @@ describe("telegram local provider server", () => {
       { chatId: 123, messageId: 11, text: "duplicate update", updateId: 20 },
       { chatId: 123, messageId: 9, text: "decreasing message", updateId: 21 },
       { chatId: 123, messageId: 11, text: "decreasing update", updateId: 19 },
-      { chatId: 123, messageId: 0, text: "zero message", updateId: 21 },
+      { chatId: 123, messageId: -1, text: "negative message", updateId: 21 },
       { chatId: 123, messageId: 11, text: "negative update", updateId: -1 },
       {
         chatId: 123,
@@ -2001,6 +2001,27 @@ describe("telegram local provider server", () => {
     });
     await expect(afterChannelPost.json()).resolves.toMatchObject({
       update: { message: { message_id: 31 }, update_id: 31 },
+    });
+  });
+
+  it("accepts scheduled message ID zero without advancing generated IDs", async () => {
+    const server = await startTelegramServer({ botToken: "test-token-placeholder" });
+    servers.push(server);
+
+    const scheduled = await injectUpdate(server, {
+      chatId: 123,
+      messageId: 0,
+      text: "scheduled message",
+      updateId: 1,
+    });
+    expect(scheduled.status).toBe(200);
+    await expect(scheduled.json()).resolves.toMatchObject({
+      update: { message: { message_id: 0 }, update_id: 1 },
+    });
+
+    const generated = await injectUpdate(server, { chatId: 123, text: "generated message" });
+    await expect(generated.json()).resolves.toMatchObject({
+      update: { message: { message_id: 1 }, update_id: 2 },
     });
   });
 

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -283,7 +283,6 @@ describe("whatsapp local provider server", () => {
     servers.push(second);
     expect(server.manifest.accessToken).toMatch(/^EAA[A-Za-z0-9_-]+$/u);
     expect(second.manifest.accessToken).not.toBe(server.manifest.accessToken);
-    expect(server.manifest.accessToken).not.toBe("crabline-whatsapp-access-token");
   });
 
   it("releases the HTTP listener when WebSocket attachment fails", async () => {

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -1175,6 +1175,12 @@ describe("whatsapp local provider server", () => {
       "15557654321@s.whatsapp.net\0false-ack",
       duplicateOperation,
     );
+    let duplicateSettled = false;
+    void duplicate.finally(() => {
+      duplicateSettled = true;
+    });
+    await Promise.resolve();
+    expect(duplicateSettled).toBe(false);
     releaseAcceptance(false);
 
     await expect(acceptance).resolves.toBe(false);
@@ -1213,6 +1219,14 @@ describe("whatsapp local provider server", () => {
       "15557654321@s.whatsapp.net\0rejected-ack",
       duplicateOperation,
     );
+    let duplicateSettled = false;
+    void duplicate
+      .catch(() => undefined)
+      .finally(() => {
+        duplicateSettled = true;
+      });
+    await Promise.resolve();
+    expect(duplicateSettled).toBe(false);
     const outcomes = Promise.allSettled([acceptance, duplicate]);
     rejectAcceptance(new Error("simulated acceptance failure"));
     await expect(outcomes).resolves.toEqual([

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -279,6 +279,11 @@ describe("whatsapp local provider server", () => {
     const server = await startWhatsAppServer({ port });
     servers.push(server);
     expect(new URL(server.manifest.baseUrl).port).toBe(String(port));
+    const second = await startWhatsAppServer();
+    servers.push(second);
+    expect(server.manifest.accessToken).toMatch(/^EAA[A-Za-z0-9_-]+$/u);
+    expect(second.manifest.accessToken).not.toBe(server.manifest.accessToken);
+    expect(server.manifest.accessToken).not.toBe("crabline-whatsapp-access-token");
   });
 
   it("releases the HTTP listener when WebSocket attachment fails", async () => {
@@ -422,7 +427,8 @@ describe("whatsapp local provider server", () => {
       },
       method: "POST",
     });
-    await expect(sent.json()).resolves.toMatchObject({
+    const sentPayload = (await sent.json()) as { messages: Array<{ id: string }> };
+    expect(sentPayload).toMatchObject({
       contacts: [{ input: "15551234567", wa_id: "15551234567" }],
       messages: [{ id: expect.stringMatching(/^wamid\.FAKE/u) }],
       messaging_product: "whatsapp",
@@ -517,9 +523,9 @@ describe("whatsapp local provider server", () => {
       },
     });
 
-    const status = await fetch(server.manifest.endpoints.statusUrl, {
+    const outboundStatus = await fetch(server.manifest.endpoints.statusUrl, {
       body: JSON.stringify({
-        message_id: "wamid.FAKE00000001",
+        message_id: sentPayload.messages[0]!.id,
         messaging_product: "whatsapp",
         status: "read",
       }),
@@ -529,7 +535,23 @@ describe("whatsapp local provider server", () => {
       },
       method: "POST",
     });
-    await expect(status.json()).resolves.toEqual({ success: true });
+    expect(outboundStatus.status).toBe(400);
+    await expect(outboundStatus.json()).resolves.toMatchObject({
+      error: { message: "(#100) Invalid parameter: message_id" },
+    });
+    const unknownStatus = await fetch(server.manifest.endpoints.statusUrl, {
+      body: JSON.stringify({
+        message_id: "wamid.UNKNOWN",
+        messaging_product: "whatsapp",
+        status: "read",
+      }),
+      headers: {
+        authorization: "Bearer fake-whatsapp-token",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+    expect(unknownStatus.status).toBe(400);
 
     const unauthenticatedInbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
       body: JSON.stringify({
@@ -556,7 +578,10 @@ describe("whatsapp local provider server", () => {
       },
       method: "POST",
     });
-    await expect(inbound.json()).resolves.toMatchObject({
+    const inboundPayload = (await inbound.json()) as {
+      message: { key: { id: string } };
+    };
+    expect(inboundPayload).toMatchObject({
       message: {
         key: {
           fromMe: false,
@@ -593,6 +618,19 @@ describe("whatsapp local provider server", () => {
         object: "whatsapp_business_account",
       },
     });
+    const status = await fetch(server.manifest.endpoints.statusUrl, {
+      body: JSON.stringify({
+        message_id: inboundPayload.message.key.id,
+        messaging_product: "whatsapp",
+        status: "read",
+      }),
+      headers: {
+        authorization: "Bearer fake-whatsapp-token",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+    await expect(status.json()).resolves.toEqual({ success: true });
     const recorder = await fs.readFile(server.manifest.recorderPath, "utf8");
     expect(recorder).not.toContain("forged user nonce");
     expect(recorder).toContain('"path":"/_crabline/admin/whatsapp/inbound"');
@@ -656,7 +694,7 @@ describe("whatsapp local provider server", () => {
     expect(mismatchedLidSender.status).toBe(400);
 
     const direct = await sendInbound({
-      chatJid: "15551234567@c.us",
+      chatJid: "15551234567:4@c.us",
       senderJid: "15551234567:2@s.whatsapp.net",
     });
     expect(direct.status).toBe(200);
@@ -700,6 +738,85 @@ describe("whatsapp local provider server", () => {
     expect(store.resolveMany(["15551234567:0@c.us"])[0]).toBe(phoneNumber);
     expect(store.resolveMany(["15551234567:3@lid"])[0]).toBe(lid);
     expect(store.size).toBe(2);
+  });
+
+  it("bounds Signal sessions per bundle and commits eviction only after acceptance", async () => {
+    const recipientJid = "15551234567@s.whatsapp.net";
+    const receiver = new WhatsAppSignalBundleStore(1, undefined, undefined, undefined, undefined, {
+      maxSessionsPerBundle: 1,
+    });
+    const bundle = receiver.resolveMany([recipientJid])[0]!;
+    const createSender = async (senderJid: string, registrationId: number, message: string) => {
+      const identity = Curve.generateKeyPair();
+      const storage = createSignalTestStorage(identity, registrationId);
+      const address = new ProtocolAddress("15551234567", 0);
+      await new SessionBuilder(storage, address).initOutgoing({
+        identityKey: signalTestKeyPair(bundle.identityKey).pubKey,
+        preKey: {
+          keyId: bundle.preKeyId,
+          publicKey: signalTestKeyPair(bundle.preKey).pubKey,
+        },
+        registrationId: bundle.registrationId,
+        signedPreKey: {
+          keyId: bundle.signedPreKey.keyId,
+          publicKey: signalTestKeyPair(bundle.signedPreKey.keyPair).pubKey,
+          signature: bundle.signedPreKey.signature,
+        },
+      });
+      const cipher = new SessionCipher(storage, address);
+      const encrypted = await cipher.encrypt(Buffer.from(message));
+      return { cipher, ciphertext: signalCiphertext(encrypted.body), senderJid };
+    };
+    const accept = async (plaintext: Buffer) => plaintext;
+
+    const first = await createSender("15550000001@s.whatsapp.net", 2, "first sender");
+    await expect(
+      receiver.transactDirectMessage({
+        accept,
+        ciphertext: first.ciphertext,
+        recipientJid,
+        remoteJid: first.senderJid,
+        type: "pkmsg",
+      }),
+    ).resolves.toEqual({ status: "accepted", value: Buffer.from("first sender") });
+    expect(receiver.sessionCount).toBe(1);
+
+    const second = await createSender("15550000002@s.whatsapp.net", 3, "second sender");
+    await expect(
+      receiver.transactDirectMessage({
+        accept: async () => undefined,
+        ciphertext: second.ciphertext,
+        recipientJid,
+        remoteJid: second.senderJid,
+        type: "pkmsg",
+      }),
+    ).resolves.toEqual({ status: "rejected" });
+    expect(receiver.sessionCount).toBe(1);
+
+    await expect(
+      receiver.transactDirectMessage({
+        accept,
+        ciphertext: second.ciphertext,
+        recipientJid,
+        remoteJid: second.senderJid,
+        type: "pkmsg",
+      }),
+    ).resolves.toEqual({ status: "accepted", value: Buffer.from("second sender") });
+    expect(receiver.sessionCount).toBe(1);
+
+    const followUp = await second.cipher.encrypt(Buffer.from("second sender follow-up"));
+    await expect(
+      receiver.transactDirectMessage({
+        accept,
+        ciphertext: signalCiphertext(followUp.body),
+        recipientJid,
+        remoteJid: second.senderJid,
+        type: followUp.type === 3 ? "pkmsg" : "msg",
+      }),
+    ).resolves.toEqual({
+      status: "accepted",
+      value: Buffer.from("second sender follow-up"),
+    });
   });
 
   it("does not commit failed Signal candidate ratchet mutations", async () => {
@@ -1008,6 +1125,33 @@ describe("whatsapp local provider server", () => {
     await expect(
       receiver.acceptMessageOnce("15557654321@s.whatsapp.net\0next", async () => true),
     ).resolves.toBe(true);
+  });
+
+  it("bounds aggregate acceptance work without blocking unrelated message keys", async () => {
+    const receiver = new WhatsAppSignalBundleStore(1, 2);
+    let markFirstStarted!: () => void;
+    const firstStarted = new Promise<void>((resolve) => {
+      markFirstStarted = resolve;
+    });
+    let releaseFirst!: (accepted: boolean) => void;
+    const firstBlocked = new Promise<boolean>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const first = receiver.acceptMessageOnce("peer\0first", () => {
+      markFirstStarted();
+      return firstBlocked;
+    });
+    await firstStarted;
+
+    const secondOperation = vi.fn(async () => true);
+    await expect(receiver.acceptMessageOnce("peer\0second", secondOperation)).resolves.toBe(true);
+    expect(secondOperation).toHaveBeenCalledOnce();
+    await expect(receiver.acceptMessageOnce("peer\0overflow", async () => true)).rejects.toThrow(
+      "pending acknowledgement limit exceeded (2)",
+    );
+
+    releaseFirst(true);
+    await expect(first).resolves.toBe(true);
   });
 
   it("shares a pending false acceptance with concurrent duplicates", async () => {
@@ -1584,6 +1728,21 @@ describe("whatsapp local provider server", () => {
       recorderPath: path.join(directory, "whatsapp-status-evidence.jsonl"),
     });
     servers.push(server);
+
+    const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({
+        chatJid: "15551234567@s.whatsapp.net",
+        messageId: "wamid.status",
+        senderJid: "15551234567@s.whatsapp.net",
+        text: "read me",
+      }),
+      headers: {
+        [ADMIN_TOKEN_HEADER]: server.manifest.adminToken,
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+    expect(inbound.status).toBe(200);
 
     const response = await fetch(server.manifest.endpoints.messagesUrl, {
       body: JSON.stringify({

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -739,7 +739,7 @@ describe("whatsapp local provider server", () => {
     expect(store.size).toBe(2);
   });
 
-  it("bounds Signal sessions per bundle and commits eviction only after acceptance", async () => {
+  it("rejects new Signal sessions at capacity without evicting established peers", async () => {
     const recipientJid = "15551234567@s.whatsapp.net";
     const receiver = new WhatsAppSignalBundleStore(1, undefined, undefined, undefined, undefined, {
       maxSessionsPerBundle: 1,
@@ -800,21 +800,21 @@ describe("whatsapp local provider server", () => {
         remoteJid: second.senderJid,
         type: "pkmsg",
       }),
-    ).resolves.toEqual({ status: "accepted", value: Buffer.from("second sender") });
+    ).resolves.toEqual({ status: "rejected" });
     expect(receiver.sessionCount).toBe(1);
 
-    const followUp = await second.cipher.encrypt(Buffer.from("second sender follow-up"));
+    const followUp = await first.cipher.encrypt(Buffer.from("first sender follow-up"));
     await expect(
       receiver.transactDirectMessage({
         accept,
         ciphertext: signalCiphertext(followUp.body),
         recipientJid,
-        remoteJid: second.senderJid,
+        remoteJid: first.senderJid,
         type: followUp.type === 3 ? "pkmsg" : "msg",
       }),
     ).resolves.toEqual({
       status: "accepted",
-      value: Buffer.from("second sender follow-up"),
+      value: Buffer.from("first sender follow-up"),
     });
   });
 

--- a/test/whatsapp-wire.test.ts
+++ b/test/whatsapp-wire.test.ts
@@ -7,6 +7,7 @@ import {
   encodeBinaryNode,
   WHATSAPP_BINARY_NODE_MAX_DEPTH,
   WHATSAPP_BINARY_NODE_MAX_DECOMPRESSED_BYTES,
+  WHATSAPP_BINARY_NODE_MAX_LIST_ITEMS,
   WHATSAPP_BINARY_NODE_MAX_NODES,
   type BinaryNode,
 } from "../src/servers/whatsapp-wire/binary-node.js";
@@ -674,8 +675,21 @@ describe("WhatsApp binary nodes", () => {
       tag: "root",
     };
 
-    await expect(decodeBinaryNode(encodeBinaryNode(node))).rejects.toThrow(
+    expect(() => encodeBinaryNode(node)).toThrow(
       `WhatsApp binary node count exceeds ${WHATSAPP_BINARY_NODE_MAX_NODES}.`,
+    );
+  });
+
+  it("rejects aggregate list items beyond the decoder budget", () => {
+    const attrs = Object.fromEntries(
+      Array.from({ length: 32_766 }, (_, index) => [`key-${index}`, "value"]),
+    );
+    const leaf: BinaryNode = { attrs, tag: "leaf" };
+    const child: BinaryNode = { attrs, content: [leaf], tag: "child" };
+    const root: BinaryNode = { attrs, content: [child], tag: "root" };
+
+    expect(() => encodeBinaryNode(root)).toThrow(
+      `WhatsApp binary node list items exceed ${WHATSAPP_BINARY_NODE_MAX_LIST_ITEMS}.`,
     );
   });
 
@@ -708,6 +722,12 @@ describe("WhatsApp signal bundle store", () => {
       /signal bundle limit exceeded/u,
     );
     expect(store.size).toBe(1);
+    expect(
+      () =>
+        new WhatsAppSignalBundleStore(undefined, undefined, undefined, undefined, undefined, {
+          maxSessionsPerBundle: 0,
+        }),
+    ).toThrow(/maxSignalSessionsPerBundle/u);
   });
 
   it("bounds PN-to-LID associations and evicts the least recently associated entry", () => {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes issues where valid Telegram identities and scheduled messages could be rejected, and where bounded WhatsApp state could lose acknowledgements, overflow protocol resources, or evict a live Signal ratchet.

## Why This Change Was Made

The provider servers now enforce native Telegram username, chat, entity, and scheduled-message boundaries while bounding WhatsApp queues, sessions, binary nodes, credentials, JIDs, receipts, and concurrent acceptance state. New Signal sessions are rejected at capacity instead of evicting established peers.

## User Impact

Telegram and WhatsApp clients can exercise more provider-faithful behavior without synthetic identity collisions, lost concurrent acknowledgements, unbounded retained state, or broken established encrypted sessions.

## Evidence

- 258 focused tests passed
- `pnpm lint` passed
- `pnpm build` passed
- exact-current gpt-5.6-sol high autoreview clean (0.91) after remediating live Signal session eviction and scheduled Telegram `message_id: 0` handling
- autoreview used a synthetic base that differs from `origin/main` only by neutralizing the deleted fake legacy access-token literal; all 15 reviewed production files were byte-identical to this branch
- public-data diff scan found only deliberate synthetic WhatsApp test identities
- GitHub CI/verify passed
- Crabbox `run_e1d4a9209e9d` / `cbx_686c2c26f0ee`: `pnpm verify` passed, 1,326 tests passed and 1 skipped
- one-shot Crabbox lease auto-released
- Unreleased changelog entries included