### PR TITLE
fix(openclaw): harden readiness artifact evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bind agent acknowledgements to the expected nonce instead of accepting an unrelated ACK.
 - Bound manifest file loading, honor probe retries, and reject empty resolved Zalo webhook secrets.
+- Require exact provider readiness recorder routes, explicit v2 artifact pointers, and normalized missing-generation corruption errors.
 - Verify downloaded npm tarball integrity, retry transient provenance lookups, and revalidate release tags immediately before publication mutations.
 - Validate effective fixture mode overrides and stop retrying permanent provider send failures.
 - Bound watch iterator return and provider cleanup during CLI shutdown, forcing process exit after deadline failures.

--- a/src/openclaw.ts
+++ b/src/openclaw.ts
@@ -104,7 +104,16 @@ function hasStringRecordValues(value: unknown): value is Record<string, string> 
   return isRecord(value) && Object.values(value).every((entry) => typeof entry === "string");
 }
 
-function isOpenClawCrablineRecorderEvent(value: unknown): boolean {
+type OpenClawCrablineRecorderEvent = {
+  accepted: true;
+  at: string;
+  method: string;
+  path: string;
+  query: Record<string, string>;
+  type: "admin" | "api";
+};
+
+function isOpenClawCrablineRecorderEvent(value: unknown): value is OpenClawCrablineRecorderEvent {
   return (
     isRecord(value) &&
     value.accepted === true &&
@@ -119,7 +128,47 @@ function isOpenClawCrablineRecorderEvent(value: unknown): boolean {
   );
 }
 
-function assertOpenClawCrablineRecorderEvidence(contents: string): void {
+function openClawCrablineProviderProbeRequest(
+  manifest: CrablineServerManifest,
+): Pick<OpenClawCrablineRecorderEvent, "method" | "path"> {
+  switch (manifest.provider) {
+    case "mattermost":
+      return {
+        method: "GET",
+        path: new URL(`${manifest.endpoints.apiRoot}/users/me`).pathname,
+      };
+    case "matrix":
+      return {
+        method: "GET",
+        path: new URL(`${manifest.endpoints.clientApiRoot}/account/whoami`).pathname,
+      };
+    case "signal":
+      return {
+        method: "GET",
+        path: new URL("/api/v1/check", manifest.baseUrl).pathname,
+      };
+    case "slack":
+      return {
+        method: "POST",
+        path: new URL("auth.test", manifest.endpoints.apiRoot).pathname,
+      };
+    case "telegram":
+      return { method: "GET", path: "/bot<redacted>/getMe" };
+    case "whatsapp":
+      return {
+        method: "GET",
+        path: new URL(manifest.endpoints.phoneNumberUrl).pathname,
+      };
+    case "zalo":
+      return { method: "POST", path: "/bot<redacted>/getMe" };
+  }
+}
+
+function assertOpenClawCrablineRecorderEvidence(
+  contents: string,
+  manifest: CrablineServerManifest,
+): void {
+  const expectedRequest = openClawCrablineProviderProbeRequest(manifest);
   let recorderEvidence = false;
   for (const line of contents.split(/\r?\n/u)) {
     if (!line.trim()) {
@@ -139,7 +188,13 @@ function assertOpenClawCrablineRecorderEvidence(contents: string): void {
         "OpenClaw Crabline provider probe produced no valid JSONL recorder evidence.",
       );
     }
-    recorderEvidence = true;
+    if (
+      event.type === "api" &&
+      event.method === expectedRequest.method &&
+      event.path === expectedRequest.path
+    ) {
+      recorderEvidence = true;
+    }
   }
   if (!recorderEvidence) {
     throw new Error("OpenClaw Crabline provider probe produced no valid JSONL recorder evidence.");
@@ -550,7 +605,7 @@ export async function runOpenClawCrablineProviderReadiness(
     const recorderSnapshot = await readOwnedRecorderSnapshot(recorderPath, recorderDirectory);
     recorderIdentity = recorderSnapshot.identity;
     const recorderSnapshotContents = recorderSnapshot.contents;
-    assertOpenClawCrablineRecorderEvidence(recorderSnapshotContents);
+    assertOpenClawCrablineRecorderEvidence(recorderSnapshotContents, adapter.manifest);
 
     const capabilityReport = {
       result: {

--- a/src/openclaw/artifact-generation.ts
+++ b/src/openclaw/artifact-generation.ts
@@ -165,6 +165,8 @@ function parseArtifactPointer(contents: string): OpenClawCrablineArtifactPointer
     typeof value.capabilityMatrixPath !== "string" ||
     value.capabilityMatrixPath !== expected.capabilityMatrixPath ||
     value.manifestPath !== expected.manifestPath ||
+    (value.version === 2 &&
+      value.providerReadinessArtifactPath !== expected.providerReadinessArtifactPath) ||
     (value.providerReadinessArtifactPath !== undefined &&
       value.providerReadinessArtifactPath !== expected.providerReadinessArtifactPath) ||
     (value.smokeArtifactPath !== undefined &&
@@ -259,7 +261,14 @@ async function assertCurrentGenerationExists(
     pointer.providerReadinessArtifactPath,
   ]) {
     await assertGenerationIdentity();
-    const stats = await fs.lstat(path.join(outputDir, artifactPath));
+    let stats: Awaited<ReturnType<typeof fs.lstat>>;
+    try {
+      stats = await fs.lstat(path.join(outputDir, artifactPath));
+    } catch (error) {
+      throw new Error("OpenClaw Crabline current artifact generation is incomplete.", {
+        cause: error,
+      });
+    }
     if (!stats.isFile()) {
       throw new Error("OpenClaw Crabline current artifact generation is incomplete.");
     }

--- a/test/openclaw-artifact-generation.test.ts
+++ b/test/openclaw-artifact-generation.test.ts
@@ -125,6 +125,31 @@ describe("OpenClaw artifact generation publication", () => {
     }
   });
 
+  it.each(["manifestPath", "providerReadinessArtifactPath"] as const)(
+    "requires explicit v2 artifact pointer %s",
+    async (field) => {
+      const outputDir = await createTempDir();
+      try {
+        await publishOpenClawCrablineArtifactGeneration(publishParams(outputDir), {
+          createGenerationId: () => "11111111-1111-4111-8111-111111111111",
+        });
+        const pointerPath = path.join(outputDir, OPENCLAW_CRABLINE_ARTIFACT_POINTER_PATH);
+        const pointer = JSON.parse(await fs.readFile(pointerPath, "utf8")) as Record<
+          string,
+          unknown
+        >;
+        delete pointer[field];
+        await fs.writeFile(pointerPath, `${JSON.stringify(pointer, null, 2)}\n`);
+
+        await expect(readOpenClawCrablineArtifactPointer(outputDir)).rejects.toThrow(
+          "OpenClaw Crabline artifact pointer is malformed.",
+        );
+      } finally {
+        await disposeTempDir(outputDir);
+      }
+    },
+  );
+
   it("rejects caller-controlled artifact paths before creating the store", async () => {
     const outputDir = await createTempDir();
     const params = publishParams(outputDir);
@@ -382,6 +407,30 @@ describe("OpenClaw artifact generation publication", () => {
       });
       await expect(fs.stat(path.join(outputDir, first.manifestPath))).resolves.toBeDefined();
       await expect(fs.stat(path.join(outputDir, second.manifestPath))).resolves.toBeDefined();
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
+  it.each([
+    ["manifest", "manifestPath"],
+    ["capability matrix", "capabilityMatrixPath"],
+    ["provider readiness", "providerReadinessArtifactPath"],
+  ] as const)("normalizes missing current %s artifact errors", async (_label, field) => {
+    const outputDir = await createTempDir();
+    try {
+      const current = await publishOpenClawCrablineArtifactGeneration(publishParams(outputDir), {
+        createGenerationId: () => "11111111-1111-4111-8111-111111111111",
+      });
+      await fs.rm(path.join(outputDir, current[field]));
+
+      const publication = publishOpenClawCrablineArtifactGeneration(publishParams(outputDir), {
+        createGenerationId: () => "22222222-2222-4222-8222-222222222222",
+      });
+      await expect(publication).rejects.toMatchObject({
+        message: "OpenClaw Crabline current artifact generation is incomplete.",
+        cause: { code: "ENOENT" },
+      });
     } finally {
       await disposeTempDir(outputDir);
     }

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -150,7 +150,7 @@ function recorderProbeLine(extra: Record<string, unknown> = {}): string {
     accepted: true,
     at: "2026-07-13T00:00:00.000Z",
     method: "GET",
-    path: "/probe",
+    path: "/bot<redacted>/getMe",
     query: {},
     type: "api",
     ...extra,
@@ -2838,7 +2838,7 @@ describe("OpenClaw local provider bridge", () => {
     }
   });
 
-  it("probes Crabline provider readiness without claiming OpenClaw execution", async () => {
+  it("accepts exact provider API route evidence without claiming OpenClaw execution", async () => {
     const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-provider-readiness-"));
     try {
       const legacyManifestPath = path.join(outputDir, OPENCLAW_CRABLINE_MANIFEST_PATH);
@@ -3113,6 +3113,8 @@ describe("OpenClaw local provider bridge", () => {
     ["unrelated object", "{}\n"],
     ["rejected event", recorderProbeLine({ accepted: false })],
     ["non-boolean acceptance", recorderProbeLine({ accepted: "true" })],
+    ["admin-only event", recorderProbeLine({ type: "admin" })],
+    ["wrong API route", recorderProbeLine({ path: "/bot<redacted>/sendMessage" })],
     ["valid event followed by malformed JSON", `${recorderProbeLine()}not-json\n`],
   ])("fails closed on %s readiness recorder evidence", async (_label, recorderContents) => {
     const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-recorder-invalid-"));


### PR DESCRIPTION
## What Problem This Solves

OpenClaw readiness could accept recorder evidence from the wrong route, v2 artifact pointers could omit required paths, and missing generation artifacts escaped the normalized corruption error.

## Why This Change Was Made

Readiness evidence now requires the exact provider API method and path, v2 pointers require explicit manifest and readiness paths, and missing current-generation artifacts are normalized while retaining their underlying cause.

## User Impact

Readiness cannot be satisfied by admin-only or unrelated traffic, and damaged artifact generations fail with one stable, diagnosable error contract.

## Evidence

- 125 focused OpenClaw/artifact tests passed locally.
- TypeScript and formatting checks passed.
- Sol/high autoreview: clean, confidence 0.89.
- Crabbox `run_59226adfd3c6`: full `pnpm verify`, 64 files, 1471 passed, 15 skipped.
