### PR TITLE
fix(core): bind acknowledgements to expected nonce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Bind agent acknowledgements to the expected nonce instead of accepting an unrelated ACK.
 - Verify downloaded npm tarball integrity, retry transient provenance lookups, and revalidate release tags immediately before publication mutations.
 - Validate effective fixture mode overrides and stop retrying permanent provider send failures.
 - Bound watch iterator return and provider cleanup during CLI shutdown, forcing process exit after deadline failures.

--- a/src/core/matcher.ts
+++ b/src/core/matcher.ts
@@ -2,8 +2,31 @@ import { extractNonces } from "./nonces.js";
 import { compileInboundRegex } from "./safe-regex.js";
 import type { InboundEnvelope, InboundMatchConfig } from "../providers/types.js";
 
-const EXACT_ACK_TOKEN =
-  /(?<![\p{ID_Continue}\p{Mark}\p{Cf}])ACK(?![\p{ID_Continue}\p{Mark}\p{Cf}])/u;
+const EXACT_ACK_WORD =
+  /(?<![\p{ID_Continue}\p{Mark}\p{Cf}])ACK(?![\p{ID_Continue}\p{Mark}\p{Cf}])/gu;
+const ACK_SEPARATOR = /[\p{White_Space}\p{P}\p{S}]/u;
+const IDENTIFIER_CONTINUATION = /[a-z0-9-]/iu;
+
+function hasAcknowledgementForNonce(text: string, nonce: string): boolean {
+  for (const match of text.matchAll(EXACT_ACK_WORD)) {
+    let offset = match.index + match[0].length;
+    while (offset < text.length) {
+      const character = String.fromCodePoint(text.codePointAt(offset)!);
+      if (!ACK_SEPARATOR.test(character)) {
+        break;
+      }
+      offset += character.length;
+    }
+    const followingCharacter = text[offset + nonce.length];
+    if (
+      text.startsWith(nonce, offset) &&
+      (!followingCharacter || !IDENTIFIER_CONTINUATION.test(followingCharacter))
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
 
 export function matchesInbound(
   envelope: InboundEnvelope,
@@ -20,7 +43,7 @@ export function matchesInbound(
 
   if (
     options?.requireAcknowledgement &&
-    (!EXACT_ACK_TOKEN.test(text) || !extractedNonces.includes(nonce))
+    (!extractedNonces.includes(nonce) || !hasAcknowledgementForNonce(text, nonce))
   ) {
     return false;
   }

--- a/test/matcher.test.ts
+++ b/test/matcher.test.ts
@@ -101,7 +101,9 @@ describe("nonce + matcher", () => {
     expect(matchesReply(`ACKNOWLEDGED ${nonce}`)).toBe(false);
     expect(matchesReply(`ack ${nonce}`)).toBe(false);
     expect(matchesReply(`ACK ${otherNonce}`)).toBe(false);
+    expect(matchesReply(`ACK ${otherNonce} then ${nonce}`)).toBe(false);
     expect(matchesReply(`ACK ${nonce}-suffix`)).toBe(false);
+    expect(matchesReply(`ACK ${nonce}-suffix then ${nonce}`)).toBe(false);
     expect(matchesReply(`\u0301ACK ${nonce}`)).toBe(false);
     expect(matchesReply(`ACK\u0301 ${nonce}`)).toBe(false);
     expect(matchesReply(`\u20ddACK ${nonce}`)).toBe(false);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where agent-mode fixtures could accept an ACK for a different nonce when the expected nonce appeared elsewhere in the same message.

## Why This Change Was Made

The matcher now requires the standalone ACK and expected nonce to form one acknowledgement sequence, while preserving supported punctuation and Unicode boundary behavior.

## User Impact

Agent fixtures no longer report false success for replies that acknowledge another run.

## Evidence

- `pnpm exec vitest run test/matcher.test.ts test/run.behavior.test.ts` (44 passed)
- Sol/high autoreview thread `019f5f55-633e-7590-b74f-ab1caca89338`: clean, confidence 0.93
- Crabbox `run_7f2e2360f429`: `pnpm verify` passed, 64 files, 1,464 tests passed, 15 skipped
