### PR TITLE
fix(telegram): enforce native destination boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Track actionlint updates, container image pins, and pull-request governance in the repository security checks.
 - Revalidate release tags before idempotent publication success and enforce the development toolchain's Node floor.
 - Honor HTTP response age when caching JWT keys, reject unsupported critical JWS headers and malformed provider key metadata, preserve signing-service failure status, and protect webhook routing and framing headers.
+- Enforce Telegram destination prefixes, username canonicalization, topic IDs, and signed 52-bit chat identifier boundaries.
 - Verify downloaded npm tarball integrity, retry transient provenance lookups, and revalidate release tags immediately before publication mutations.
 - Validate effective fixture mode overrides and stop retrying permanent provider send failures.
 - Bound watch iterator return and provider cleanup during CLI shutdown, forcing process exit after deadline failures.

--- a/README.md
+++ b/README.md
@@ -426,6 +426,9 @@ Examples:
 - Slack threads: `1700000000.000100`
 - Telegram chats: `-1001234567890` or `@channelusername`
 - Telegram topics: `42`
+- Telegram username targets require `@`, contain 4-32 letters, digits, or
+  underscores, and normalize to lowercase. Numeric chat IDs must be nonzero and
+  have an absolute value no greater than `2^52 - 1`.
 - WhatsApp Cloud API users: digits-only `wa_id` values such as `15551234567`
 - WhatsApp groups: `120363001234567890@g.us`
 - Discord channels and threads: Discord snowflake ids such as

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -557,6 +557,9 @@ as `telegram:`, `discord:`, or `slack:`.
 - Slack threads: `1700000000.000100`
 - Telegram chats: `-1001234567890` or `@channelusername`
 - Telegram topics: `42`
+- Telegram username targets require `@`, contain 4-32 letters, digits, or
+  underscores, and normalize to lowercase. Numeric chat IDs must be nonzero and
+  have an absolute value no greater than `2^52 - 1`.
 - Built-in WhatsApp Cloud API users: digits-only `wa_id` values such as
   `15551234567`
 - OpenClaw WhatsApp bridge users: `15551234567@s.whatsapp.net`

--- a/src/providers/target-normalizers.ts
+++ b/src/providers/target-normalizers.ts
@@ -1,7 +1,10 @@
 import type { BuiltinAdapterId, FixtureDefinition, ProviderPlatform } from "../config/schema.js";
 import { CrablineError } from "../core/errors.js";
 import { isMatrixEventId, isMatrixRoomId } from "../matrix-ids.js";
-import { TELEGRAM_NATIVE_CHAT_ID_MAX } from "../servers/telegram-identity.js";
+import {
+  canonicalizeTelegramUsername,
+  TELEGRAM_NATIVE_CHAT_ID_MAX,
+} from "../servers/telegram-identity.js";
 import type { LocalMockTargetCodec } from "./local-mock.js";
 import { matchesNativeId, type NativeIdRule } from "./native-ids.js";
 import { slackTargetKey, SLACK_SEND_TARGET_ID_RULE, SLACK_TS_RULE } from "./slack-ids.js";
@@ -263,13 +266,6 @@ const SLACK_TARGET_CODEC: LocalMockTargetCodec = {
   },
 };
 
-const TELEGRAM_BASE_CODEC = createNativeTargetCodec({
-  channel: TELEGRAM_CHAT_ID_RULE,
-  channelLabel: "Telegram chat_id",
-  thread: TELEGRAM_MESSAGE_THREAD_ID_RULE,
-  threadLabel: "Telegram message_thread_id",
-});
-
 export function parseCanonicalTelegramTopic(
   value: string,
 ): { chatId: string; topicId: string } | undefined {
@@ -298,7 +294,11 @@ function parseCanonicalTelegramTopicWithRule(
   ) {
     return undefined;
   }
-  return { chatId, topicId };
+  const canonicalChatId =
+    chatId.startsWith("@") && chatRule === TELEGRAM_CHAT_ID_RULE
+      ? canonicalizeTelegramUsername(chatId)
+      : chatId;
+  return canonicalChatId ? { chatId: canonicalChatId, topicId } : undefined;
 }
 
 const TELEGRAM_TARGET_CODEC: LocalMockTargetCodec = {
@@ -306,21 +306,24 @@ const TELEGRAM_TARGET_CODEC: LocalMockTargetCodec = {
     const canonicalTopic = target.threadId
       ? parseCanonicalTelegramTopic(target.threadId)
       : undefined;
-    const targetChatId = target.channelId ?? target.id;
-    if (
-      canonicalTopic &&
-      requireNativeId(targetChatId, TELEGRAM_CHAT_ID_RULE, "Telegram chat_id") !==
-        canonicalTopic.chatId
-    ) {
+    const targetChatIdValue = requireNativeId(
+      target.channelId ?? target.id,
+      TELEGRAM_CHAT_ID_RULE,
+      "Telegram chat_id",
+    );
+    const targetChatId = targetChatIdValue.startsWith("@")
+      ? canonicalizeTelegramUsername(targetChatIdValue)!
+      : targetChatIdValue;
+    if (canonicalTopic && targetChatId !== canonicalTopic.chatId) {
       throw new CrablineError("Telegram canonical topic chat_id must match the target chat_id.", {
         kind: "config",
       });
     }
-    const normalized = TELEGRAM_BASE_CODEC.normalize({
-      ...target,
-      ...(canonicalTopic ? { channelId: canonicalTopic.chatId } : {}),
-      threadId: undefined,
-    });
+    const normalized: NormalizedTarget = {
+      channelId: canonicalTopic?.chatId ?? targetChatId,
+      id: target.id,
+      metadata: target.metadata,
+    };
     if (!target.threadId) {
       return normalized;
     }

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -388,8 +388,15 @@ function telegramNumericChatId(value: unknown): number | undefined {
   if (!stringValue || !/^-?\d+$/u.test(stringValue)) {
     return undefined;
   }
-  const integerValue = toIntegerValue(stringValue);
-  return integerValue === 0 ? undefined : integerValue;
+  const integerValue = BigInt(stringValue);
+  if (
+    integerValue === 0n ||
+    integerValue < -TELEGRAM_NATIVE_CHAT_ID_MAX ||
+    integerValue > TELEGRAM_NATIVE_CHAT_ID_MAX
+  ) {
+    return undefined;
+  }
+  return Number(integerValue);
 }
 
 async function appendEvent(state: TelegramServerState, event: TelegramServerEvent) {
@@ -448,12 +455,19 @@ function createChat(chatId: number): TelegramChat {
   };
 }
 
-function telegramChatUsername(value: unknown): string | undefined {
+function telegramDestinationUsername(value: unknown): string | undefined {
+  const username = toStringValue(value);
+  return username ? canonicalizeTelegramUsername(username) : undefined;
+}
+
+function telegramStoredUsername(value: unknown): string | undefined {
   const username = toStringValue(value)?.trim();
   if (!username) {
     return undefined;
   }
-  return canonicalizeTelegramUsername(username.startsWith("@") ? username : `@${username}`);
+  return canonicalizeTelegramUsername(username.startsWith("@") ? username : `@${username}`)?.slice(
+    1,
+  );
 }
 
 function telegramChatType(value: unknown): TelegramChat["type"] | undefined {
@@ -464,13 +478,18 @@ function telegramChatType(value: unknown): TelegramChat["type"] | undefined {
 
 function registerTelegramChat(state: TelegramServerState, chat: TelegramChat): void {
   const previous = state.chatsById.get(chat.id);
-  const previousUsername = telegramChatUsername(previous?.username);
+  const previousUsername = telegramStoredUsername(previous?.username);
   if (previousUsername && state.chatsByUsername.get(previousUsername)?.id === chat.id) {
     state.chatsByUsername.delete(previousUsername);
   }
-  const stored = { ...chat };
+  const username = telegramStoredUsername(chat.username);
+  const stored: TelegramChat = {
+    id: chat.id,
+    ...(chat.title ? { title: chat.title } : {}),
+    type: chat.type,
+    ...(username ? { username } : {}),
+  };
   state.chatsById.set(chat.id, stored);
-  const username = telegramChatUsername(chat.username);
   if (username) {
     state.chatsByUsername.set(username, stored);
   }
@@ -488,11 +507,12 @@ function resolveTelegramChat(state: TelegramServerState, value: unknown): Telegr
     }
     return state.chatsById.get(chatId) ?? createChat(chatId);
   }
-  const username = telegramChatUsername(stringValue);
+  const username = telegramDestinationUsername(stringValue);
   if (!username) {
     return undefined;
   }
-  const registered = state.chatsByUsername.get(username);
+  const storedUsername = username.slice(1);
+  const registered = state.chatsByUsername.get(storedUsername);
   if (registered) {
     return registered;
   }
@@ -502,7 +522,7 @@ function resolveTelegramChat(state: TelegramServerState, value: unknown): Telegr
     : {
         id: chatId,
         type: inferTelegramChatType(chatId),
-        username: username.slice(1),
+        username: storedUsername,
       };
 }
 
@@ -515,13 +535,13 @@ function telegramChatFromRecord(value: unknown): TelegramChat | undefined {
   if (id === undefined || !type) {
     return undefined;
   }
-  const username = telegramChatUsername(value.username);
+  const username = telegramStoredUsername(value.username);
   const title = toStringValue(value.title);
   return {
     id,
     ...(title ? { title } : {}),
     type,
-    ...(username ? { username: username.slice(1) } : {}),
+    ...(username ? { username } : {}),
   };
 }
 
@@ -581,7 +601,7 @@ function createOutboundMessage(
   if (!chat) {
     return undefined;
   }
-  const parsedThreadId = toIntegerValue(body.message_thread_id);
+  const parsedThreadId = telegramMessageThreadId(body.message_thread_id);
   if (body.message_thread_id !== undefined && parsedThreadId === undefined) {
     return undefined;
   }
@@ -589,13 +609,12 @@ function createOutboundMessage(
   if (messageId === undefined) {
     return undefined;
   }
-  const threadId = parsedThreadId !== undefined && parsedThreadId > 0 ? parsedThreadId : undefined;
   return {
     chat,
     date: Math.floor(Date.now() / 1000),
     from: createBotUser(state),
     message_id: messageId,
-    ...(threadId !== undefined ? { message_thread_id: threadId } : {}),
+    ...(parsedThreadId !== undefined ? { message_thread_id: parsedThreadId } : {}),
     text,
   };
 }
@@ -613,7 +632,7 @@ function createOutboundMediaMessage(
   if (!chat || !fileName) {
     return undefined;
   }
-  const parsedThreadId = toIntegerValue(body.message_thread_id);
+  const parsedThreadId = telegramMessageThreadId(body.message_thread_id);
   if (body.message_thread_id !== undefined && parsedThreadId === undefined) {
     return undefined;
   }
@@ -621,7 +640,6 @@ function createOutboundMediaMessage(
   if (messageId === undefined) {
     return undefined;
   }
-  const threadId = parsedThreadId !== undefined && parsedThreadId > 0 ? parsedThreadId : undefined;
   const duration = Math.max(0, toIntegerValue(body.duration) ?? 0);
   const height = Math.max(1, toIntegerValue(body.height) ?? 1);
   const width = Math.max(1, toIntegerValue(body.width) ?? 1);
@@ -671,7 +689,7 @@ function createOutboundMediaMessage(
             mime_type: "application/octet-stream",
           },
     message_id: messageId,
-    ...(threadId !== undefined ? { message_thread_id: threadId } : {}),
+    ...(parsedThreadId !== undefined ? { message_thread_id: parsedThreadId } : {}),
   };
 }
 
@@ -685,17 +703,16 @@ function createEditedMessage(
   if (!chat || messageId === undefined || messageId < 1) {
     return undefined;
   }
-  const parsedThreadId = toIntegerValue(body.message_thread_id);
+  const parsedThreadId = telegramMessageThreadId(body.message_thread_id);
   if (body.message_thread_id !== undefined && parsedThreadId === undefined) {
     return undefined;
   }
-  const threadId = parsedThreadId !== undefined && parsedThreadId > 0 ? parsedThreadId : undefined;
   return {
     chat,
     date: Math.floor(Date.now() / 1000),
     from: createBotUser(state),
     message_id: messageId,
-    ...(threadId !== undefined ? { message_thread_id: threadId } : {}),
+    ...(parsedThreadId !== undefined ? { message_thread_id: parsedThreadId } : {}),
     text,
   };
 }
@@ -719,10 +736,9 @@ function createInboundUpdate(
   const messageIdValue = body.messageId ?? body.message_id;
   const updateIdValue = body.updateId ?? body.update_id;
   const fromId = toIntegerValue(fromIdValue);
-  const parsedThreadId = toIntegerValue(threadIdValue);
-  const threadId = parsedThreadId !== undefined && parsedThreadId > 0 ? parsedThreadId : undefined;
+  const threadId = telegramMessageThreadId(threadIdValue);
   const fromUsernameValue = body.fromUsername ?? body.from_username;
-  const fromUsername = telegramChatUsername(fromUsernameValue);
+  const fromUsername = telegramStoredUsername(fromUsernameValue);
   const messageId = toIntegerValue(messageIdValue);
   const updateId = toIntegerValue(updateIdValue);
   const explicitChatType = telegramChatType(body.chatType ?? body.chat_type);
@@ -730,7 +746,7 @@ function createInboundUpdate(
     ((body.chatType !== undefined || body.chat_type !== undefined) && !explicitChatType) ||
     (fromIdValue !== undefined && (fromId === undefined || fromId < 1)) ||
     (fromUsernameValue !== undefined && !fromUsername) ||
-    (threadIdValue !== undefined && parsedThreadId === undefined) ||
+    (threadIdValue !== undefined && threadId === undefined) ||
     (messageIdValue !== undefined && (messageId === undefined || messageId < 0)) ||
     (updateIdValue !== undefined && (updateId === undefined || updateId < 1))
   ) {
@@ -748,7 +764,7 @@ function createInboundUpdate(
         first_name: toStringValue(body.fromName ?? body.from_name) ?? "QA User",
         id: fromId ?? 100001,
         is_bot: false,
-        ...(fromUsername ? { username: fromUsername.slice(1) } : {}),
+        ...(fromUsername ? { username: fromUsername } : {}),
       },
       message_id: messageId ?? nextTelegramMessageId(state, chat.id),
       ...(entities && entities.length > 0 ? { entities } : {}),
@@ -822,6 +838,31 @@ function isTelegramUtf16Boundary(text: string, index: number): boolean {
 
 function hasTelegramMedia(value: Record<string, unknown>): boolean {
   return TELEGRAM_MEDIA_FIELDS.some((field) => value[field] !== undefined);
+}
+
+function telegramMessageThreadId(value: unknown): number | undefined {
+  const threadId = toIntegerValue(value);
+  return threadId !== undefined && threadId > 0 ? threadId : undefined;
+}
+
+function hasValidTelegramMessageThreadIds(body: Record<string, unknown>): boolean {
+  const values = [
+    body.messageThreadId,
+    body.message_thread_id,
+    ...TELEGRAM_MESSAGE_UPDATE_FIELDS.flatMap((field) => {
+      const message = body[field];
+      return isJsonObject(message) ? [message.message_thread_id] : [];
+    }),
+  ];
+  const callbackQuery = isJsonObject(body.callback_query) ? body.callback_query : undefined;
+  const callbackMessage =
+    callbackQuery && isJsonObject(callbackQuery.message) ? callbackQuery.message : undefined;
+  if (callbackMessage) {
+    values.push(callbackMessage.message_thread_id);
+  }
+  return values.every(
+    (value) => value === undefined || telegramMessageThreadId(value) !== undefined,
+  );
 }
 
 function explicitTelegramId(
@@ -1042,8 +1083,6 @@ function hasValidExplicitTelegramIdentities(body: Record<string, unknown>): bool
       body.from_id,
       body.messageId,
       body.message_id,
-      body.messageThreadId,
-      body.message_thread_id,
       body.updateId,
       body.update_id,
     ].every((value) => value === undefined || toIntegerValue(value) !== undefined)
@@ -1068,7 +1107,7 @@ function isValidIgnoredTelegramUpdate(body: Record<string, unknown>): boolean {
       (message.from !== undefined &&
         (!isJsonObject(message.from) || (toIntegerValue(message.from.id) ?? 0) < 1)) ||
       (message.message_thread_id !== undefined &&
-        toIntegerValue(message.message_thread_id) === undefined)
+        telegramMessageThreadId(message.message_thread_id) === undefined)
     ) {
       return false;
     }
@@ -1130,6 +1169,7 @@ async function handleTelegramAdminInbound(params: {
     const nextMessageId =
       messageChatId === undefined ? undefined : nextTelegramMessageId(params.state, messageChatId);
     if (
+      !hasValidTelegramMessageThreadIds(params.body) ||
       explicitMessageId === undefined ||
       explicitMessageChatId === false ||
       explicitUpdateId === undefined ||

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -986,7 +986,7 @@ describe("OpenClaw local provider bridge", () => {
     ).toBe(maxUsername);
     for (const target of ["channel:@abc", `channel:@${"a".repeat(33)}`]) {
       expect(() => createOpenClawCrablineAgentDelivery({ manifest, target })).toThrow(
-        "Telegram usernames must contain 4-32 letters, digits, or underscores.",
+        /Telegram usernames/u,
       );
     }
 

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -119,7 +119,7 @@ describe("registry", () => {
   });
 
   it("enforces Telegram's native username length in shared target normalization", () => {
-    expect(normalizeBuiltinTarget("telegram", { id: "@abcd", metadata: {} })).toMatchObject({
+    expect(normalizeBuiltinTarget("telegram", { id: "@Abcd", metadata: {} })).toMatchObject({
       channelId: "@abcd",
     });
     expect(
@@ -127,11 +127,22 @@ describe("registry", () => {
     ).toMatchObject({
       channelId: `@${"a".repeat(32)}`,
     });
-    for (const id of ["@abc", `@${"a".repeat(33)}`]) {
+    for (const id of ["abcd", "@abc", `@${"a".repeat(33)}`]) {
       expect(() => normalizeBuiltinTarget("telegram", { id, metadata: {} })).toThrow(
         /native Telegram chat id/u,
       );
     }
+    expect(
+      normalizeBuiltinTarget("telegram", {
+        channelId: "@ExampleGroup",
+        id: "topic",
+        metadata: {},
+        threadId: "@examplegroup:42",
+      }),
+    ).toMatchObject({
+      channelId: "@examplegroup",
+      threadId: "@examplegroup:42",
+    });
   });
 
   it("enforces Discord snowflake uint64 bounds", () => {

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -172,7 +172,7 @@ describe("telegram local provider server", () => {
       result: { chat: { id: expect.any(Number), type: "supergroup" } },
     });
 
-    for (const chatId of ["@abc"]) {
+    for (const chatId of ["abcd", "@abc"]) {
       const shortUsername = await fetch(
         `${server.manifest.baseUrl}/bot123456:fake-token/sendMessage`,
         {
@@ -232,7 +232,7 @@ describe("telegram local provider server", () => {
               id: -1001111111111,
               title: "Announcements",
               type: "channel",
-              username: "  @Crabline_News  ",
+              username: "  Crabline_News  ",
             },
           },
           update_id: 1,
@@ -319,50 +319,62 @@ describe("telegram local provider server", () => {
     expect(staleUsername.result.chat.type).toBe("supergroup");
   });
 
-  it("normalizes non-positive topic ids while preserving private-chat topics", async () => {
+  it("rejects non-positive topic ids across text, media, edit, and admin paths", async () => {
     const server = await startTelegramServer({ botToken: "test-token-placeholder" });
     servers.push(server);
-    const sendMessage = (messageThreadId: number) =>
-      fetch(`${server.manifest.baseUrl}/bottest-token-placeholder/sendMessage`, {
-        body: JSON.stringify({
-          chat_id: 42,
-          message_thread_id: messageThreadId,
-          text: "private topic",
-        }),
-        headers: { "content-type": "application/json" },
-        method: "POST",
-      });
+    const apiRoot = `${server.manifest.baseUrl}/bottest-token-placeholder`;
 
     for (const messageThreadId of [0, -1]) {
-      const response = await sendMessage(messageThreadId);
-      const payload = (await response.json()) as {
-        result: { message_thread_id?: number };
-      };
-      expect(response.status).toBe(200);
-      expect(payload.result).not.toHaveProperty("message_thread_id");
+      for (const [method, body] of [
+        [
+          "sendMessage",
+          { chat_id: 42, message_thread_id: messageThreadId, text: "invalid text topic" },
+        ],
+        ["sendPhoto", { chat_id: 42, message_thread_id: messageThreadId, photo: "fixture.png" }],
+        [
+          "editMessageText",
+          {
+            chat_id: 42,
+            message_id: 1,
+            message_thread_id: messageThreadId,
+            text: "invalid edit topic",
+          },
+        ],
+      ] as const) {
+        const response = await fetch(`${apiRoot}/${method}`, {
+          body: JSON.stringify(body),
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        });
+        expect(response.status).toBe(400);
+      }
+
+      for (const body of [
+        { chatId: 42, messageThreadId, text: "invalid admin text topic" },
+        { chatId: 42, messageThreadId, photo: [] },
+        {
+          message: {
+            chat: { id: 42, type: "private" },
+            message_id: 1,
+            message_thread_id: messageThreadId,
+            photo: [{ file_id: "photo", file_unique_id: "unique", height: 1, width: 1 }],
+          },
+          update_id: 1,
+        },
+      ]) {
+        const response = await injectUpdate(server, body);
+        expect(response.status).toBe(400);
+      }
     }
 
-    const privateTopic = await sendMessage(42);
-    await expect(privateTopic.json()).resolves.toMatchObject({
-      result: {
-        chat: { id: 42, type: "private" },
-        message_thread_id: 42,
-      },
+    const privateTopic = await fetch(`${apiRoot}/sendMessage`, {
+      body: JSON.stringify({ chat_id: 42, message_thread_id: 42, text: "private topic" }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
     });
-
-    for (const messageThreadId of [0, -1]) {
-      const response = await injectUpdate(server, {
-        chatId: 42,
-        messageThreadId,
-        text: "private inbound",
-      });
-      const payload = (await response.json()) as {
-        update: { message: { message_thread_id?: number } };
-      };
-      expect(response.status).toBe(200);
-      expect(payload.update.message).not.toHaveProperty("message_thread_id");
-    }
-
+    await expect(privateTopic.json()).resolves.toMatchObject({
+      result: { chat: { id: 42, type: "private" }, message_thread_id: 42 },
+    });
     const privateInboundTopic = await injectUpdate(server, {
       chatId: 42,
       messageThreadId: 42,
@@ -2376,6 +2388,32 @@ describe("telegram local provider server", () => {
     ]) {
       const response = await injectUpdate(server, body);
       expect(response.status).toBe(400);
+    }
+
+    const maxNativeChatId = String((1n << 52n) - 1n);
+    for (const chatId of [maxNativeChatId, `-${maxNativeChatId}`]) {
+      const response = await fetch(
+        `${server.manifest.baseUrl}/bottest-token-placeholder/sendMessage`,
+        {
+          body: JSON.stringify({ chat_id: chatId, text: "native boundary" }),
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        },
+      );
+      expect(response.status).toBe(200);
+    }
+    for (const chatId of [String(1n << 52n), String(-(1n << 52n))]) {
+      const outbound = await fetch(
+        `${server.manifest.baseUrl}/bottest-token-placeholder/sendMessage`,
+        {
+          body: JSON.stringify({ chat_id: chatId, text: "out of range chat" }),
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        },
+      );
+      expect(outbound.status).toBe(400);
+      const inbound = await injectUpdate(server, { chatId, text: "out of range chat" });
+      expect(inbound.status).toBe(400);
     }
 
     const outbound = await fetch(


### PR DESCRIPTION
## What Problem This Solves

Fixes Telegram destinations that accepted unprefixed usernames, non-positive topic IDs, out-of-range numeric chat IDs, or non-canonical username forms.

## Why This Change Was Made

Destination normalization now preserves Telegram's native `@username` form, canonicalizes username casing, enforces positive topic identifiers, and restricts numeric chat IDs to Telegram's signed 52-bit range while retaining valid four-character collectible usernames.

## User Impact

Invalid Telegram targets fail early and valid targets resolve consistently across configuration, outbound calls, and admin-injected updates.

## Evidence

- Focused Vitest suite after rebase: 175 tests passed
- `oxfmt --check` on all changed files
- `tsc -p tsconfig.test.json --noEmit`
- Autoreview with `gpt-5.6-sol`, high reasoning: clean (0.86 confidence)
- Exact-head Crabbox Linux `pnpm verify`: 64 test files passed, 1483 tests passed, 15 skipped (`run_97aaa80b41a3`)
