### PR TITLE
fix(runtime): harden config and probe boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Bind agent acknowledgements to the expected nonce instead of accepting an unrelated ACK.
+- Bound manifest file loading, honor probe retries, and reject empty resolved Zalo webhook secrets.
 - Verify downloaded npm tarball integrity, retry transient provenance lookups, and revalidate release tags immediately before publication mutations.
 - Validate effective fixture mode overrides and stop retrying permanent provider send failures.
 - Bound watch iterator return and provider cleanup during CLI shutdown, forcing process exit after deadline failures.

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -1,10 +1,12 @@
-import { readFile, stat } from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
+import { open, stat, type FileHandle } from "node:fs/promises";
 import path from "node:path";
 import YAML from "yaml";
 import { CrablineError, ensureErrorMessage } from "../core/errors.js";
 import { type ManifestDefinition, ManifestSchema } from "./schema.js";
 
 const DEFAULT_CONFIG_CANDIDATES = ["crabline.yaml", "crabline.yml", "crabline.json"] as const;
+const MAX_MANIFEST_BYTES = 1024 * 1024;
 
 class DuplicateJsonKeyError extends SyntaxError {}
 
@@ -52,6 +54,39 @@ function parseJson(raw: string): unknown {
   return parsed;
 }
 
+async function readManifestFile(resolvedPath: string): Promise<string> {
+  let handle: FileHandle | undefined;
+  try {
+    handle = await open(
+      resolvedPath,
+      process.platform === "win32" ? "r" : fsConstants.O_RDONLY | fsConstants.O_NONBLOCK,
+    );
+    const stats = await handle.stat();
+    if (!stats.isFile()) {
+      throw new Error("Config path must be a regular file.");
+    }
+    if (stats.size > MAX_MANIFEST_BYTES) {
+      throw new Error(`Config file exceeds the ${MAX_MANIFEST_BYTES}-byte limit.`);
+    }
+
+    const buffer = Buffer.alloc(MAX_MANIFEST_BYTES + 1);
+    let offset = 0;
+    while (offset < buffer.length) {
+      const { bytesRead } = await handle.read(buffer, offset, buffer.length - offset, null);
+      if (bytesRead === 0) {
+        break;
+      }
+      offset += bytesRead;
+    }
+    if (offset > MAX_MANIFEST_BYTES) {
+      throw new Error(`Config file exceeds the ${MAX_MANIFEST_BYTES}-byte limit.`);
+    }
+    return buffer.toString("utf8", 0, offset);
+  } finally {
+    await handle?.close();
+  }
+}
+
 export async function resolveConfigPath(explicitPath?: string): Promise<string> {
   if (explicitPath) {
     return path.resolve(explicitPath);
@@ -88,7 +123,7 @@ export async function loadManifest(
   const resolvedPath = await resolveConfigPath(configPath);
   let raw: string;
   try {
-    raw = await readFile(resolvedPath, "utf8");
+    raw = await readManifestFile(resolvedPath);
   } catch (error) {
     throw configLoadError(resolvedPath, error, ensureErrorMessage(error));
   }

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -270,6 +270,10 @@ async function abortAndDrainInboundWait(
   );
 }
 
+function isPermanentFailure(result: CommandRunResult): boolean {
+  return result.failureKind === "auth" || result.failureKind === "config";
+}
+
 export async function runFixtureCommand(params: {
   fixtureId: string;
   manifest: ManifestDefinition;
@@ -309,6 +313,7 @@ export async function runFixtureCommand(params: {
     providerId: fixture.provider,
     userName: params.manifest.userName,
   };
+  const maxAttempts = fixture.retries + 1;
 
   let result: CommandRunResult | undefined;
   try {
@@ -345,30 +350,51 @@ export async function runFixtureCommand(params: {
     if (result) {
       // Preflight failures still flow through provider cleanup before returning.
     } else if (mode === "probe") {
-      try {
-        if (contextBase.config.adapter === "script") {
-          assertScriptStdinPayloadSize(scriptPayloadBase(contextBase));
+      let attempts = 0;
+      let lastFailure: CommandRunResult | null = null;
+      while (attempts < maxAttempts) {
+        attempts += 1;
+        try {
+          if (contextBase.config.adapter === "script") {
+            assertScriptStdinPayloadSize(scriptPayloadBase(contextBase));
+          }
+          const probeResult = await withFixtureDeadline(
+            async (signal) => await provider.probe({ ...contextBase, signal }),
+            fixture.timeoutMs,
+            "probe",
+          );
+          const probeAttempt: CommandRunResult = {
+            diagnostics: probeResult.details,
+            failureKind: probeResult.healthy ? undefined : "connectivity",
+            fixtureId: fixture.id,
+            mode,
+            ok: probeResult.healthy,
+            providerId: fixture.provider,
+          };
+          if (probeAttempt.ok) {
+            return (result = probeAttempt);
+          }
+          lastFailure = probeAttempt;
+        } catch (error) {
+          lastFailure = toFailure(fixture.id, fixture.provider, mode, error, "connectivity");
+          if (error instanceof UnsettledProviderOperationError) {
+            abortDrainFailed = true;
+            unsettledProviderOperations.push(error.operation);
+            break;
+          }
+          if (isPermanentFailure(lastFailure)) {
+            break;
+          }
         }
-        const probeResult = await withFixtureDeadline(
-          async (signal) => await provider.probe({ ...contextBase, signal }),
-          fixture.timeoutMs,
-          "probe",
-        );
-        return (result = {
-          diagnostics: probeResult.details,
-          failureKind: probeResult.healthy ? undefined : "connectivity",
-          fixtureId: fixture.id,
-          mode,
-          ok: probeResult.healthy,
-          providerId: fixture.provider,
-        });
-      } catch (error) {
-        if (error instanceof UnsettledProviderOperationError) {
-          abortDrainFailed = true;
-          unsettledProviderOperations.push(error.operation);
-        }
-        return (result = toFailure(fixture.id, fixture.provider, mode, error, "connectivity"));
       }
+      return (result = lastFailure ?? {
+        diagnostics: ["unknown failure"],
+        failureKind: "connectivity",
+        fixtureId: fixture.id,
+        mode,
+        ok: false,
+        providerId: fixture.provider,
+      });
     } else {
       let compiledInboundRegex: ReturnType<typeof compileInboundRegex> | undefined;
       if (fixture.inboundMatch.strategy === "regex" && fixture.inboundMatch.pattern) {
@@ -393,7 +419,6 @@ export async function runFixtureCommand(params: {
         : fixture.inboundMatch;
 
       let attempts = 0;
-      const maxAttempts = fixture.retries + 1;
       let lastFailure: CommandRunResult | null = null;
 
       while (attempts < maxAttempts) {
@@ -434,7 +459,7 @@ export async function runFixtureCommand(params: {
               unsettledProviderOperations.push(error.operation);
               break;
             }
-            if (lastFailure.failureKind === "auth" || lastFailure.failureKind === "config") {
+            if (isPermanentFailure(lastFailure)) {
               break;
             }
             continue;

--- a/src/providers/builtin/zalo.ts
+++ b/src/providers/builtin/zalo.ts
@@ -20,16 +20,18 @@ export function resolveZaloAdapterConfig(
   config: ProviderConfig,
   env: ZaloEnvironment = process.env,
 ) {
-  if (
-    config.zalo?.webhookSecret === undefined &&
-    env.ZALO_WEBHOOK_SECRET !== undefined &&
-    !env.ZALO_WEBHOOK_SECRET.trim()
-  ) {
-    throw new Error("ZALO_WEBHOOK_SECRET must not be empty or whitespace-only.");
+  const configuredWebhookSecret = config.zalo?.webhookSecret;
+  const webhookSecret = configuredWebhookSecret ?? env.ZALO_WEBHOOK_SECRET;
+  if (webhookSecret !== undefined && !webhookSecret.trim()) {
+    throw new Error(
+      configuredWebhookSecret === undefined
+        ? "ZALO_WEBHOOK_SECRET must not be empty or whitespace-only."
+        : "Zalo webhookSecret must not be empty or whitespace-only.",
+    );
   }
   return {
     botToken: config.zalo?.botToken ?? env.ZALO_BOT_TOKEN ?? "local-mock-zalo-token",
-    webhookSecret: config.zalo?.webhookSecret ?? env.ZALO_WEBHOOK_SECRET,
+    webhookSecret,
   };
 }
 

--- a/test/load.test.ts
+++ b/test/load.test.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
-import { mkdir, realpath, stat } from "node:fs/promises";
+import { execFileSync } from "node:child_process";
+import { mkdir, realpath, stat, writeFile } from "node:fs/promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { loadManifest, resolveConfigPath } from "../src/config/load.js";
 import { createTempDir, disposeTempDir, writeJson, writeText } from "./test-helpers.js";
@@ -88,6 +89,35 @@ describe("config load", () => {
     expect(loaded.manifest.fixtures).toContainEqual(
       expect.objectContaining({ id: "loopback-roundtrip", provider: "local" }),
     );
+  });
+
+  it("rejects explicit non-regular config paths", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+
+    await expect(loadManifest(directory)).rejects.toThrow(/must be a regular file/u);
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "rejects an explicit FIFO without waiting for a writer",
+    async () => {
+      const directory = await createTempDir();
+      directories.push(directory);
+      const configPath = path.join(directory, "crabline.yaml");
+      execFileSync("mkfifo", [configPath]);
+
+      await expect(loadManifest(configPath)).rejects.toThrow(/must be a regular file/u);
+    },
+    1_000,
+  );
+
+  it("rejects oversized config files before parsing", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const configPath = path.join(directory, "crabline.yaml");
+    await writeFile(configPath, Buffer.alloc(1024 * 1024 + 1, 0x20));
+
+    await expect(loadManifest(configPath)).rejects.toThrow(/exceeds the 1048576-byte limit/u);
   });
 
   it("rejects invalid inbound regular expressions during config load", async () => {

--- a/test/run.behavior.test.ts
+++ b/test/run.behavior.test.ts
@@ -572,6 +572,97 @@ describe("run behavior", () => {
     expect(abortedOperations).toBe(2);
   });
 
+  it.each(["error", "unhealthy"] as const)(
+    "retries a transient probe %s and succeeds",
+    async (firstOutcome) => {
+      let probeCalls = 0;
+      const provider: ProviderAdapter = {
+        id: "mock",
+        platform: "loopback",
+        status: "ready",
+        supports: ["probe"],
+        normalizeTarget(target) {
+          return { id: target.id, metadata: target.metadata };
+        },
+        probe: async () => {
+          probeCalls += 1;
+          if (probeCalls === 1) {
+            if (firstOutcome === "error") {
+              throw new CrablineError("transient probe failure", { kind: "connectivity" });
+            }
+            return { details: ["temporarily unavailable"], healthy: false };
+          }
+          return { details: ["ready"], healthy: true };
+        },
+        send: async () => {
+          throw new Error("send must not run");
+        },
+        waitForInbound: async () => {
+          throw new Error("wait must not run");
+        },
+      };
+      const retryingManifest = withAllCapabilities({
+        ...manifest,
+        fixtures: [{ ...manifest.fixtures[0]!, retries: 1 }],
+      });
+
+      const result = await runFixtureCommand({
+        fixtureId: "fixture",
+        manifest: retryingManifest,
+        manifestPath: "/tmp/crabline.yaml",
+        modeOverride: "probe",
+        registry: buildRegistry(provider),
+      });
+
+      expect(result).toMatchObject({ diagnostics: ["ready"], ok: true });
+      expect(probeCalls).toBe(2);
+    },
+  );
+
+  it.each(["auth", "config"] as const)(
+    "does not retry permanent %s probe failures",
+    async (failureKind) => {
+      let probeCalls = 0;
+      const provider: ProviderAdapter = {
+        id: "mock",
+        platform: "loopback",
+        status: "ready",
+        supports: ["probe"],
+        normalizeTarget(target) {
+          return { id: target.id, metadata: target.metadata };
+        },
+        probe: async () => {
+          probeCalls += 1;
+          throw new CrablineError(`permanent ${failureKind} probe failure`, {
+            kind: failureKind,
+          });
+        },
+        send: async () => {
+          throw new Error("send must not run");
+        },
+        waitForInbound: async () => {
+          throw new Error("wait must not run");
+        },
+      };
+      const retryingManifest = withAllCapabilities({
+        ...manifest,
+        fixtures: [{ ...manifest.fixtures[0]!, retries: 3 }],
+      });
+
+      const result = await runFixtureCommand({
+        fixtureId: "fixture",
+        manifest: retryingManifest,
+        manifestPath: "/tmp/crabline.yaml",
+        modeOverride: "probe",
+        registry: buildRegistry(provider),
+      });
+
+      expect(result).toMatchObject({ failureKind, ok: false });
+      expect(result.diagnostics).toContain(`permanent ${failureKind} probe failure`);
+      expect(probeCalls).toBe(1);
+    },
+  );
+
   it("classifies plain provider failures by execution stage", async () => {
     let stage: "probe" | "send" | "wait" = "probe";
     const provider: ProviderAdapter = {

--- a/test/zalo-provider.test.ts
+++ b/test/zalo-provider.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { normalizeZaloWebhookPayload, ZaloProviderAdapter } from "../src/providers/builtin/zalo.js";
+import {
+  normalizeZaloWebhookPayload,
+  resolveZaloAdapterConfig,
+  ZaloProviderAdapter,
+} from "../src/providers/builtin/zalo.js";
 import {
   normalizeBuiltinTarget,
   ZALO_UNSUPPORTED_THREAD_TARGET_ERROR,
@@ -244,6 +248,37 @@ describe("Zalo webhook normalizer", () => {
       ).toThrow(/ZALO_WEBHOOK_SECRET must not be empty/u);
     },
   );
+
+  it.each(["", " \t"])(
+    "rejects explicitly empty webhook secrets from programmatic config",
+    async (secret) => {
+      const config = await createLocalMockConfig("zalo", "/zalo/webhook");
+      config.zalo!.webhookSecret = secret;
+
+      expect(
+        () =>
+          new ZaloProviderAdapter("zalo", config, "crabline", {
+            env: { ZALO_WEBHOOK_SECRET: "test-token-placeholder" },
+          }),
+      ).toThrow(/Zalo webhookSecret must not be empty/u);
+    },
+  );
+
+  it("preserves configured webhook secret precedence and environment fallback", async () => {
+    const config = await createLocalMockConfig("zalo", "/zalo/webhook");
+    config.zalo!.webhookSecret = "test-auth-token";
+
+    expect(
+      resolveZaloAdapterConfig(config, { ZALO_WEBHOOK_SECRET: "test-token-placeholder" })
+        .webhookSecret,
+    ).toBe("test-auth-token");
+
+    delete config.zalo!.webhookSecret;
+    expect(
+      resolveZaloAdapterConfig(config, { ZALO_WEBHOOK_SECRET: "test-token-placeholder" })
+        .webhookSecret,
+    ).toBe("test-token-placeholder");
+  });
 });
 
 runLocalMockProviderContract({


### PR DESCRIPTION
## What Problem This Solves

Manifest loading could block on special files or consume unbounded input, probe fixtures ignored their retry setting, and an explicitly empty resolved Zalo webhook secret disabled authentication.

## Why This Change Was Made

The runtime now opens manifests through a bounded regular-file path, applies the configured retry budget to transient probe failures, and validates the effective Zalo webhook secret after config/environment resolution.

## User Impact

Config loading fails fast on unsafe inputs, probe retries behave consistently with other fixture modes, and Zalo webhook authentication cannot be silently disabled by whitespace-only configuration.

## Evidence

- 79 focused tests passed locally.
- TypeScript and formatting checks passed.
- Sol/high autoreview: clean, confidence 0.93.
- Crabbox `run_ec14441dedfe`: full `pnpm verify`, 64 files, 1474 passed, 15 skipped.
