### PR TITLE
fix(servers): validate native admin ingress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Reject non-positive Telegram admin message IDs and enforce native Mattermost channel types and unique normalized usernames.
 - Scope iMessage direct waits and Matrix and Mattermost thread correlation to their native conversations.
 - Escape visually unsafe Unicode controls in JSON reports, return a stable error document for unserializable values, and preserve Node write encoding semantics in test captures.
 - Ignore typeless Slack callbacks and redact URL fragments from Zalo recorder evidence.

--- a/src/servers/mattermost.ts
+++ b/src/servers/mattermost.ts
@@ -34,6 +34,9 @@ const DEFAULT_MAX_COMMITTED_CHANNELS = 1_000;
 const DEFAULT_MAX_COMMITTED_POSTS = 1_000;
 const DEFAULT_MAX_COMMITTED_USERS = 1_000;
 const MATTERMOST_ID_PATTERN = /^[a-z0-9]{26}(?![\s\S])/u;
+const MATTERMOST_USERNAME_PATTERN = /^[a-z0-9._-]{1,64}$/u;
+const MATTERMOST_CHANNEL_TYPES = new Set(["D", "G", "O", "P"]);
+const MATTERMOST_RESTRICTED_USERNAMES = new Set(["all", "channel", "matterbot", "system"]);
 
 function resolvePositiveLimit(value: number | undefined, name: string, fallback: number): number {
   if (value === undefined) {
@@ -95,6 +98,7 @@ type MattermostServerState = {
   pendingEvents: MattermostWebSocketEvent[];
   posts: Map<string, MattermostPost>;
   recorderPath: string;
+  userIdsByUsername: Map<string, string>;
   users: Map<string, { id: string; username: string; update_at: number }>;
   websocketClients: Map<WebSocket, number>;
 };
@@ -196,6 +200,17 @@ function readMattermostId(value: unknown): string | undefined {
 
 function isMattermostId(value: string): boolean {
   return MATTERMOST_ID_PATTERN.test(value);
+}
+
+function normalizeMattermostUsername(value: unknown): string | undefined {
+  if (typeof value !== "string" || value !== value.trim()) {
+    return undefined;
+  }
+  const normalized = value.toLowerCase();
+  return MATTERMOST_USERNAME_PATTERN.test(normalized) &&
+    !MATTERMOST_RESTRICTED_USERNAMES.has(normalized)
+    ? normalized
+    : undefined;
 }
 
 function requestHasJsonMediaType(request: IncomingMessage): boolean {
@@ -455,8 +470,26 @@ function handleAdminInbound(params: {
   const previousUser = params.state.users.get(senderId);
   const previousChannel = params.state.channels.get(channelId);
   const senderName =
-    readMattermostString(params.body.senderName) ?? previousUser?.username ?? senderId;
-  const channelType = readMattermostString(params.body.channelType) ?? previousChannel?.type ?? "D";
+    params.body.senderName === undefined
+      ? (previousUser?.username ?? senderId)
+      : normalizeMattermostUsername(params.body.senderName);
+  if (!senderName) {
+    return jsonResponse(
+      { error: "senderName must be a valid Mattermost username", ok: false },
+      400,
+    );
+  }
+  const usernameOwner = params.state.userIdsByUsername.get(senderName);
+  if (usernameOwner && usernameOwner !== senderId) {
+    return jsonResponse({ error: "senderName is already in use", ok: false }, 400);
+  }
+  const channelType =
+    params.body.channelType === undefined
+      ? (previousChannel?.type ?? "D")
+      : readMattermostString(params.body.channelType);
+  if (!channelType || !MATTERMOST_CHANNEL_TYPES.has(channelType)) {
+    return jsonResponse({ error: "channelType is not supported", ok: false }, 400);
+  }
   const channelName =
     readMattermostString(params.body.channelName ?? params.body.channel_name) ??
     previousChannel?.name ??
@@ -514,6 +547,10 @@ function handleAdminInbound(params: {
     return jsonResponse({ error: "Inbound event is too large", ok: false }, 413);
   }
   const previousNextPost = params.state.nextPost;
+  if (previousUser?.username !== senderName) {
+    params.state.userIdsByUsername.delete(previousUser?.username ?? "");
+  }
+  params.state.userIdsByUsername.set(senderName, senderId);
   params.state.users.set(senderId, { id: senderId, update_at: Date.now(), username: senderName });
   params.state.channels.set(channelId, channel);
   if (rootPost) {
@@ -528,8 +565,12 @@ function handleAdminInbound(params: {
     params.state.nextPost = previousNextPost;
     if (previousUser) {
       params.state.users.set(senderId, previousUser);
+      params.state.userIdsByUsername.set(previousUser.username, senderId);
     } else {
       params.state.users.delete(senderId);
+    }
+    if (previousUser?.username !== senderName) {
+      params.state.userIdsByUsername.delete(senderName);
     }
     if (previousChannel) {
       params.state.channels.set(channelId, previousChannel);
@@ -560,7 +601,8 @@ async function handleApi(params: {
     if (username instanceof Response) {
       return username;
     }
-    const user = [...state.users.values()].find((entry) => entry.username === username);
+    const userId = state.userIdsByUsername.get(username.toLowerCase());
+    const user = userId ? state.users.get(userId) : undefined;
     return user ? jsonResponse(user) : mattermostError("User not found", 404);
   }
   const userMatch = /^\/users\/([^/]+)$/u.exec(apiPath);
@@ -966,7 +1008,10 @@ export async function startMattermostServer(
 ): Promise<StartedMattermostServer> {
   const host = params.host ?? "127.0.0.1";
   const botUserId = params.botUserId ?? mattermostId("crabline-mattermost-bot");
-  const botUsername = params.botUsername ?? "crabline_bot";
+  const botUsername = normalizeMattermostUsername(params.botUsername ?? "crabline_bot");
+  if (!botUsername) {
+    throw new Error("botUsername must be a valid Mattermost username.");
+  }
   const maxWebSocketMessageBytes = resolvePositiveLimit(
     params.maxWebSocketMessageBytes,
     "maxWebSocketMessageBytes",
@@ -1011,6 +1056,7 @@ export async function startMattermostServer(
     pendingEvents: [],
     posts: new Map(),
     recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "mattermost.jsonl"),
+    userIdsByUsername: new Map([[botUsername, botUserId]]),
     users: new Map([[botUserId, { id: botUserId, update_at: Date.now(), username: botUsername }]]),
     websocketClients: new Map(),
   };

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -747,7 +747,7 @@ function createInboundUpdate(
     (fromIdValue !== undefined && (fromId === undefined || fromId < 1)) ||
     (fromUsernameValue !== undefined && !fromUsername) ||
     (threadIdValue !== undefined && threadId === undefined) ||
-    (messageIdValue !== undefined && (messageId === undefined || messageId < 0)) ||
+    (messageIdValue !== undefined && (messageId === undefined || messageId < 1)) ||
     (updateIdValue !== undefined && (updateId === undefined || updateId < 1))
   ) {
     return undefined;

--- a/test/mattermost-server.test.ts
+++ b/test/mattermost-server.test.ts
@@ -233,6 +233,82 @@ describe("Mattermost local provider server", () => {
     }
   });
 
+  it("validates native channel types and unique normalized usernames on admin ingress", async () => {
+    const server = await startMattermostServer({ adminToken: "admin", botToken: "fake" });
+    servers.push(server);
+    const inject = (body: Record<string, unknown>) =>
+      fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify(body),
+        headers: {
+          "content-type": "application/json",
+          "x-crabline-admin-token": "admin",
+        },
+        method: "POST",
+      });
+
+    for (const channelType of ["", "X", "BO"]) {
+      const response = await inject({
+        channelId: CHANNEL_ID,
+        channelType,
+        senderId: USER_ID,
+        text: "invalid channel type",
+      });
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toMatchObject({
+        error: "channelType is not supported",
+        ok: false,
+      });
+    }
+
+    const missingChannel = await fetch(
+      `${server.manifest.endpoints.apiRoot}/channels/${CHANNEL_ID}`,
+      { headers: { authorization: "Bearer fake" } },
+    );
+    expect(missingChannel.status).toBe(404);
+
+    const accepted = await inject({
+      channelId: CHANNEL_ID,
+      channelType: "O",
+      senderId: USER_ID,
+      senderName: "Alice",
+      text: "normalized sender",
+    });
+    expect(accepted.status).toBe(200);
+    const normalizedUser = await fetch(
+      `${server.manifest.endpoints.apiRoot}/users/username/ALICE`,
+      { headers: { authorization: "Bearer fake" } },
+    );
+    await expect(normalizedUser.json()).resolves.toMatchObject({
+      id: USER_ID,
+      username: "alice",
+    });
+
+    for (const senderName of ["ALICE", "bad name", "system", "a".repeat(65)]) {
+      const response = await inject({
+        channelId: OTHER_CHANNEL_ID,
+        senderId: OTHER_USER_ID,
+        senderName,
+        text: "invalid sender name",
+      });
+      expect(response.status).toBe(400);
+    }
+
+    const defaulted = await inject({
+      channelId: OTHER_CHANNEL_ID,
+      senderId: OTHER_USER_ID,
+      text: "default sender name",
+    });
+    expect(defaulted.status).toBe(200);
+    const defaultUser = await fetch(
+      `${server.manifest.endpoints.apiRoot}/users/username/${OTHER_USER_ID}`,
+      { headers: { authorization: "Bearer fake" } },
+    );
+    await expect(defaultUser.json()).resolves.toMatchObject({
+      id: OTHER_USER_ID,
+      username: OTHER_USER_ID,
+    });
+  });
+
   it("returns native route errors with request IDs and parses Bearer credentials exactly", async () => {
     const server = await startMattermostServer({ botToken: "fake" });
     servers.push(server);
@@ -988,7 +1064,7 @@ describe("Mattermost local provider server", () => {
     const user = await fetch(`${server.manifest.endpoints.apiRoot}/users/${USER_ID}`, {
       headers: { authorization: "Bearer fake" },
     });
-    await expect(user.json()).resolves.toMatchObject({ username: "Alice" });
+    await expect(user.json()).resolves.toMatchObject({ username: "alice" });
     const channel = await fetch(`${server.manifest.endpoints.apiRoot}/channels/${CHANNEL_ID}`, {
       headers: { authorization: "Bearer fake" },
     });

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -2016,24 +2016,21 @@ describe("telegram local provider server", () => {
     });
   });
 
-  it("accepts scheduled message ID zero without advancing generated IDs", async () => {
+  it("rejects message ID zero on admin ingress without advancing generated IDs", async () => {
     const server = await startTelegramServer({ botToken: "test-token-placeholder" });
     servers.push(server);
 
-    const scheduled = await injectUpdate(server, {
+    const rejected = await injectUpdate(server, {
       chatId: 123,
       messageId: 0,
-      text: "scheduled message",
+      text: "invalid message",
       updateId: 1,
     });
-    expect(scheduled.status).toBe(200);
-    await expect(scheduled.json()).resolves.toMatchObject({
-      update: { message: { message_id: 0 }, update_id: 1 },
-    });
+    expect(rejected.status).toBe(400);
 
     const generated = await injectUpdate(server, { chatId: 123, text: "generated message" });
     await expect(generated.json()).resolves.toMatchObject({
-      update: { message: { message_id: 1 }, update_id: 2 },
+      update: { message: { message_id: 1 }, update_id: 1 },
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

Admin ingress accepted invalid Telegram message IDs and under-validated Mattermost channel and username state.

## Why This Change Was Made

Enforce provider-native Telegram and Mattermost validation, normalized username uniqueness, and deterministic lookup behavior.

## User Impact

Injected admin state now follows the same identity and channel constraints that compatible provider clients observe.

## Evidence

- 81 focused tests passed
- format, typecheck, and lint passed
- gpt-5.6-sol high autoreview clean
- Crabbox Linux `pnpm verify`: 64 files, 1513 passed, 15 skipped
