### PR TITLE
fix(feishu): redact verification tokens from recorder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Escape visually unsafe Unicode controls in JSON reports, return a stable error document for unserializable values, and preserve Node write encoding semantics in test captures.
 - Ignore typeless Slack callbacks and redact URL fragments from Zalo recorder evidence.
+- Redact Feishu verification tokens from recorder payloads and release replay reservations after recorder failures.
 - Bind agent acknowledgements to the expected nonce instead of accepting an unrelated ACK.
 - Bound manifest file loading, honor probe retries, and reject empty resolved Zalo webhook secrets.
 - Require exact provider readiness recorder routes, explicit v2 artifact pointers, and normalized missing-generation corruption errors.

--- a/src/providers/builtin/feishu.ts
+++ b/src/providers/builtin/feishu.ts
@@ -256,12 +256,13 @@ export function normalizeFeishuWebhookPayload(payload: unknown) {
     throw new CrablineError("Feishu webhook payload must be an object", { kind: "inbound" });
   }
 
+  const recordedPayload = redactFeishuVerificationTokens(payload);
   const event = optionalRecord(payload, "event");
   const message = event ? optionalRecord(event, "message") : undefined;
   if (!message) {
     return genericMockPayloadWithNativeThread({
       channelRule: FEISHU_CHAT_ID_RULE,
-      payload,
+      payload: recordedPayload,
       threadRule: FEISHU_MESSAGE_ID_RULE,
     });
   }
@@ -300,12 +301,24 @@ export function normalizeFeishuWebhookPayload(payload: unknown) {
         : false,
     ),
     id: requireNativeInboundId(messageId, FEISHU_MESSAGE_ID_RULE, "Feishu message_id"),
-    raw: payload,
+    raw: recordedPayload,
     text,
     threadId: rootId
       ? requireNativeInboundId(rootId, FEISHU_MESSAGE_ID_RULE, "Feishu root_id")
       : requireNativeInboundId(chatId, FEISHU_CHAT_ID_RULE, "Feishu chat_id"),
   };
+}
+
+function redactFeishuVerificationTokens(payload: Record<string, unknown>): Record<string, unknown> {
+  const redacted = { ...payload };
+  delete redacted.token;
+  const header = optionalRecord(payload, "header");
+  if (header) {
+    const redactedHeader = { ...header };
+    delete redactedHeader.token;
+    redacted.header = redactedHeader;
+  }
+  return redacted;
 }
 
 function parseFeishuText(content: string | undefined): string | null | undefined {

--- a/test/feishu-provider.test.ts
+++ b/test/feishu-provider.test.ts
@@ -1,5 +1,5 @@
 import { createCipheriv, createHash } from "node:crypto";
-import { readFile } from "node:fs/promises";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { describe, expect, it, vi } from "vitest";
 import {
   createFeishuWebhookAuthenticator,
@@ -417,6 +417,36 @@ describe("Feishu webhook normalizer", () => {
     });
   });
 
+  it("removes verification tokens from normalized recorder payloads", () => {
+    const payload = {
+      event: {
+        message: {
+          chat_id: "oc_abc123",
+          content: JSON.stringify({ text: "redacted" }),
+          message_id: "om_redacted123",
+          message_type: "text",
+        },
+      },
+      header: { event_id: "event-redacted", token: "sample" },
+      schema: "2.0",
+      token: "sample",
+    };
+
+    const normalized = normalizeFeishuWebhookPayload(payload);
+    expect(normalized).toMatchObject({
+      raw: {
+        header: { event_id: "event-redacted" },
+        schema: "2.0",
+      },
+    });
+    expect(normalized.raw).not.toHaveProperty("token");
+    expect(normalized.raw).not.toHaveProperty("header.token");
+    expect(payload).toMatchObject({
+      header: { token: "sample" },
+      token: "sample",
+    });
+  });
+
   it("acknowledges unsupported and empty native messages without recording them", () => {
     expect(
       handleFeishuWebhookPayload({
@@ -644,6 +674,76 @@ describe("Feishu webhook normalizer", () => {
       };
       expect((await send(rejectedPayload)).status).toBe(400);
       expect((await send(rejectedPayload)).status).toBe(400);
+    } finally {
+      await provider.cleanup();
+    }
+  });
+
+  it("releases replay reservations after recorder write failures", async () => {
+    const config = await createLocalMockConfig("feishu", "/feishu/webhook");
+    const encryptKey = "encrypt-key";
+    const now = 1_700_000_000_000;
+    const blockedDirectory = `${config.feishu!.recorder.path!}.blocked`;
+    await writeFile(blockedDirectory, "not a directory");
+    config.feishu!.encryptKey = encryptKey;
+    config.feishu!.verificationToken = "sample";
+    config.feishu!.recorder.path = `${blockedDirectory}/feishu.jsonl`;
+    const provider = new FeishuProviderAdapter("feishu", config, "crabline", {
+      env: {},
+      now: () => now,
+    });
+    const context = createProviderContext("feishu", config, {
+      id: "oc_abc123",
+      metadata: {},
+    });
+    const endpoint = (await provider.probe(context)).details
+      .find((detail) => detail.startsWith("webhook endpoint "))
+      ?.replace("webhook endpoint ", "");
+    expect(endpoint).toBeDefined();
+    const nativePayload = {
+      event: {
+        message: {
+          chat_id: "oc_abc123",
+          content: JSON.stringify({ text: "retry after recorder failure" }),
+          message_id: "om_retry123",
+          message_type: "text",
+        },
+      },
+      header: { event_id: "event-retry", token: "sample" },
+      schema: "2.0",
+    };
+    const rawBody = JSON.stringify({
+      encrypt: encryptFeishuPayload(nativePayload, encryptKey),
+    });
+    const timestamp = String(now / 1_000);
+    const nonce = "recorder-failure";
+    const signature = createHash("sha256")
+      .update(timestamp + nonce + encryptKey + rawBody)
+      .digest("hex");
+    const send = () =>
+      fetch(endpoint!, {
+        body: rawBody,
+        headers: {
+          "content-type": "application/json",
+          "x-lark-request-nonce": nonce,
+          "x-lark-request-timestamp": timestamp,
+          "x-lark-signature": signature,
+        },
+        method: "POST",
+      });
+
+    try {
+      expect((await send()).status).toBe(500);
+      await rm(blockedDirectory);
+      await mkdir(blockedDirectory);
+      expect((await send()).status).toBe(200);
+      expect((await send()).status).toBe(200);
+      const records = (await readFile(config.feishu!.recorder.path!, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as { raw: unknown });
+      expect(records).toHaveLength(1);
+      expect(records[0]?.raw).not.toHaveProperty("header.token");
     } finally {
       await provider.cleanup();
     }


### PR DESCRIPTION
## What Problem This Solves

Feishu verification tokens could be retained in recorder evidence, and a recorder write failure could leave a replay reservation consumed.

## Why This Change Was Made

Redact verification tokens from both payload and header evidence, and release the replay reservation when persistence fails.

## User Impact

Feishu webhook evidence no longer stores verification secrets, while retry behavior remains available after transient recorder failures.

## Evidence

- 26 focused tests passed
- format, typecheck, and lint passed
- gpt-5.6-sol high autoreview clean
- Crabbox Linux `pnpm verify` passed on the branch
