### PR TITLE
fix(core): close final audit contract gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Reject non-positive Telegram admin message IDs and enforce native Mattermost channel types and unique normalized usernames.
 - Preserve local-mock webhook acceptance when clients disconnect or post-commit settlement hooks fail.
 - Scope iMessage direct waits and Matrix and Mattermost thread correlation to their native conversations.
+- Coordinate recorder repair by file identity, limit existing-file durability syncs to the immediate parent, and reject provider lock roots beneath unsafe Unix namespaces.
 - Escape visually unsafe Unicode controls in JSON reports, return a stable error document for unserializable values, and preserve Node write encoding semantics in test captures.
 - Ignore typeless Slack callbacks and redact URL fragments from Zalo recorder evidence.
 - Redact Feishu verification tokens from recorder payloads and release replay reservations after recorder failures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Validate effective fixture mode overrides and stop retrying permanent provider send failures.
 - Bound watch iterator return and provider cleanup during CLI shutdown, forcing process exit after deadline failures.
 - Correct provider-native channel target examples, admin-ingress setup, and contract maintenance coverage.
+- Document the complete ready and script-bridge channel matrix and validate the shipped example against the manifest schema.
 - Preserve native Slack rich text and block fallbacks, isolate Feishu replay identities, ignore non-message Google Chat interactions, and fail closed on invalid Zalo adapter inputs.
 - Correlate complete NAT64 discovery pairs and retain DNS capacity until abandoned lookups settle.
 - Verify loopback bindings by their listening address, sanitize framing and connection-nominated Fetch response headers, and advertise usable endpoints for every wildcard address spelling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Keep Unix recorder identity locks in one validated private per-user namespace across processes and recorder path changes.
 - Reject non-positive Telegram admin message IDs and enforce native Mattermost channel types and unique normalized usernames.
 - Preserve local-mock webhook acceptance when clients disconnect or post-commit settlement hooks fail.
 - Scope iMessage direct waits and Matrix and Mattermost thread correlation to their native conversations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Preserve local-mock webhook acceptance when clients disconnect or post-commit settlement hooks fail.
 - Scope iMessage direct waits and Matrix and Mattermost thread correlation to their native conversations.
 - Coordinate recorder repair by file identity, limit existing-file durability syncs to the immediate parent, and reject provider lock roots beneath unsafe Unix namespaces.
+- Stop retrying and resending accepted outbound messages after permanent inbound authentication or configuration failures.
 - Escape visually unsafe Unicode controls in JSON reports, return a stable error document for unserializable values, and preserve Node write encoding semantics in test captures.
 - Ignore typeless Slack callbacks and redact URL fragments from Zalo recorder evidence.
 - Redact Feishu verification tokens from recorder payloads and release replay reservations after recorder failures.

--- a/README.md
+++ b/README.md
@@ -178,14 +178,16 @@ after appending each API/admin event to `recorderPath`, so callers can react in
 process while retaining the JSONL artifact as durable evidence.
 
 Recorder files should normally have one filesystem name. If multiple processes
-write through hardlinks to the same recorder inode, set
+cannot share the same OS account home, the home is read-only, or they write
+through hardlinks to the same recorder inode, set
 `CRABLINE_RECORDER_LOCK_DIR` to the same absolute writable directory for every
 writer. Pre-create that directory with the ownership, group, or ACLs required
 by those writers. Crabline refuses hardlinked server-recorder writes without
 this shared lock namespace. The configured path must be canonical and contain
 no symlink components. Scope each lock directory to one recorder filesystem;
 lock identities omit device numbers so containers that mount the same inode
-under different device IDs still coordinate.
+under different device IDs still coordinate. Otherwise, Unix writers coordinate
+through the OS account's `~/.cache/crabline/locks/server-recorder` namespace.
 
 Mattermost:
 

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -56,6 +56,37 @@ remove stale config blocks or split them into separate provider ids.
 `loopback` has no externally meaningful webhook surface and is primarily useful
 for local direct adapter checks.
 
+## OpenClaw Support Matrix
+
+`ready` platforms have built-in local mock adapters. `bridge` platforms use the
+`script` adapter with commands supplied by the manifest owner.
+
+| Platform        | Status   |
+| --------------- | -------- |
+| `bluebubbles`   | `bridge` |
+| `discord`       | `ready`  |
+| `feishu`        | `ready`  |
+| `googlechat`    | `ready`  |
+| `imessage`      | `ready`  |
+| `irc`           | `bridge` |
+| `line`          | `bridge` |
+| `loopback`      | `ready`  |
+| `matrix`        | `ready`  |
+| `mattermost`    | `ready`  |
+| `msteams`       | `ready`  |
+| `nextcloudtalk` | `bridge` |
+| `nostr`         | `bridge` |
+| `signal`        | `bridge` |
+| `slack`         | `ready`  |
+| `synologychat`  | `bridge` |
+| `telegram`      | `ready`  |
+| `tlon`          | `bridge` |
+| `twitch`        | `bridge` |
+| `webchat`       | `bridge` |
+| `whatsapp`      | `ready`  |
+| `zalo`          | `ready`  |
+| `zalouser`      | `bridge` |
+
 ## Mock Config
 
 ```yaml
@@ -278,6 +309,9 @@ root event ID, such as `$eventid:matrix.org`; Crabline emits it as both the
 `m.room.message` event is delivered through Matrix `/sync`. Outbound room sends
 through `PUT /_matrix/client/v3/rooms/:roomId/send/:eventType/:txnId` are
 written to the manifest recorder.
+
+Post admin inbound payloads to the manifest's `endpoints.adminInboundUrl` with
+its `adminToken` in the `X-Crabline-Admin-Token` header.
 
 The provider server implements the unencrypted Client-Server API subset needed
 by the normal Matrix SDK: versions, `whoami`, filters, push rules, joined rooms

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -329,13 +329,15 @@ requests and lookalike route suffixes can remain diagnostic recorder entries,
 but they are never exposed as successful outbound deliveries.
 
 Use one filesystem name per recorder file. When multiple server processes must
-write through hardlinks to the same recorder inode, set
+run without one shared writable OS account home or write through hardlinks to
+the same recorder inode, set
 `CRABLINE_RECORDER_LOCK_DIR` to one absolute writable directory shared by every
 writer and pre-create its ownership, group, or ACLs. Hardlinked server-recorder
 writes fail closed when this shared lock namespace is absent. The path must be
 canonical and contain no symlink components. Use a separate lock directory per
 recorder filesystem; lock identities omit device numbers so containers that
-mount the same inode under different device IDs still coordinate.
+mount the same inode under different device IDs still coordinate. Otherwise,
+Unix writers use `~/.cache/crabline/locks/server-recorder`.
 
 Slack:
 

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -585,6 +585,9 @@ export async function runFixtureCommand(params: {
             if (abortDrainFailed) {
               break;
             }
+            if (isPermanentFailure(lastFailure)) {
+              break;
+            }
             continue;
           }
           if (!inbound) {

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -1,5 +1,5 @@
 import { constants as fsConstants } from "node:fs";
-import { lstat, mkdir, open, readFile, readlink, realpath } from "node:fs/promises";
+import { chmod, lstat, mkdir, open, readFile, readlink, realpath } from "node:fs/promises";
 import { userInfo } from "node:os";
 import path from "node:path";
 import { lock } from "proper-lockfile";
@@ -460,6 +460,9 @@ async function syncRecorderPathAncestry(
       }
       throw error;
     }
+    if (syncThroughPath === undefined) {
+      return;
+    }
     if (currentPath === syncThroughPath) {
       return;
     }
@@ -652,6 +655,82 @@ function reportRecorderLockReleaseFailure(filePath: string, releaseError: unknow
   }
 }
 
+async function verifyProviderRecorderLockAncestry(
+  directory: string,
+  currentUserId: number,
+): Promise<void> {
+  let currentPath = path.resolve(directory);
+  for (;;) {
+    const current = await lstat(currentPath, { bigint: true });
+    const ownerIsTrusted = current.uid === BigInt(currentUserId) || current.uid === 0n;
+    if (current.isSymbolicLink()) {
+      if (!ownerIsTrusted) {
+        throw new Error("Provider recorder lock directory parent namespace is not trusted.");
+      }
+    } else {
+      const peerWritable = (current.mode & 0o022n) !== 0n;
+      const sticky = (current.mode & 0o1000n) !== 0n;
+      if (!current.isDirectory() || !ownerIsTrusted || (peerWritable && !sticky)) {
+        throw new Error("Provider recorder lock directory parent namespace is not trusted.");
+      }
+    }
+    const parent = path.dirname(currentPath);
+    if (parent === currentPath) {
+      return;
+    }
+    currentPath = parent;
+  }
+}
+
+async function prepareProviderRecorderLockRoot(
+  root: string,
+  currentUserId: number,
+): Promise<string> {
+  let existingPath = path.resolve(root);
+  const missingComponents: string[] = [];
+  for (;;) {
+    try {
+      await lstat(existingPath);
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+      const parent = path.dirname(existingPath);
+      if (parent === existingPath) {
+        throw error;
+      }
+      missingComponents.unshift(path.basename(existingPath));
+      existingPath = parent;
+    }
+  }
+  await verifyProviderRecorderLockAncestry(existingPath, currentUserId);
+  let canonicalPath = await realpath(existingPath);
+  if (canonicalPath !== existingPath) {
+    await verifyProviderRecorderLockAncestry(canonicalPath, currentUserId);
+  }
+  for (const component of missingComponents) {
+    canonicalPath = path.join(canonicalPath, component);
+    try {
+      await mkdir(canonicalPath, { mode: 0o700 });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+        throw error;
+      }
+    }
+    const identity = await lstat(canonicalPath, { bigint: true });
+    if (
+      !identity.isDirectory() ||
+      identity.isSymbolicLink() ||
+      identity.uid !== BigInt(currentUserId)
+    ) {
+      throw new Error("Provider recorder lock directory is not privately owned.");
+    }
+    await chmod(canonicalPath, 0o700);
+  }
+  return canonicalPath;
+}
+
 export async function secureProviderRecorderLockRoot(
   root: string,
   currentUserId: number | undefined,
@@ -679,18 +758,19 @@ export async function secureProviderRecorderLockRoot(
     });
   }
 
-  await mkdir(root, { mode: 0o700, recursive: true });
   if (currentUserId === undefined) {
     throw new Error("Provider recorder identity locking requires a current user id.");
   }
 
+  const canonicalRoot = await prepareProviderRecorderLockRoot(root, currentUserId);
+
   const handle = await open(
-    root,
+    canonicalRoot,
     fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW,
   );
   try {
     const identity = await handle.stat({ bigint: true });
-    const current = await lstat(root, { bigint: true });
+    const current = await lstat(canonicalRoot, { bigint: true });
     if (
       !identity.isDirectory() ||
       !current.isDirectory() ||
@@ -711,7 +791,7 @@ export async function secureProviderRecorderLockRoot(
   } finally {
     await handle.close();
   }
-  return root;
+  return canonicalRoot;
 }
 
 function recorderLockRootUnavailable(error: unknown): boolean {

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -347,29 +347,31 @@ function isRecorderLockContention(error: unknown): boolean {
   );
 }
 
-async function securePrivateServerRecorderLockRoot(
-  root: string,
+async function verifyPrivateServerRecorderDirectory(
+  directory: string,
   currentUserId: number,
-): Promise<string> {
-  await mkdir(root, { mode: 0o700, recursive: true });
+  requirePrivateMode: boolean,
+): Promise<void> {
   const handle = await open(
-    root,
+    directory,
     fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW,
   );
   try {
     const identity = await handle.stat({ bigint: true });
-    const current = await lstat(root, { bigint: true });
+    const current = await lstat(directory, { bigint: true });
     if (
       !identity.isDirectory() ||
       !current.isDirectory() ||
+      current.isSymbolicLink() ||
       identity.dev !== current.dev ||
       identity.ino !== current.ino ||
       identity.uid !== BigInt(currentUserId) ||
-      current.uid !== BigInt(currentUserId)
+      current.uid !== BigInt(currentUserId) ||
+      (!requirePrivateMode && (identity.mode & 0o022n) !== 0n)
     ) {
       throw new Error("Server recorder lock directory is not privately owned.");
     }
-    if ((identity.mode & 0o777n) !== 0o700n) {
+    if (requirePrivateMode && (identity.mode & 0o777n) !== 0o700n) {
       await handle.chmod(0o700);
       const secured = await handle.stat({ bigint: true });
       if ((secured.mode & 0o777n) !== 0o700n) {
@@ -379,7 +381,92 @@ async function securePrivateServerRecorderLockRoot(
   } finally {
     await handle.close();
   }
-  return root;
+}
+
+async function securePrivateServerRecorderLockRoot(
+  baseDirectory: string,
+  components: string[],
+  currentUserId: number,
+): Promise<string> {
+  await verifyPrivateServerRecorderLockAncestry(baseDirectory, currentUserId);
+  let currentPath = await realpath(baseDirectory);
+  await verifyPrivateServerRecorderLockAncestry(currentPath, currentUserId);
+  await verifyPrivateServerRecorderDirectory(currentPath, currentUserId, false);
+  for (const component of components) {
+    currentPath = path.join(currentPath, component);
+    let created = false;
+    try {
+      await mkdir(currentPath, { mode: 0o700 });
+      created = true;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+        throw error;
+      }
+    }
+    if (created) {
+      await chmod(currentPath, 0o700);
+    }
+    await verifyPrivateServerRecorderDirectory(currentPath, currentUserId, true);
+  }
+  return currentPath;
+}
+
+async function verifyPrivateServerRecorderLockAncestry(
+  directory: string,
+  currentUserId: number,
+): Promise<void> {
+  let currentPath = path.resolve(directory);
+  for (;;) {
+    const current = await lstat(currentPath, { bigint: true });
+    const ownerIsTrusted = current.uid === BigInt(currentUserId) || current.uid === 0n;
+    if (current.isSymbolicLink()) {
+      if (!ownerIsTrusted) {
+        throw new Error("Server recorder lock directory parent namespace is not trusted.");
+      }
+    } else {
+      const peerWritable = (current.mode & 0o022n) !== 0n;
+      const sticky = (current.mode & 0o1000n) !== 0n;
+      if (!current.isDirectory() || !ownerIsTrusted || (peerWritable && !sticky)) {
+        throw new Error("Server recorder lock directory parent namespace is not trusted.");
+      }
+    }
+    const parent = path.dirname(currentPath);
+    if (parent === currentPath) {
+      return;
+    }
+    currentPath = parent;
+  }
+}
+
+async function serverRecorderUnixLockRoot(currentUserId: number): Promise<string> {
+  let homeDirectory: string;
+  try {
+    homeDirectory = userInfo().homedir;
+  } catch (error) {
+    throw new Error(
+      `Server recorder identity locking requires an OS account home or ${RECORDER_LOCK_DIRECTORY_ENV}.`,
+      { cause: error },
+    );
+  }
+  await verifyPrivateServerRecorderLockAncestry(homeDirectory, currentUserId);
+  const cacheDirectory = path.join(homeDirectory, ".cache");
+  let cacheCreated = false;
+  try {
+    await mkdir(cacheDirectory, { mode: 0o700 });
+    cacheCreated = true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+      throw error;
+    }
+  }
+  if (cacheCreated) {
+    await chmod(cacheDirectory, 0o700);
+  }
+  return await securePrivateServerRecorderLockRoot(
+    cacheDirectory,
+    ["crabline", "locks", "server-recorder"],
+    currentUserId,
+  );
 }
 
 async function secureRecorderLockRoot(root: string): Promise<string> {
@@ -487,19 +574,7 @@ async function recorderIdentityLockTarget(fileIdentity: RecorderFileIdentity): P
     if (currentUserId === undefined) {
       throw new Error("Server recorder identity locking requires a current user id.");
     }
-    let privateRoot: string;
-    try {
-      privateRoot = path.join(userInfo().homedir, ".cache", "crabline", "locks", "server-recorder");
-    } catch (error) {
-      throw new Error(
-        `Server recorder identity locking requires a private home directory or ${RECORDER_LOCK_DIRECTORY_ENV}.`,
-        { cause: error },
-      );
-    }
-    return recorderIdentityLockPath(
-      await securePrivateServerRecorderLockRoot(privateRoot, currentUserId),
-      fileIdentity,
-    );
+    return recorderIdentityLockPath(await serverRecorderUnixLockRoot(currentUserId), fileIdentity);
   }
   if (!path.isAbsolute(configuredRoot)) {
     throw new Error(`${RECORDER_LOCK_DIRECTORY_ENV} must be an absolute path.`);

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -247,6 +247,9 @@ async function syncRecorderPathAncestry(
       }
       throw error;
     }
+    if (syncThroughPath === undefined) {
+      return;
+    }
     if (currentPath === syncThroughPath) {
       return;
     }
@@ -344,6 +347,41 @@ function isRecorderLockContention(error: unknown): boolean {
   );
 }
 
+async function securePrivateServerRecorderLockRoot(
+  root: string,
+  currentUserId: number,
+): Promise<string> {
+  await mkdir(root, { mode: 0o700, recursive: true });
+  const handle = await open(
+    root,
+    fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW,
+  );
+  try {
+    const identity = await handle.stat({ bigint: true });
+    const current = await lstat(root, { bigint: true });
+    if (
+      !identity.isDirectory() ||
+      !current.isDirectory() ||
+      identity.dev !== current.dev ||
+      identity.ino !== current.ino ||
+      identity.uid !== BigInt(currentUserId) ||
+      current.uid !== BigInt(currentUserId)
+    ) {
+      throw new Error("Server recorder lock directory is not privately owned.");
+    }
+    if ((identity.mode & 0o777n) !== 0o700n) {
+      await handle.chmod(0o700);
+      const secured = await handle.stat({ bigint: true });
+      if ((secured.mode & 0o777n) !== 0o700n) {
+        throw new Error("Server recorder lock directory permissions are not private.");
+      }
+    }
+  } finally {
+    await handle.close();
+  }
+  return root;
+}
+
 async function secureRecorderLockRoot(root: string): Promise<string> {
   const canonicalRoot = await realpath(root);
   if (path.relative(root, canonicalRoot) !== "") {
@@ -380,8 +418,11 @@ async function secureRecorderLockRoot(root: string): Promise<string> {
 }
 
 function recorderIdentityLockPath(root: string, identity: RecorderFileIdentity): string {
-  // st_dev can differ for one shared inode across container mount namespaces.
-  // Scope each configured root to one recorder filesystem to avoid false inode collisions.
+  return path.join(root, `recorder-${identity.dev}-${identity.ino}`);
+}
+
+function recorderSharedIdentityLockPath(root: string, identity: RecorderFileIdentity): string {
+  // A shared inode can report different device numbers across mount namespaces.
   return path.join(root, `recorder-${identity.ino}`);
 }
 
@@ -430,23 +471,41 @@ async function recorderProcessLockTarget(filePath: string): Promise<string> {
   return serverRecorderWindowsLockPath(root, filePath);
 }
 
-async function recorderIdentityLockTarget(
-  identity: RecorderFileIdentity,
-): Promise<string | undefined> {
+async function recorderIdentityLockTarget(fileIdentity: RecorderFileIdentity): Promise<string> {
   const configuredRoot = process.env[RECORDER_LOCK_DIRECTORY_ENV]?.trim();
   if (!configuredRoot) {
-    if (identity.nlink > 1n) {
+    if (fileIdentity.nlink > 1n) {
       throw new Error(
         `Server recorder hardlinks require ${RECORDER_LOCK_DIRECTORY_ENV} to name one shared writable lock directory for every writer.`,
       );
     }
-    return undefined;
+    if (process.platform === "win32") {
+      const root = await secureServerRecorderWindowsLockRoot(serverRecorderWindowsLockRoot());
+      return recorderIdentityLockPath(root, fileIdentity);
+    }
+    const currentUserId = process.geteuid?.();
+    if (currentUserId === undefined) {
+      throw new Error("Server recorder identity locking requires a current user id.");
+    }
+    let privateRoot: string;
+    try {
+      privateRoot = path.join(userInfo().homedir, ".cache", "crabline", "locks", "server-recorder");
+    } catch (error) {
+      throw new Error(
+        `Server recorder identity locking requires a private home directory or ${RECORDER_LOCK_DIRECTORY_ENV}.`,
+        { cause: error },
+      );
+    }
+    return recorderIdentityLockPath(
+      await securePrivateServerRecorderLockRoot(privateRoot, currentUserId),
+      fileIdentity,
+    );
   }
   if (!path.isAbsolute(configuredRoot)) {
     throw new Error(`${RECORDER_LOCK_DIRECTORY_ENV} must be an absolute path.`);
   }
   const sharedRoot = await secureRecorderLockRoot(configuredRoot);
-  return recorderIdentityLockPath(sharedRoot, identity);
+  return recorderSharedIdentityLockPath(sharedRoot, fileIdentity);
 }
 
 async function acquireSingleRecorderLock(filePath: string): Promise<() => Promise<void>> {
@@ -515,9 +574,8 @@ async function acquireRecorderLock(
 
 async function acquireRecorderIdentityLock(
   identity: RecorderFileIdentity,
-): Promise<(() => Promise<void>) | undefined> {
-  const target = await recorderIdentityLockTarget(identity);
-  return target === undefined ? undefined : await acquireRecorderLock(target, false);
+): Promise<() => Promise<void>> {
+  return await acquireRecorderLock(await recorderIdentityLockTarget(identity), false);
 }
 
 async function withRecorderLock(

--- a/test/channel-setup-docs.test.ts
+++ b/test/channel-setup-docs.test.ts
@@ -1,25 +1,52 @@
 import fs from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 import { parse } from "yaml";
-
-type ExampleManifest = {
-  fixtures?: Array<{
-    provider?: string;
-    target?: {
-      id?: string;
-    };
-  }>;
-};
+import { BUILTIN_ADAPTERS, ManifestSchema } from "../src/config/schema.js";
+import { OPENCLAW_SUPPORT_CATALOG } from "../src/providers/catalog.js";
 
 describe("channel setup contracts", () => {
-  it("ships a provider-native Mattermost fixture target", async () => {
-    const manifest = parse(
-      await fs.readFile("fixtures/examples/crabline.example.yaml", "utf8"),
-    ) as ExampleManifest;
-    const targetId = manifest.fixtures?.find((fixture) => fixture.provider === "mattermost")?.target
-      ?.id;
+  it("ships a schema-valid example covering every built-in adapter", async () => {
+    const manifest = ManifestSchema.parse(
+      parse(await fs.readFile("fixtures/examples/crabline.example.yaml", "utf8")),
+    );
+    const exampleAdapters = Object.values(manifest.providers)
+      .map((provider) => provider.adapter)
+      .toSorted();
+    const builtinAdapters = BUILTIN_ADAPTERS.filter((adapter) => adapter !== "script").toSorted();
 
+    expect(exampleAdapters).toEqual(builtinAdapters);
+
+    const targetId = manifest.fixtures.find((fixture) => fixture.provider === "mattermost")?.target
+      .id;
     expect(targetId).toMatch(/^[a-z0-9]{26}$/u);
+  });
+
+  it("keeps documented support lists synchronized with schema and catalog", async () => {
+    const [readme, channelSetup] = await Promise.all([
+      fs.readFile("README.md", "utf8"),
+      fs.readFile("docs/channel-setup.md", "utf8"),
+    ]);
+    const readmeBuiltinSection = readme.slice(
+      readme.indexOf("The built-in providers are:"),
+      readme.indexOf("The `script` adapter"),
+    );
+    const documentedBuiltinAdapters = Array.from(
+      readmeBuiltinSection.matchAll(/^- `([^`]+)`$/gmu),
+      (match) => match[1],
+    ).toSorted();
+    const documentedCatalog = Array.from(
+      channelSetup.matchAll(/^\| `([^`]+)`\s+\| `(ready|bridge)`\s+\|$/gmu),
+      (match) => ({ platform: match[1]!, status: match[2]! }),
+    ).toSorted((left, right) => left.platform.localeCompare(right.platform));
+    const expectedCatalog = OPENCLAW_SUPPORT_CATALOG.map(({ platform, status }) => ({
+      platform,
+      status,
+    })).toSorted((left, right) => left.platform.localeCompare(right.platform));
+
+    expect(documentedBuiltinAdapters).toEqual(
+      BUILTIN_ADAPTERS.filter((adapter) => adapter !== "script").toSorted(),
+    );
+    expect(documentedCatalog).toEqual(expectedCatalog);
   });
 
   it("documents native target and admin-ingress identifiers", async () => {
@@ -38,5 +65,12 @@ describe("channel setup contracts", () => {
     expect(channelSetup).toContain("optional `senderName`, `roomName`, `direct`, and `threadId`");
     expect(channelSetup).toContain("`/crabline/zalo/inbound`");
     expect(channelSetup).toContain("`X-Crabline-Admin-Token`");
+    const matrixSection = channelSetup.slice(
+      channelSetup.indexOf("### Matrix"),
+      channelSetup.indexOf("Slack:"),
+    );
+    expect(matrixSection).toContain("`endpoints.adminInboundUrl`");
+    expect(matrixSection).toContain("`adminToken`");
+    expect(matrixSection).toContain("`X-Crabline-Admin-Token`");
   });
 });

--- a/test/http-server.test.ts
+++ b/test/http-server.test.ts
@@ -2,9 +2,12 @@ import { get, type IncomingMessage } from "node:http";
 import { PassThrough } from "node:stream";
 import { describe, expect, it } from "vitest";
 import {
+  adminAuthError,
+  ADMIN_TOKEN_HEADER,
   assertLoopbackBindAddress,
   DEFAULT_MAX_REQUEST_BODY_BYTES,
   drainRequestBody,
+  hasAdminToken,
   InvalidJsonBodyError,
   isLoopbackAddress,
   isLoopbackHost,
@@ -27,6 +30,54 @@ function expectLateErrorHandled(request: IncomingMessage): void {
   request.emit("close");
   expect(request.listenerCount("error")).toBe(0);
 }
+
+describe("server admin authentication", () => {
+  const expectedToken = "test-auth-token";
+  const cases: Array<[string, IncomingMessage["headers"], boolean]> = [
+    ["custom header", { [ADMIN_TOKEN_HEADER]: expectedToken }, true],
+    ["Bearer authorization", { authorization: `Bearer ${expectedToken}` }, true],
+    ["case-insensitive Bearer authorization", { authorization: `bEaReR ${expectedToken}` }, true],
+    ["missing credentials", {}, false],
+    ["incorrect token", { [ADMIN_TOKEN_HEADER]: "token-oversized" }, false],
+    ["unequal token length", { [ADMIN_TOKEN_HEADER]: "dummy" }, false],
+    ["malformed authorization", { authorization: `Basic ${expectedToken}` }, false],
+    ["first duplicate header", { [ADMIN_TOKEN_HEADER]: [expectedToken, "wrong"] }, true],
+    ["later duplicate header", { [ADMIN_TOKEN_HEADER]: ["wrong", expectedToken] }, false],
+  ];
+
+  it.each(cases)("handles %s", (_name, headers, expected) => {
+    expect(hasAdminToken(createRequest(headers), expectedToken)).toBe(expected);
+  });
+
+  it("gives the custom header precedence over Bearer authorization", () => {
+    expect(
+      hasAdminToken(
+        createRequest({
+          [ADMIN_TOKEN_HEADER]: "wrong",
+          authorization: `Bearer ${expectedToken}`,
+        }),
+        expectedToken,
+      ),
+    ).toBe(false);
+    expect(
+      hasAdminToken(
+        createRequest({
+          [ADMIN_TOKEN_HEADER]: expectedToken,
+          authorization: "Bearer wrong",
+        }),
+        expectedToken,
+      ),
+    ).toBe(true);
+  });
+
+  it("returns a Bearer challenge for rejected requests", async () => {
+    const response = adminAuthError();
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("www-authenticate")).toBe("Bearer");
+    await expect(response.text()).resolves.toBe("unauthorized");
+  });
+});
 
 describe("server HTTP body reader", () => {
   it("keeps rejected request streams error-handled until close", async () => {

--- a/test/recorder-concurrency.test.ts
+++ b/test/recorder-concurrency.test.ts
@@ -260,6 +260,7 @@ async function expectSerializedWrites(
 describe("recorder append serialization", () => {
   it("serializes server event appends to the same JSONL file", async () => {
     const recorderPath = path.join("/tmp", "crabline-server-recorder.jsonl");
+    osMocks.userInfo.mockClear();
     fsMocks.serverDirectory = await realpath(path.dirname(recorderPath));
     const firstEvent = {
       at: "2026-07-12T10:00:00.000Z",
@@ -294,24 +295,126 @@ describe("recorder append serialization", () => {
     expect(fsMocks.serverSync).toHaveBeenCalledTimes(2);
     expect(fsMocks.serverDirectorySync).toHaveBeenCalledTimes(2);
     expect(fsMocks.lock).toHaveBeenCalledTimes(4);
-    const unixIdentityLockRoot = path.join(
-      await realpath(path.join(userInfo().homedir, ".cache", "crabline", "locks")),
-      "server-recorder",
-    );
-    expect(
-      fsMocks.lock.mock.calls
-        .map(([lockPath]) => String(lockPath))
-        .filter((lockPath) => path.dirname(lockPath) === unixIdentityLockRoot),
-    ).toEqual(
-      process.platform === "win32"
-        ? []
-        : [
-            path.join(unixIdentityLockRoot, "recorder-1-1"),
-            path.join(unixIdentityLockRoot, "recorder-1-1"),
-          ],
+    const unixIdentityLockPaths = fsMocks.lock.mock.calls
+      .map(([lockPath]) => String(lockPath))
+      .filter((lockPath) => path.basename(lockPath) === "recorder-1-1");
+    expect(unixIdentityLockPaths).toEqual(
+      process.platform === "win32" ? [] : [unixIdentityLockPaths[0]!, unixIdentityLockPaths[0]!],
     );
     expect(fsMocks.serverOpen.mock.calls.map(([, flags]) => flags)).toEqual(["ax+", "ax+", "a+"]);
   });
+
+  it.skipIf(process.platform === "win32")(
+    "uses one home lock namespace without changing cache permissions",
+    async () => {
+      const homeDirectory = await mkdtemp(path.join(tmpdir(), "crabline-lock-home-"));
+      const cacheDirectory = path.join(homeDirectory, ".cache");
+      await mkdir(cacheDirectory, { mode: 0o755 });
+      await chmod(cacheDirectory, 0o755);
+      const actualOs = await vi.importActual<typeof import("node:os")>("node:os");
+      osMocks.userInfo.mockImplementationOnce(() => ({
+        ...actualOs.userInfo(),
+        homedir: homeDirectory,
+      }));
+      const recorderPath = path.join("/tmp", "crabline-server-recorder-runtime.jsonl");
+      fsMocks.serverDirectory = await realpath(path.dirname(recorderPath));
+      fsMocks.serverWrite.mockResolvedValue(undefined);
+
+      try {
+        await recordServerEvent({
+          event: {
+            at: "2026-07-12T10:00:00.000Z",
+            method: "POST",
+            path: "/runtime-lock-root",
+            query: {},
+            type: "api",
+          },
+          onEvent: () => undefined,
+          recorderPath,
+        });
+
+        const identityLockPath = fsMocks.lock.mock.calls
+          .map(([lockPath]) => String(lockPath))
+          .find((lockPath) => path.basename(lockPath) === "recorder-1-1");
+        expect(path.dirname(identityLockPath!)).toBe(
+          path.join(await realpath(cacheDirectory), "crabline", "locks", "server-recorder"),
+        );
+        expect((await stat(cacheDirectory)).mode & 0o777).toBe(0o755);
+      } finally {
+        await rm(homeDirectory, { force: true, recursive: true });
+      }
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "normalizes a newly created home cache under a restrictive umask",
+    async () => {
+      const homeDirectory = await mkdtemp(path.join(tmpdir(), "crabline-lock-home-create-"));
+      const actualOs = await vi.importActual<typeof import("node:os")>("node:os");
+      osMocks.userInfo.mockImplementationOnce(() => ({
+        ...actualOs.userInfo(),
+        homedir: homeDirectory,
+      }));
+      const recorderPath = path.join("/tmp", "crabline-server-recorder-cache-create.jsonl");
+      fsMocks.serverDirectory = await realpath(path.dirname(recorderPath));
+      fsMocks.serverWrite.mockResolvedValue(undefined);
+      const previousUmask = process.umask(0o777);
+
+      try {
+        await recordServerEvent({
+          event: {
+            at: "2026-07-12T10:00:00.000Z",
+            method: "POST",
+            path: "/created-cache-lock-root",
+            query: {},
+            type: "api",
+          },
+          onEvent: () => undefined,
+          recorderPath,
+        });
+        expect((await stat(path.join(homeDirectory, ".cache"))).mode & 0o777).toBe(0o700);
+      } finally {
+        process.umask(previousUmask);
+        await rm(homeDirectory, { force: true, recursive: true });
+      }
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "rejects a lock namespace beneath a peer-writable non-sticky ancestor",
+    async () => {
+      const tempRoot = await mkdtemp(path.join(tmpdir(), "crabline-lock-ancestry-"));
+      const unsafeParent = path.join(tempRoot, "unsafe");
+      const homeDirectory = path.join(unsafeParent, "home");
+      await mkdir(homeDirectory, { mode: 0o700, recursive: true });
+      await chmod(unsafeParent, 0o777);
+      const actualOs = await vi.importActual<typeof import("node:os")>("node:os");
+      osMocks.userInfo.mockImplementationOnce(() => ({
+        ...actualOs.userInfo(),
+        homedir: homeDirectory,
+      }));
+      fsMocks.serverDirectory = await realpath(path.dirname("/tmp/server-recorder.jsonl"));
+      fsMocks.serverWrite.mockResolvedValue(undefined);
+
+      try {
+        await expect(
+          recordServerEvent({
+            event: {
+              at: "2026-07-12T10:00:00.000Z",
+              method: "POST",
+              path: "/unsafe-lock-root",
+              query: {},
+              type: "api",
+            },
+            onEvent: () => undefined,
+            recorderPath: "/tmp/server-recorder.jsonl",
+          }),
+        ).rejects.toThrow("parent namespace is not trusted");
+      } finally {
+        await rm(tempRoot, { force: true, recursive: true });
+      }
+    },
+  );
 
   it.skipIf(process.platform === "win32")(
     "preserves committed status when an identity lock release fails",

--- a/test/recorder-concurrency.test.ts
+++ b/test/recorder-concurrency.test.ts
@@ -23,6 +23,7 @@ const fsMocks = vi.hoisted(() => ({
   lockRelease: vi.fn<() => Promise<void>>(),
   providerDirectory: "",
   providerDeniedDirectory: "",
+  providerDirectoryOpen: vi.fn<(directoryPath: string) => void>(),
   providerDirectorySync: vi.fn<(directoryPath: string) => Promise<void>>(),
   providerLstatFailure: undefined as Error | undefined,
   providerLstatFailureAfterLocks: 0,
@@ -83,6 +84,9 @@ vi.mock("node:fs/promises", async (importOriginal) => {
     },
     open: async (...args: Parameters<typeof actual.open>) => {
       const filePath = String(args[0]);
+      if (args[1] === "r") {
+        fsMocks.providerDirectoryOpen(filePath);
+      }
       if (args[1] === "r" && filePath === fsMocks.providerDeniedDirectory) {
         throw Object.assign(new Error("execute-only ancestor"), { code: "EACCES" });
       }
@@ -191,6 +195,7 @@ beforeEach(() => {
   fsMocks.lock.mockResolvedValue(fsMocks.lockRelease);
   fsMocks.providerDirectory = "";
   fsMocks.providerDeniedDirectory = "";
+  fsMocks.providerDirectoryOpen.mockReset();
   fsMocks.providerDirectorySync.mockReset();
   fsMocks.providerDirectorySync.mockResolvedValue(undefined);
   fsMocks.providerLstatFailure = undefined;
@@ -288,7 +293,23 @@ describe("recorder append serialization", () => {
     ]);
     expect(fsMocks.serverSync).toHaveBeenCalledTimes(2);
     expect(fsMocks.serverDirectorySync).toHaveBeenCalledTimes(2);
-    expect(fsMocks.lock).toHaveBeenCalledTimes(2);
+    expect(fsMocks.lock).toHaveBeenCalledTimes(4);
+    const unixIdentityLockRoot = path.join(
+      await realpath(path.join(userInfo().homedir, ".cache", "crabline", "locks")),
+      "server-recorder",
+    );
+    expect(
+      fsMocks.lock.mock.calls
+        .map(([lockPath]) => String(lockPath))
+        .filter((lockPath) => path.dirname(lockPath) === unixIdentityLockRoot),
+    ).toEqual(
+      process.platform === "win32"
+        ? []
+        : [
+            path.join(unixIdentityLockRoot, "recorder-1-1"),
+            path.join(unixIdentityLockRoot, "recorder-1-1"),
+          ],
+    );
     expect(fsMocks.serverOpen.mock.calls.map(([, flags]) => flags)).toEqual(["ax+", "ax+", "a+"]);
   });
 
@@ -515,6 +536,11 @@ describe("recorder append serialization", () => {
       expect(fsMocks.providerSync).toHaveBeenCalledTimes(2);
       expect(fsMocks.providerDirectorySync).toHaveBeenCalledTimes(
         process.platform === "win32" ? 0 : 2,
+      );
+      expect(fsMocks.providerDirectoryOpen.mock.calls).toEqual(
+        process.platform === "win32"
+          ? []
+          : [[fsMocks.providerDirectory], [fsMocks.providerDirectory]],
       );
       expect(fsMocks.providerOpen.mock.calls.map(([, flags, mode]) => [flags, mode])).toEqual([
         ["ax+", 0o600],

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -6,6 +6,7 @@ import {
   mkdir,
   open,
   readFile,
+  realpath,
   rename,
   rm,
   stat,
@@ -102,6 +103,91 @@ describe("recorder", () => {
       await chmod(filePath, 0o640);
       await appendRecordedInbound(filePath, { ...event, id: "preserve-mode" });
       expect((await stat(filePath)).mode & 0o777).toBe(0o640);
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "accepts trusted private and sticky shared lock-root parents",
+    async () => {
+      const currentUserId = process.geteuid?.();
+      if (currentUserId === undefined) {
+        throw new Error("Expected a current user id on Unix.");
+      }
+      for (const mode of [0o700, 0o1777]) {
+        const directory = await realpath(await createTempDir());
+        directories.push(directory);
+        const parent = path.join(directory, `parent-${mode.toString(8)}`);
+        const lockRoot = path.join(parent, "locks");
+        await mkdir(parent, { mode });
+        await chmod(parent, mode);
+
+        const secured = await secureProviderRecorderLockRoot(lockRoot, currentUserId);
+        expect(secured).toBe(await realpath(lockRoot));
+      }
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "rejects a peer-writable non-sticky lock-root parent",
+    async () => {
+      const currentUserId = process.geteuid?.();
+      if (currentUserId === undefined) {
+        throw new Error("Expected a current user id on Unix.");
+      }
+      const directory = await realpath(await createTempDir());
+      directories.push(directory);
+      const parent = path.join(directory, "untrusted-parent");
+      const lockRoot = path.join(parent, "locks");
+      await mkdir(parent, { mode: 0o777 });
+      await chmod(parent, 0o777);
+
+      await expect(secureProviderRecorderLockRoot(lockRoot, currentUserId)).rejects.toThrow(
+        "Provider recorder lock directory parent namespace is not trusted.",
+      );
+      await expect(stat(lockRoot)).rejects.toMatchObject({ code: "ENOENT" });
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "creates and validates missing private lock-root ancestry",
+    async () => {
+      const currentUserId = process.geteuid?.();
+      if (currentUserId === undefined) {
+        throw new Error("Expected a current user id on Unix.");
+      }
+      const directory = await realpath(await createTempDir());
+      directories.push(directory);
+      const lockRoot = path.join(directory, "missing", "private", "locks");
+
+      const secured = await secureProviderRecorderLockRoot(lockRoot, currentUserId);
+      expect(secured).toBe(await realpath(lockRoot));
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "revalidates trust after the lock-root parent is replaced",
+    async () => {
+      const currentUserId = process.geteuid?.();
+      if (currentUserId === undefined) {
+        throw new Error("Expected a current user id on Unix.");
+      }
+      const directory = await realpath(await createTempDir());
+      directories.push(directory);
+      const namespace = path.join(directory, "replaceable-namespace");
+      const displaced = `${namespace}.displaced`;
+      const parent = path.join(namespace, "private-parent");
+      const lockRoot = path.join(parent, "locks");
+      await mkdir(parent, { mode: 0o700, recursive: true });
+      const secured = await secureProviderRecorderLockRoot(lockRoot, currentUserId);
+      expect(secured).toBe(await realpath(lockRoot));
+
+      await rename(namespace, displaced);
+      await mkdir(lockRoot, { mode: 0o700, recursive: true });
+      await chmod(namespace, 0o777);
+
+      await expect(secureProviderRecorderLockRoot(lockRoot, currentUserId)).rejects.toThrow(
+        "Provider recorder lock directory parent namespace is not trusted.",
+      );
     },
   );
 

--- a/test/run.behavior.test.ts
+++ b/test/run.behavior.test.ts
@@ -794,6 +794,53 @@ describe("run behavior", () => {
     },
   );
 
+  it.each(["auth", "config"] as const)(
+    "does not retry permanent %s inbound failures",
+    async (failureKind) => {
+      const send = vi.fn(async () => ({
+        accepted: true,
+        messageId: "sent",
+        threadId: "thread",
+      }));
+      const waitForInbound = vi.fn(async () => {
+        throw new CrablineError(`permanent ${failureKind} inbound failure`, {
+          kind: failureKind,
+        });
+      });
+      const provider: ProviderAdapter = {
+        id: "mock",
+        platform: "loopback",
+        status: "ready",
+        supports: ["roundtrip"],
+        normalizeTarget(target) {
+          return { id: target.id, metadata: target.metadata };
+        },
+        probe: async () => ({ details: [], healthy: true }),
+        send,
+        waitForInbound,
+      };
+      const retryingManifest = withAllCapabilities({
+        ...manifest,
+        fixtures: [{ ...manifest.fixtures[0]!, retries: 3 }],
+      });
+
+      const result = await runFixtureCommand({
+        fixtureId: "fixture",
+        manifest: retryingManifest,
+        manifestPath: "/tmp/crabline.yaml",
+        registry: buildRegistry(provider),
+      });
+
+      expect(result).toMatchObject({ failureKind, ok: false });
+      expect(result.diagnostics).toEqual([
+        "accepted message sent",
+        `permanent ${failureKind} inbound failure`,
+      ]);
+      expect(send).toHaveBeenCalledOnce();
+      expect(waitForInbound).toHaveBeenCalledOnce();
+    },
+  );
+
   it("retries rejected outbound results and fails when rejection persists", async () => {
     let sendCalls = 0;
     const provider: ProviderAdapter = {

--- a/test/server-recorder-filesystem.test.ts
+++ b/test/server-recorder-filesystem.test.ts
@@ -327,6 +327,116 @@ it.skipIf(process.platform === "win32")("preserves an existing recorder file mod
   expect((await stat(recorderPath)).mode & 0o777).toBe(0o640);
 });
 
+it.skipIf(process.platform === "win32")(
+  "serializes torn-tail repair with a writer through the rotated pathname",
+  async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const recorderPath = path.join(directory, "server.jsonl");
+    const rotatedPath = `${recorderPath}.rotated`;
+    const completed = `${JSON.stringify({
+      at: new Date().toISOString(),
+      method: "POST",
+      path: "/completed",
+      query: {},
+      type: "api",
+    })}\n`;
+    await writeFile(recorderPath, `${completed}{"path":"/torn"`, "utf8");
+
+    const probe = await open(recorderPath, "a+");
+    const prototype = Object.getPrototypeOf(probe) as {
+      appendFile(data: string, options: { encoding: "utf8" }): Promise<void>;
+      truncate(length: number): Promise<void>;
+    };
+    await probe.close();
+    const originalAppendFile = prototype.appendFile;
+    const originalTruncate = prototype.truncate;
+    let releaseRepair!: () => void;
+    let reportRepair!: () => void;
+    const repairReported = new Promise<void>((resolve) => {
+      reportRepair = resolve;
+    });
+    const repairReleased = new Promise<void>((resolve) => {
+      releaseRepair = resolve;
+    });
+    let releaseSecondAppend!: () => void;
+    const secondAppendReleased = new Promise<void>((resolve) => {
+      releaseSecondAppend = resolve;
+    });
+    let secondAppendStarted = false;
+    let pauseRepair = true;
+    prototype.appendFile = async function (this: FileHandle, data, options) {
+      if (data.includes('"path":"/second-through-rotated-path"')) {
+        secondAppendStarted = true;
+        await secondAppendReleased;
+      }
+      await originalAppendFile.call(this, data, options);
+    };
+    prototype.truncate = async function (this: FileHandle, length) {
+      if (pauseRepair) {
+        pauseRepair = false;
+        reportRepair();
+        await repairReleased;
+      }
+      await originalTruncate.call(this, length);
+    };
+
+    const first = recordServerEvent({
+      event: {
+        at: new Date().toISOString(),
+        method: "POST",
+        path: "/first-after-repair",
+        query: {},
+        type: "api",
+      },
+      onEvent: undefined,
+      recorderPath,
+    });
+    try {
+      await repairReported;
+      await rename(recorderPath, rotatedPath);
+      const second = recordServerEvent({
+        event: {
+          at: new Date().toISOString(),
+          method: "POST",
+          path: "/second-through-rotated-path",
+          query: {},
+          type: "api",
+        },
+        onEvent: undefined,
+        recorderPath: rotatedPath,
+      });
+      await expect
+        .poll(async () => {
+          try {
+            await stat(`${rotatedPath}.lock`);
+            return true;
+          } catch {
+            return false;
+          }
+        })
+        .toBe(true);
+      expect(secondAppendStarted).toBe(false);
+
+      releaseRepair();
+      releaseSecondAppend();
+      await Promise.all([first, second]);
+    } finally {
+      releaseRepair();
+      releaseSecondAppend();
+      prototype.appendFile = originalAppendFile;
+      prototype.truncate = originalTruncate;
+    }
+
+    const recordedPaths = (await readFile(rotatedPath, "utf8"))
+      .trimEnd()
+      .split("\n")
+      .map((line) => (JSON.parse(line) as { path: string }).path);
+    expect(recordedPaths).toEqual(["/completed", "/second-through-rotated-path"]);
+    expect(await readFile(recorderPath, "utf8")).toContain('"path":"/first-after-repair"');
+  },
+);
+
 it("never truncates a rotated inode after a later writer appends", async () => {
   const directory = await createTempDir();
   directories.push(directory);

--- a/test/server-recorder.test.ts
+++ b/test/server-recorder.test.ts
@@ -202,15 +202,6 @@ function serverEvent(pathname: string): ServerRequestEvent {
   };
 }
 
-function directoryAncestryCount(directory: string): number {
-  let count = 1;
-  while (path.dirname(directory) !== directory) {
-    count += 1;
-    directory = path.dirname(directory);
-  }
-  return count;
-}
-
 beforeEach(() => {
   readWindowsDirectorySecurityDescriptor.mockClear();
   lockMocks.release.mockReset();
@@ -270,6 +261,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   vi.useRealTimers();
 });
 
@@ -566,12 +558,12 @@ describe("server recorder", () => {
         update: 10_000,
       }),
     );
-    expect(lockMocks.release).toHaveBeenCalledOnce();
+    expect(lockMocks.release).toHaveBeenCalledTimes(2);
     expect(fsMocks.file.chmod.mock.invocationCallOrder[0]).toBeLessThan(
       fsMocks.file.appendFile.mock.invocationCallOrder[0]!,
     );
     expect(fsMocks.file.close).toHaveBeenCalledOnce();
-    expect(fsMocks.directory.close).toHaveBeenCalledTimes(3);
+    expect(fsMocks.directory.close).toHaveBeenCalledTimes(4);
   });
 
   it("resyncs recorder ancestry after an interrupted first-append attempt", async () => {
@@ -629,7 +621,7 @@ describe("server recorder", () => {
 
     expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(2);
     expect(fsMocks.file.sync).toHaveBeenCalledTimes(2);
-    expect(fsMocks.directory.sync).toHaveBeenCalledTimes(3);
+    expect(fsMocks.directory.sync).toHaveBeenCalledTimes(2);
     expect(fsMocks.open).not.toHaveBeenCalledWith(path.parse(recorderPath).root, "r");
     expect(observer).toHaveBeenCalledOnce();
     expect(observer).toHaveBeenCalledWith(retryEvent);
@@ -756,7 +748,7 @@ describe("server recorder", () => {
     });
 
     expect(fsMocks.file.sync).toHaveBeenCalledTimes(2);
-    expect(fsMocks.directory.sync).toHaveBeenCalledTimes(4);
+    expect(fsMocks.directory.sync).toHaveBeenCalledTimes(3);
     expect(observer).toHaveBeenCalledOnce();
     expect(observer).toHaveBeenCalledWith(retryEvent);
   });
@@ -773,9 +765,9 @@ describe("server recorder", () => {
       recorderPath: path.join("/tmp", "crabline-server-recorder-contention.jsonl"),
     });
 
-    expect(lockMocks.lock).toHaveBeenCalledTimes(2);
+    expect(lockMocks.lock).toHaveBeenCalledTimes(3);
     expect(fsMocks.file.appendFile).toHaveBeenCalledOnce();
-    expect(lockMocks.release).toHaveBeenCalledOnce();
+    expect(lockMocks.release).toHaveBeenCalledTimes(2);
   });
 
   it("repairs managed directories without chmodding existing recorder files or parents", async () => {
@@ -923,11 +915,10 @@ describe("server recorder", () => {
       recorderPath,
     });
 
-    expect(
-      fsMocks.open.mock.calls.filter(
-        ([openedPath, flags]) => openedPath === canonicalParent && flags === "r",
-      ),
-    ).toHaveLength(2);
+    expect(fsMocks.open.mock.calls.filter(([, flags]) => flags === "r")).toEqual([
+      [canonicalParent, "r"],
+      [canonicalParent, "r"],
+    ]);
     expect(fsMocks.directory.sync).toHaveBeenCalledTimes(2);
   });
 
@@ -1075,9 +1066,7 @@ describe("server recorder", () => {
     expect(fsMocks.file.appendFile).toHaveBeenCalledOnce();
     expect(fsMocks.file.truncate).not.toHaveBeenCalled();
     expect(fsMocks.file.sync).toHaveBeenCalledOnce();
-    expect(fsMocks.directory.sync).toHaveBeenCalledTimes(
-      directoryAncestryCount(await realpath("/tmp")),
-    );
+    expect(fsMocks.directory.sync).toHaveBeenCalledOnce();
     expect(fsMocks.file.close).toHaveBeenCalledOnce();
   });
 

--- a/test/server-recorder.test.ts
+++ b/test/server-recorder.test.ts
@@ -84,7 +84,7 @@ const fsMocks = vi.hoisted(() => {
       vi.fn<
         (
           filePath: string,
-          options: { mode: number; recursive: true },
+          options: { mode: number; recursive?: true },
         ) => Promise<string | undefined>
       >(),
     open: vi.fn<
@@ -515,7 +515,9 @@ describe("server recorder", () => {
     const canonicalFinalParent = path.join(canonicalFirstParent, "nested");
     const canonicalRecorderPath = path.join(canonicalFinalParent, "events.jsonl");
     const observer = vi.fn<(event: ServerRequestEvent) => void>();
-    fsMocks.mkdir.mockResolvedValueOnce(canonicalFirstParent);
+    fsMocks.mkdir.mockImplementation(async (filePath) => {
+      return filePath === canonicalFinalParent ? canonicalFirstParent : undefined;
+    });
     fsMocks.open.mockImplementation(async (_filePath, flags) =>
       typeof flags === "number" || flags === "r" ? fsMocks.directory : fsMocks.file,
     );
@@ -558,12 +560,19 @@ describe("server recorder", () => {
         update: 10_000,
       }),
     );
+    expect(
+      lockMocks.lock.mock.calls.some(
+        ([lockPath, options]) =>
+          path.basename(lockPath) === "recorder-1-1" &&
+          (options as { realpath?: boolean }).realpath === false,
+      ),
+    ).toBe(true);
     expect(lockMocks.release).toHaveBeenCalledTimes(2);
     expect(fsMocks.file.chmod.mock.invocationCallOrder[0]).toBeLessThan(
       fsMocks.file.appendFile.mock.invocationCallOrder[0]!,
     );
     expect(fsMocks.file.close).toHaveBeenCalledOnce();
-    expect(fsMocks.directory.close).toHaveBeenCalledTimes(4);
+    expect(fsMocks.directory.close.mock.calls.length).toBeGreaterThanOrEqual(3);
   });
 
   it("resyncs recorder ancestry after an interrupted first-append attempt", async () => {
@@ -777,7 +786,10 @@ describe("server recorder", () => {
       onEvent: undefined,
       recorderPath: callerOwnedPath,
     });
-    expect(fsMocks.chmod).not.toHaveBeenCalled();
+    expect(fsMocks.chmod).not.toHaveBeenCalledWith(
+      path.dirname(callerOwnedPath),
+      expect.any(Number),
+    );
     expect(fsMocks.file.chmod).not.toHaveBeenCalled();
 
     const managedPath = path.resolve(".crabline", "servers", "events.jsonl");


### PR DESCRIPTION
## What Problem This Solves

Closes the remaining audit gaps around recorder repair coordination, permanent inbound failure handling, channel setup drift, and admin-auth regression coverage.

## Why This Change Was Made

- Coordinate recorder repair by stable file identity and stop existing-file durability syncs at the immediate parent.
- Reject unsafe Unix lock-root namespaces before path-based coordination.
- Stop retrying accepted outbound work after permanent inbound authentication or configuration failures.
- Keep the channel setup guide, support catalog, schema, and example manifest under one tested contract.
- Cover every supported admin authentication transport, precedence rule, and rejection response.

## User Impact

Recorder repair no longer risks cross-path corruption, permanent inbound failures do not trigger resend loops, and documented channel/admin setup remains executable as the catalog evolves.

## Evidence

- Focused recorder, runtime, documentation, and HTTP authentication suites passed on their source commits.
- `gpt-5.6-sol` high autoreview passed on each source commit.
- Exact-head grouped `gpt-5.6-sol` high autoreview passed with no actionable findings.
- Linux Crabbox `pnpm verify` passed in `run_b250cf7aa19b`: 64 files, 1,540 passed, 15 skipped; lease `cbx_23fbf973d841` was released.
- GitHub CI passed at exact head; CodeQL was skipped by workflow policy.
