### PR TITLE
fix(openclaw): reject incomplete smoke artifact generations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Keep fixture-local iMessage target IDs separate from provider-native thread aliases.
 - Case-fold Zalo recorder credential keys and fully redact ambiguous malformed URL authorities.
 - Keep lazy provider watches registered for cleanup after nonterminal iterator throws.
-- Version artifact generations so legacy recorder manifests can migrate while new snapshots retain strict locality and completeness checks.
+- Version artifact generations so legacy recorder manifests can migrate while new snapshots retain explicit presence, locality, identity, and completeness checks.
 - Randomize WhatsApp XEdDSA signatures with fresh entropy while preserving their wire encoding.
 - Suppress serve readiness output when shutdown begins during ready-file publication.
 - Treat Unicode format characters as continuations when recognizing standalone acknowledgement tokens.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Keep fixture-local iMessage target IDs separate from provider-native thread aliases.
 - Case-fold Zalo recorder credential keys and fully redact ambiguous malformed URL authorities.
 - Keep lazy provider watches registered for cleanup after nonterminal iterator throws.
+- Fence readiness recorder paths, validate complete JSONL evidence, and reject generations with missing recorder snapshots.
 - Randomize WhatsApp XEdDSA signatures with fresh entropy while preserving their wire encoding.
 - Suppress serve readiness output when shutdown begins during ready-file publication.
 - Treat Unicode format characters as continuations when recognizing standalone acknowledgement tokens.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Keep fixture-local iMessage target IDs separate from provider-native thread aliases.
 - Case-fold Zalo recorder credential keys and fully redact ambiguous malformed URL authorities.
 - Keep lazy provider watches registered for cleanup after nonterminal iterator throws.
-- Fence readiness recorder paths, validate complete JSONL evidence, and reject generations with missing recorder snapshots.
+- Version artifact generations so legacy recorder manifests can migrate while new snapshots retain strict locality and completeness checks.
 - Randomize WhatsApp XEdDSA signatures with fresh entropy while preserving their wire encoding.
 - Suppress serve readiness output when shutdown begins during ready-file publication.
 - Treat Unicode format characters as continuations when recognizing standalone acknowledgement tokens.

--- a/src/openclaw.ts
+++ b/src/openclaw.ts
@@ -107,6 +107,7 @@ function hasStringRecordValues(value: unknown): value is Record<string, string> 
 function isOpenClawCrablineRecorderEvent(value: unknown): boolean {
   return (
     isRecord(value) &&
+    value.accepted === true &&
     typeof value.at === "string" &&
     Number.isFinite(Date.parse(value.at)) &&
     typeof value.method === "string" &&

--- a/src/openclaw.ts
+++ b/src/openclaw.ts
@@ -42,7 +42,11 @@ import {
 } from "./openclaw/shared.js";
 import { publishOpenClawCrablineArtifactGeneration } from "./openclaw/artifact-generation.js";
 import { isAcceptedOpenClawCrablineOutbound } from "./openclaw/outbound-contract.js";
-import { syncParentDirectory } from "./openclaw/private-file.js";
+import {
+  securePrivateDirectory,
+  syncParentDirectory,
+  type SecuredPrivateDirectory,
+} from "./openclaw/private-file.js";
 import {
   acquireOpenClawCrablineSmokeRunLock,
   releaseOpenClawCrablineSmokeRunLock,
@@ -96,17 +100,49 @@ function isOpenClawCrablineRecorderTemporary(name: string): boolean {
   return channel !== undefined && isCrablineServerChannel(channel);
 }
 
-function hasOpenClawCrablineRecorderEvidence(contents: string): boolean {
-  return contents.split(/\r?\n/u).some((line) => {
+function hasStringRecordValues(value: unknown): value is Record<string, string> {
+  return isRecord(value) && Object.values(value).every((entry) => typeof entry === "string");
+}
+
+function isOpenClawCrablineRecorderEvent(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    typeof value.at === "string" &&
+    Number.isFinite(Date.parse(value.at)) &&
+    typeof value.method === "string" &&
+    value.method.length > 0 &&
+    typeof value.path === "string" &&
+    value.path.startsWith("/") &&
+    hasStringRecordValues(value.query) &&
+    (value.type === "admin" || value.type === "api")
+  );
+}
+
+function assertOpenClawCrablineRecorderEvidence(contents: string): void {
+  let recorderEvidence = false;
+  for (const line of contents.split(/\r?\n/u)) {
     if (!line.trim()) {
-      return false;
+      continue;
     }
+    let event: unknown;
     try {
-      return isRecord(JSON.parse(line));
-    } catch {
-      return false;
+      event = JSON.parse(line);
+    } catch (error) {
+      throw new Error(
+        "OpenClaw Crabline provider probe produced no valid JSONL recorder evidence.",
+        { cause: error },
+      );
     }
-  });
+    if (!isOpenClawCrablineRecorderEvent(event)) {
+      throw new Error(
+        "OpenClaw Crabline provider probe produced no valid JSONL recorder evidence.",
+      );
+    }
+    recorderEvidence = true;
+  }
+  if (!recorderEvidence) {
+    throw new Error("OpenClaw Crabline provider probe produced no valid JSONL recorder evidence.");
+  }
 }
 
 function isOpenClawCrablineRecorderTemporaryLock(name: string): boolean {
@@ -171,10 +207,13 @@ async function reclaimOpenClawCrablineRecorderTemporaryLock(
 }
 
 async function reclaimOpenClawCrablineRecorderTemporaries(
-  directoryPath: string,
+  directory: SecuredPrivateDirectory,
   lock: Awaited<ReturnType<typeof acquireOpenClawCrablineSmokeRunLock>>,
 ): Promise<void> {
+  const directoryPath = directory.directoryPath;
+  await directory.assertIdentityAt();
   for (const entry of await fs.readdir(directoryPath, { withFileTypes: true })) {
+    await directory.assertIdentityAt();
     const tombstoneBaseName = entry.isDirectory()
       ? openClawCrablineRecorderLockTombstoneBaseName(entry.name)
       : null;
@@ -199,7 +238,80 @@ async function reclaimOpenClawCrablineRecorderTemporaries(
     const temporaryPath = path.join(directoryPath, entry.name);
     await fs.rm(temporaryPath, { force: true });
     await syncParentDirectory(temporaryPath);
+    await directory.assertIdentityAt();
   }
+  await directory.assertIdentityAt();
+}
+
+type RecorderSnapshotIdentity = {
+  device: bigint;
+  inode: bigint;
+  userId: bigint;
+};
+
+function assertOwnedRecorderStats(
+  stats: BigIntStats,
+  expected?: RecorderSnapshotIdentity,
+): RecorderSnapshotIdentity {
+  const currentUserId = process.geteuid?.();
+  if (
+    !stats.isFile() ||
+    stats.nlink !== 1n ||
+    stats.ino <= 0n ||
+    (currentUserId !== undefined && stats.uid !== BigInt(currentUserId)) ||
+    (expected !== undefined &&
+      (stats.dev !== expected.device ||
+        stats.ino !== expected.inode ||
+        stats.uid !== expected.userId))
+  ) {
+    throw new Error("OpenClaw Crabline recorder snapshot identity is invalid.");
+  }
+  return {
+    device: stats.dev,
+    inode: stats.ino,
+    userId: stats.uid,
+  };
+}
+
+async function readOwnedRecorderSnapshot(
+  recorderPath: string,
+  directory: SecuredPrivateDirectory,
+): Promise<{ contents: string; identity: RecorderSnapshotIdentity }> {
+  await directory.assertIdentityAt();
+  const handle = await fs.open(recorderPath, "r");
+  try {
+    const identity = assertOwnedRecorderStats(await handle.stat({ bigint: true }));
+    assertOwnedRecorderStats(await fs.lstat(recorderPath, { bigint: true }), identity);
+    const contents = await handle.readFile("utf8");
+    await directory.assertIdentityAt();
+    assertOwnedRecorderStats(await fs.lstat(recorderPath, { bigint: true }), identity);
+    return { contents, identity };
+  } finally {
+    await handle.close();
+  }
+}
+
+async function removeOwnedRecorderTemporary(params: {
+  directory: SecuredPrivateDirectory;
+  identity?: RecorderSnapshotIdentity;
+  recorderPath: string;
+  syncParent: (filePath: string) => Promise<void>;
+}): Promise<void> {
+  await params.directory.assertIdentityAt();
+  let stats: BigIntStats;
+  try {
+    stats = await fs.lstat(params.recorderPath, { bigint: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      await params.syncParent(params.recorderPath);
+      return;
+    }
+    throw error;
+  }
+  assertOwnedRecorderStats(stats, params.identity);
+  await fs.rm(params.recorderPath);
+  await params.directory.assertIdentityAt();
+  await params.syncParent(params.recorderPath);
 }
 
 function createOpenClawCrablineProviderAdapter(
@@ -369,14 +481,20 @@ export async function runOpenClawCrablineProviderReadiness(
   let outcome:
     | { committed: false; error: unknown }
     | { committed: true; result: OpenClawCrablineProviderReadinessResult };
+  let recorderDirectory: SecuredPrivateDirectory | undefined;
+  let recorderIdentity: RecorderSnapshotIdentity | undefined;
   let recorderPath: string | undefined;
 
   try {
-    const recorderDirectory = path.join(outputDir, "artifacts", "crabline");
-    await fs.mkdir(recorderDirectory, { recursive: true });
+    const artifactsDirectory = await securePrivateDirectory(path.join(outputDir, "artifacts"));
+    recorderDirectory = await securePrivateDirectory(
+      path.join(artifactsDirectory.directoryPath, "crabline"),
+    );
+    await artifactsDirectory.assertIdentityAt();
+    await recorderDirectory.assertIdentityAt();
     await reclaimOpenClawCrablineRecorderTemporaries(recorderDirectory, smokeLock);
     recorderPath = path.join(
-      recorderDirectory,
+      recorderDirectory.directoryPath,
       `.${params.selection.channel}-fake-provider.${randomUUID()}.jsonl.tmp`,
     );
     const adapter = await (dependencies.startAdapter ?? startOpenClawCrablineAdapter)({
@@ -428,12 +546,10 @@ export async function runOpenClawCrablineProviderReadiness(
     if (probeFailed) {
       throw probeFailure;
     }
-    const recorderSnapshotContents = await fs.readFile(recorderPath, "utf8");
-    if (!hasOpenClawCrablineRecorderEvidence(recorderSnapshotContents)) {
-      throw new Error(
-        "OpenClaw Crabline provider probe produced no valid JSONL recorder evidence.",
-      );
-    }
+    const recorderSnapshot = await readOwnedRecorderSnapshot(recorderPath, recorderDirectory);
+    recorderIdentity = recorderSnapshot.identity;
+    const recorderSnapshotContents = recorderSnapshot.contents;
+    assertOpenClawCrablineRecorderEvidence(recorderSnapshotContents);
 
     const capabilityReport = {
       result: {
@@ -469,8 +585,12 @@ export async function runOpenClawCrablineProviderReadiness(
     });
     let recorderCleanupWarning: string | undefined;
     try {
-      await fs.rm(recorderPath, { force: true });
-      await syncRecorderParent(recorderPath);
+      await removeOwnedRecorderTemporary({
+        directory: recorderDirectory,
+        identity: recorderIdentity,
+        recorderPath,
+        syncParent: syncRecorderParent,
+      });
       recorderPath = undefined;
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
@@ -500,10 +620,14 @@ export async function runOpenClawCrablineProviderReadiness(
     };
   } catch (error) {
     let primaryError = error;
-    if (recorderPath) {
+    if (recorderPath && recorderDirectory) {
       try {
-        await fs.rm(recorderPath, { force: true });
-        await syncRecorderParent(recorderPath);
+        await removeOwnedRecorderTemporary({
+          directory: recorderDirectory,
+          ...(recorderIdentity ? { identity: recorderIdentity } : {}),
+          recorderPath,
+          syncParent: syncRecorderParent,
+        });
         recorderPath = undefined;
       } catch (cleanupError) {
         if (primaryError instanceof Error) {

--- a/src/openclaw/artifact-generation.ts
+++ b/src/openclaw/artifact-generation.ts
@@ -248,7 +248,7 @@ async function assertCurrentGenerationExists(
     OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY,
     pointer.generation,
   );
-  if (recorderPaths[1] === undefined && recorderPaths[2] === undefined) {
+  if (recorderPaths.every((recorderPath) => recorderPath === undefined)) {
     return;
   }
   const resolvedRecorderPaths = recorderPaths.map((recorderPath) =>
@@ -415,7 +415,9 @@ export async function publishOpenClawCrablineArtifactGeneration(
       : undefined;
     const publishedManifest = recorderSnapshotPath
       ? { ...params.manifest, recorderPath: recorderSnapshotPath }
-      : params.manifest;
+      : Object.fromEntries(
+          Object.entries(params.manifest).filter(([key]) => key !== "recorderPath"),
+        );
     const providerReadinessBase = recorderSnapshotPath
       ? withRecorderSnapshotPath(params.providerReadiness, recorderSnapshotPath)
       : params.providerReadiness;

--- a/src/openclaw/artifact-generation.ts
+++ b/src/openclaw/artifact-generation.ts
@@ -99,20 +99,25 @@ function artifactRemovalTombstoneBaseName(name: string): string | null {
     : null;
 }
 
-function withRecorderSnapshotPath(
+function withPublishedRecorderPath(
   providerReadiness: Record<string, unknown>,
-  recorderPath: string,
+  recorderPath: string | undefined,
 ): Record<string, unknown> {
   const result = providerReadiness.result;
   if (!result || typeof result !== "object" || Array.isArray(result)) {
     throw new Error("OpenClaw Crabline provider readiness result is malformed.");
   }
+  const publishedResult: Record<string, unknown> = {
+    ...(result as Record<string, unknown>),
+  };
+  if (recorderPath === undefined) {
+    delete publishedResult.recorderPath;
+  } else {
+    publishedResult.recorderPath = recorderPath;
+  }
   return {
     ...providerReadiness,
-    result: {
-      ...result,
-      recorderPath,
-    },
+    result: publishedResult,
   };
 }
 
@@ -494,9 +499,10 @@ export async function publishOpenClawCrablineArtifactGeneration(
       : Object.fromEntries(
           Object.entries(params.manifest).filter(([key]) => key !== "recorderPath"),
         );
-    const providerReadinessBase = recorderSnapshotPath
-      ? withRecorderSnapshotPath(params.providerReadiness, recorderSnapshotPath)
-      : params.providerReadiness;
+    const providerReadinessBase = withPublishedRecorderPath(
+      params.providerReadiness,
+      recorderSnapshotPath,
+    );
     const providerReadiness = {
       ...providerReadinessBase,
       manifestPath: pointer.manifestPath,

--- a/src/openclaw/artifact-generation.ts
+++ b/src/openclaw/artifact-generation.ts
@@ -301,12 +301,13 @@ async function assertCurrentGenerationExists(
   if (manifest.recorderPath !== undefined && typeof manifest.recorderPath !== "string") {
     throw new Error("OpenClaw Crabline current artifact generation is incomplete.");
   }
+  // The artifact store is owner-only; v1 compatibility covers historical layouts, not hostile same-owner rewrites.
   if (
     pointer.version === 1 &&
-    manifestRecorderPath !== undefined &&
     providerReadinessRecorderPath === undefined &&
     smokeRecorderPath === undefined &&
-    path.dirname(path.resolve(outputDir, manifestRecorderPath)) !== generationDirectory
+    (manifestRecorderPath === undefined ||
+      path.dirname(path.resolve(outputDir, manifestRecorderPath)) !== generationDirectory)
   ) {
     return;
   }

--- a/src/openclaw/artifact-generation.ts
+++ b/src/openclaw/artifact-generation.ts
@@ -203,6 +203,77 @@ async function assertCurrentGenerationExists(
       throw new Error("OpenClaw Crabline current artifact generation is incomplete.");
     }
   }
+
+  const readArtifactObject = async (artifactPath: string): Promise<Record<string, unknown>> => {
+    try {
+      const value = JSON.parse(await fs.readFile(path.join(outputDir, artifactPath), "utf8"));
+      if (value === null || typeof value !== "object" || Array.isArray(value)) {
+        throw new Error("artifact is not an object");
+      }
+      return value as Record<string, unknown>;
+    } catch (error) {
+      throw new Error("OpenClaw Crabline current artifact generation is incomplete.", {
+        cause: error,
+      });
+    }
+  };
+  const readNestedRecorderPath = (value: unknown): string | undefined => {
+    if (value === null || typeof value !== "object" || Array.isArray(value)) {
+      return undefined;
+    }
+    const result = (value as Record<string, unknown>).result;
+    if (result === null || typeof result !== "object" || Array.isArray(result)) {
+      return undefined;
+    }
+    const recorderPath = (result as Record<string, unknown>).recorderPath;
+    if (recorderPath !== undefined && typeof recorderPath !== "string") {
+      throw new Error("OpenClaw Crabline current artifact generation is incomplete.");
+    }
+    return recorderPath;
+  };
+
+  const manifest = await readArtifactObject(pointer.manifestPath);
+  const readiness = await readArtifactObject(pointer.providerReadinessArtifactPath);
+  const recorderPaths = [
+    typeof manifest.recorderPath === "string" ? manifest.recorderPath : undefined,
+    readNestedRecorderPath(readiness.providerReadiness),
+    readNestedRecorderPath(readiness.smoke),
+  ];
+  if (manifest.recorderPath !== undefined && typeof manifest.recorderPath !== "string") {
+    throw new Error("OpenClaw Crabline current artifact generation is incomplete.");
+  }
+
+  const generationDirectory = path.resolve(
+    outputDir,
+    OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY,
+    pointer.generation,
+  );
+  const generationRecorderPaths = recorderPaths.filter(
+    (recorderPath): recorderPath is string =>
+      recorderPath !== undefined &&
+      path.dirname(path.resolve(outputDir, recorderPath)) === generationDirectory,
+  );
+  if (generationRecorderPaths.length === 0) {
+    return;
+  }
+  if (
+    recorderPaths.some((recorderPath) => recorderPath === undefined) ||
+    new Set(recorderPaths.map((recorderPath) => path.resolve(outputDir, recorderPath!))).size !== 1
+  ) {
+    throw new Error("OpenClaw Crabline current artifact generation is incomplete.");
+  }
+  const recorderPath = path.resolve(outputDir, generationRecorderPaths[0]!);
+  try {
+    const recorderStats = await fs.lstat(recorderPath, { bigint: true });
+    if (recorderStats.isFile() && recorderStats.nlink === 1n) {
+      return;
+    }
+  } catch (error) {
+    throw new Error("OpenClaw Crabline current artifact generation is incomplete.", {
+      cause: error,
+    });
+  }
+  throw new Error("OpenClaw Crabline current artifact generation is incomplete.");
 }
 
 async function pruneArtifactStore(params: {

--- a/src/openclaw/artifact-generation.ts
+++ b/src/openclaw/artifact-generation.ts
@@ -248,21 +248,22 @@ async function assertCurrentGenerationExists(
     OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY,
     pointer.generation,
   );
-  const generationRecorderPaths = recorderPaths.filter(
-    (recorderPath): recorderPath is string =>
-      recorderPath !== undefined &&
-      path.dirname(path.resolve(outputDir, recorderPath)) === generationDirectory,
-  );
-  if (generationRecorderPaths.length === 0) {
+  if (recorderPaths[1] === undefined && recorderPaths[2] === undefined) {
     return;
   }
+  const resolvedRecorderPaths = recorderPaths.map((recorderPath) =>
+    recorderPath === undefined ? undefined : path.resolve(outputDir, recorderPath),
+  );
   if (
-    recorderPaths.some((recorderPath) => recorderPath === undefined) ||
-    new Set(recorderPaths.map((recorderPath) => path.resolve(outputDir, recorderPath!))).size !== 1
+    resolvedRecorderPaths.some(
+      (recorderPath) =>
+        recorderPath === undefined || path.dirname(recorderPath) !== generationDirectory,
+    ) ||
+    new Set(resolvedRecorderPaths).size !== 1
   ) {
     throw new Error("OpenClaw Crabline current artifact generation is incomplete.");
   }
-  const recorderPath = path.resolve(outputDir, generationRecorderPaths[0]!);
+  const recorderPath = resolvedRecorderPaths[0]!;
   try {
     const recorderStats = await fs.lstat(recorderPath, { bigint: true });
     if (recorderStats.isFile() && recorderStats.nlink === 1n) {

--- a/src/openclaw/artifact-generation.ts
+++ b/src/openclaw/artifact-generation.ts
@@ -33,7 +33,7 @@ export type OpenClawCrablineArtifactPointer = {
   previousGeneration?: string;
   providerReadinessArtifactPath: string;
   smokeArtifactPath: string;
-  version: 1;
+  version: 1 | 2;
 };
 
 export type PublishedOpenClawCrablineArtifactGeneration = OpenClawCrablineArtifactPointer & {
@@ -121,7 +121,7 @@ function parseArtifactPointer(contents: string): OpenClawCrablineArtifactPointer
     throw new Error("OpenClaw Crabline artifact pointer is malformed.");
   }
   const value = parsed as Partial<OpenClawCrablineArtifactPointer>;
-  if (value.version !== 1) {
+  if (value.version !== 1 && value.version !== 2) {
     throw new Error("OpenClaw Crabline artifact pointer is malformed.");
   }
   assertGenerationName(value.generation, "generation");
@@ -167,7 +167,7 @@ function parseArtifactPointer(contents: string): OpenClawCrablineArtifactPointer
     manifestPath: value.manifestPath,
     providerReadinessArtifactPath: value.providerReadinessArtifactPath ?? value.smokeArtifactPath!,
     smokeArtifactPath: value.smokeArtifactPath ?? value.providerReadinessArtifactPath!,
-    version: 1,
+    version: value.version,
   };
 }
 
@@ -202,6 +202,9 @@ async function assertCurrentGenerationExists(
     if (!stats.isFile()) {
       throw new Error("OpenClaw Crabline current artifact generation is incomplete.");
     }
+  }
+  if (pointer.version === 1) {
+    return;
   }
 
   const readArtifactObject = async (artifactPath: string): Promise<Record<string, unknown>> => {
@@ -401,7 +404,7 @@ export async function publishOpenClawCrablineArtifactGeneration(
         providerReadinessArtifactPath,
       ),
       smokeArtifactPath: generationArtifactPath(generation, providerReadinessArtifactPath),
-      version: 1,
+      version: 2,
     };
     if (
       params.recorderSnapshot &&

--- a/src/openclaw/artifact-generation.ts
+++ b/src/openclaw/artifact-generation.ts
@@ -26,15 +26,21 @@ const STAGING_NAME_PATTERN =
   /^\.staging-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
 const REMOVAL_TOMBSTONE_PATTERN =
   /^\.(.+)\.\d+\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.remove$/iu;
-export type OpenClawCrablineArtifactPointer = {
+type OpenClawCrablineArtifactPointerBase = {
   capabilityMatrixPath: string;
   generation: string;
   manifestPath: string;
   previousGeneration?: string;
   providerReadinessArtifactPath: string;
   smokeArtifactPath: string;
-  version: 1 | 2;
 };
+
+export type OpenClawCrablineArtifactPointer =
+  | (OpenClawCrablineArtifactPointerBase & { version: 1 })
+  | (OpenClawCrablineArtifactPointerBase & {
+      recorderSnapshotPath: string | null;
+      version: 2;
+    });
 
 export type PublishedOpenClawCrablineArtifactGeneration = OpenClawCrablineArtifactPointer & {
   pointerPath: string;
@@ -120,7 +126,10 @@ function parseArtifactPointer(contents: string): OpenClawCrablineArtifactPointer
   if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
     throw new Error("OpenClaw Crabline artifact pointer is malformed.");
   }
-  const value = parsed as Partial<OpenClawCrablineArtifactPointer>;
+  const value = parsed as Partial<OpenClawCrablineArtifactPointerBase> & {
+    recorderSnapshotPath?: unknown;
+    version?: unknown;
+  };
   if (value.version !== 1 && value.version !== 2) {
     throw new Error("OpenClaw Crabline artifact pointer is malformed.");
   }
@@ -159,16 +168,39 @@ function parseArtifactPointer(contents: string): OpenClawCrablineArtifactPointer
   ) {
     throw new Error("OpenClaw Crabline artifact pointer is malformed.");
   }
+  if (value.version === 1 && value.recorderSnapshotPath !== undefined) {
+    throw new Error("OpenClaw Crabline artifact pointer is malformed.");
+  }
+  if (value.version === 2) {
+    if (value.recorderSnapshotPath !== null && typeof value.recorderSnapshotPath !== "string") {
+      throw new Error("OpenClaw Crabline artifact pointer is malformed.");
+    }
+    if (typeof value.recorderSnapshotPath === "string") {
+      const recorderFileName = path.basename(value.recorderSnapshotPath);
+      if (
+        !recorderFileName.endsWith(".jsonl") ||
+        value.recorderSnapshotPath !== generationArtifactPath(value.generation, recorderFileName)
+      ) {
+        throw new Error("OpenClaw Crabline artifact pointer is malformed.");
+      }
+    }
+  }
 
-  return {
+  const pointer = {
     capabilityMatrixPath: value.capabilityMatrixPath,
     generation: value.generation,
     ...(value.previousGeneration ? { previousGeneration: value.previousGeneration } : {}),
     manifestPath: value.manifestPath,
     providerReadinessArtifactPath: value.providerReadinessArtifactPath ?? value.smokeArtifactPath!,
     smokeArtifactPath: value.smokeArtifactPath ?? value.providerReadinessArtifactPath!,
-    version: value.version,
   };
+  return value.version === 1
+    ? { ...pointer, version: 1 }
+    : {
+        ...pointer,
+        recorderSnapshotPath: value.recorderSnapshotPath as string | null,
+        version: 2,
+      };
 }
 
 export async function readOpenClawCrablineArtifactPointer(
@@ -193,23 +225,47 @@ async function assertCurrentGenerationExists(
   outputDir: string,
   pointer: OpenClawCrablineArtifactPointer,
 ): Promise<void> {
+  const generationDirectory = path.resolve(
+    outputDir,
+    OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY,
+    pointer.generation,
+  );
+  let currentGeneration: Awaited<ReturnType<typeof captureDirectoryIdentity>>;
+  try {
+    currentGeneration = await captureDirectoryIdentity(generationDirectory);
+  } catch (error) {
+    throw new Error("OpenClaw Crabline current artifact generation is incomplete.", {
+      cause: error,
+    });
+  }
+  const assertGenerationIdentity = async (): Promise<void> => {
+    try {
+      await currentGeneration.assertIdentityAt();
+    } catch (error) {
+      throw new Error("OpenClaw Crabline current artifact generation is incomplete.", {
+        cause: error,
+      });
+    }
+  };
+
   for (const artifactPath of [
     pointer.manifestPath,
     pointer.capabilityMatrixPath,
     pointer.providerReadinessArtifactPath,
   ]) {
+    await assertGenerationIdentity();
     const stats = await fs.lstat(path.join(outputDir, artifactPath));
     if (!stats.isFile()) {
       throw new Error("OpenClaw Crabline current artifact generation is incomplete.");
     }
-  }
-  if (pointer.version === 1) {
-    return;
+    await assertGenerationIdentity();
   }
 
   const readArtifactObject = async (artifactPath: string): Promise<Record<string, unknown>> => {
     try {
+      await assertGenerationIdentity();
       const value = JSON.parse(await fs.readFile(path.join(outputDir, artifactPath), "utf8"));
+      await assertGenerationIdentity();
       if (value === null || typeof value !== "object" || Array.isArray(value)) {
         throw new Error("artifact is not an object");
       }
@@ -237,21 +293,27 @@ async function assertCurrentGenerationExists(
 
   const manifest = await readArtifactObject(pointer.manifestPath);
   const readiness = await readArtifactObject(pointer.providerReadinessArtifactPath);
-  const recorderPaths = [
-    typeof manifest.recorderPath === "string" ? manifest.recorderPath : undefined,
-    readNestedRecorderPath(readiness.providerReadiness),
-    readNestedRecorderPath(readiness.smoke),
-  ];
+  const manifestRecorderPath =
+    typeof manifest.recorderPath === "string" ? manifest.recorderPath : undefined;
+  const providerReadinessRecorderPath = readNestedRecorderPath(readiness.providerReadiness);
+  const smokeRecorderPath = readNestedRecorderPath(readiness.smoke);
+  const recorderPaths = [manifestRecorderPath, providerReadinessRecorderPath, smokeRecorderPath];
   if (manifest.recorderPath !== undefined && typeof manifest.recorderPath !== "string") {
     throw new Error("OpenClaw Crabline current artifact generation is incomplete.");
   }
-
-  const generationDirectory = path.resolve(
-    outputDir,
-    OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY,
-    pointer.generation,
-  );
-  if (recorderPaths.every((recorderPath) => recorderPath === undefined)) {
+  if (
+    pointer.version === 1 &&
+    manifestRecorderPath !== undefined &&
+    providerReadinessRecorderPath === undefined &&
+    smokeRecorderPath === undefined &&
+    path.dirname(path.resolve(outputDir, manifestRecorderPath)) !== generationDirectory
+  ) {
+    return;
+  }
+  if (pointer.version === 2 && pointer.recorderSnapshotPath === null) {
+    if (recorderPaths.some((recorderPath) => recorderPath !== undefined)) {
+      throw new Error("OpenClaw Crabline current artifact generation is incomplete.");
+    }
     return;
   }
   const resolvedRecorderPaths = recorderPaths.map((recorderPath) =>
@@ -267,9 +329,18 @@ async function assertCurrentGenerationExists(
     throw new Error("OpenClaw Crabline current artifact generation is incomplete.");
   }
   const recorderPath = resolvedRecorderPaths[0]!;
+  if (
+    pointer.version === 2 &&
+    pointer.recorderSnapshotPath !== null &&
+    recorderPath !== path.resolve(outputDir, pointer.recorderSnapshotPath)
+  ) {
+    throw new Error("OpenClaw Crabline current artifact generation is incomplete.");
+  }
   try {
+    await assertGenerationIdentity();
     const recorderStats = await fs.lstat(recorderPath, { bigint: true });
     if (recorderStats.isFile() && recorderStats.nlink === 1n) {
+      await assertGenerationIdentity();
       return;
     }
   } catch (error) {
@@ -391,6 +462,16 @@ export async function publishOpenClawCrablineArtifactGeneration(
   let primaryError: unknown;
   let published: PublishedOpenClawCrablineArtifactGeneration | undefined;
   try {
+    if (
+      params.recorderSnapshot &&
+      (path.basename(params.recorderSnapshot.fileName) !== params.recorderSnapshot.fileName ||
+        !params.recorderSnapshot.fileName.endsWith(".jsonl"))
+    ) {
+      throw new Error("OpenClaw Crabline recorder snapshot filename is malformed.");
+    }
+    const recorderSnapshotPath = params.recorderSnapshot
+      ? generationArtifactPath(generation, params.recorderSnapshot.fileName)
+      : undefined;
     const pointer: OpenClawCrablineArtifactPointer = {
       capabilityMatrixPath: generationArtifactPath(
         generation,
@@ -403,19 +484,10 @@ export async function publishOpenClawCrablineArtifactGeneration(
         generation,
         providerReadinessArtifactPath,
       ),
+      recorderSnapshotPath: recorderSnapshotPath ?? null,
       smokeArtifactPath: generationArtifactPath(generation, providerReadinessArtifactPath),
       version: 2,
     };
-    if (
-      params.recorderSnapshot &&
-      (path.basename(params.recorderSnapshot.fileName) !== params.recorderSnapshot.fileName ||
-        !params.recorderSnapshot.fileName.endsWith(".jsonl"))
-    ) {
-      throw new Error("OpenClaw Crabline recorder snapshot filename is malformed.");
-    }
-    const recorderSnapshotPath = params.recorderSnapshot
-      ? generationArtifactPath(generation, params.recorderSnapshot.fileName)
-      : undefined;
     const publishedManifest = recorderSnapshotPath
       ? { ...params.manifest, recorderPath: recorderSnapshotPath }
       : Object.fromEntries(

--- a/src/servers/matrix.ts
+++ b/src/servers/matrix.ts
@@ -1015,6 +1015,7 @@ export async function startMatrixServer(
         state,
         url,
       });
+      event.accepted ??= response.ok;
       await appendEvent(state, event, response.ok && ["DELETE", "POST", "PUT"].includes(method));
       return response;
     },

--- a/src/servers/mattermost.ts
+++ b/src/servers/mattermost.ts
@@ -799,6 +799,7 @@ async function handleRequest(request: IncomingMessage, state: MattermostServerSt
   if (method === "POST" && url.pathname === "/api/v4/posts") {
     event.accepted = response.status === 201;
   }
+  event.accepted ??= response.ok;
   await appendEvent(state, event, response.ok && method !== "GET");
   return response;
 }

--- a/src/servers/signal.ts
+++ b/src/servers/signal.ts
@@ -113,7 +113,7 @@ export type StartSignalServerParams = {
 
 async function appendEvent(
   state: SignalServerState,
-  event: ServerRequestEvent,
+  event: SignalRecorderEvent,
   committed = false,
 ): Promise<void> {
   const params = { event, onEvent: state.onEvent, recorderPath: state.recorderPath };
@@ -839,6 +839,7 @@ async function handleRequest(params: {
     }
   } else if (url.pathname === "/api/v1/check" && params.request.method === "GET") {
     await appendEvent(params.state, {
+      accepted: true,
       at: new Date().toISOString(),
       method: "GET",
       path: url.pathname,

--- a/src/servers/slack.ts
+++ b/src/servers/slack.ts
@@ -1204,17 +1204,18 @@ async function handleRequest(params: { request: IncomingMessage; state: SlackSer
     state: params.state,
   });
   const mutation = ["chat.postMessage", "conversations.open"].includes(methodMatch[1]);
-  const payload = mutation
+  const recordsAcceptance = mutation || methodMatch[1] === "auth.test";
+  const payload = recordsAcceptance
     ? ((await response
         .clone()
         .json()
         .catch(() => undefined)) as unknown)
     : undefined;
   const committed = isJsonObject(payload) && payload.ok === true;
-  if (methodMatch[1] === "chat.postMessage") {
+  if (methodMatch[1] === "auth.test" || methodMatch[1] === "chat.postMessage") {
     event.accepted = committed;
   }
-  await appendEvent(params.state, event, committed);
+  await appendEvent(params.state, event, mutation && committed);
   return response;
 }
 

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -1911,13 +1911,15 @@ async function handleRequest(params: { request: IncomingMessage; state: Telegram
     }
     return response;
   }
-  await appendEvent(params.state, event);
-  return await handleTelegramApi({
+  const response = await handleTelegramApi({
     body,
     method: botPath.method,
     request: params.request,
     state: params.state,
   });
+  event.accepted = response.ok;
+  await appendEvent(params.state, event);
+  return response;
 }
 
 async function serveRequest(params: {

--- a/src/servers/whatsapp.ts
+++ b/src/servers/whatsapp.ts
@@ -157,7 +157,7 @@ function graphAuthError(): Response {
   });
 }
 
-async function appendEvent(state: WhatsAppServerState, event: ServerRequestEvent) {
+async function appendEvent(state: WhatsAppServerState, event: WhatsAppRecorderEvent) {
   await recordServerEvent({ event, onEvent: state.onEvent, recorderPath: state.recorderPath });
 }
 
@@ -512,6 +512,7 @@ async function handleRequest(params: { request: IncomingMessage; state: WhatsApp
   if (url.pathname === phoneNumberPath && params.request.method === "GET") {
     const body = queryRecord(url);
     await appendEvent(params.state, {
+      accepted: true,
       at: new Date().toISOString(),
       body,
       method: params.request.method,

--- a/src/servers/zalo.ts
+++ b/src/servers/zalo.ts
@@ -810,17 +810,20 @@ async function handleZaloMethod(
     return sendResponse;
   }
 
-  if (method !== "setWebhook") {
-    await appendEvent(state, event);
-  }
-
   if (method === "getMe") {
-    return zaloOk({
+    const getMeResponse = zaloOk({
       account_name: state.botName,
       account_type: "BASIC",
       can_join_groups: true,
       id: state.botId,
     });
+    event.accepted = getMeResponse.ok;
+    await appendEvent(state, event);
+    return getMeResponse;
+  }
+
+  if (method !== "setWebhook") {
+    await appendEvent(state, event);
   }
   if (method === "getUpdates") {
     if (state.webhook?.url || state.webhookTransitionPending) {

--- a/test/openclaw-artifact-generation.test.ts
+++ b/test/openclaw-artifact-generation.test.ts
@@ -185,6 +185,9 @@ describe("OpenClaw artifact generation publication", () => {
       ]) {
         expect((await fs.stat(path.join(outputDir, artifactPath))).mode & 0o777).toBe(0o600);
       }
+      await expect(
+        fs.readFile(path.join(outputDir, result.manifestPath), "utf8"),
+      ).resolves.not.toContain("recorderPath");
       expect(
         (
           await fs.stat(

--- a/test/openclaw-artifact-generation.test.ts
+++ b/test/openclaw-artifact-generation.test.ts
@@ -241,6 +241,47 @@ describe("OpenClaw artifact generation publication", () => {
     }
   });
 
+  it("rejects recorder references redirected outside the current generation", async () => {
+    const outputDir = await createTempDir();
+    try {
+      const first = await publishOpenClawCrablineArtifactGeneration(
+        publishParamsWithRecorderSnapshot(outputDir),
+        { createGenerationId: () => "11111111-1111-4111-8111-111111111111" },
+      );
+      const second = await publishOpenClawCrablineArtifactGeneration(
+        publishParamsWithRecorderSnapshot(outputDir),
+        { createGenerationId: () => "22222222-2222-4222-8222-222222222222" },
+      );
+      const firstManifest = JSON.parse(
+        await fs.readFile(path.join(outputDir, first.manifestPath), "utf8"),
+      ) as { recorderPath: string };
+      const secondManifestPath = path.join(outputDir, second.manifestPath);
+      const secondManifest = JSON.parse(await fs.readFile(secondManifestPath, "utf8")) as Record<
+        string,
+        unknown
+      >;
+      secondManifest.recorderPath = firstManifest.recorderPath;
+      await fs.writeFile(secondManifestPath, `${JSON.stringify(secondManifest)}\n`);
+
+      const readinessPath = path.join(outputDir, second.providerReadinessArtifactPath);
+      const readiness = JSON.parse(await fs.readFile(readinessPath, "utf8")) as {
+        providerReadiness: { result: { recorderPath: string } };
+        smoke: { result: { recorderPath: string } };
+      };
+      readiness.providerReadiness.result.recorderPath = firstManifest.recorderPath;
+      readiness.smoke.result.recorderPath = firstManifest.recorderPath;
+      await fs.writeFile(readinessPath, `${JSON.stringify(readiness)}\n`);
+
+      await expect(
+        publishOpenClawCrablineArtifactGeneration(publishParamsWithRecorderSnapshot(outputDir), {
+          createGenerationId: () => "33333333-3333-4333-8333-333333333333",
+        }),
+      ).rejects.toThrow("OpenClaw Crabline current artifact generation is incomplete.");
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
   it("preserves a generation when pointer publication fails after the rename", async () => {
     const outputDir = await createTempDir();
     const lock = createLock();

--- a/test/openclaw-artifact-generation.test.ts
+++ b/test/openclaw-artifact-generation.test.ts
@@ -258,6 +258,35 @@ describe("OpenClaw artifact generation publication", () => {
     }
   });
 
+  it("replaces a legacy generation without recorder evidence", async () => {
+    const outputDir = await createTempDir();
+    try {
+      const first = await publishOpenClawCrablineArtifactGeneration(publishParams(outputDir), {
+        createGenerationId: () => "11111111-1111-4111-8111-111111111111",
+      });
+      const pointerPath = path.join(outputDir, OPENCLAW_CRABLINE_ARTIFACT_POINTER_PATH);
+      const legacyPointer = JSON.parse(await fs.readFile(pointerPath, "utf8")) as Record<
+        string,
+        unknown
+      >;
+      delete legacyPointer.recorderSnapshotPath;
+      legacyPointer.version = 1;
+      await fs.writeFile(pointerPath, `${JSON.stringify(legacyPointer, null, 2)}\n`);
+
+      const replacement = await publishOpenClawCrablineArtifactGeneration(
+        publishParams(outputDir),
+        { createGenerationId: () => "22222222-2222-4222-8222-222222222222" },
+      );
+
+      expect(replacement).toMatchObject({
+        previousGeneration: first.generation,
+        version: 2,
+      });
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
   it("rejects a current pointer downgraded without a legacy manifest shape", async () => {
     const outputDir = await createTempDir();
     try {

--- a/test/openclaw-artifact-generation.test.ts
+++ b/test/openclaw-artifact-generation.test.ts
@@ -61,6 +61,16 @@ function publishParams(outputDir: string, lock = createLock()) {
   };
 }
 
+function publishParamsWithRecorderSnapshot(outputDir: string, lock = createLock()) {
+  return {
+    ...publishParams(outputDir, lock),
+    recorderSnapshot: {
+      contents: '{"accepted":true}\n',
+      fileName: "telegram-fake-provider.jsonl",
+    },
+  };
+}
+
 describe("OpenClaw artifact generation publication", () => {
   it("documents runtime pruning of abandoned artifact generations", async () => {
     const channelSetup = await fs.readFile(
@@ -191,6 +201,41 @@ describe("OpenClaw artifact generation publication", () => {
           "generation-11111111-1111-4111-8111-111111111111",
         ),
       );
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
+  it("rejects publication when the current generation lost its recorder snapshot", async () => {
+    const outputDir = await createTempDir();
+    const firstGeneration = "generation-11111111-1111-4111-8111-111111111111";
+    const secondGeneration = "generation-22222222-2222-4222-8222-222222222222";
+    try {
+      const first = await publishOpenClawCrablineArtifactGeneration(
+        publishParamsWithRecorderSnapshot(outputDir),
+        { createGenerationId: () => firstGeneration.slice("generation-".length) },
+      );
+      const second = await publishOpenClawCrablineArtifactGeneration(
+        publishParamsWithRecorderSnapshot(outputDir),
+        { createGenerationId: () => secondGeneration.slice("generation-".length) },
+      );
+      const secondManifest = JSON.parse(
+        await fs.readFile(path.join(outputDir, second.manifestPath), "utf8"),
+      ) as { recorderPath: string };
+      await fs.rm(path.join(outputDir, secondManifest.recorderPath));
+
+      await expect(
+        publishOpenClawCrablineArtifactGeneration(publishParamsWithRecorderSnapshot(outputDir), {
+          createGenerationId: () => "33333333-3333-4333-8333-333333333333",
+        }),
+      ).rejects.toThrow("OpenClaw Crabline current artifact generation is incomplete.");
+
+      await expect(readOpenClawCrablineArtifactPointer(outputDir)).resolves.toMatchObject({
+        generation: secondGeneration,
+        previousGeneration: firstGeneration,
+      });
+      await expect(fs.stat(path.join(outputDir, first.manifestPath))).resolves.toBeDefined();
+      await expect(fs.stat(path.join(outputDir, second.manifestPath))).resolves.toBeDefined();
     } finally {
       await disposeTempDir(outputDir);
     }

--- a/test/openclaw-artifact-generation.test.ts
+++ b/test/openclaw-artifact-generation.test.ts
@@ -213,6 +213,47 @@ describe("OpenClaw artifact generation publication", () => {
     }
   });
 
+  it("removes recorder references when publishing without a snapshot", async () => {
+    const outputDir = await createTempDir();
+    const params = publishParams(outputDir);
+    const paramsWithRecorderReference = {
+      ...params,
+      providerReadiness: {
+        result: {
+          proof: "provider-api-probe",
+          provider: "telegram",
+          ready: true,
+          recorderPath: "/tmp/crabline/telegram.jsonl",
+        },
+      },
+    };
+    try {
+      const first = await publishOpenClawCrablineArtifactGeneration(paramsWithRecorderReference, {
+        createGenerationId: () => "11111111-1111-4111-8111-111111111111",
+      });
+      const readiness = JSON.parse(
+        await fs.readFile(path.join(outputDir, first.providerReadinessArtifactPath), "utf8"),
+      ) as {
+        providerReadiness: { result: Record<string, unknown> };
+        smoke: { result: Record<string, unknown> };
+      };
+      expect(readiness.providerReadiness.result).not.toHaveProperty("recorderPath");
+      expect(readiness.smoke.result).not.toHaveProperty("recorderPath");
+
+      await expect(
+        publishOpenClawCrablineArtifactGeneration(paramsWithRecorderReference, {
+          createGenerationId: () => "22222222-2222-4222-8222-222222222222",
+        }),
+      ).resolves.toMatchObject({
+        previousGeneration: first.generation,
+        recorderSnapshotPath: null,
+        version: 2,
+      });
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
   it("replaces a legacy generation with an external recorder path", async () => {
     const outputDir = await createTempDir();
     try {

--- a/test/openclaw-artifact-generation.test.ts
+++ b/test/openclaw-artifact-generation.test.ts
@@ -96,6 +96,7 @@ describe("OpenClaw artifact generation publication", () => {
       const pointerPath = path.join(outputDir, OPENCLAW_CRABLINE_ARTIFACT_POINTER_PATH);
       const pointer = JSON.parse(await fs.readFile(pointerPath, "utf8")) as Record<string, unknown>;
       delete pointer.providerReadinessArtifactPath;
+      delete pointer.recorderSnapshotPath;
       pointer.version = 1;
       await fs.writeFile(pointerPath, `${JSON.stringify(pointer, null, 2)}\n`);
 
@@ -177,6 +178,7 @@ describe("OpenClaw artifact generation publication", () => {
         generation: result.generation,
         manifestPath: result.manifestPath,
         providerReadinessArtifactPath: result.providerReadinessArtifactPath,
+        recorderSnapshotPath: null,
         smokeArtifactPath: result.providerReadinessArtifactPath,
         version: 2,
       });
@@ -222,6 +224,7 @@ describe("OpenClaw artifact generation publication", () => {
         string,
         unknown
       >;
+      delete legacyPointer.recorderSnapshotPath;
       legacyPointer.version = 1;
       await fs.writeFile(pointerPath, `${JSON.stringify(legacyPointer, null, 2)}\n`);
 
@@ -250,6 +253,30 @@ describe("OpenClaw artifact generation publication", () => {
       await expect(
         fs.readFile(path.join(outputDir, replacement.manifestPath), "utf8"),
       ).resolves.not.toContain("recorderPath");
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
+  it("rejects a current pointer downgraded without a legacy manifest shape", async () => {
+    const outputDir = await createTempDir();
+    try {
+      await publishOpenClawCrablineArtifactGeneration(
+        publishParamsWithRecorderSnapshot(outputDir),
+        {
+          createGenerationId: () => "11111111-1111-4111-8111-111111111111",
+        },
+      );
+      const pointerPath = path.join(outputDir, OPENCLAW_CRABLINE_ARTIFACT_POINTER_PATH);
+      const pointer = JSON.parse(await fs.readFile(pointerPath, "utf8")) as Record<string, unknown>;
+      pointer.version = 1;
+      await fs.writeFile(pointerPath, `${JSON.stringify(pointer, null, 2)}\n`);
+
+      await expect(
+        publishOpenClawCrablineArtifactGeneration(publishParamsWithRecorderSnapshot(outputDir), {
+          createGenerationId: () => "22222222-2222-4222-8222-222222222222",
+        }),
+      ).rejects.toThrow("OpenClaw Crabline artifact pointer is malformed.");
     } finally {
       await disposeTempDir(outputDir);
     }
@@ -285,6 +312,40 @@ describe("OpenClaw artifact generation publication", () => {
       });
       await expect(fs.stat(path.join(outputDir, first.manifestPath))).resolves.toBeDefined();
       await expect(fs.stat(path.join(outputDir, second.manifestPath))).resolves.toBeDefined();
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
+  it("rejects publication when current recorder references are removed", async () => {
+    const outputDir = await createTempDir();
+    try {
+      const current = await publishOpenClawCrablineArtifactGeneration(
+        publishParamsWithRecorderSnapshot(outputDir),
+        { createGenerationId: () => "11111111-1111-4111-8111-111111111111" },
+      );
+      const manifestPath = path.join(outputDir, current.manifestPath);
+      const currentManifest = JSON.parse(await fs.readFile(manifestPath, "utf8")) as Record<
+        string,
+        unknown
+      >;
+      delete currentManifest.recorderPath;
+      await fs.writeFile(manifestPath, `${JSON.stringify(currentManifest, null, 2)}\n`);
+
+      const readinessPath = path.join(outputDir, current.providerReadinessArtifactPath);
+      const readiness = JSON.parse(await fs.readFile(readinessPath, "utf8")) as {
+        providerReadiness: { result: Record<string, unknown> };
+        smoke: { result: Record<string, unknown> };
+      };
+      delete readiness.providerReadiness.result.recorderPath;
+      delete readiness.smoke.result.recorderPath;
+      await fs.writeFile(readinessPath, `${JSON.stringify(readiness, null, 2)}\n`);
+
+      await expect(
+        publishOpenClawCrablineArtifactGeneration(publishParamsWithRecorderSnapshot(outputDir), {
+          createGenerationId: () => "22222222-2222-4222-8222-222222222222",
+        }),
+      ).rejects.toThrow("OpenClaw Crabline current artifact generation is incomplete.");
     } finally {
       await disposeTempDir(outputDir);
     }
@@ -330,6 +391,32 @@ describe("OpenClaw artifact generation publication", () => {
       await disposeTempDir(outputDir);
     }
   });
+
+  it.skipIf(process.platform === "win32")(
+    "rejects a current generation redirected through a directory symlink",
+    async () => {
+      const outputDir = await createTempDir();
+      const storePath = path.join(outputDir, OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY);
+      try {
+        const current = await publishOpenClawCrablineArtifactGeneration(
+          publishParamsWithRecorderSnapshot(outputDir),
+          { createGenerationId: () => "11111111-1111-4111-8111-111111111111" },
+        );
+        const generationPath = path.join(storePath, current.generation);
+        const displacedPath = `${generationPath}.displaced`;
+        await fs.rename(generationPath, displacedPath);
+        await fs.symlink(displacedPath, generationPath, "dir");
+
+        await expect(
+          publishOpenClawCrablineArtifactGeneration(publishParamsWithRecorderSnapshot(outputDir), {
+            createGenerationId: () => "22222222-2222-4222-8222-222222222222",
+          }),
+        ).rejects.toThrow("OpenClaw Crabline current artifact generation is incomplete.");
+      } finally {
+        await disposeTempDir(outputDir);
+      }
+    },
+  );
 
   it("preserves a generation when pointer publication fails after the rename", async () => {
     const outputDir = await createTempDir();

--- a/test/openclaw-artifact-generation.test.ts
+++ b/test/openclaw-artifact-generation.test.ts
@@ -96,11 +96,13 @@ describe("OpenClaw artifact generation publication", () => {
       const pointerPath = path.join(outputDir, OPENCLAW_CRABLINE_ARTIFACT_POINTER_PATH);
       const pointer = JSON.parse(await fs.readFile(pointerPath, "utf8")) as Record<string, unknown>;
       delete pointer.providerReadinessArtifactPath;
+      pointer.version = 1;
       await fs.writeFile(pointerPath, `${JSON.stringify(pointer, null, 2)}\n`);
 
       await expect(readOpenClawCrablineArtifactPointer(outputDir)).resolves.toMatchObject({
         providerReadinessArtifactPath: result.providerReadinessArtifactPath,
         smokeArtifactPath: result.smokeArtifactPath,
+        version: 1,
       });
     } finally {
       await disposeTempDir(outputDir);
@@ -176,7 +178,7 @@ describe("OpenClaw artifact generation publication", () => {
         manifestPath: result.manifestPath,
         providerReadinessArtifactPath: result.providerReadinessArtifactPath,
         smokeArtifactPath: result.providerReadinessArtifactPath,
-        version: 1,
+        version: 2,
       });
       for (const artifactPath of [
         result.manifestPath,
@@ -204,6 +206,50 @@ describe("OpenClaw artifact generation publication", () => {
           "generation-11111111-1111-4111-8111-111111111111",
         ),
       );
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
+  it("replaces a legacy generation with an external recorder path", async () => {
+    const outputDir = await createTempDir();
+    try {
+      const first = await publishOpenClawCrablineArtifactGeneration(publishParams(outputDir), {
+        createGenerationId: () => "11111111-1111-4111-8111-111111111111",
+      });
+      const pointerPath = path.join(outputDir, OPENCLAW_CRABLINE_ARTIFACT_POINTER_PATH);
+      const legacyPointer = JSON.parse(await fs.readFile(pointerPath, "utf8")) as Record<
+        string,
+        unknown
+      >;
+      legacyPointer.version = 1;
+      await fs.writeFile(pointerPath, `${JSON.stringify(legacyPointer, null, 2)}\n`);
+
+      const legacyManifestPath = path.join(outputDir, first.manifestPath);
+      const legacyManifest = JSON.parse(await fs.readFile(legacyManifestPath, "utf8")) as Record<
+        string,
+        unknown
+      >;
+      legacyManifest.recorderPath = "/tmp/crabline/legacy-telegram.jsonl";
+      await fs.writeFile(legacyManifestPath, `${JSON.stringify(legacyManifest, null, 2)}\n`);
+
+      const replacement = await publishOpenClawCrablineArtifactGeneration(
+        publishParams(outputDir),
+        { createGenerationId: () => "22222222-2222-4222-8222-222222222222" },
+      );
+
+      expect(replacement).toMatchObject({
+        previousGeneration: first.generation,
+        version: 2,
+      });
+      await expect(readOpenClawCrablineArtifactPointer(outputDir)).resolves.toMatchObject({
+        generation: replacement.generation,
+        previousGeneration: first.generation,
+        version: 2,
+      });
+      await expect(
+        fs.readFile(path.join(outputDir, replacement.manifestPath), "utf8"),
+      ).resolves.not.toContain("recorderPath");
     } finally {
       await disposeTempDir(outputDir);
     }

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -3111,6 +3111,8 @@ describe("OpenClaw local provider bridge", () => {
     ["malformed", "not-json\n"],
     ["non-record JSON", "null\n42\n[]\n"],
     ["unrelated object", "{}\n"],
+    ["rejected event", recorderProbeLine({ accepted: false })],
+    ["non-boolean acceptance", recorderProbeLine({ accepted: "true" })],
     ["valid event followed by malformed JSON", `${recorderProbeLine()}not-json\n`],
   ])("fails closed on %s readiness recorder evidence", async (_label, recorderContents) => {
     const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-recorder-invalid-"));

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -145,6 +145,18 @@ async function readPublishedArtifactGeneration(
   );
 }
 
+function recorderProbeLine(extra: Record<string, unknown> = {}): string {
+  return `${JSON.stringify({
+    accepted: true,
+    at: "2026-07-13T00:00:00.000Z",
+    method: "GET",
+    path: "/probe",
+    query: {},
+    type: "api",
+    ...extra,
+  })}\n`;
+}
+
 const manifest: CrablineServerManifest = {
   adminToken: "crabline-admin-token",
   baseUrl: "http://127.0.0.1:1234",
@@ -2846,7 +2858,7 @@ describe("OpenClaw local provider bridge", () => {
                 recorderPath: params.recorderPath!,
               },
               probe: async () => {
-                await fs.writeFile(params.recorderPath!, '{"event":"probe"}\n');
+                await fs.writeFile(params.recorderPath!, recorderProbeLine());
                 return {
                   ok: true,
                   result: {
@@ -2979,7 +2991,7 @@ describe("OpenClaw local provider bridge", () => {
       );
       await expect(
         fs.readFile(path.join(outputDir, writtenManifest.recorderPath!), "utf8"),
-      ).resolves.toBe('{"event":"probe"}\n');
+      ).resolves.toBe(recorderProbeLine());
       expect(
         (await fs.readdir(path.join(outputDir, "artifacts", "crabline"))).filter((entry) =>
           entry.endsWith(".tmp"),
@@ -3022,7 +3034,7 @@ describe("OpenClaw local provider bridge", () => {
           {
             startAdapter: async (params) => {
               recorderPath = params.recorderPath;
-              await fs.writeFile(recorderPath!, '{"event":"probe"}\n');
+              await fs.writeFile(recorderPath!, recorderProbeLine());
               return {
                 close: async () => undefined,
                 manifest: { ...manifest, recorderPath: recorderPath! },
@@ -3098,6 +3110,8 @@ describe("OpenClaw local provider bridge", () => {
     ["whitespace-only", " \n\t\r\n"],
     ["malformed", "not-json\n"],
     ["non-record JSON", "null\n42\n[]\n"],
+    ["unrelated object", "{}\n"],
+    ["valid event followed by malformed JSON", `${recorderProbeLine()}not-json\n`],
   ])("fails closed on %s readiness recorder evidence", async (_label, recorderContents) => {
     const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-recorder-invalid-"));
     const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
@@ -3145,10 +3159,7 @@ describe("OpenClaw local provider bridge", () => {
     let run = 0;
     const startAdapter = async (params: Parameters<typeof startOpenClawCrablineAdapter>[0]) => {
       const currentRun = ++run;
-      await fs.writeFile(
-        params.recorderPath!,
-        `${JSON.stringify({ event: "probe", run: currentRun })}\n`,
-      );
+      await fs.writeFile(params.recorderPath!, recorderProbeLine({ run: currentRun }));
       return {
         close: async () => undefined,
         manifest: {
@@ -3166,7 +3177,7 @@ describe("OpenClaw local provider bridge", () => {
       const firstRecorderPath = (first.providerReadiness as { result: { recorderPath: string } })
         .result.recorderPath;
       await expect(fs.readFile(path.join(outputDir, firstRecorderPath), "utf8")).resolves.toBe(
-        '{"event":"probe","run":1}\n',
+        recorderProbeLine({ run: 1 }),
       );
 
       const second = await runProviderReadinessWithDependencies(
@@ -3178,15 +3189,57 @@ describe("OpenClaw local provider bridge", () => {
 
       expect(secondRecorderPath).not.toBe(firstRecorderPath);
       await expect(fs.readFile(path.join(outputDir, firstRecorderPath), "utf8")).resolves.toBe(
-        '{"event":"probe","run":1}\n',
+        recorderProbeLine({ run: 1 }),
       );
       await expect(fs.readFile(path.join(outputDir, secondRecorderPath), "utf8")).resolves.toBe(
-        '{"event":"probe","run":2}\n',
+        recorderProbeLine({ run: 2 }),
       );
     } finally {
       await fs.rm(outputDir, { recursive: true, force: true });
     }
   });
+
+  it.each(["artifacts", "recorder"] as const)(
+    "rejects a symlinked %s directory without touching external recorder files",
+    async (component) => {
+      if (process.platform === "win32") {
+        return;
+      }
+      const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-recorder-symlink-"));
+      const externalDirectory = await fs.mkdtemp(
+        path.join(os.tmpdir(), "crabline-recorder-external-"),
+      );
+      const staleName = ".telegram-fake-provider.11111111-1111-4111-8111-111111111111.jsonl.tmp";
+      const sentinelPath = path.join(externalDirectory, staleName);
+      const startAdapter = vi.fn<typeof startOpenClawCrablineAdapter>();
+      try {
+        await fs.writeFile(sentinelPath, "preserve\n");
+        if (component === "artifacts") {
+          await fs.symlink(externalDirectory, path.join(outputDir, "artifacts"), "dir");
+        } else {
+          const artifactsDirectory = path.join(outputDir, "artifacts");
+          await fs.mkdir(artifactsDirectory);
+          await fs.symlink(externalDirectory, path.join(artifactsDirectory, "crabline"), "dir");
+        }
+
+        await expect(
+          runProviderReadinessWithDependencies(
+            {
+              outputDir,
+              selection: resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" }),
+            },
+            { startAdapter },
+          ),
+        ).rejects.toThrow("Private directory path identity changed during publication.");
+
+        expect(startAdapter).not.toHaveBeenCalled();
+        await expect(fs.readFile(sentinelPath, "utf8")).resolves.toBe("preserve\n");
+      } finally {
+        await fs.rm(outputDir, { recursive: true, force: true });
+        await fs.rm(externalDirectory, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("reclaims only exact stale readiness recorder temporaries", async () => {
     const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-recorder-recovery-"));
@@ -3217,7 +3270,7 @@ describe("OpenClaw local provider bridge", () => {
         { outputDir, selection },
         {
           startAdapter: async (params) => {
-            await fs.writeFile(params.recorderPath!, '{"event":"probe"}\n');
+            await fs.writeFile(params.recorderPath!, recorderProbeLine());
             return {
               close: async () => undefined,
               manifest: { ...manifest, recorderPath: params.recorderPath! },
@@ -3268,7 +3321,7 @@ describe("OpenClaw local provider bridge", () => {
     const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
     let rmSpy: ReturnType<typeof vi.spyOn> | undefined;
     const startAdapter = async (params: Parameters<typeof startOpenClawCrablineAdapter>[0]) => {
-      await fs.writeFile(params.recorderPath!, '{"event":"probe"}\n');
+      await fs.writeFile(params.recorderPath!, recorderProbeLine());
       return {
         close: async () => undefined,
         manifest: { ...manifest, recorderPath: params.recorderPath! },
@@ -3340,7 +3393,7 @@ describe("OpenClaw local provider bridge", () => {
           { outputDir, selection },
           {
             startAdapter: async (params) => {
-              await fs.writeFile(params.recorderPath!, '{"event":"probe"}\n');
+              await fs.writeFile(params.recorderPath!, recorderProbeLine());
               return {
                 close: async () => undefined,
                 manifest: { ...manifest, recorderPath: params.recorderPath! },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where OpenClaw smoke runs could accept stale, foreign, incomplete, or internally inconsistent artifact generations, allowing later runs to consume invalid readiness and recorder evidence.

## Why This Change Was Made

Artifact publication now uses versioned generation metadata, generation-local recorder snapshots, strict readiness acceptance evidence, and identity-fenced publication and retention. Legacy generations migrate through explicit compatibility rules without weakening new v2 validation.

## User Impact

Operators get deterministic, self-consistent smoke artifacts: malformed or cross-generation evidence is rejected, valid legacy output migrates, and recorderless publications remain reusable.

## Evidence

- 118 focused artifact and OpenClaw tests passed
- `pnpm lint` passed
- `pnpm build` passed
- exact-current gpt-5.6-sol high autoreview clean (0.86) after fixing recorderless readiness references
- GitHub CI `verify` passed; CodeQL skipped for this event
- Crabbox `pnpm verify` passed: 63 files, 1351 tests passed, 1 skipped (`run_6780507efd21`, lease `cbx_ad969a28ef02` auto-released)
- preserved pre-existing local artifact hash unchanged throughout testing
- public-data diff scan clean
- Unreleased changelog entry included