### PR TITLE
fix(script): terminate Windows process trees reliably

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Case-fold Zalo recorder credential keys and fully redact ambiguous malformed URL authorities.
 - Keep lazy provider watches registered for cleanup after nonterminal iterator throws.
 - Version artifact generations so legacy recorder manifests can migrate while new snapshots retain explicit presence, locality, identity, and completeness checks.
+- Terminate complete Windows script process trees through kill-on-close Job Objects.
 - Randomize WhatsApp XEdDSA signatures with fresh entropy while preserving their wire encoding.
 - Suppress serve readiness output when shutdown begins during ready-file publication.
 - Treat Unicode format characters as continuations when recognizing standalone acknowledgement tokens.

--- a/src/providers/builtin/script.ts
+++ b/src/providers/builtin/script.ts
@@ -469,7 +469,12 @@ async function spawnScriptChild(
       stdio: ["pipe", "pipe", "pipe"],
     });
   }
-  return { child, observedAtMs: Date.now(), startedAtMs };
+  const observedAtMs = Date.now();
+  if (signal?.aborted) {
+    await terminateChild(child, startedAtMs, observedAtMs);
+    throw signal.reason ?? new Error("Script command aborted.");
+  }
+  return { child, observedAtMs, startedAtMs };
 }
 
 type ScriptWatchIterator = AsyncIterableIterator<InboundEnvelope> & {

--- a/src/providers/builtin/script.ts
+++ b/src/providers/builtin/script.ts
@@ -272,7 +272,13 @@ function ensureWindowsJobHelper(): string | undefined {
   if (windowsJobHelperPath !== undefined) {
     return windowsJobHelperPath ?? undefined;
   }
-  const directory = mkdtempSync(path.join(tmpdir(), "crabline-script-job-"));
+  let directory: string;
+  try {
+    directory = mkdtempSync(path.join(tmpdir(), "crabline-script-job-"));
+  } catch {
+    windowsJobHelperPath = null;
+    return undefined;
+  }
   const helperPath = path.join(directory, "crabline-script-job.exe");
   try {
     execFileSync(

--- a/src/providers/builtin/script.ts
+++ b/src/providers/builtin/script.ts
@@ -1,4 +1,11 @@
-import { spawn, type ChildProcess, type ChildProcessByStdio } from "node:child_process";
+import {
+  execFileSync,
+  spawn,
+  type ChildProcess,
+  type ChildProcessByStdio,
+} from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import type { Readable, Writable } from "node:stream";
 import { z } from "zod";
@@ -16,6 +23,200 @@ const MAX_SCRIPT_OUTPUT_BYTES = 1024 * 1024;
 const SCRIPT_WAIT_EXIT_GRACE_MS = 250;
 const CHILD_CLOSE_TIMEOUT_MS = 1_000;
 const WINDOWS_TERMINATION_COMMAND_TIMEOUT_MS = 2_500;
+const WINDOWS_JOB_COMMAND_ENV = "CRABLINE_INTERNAL_SCRIPT_JOB_COMMAND";
+const WINDOWS_JOB_SHELL_ENV = "CRABLINE_INTERNAL_SCRIPT_JOB_SHELL";
+const WINDOWS_JOB_HELPER_SOURCE_ENV = "CRABLINE_INTERNAL_SCRIPT_JOB_HELPER_SOURCE";
+const WINDOWS_JOB_HELPER_OUTPUT_ENV = "CRABLINE_INTERNAL_SCRIPT_JOB_HELPER_OUTPUT";
+const WINDOWS_JOB_HELPER_SOURCE = [
+  "using System;",
+  "using System.ComponentModel;",
+  "using System.Runtime.InteropServices;",
+  "using System.Text;",
+  "public static class CrablineScriptJob{",
+  "private const uint CreateSuspended=0x00000004;",
+  "private const uint ExtendedStartupInfoPresent=0x00080000;",
+  "private const uint Infinite=0xffffffff;",
+  "private const uint JobObjectLimitKillOnJobClose=0x00002000;",
+  "private const int ProcThreadAttributeJobList=0x0002000d;",
+  "private const uint StartfUseStdHandles=0x00000100;",
+  "private const uint DuplicateSameAccess=0x00000002;",
+  "private const uint ResumeThreadFailed=0xffffffff;",
+  "private const int JobObjectExtendedLimitInformationClass=9;",
+  "private const int StdInputHandle=-10;",
+  "private const int StdOutputHandle=-11;",
+  "private const int StdErrorHandle=-12;",
+  "[StructLayout(LayoutKind.Sequential)]",
+  "private struct ProcessInformation{",
+  "public IntPtr Process;",
+  "public IntPtr Thread;",
+  "public uint ProcessId;",
+  "public uint ThreadId;",
+  "}",
+  "[StructLayout(LayoutKind.Sequential)]",
+  "private struct StartupInfo{",
+  "public int Size;",
+  "public IntPtr Reserved;",
+  "public IntPtr Desktop;",
+  "public IntPtr Title;",
+  "public int X;",
+  "public int Y;",
+  "public int XSize;",
+  "public int YSize;",
+  "public int XCountChars;",
+  "public int YCountChars;",
+  "public int FillAttribute;",
+  "public uint Flags;",
+  "public short ShowWindow;",
+  "public short Reserved2Size;",
+  "public IntPtr Reserved2;",
+  "public IntPtr StandardInput;",
+  "public IntPtr StandardOutput;",
+  "public IntPtr StandardError;",
+  "}",
+  "[StructLayout(LayoutKind.Sequential)]",
+  "private struct StartupInfoEx{",
+  "public StartupInfo StartupInfo;",
+  "public IntPtr AttributeList;",
+  "}",
+  "[StructLayout(LayoutKind.Sequential)]",
+  "private struct JobObjectBasicLimitInformation{",
+  "public long PerProcessUserTimeLimit;",
+  "public long PerJobUserTimeLimit;",
+  "public uint LimitFlags;",
+  "public UIntPtr MinimumWorkingSetSize;",
+  "public UIntPtr MaximumWorkingSetSize;",
+  "public uint ActiveProcessLimit;",
+  "public IntPtr Affinity;",
+  "public uint PriorityClass;",
+  "public uint SchedulingClass;",
+  "}",
+  "[StructLayout(LayoutKind.Sequential)]",
+  "private struct IoCounters{",
+  "public ulong ReadOperationCount;",
+  "public ulong WriteOperationCount;",
+  "public ulong OtherOperationCount;",
+  "public ulong ReadTransferCount;",
+  "public ulong WriteTransferCount;",
+  "public ulong OtherTransferCount;",
+  "}",
+  "[StructLayout(LayoutKind.Sequential)]",
+  "private struct JobObjectExtendedLimitInformation{",
+  "public JobObjectBasicLimitInformation BasicLimitInformation;",
+  "public IoCounters IoInfo;",
+  "public UIntPtr ProcessMemoryLimit;",
+  "public UIntPtr JobMemoryLimit;",
+  "public UIntPtr PeakProcessMemoryUsed;",
+  "public UIntPtr PeakJobMemoryUsed;",
+  "}",
+  '[DllImport("kernel32.dll",SetLastError=true,CharSet=CharSet.Unicode)]',
+  "[return:MarshalAs(UnmanagedType.Bool)]",
+  "private static extern bool CreateProcess(string applicationName,StringBuilder commandLine,IntPtr processAttributes,IntPtr threadAttributes,bool inheritHandles,uint creationFlags,IntPtr environment,string currentDirectory,ref StartupInfoEx startupInfo,out ProcessInformation processInformation);",
+  '[DllImport("kernel32.dll",SetLastError=true)]',
+  "private static extern IntPtr CreateJobObject(IntPtr jobAttributes,string name);",
+  '[DllImport("kernel32.dll",SetLastError=true)]',
+  "[return:MarshalAs(UnmanagedType.Bool)]",
+  "private static extern bool SetInformationJobObject(IntPtr job,int informationClass,ref JobObjectExtendedLimitInformation information,uint informationLength);",
+  '[DllImport("kernel32.dll",SetLastError=true)]',
+  "[return:MarshalAs(UnmanagedType.Bool)]",
+  "private static extern bool InitializeProcThreadAttributeList(IntPtr attributeList,int attributeCount,int flags,ref IntPtr size);",
+  '[DllImport("kernel32.dll",SetLastError=true)]',
+  "[return:MarshalAs(UnmanagedType.Bool)]",
+  "private static extern bool UpdateProcThreadAttribute(IntPtr attributeList,uint flags,IntPtr attribute,IntPtr value,IntPtr size,IntPtr previousValue,IntPtr returnSize);",
+  '[DllImport("kernel32.dll")]',
+  "private static extern void DeleteProcThreadAttributeList(IntPtr attributeList);",
+  '[DllImport("kernel32.dll",SetLastError=true)]',
+  "[return:MarshalAs(UnmanagedType.Bool)]",
+  "private static extern bool DuplicateHandle(IntPtr sourceProcess,IntPtr sourceHandle,IntPtr targetProcess,out IntPtr targetHandle,uint desiredAccess,bool inheritHandle,uint options);",
+  '[DllImport("kernel32.dll")]',
+  "private static extern IntPtr GetCurrentProcess();",
+  '[DllImport("kernel32.dll",SetLastError=true)]',
+  "private static extern IntPtr GetStdHandle(int standardHandle);",
+  '[DllImport("kernel32.dll",SetLastError=true)]',
+  "private static extern uint ResumeThread(IntPtr thread);",
+  '[DllImport("kernel32.dll",SetLastError=true)]',
+  "private static extern uint WaitForSingleObject(IntPtr handle,uint milliseconds);",
+  '[DllImport("kernel32.dll",SetLastError=true)]',
+  "[return:MarshalAs(UnmanagedType.Bool)]",
+  "private static extern bool GetExitCodeProcess(IntPtr process,out uint exitCode);",
+  '[DllImport("kernel32.dll",SetLastError=true)]',
+  "[return:MarshalAs(UnmanagedType.Bool)]",
+  "private static extern bool TerminateProcess(IntPtr process,uint exitCode);",
+  '[DllImport("kernel32.dll")]',
+  "[return:MarshalAs(UnmanagedType.Bool)]",
+  "private static extern bool CloseHandle(IntPtr handle);",
+  "private static void ThrowLastError(string operation){throw new Win32Exception(Marshal.GetLastWin32Error(),operation);}",
+  "private static IntPtr DuplicateStandardHandle(int standardHandle){",
+  "IntPtr source=GetStdHandle(standardHandle);",
+  "IntPtr duplicate=IntPtr.Zero;",
+  "IntPtr process=GetCurrentProcess();",
+  'if(source==IntPtr.Zero||source==new IntPtr(-1)||!DuplicateHandle(process,source,process,out duplicate,0,true,DuplicateSameAccess)){ThrowLastError("Could not duplicate a script standard handle.");}',
+  "return duplicate;",
+  "}",
+  "private static int Run(string applicationName,string commandLine){",
+  "IntPtr job=IntPtr.Zero;",
+  "IntPtr attributeList=IntPtr.Zero;",
+  "IntPtr jobList=IntPtr.Zero;",
+  "IntPtr standardInput=IntPtr.Zero;",
+  "IntPtr standardOutput=IntPtr.Zero;",
+  "IntPtr standardError=IntPtr.Zero;",
+  "ProcessInformation processInformation=new ProcessInformation();",
+  "bool processCreated=false;",
+  "try{",
+  "job=CreateJobObject(IntPtr.Zero,null);",
+  'if(job==IntPtr.Zero){ThrowLastError("Could not create the script job object.");}',
+  "JobObjectExtendedLimitInformation limits=new JobObjectExtendedLimitInformation();",
+  "limits.BasicLimitInformation.LimitFlags=JobObjectLimitKillOnJobClose;",
+  'if(!SetInformationJobObject(job,JobObjectExtendedLimitInformationClass,ref limits,(uint)Marshal.SizeOf(typeof(JobObjectExtendedLimitInformation)))){ThrowLastError("Could not configure the script job object.");}',
+  "IntPtr attributeListSize=IntPtr.Zero;",
+  "InitializeProcThreadAttributeList(IntPtr.Zero,1,0,ref attributeListSize);",
+  "attributeList=Marshal.AllocHGlobal(attributeListSize);",
+  'if(!InitializeProcThreadAttributeList(attributeList,1,0,ref attributeListSize)){ThrowLastError("Could not initialize the script job attribute list.");}',
+  "jobList=Marshal.AllocHGlobal(IntPtr.Size);",
+  "Marshal.WriteIntPtr(jobList,job);",
+  'if(!UpdateProcThreadAttribute(attributeList,0,new IntPtr(ProcThreadAttributeJobList),jobList,new IntPtr(IntPtr.Size),IntPtr.Zero,IntPtr.Zero)){ThrowLastError("Could not bind the script process to its job object.");}',
+  "standardInput=DuplicateStandardHandle(StdInputHandle);",
+  "standardOutput=DuplicateStandardHandle(StdOutputHandle);",
+  "standardError=DuplicateStandardHandle(StdErrorHandle);",
+  "StartupInfoEx startupInfo=new StartupInfoEx();",
+  "startupInfo.StartupInfo.Size=Marshal.SizeOf(typeof(StartupInfoEx));",
+  "startupInfo.StartupInfo.Flags=StartfUseStdHandles;",
+  "startupInfo.StartupInfo.StandardInput=standardInput;",
+  "startupInfo.StartupInfo.StandardOutput=standardOutput;",
+  "startupInfo.StartupInfo.StandardError=standardError;",
+  "startupInfo.AttributeList=attributeList;",
+  'if(!CreateProcess(applicationName,new StringBuilder(commandLine),IntPtr.Zero,IntPtr.Zero,true,CreateSuspended|ExtendedStartupInfoPresent,IntPtr.Zero,Environment.CurrentDirectory,ref startupInfo,out processInformation)){ThrowLastError("Could not start the script command.");}',
+  "processCreated=true;",
+  'if(ResumeThread(processInformation.Thread)==ResumeThreadFailed){ThrowLastError("Could not resume the script command.");}',
+  'if(WaitForSingleObject(processInformation.Process,Infinite)==Infinite){ThrowLastError("Could not wait for the script command.");}',
+  "uint exitCode;",
+  'if(!GetExitCodeProcess(processInformation.Process,out exitCode)){ThrowLastError("Could not read the script exit code.");}',
+  "return unchecked((int)exitCode);",
+  "}finally{",
+  "if(processCreated&&processInformation.Process!=IntPtr.Zero){TerminateProcess(processInformation.Process,1);}",
+  "if(processInformation.Thread!=IntPtr.Zero){CloseHandle(processInformation.Thread);}",
+  "if(processInformation.Process!=IntPtr.Zero){CloseHandle(processInformation.Process);}",
+  "if(standardInput!=IntPtr.Zero){CloseHandle(standardInput);}",
+  "if(standardOutput!=IntPtr.Zero){CloseHandle(standardOutput);}",
+  "if(standardError!=IntPtr.Zero){CloseHandle(standardError);}",
+  "if(attributeList!=IntPtr.Zero){DeleteProcThreadAttributeList(attributeList);Marshal.FreeHGlobal(attributeList);}",
+  "if(jobList!=IntPtr.Zero){Marshal.FreeHGlobal(jobList);}",
+  "if(job!=IntPtr.Zero){CloseHandle(job);}",
+  "}",
+  "}",
+  "public static int Main(){",
+  "try{",
+  `string shellValue=Environment.GetEnvironmentVariable("${WINDOWS_JOB_SHELL_ENV}");`,
+  `string commandValue=Environment.GetEnvironmentVariable("${WINDOWS_JOB_COMMAND_ENV}");`,
+  `Environment.SetEnvironmentVariable("${WINDOWS_JOB_SHELL_ENV}",null);`,
+  `Environment.SetEnvironmentVariable("${WINDOWS_JOB_COMMAND_ENV}",null);`,
+  'if(String.IsNullOrEmpty(shellValue)||String.IsNullOrEmpty(commandValue)){throw new InvalidOperationException("Missing script job configuration.");}',
+  "string shell=Encoding.UTF8.GetString(Convert.FromBase64String(shellValue));",
+  "string commandLine=Encoding.UTF8.GetString(Convert.FromBase64String(commandValue));",
+  "return Run(shell,commandLine);",
+  "}catch(Exception error){Console.Error.WriteLine(error.Message);return 1;}",
+  "}",
+  "}",
+].join("");
 const WINDOWS_PROCESS_TERMINATOR_SOURCE = [
   "using System;",
   "using System.Runtime.InteropServices;",
@@ -55,6 +256,142 @@ const WINDOWS_PROCESS_TERMINATOR_SOURCE = [
   "}",
   "}",
 ].join("");
+
+let windowsJobHelperPath: string | undefined;
+
+function removeWindowsJobHelper(directory: string): void {
+  try {
+    rmSync(directory, { force: true, recursive: true });
+  } catch {
+    // The helper may still be exiting during process shutdown.
+  }
+}
+
+function ensureWindowsJobHelper(): string {
+  if (windowsJobHelperPath) {
+    return windowsJobHelperPath;
+  }
+  const directory = mkdtempSync(path.join(tmpdir(), "crabline-script-job-"));
+  const helperPath = path.join(directory, "crabline-script-job.exe");
+  try {
+    execFileSync(
+      "powershell.exe",
+      [
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        `Add-Type -TypeDefinition $env:${WINDOWS_JOB_HELPER_SOURCE_ENV} -Language CSharp -OutputAssembly $env:${WINDOWS_JOB_HELPER_OUTPUT_ENV} -OutputType ConsoleApplication`,
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          [WINDOWS_JOB_HELPER_OUTPUT_ENV]: helperPath,
+          [WINDOWS_JOB_HELPER_SOURCE_ENV]: WINDOWS_JOB_HELPER_SOURCE,
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+        timeout: 15_000,
+        windowsHide: true,
+      },
+    );
+  } catch (error) {
+    removeWindowsJobHelper(directory);
+    const stderr =
+      typeof (error as { stderr?: unknown }).stderr === "string"
+        ? (error as { stderr: string }).stderr.trim()
+        : "";
+    throw new Error(
+      stderr
+        ? `Windows script job helper compilation failed.\n${stderr}`
+        : "Windows script job helper compilation failed.",
+      { cause: error },
+    );
+  }
+  windowsJobHelperPath = helperPath;
+  process.once("exit", () => removeWindowsJobHelper(directory));
+  return helperPath;
+}
+
+function quoteWindowsArgument(value: string): string {
+  if (!value) {
+    return '""';
+  }
+  if (!/[\s"]/u.test(value)) {
+    return value;
+  }
+  let quoted = '"';
+  let backslashes = 0;
+  for (const character of value) {
+    if (character === "\\") {
+      backslashes += 1;
+      continue;
+    }
+    if (character === '"') {
+      quoted += `${"\\".repeat(backslashes * 2 + 1)}"`;
+      backslashes = 0;
+      continue;
+    }
+    quoted += "\\".repeat(backslashes) + character;
+    backslashes = 0;
+  }
+  return `${quoted}${"\\".repeat(backslashes * 2)}"`;
+}
+
+function windowsShellCommand(
+  command: string,
+  shell?: string,
+): {
+  commandLine: string;
+  shell: string;
+} {
+  const resolvedShell = shell ?? process.env.ComSpec ?? process.env.COMSPEC ?? "cmd.exe";
+  const shellCommand = quoteWindowsArgument(resolvedShell);
+  const shellName = path.win32.basename(resolvedShell).toLowerCase();
+  return {
+    commandLine:
+      shellName === "cmd" || shellName === "cmd.exe"
+        ? `${shellCommand} /d /s /c "${command}"`
+        : `${shellCommand} -c ${quoteWindowsArgument(command)}`,
+    shell: resolvedShell,
+  };
+}
+
+function spawnScriptChild(params: {
+  command: string;
+  cwd?: string | undefined;
+  shell?: string | undefined;
+}): { child: SpawnedScriptChild; observedAtMs: number; startedAtMs: number } {
+  const cwd = params.cwd ? path.resolve(params.cwd) : process.cwd();
+  let startedAtMs: number;
+  let child: SpawnedScriptChild;
+  if (process.platform === "win32") {
+    const helperPath = ensureWindowsJobHelper();
+    const shellCommand = windowsShellCommand(params.command, params.shell);
+    startedAtMs = Date.now();
+    child = spawn(helperPath, [], {
+      cwd,
+      env: {
+        ...process.env,
+        [WINDOWS_JOB_COMMAND_ENV]: Buffer.from(shellCommand.commandLine).toString("base64"),
+        [WINDOWS_JOB_SHELL_ENV]: Buffer.from(shellCommand.shell).toString("base64"),
+      },
+      shell: false,
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+    });
+  } else {
+    startedAtMs = Date.now();
+    child = spawn(params.command, {
+      cwd,
+      env: process.env,
+      shell: params.shell ?? true,
+      detached: true,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+  }
+  return { child, observedAtMs: Date.now(), startedAtMs };
+}
 
 type ScriptWatchIterator = AsyncIterableIterator<InboundEnvelope> & {
   [Symbol.asyncIterator](): ScriptWatchIterator;
@@ -237,7 +574,7 @@ async function terminateChild(
     const childRunning = isChildRunning(child);
     if (process.platform === "win32") {
       if (child.pid) {
-        await runTerminationCommand("powershell.exe", [
+        const treeTerminated = await runTerminationCommand("powershell.exe", [
           "-NoLogo",
           "-NoProfile",
           "-NonInteractive",
@@ -249,6 +586,13 @@ async function terminateChild(
             childRunning,
           ),
         ]);
+        if (!treeTerminated && isChildRunning(child)) {
+          try {
+            child.kill("SIGKILL");
+          } catch {
+            // Closing the helper handle is the bounded fallback for its Job Object.
+          }
+        }
       }
     } else if (child.pid) {
       try {
@@ -818,18 +1162,15 @@ function runScript<T>(params: {
     params.shell,
   );
   return new Promise((resolve, reject) => {
-    const childStartedAtMs = Date.now();
-    let childObservedAtMs = childStartedAtMs;
     let child: SpawnedScriptChild;
+    let childStartedAtMs: number;
+    let childObservedAtMs: number;
     try {
-      child = spawn(params.command, {
-        cwd: params.cwd ? path.resolve(params.cwd) : process.cwd(),
-        env: process.env,
-        shell: params.shell ?? true,
-        detached: process.platform !== "win32",
-        stdio: ["pipe", "pipe", "pipe"],
-      });
-      childObservedAtMs = Date.now();
+      ({
+        child,
+        observedAtMs: childObservedAtMs,
+        startedAtMs: childStartedAtMs,
+      } = spawnScriptChild(params));
     } catch (error) {
       reject(
         new CrablineError(
@@ -1019,18 +1360,15 @@ function watchScript(params: {
       serializedPayload,
       params.shell,
     );
-    const childStartedAtMs = Date.now();
-    let childObservedAtMs = childStartedAtMs;
     let child: SpawnedScriptChild;
+    let childStartedAtMs: number;
+    let childObservedAtMs: number;
     try {
-      child = spawn(params.command, {
-        cwd: params.cwd ? path.resolve(params.cwd) : process.cwd(),
-        env: process.env,
-        shell: params.shell ?? true,
-        detached: process.platform !== "win32",
-        stdio: ["pipe", "pipe", "pipe"],
-      });
-      childObservedAtMs = Date.now();
+      ({
+        child,
+        observedAtMs: childObservedAtMs,
+        startedAtMs: childStartedAtMs,
+      } = spawnScriptChild(params));
     } catch (error) {
       throw new CrablineError(
         formatScriptError(

--- a/src/providers/builtin/script.ts
+++ b/src/providers/builtin/script.ts
@@ -203,9 +203,8 @@ const WINDOWS_JOB_HELPER_SOURCE = [
   "if(job!=IntPtr.Zero){CloseHandle(job);}",
   "}",
   "}",
-  "public static int Main(string[] arguments){",
+  "public static int Main(){",
   "try{",
-  'if(arguments.Length==1&&arguments[0]=="--probe"){return 0;}',
   `string shellValue=Environment.GetEnvironmentVariable("${WINDOWS_JOB_SHELL_ENV}");`,
   `string commandValue=Environment.GetEnvironmentVariable("${WINDOWS_JOB_COMMAND_ENV}");`,
   `Environment.SetEnvironmentVariable("${WINDOWS_JOB_SHELL_ENV}",null);`,
@@ -302,7 +301,13 @@ function ensureWindowsJobHelper(): string | undefined {
         windowsHide: true,
       },
     );
-    execFileSync(helperPath, ["--probe"], {
+    const probeCommand = windowsShellCommand("exit 0");
+    execFileSync(helperPath, [], {
+      env: {
+        ...process.env,
+        [WINDOWS_JOB_COMMAND_ENV]: Buffer.from(probeCommand.commandLine).toString("base64"),
+        [WINDOWS_JOB_SHELL_ENV]: Buffer.from(probeCommand.shell).toString("base64"),
+      },
       stdio: "ignore",
       timeout: 5_000,
       windowsHide: true,

--- a/src/providers/builtin/script.ts
+++ b/src/providers/builtin/script.ts
@@ -203,8 +203,9 @@ const WINDOWS_JOB_HELPER_SOURCE = [
   "if(job!=IntPtr.Zero){CloseHandle(job);}",
   "}",
   "}",
-  "public static int Main(){",
+  "public static int Main(string[] arguments){",
   "try{",
+  'if(arguments.Length==1&&arguments[0]=="--probe"){return 0;}',
   `string shellValue=Environment.GetEnvironmentVariable("${WINDOWS_JOB_SHELL_ENV}");`,
   `string commandValue=Environment.GetEnvironmentVariable("${WINDOWS_JOB_COMMAND_ENV}");`,
   `Environment.SetEnvironmentVariable("${WINDOWS_JOB_SHELL_ENV}",null);`,
@@ -257,7 +258,7 @@ const WINDOWS_PROCESS_TERMINATOR_SOURCE = [
   "}",
 ].join("");
 
-let windowsJobHelperPath: string | undefined;
+let windowsJobHelperPath: string | null | undefined;
 
 function removeWindowsJobHelper(directory: string): void {
   try {
@@ -267,9 +268,9 @@ function removeWindowsJobHelper(directory: string): void {
   }
 }
 
-function ensureWindowsJobHelper(): string {
-  if (windowsJobHelperPath) {
-    return windowsJobHelperPath;
+function ensureWindowsJobHelper(): string | undefined {
+  if (windowsJobHelperPath !== undefined) {
+    return windowsJobHelperPath ?? undefined;
   }
   const directory = mkdtempSync(path.join(tmpdir(), "crabline-script-job-"));
   const helperPath = path.join(directory, "crabline-script-job.exe");
@@ -295,18 +296,15 @@ function ensureWindowsJobHelper(): string {
         windowsHide: true,
       },
     );
-  } catch (error) {
+    execFileSync(helperPath, ["--probe"], {
+      stdio: "ignore",
+      timeout: 5_000,
+      windowsHide: true,
+    });
+  } catch {
     removeWindowsJobHelper(directory);
-    const stderr =
-      typeof (error as { stderr?: unknown }).stderr === "string"
-        ? (error as { stderr: string }).stderr.trim()
-        : "";
-    throw new Error(
-      stderr
-        ? `Windows script job helper compilation failed.\n${stderr}`
-        : "Windows script job helper compilation failed.",
-      { cause: error },
-    );
+    windowsJobHelperPath = null;
+    return undefined;
   }
   windowsJobHelperPath = helperPath;
   process.once("exit", () => removeWindowsJobHelper(directory));
@@ -367,19 +365,29 @@ function spawnScriptChild(params: {
   let child: SpawnedScriptChild;
   if (process.platform === "win32") {
     const helperPath = ensureWindowsJobHelper();
-    const shellCommand = windowsShellCommand(params.command, params.shell);
     startedAtMs = Date.now();
-    child = spawn(helperPath, [], {
-      cwd,
-      env: {
-        ...process.env,
-        [WINDOWS_JOB_COMMAND_ENV]: Buffer.from(shellCommand.commandLine).toString("base64"),
-        [WINDOWS_JOB_SHELL_ENV]: Buffer.from(shellCommand.shell).toString("base64"),
-      },
-      shell: false,
-      stdio: ["pipe", "pipe", "pipe"],
-      windowsHide: true,
-    });
+    if (helperPath) {
+      const shellCommand = windowsShellCommand(params.command, params.shell);
+      child = spawn(helperPath, [], {
+        cwd,
+        env: {
+          ...process.env,
+          [WINDOWS_JOB_COMMAND_ENV]: Buffer.from(shellCommand.commandLine).toString("base64"),
+          [WINDOWS_JOB_SHELL_ENV]: Buffer.from(shellCommand.shell).toString("base64"),
+        },
+        shell: false,
+        stdio: ["pipe", "pipe", "pipe"],
+        windowsHide: true,
+      });
+    } else {
+      child = spawn(params.command, {
+        cwd,
+        env: process.env,
+        shell: params.shell ?? true,
+        stdio: ["pipe", "pipe", "pipe"],
+        windowsHide: true,
+      });
+    }
   } else {
     startedAtMs = Date.now();
     child = spawn(params.command, {

--- a/src/providers/builtin/script.ts
+++ b/src/providers/builtin/script.ts
@@ -1,8 +1,9 @@
 import {
-  execFileSync,
+  execFile,
   spawn,
   type ChildProcess,
   type ChildProcessByStdio,
+  type ExecFileOptions,
 } from "node:child_process";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -258,6 +259,7 @@ const WINDOWS_PROCESS_TERMINATOR_SOURCE = [
 ].join("");
 
 let windowsJobHelperPath: string | null | undefined;
+let windowsJobHelperPromise: Promise<string | undefined> | undefined;
 
 function removeWindowsJobHelper(directory: string): void {
   try {
@@ -267,7 +269,27 @@ function removeWindowsJobHelper(directory: string): void {
   }
 }
 
-function ensureWindowsJobHelper(): string | undefined {
+function runWindowsJobHelperCommand(
+  executable: string,
+  args: string[],
+  options: ExecFileOptions,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    try {
+      execFile(executable, args, options, (error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    } catch (error) {
+      reject(error);
+    }
+  });
+}
+
+async function createWindowsJobHelper(): Promise<string | undefined> {
   if (windowsJobHelperPath !== undefined) {
     return windowsJobHelperPath ?? undefined;
   }
@@ -280,7 +302,7 @@ function ensureWindowsJobHelper(): string | undefined {
   }
   const helperPath = path.join(directory, "crabline-script-job.exe");
   try {
-    execFileSync(
+    await runWindowsJobHelperCommand(
       "powershell.exe",
       [
         "-NoLogo",
@@ -290,25 +312,22 @@ function ensureWindowsJobHelper(): string | undefined {
         `Add-Type -TypeDefinition $env:${WINDOWS_JOB_HELPER_SOURCE_ENV} -Language CSharp -OutputAssembly $env:${WINDOWS_JOB_HELPER_OUTPUT_ENV} -OutputType ConsoleApplication`,
       ],
       {
-        encoding: "utf8",
         env: {
           ...process.env,
           [WINDOWS_JOB_HELPER_OUTPUT_ENV]: helperPath,
           [WINDOWS_JOB_HELPER_SOURCE_ENV]: WINDOWS_JOB_HELPER_SOURCE,
         },
-        stdio: ["ignore", "pipe", "pipe"],
         timeout: 15_000,
         windowsHide: true,
       },
     );
     const probeCommand = windowsShellCommand("exit 0");
-    execFileSync(helperPath, [], {
+    await runWindowsJobHelperCommand(helperPath, [], {
       env: {
         ...process.env,
         [WINDOWS_JOB_COMMAND_ENV]: Buffer.from(probeCommand.commandLine).toString("base64"),
         [WINDOWS_JOB_SHELL_ENV]: Buffer.from(probeCommand.shell).toString("base64"),
       },
-      stdio: "ignore",
       timeout: 5_000,
       windowsHide: true,
     });
@@ -320,6 +339,41 @@ function ensureWindowsJobHelper(): string | undefined {
   windowsJobHelperPath = helperPath;
   process.once("exit", () => removeWindowsJobHelper(directory));
   return helperPath;
+}
+
+function ensureWindowsJobHelper(): Promise<string | undefined> {
+  if (windowsJobHelperPath !== undefined) {
+    return Promise.resolve(windowsJobHelperPath ?? undefined);
+  }
+  windowsJobHelperPromise ??= createWindowsJobHelper().finally(() => {
+    windowsJobHelperPromise = undefined;
+  });
+  return windowsJobHelperPromise;
+}
+
+function waitForPromiseOrAbort<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) {
+    return promise;
+  }
+  if (signal.aborted) {
+    return Promise.reject(signal.reason ?? new Error("Script command aborted."));
+  }
+  return new Promise((resolve, reject) => {
+    const abort = () => {
+      reject(signal.reason ?? new Error("Script command aborted."));
+    };
+    signal.addEventListener("abort", abort, { once: true });
+    void promise.then(
+      (value) => {
+        signal.removeEventListener("abort", abort);
+        resolve(value);
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", abort);
+        reject(error);
+      },
+    );
+  });
 }
 
 function quoteWindowsArgument(value: string): string {
@@ -366,16 +420,22 @@ function windowsShellCommand(
   };
 }
 
-function spawnScriptChild(params: {
-  command: string;
-  cwd?: string | undefined;
-  shell?: string | undefined;
-}): { child: SpawnedScriptChild; observedAtMs: number; startedAtMs: number } {
+async function spawnScriptChild(
+  params: {
+    command: string;
+    cwd?: string | undefined;
+    shell?: string | undefined;
+  },
+  signal?: AbortSignal,
+): Promise<{ child: SpawnedScriptChild; observedAtMs: number; startedAtMs: number }> {
   const cwd = params.cwd ? path.resolve(params.cwd) : process.cwd();
   let startedAtMs: number;
   let child: SpawnedScriptChild;
   if (process.platform === "win32") {
-    const helperPath = ensureWindowsJobHelper();
+    const helperPath = await waitForPromiseOrAbort(ensureWindowsJobHelper(), signal);
+    if (signal?.aborted) {
+      throw signal.reason ?? new Error("Script command aborted.");
+    }
     startedAtMs = Date.now();
     if (helperPath) {
       const shellCommand = windowsShellCommand(params.command, params.shell);
@@ -1181,42 +1241,17 @@ function runScript<T>(params: {
     params.shell,
   );
   return new Promise((resolve, reject) => {
-    let child: SpawnedScriptChild;
-    let childStartedAtMs: number;
-    let childObservedAtMs: number;
-    try {
-      ({
-        child,
-        observedAtMs: childObservedAtMs,
-        startedAtMs: childStartedAtMs,
-      } = spawnScriptChild(params));
-    } catch (error) {
-      reject(
-        new CrablineError(
-          formatScriptError(
-            "Script command failed to start.",
-            ensureErrorMessage(error),
-            params.command,
-            diagnostics,
-          ),
-          { kind: "connectivity" },
-        ),
-      );
-      return;
-    }
-
+    let child: SpawnedScriptChild | undefined;
+    let childStartedAtMs = 0;
+    let childObservedAtMs = 0;
     const stdout: Buffer[] = [];
     const stderr: Buffer[] = [];
     let deadlineExceeded = false;
     let outputBytes = 0;
     let settled = false;
+    let timeout: NodeJS.Timeout;
     let timeoutGrace: NodeJS.Timeout | undefined;
-    const abort = () => {
-      finish(async () => {
-        await terminateChild(child, childStartedAtMs, childObservedAtMs);
-        reject(params.signal?.reason ?? new Error("Script command aborted."));
-      });
-    };
+    const spawnAbortController = new AbortController();
 
     const finish = (callback: () => Promise<void> | void) => {
       if (settled) {
@@ -1225,13 +1260,27 @@ function runScript<T>(params: {
       settled = true;
       clearTimeout(timeout);
       clearTimeout(timeoutGrace);
+      spawnAbortController.abort();
       params.signal?.removeEventListener("abort", abort);
       void callback();
     };
 
+    const stopChild = async () => {
+      if (child) {
+        await terminateChild(child, childStartedAtMs, childObservedAtMs);
+      }
+    };
+
+    const abort = () => {
+      finish(async () => {
+        await stopChild();
+        reject(params.signal?.reason ?? new Error("Script command aborted."));
+      });
+    };
+
     const failForOutputLimit = () => {
       finish(async () => {
-        await terminateChild(child, childStartedAtMs, childObservedAtMs);
+        await stopChild();
         reject(
           new CrablineError(`Script command exceeded ${MAX_SCRIPT_OUTPUT_BYTES} bytes of output.`, {
             kind: "connectivity",
@@ -1240,88 +1289,91 @@ function runScript<T>(params: {
       });
     };
 
-    child.stdout.on("data", (chunk) => {
-      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-      outputBytes += buffer.length;
-      if (outputBytes > MAX_SCRIPT_OUTPUT_BYTES) {
-        failForOutputLimit();
-        return;
-      }
-      stdout.push(buffer);
-    });
-
-    child.stderr.on("data", (chunk) => {
-      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-      outputBytes += buffer.length;
-      if (outputBytes > MAX_SCRIPT_OUTPUT_BYTES) {
-        failForOutputLimit();
-        return;
-      }
-      stderr.push(buffer);
-    });
-
-    child.stdin.on("error", () => {
-      // Child closure is reported through the process error/close handlers.
-    });
-    child.once("error", (error) => {
-      finish(() => {
-        reject(
-          new CrablineError(
-            formatScriptError(
-              "Script command failed to start.",
-              ensureErrorMessage(error),
-              params.command,
-              diagnostics,
-            ),
-            { kind: "connectivity" },
-          ),
-        );
+    const startChild = (spawnedChild: SpawnedScriptChild) => {
+      spawnedChild.stdout.on("data", (chunk) => {
+        const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+        outputBytes += buffer.length;
+        if (outputBytes > MAX_SCRIPT_OUTPUT_BYTES) {
+          failForOutputLimit();
+          return;
+        }
+        stdout.push(buffer);
       });
-    });
-    child.once("close", (code, signal) => {
-      finish(() => {
-        const stdoutText = Buffer.concat(stdout).toString("utf8");
-        const stderrText = Buffer.concat(stderr).toString("utf8");
-        if (code !== 0) {
+
+      spawnedChild.stderr.on("data", (chunk) => {
+        const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+        outputBytes += buffer.length;
+        if (outputBytes > MAX_SCRIPT_OUTPUT_BYTES) {
+          failForOutputLimit();
+          return;
+        }
+        stderr.push(buffer);
+      });
+
+      spawnedChild.stdin.on("error", () => {
+        // Child closure is reported through the process error/close handlers.
+      });
+      spawnedChild.once("error", (error) => {
+        finish(() => {
           reject(
             new CrablineError(
               formatScriptError(
-                `Script command failed${signal ? ` (${signal})` : ""}.`,
-                stderrText.trim() ? stderrText : stdoutText,
+                "Script command failed to start.",
+                ensureErrorMessage(error),
                 params.command,
                 diagnostics,
               ),
               { kind: "connectivity" },
             ),
           );
-          return;
-        }
-
-        try {
-          const result = parseScriptJson({
-            command: params.command,
-            diagnostics,
-            output: stdoutText,
-            schema: params.schema,
-          });
-          if (deadlineExceeded && !params.acceptResultDuringTimeoutGrace?.(result)) {
+        });
+      });
+      spawnedChild.once("close", (code, signal) => {
+        finish(() => {
+          const stdoutText = Buffer.concat(stdout).toString("utf8");
+          const stderrText = Buffer.concat(stderr).toString("utf8");
+          if (code !== 0) {
             reject(
-              new CrablineError(`Script command timed out after ${params.timeoutMs}ms.`, {
-                kind: "timeout",
-              }),
+              new CrablineError(
+                formatScriptError(
+                  `Script command failed${signal ? ` (${signal})` : ""}.`,
+                  stderrText.trim() ? stderrText : stdoutText,
+                  params.command,
+                  diagnostics,
+                ),
+                { kind: "connectivity" },
+              ),
             );
             return;
           }
-          resolve(result);
-        } catch (error) {
-          reject(error);
-        }
+
+          try {
+            const result = parseScriptJson({
+              command: params.command,
+              diagnostics,
+              output: stdoutText,
+              schema: params.schema,
+            });
+            if (deadlineExceeded && !params.acceptResultDuringTimeoutGrace?.(result)) {
+              reject(
+                new CrablineError(`Script command timed out after ${params.timeoutMs}ms.`, {
+                  kind: "timeout",
+                }),
+              );
+              return;
+            }
+            resolve(result);
+          } catch (error) {
+            reject(error);
+          }
+        });
       });
-    });
+      spawnedChild.stdin.end(serializedPayload);
+    };
 
     const failForTimeout = () => {
       finish(async () => {
-        await terminateChild(child, childStartedAtMs, childObservedAtMs);
+        await stopChild();
         reject(
           new CrablineError(`Script command timed out after ${params.timeoutMs}ms.`, {
             kind: "timeout",
@@ -1329,7 +1381,7 @@ function runScript<T>(params: {
         );
       });
     };
-    const timeout = setTimeout(() => {
+    timeout = setTimeout(() => {
       const timeoutGraceMs = params.timeoutGraceMs ?? 0;
       if (timeoutGraceMs <= 0) {
         failForTimeout();
@@ -1341,12 +1393,42 @@ function runScript<T>(params: {
     }, params.timeoutMs);
     timeout.unref();
 
+    params.signal?.addEventListener("abort", abort, { once: true });
     if (params.signal?.aborted) {
       abort();
       return;
     }
-    params.signal?.addEventListener("abort", abort, { once: true });
-    child.stdin.end(serializedPayload);
+
+    void spawnScriptChild(params, spawnAbortController.signal).then(
+      (spawned) => {
+        if (settled) {
+          void terminateChild(spawned.child, spawned.startedAtMs, spawned.observedAtMs);
+          return;
+        }
+        child = spawned.child;
+        childStartedAtMs = spawned.startedAtMs;
+        childObservedAtMs = spawned.observedAtMs;
+        startChild(spawned.child);
+      },
+      (error: unknown) => {
+        if (settled) {
+          return;
+        }
+        finish(() => {
+          reject(
+            new CrablineError(
+              formatScriptError(
+                "Script command failed to start.",
+                ensureErrorMessage(error),
+                params.command,
+                diagnostics,
+              ),
+              { kind: "connectivity" },
+            ),
+          );
+        });
+      },
+    );
   });
 }
 
@@ -1382,13 +1464,22 @@ function watchScript(params: {
     let child: SpawnedScriptChild;
     let childStartedAtMs: number;
     let childObservedAtMs: number;
+    const spawnSignal = params.context.signal
+      ? AbortSignal.any([params.cancelSignal, params.context.signal])
+      : params.cancelSignal;
     try {
       ({
         child,
         observedAtMs: childObservedAtMs,
         startedAtMs: childStartedAtMs,
-      } = spawnScriptChild(params));
+      } = await spawnScriptChild(params, spawnSignal));
     } catch (error) {
+      if (params.cancelSignal.aborted) {
+        return;
+      }
+      if (params.context.signal?.aborted) {
+        throw params.context.signal.reason ?? new Error("Script watch command aborted.");
+      }
       throw new CrablineError(
         formatScriptError(
           "Script watch command failed to start.",

--- a/test/script-provider-windows.test.ts
+++ b/test/script-provider-windows.test.ts
@@ -8,11 +8,19 @@ import type { ProviderContext } from "../src/providers/types.js";
 
 const spawnMock = vi.hoisted(() => vi.fn());
 const execFileSyncMock = vi.hoisted(() => vi.fn());
+const mkdtempSyncMock = vi.hoisted(() => vi.fn(() => "C:\\Temp\\crabline-script-job-test"));
+const rmSyncMock = vi.hoisted(() => vi.fn());
 
 vi.mock("node:child_process", async (importOriginal) => ({
   ...(await importOriginal<typeof import("node:child_process")>()),
   execFileSync: execFileSyncMock,
   spawn: spawnMock,
+}));
+
+vi.mock("node:fs", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:fs")>()),
+  mkdtempSync: mkdtempSyncMock,
+  rmSync: rmSyncMock,
 }));
 
 type FakeChild = ChildProcess & {
@@ -84,6 +92,8 @@ function createContext(): ProviderContext {
 beforeEach(() => {
   vi.useFakeTimers();
   execFileSyncMock.mockClear();
+  mkdtempSyncMock.mockClear();
+  rmSyncMock.mockClear();
   spawnMock.mockReset();
   Object.defineProperty(process, "platform", {
     configurable: true,
@@ -100,12 +110,16 @@ afterEach(() => {
 });
 
 describe("script provider Windows cleanup", () => {
-  it.each(["compile", "probe"] as const)(
+  it.each(["temp", "compile", "probe"] as const)(
     "falls back to direct shell execution when Job Object helper %s is blocked",
     async (blockedStage) => {
       vi.resetModules();
       execFileSyncMock.mockReset();
-      if (blockedStage === "compile") {
+      if (blockedStage === "temp") {
+        mkdtempSyncMock.mockImplementationOnce(() => {
+          throw new Error("blocked");
+        });
+      } else if (blockedStage === "compile") {
         execFileSyncMock.mockImplementationOnce(() => {
           throw new Error("blocked");
         });

--- a/test/script-provider-windows.test.ts
+++ b/test/script-provider-windows.test.ts
@@ -7,13 +7,13 @@ import { ScriptProviderAdapter } from "../src/providers/builtin/script.js";
 import type { ProviderContext } from "../src/providers/types.js";
 
 const spawnMock = vi.hoisted(() => vi.fn());
-const execFileSyncMock = vi.hoisted(() => vi.fn());
+const execFileMock = vi.hoisted(() => vi.fn());
 const mkdtempSyncMock = vi.hoisted(() => vi.fn(() => "C:\\Temp\\crabline-script-job-test"));
 const rmSyncMock = vi.hoisted(() => vi.fn());
 
 vi.mock("node:child_process", async (importOriginal) => ({
   ...(await importOriginal<typeof import("node:child_process")>()),
-  execFileSync: execFileSyncMock,
+  execFile: execFileMock,
   spawn: spawnMock,
 }));
 
@@ -57,6 +57,18 @@ function createCleanupChild(code: number, beforeClose?: () => void): FakeChild {
   return child;
 }
 
+function completeExecFileSuccessfully(...args: unknown[]): FakeChild {
+  const callback = args.at(-1) as (error: null, stdout: string, stderr: string) => void;
+  void Promise.resolve().then(() => callback(null, "", ""));
+  return createFakeChild(9000);
+}
+
+async function flushScriptSpawn(): Promise<void> {
+  for (let index = 0; index < 12; index += 1) {
+    await Promise.resolve();
+  }
+}
+
 function createContext(): ProviderContext {
   return {
     config: {
@@ -91,7 +103,8 @@ function createContext(): ProviderContext {
 
 beforeEach(() => {
   vi.useFakeTimers();
-  execFileSyncMock.mockClear();
+  execFileMock.mockReset();
+  execFileMock.mockImplementation(completeExecFileSuccessfully);
   mkdtempSyncMock.mockClear();
   rmSyncMock.mockClear();
   spawnMock.mockReset();
@@ -114,18 +127,17 @@ describe("script provider Windows cleanup", () => {
     "falls back to direct shell execution when Job Object helper %s is blocked",
     async (blockedStage) => {
       vi.resetModules();
-      execFileSyncMock.mockReset();
       if (blockedStage === "temp") {
         mkdtempSyncMock.mockImplementationOnce(() => {
           throw new Error("blocked");
         });
       } else if (blockedStage === "compile") {
-        execFileSyncMock.mockImplementationOnce(() => {
+        execFileMock.mockImplementationOnce(() => {
           throw new Error("blocked");
         });
       } else {
-        execFileSyncMock
-          .mockImplementationOnce(() => undefined)
+        execFileMock
+          .mockImplementationOnce(completeExecFileSuccessfully)
           .mockImplementationOnce(() => {
             throw new Error("blocked");
           });
@@ -145,6 +157,7 @@ describe("script provider Windows cleanup", () => {
           text: "payload",
         })
         .catch((error: unknown) => error);
+      await flushScriptSpawn();
       scriptChild.emit("close", 7, null);
       await failurePromise;
 
@@ -155,6 +168,32 @@ describe("script provider Windows cleanup", () => {
       });
     },
   );
+
+  it("counts Job Object helper bootstrap against the command timeout", async () => {
+    vi.resetModules();
+    execFileMock.mockReset();
+    execFileMock.mockReturnValueOnce(createFakeChild(1109));
+    const { ScriptProviderAdapter: IsolatedScriptProviderAdapter } =
+      await import("../src/providers/builtin/script.js");
+    const context = createContext();
+    const provider = new IsolatedScriptProviderAdapter(context);
+
+    const failurePromise = provider
+      .send({
+        ...context,
+        mode: "send",
+        nonce: "nonce",
+        text: "payload",
+      })
+      .catch((error: unknown) => error);
+    await vi.advanceTimersByTimeAsync(context.fixture.timeoutMs);
+    const failure = await failurePromise;
+
+    expect(ensureErrorMessage(failure)).toContain(
+      `Script command timed out after ${context.fixture.timeoutMs}ms.`,
+    );
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
 
   it("starts scripts inside an atomic kill-on-close Job Object", async () => {
     const scriptChild = createFakeChild(1111);
@@ -170,19 +209,20 @@ describe("script provider Windows cleanup", () => {
         text: "payload",
       })
       .catch((error: unknown) => error);
+    await flushScriptSpawn();
     scriptChild.emit("close", 7, null);
     await failurePromise;
 
-    expect(execFileSyncMock).toHaveBeenCalledTimes(2);
-    const compileOptions = execFileSyncMock.mock.calls[0]?.[2] as
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+    const compileOptions = execFileMock.mock.calls[0]?.[2] as
       | { env?: NodeJS.ProcessEnv }
       | undefined;
     const helperSource = compileOptions?.env?.CRABLINE_INTERNAL_SCRIPT_JOB_HELPER_SOURCE;
     expect(helperSource).toContain("JobObjectLimitKillOnJobClose");
     expect(helperSource).toContain("ProcThreadAttributeJobList");
     expect(helperSource).toContain("CreateSuspended|ExtendedStartupInfoPresent");
-    expect(execFileSyncMock.mock.calls[1]?.[1]).toEqual([]);
-    expect(execFileSyncMock.mock.calls[1]?.[2]).toMatchObject({
+    expect(execFileMock.mock.calls[1]?.[1]).toEqual([]);
+    expect(execFileMock.mock.calls[1]?.[2]).toMatchObject({
       env: {
         CRABLINE_INTERNAL_SCRIPT_JOB_COMMAND: expect.any(String),
         CRABLINE_INTERNAL_SCRIPT_JOB_SHELL: expect.any(String),
@@ -213,6 +253,7 @@ describe("script provider Windows cleanup", () => {
           text: "payload",
         })
         .catch((error: unknown) => error);
+      await flushScriptSpawn();
       scriptChild.stderr.write("opaque-value failed");
       scriptChild.emit("close", 7, null);
       const failure = await failurePromise;
@@ -237,6 +278,7 @@ describe("script provider Windows cleanup", () => {
         text: "payload",
       })
       .catch((error: unknown) => error);
+    await flushScriptSpawn();
     scriptChild.stderr.write("opaque-value failed");
     scriptChild.emit("close", 7, null);
     const failure = await failurePromise;
@@ -260,6 +302,7 @@ describe("script provider Windows cleanup", () => {
         text: "payload",
       })
       .catch((error: unknown) => error);
+    await flushScriptSpawn();
     scriptChild.stderr.write("opaque-value");
     scriptChild.emit("close", 7, null);
     const failure = await failurePromise;
@@ -283,6 +326,7 @@ describe("script provider Windows cleanup", () => {
         text: "payload",
       })
       .catch((error: unknown) => error);
+    await flushScriptSpawn();
     scriptChild.stderr.write('opaque"value');
     scriptChild.emit("close", 7, null);
     const failure = await failurePromise;
@@ -306,6 +350,7 @@ describe("script provider Windows cleanup", () => {
         text: "payload",
       })
       .catch((error: unknown) => error);
+    await flushScriptSpawn();
     scriptChild.stderr.write("opaque-value");
     scriptChild.emit("close", 7, null);
     const failure = await failurePromise;
@@ -332,6 +377,7 @@ describe("script provider Windows cleanup", () => {
           text: "payload",
         })
         .catch((error: unknown) => error);
+      await flushScriptSpawn();
       scriptChild.stderr.write("opaque-value");
       scriptChild.emit("close", 7, null);
       const failure = await failurePromise;

--- a/test/script-provider-windows.test.ts
+++ b/test/script-provider-windows.test.ts
@@ -100,6 +100,48 @@ afterEach(() => {
 });
 
 describe("script provider Windows cleanup", () => {
+  it.each(["compile", "probe"] as const)(
+    "falls back to direct shell execution when Job Object helper %s is blocked",
+    async (blockedStage) => {
+      vi.resetModules();
+      execFileSyncMock.mockReset();
+      if (blockedStage === "compile") {
+        execFileSyncMock.mockImplementationOnce(() => {
+          throw new Error("blocked");
+        });
+      } else {
+        execFileSyncMock
+          .mockImplementationOnce(() => undefined)
+          .mockImplementationOnce(() => {
+            throw new Error("blocked");
+          });
+      }
+      const scriptChild = createFakeChild(1110);
+      spawnMock.mockReturnValueOnce(scriptChild);
+      const { ScriptProviderAdapter: IsolatedScriptProviderAdapter } =
+        await import("../src/providers/builtin/script.js");
+      const context = createContext();
+      const provider = new IsolatedScriptProviderAdapter(context);
+
+      const failurePromise = provider
+        .send({
+          ...context,
+          mode: "send",
+          nonce: "nonce",
+          text: "payload",
+        })
+        .catch((error: unknown) => error);
+      scriptChild.emit("close", 7, null);
+      await failurePromise;
+
+      expect(spawnMock.mock.calls[0]?.[0]).toBe("node send.mjs");
+      expect(spawnMock.mock.calls[0]?.[1]).toMatchObject({
+        shell: true,
+        windowsHide: true,
+      });
+    },
+  );
+
   it("starts scripts inside an atomic kill-on-close Job Object", async () => {
     const scriptChild = createFakeChild(1111);
     spawnMock.mockReturnValueOnce(scriptChild);
@@ -117,7 +159,7 @@ describe("script provider Windows cleanup", () => {
     scriptChild.emit("close", 7, null);
     await failurePromise;
 
-    expect(execFileSyncMock).toHaveBeenCalledOnce();
+    expect(execFileSyncMock).toHaveBeenCalledTimes(2);
     const compileOptions = execFileSyncMock.mock.calls[0]?.[2] as
       | { env?: NodeJS.ProcessEnv }
       | undefined;
@@ -125,6 +167,7 @@ describe("script provider Windows cleanup", () => {
     expect(helperSource).toContain("JobObjectLimitKillOnJobClose");
     expect(helperSource).toContain("ProcThreadAttributeJobList");
     expect(helperSource).toContain("CreateSuspended|ExtendedStartupInfoPresent");
+    expect(execFileSyncMock.mock.calls[1]?.[1]).toEqual(["--probe"]);
     expect(spawnMock.mock.calls[0]?.[0]).toMatch(/crabline-script-job\.exe$/u);
     expect(spawnMock.mock.calls[0]?.[1]).toEqual([]);
     expect(spawnMock.mock.calls[0]?.[2]).toMatchObject({

--- a/test/script-provider-windows.test.ts
+++ b/test/script-provider-windows.test.ts
@@ -236,6 +236,29 @@ describe("script provider Windows cleanup", () => {
     });
   });
 
+  it("terminates a watch child when cancellation fires during spawn handoff", async () => {
+    const controller = new AbortController();
+    const cancellation = new Error("watch cancelled");
+    const scriptChild = createFakeChild(1112);
+    spawnMock
+      .mockImplementationOnce(() => {
+        controller.abort(cancellation);
+        return scriptChild;
+      })
+      .mockImplementationOnce(() => createCleanupChild(0));
+    const context = createContext();
+    context.signal = controller.signal;
+    const provider = new ScriptProviderAdapter(context);
+
+    const iterator = provider.watch(context);
+    await expect(iterator.next()).rejects.toBe(cancellation);
+
+    expect(spawnMock.mock.calls[1]?.[0]).toBe("powershell.exe");
+    expect(scriptChild.stdin.destroyed).toBe(true);
+    expect(scriptChild.stdout.destroyed).toBe(true);
+    expect(scriptChild.stderr.destroyed).toBe(true);
+  });
+
   it.each([":", "="])(
     "redacts diagnostics for Windows slash options using %s",
     async (separator) => {

--- a/test/script-provider-windows.test.ts
+++ b/test/script-provider-windows.test.ts
@@ -7,9 +7,11 @@ import { ScriptProviderAdapter } from "../src/providers/builtin/script.js";
 import type { ProviderContext } from "../src/providers/types.js";
 
 const spawnMock = vi.hoisted(() => vi.fn());
+const execFileSyncMock = vi.hoisted(() => vi.fn());
 
 vi.mock("node:child_process", async (importOriginal) => ({
   ...(await importOriginal<typeof import("node:child_process")>()),
+  execFileSync: execFileSyncMock,
   spawn: spawnMock,
 }));
 
@@ -81,6 +83,7 @@ function createContext(): ProviderContext {
 
 beforeEach(() => {
   vi.useFakeTimers();
+  execFileSyncMock.mockClear();
   spawnMock.mockReset();
   Object.defineProperty(process, "platform", {
     configurable: true,
@@ -97,6 +100,39 @@ afterEach(() => {
 });
 
 describe("script provider Windows cleanup", () => {
+  it("starts scripts inside an atomic kill-on-close Job Object", async () => {
+    const scriptChild = createFakeChild(1111);
+    spawnMock.mockReturnValueOnce(scriptChild);
+    const context = createContext();
+    const provider = new ScriptProviderAdapter(context);
+
+    const failurePromise = provider
+      .send({
+        ...context,
+        mode: "send",
+        nonce: "nonce",
+        text: "payload",
+      })
+      .catch((error: unknown) => error);
+    scriptChild.emit("close", 7, null);
+    await failurePromise;
+
+    expect(execFileSyncMock).toHaveBeenCalledOnce();
+    const compileOptions = execFileSyncMock.mock.calls[0]?.[2] as
+      | { env?: NodeJS.ProcessEnv }
+      | undefined;
+    const helperSource = compileOptions?.env?.CRABLINE_INTERNAL_SCRIPT_JOB_HELPER_SOURCE;
+    expect(helperSource).toContain("JobObjectLimitKillOnJobClose");
+    expect(helperSource).toContain("ProcThreadAttributeJobList");
+    expect(helperSource).toContain("CreateSuspended|ExtendedStartupInfoPresent");
+    expect(spawnMock.mock.calls[0]?.[0]).toMatch(/crabline-script-job\.exe$/u);
+    expect(spawnMock.mock.calls[0]?.[1]).toEqual([]);
+    expect(spawnMock.mock.calls[0]?.[2]).toMatchObject({
+      shell: false,
+      windowsHide: true,
+    });
+  });
+
   it.each([":", "="])(
     "redacts diagnostics for Windows slash options using %s",
     async (separator) => {
@@ -332,7 +368,7 @@ describe("script provider Windows cleanup", () => {
     expect(spawnMock.mock.calls[1]?.[0]).toBe("powershell.exe");
   });
 
-  it("does not infer descendants after the direct shell has already exited", async () => {
+  it("relies on the closed Job Object after the direct shell has already exited", async () => {
     const scriptChild = createFakeChild(6789);
     Object.defineProperty(scriptChild, "exitCode", {
       configurable: true,

--- a/test/script-provider-windows.test.ts
+++ b/test/script-provider-windows.test.ts
@@ -181,7 +181,13 @@ describe("script provider Windows cleanup", () => {
     expect(helperSource).toContain("JobObjectLimitKillOnJobClose");
     expect(helperSource).toContain("ProcThreadAttributeJobList");
     expect(helperSource).toContain("CreateSuspended|ExtendedStartupInfoPresent");
-    expect(execFileSyncMock.mock.calls[1]?.[1]).toEqual(["--probe"]);
+    expect(execFileSyncMock.mock.calls[1]?.[1]).toEqual([]);
+    expect(execFileSyncMock.mock.calls[1]?.[2]).toMatchObject({
+      env: {
+        CRABLINE_INTERNAL_SCRIPT_JOB_COMMAND: expect.any(String),
+        CRABLINE_INTERNAL_SCRIPT_JOB_SHELL: expect.any(String),
+      },
+    });
     expect(spawnMock.mock.calls[0]?.[0]).toMatch(/crabline-script-job\.exe$/u);
     expect(spawnMock.mock.calls[0]?.[1]).toEqual([]);
     expect(spawnMock.mock.calls[0]?.[2]).toMatchObject({

--- a/test/script-provider.test.ts
+++ b/test/script-provider.test.ts
@@ -326,6 +326,49 @@ describe("script provider", () => {
     },
   );
 
+  it.runIf(process.platform === "win32")(
+    "kills descendants when the direct Windows shell exits",
+    async () => {
+      const context = await createContext();
+      const watchScript = path.join(
+        path.dirname(context.manifestPath),
+        "watch-windows-descendant.mjs",
+      );
+      await writeText(
+        watchScript,
+        'import {spawn} from "node:child_process";const descendant=spawn(process.execPath,["-e","setInterval(()=>{},1000)"],{stdio:["ignore","inherit","ignore"]});descendant.unref();process.stdout.write(JSON.stringify({author:"assistant",id:String(descendant.pid),raw:{leaderPid:process.pid},sentAt:new Date().toISOString(),text:"watch payload",threadId:"thread-1"})+"\\n");',
+      );
+      context.config.script!.commands.watch = `node ${JSON.stringify(watchScript)}`;
+      const provider = new ScriptProviderAdapter(context);
+      const iterator = provider.watch(context);
+      let descendantPid = 0;
+      let descendantExited = false;
+      try {
+        const watched = await iterator.next();
+        descendantPid = Number(watched.value?.id);
+        const leaderPid = Number(
+          (watched.value?.raw as { leaderPid?: number } | undefined)?.leaderPid,
+        );
+        expect(Number.isInteger(descendantPid)).toBe(true);
+        expect(Number.isInteger(leaderPid)).toBe(true);
+        await expect(waitForProcessExit(leaderPid, 2000)).resolves.toBe(true);
+
+        descendantExited = await waitForProcessExit(descendantPid, 2000);
+        expect(descendantExited).toBe(true);
+        await expect(iterator.next()).resolves.toMatchObject({ done: true });
+      } finally {
+        if (descendantPid > 0 && !descendantExited) {
+          try {
+            process.kill(descendantPid, "SIGKILL");
+          } catch {
+            // The Job Object cleanup already stopped the descendant.
+          }
+        }
+        await iterator.return();
+      }
+    },
+  );
+
   it("enforces command deadlines in the parent process", async () => {
     const context = await createContext();
     const sendScript = path.join(path.dirname(context.manifestPath), "send-hanging.mjs");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where script-backed providers on Windows could leave descendant processes running, exceed configured deadlines during helper bootstrap, or race cancellation while spawning.

## Why This Change Was Made

Windows commands now use kill-on-close Job Objects with bounded helper setup, validated fallback behavior, deadline accounting across bootstrap and execution, and cancellation-safe spawn handoff.

## User Impact

Script provider timeouts and cancellation now clean up complete Windows process trees predictably without hanging startup or leaking descendants.

## Evidence

- focused current-base tests: 63 passed, 1 skipped
- native Windows Crabbox: 18 passed, including descendant cleanup after shell exit
- `pnpm lint` passed
- `pnpm build` passed
- exact-current gpt-5.6-sol high autoreview clean (0.84)
- GitHub CI `verify` passed; CodeQL skipped for this event
- Linux Crabbox `pnpm verify` passed: 63 files, 1357 tests passed, 2 skipped (`run_3d6d15698032`, lease `cbx_ab76d78d0968` auto-released)
- public-data diff scan clean
- Unreleased changelog entry included