### PR TITLE
fix(providers): harden webhook callback fidelity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Escape visually unsafe Unicode controls in JSON reports, return a stable error document for unserializable values, and preserve Node write encoding semantics in test captures.
+- Ignore typeless Slack callbacks and redact URL fragments from Zalo recorder evidence.
 - Bind agent acknowledgements to the expected nonce instead of accepting an unrelated ACK.
 - Bound manifest file loading, honor probe retries, and reject empty resolved Zalo webhook secrets.
 - Require exact provider readiness recorder routes, explicit v2 artifact pointers, and normalized missing-generation corruption errors.

--- a/src/providers/builtin/slack.ts
+++ b/src/providers/builtin/slack.ts
@@ -323,7 +323,7 @@ export function handleSlackWebhookPayload(payload: unknown): Response | undefine
     }
     const eventType = optionalString(payload.event, "type");
     if (!eventType) {
-      return undefined;
+      return new Response(null, { status: 200 });
     }
     if (eventType !== "message" && eventType !== "app_mention") {
       return new Response(null, { status: 200 });

--- a/src/servers/zalo.ts
+++ b/src/servers/zalo.ts
@@ -249,6 +249,11 @@ function redactSensitiveSearchParams(searchParams: URLSearchParams): boolean {
   return redacted;
 }
 
+function redactUrlFragment(value: string): string {
+  const fragmentStart = value.indexOf("#");
+  return fragmentStart < 0 ? value : `${value.slice(0, fragmentStart)}#<redacted>`;
+}
+
 function redactMalformedUrlCredentials(value: string): string {
   const credentialRedacted = value.replace(
     /^(\s*)((?:[a-z][a-z0-9+.-]*:)?\/\/)[^/?#]*@/iu,
@@ -257,18 +262,19 @@ function redactMalformedUrlCredentials(value: string): string {
   if (credentialRedacted === value) {
     return "<redacted>";
   }
-  const queryStart = credentialRedacted.indexOf("?");
-  const fragmentStart = credentialRedacted.indexOf("#", queryStart + 1);
+  const fragmentRedacted = redactUrlFragment(credentialRedacted);
+  const queryStart = fragmentRedacted.indexOf("?");
+  const fragmentStart = fragmentRedacted.indexOf("#", queryStart + 1);
   if (queryStart < 0 || (fragmentStart >= 0 && fragmentStart < queryStart)) {
-    return credentialRedacted;
+    return fragmentRedacted;
   }
-  const queryEnd = fragmentStart >= 0 ? fragmentStart : credentialRedacted.length;
-  const searchParams = new URLSearchParams(credentialRedacted.slice(queryStart + 1, queryEnd));
+  const queryEnd = fragmentStart >= 0 ? fragmentStart : fragmentRedacted.length;
+  const searchParams = new URLSearchParams(fragmentRedacted.slice(queryStart + 1, queryEnd));
   if (!redactSensitiveSearchParams(searchParams)) {
-    return credentialRedacted;
+    return fragmentRedacted;
   }
   const search = searchParams.toString().replaceAll("%3Credacted%3E", "<redacted>");
-  return `${credentialRedacted.slice(0, queryStart)}?${search}${credentialRedacted.slice(queryEnd)}`;
+  return `${fragmentRedacted.slice(0, queryStart)}?${search}${fragmentRedacted.slice(queryEnd)}`;
 }
 
 function redactUrlCredentials(value: string): string {
@@ -280,11 +286,12 @@ function redactUrlCredentials(value: string): string {
   }
   const hasCredentials = Boolean(url.username || url.password);
   const redactedQuery = redactSensitiveSearchParams(url.searchParams);
+  const hasFragment = url.hash.length > 0;
   if (!hasCredentials && !redactedQuery) {
-    return value;
+    return hasFragment ? redactUrlFragment(value) : value;
   }
   const search = url.search.replaceAll("%3Credacted%3E", "<redacted>");
-  return `${url.protocol}//${hasCredentials ? "<redacted>@" : ""}${url.host}${url.pathname}${search}${url.hash}`;
+  return `${url.protocol}//${hasCredentials ? "<redacted>@" : ""}${url.host}${url.pathname}${search}${hasFragment ? "#<redacted>" : ""}`;
 }
 
 function requireParam(body: Record<string, unknown>, name: string): string | Response {

--- a/test/slack-provider.test.ts
+++ b/test/slack-provider.test.ts
@@ -631,7 +631,7 @@ describe("slack provider", () => {
     expect(accepted.status).toBe(200);
   });
 
-  it("acknowledges authenticated unsupported and textless callbacks without recording them", async () => {
+  it("acknowledges unsupported, typeless, and textless callbacks without recording them", async () => {
     const signingSecret = "test-token-placeholder";
     const config = await createSlackConfig(0, signingSecret);
     const provider = new SlackProviderAdapter("slack", config, "crabline");
@@ -664,6 +664,19 @@ describe("slack provider", () => {
         minute_rate_limited: 1_700_000_000,
         team_id: "TCRABLINE",
         type: "app_rate_limited",
+      },
+      {
+        event: {
+          channel: "C1234567890",
+          message: {
+            text: "typeless callback must not be recorded",
+            ts: "1700000003.000400",
+            type: "message",
+            user: "U1234567890",
+          },
+          subtype: "message_changed",
+        },
+        type: "event_callback",
       },
     ]) {
       const body = JSON.stringify(payload);

--- a/test/zalo-server.test.ts
+++ b/test/zalo-server.test.ts
@@ -197,6 +197,7 @@ describe("Zalo local provider server", () => {
       ] as Array<[string, string]>) {
         webhookUrl.searchParams.set(key, value);
       }
+      webhookUrl.hash = "fragment-credential-placeholder";
       const setWebhook = await fetch(
         `${server.manifest.baseUrl}/bottest-token-placeholder/setWebhook`,
         {
@@ -207,6 +208,8 @@ describe("Zalo local provider server", () => {
                 {
                   callbackUrl:
                     "http://fixture-user:placeholder@example.com/hook?api_key=placeholder",
+                  fidelityUrl:
+                    "https://EXAMPLE.com:443/hook?callbackId=a%20b#fragment-fidelity-credential",
                 },
               ],
               invalidCallbackUrl: [
@@ -285,21 +288,26 @@ describe("Zalo local provider server", () => {
       const recorder = await fs.readFile(recorderPath, "utf8");
       expect(recorder).toContain('"secret_token":"<redacted>"');
       expect(recorder).toContain(
-        `http://<redacted>@127.0.0.1:${address.port}/zalo?mode=test&accessToken=<redacted>&password=<redacted>&apiKey=<redacted>&clientSecret=<redacted>&auth=<redacted>&callbackId=keep`,
+        `http://<redacted>@127.0.0.1:${address.port}/zalo?mode=test&accessToken=<redacted>&password=<redacted>&apiKey=<redacted>&clientSecret=<redacted>&auth=<redacted>&callbackId=keep#<redacted>`,
       );
       expect(recorder.match(/"url":"<redacted>"/gu)).toHaveLength(2);
       expect(recorder).not.toContain("test-auth-token");
       expect(recorder).not.toContain("alice");
       expect(recorder).not.toContain("sample");
+      expect(recorder).not.toContain("fragment-credential-placeholder");
       expect(recorder).not.toContain("credential-placeholder");
       expect(recorder).not.toContain("protocol-user");
       expect(recorder).not.toContain("fixture-user");
       expect(recorder).toContain(
         '"callbackUrl":"http://<redacted>@example.com/hook?api_key=<redacted>"',
       );
+      expect(recorder).toContain(
+        '"fidelityUrl":"https://EXAMPLE.com:443/hook?callbackId=a%20b#<redacted>"',
+      );
       expect(recorder).toContain('"invalidCallbackUrl":"<redacted>"');
       expect(recorder).not.toContain("ambiguous-user");
       expect(recorder).not.toContain("ambiguous-credential-placeholder");
+      expect(recorder).not.toContain("fragment-fidelity-credential");
       for (const secret of ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot"]) {
         expect(recorder).not.toContain(secret);
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes typeless Slack callbacks being normalized as messages and URL fragments leaking into Zalo recorder evidence.

## Why This Change Was Made

Slack now acknowledges event callbacks that omit the native event discriminator without recording them. Zalo URL normalization redacts fragments for both valid and malformed credential-bearing URLs while preserving non-sensitive URL fidelity.

## User Impact

Malformed Slack callbacks no longer create synthetic inbound messages, and recorder artifacts no longer retain credentials or opaque secrets placed in URL fragments.

## Evidence

- Focused Vitest suite: 42 tests passed
- `oxfmt --check`, `oxlint`, and `tsc -p tsconfig.test.json --noEmit`
- Autoreview with `gpt-5.6-sol`, high reasoning: clean (0.92 confidence)
- Exact-head Crabbox Linux `pnpm verify`: 64 test files passed, 1483 tests passed, 15 skipped (`run_2485ae3ab9cc`)
