### PR TITLE
fix(core): harden JSON reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Escape visually unsafe Unicode controls in JSON reports, return a stable error document for unserializable values, and preserve Node write encoding semantics in test captures.
 - Bind agent acknowledgements to the expected nonce instead of accepting an unrelated ACK.
 - Bound manifest file loading, honor probe retries, and reject empty resolved Zalo webhook secrets.
 - Require exact provider readiness recorder routes, explicit v2 artifact pointers, and normalized missing-generation corruption errors.

--- a/src/core/reporters.ts
+++ b/src/core/reporters.ts
@@ -5,6 +5,14 @@ const BIDI_CONTROL_CODE_POINTS = new Set([
   0x061c, 0x200e, 0x200f, 0x202a, 0x202b, 0x202c, 0x202d, 0x202e, 0x2066, 0x2067, 0x2068, 0x2069,
 ]);
 
+const UNSAFE_JSON_CODE_POINTS = /[\u061c\u200e\u200f\u2028\u2029\u202a-\u202e\u2066-\u2069]/gu;
+const JSON_SERIALIZATION_ERROR = `{
+  "error": {
+    "message": "Unable to serialize JSON output."
+  },
+  "ok": false
+}`;
+
 export function sanitizeTerminalText(value: string, singleLine = false): string {
   let sanitized = "";
   for (const character of value) {
@@ -54,7 +62,16 @@ export function formatRunResultText(result: CommandRunResult | SuiteRunResult): 
 }
 
 export function formatJson(result: unknown): string {
-  return JSON.stringify(result === undefined ? null : result, null, 2) ?? "null";
+  let serialized: string | undefined;
+  try {
+    serialized = JSON.stringify(result === undefined ? null : result, null, 2);
+  } catch {
+    return JSON_SERIALIZATION_ERROR;
+  }
+  return (serialized ?? "null").replace(
+    UNSAFE_JSON_CODE_POINTS,
+    (character) => String.raw`\u${character.codePointAt(0)!.toString(16).padStart(4, "0")}`,
+  );
 }
 
 function formatSingleResult(result: CommandRunResult): string {

--- a/test/reporters-errors.test.ts
+++ b/test/reporters-errors.test.ts
@@ -79,6 +79,43 @@ describe("errors and reporters", () => {
     expect(formatJson(() => undefined)).toBe("null");
   });
 
+  it("escapes visually unsafe Unicode controls without changing parsed JSON values", () => {
+    const controls =
+      "\u061c\u200e\u200f\u2028\u2029\u202a\u202b\u202c\u202d\u202e\u2066\u2067\u2068\u2069";
+    const output = formatJson({ [controls]: controls });
+
+    expect(output).not.toMatch(/[\u061c\u200e\u200f\u2028\u2029\u202a-\u202e\u2066-\u2069]/u);
+    for (const character of controls) {
+      expect(output).toContain(
+        String.raw`\u${character.codePointAt(0)!.toString(16).padStart(4, "0")}`,
+      );
+    }
+    expect(JSON.parse(output)).toEqual({ [controls]: controls });
+  });
+
+  it("returns a stable error envelope when JSON serialization fails", () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    const throwingValue = {
+      toJSON() {
+        throw new Error("sensitive serialization detail");
+      },
+    };
+    const expected = {
+      error: {
+        message: "Unable to serialize JSON output.",
+      },
+      ok: false,
+    };
+    const expectedOutput = JSON.stringify(expected, null, 2);
+
+    for (const value of [cyclic, { value: 1n }, throwingValue]) {
+      const output = formatJson(value);
+      expect(output).toBe(expectedOutput);
+      expect(output).not.toContain("sensitive serialization detail");
+    }
+  });
+
   it("neutralizes terminal controls in text output", () => {
     const output = formatRunResultText({
       diagnostics: ["first\u001b[2J\rsecond\nthird\u202e"],

--- a/test/test-helpers.test.ts
+++ b/test/test-helpers.test.ts
@@ -117,6 +117,19 @@ describe("test helpers", () => {
     expect(stderrCallback).toHaveBeenCalledWith(null);
   });
 
+  it("captures the bytes produced by write encodings", async () => {
+    const encodedString = "é";
+    const encodedBytes = Buffer.from(encodedString, "utf8");
+
+    const captured = await captureWrites(() => {
+      process.stdout.write(encodedString, "latin1");
+      process.stderr.write(encodedBytes, "latin1");
+    });
+
+    expect(captured.stdout).toEqual([Buffer.from(encodedString, "latin1").toString("utf8")]);
+    expect(captured.stderr).toEqual([encodedBytes.toString("utf8")]);
+  });
+
   it("restores the outer capture after a nested capture settles", async () => {
     const stdoutWrite = process.stdout.write;
     const stderrWrite = process.stderr.write;

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -136,9 +136,9 @@ const createCaptureWriter =
       return originalWrite.call(target, chunk, encodingOrCallback, callback);
     }
     const encoding = typeof encodingOrCallback === "string" ? encodingOrCallback : undefined;
-    capture[stream].push(
-      typeof chunk === "string" ? chunk : Buffer.from(chunk).toString(encoding ?? "utf8"),
-    );
+    const bytes =
+      typeof chunk === "string" ? Buffer.from(chunk, encoding ?? "utf8") : Buffer.from(chunk);
+    capture[stream].push(bytes.toString("utf8"));
     const completion = typeof encodingOrCallback === "function" ? encodingOrCallback : callback;
     if (completion) {
       queueMicrotask(() => completion(null));


### PR DESCRIPTION
## What Problem This Solves

Fixes JSON reporting cases where unusual payloads could crash serialization, emit bidi or line-separator controls verbatim, or be captured with Node write encodings reversed.

## Why This Change Was Made

The reporter now returns a stable error envelope for cyclic, BigInt, or throwing `toJSON` values and escapes unsafe control characters without changing parsed JSON values. Test output capture now follows Node's string encoding semantics.

## User Impact

CLI JSON output remains machine-readable and stable even for hostile or non-serializable error values.

## Evidence

- Focused Vitest suite: 16 tests passed
- `oxfmt --check` on all changed files
- `tsc -p tsconfig.test.json --noEmit`
- Autoreview with `gpt-5.6-sol`, high reasoning: clean (0.95 confidence)
- Exact-head Crabbox Linux `pnpm verify`: 64 test files passed, 1486 tests passed, 15 skipped (`run_f1d8613f3006`)
