### PR TITLE
fix(http): harden webhook transport boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Revalidate release tags before idempotent publication success and enforce the development toolchain's Node floor.
 - Honor HTTP response age when caching JWT keys, reject unsupported critical JWS headers and malformed provider key metadata, preserve signing-service failure status, and protect webhook routing and framing headers.
 - Enforce Telegram destination prefixes, username canonicalization, topic IDs, and signed 52-bit chat identifier boundaries.
+- Bound GET and HEAD webhook bodies, reject invalid loopback callback exposure, and cancel response streams when clients disconnect.
 - Verify downloaded npm tarball integrity, retry transient provenance lookups, and revalidate release tags immediately before publication mutations.
 - Validate effective fixture mode overrides and stop retrying permanent provider send failures.
 - Bound watch iterator return and provider cleanup during CLI shutdown, forcing process exit after deadline failures.

--- a/src/providers/builtin/external-webhook-auth.ts
+++ b/src/providers/builtin/external-webhook-auth.ts
@@ -33,6 +33,14 @@ export function requireExternalWebhookAuthentication(params: {
       });
     }
   });
+  for (const callbackUrl of callbackUrls) {
+    if (callbackUrl.url.protocol !== "http:" && callbackUrl.url.protocol !== "https:") {
+      throw new CrablineError(
+        `${params.provider} authenticated external webhooks require HTTPS; plain HTTP is allowed only for loopback-local ingress.`,
+        { kind: "config" },
+      );
+    }
+  }
   const externallyReachable =
     !hostIsLoopback || callbackUrls.some((callbackUrl) => !callbackUrl.isLoopback);
   if (externallyReachable && !params.authenticated) {

--- a/src/providers/webhook-server.ts
+++ b/src/providers/webhook-server.ts
@@ -2,6 +2,7 @@ import { createServer, type IncomingMessage, type ServerResponse } from "node:ht
 import { isCanonicalHttpPath } from "../core/http-path.js";
 import {
   advertisedHostForBindAddress,
+  assertLoopbackBindAddress,
   closeServer,
   formatUrlHost,
   writeFetchResponseHeaders,
@@ -88,10 +89,11 @@ async function toFetchRequest(
   maxBodyBytes: number,
   bodyTimeoutMs: number,
 ): Promise<Request> {
+  const requestBody = await readRequestBody(request, maxBodyBytes, bodyTimeoutMs);
   const body =
-    request.method === "GET" || request.method === "HEAD"
+    request.method === "GET" || request.method === "HEAD" || requestBody.length === 0
       ? undefined
-      : await readRequestBody(request, maxBodyBytes, bodyTimeoutMs);
+      : requestBody;
 
   const init: RequestInit = {
     headers: request.headers as Record<string, string>,
@@ -303,6 +305,12 @@ export async function startWebhookServer(params: {
   const address = server.address();
   if (!address || typeof address === "string") {
     throw new Error("Unable to resolve webhook server address.");
+  }
+  try {
+    assertLoopbackBindAddress(params.host, address.address, "Webhook server");
+  } catch (error) {
+    await closeServer(server, params.shutdownGraceMs);
+    throw error;
   }
   const advertisedHost = advertisedHostForBindAddress(params.host, address.address);
 

--- a/src/servers/http.ts
+++ b/src/servers/http.ts
@@ -229,6 +229,19 @@ export function advertisedHostForBindAddress(host: string, boundAddress: string)
   return isLoopbackHost(host) && isLoopbackAddress(boundAddress) ? boundAddress : host;
 }
 
+export function assertLoopbackBindAddress(
+  configuredHost: string,
+  boundAddress: string,
+  serverName: string,
+): void {
+  if (isLoopbackHost(configuredHost) && !isLoopbackAddress(boundAddress)) {
+    throw new CrablineError(
+      `${serverName} resolved a loopback hostname to non-loopback address ${boundAddress}.`,
+      { kind: "connectivity" },
+    );
+  }
+}
+
 export function writeFetchResponseHeaders(response: ServerResponse, fetchResponse: Response): void {
   const preserveRepresentationLength =
     response.req?.method === "HEAD" || fetchResponse.status === 304;
@@ -265,51 +278,88 @@ export async function writeResponse(
   response: ServerResponse,
   fetchResponse: Response,
 ): Promise<void> {
-  const body = Buffer.from(await fetchResponse.arrayBuffer());
-  response.statusCode = fetchResponse.status;
-  writeFetchResponseHeaders(response, fetchResponse);
-  await new Promise<void>((resolve, reject) => {
+  const reader = fetchResponse.body?.getReader();
+  let cancellation: Promise<void> | undefined;
+  let rejectStopped!: (error: Error) => void;
+  let stoppedError: Error | undefined;
+  const stopped = new Promise<never>((_, reject) => {
+    rejectStopped = reject;
+  });
+  void stopped.catch(() => {});
+
+  const cancelBody = (reason: Error) => {
+    if (!reader || cancellation) {
+      return;
+    }
+    cancellation = reader.cancel(reason).catch(() => {});
+  };
+  const stop = (error: Error) => {
+    if (stoppedError) {
+      return;
+    }
+    stoppedError = error;
+    cancelBody(error);
+    rejectStopped(error);
+  };
+  const onClose = () => {
+    if (!response.writableFinished) {
+      stop(new Error("HTTP response closed before delivery completed."));
+    }
+  };
+  const onError = (error: Error) => stop(error);
+  const onRequestAborted = () => stop(new Error("HTTP response request was aborted."));
+  response.once("close", onClose);
+  response.once("error", onError);
+  response.req?.once("aborted", onRequestAborted);
+
+  try {
     if (
       response.destroyed ||
       response.req?.aborted ||
       response.req?.socket.destroyed ||
       response.socket?.destroyed
     ) {
-      reject(new Error("HTTP response closed before delivery completed."));
-      return;
+      throw new Error("HTTP response closed before delivery completed.");
     }
-    const cleanup = () => {
-      response.off("close", onClose);
-      response.off("error", onError);
-      response.off("finish", onFinish);
-    };
-    const onClose = () => {
-      if (response.writableFinished) {
-        cleanup();
-        resolve();
-        return;
+
+    const chunks: Buffer[] = [];
+    let bodyLength = 0;
+    if (reader) {
+      while (true) {
+        const chunk = await Promise.race([reader.read(), stopped]);
+        if (chunk.done) {
+          break;
+        }
+        if (chunk.value.byteLength > 0) {
+          const buffer = Buffer.from(chunk.value);
+          chunks.push(buffer);
+          bodyLength += buffer.length;
+        }
       }
-      cleanup();
-      reject(new Error("HTTP response closed before delivery completed."));
-    };
-    const onError = (error: Error) => {
-      cleanup();
-      reject(error);
-    };
-    const onFinish = () => {
-      cleanup();
-      resolve();
-    };
-    response.once("close", onClose);
-    response.once("error", onError);
-    response.once("finish", onFinish);
+    }
+
+    const body = Buffer.concat(chunks, bodyLength);
+    response.statusCode = fetchResponse.status;
+    writeFetchResponseHeaders(response, fetchResponse);
+    let onFinish!: () => void;
+    const finished = new Promise<void>((resolve) => {
+      onFinish = resolve;
+      response.once("finish", onFinish);
+    });
     try {
       response.end(body);
-    } catch (error) {
-      cleanup();
-      reject(error);
+      await Promise.race([finished, stopped]);
+    } finally {
+      response.off("finish", onFinish);
     }
-  });
+  } catch (error) {
+    cancelBody(error instanceof Error ? error : new Error(String(error)));
+    throw error;
+  } finally {
+    response.off("close", onClose);
+    response.off("error", onError);
+    response.req?.off("aborted", onRequestAborted);
+  }
 }
 
 export function closeServer(
@@ -398,12 +448,11 @@ export async function startHttpJsonServer(params: {
       kind: "connectivity",
     });
   }
-  if (isLoopbackHost(params.host) && !isLoopbackAddress(address.address)) {
+  try {
+    assertLoopbackBindAddress(params.host, address.address, params.serverName);
+  } catch (error) {
     await closeServer(server);
-    throw new CrablineError(
-      `${params.serverName} resolved a loopback hostname to non-loopback address ${address.address}.`,
-      { kind: "connectivity" },
-    );
+    throw error;
   }
   const advertisedHost = advertisedHostForBindAddress(params.host, address.address);
   return {

--- a/test/external-webhook-auth.test.ts
+++ b/test/external-webhook-auth.test.ts
@@ -130,6 +130,19 @@ describe("external webhook authentication policy", () => {
     ).not.toThrow();
   });
 
+  it.each(["ftp://127.0.0.1/events", "file:///events", "ws://localhost/events"])(
+    "rejects non-HTTP callback protocol %s even on loopback",
+    (publicUrl) => {
+      expect(() =>
+        requireExternalWebhookAuthentication({
+          ...base,
+          authenticated: false,
+          webhook: { host: "127.0.0.1", publicUrl },
+        }),
+      ).toThrow(/require HTTPS/u);
+    },
+  );
+
   it.each([
     ["127.0.0.1", "http://127.0.0.1:8787/events"],
     ["localhost", "http://localhost:8787/events"],

--- a/test/http-server.test.ts
+++ b/test/http-server.test.ts
@@ -2,6 +2,7 @@ import { get, type IncomingMessage } from "node:http";
 import { PassThrough } from "node:stream";
 import { describe, expect, it } from "vitest";
 import {
+  assertLoopbackBindAddress,
   DEFAULT_MAX_REQUEST_BODY_BYTES,
   drainRequestBody,
   InvalidJsonBodyError,
@@ -137,6 +138,14 @@ describe("server HTTP body reader", () => {
     expect(isLoopbackAddress("127.0.0.1")).toBe(true);
     expect(isLoopbackAddress("[::1]")).toBe(true);
     expect(isLoopbackAddress("192.0.2.1")).toBe(false);
+  });
+
+  it("rejects loopback-looking hostnames that bind to external addresses", () => {
+    expect(() => assertLoopbackBindAddress("localhost", "192.0.2.10", "test server")).toThrow(
+      /resolved a loopback hostname to non-loopback address 192\.0\.2\.10/u,
+    );
+    expect(() => assertLoopbackBindAddress("localhost", "127.0.0.1", "test server")).not.toThrow();
+    expect(() => assertLoopbackBindAddress("0.0.0.0", "0.0.0.0", "test server")).not.toThrow();
   });
 
   it.each([
@@ -438,6 +447,61 @@ describe("server HTTP body reader", () => {
       request.destroy();
       await requestAborted;
       releaseHandler?.();
+      await expect.poll(() => failed).toBe(1);
+      expect(succeeded).toBe(0);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("cancels a pending response body when the client disconnects", async () => {
+    let reportBodyStarted!: () => void;
+    const bodyStarted = new Promise<void>((resolve) => {
+      reportBodyStarted = resolve;
+    });
+    let reportCancelled!: () => void;
+    const cancelled = new Promise<void>((resolve) => {
+      reportCancelled = resolve;
+    });
+    let failed = 0;
+    let succeeded = 0;
+    const server = await startHttpJsonServer({
+      async handle() {
+        return {
+          onWriteFailure() {
+            failed++;
+          },
+          onWriteSuccess() {
+            succeeded++;
+          },
+          response: new Response(
+            new ReadableStream({
+              cancel() {
+                reportCancelled();
+              },
+              start() {
+                reportBodyStarted();
+              },
+            }),
+          ),
+        };
+      },
+      host: "127.0.0.1",
+      port: 0,
+      serverName: "test",
+    });
+
+    try {
+      const request = get(server.baseUrl);
+      request.on("error", () => {});
+      await bodyStarted;
+      request.destroy();
+      await expect(
+        Promise.race([
+          cancelled.then(() => "cancelled"),
+          new Promise<string>((resolve) => setTimeout(() => resolve("timed out"), 500)),
+        ]),
+      ).resolves.toBe("cancelled");
       await expect.poll(() => failed).toBe(1);
       expect(succeeded).toBe(0);
     } finally {

--- a/test/webhook-server.test.ts
+++ b/test/webhook-server.test.ts
@@ -406,6 +406,38 @@ describe("webhook server", () => {
     expect(handlerInvoked).toBe(true);
   });
 
+  it("applies body timeouts to GET routes before invoking the handler", async () => {
+    let handlerInvoked = false;
+    const server = await startWebhookServer({
+      bodyTimeoutMs: 20,
+      async handle() {
+        handlerInvoked = true;
+        return new Response("ok");
+      },
+      host: "127.0.0.1",
+      methods: ["GET"],
+      path: "/slack/events",
+      port: 0,
+    });
+    cleanups.push(() => server.close());
+    const endpoint = new URL(server.endpointUrl);
+    const socket = connect(Number(endpoint.port), endpoint.hostname);
+    let response = "";
+    socket.setEncoding("utf8");
+    socket.on("data", (chunk) => {
+      response += chunk;
+    });
+    await once(socket, "connect");
+    socket.write(
+      "GET /slack/events HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: 5\r\nConnection: close\r\n\r\n1",
+    );
+    await once(socket, "close");
+
+    expect(response).toContain("HTTP/1.1 408");
+    expect(response).toContain("request body timeout");
+    expect(handlerInvoked).toBe(false);
+  });
+
   it("does not let a slow request body block shutdown", async () => {
     const server = await startWebhookServer({
       bodyTimeoutMs: 10_000,


### PR DESCRIPTION
## What Problem This Solves

Fixes webhook transport cases where GET or HEAD bodies could bypass limits, loopback-looking hostnames could bind externally, unsupported callback protocols could be accepted, or a disconnected client could leave a response stream running indefinitely.

## Why This Change Was Made

Webhook requests now apply bounded body reads to every admitted method, callback policy rejects non-HTTP schemes, and post-bind validation verifies that loopback hostnames resolved to loopback addresses. HTTP response buffering now observes disconnects and cancels pending Fetch body streams before invoking delivery-failure callbacks.

## User Impact

Webhook listeners enforce the same resource and exposure boundaries across methods, and lifecycle callbacks settle promptly when clients disconnect.

## Evidence

- Focused Vitest suite: 64 tests passed
- `oxfmt --check`, `oxlint`, and `tsc -p tsconfig.test.json --noEmit`
- Autoreview with `gpt-5.6-sol`, high reasoning: clean (0.93 confidence)
- Exact-head Crabbox Linux `pnpm verify`: 64 test files passed, 1489 tests passed, 15 skipped (`run_dbd9a6386427`)
