### PR TITLE
fix(providers): harden auth and webhook delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Require exact provider readiness recorder routes, explicit v2 artifact pointers, and normalized missing-generation corruption errors.
 - Track actionlint updates, container image pins, and pull-request governance in the repository security checks.
 - Revalidate release tags before idempotent publication success and enforce the development toolchain's Node floor.
+- Honor HTTP response age when caching JWT keys, reject unsupported critical JWS headers and malformed provider key metadata, preserve signing-service failure status, and protect webhook routing and framing headers.
 - Verify downloaded npm tarball integrity, retry transient provenance lookups, and revalidate release tags immediately before publication mutations.
 - Validate effective fixture mode overrides and stop retrying permanent provider send failures.
 - Bound watch iterator return and provider cleanup during CLI shutdown, forcing process exit after deadline failures.

--- a/src/providers/builtin/googlechat.ts
+++ b/src/providers/builtin/googlechat.ts
@@ -1,4 +1,4 @@
-import { createPublicKey } from "node:crypto";
+import { createPublicKey, type KeyObject } from "node:crypto";
 import path from "node:path";
 import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
@@ -6,6 +6,7 @@ import { LocalMockProviderAdapter } from "../local-mock.js";
 import type { ProviderAdapter } from "../types.js";
 import {
   createCachedJwtKeyResolver,
+  JwtKeyInfrastructureError,
   readBearerToken,
   resolveHttpCacheExpiry,
   verifySignedJwt,
@@ -52,8 +53,8 @@ type GoogleChatAuthRuntime = {
 };
 
 type GoogleCertificate = {
-  certificate: string;
   kid: string;
+  key: KeyObject;
 };
 
 export function createGoogleChatWebhookAuthenticator(
@@ -76,22 +77,41 @@ export function createGoogleChatWebhookAuthenticator(
   const createCertificateResolver = (certificateUrl: string) => {
     return createCachedJwtKeyResolver<GoogleCertificate>({
       async fetchKeys(signal) {
-        const fetchedAt = runtime.now?.() ?? Date.now();
-        const response = await fetchImpl(certificateUrl, { signal });
-        if (!response.ok) {
-          throw new Error(`Google certificate fetch failed with HTTP ${response.status}.`);
+        try {
+          const requestedAt = runtime.now?.() ?? Date.now();
+          const response = await fetchImpl(certificateUrl, { signal });
+          if (!response.ok) {
+            throw new Error(`Google certificate fetch failed with HTTP ${response.status}.`);
+          }
+          const body: unknown = await response.json();
+          if (!isRecord(body)) {
+            throw new Error("Google certificate response must be an object.");
+          }
+          const values = Object.entries(body).map(([kid, certificate]) => {
+            if (typeof certificate !== "string") {
+              throw new Error("Google certificate response values must be strings.");
+            }
+            const key = createPublicKey(certificate);
+            if (key.asymmetricKeyType !== "rsa") {
+              throw new Error("Google certificate response keys must use RSA.");
+            }
+            return { kid, key };
+          });
+          if (values.length === 0) {
+            throw new Error("Google certificate response must include signing keys.");
+          }
+          return {
+            expiresAt: resolveHttpCacheExpiry(response, requestedAt),
+            values,
+          };
+        } catch (error) {
+          throw error instanceof JwtKeyInfrastructureError
+            ? error
+            : new JwtKeyInfrastructureError(
+                error instanceof Error ? error.message : "Google certificate fetch failed.",
+                { cause: error },
+              );
         }
-        const body: unknown = await response.json();
-        if (!isRecord(body)) {
-          throw new Error("Google certificate response must be an object.");
-        }
-        const values = Object.entries(body).flatMap(([kid, certificate]) =>
-          typeof certificate === "string" ? [{ certificate, kid }] : [],
-        );
-        return {
-          expiresAt: resolveHttpCacheExpiry(response, fetchedAt),
-          values,
-        };
       },
       keyId: (value) => value.kid,
       now: runtime.now,
@@ -144,7 +164,7 @@ export function createGoogleChatWebhookAuthenticator(
           const certificate = await (certificateUrl === GOOGLE_OAUTH_CERTS_URL
             ? resolveGoogleIdentityCertificate(header)
             : resolveGoogleChatCertificate(header));
-          return createPublicKey(certificate.certificate);
+          return certificate.key;
         },
         token,
       });
@@ -164,13 +184,20 @@ export function createGoogleChatWebhookAuthenticator(
         throw new Error("Google Chat ID token identity is invalid.");
       }
       return undefined;
-    } catch {
-      return new Response("unauthorized", {
-        headers: { "www-authenticate": "Bearer" },
-        status: 401,
-      });
+    } catch (error) {
+      return googleAuthenticationResponse(error instanceof JwtKeyInfrastructureError ? 503 : 401);
     }
   };
+}
+
+function googleAuthenticationResponse(status: 401 | 503): Response {
+  return new Response(status === 401 ? "unauthorized" : "service unavailable", {
+    headers: {
+      "cache-control": "no-store",
+      ...(status === 401 ? { "www-authenticate": "Bearer" } : {}),
+    },
+    status,
+  });
 }
 
 export function matchesGoogleChatThread(

--- a/src/providers/builtin/msteams.ts
+++ b/src/providers/builtin/msteams.ts
@@ -52,6 +52,20 @@ type BotConnectorKey = JsonWebKey & {
   kid?: string | undefined;
 };
 
+function parseBotConnectorKey(value: unknown): BotConnectorKey {
+  if (!isRecord(value)) {
+    throw new Error("Bot Connector signing key must be an object.");
+  }
+  if (
+    value.endorsements !== undefined &&
+    (!Array.isArray(value.endorsements) ||
+      !value.endorsements.every((endorsement) => typeof endorsement === "string"))
+  ) {
+    throw new Error("Bot Connector signing key endorsements must be a string array.");
+  }
+  return value as BotConnectorKey;
+}
+
 export function createMsTeamsWebhookAuthenticator(
   config: ProviderConfig,
   runtime: MsTeamsAuthRuntime = {},
@@ -64,30 +78,31 @@ export function createMsTeamsWebhookAuthenticator(
   const resolveSigningKey = createCachedJwtKeyResolver<BotConnectorKey>({
     async fetchKeys(signal) {
       try {
-        const fetchedAt = runtime.now?.() ?? Date.now();
+        const metadataRequestedAt = runtime.now?.() ?? Date.now();
         const metadataResponse = await fetchImpl(BOT_CONNECTOR_OPENID_URL, { signal });
         if (!metadataResponse.ok) {
           throw new Error(
             `Bot Connector metadata fetch failed with HTTP ${metadataResponse.status}.`,
           );
         }
-        const metadataExpiry = resolveHttpCacheExpiry(metadataResponse, fetchedAt);
+        const metadataExpiry = resolveHttpCacheExpiry(metadataResponse, metadataRequestedAt);
         const metadata = (await metadataResponse.json()) as { jwks_uri?: unknown };
         if (typeof metadata.jwks_uri !== "string") {
           throw new Error("Bot Connector metadata omitted jwks_uri.");
         }
+        const keysRequestedAt = runtime.now?.() ?? Date.now();
         const keysResponse = await fetchImpl(metadata.jwks_uri, { signal });
         if (!keysResponse.ok) {
           throw new Error(`Bot Connector key fetch failed with HTTP ${keysResponse.status}.`);
         }
-        const keyExpiry = resolveHttpCacheExpiry(keysResponse, fetchedAt);
+        const keyExpiry = resolveHttpCacheExpiry(keysResponse, keysRequestedAt);
         const keys = (await keysResponse.json()) as { keys?: unknown };
         if (!Array.isArray(keys.keys)) {
           throw new Error("Bot Connector key response omitted keys.");
         }
         return {
           expiresAt: Math.min(metadataExpiry, keyExpiry),
-          values: keys.keys as BotConnectorKey[],
+          values: keys.keys.map(parseBotConnectorKey),
         };
       } catch (error) {
         throw error instanceof JwtKeyInfrastructureError
@@ -129,7 +144,11 @@ export function createMsTeamsWebhookAuthenticator(
             throw new Error("Bot Connector JWT key does not endorse the activity channel.");
           }
           try {
-            return createPublicKey({ format: "jwk", key });
+            const publicKey = createPublicKey({ format: "jwk", key });
+            if (publicKey.asymmetricKeyType !== "rsa") {
+              throw new Error("Bot Connector JWT signing key must use RSA.");
+            }
+            return publicKey;
           } catch (error) {
             throw new JwtKeyInfrastructureError("Bot Connector JWT signing key is invalid.", {
               cause: error,

--- a/src/providers/signed-jwt.ts
+++ b/src/providers/signed-jwt.ts
@@ -46,6 +46,17 @@ function decodeJsonPart(value: string): Record<string, unknown> {
 }
 
 function readHeader(value: Record<string, unknown>): JwtHeader {
+  if ("crit" in value) {
+    const critical = value.crit;
+    if (
+      !Array.isArray(critical) ||
+      critical.length === 0 ||
+      !critical.every((name): name is string => typeof name === "string" && name.length > 0)
+    ) {
+      throw new Error("JWT crit header must be a non-empty array of parameter names.");
+    }
+    throw new Error("JWT critical header parameters are unsupported.");
+  }
   if (value.alg !== "RS256" || typeof value.kid !== "string" || !value.kid) {
     throw new Error("JWT must use RS256 and include a key id.");
   }
@@ -114,46 +125,60 @@ function cacheControlDirectiveName(value: string): string | undefined {
   return /^[ \t]*([!#$%&'*+\-.^_`|~0-9A-Za-z]+)/u.exec(value)?.[1]?.toLowerCase();
 }
 
-export function resolveHttpCacheExpiry(response: Response, now: number): number {
+export function resolveHttpCacheExpiry(response: Response, requestTime: number): number {
   const cacheControl = response.headers.get("cache-control");
   const cacheControlDirectives = splitCacheControlDirectives(cacheControl ?? "");
   if (!cacheControlDirectives) {
-    return now;
+    return requestTime;
   }
   if (/(?:^|,)\s*(?:no-cache|no-store)(?:\s*(?:=|,|$))/iu.test(cacheControl ?? "")) {
-    return now;
+    return requestTime;
   }
   const ageHeader = response.headers.get("age");
   const ageSeconds = ageHeader && /^\d+$/u.test(ageHeader) ? Number.parseInt(ageHeader, 10) : 0;
+  const dateHeader = response.headers.get("date");
+  const parsedDate = dateHeader === null ? Number.NaN : Date.parse(dateHeader);
+  const dateValue = Number.isFinite(parsedDate) ? parsedDate : undefined;
+  const apparentAgeMs = dateValue === undefined ? 0 : Math.max(0, requestTime - dateValue);
+  const currentAgeMs = Math.max(apparentAgeMs, ageSeconds * 1_000);
   const maxAgeDirectives = cacheControlDirectives.filter(
     (directive) => cacheControlDirectiveName(directive) === "max-age",
   );
   if (maxAgeDirectives.length > 0) {
     if (maxAgeDirectives.length !== 1) {
-      return now;
+      return requestTime;
     }
     const maxAge = /^[ \t]*max-age[ \t]*=[ \t]*(?:"(\d+)"|(\d+))[ \t]*$/iu.exec(
       maxAgeDirectives[0]!,
     );
     if (!maxAge) {
-      return now;
+      return requestTime;
     }
     const maxAgeSeconds = Number(maxAge[1] ?? maxAge[2]);
     if (!Number.isSafeInteger(maxAgeSeconds)) {
-      return now;
+      return requestTime;
     }
     return (
-      now + Math.min(MAX_HTTP_CACHE_AGE_SECONDS, Math.max(0, maxAgeSeconds - ageSeconds)) * 1_000
+      requestTime +
+      Math.min(
+        MAX_HTTP_CACHE_AGE_SECONDS * 1_000,
+        Math.max(0, maxAgeSeconds * 1_000 - currentAgeMs),
+      )
     );
   }
   const expiresHeader = response.headers.get("expires");
   if (expiresHeader === null) {
-    return now + Math.max(0, 60 * 60 - ageSeconds) * 1_000;
+    return requestTime + Math.max(0, 60 * 60 * 1_000 - currentAgeMs);
   }
   const expires = Date.parse(expiresHeader);
-  return Number.isFinite(expires) && expires > now
-    ? Math.min(expires, now + MAX_HTTP_CACHE_AGE_SECONDS * 1_000)
-    : now;
+  if (!Number.isFinite(expires)) {
+    return requestTime;
+  }
+  const freshnessLifetimeMs = Math.max(0, expires - (dateValue ?? requestTime));
+  return (
+    requestTime +
+    Math.min(MAX_HTTP_CACHE_AGE_SECONDS * 1_000, Math.max(0, freshnessLifetimeMs - currentAgeMs))
+  );
 }
 
 function validateRemoteJwtKeySet<T>(

--- a/src/servers/webhook-target.ts
+++ b/src/servers/webhook-target.ts
@@ -34,6 +34,18 @@ const GLOBAL_IPV6_EXCEPTIONS = createGlobalIpv6Exceptions();
 const ALLOCATED_GLOBAL_IPV6_RANGES = createAllocatedGlobalIpv6Ranges();
 const RFC6052_PREFIX_LENGTHS = [32, 40, 48, 56, 64, 96] as const;
 const IPV4ONLY_ADDRESSES = new Set(["192.0.0.170", "192.0.0.171"]);
+const SENDER_CONTROLLED_WEBHOOK_HEADERS = new Set([
+  "connection",
+  "content-length",
+  "expect",
+  "host",
+  "keep-alive",
+  "proxy-connection",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
 
 type WebhookDnsLookupResult = ReadonlyArray<{ address: string; family: number }>;
 type WebhookDnsLookup = (hostname: string) => Promise<WebhookDnsLookupResult>;
@@ -518,10 +530,29 @@ type PostWebhookRequestParams = {
   url: URL;
 };
 
+function webhookRequestHeaders(
+  body: string,
+  headerEntries: PostWebhookRequestParams["headerEntries"],
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    "content-length": String(Buffer.byteLength(body)),
+    "content-type": "application/json",
+  };
+  for (const [name, value] of headerEntries ?? []) {
+    const normalizedName = name.toLowerCase();
+    if (SENDER_CONTROLLED_WEBHOOK_HEADERS.has(normalizedName)) {
+      throw new Error(`Webhook header "${name}" is controlled by the sender.`);
+    }
+    headers[normalizedName] = value;
+  }
+  return headers;
+}
+
 async function sendWebhookRequest(
   params: PostWebhookRequestParams,
   resolveOnHeaders: boolean,
 ): Promise<WebhookResponse> {
+  const headers = webhookRequestHeaders(params.body, params.headerEntries);
   return await new Promise<WebhookResponse>((resolve, reject) => {
     const address = params.address;
     let settled = false;
@@ -542,11 +573,7 @@ async function sendWebhookRequest(
       {
         agent: false,
         ...(address ? { family: address.family } : {}),
-        headers: {
-          "content-length": String(Buffer.byteLength(params.body)),
-          "content-type": "application/json",
-          ...Object.fromEntries(params.headerEntries ?? []),
-        },
+        headers,
         ...(address
           ? {
               lookup: (_hostname, _options, callback) =>

--- a/test/googlechat-provider.test.ts
+++ b/test/googlechat-provider.test.ts
@@ -194,6 +194,51 @@ describe("Google Chat webhook authentication", () => {
     ).resolves.toMatchObject({ status: 401 });
   });
 
+  it("distinguishes Google signing infrastructure failures from invalid credentials", async () => {
+    const config = await createLocalMockConfig("googlechat", "/googlechat/webhook");
+    config.googlechat!.endpointUrl = "https://chat.example.test/googlechat/webhook";
+    const keys = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const now = Date.now();
+    const body = JSON.stringify({ chat: { messagePayload: {} } });
+    const signedRequest = signedJwt(keys.privateKey, {
+      aud: config.googlechat!.endpointUrl,
+      email: "chat@system.gserviceaccount.com",
+      email_verified: true,
+      exp: Math.floor(now / 1000) + 60,
+      iss: "https://accounts.google.com",
+    });
+    const request = () =>
+      new Request(config.googlechat!.endpointUrl!, {
+        headers: { authorization: `Bearer ${signedRequest}` },
+      });
+
+    for (const fetchImpl of [
+      async () => {
+        throw new Error("Google certificate service unavailable");
+      },
+      async () => Response.json({ "test-key": "not a certificate" }),
+    ]) {
+      const authenticate = createGoogleChatWebhookAuthenticator(config, {
+        fetch: fetchImpl,
+        now: () => now,
+      });
+      const response = await authenticate!(request(), body);
+      expect(response?.status).toBe(503);
+      expect(response?.headers.get("cache-control")).toBe("no-store");
+      expect(response?.headers.get("www-authenticate")).toBeNull();
+      await expect(response?.text()).resolves.toBe("service unavailable");
+    }
+
+    const authenticate = createGoogleChatWebhookAuthenticator(config, {
+      fetch: async () =>
+        Response.json({
+          "other-key": keys.publicKey.export({ format: "pem", type: "spki" }).toString(),
+        }),
+      now: () => now,
+    });
+    await expect(authenticate!(request(), body)).resolves.toMatchObject({ status: 401 });
+  });
+
   it("acknowledges authenticated lifecycle events without recording them", async () => {
     const config = await createLocalMockConfig("googlechat", "/googlechat/webhook");
     config.googlechat!.endpointUrl = "https://chat.example.test/googlechat/webhook";

--- a/test/msteams-provider.test.ts
+++ b/test/msteams-provider.test.ts
@@ -256,6 +256,24 @@ describe("Microsoft Teams webhook authentication", () => {
         body,
       ),
     ).resolves.toMatchObject({ status: 401 });
+
+    const differentEndorsementAuthenticator = createMsTeamsWebhookAuthenticator(config, {
+      fetch: async (input: string | URL | Request) =>
+        String(input).includes("openidconfiguration")
+          ? Response.json({ jwks_uri: "https://login.example.test/keys" })
+          : Response.json({
+              keys: [{ ...jwk, endorsements: ["msteams-extra"], kid: "test-key" }],
+            }),
+      now: () => now,
+    });
+    await expect(
+      differentEndorsementAuthenticator!(
+        new Request(url, {
+          headers: { authorization: `Bearer ${header}.${payload}.${signature}` },
+        }),
+        body,
+      ),
+    ).resolves.toMatchObject({ status: 401 });
   });
 
   it("distinguishes Bot Connector signing infrastructure failures from invalid credentials", async () => {
@@ -326,6 +344,24 @@ describe("Microsoft Teams webhook authentication", () => {
         JSON.stringify({ channelId: "msteams", serviceUrl, type: "message" }),
       ),
     ).resolves.toMatchObject({ status: 503 });
+
+    for (const endorsements of ["prefix-msteams-suffix", ["msteams", 1]]) {
+      const malformedEndorsementsAuthenticator = createMsTeamsWebhookAuthenticator(config, {
+        fetch: async (input: string | URL | Request) =>
+          String(input).includes("openidconfiguration")
+            ? Response.json({ jwks_uri: "https://login.example.test/keys" })
+            : Response.json({ keys: [{ endorsements, kid: "test-key", kty: "RSA" }] }),
+        now: () => now,
+      });
+      await expect(
+        malformedEndorsementsAuthenticator!(
+          new Request("https://bot.example.test/msteams/webhook", {
+            headers: { authorization: `Bearer ${signedRequest}` },
+          }),
+          JSON.stringify({ channelId: "msteams", serviceUrl, type: "message" }),
+        ),
+      ).resolves.toMatchObject({ status: 503 });
+    }
   });
 
   it("acknowledges authenticated non-message activities without recording them", async () => {

--- a/test/signed-jwt.test.ts
+++ b/test/signed-jwt.test.ts
@@ -10,10 +10,11 @@ import {
 function signedJwt(
   privateKey: ReturnType<typeof generateKeyPairSync>["privateKey"],
   claims: Record<string, unknown>,
+  headerOverrides: Record<string, unknown> = {},
 ): string {
-  const header = Buffer.from(JSON.stringify({ alg: "RS256", kid: "test-key" })).toString(
-    "base64url",
-  );
+  const header = Buffer.from(
+    JSON.stringify({ alg: "RS256", kid: "test-key", ...headerOverrides }),
+  ).toString("base64url");
   const payload = Buffer.from(JSON.stringify(claims)).toString("base64url");
   const signature = sign("RSA-SHA256", Buffer.from(`${header}.${payload}`), privateKey).toString(
     "base64url",
@@ -111,6 +112,56 @@ describe("signed JWT remote key cache", () => {
     }
   });
 
+  it("rejects critical JWS extensions before resolving a signing key", async () => {
+    const keys = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const now = 1_700_000_000_000;
+    const resolveKey = vi.fn(async () => keys.publicKey);
+    const claims = {
+      aud: "crabline",
+      exp: Math.floor(now / 1000) + 60,
+      iss: "issuer",
+    };
+    const signedRequest = signedJwt(keys.privateKey, claims, {
+      crit: ["custom"],
+      custom: true,
+    });
+
+    await expect(
+      verifySignedJwt({
+        audience: "crabline",
+        issuers: ["issuer"],
+        now: () => now,
+        resolveKey,
+        ["token"]: signedRequest,
+      }),
+    ).rejects.toThrow(/critical header parameters are unsupported/u);
+    expect(resolveKey).not.toHaveBeenCalled();
+  });
+
+  it.each([[], "custom", [""], [1]])("rejects malformed JWS crit headers: %j", async (crit) => {
+    const keys = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const now = 1_700_000_000_000;
+    const signedRequest = signedJwt(
+      keys.privateKey,
+      {
+        aud: "crabline",
+        exp: Math.floor(now / 1000) + 60,
+        iss: "issuer",
+      },
+      { crit },
+    );
+
+    await expect(
+      verifySignedJwt({
+        audience: "crabline",
+        issuers: ["issuer"],
+        now: () => now,
+        resolveKey: async () => keys.publicKey,
+        ["token"]: signedRequest,
+      }),
+    ).rejects.toThrow(/crit header must be a non-empty array/u);
+  });
+
   it("does not cache responses marked no-cache or no-store", () => {
     const now = 1_700_000_000_000;
 
@@ -159,6 +210,70 @@ describe("signed JWT remote key cache", () => {
         now,
       ),
     ).toBe(now + 86_400_000);
+  });
+
+  it("uses the greater of apparent Date age and Age header age", () => {
+    const now = 1_700_000_000_000;
+
+    expect(
+      resolveHttpCacheExpiry(
+        new Response(null, {
+          headers: {
+            age: "120",
+            "cache-control": "public, max-age=3600",
+            date: new Date(now - 600_000).toUTCString(),
+          },
+        }),
+        now,
+      ),
+    ).toBe(now + 3_000_000);
+    expect(
+      resolveHttpCacheExpiry(
+        new Response(null, {
+          headers: {
+            age: "900",
+            "cache-control": "public, max-age=3600",
+            date: new Date(now - 600_000).toUTCString(),
+          },
+        }),
+        now,
+      ),
+    ).toBe(now + 2_700_000);
+  });
+
+  it("ignores malformed or future Date values when calculating apparent age", () => {
+    const now = 1_700_000_000_000;
+
+    for (const date of ["not-a-date", new Date(now + 600_000).toUTCString()]) {
+      expect(
+        resolveHttpCacheExpiry(
+          new Response(null, {
+            headers: {
+              age: "120",
+              "cache-control": "public, max-age=3600",
+              date,
+            },
+          }),
+          now,
+        ),
+      ).toBe(now + 3_480_000);
+    }
+  });
+
+  it("expires cache entries when apparent response age reaches the freshness boundary", () => {
+    const now = 1_700_000_000_000;
+
+    expect(
+      resolveHttpCacheExpiry(
+        new Response(null, {
+          headers: {
+            "cache-control": "public, max-age=3600",
+            date: new Date(now - 3_600_000).toUTCString(),
+          },
+        }),
+        now,
+      ),
+    ).toBe(now);
   });
 
   it("clamps absurd cache lifetimes and rejects unsafe max-age values", () => {

--- a/test/webhook-target.test.ts
+++ b/test/webhook-target.test.ts
@@ -405,4 +405,26 @@ describe("webhook target validation", () => {
       );
     }
   });
+
+  it.each([
+    "Connection",
+    "Content-Length",
+    "Expect",
+    "Host",
+    "Keep-Alive",
+    "Proxy-Connection",
+    "TE",
+    "Trailer",
+    "Transfer-Encoding",
+    "Upgrade",
+  ])("rejects sender-controlled custom webhook header %s", async (name) => {
+    await expect(
+      postWebhookRequest({
+        body: "{}",
+        headerEntries: [[name, "unsafe"]],
+        timeoutMs: 100,
+        url: new URL("http://127.0.0.1:1/webhook"),
+      }),
+    ).rejects.toThrow(`Webhook header "${name}" is controlled by the sender.`);
+  });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes provider authentication and webhook delivery cases that could accept unsupported JWT extensions, misclassify key-service failures, trust malformed Teams endorsements, or allow custom headers to override request routing and framing.

## Why This Change Was Made

JWT verification now applies response-age-aware cache freshness and rejects unsupported critical headers. Provider key metadata is validated strictly, Google key infrastructure failures preserve their service status, and webhook delivery filters sender-controlled transport headers.

## User Impact

Provider authentication fails closed with accurate status codes, while webhook destinations can no longer override protected HTTP routing or body framing through custom headers.

## Evidence

- Focused Vitest suite: 142 tests passed
- `oxfmt --check` on all changed files
- `tsc -p tsconfig.test.json --noEmit`
- Autoreview with `gpt-5.6-sol`, high reasoning: clean (0.93 confidence)
- Exact-head Crabbox Linux `pnpm verify`: 64 test files passed, 1502 tests passed, 15 skipped (`run_66dc56da076d`)
