### PR TITLE
fix(providers): preserve committed webhook acceptance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Reject non-positive Telegram admin message IDs and enforce native Mattermost channel types and unique normalized usernames.
+- Preserve local-mock webhook acceptance when clients disconnect or post-commit settlement hooks fail.
 - Scope iMessage direct waits and Matrix and Mattermost thread correlation to their native conversations.
 - Escape visually unsafe Unicode controls in JSON reports, return a stable error document for unserializable values, and preserve Node write encoding semantics in test captures.
 - Ignore typeless Slack callbacks and redact URL fragments from Zalo recorder evidence.

--- a/src/providers/local-mock.ts
+++ b/src/providers/local-mock.ts
@@ -251,6 +251,20 @@ function mockReplyText(params: { platform: ProviderPlatform; text: string }) {
   return `[${params.platform} mock] ${params.text}`;
 }
 
+function reportPostCommitWebhookSettlementFailure(providerId: string, error: unknown): void {
+  try {
+    process.emitWarning(
+      `Webhook acceptance committed for provider ${JSON.stringify(providerId)}, but settlement failed: ${ensureErrorMessage(error)}`,
+      {
+        code: "CRABLINE_WEBHOOK_SETTLEMENT",
+        type: "ProviderWebhookWarning",
+      },
+    );
+  } catch {
+    // Error reporting must not change the result of an accepted webhook.
+  }
+}
+
 export class LocalMockProviderAdapter implements ProviderAdapter {
   readonly id;
   readonly platform;
@@ -546,6 +560,21 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
       settle(response.ok);
       return response;
     };
+    const settleCommittedAcceptance = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      try {
+        this.#options.settleWebhookRequest?.({
+          accepted: true,
+          payload: rawPayload,
+          rawBody,
+        });
+      } catch (error) {
+        reportPostCommitWebhookSettlementFailure(this.id, error);
+      }
+    };
     try {
       const directResponse = await this.#options.handleWebhookPayload?.(
         rawPayload,
@@ -580,6 +609,12 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
           new Response("payload requires message.threadId and message.text", { status: 400 }),
         );
       }
+      const successResponse =
+        (await this.#options.createWebhookSuccessResponse?.(rawPayload, id)) ??
+        new Response(JSON.stringify({ ok: true, id }), {
+          headers: { "content-type": "application/json" },
+          status: 200,
+        });
       await appendRecordedInbound(this.#recorderPath, {
         author: authorFromPayload(payload),
         id,
@@ -590,13 +625,8 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
         text,
         threadId,
       });
-      return respond(
-        (await this.#options.createWebhookSuccessResponse?.(rawPayload, id)) ??
-          new Response(JSON.stringify({ ok: true, id }), {
-            headers: { "content-type": "application/json" },
-            status: 200,
-          }),
-      );
+      settleCommittedAcceptance();
+      return successResponse;
     } catch (error) {
       settle(false);
       throw error;

--- a/test/local-mock-provider.test.ts
+++ b/test/local-mock-provider.test.ts
@@ -620,6 +620,109 @@ describe("local mock provider", () => {
     });
   });
 
+  it("constructs the provider success response before committing the webhook", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const recorderPath = path.join(directory, "success-response-abort.jsonl");
+    let handleRequest: ((request: Request) => Promise<Response>) | undefined;
+    webhookMocks.startWebhookServer.mockImplementationOnce(async (params) => {
+      handleRequest = params.handle;
+      return {
+        async close() {},
+        endpointUrl: "http://127.0.0.1:43210/slack/events",
+      };
+    });
+    const settleWebhookRequest = vi.fn();
+    const config = createConfig();
+    const provider = new LocalMockProviderAdapter({
+      codec: createGenericLocalMockTargetCodec("slack"),
+      config,
+      id: "provider-a",
+      options: {
+        createWebhookSuccessResponse() {
+          throw new DOMException("response construction aborted", "AbortError");
+        },
+        defaultWebhook: { host: "127.0.0.1", path: "/slack/events", port: 0 },
+        endpointLabel: "events endpoint",
+        platform: "slack",
+        recorderPath,
+        settleWebhookRequest,
+      },
+    });
+    providers.push(provider);
+    await provider.probe(createContext(config));
+
+    await expect(
+      handleRequest!(
+        new Request("http://127.0.0.1:43210/slack/events", {
+          body: JSON.stringify({ id: "event-1", text: "hello", threadId: "C1234567890" }),
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        }),
+      ),
+    ).rejects.toThrow(/response construction aborted/u);
+
+    await expect(readFile(recorderPath, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+    expect(settleWebhookRequest).toHaveBeenCalledOnce();
+    expect(settleWebhookRequest).toHaveBeenCalledWith(expect.objectContaining({ accepted: false }));
+  });
+
+  it("preserves accepted webhook success when post-commit settlement fails", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const recorderPath = path.join(directory, "settlement-failure.jsonl");
+    let handleRequest: ((request: Request) => Promise<Response>) | undefined;
+    webhookMocks.startWebhookServer.mockImplementationOnce(async (params) => {
+      handleRequest = params.handle;
+      return {
+        async close() {},
+        endpointUrl: "http://127.0.0.1:43210/slack/events",
+      };
+    });
+    const emitWarning = vi.spyOn(process, "emitWarning").mockImplementation(() => {});
+    const config = createConfig();
+    const provider = new LocalMockProviderAdapter({
+      codec: createGenericLocalMockTargetCodec("slack"),
+      config,
+      id: "provider-a",
+      options: {
+        defaultWebhook: { host: "127.0.0.1", path: "/slack/events", port: 0 },
+        endpointLabel: "events endpoint",
+        platform: "slack",
+        recorderPath,
+        settleWebhookRequest() {
+          throw new Error("settlement failed");
+        },
+      },
+    });
+    providers.push(provider);
+    await provider.probe(createContext(config));
+
+    try {
+      const response = await handleRequest!(
+        new Request("http://127.0.0.1:43210/slack/events", {
+          body: JSON.stringify({ id: "event-1", text: "hello", threadId: "C1234567890" }),
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        }),
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({ id: "event-1", ok: true });
+      expect(JSON.parse((await readFile(recorderPath, "utf8")).trim())).toMatchObject({
+        id: "event-1",
+        text: "hello",
+        threadId: "C1234567890",
+      });
+      expect(emitWarning).toHaveBeenCalledWith(
+        expect.stringContaining("settlement failed"),
+        expect.objectContaining({ code: "CRABLINE_WEBHOOK_SETTLEMENT" }),
+      );
+    } finally {
+      emitWarning.mockRestore();
+    }
+  });
+
   it("rejects an empty webhook thread id", async () => {
     let handleRequest: ((request: Request) => Promise<Response>) | undefined;
     webhookMocks.startWebhookServer.mockImplementationOnce(async (params) => {


### PR DESCRIPTION
## What Problem This Solves

Webhook acceptance could be reported as failed after the event was already committed, allowing a retry to duplicate persisted evidence.

## Why This Change Was Made

Preserve committed acceptance across post-commit response failures and keep retry state aligned with recorder durability.

## User Impact

Provider webhook retries no longer duplicate events that Crabline has already durably accepted.

## Evidence

- 84 focused tests passed
- format, typecheck, and lint passed
- gpt-5.6-sol high autoreview clean
- Crabbox Linux `pnpm verify`: 64 files, 1513 passed, 15 skipped
