### PR TITLE
fix(providers): scope chat thread routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Scope iMessage direct waits and Matrix and Mattermost thread correlation to their native conversations.
 - Escape visually unsafe Unicode controls in JSON reports, return a stable error document for unserializable values, and preserve Node write encoding semantics in test captures.
 - Ignore typeless Slack callbacks and redact URL fragments from Zalo recorder evidence.
 - Bind agent acknowledgements to the expected nonce instead of accepting an unrelated ACK.

--- a/src/providers/builtin/imessage.ts
+++ b/src/providers/builtin/imessage.ts
@@ -63,10 +63,10 @@ export function matchesIMessageThread(
   const rawPayload = isRecord(raw) ? raw : undefined;
   const data = rawPayload ? (optionalRecord(rawPayload, "data") ?? rawPayload) : undefined;
   const recipientAlias = data ? optionalString(data, "chatIdentifier") : undefined;
-  if (expectedThreadId === undefined) {
-    return true;
+  const expectedIdentifiers = new Set([target.channelId ?? target.id]);
+  if (expectedThreadId !== undefined) {
+    expectedIdentifiers.add(expectedThreadId);
   }
-  const expectedIdentifiers = new Set([expectedThreadId, target.channelId ?? target.id]);
   return (
     expectedIdentifiers.has(candidateThreadId) ||
     (recipientAlias !== undefined && expectedIdentifiers.has(recipientAlias))

--- a/src/providers/builtin/matrix.ts
+++ b/src/providers/builtin/matrix.ts
@@ -85,14 +85,13 @@ export function matchesMatrixThread(
   if (!expectedThreadId) {
     return true;
   }
-  const scopedExpected =
-    target.channelId && isMatrixEventId(expectedThreadId)
-      ? matrixThreadKey(target.channelId, expectedThreadId)
-      : expectedThreadId;
+  if (target.channelId && isMatrixEventId(expectedThreadId)) {
+    return candidateThreadId === matrixThreadKey(target.channelId, expectedThreadId);
+  }
   return (
     candidateThreadId === expectedThreadId ||
-    candidateThreadId === scopedExpected ||
-    (isMatrixRoomId(scopedExpected) && candidateThreadId.startsWith(`${scopedExpected}:thread:`))
+    (isMatrixRoomId(expectedThreadId) &&
+      candidateThreadId.startsWith(`${expectedThreadId}:thread:`))
   );
 }
 

--- a/src/providers/builtin/mattermost.ts
+++ b/src/providers/builtin/mattermost.ts
@@ -158,17 +158,17 @@ export function matchesMattermostThread(
   if (!expectedThreadId) {
     return true;
   }
-  const scopedExpected =
+  if (
     target.channelId &&
     MATTERMOST_ID_RULE.pattern.test(expectedThreadId) &&
     expectedThreadId !== target.channelId
-      ? mattermostThreadKey(target.channelId, expectedThreadId)
-      : expectedThreadId;
+  ) {
+    return candidateThreadId === mattermostThreadKey(target.channelId, expectedThreadId);
+  }
   return (
     candidateThreadId === expectedThreadId ||
-    candidateThreadId === scopedExpected ||
-    (MATTERMOST_ID_RULE.pattern.test(scopedExpected) &&
-      candidateThreadId.startsWith(`${scopedExpected}:thread:`))
+    (MATTERMOST_ID_RULE.pattern.test(expectedThreadId) &&
+      candidateThreadId.startsWith(`${expectedThreadId}:thread:`))
   );
 }
 

--- a/test/imessage-provider.test.ts
+++ b/test/imessage-provider.test.ts
@@ -56,6 +56,23 @@ describe("iMessage thread matching", () => {
     ).toBe(false);
   });
 
+  it("scopes direct targets even when no explicit thread is expected", () => {
+    const target = { id: "+15551234567" };
+
+    expect(
+      matchesIMessageThread("iMessage;-;unrelated-guid", undefined, target, {
+        chatGuid: "iMessage;-;unrelated-guid",
+        chatIdentifier: "+15557654321",
+      }),
+    ).toBe(false);
+    expect(
+      matchesIMessageThread("iMessage;-;expected-guid", undefined, target, {
+        chatGuid: "iMessage;-;expected-guid",
+        chatIdentifier: "+15551234567",
+      }),
+    ).toBe(true);
+  });
+
   it("does not treat fixture-local ids as provider thread aliases", () => {
     expect(
       matchesIMessageThread(
@@ -112,6 +129,70 @@ describe("iMessage thread matching", () => {
         id: "imsg-guid-alias",
         text: "recipient alias",
         threadId: "iMessage;-;chat-guid-1",
+      });
+    } finally {
+      await provider.cleanup();
+    }
+  });
+
+  it("does not let an unrelated direct chat satisfy a recipient wait", async () => {
+    const config = await createLocalMockConfig("imessage", "/imessage/webhook");
+    const provider = new IMessageProviderAdapter("imessage", config, "crabline");
+    const context = createProviderContext("imessage", config, {
+      id: "+15551234567",
+      metadata: {},
+    });
+    context.fixture.inboundMatch.author = "any";
+
+    try {
+      const endpoint = (await provider.probe(context)).details
+        .find((detail) => detail.startsWith("webhook endpoint "))
+        ?.replace("webhook endpoint ", "");
+      expect(endpoint).toBeDefined();
+      const since = new Date(Date.now() - 1000).toISOString();
+      const unrelated = await fetch(endpoint!, {
+        body: JSON.stringify({
+          chatGuid: "iMessage;-;unrelated-guid",
+          chatIdentifier: "+15557654321",
+          guid: "imsg-unrelated-direct",
+          text: "shared direct nonce",
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      expect(unrelated.status).toBe(200);
+
+      await expect(
+        provider.waitForInbound({
+          ...context,
+          nonce: "shared direct nonce",
+          since,
+          timeoutMs: 25,
+        }),
+      ).resolves.toBeNull();
+
+      const expected = await fetch(endpoint!, {
+        body: JSON.stringify({
+          chatGuid: "iMessage;-;expected-guid",
+          chatIdentifier: "+15551234567",
+          guid: "imsg-expected-direct",
+          text: "shared direct nonce",
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      expect(expected.status).toBe(200);
+
+      await expect(
+        provider.waitForInbound({
+          ...context,
+          nonce: "shared direct nonce",
+          since,
+          timeoutMs: 500,
+        }),
+      ).resolves.toMatchObject({
+        id: "imsg-expected-direct",
+        threadId: "iMessage;-;expected-guid",
       });
     } finally {
       await provider.cleanup();

--- a/test/matrix-provider.test.ts
+++ b/test/matrix-provider.test.ts
@@ -143,11 +143,20 @@ describe("Matrix webhook normalizer", () => {
     ).toThrow(/content\.body/u);
   });
 
-  it("matches local thread replies before native room scoping", () => {
+  it("requires native thread roots to carry their room scope", () => {
     expect(
       matchesMatrixThread("$event123:matrix.org", "$event123:matrix.org", {
         channelId: "!abc123:matrix.org",
       }),
+    ).toBe(false);
+    expect(
+      matchesMatrixThread(
+        "!abc123:matrix.org:thread:$event123:matrix.org",
+        "$event123:matrix.org",
+        {
+          channelId: "!abc123:matrix.org",
+        },
+      ),
     ).toBe(true);
   });
 

--- a/test/mattermost-provider.test.ts
+++ b/test/mattermost-provider.test.ts
@@ -244,11 +244,20 @@ describe("Mattermost webhook normalizer", () => {
     });
   });
 
-  it("matches local thread replies before native channel scoping", () => {
+  it("requires native thread roots to carry their channel scope", () => {
     expect(
       matchesMattermostThread("bbbbbbbbbbbbbbbbbbbbbbbbbb", "bbbbbbbbbbbbbbbbbbbbbbbbbb", {
         channelId: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
       }),
+    ).toBe(false);
+    expect(
+      matchesMattermostThread(
+        "aaaaaaaaaaaaaaaaaaaaaaaaaa:thread:bbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "bbbbbbbbbbbbbbbbbbbbbbbbbb",
+        {
+          channelId: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+        },
+      ),
     ).toBe(true);
   });
 


### PR DESCRIPTION
## What Problem This Solves

Inbound waits could correlate messages from unrelated iMessage direct chats or unrelated Matrix and Mattermost conversations.

## Why This Change Was Made

Scope provider-native thread matching to the normalized destination and conversation-specific thread identity.

## User Impact

Concurrent conversations can no longer satisfy each other's inbound waits.

## Evidence

- 41 focused tests passed
- format, typecheck, and lint passed
- gpt-5.6-sol high autoreview clean
- Crabbox Linux `pnpm verify`: 64 files, 1513 passed, 15 skipped
