### PR TITLE
fix(windows): harden runtime filesystem handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Escape visually unsafe Unicode controls in JSON reports, return a stable error document for unserializable values, and preserve Node write encoding semantics in test captures.
 - Ignore typeless Slack callbacks and redact URL fragments from Zalo recorder evidence.
 - Redact Feishu verification tokens from recorder payloads and release replay reservations after recorder failures.
+- Reject Windows ACL reparse and identity substitution, bound PowerShell ACL execution, and allow harmless inherit-only mutation ACEs.
 - Bind agent acknowledgements to the expected nonce instead of accepting an unrelated ACK.
 - Skip aborted Windows script helper bootstrap and retry Job Object isolation after transient bootstrap failures.
 - Bound manifest file loading, honor probe retries, and reject empty resolved Zalo webhook secrets.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Reject non-positive Telegram admin message IDs and enforce native Mattermost channel types and unique normalized usernames.
 - Preserve local-mock webhook acceptance when clients disconnect or post-commit settlement hooks fail.
 - Scope iMessage direct waits and Matrix and Mattermost thread correlation to their native conversations.
+- Open Windows recorder files with truncation-capable handles while preserving serialized append behavior.
 - Coordinate recorder repair by file identity, limit existing-file durability syncs to the immediate parent, and reject provider lock roots beneath unsafe Unix namespaces.
 - Stop retrying and resending accepted outbound messages after permanent inbound authentication or configuration failures.
 - Escape visually unsafe Unicode controls in JSON reports, return a stable error document for unserializable values, and preserve Node write encoding semantics in test captures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Ignore typeless Slack callbacks and redact URL fragments from Zalo recorder evidence.
 - Redact Feishu verification tokens from recorder payloads and release replay reservations after recorder failures.
 - Bind agent acknowledgements to the expected nonce instead of accepting an unrelated ACK.
+- Skip aborted Windows script helper bootstrap and retry Job Object isolation after transient bootstrap failures.
 - Bound manifest file loading, honor probe retries, and reject empty resolved Zalo webhook secrets.
 - Require exact provider readiness recorder routes, explicit v2 artifact pointers, and normalized missing-generation corruption errors.
 - Track actionlint updates, container image pins, and pull-request governance in the repository security checks.

--- a/src/openclaw/private-file.ts
+++ b/src/openclaw/private-file.ts
@@ -7,6 +7,7 @@ import { performance } from "node:perf_hooks";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
+const WINDOWS_ACL_COMMAND_TIMEOUT_MS = 15_000;
 
 const WINDOWS_CREATE_OWNER_ONLY_FILE_SCRIPT = String.raw`
 $ErrorActionPreference = "Stop"
@@ -564,6 +565,7 @@ $mutationRights = (
   [System.Security.AccessControl.FileSystemRights]::TakeOwnership
 )
 $genericMutationRights = [uint32]0x50000000
+$inheritOnly = [System.Security.AccessControl.PropagationFlags]::InheritOnly
 $mutationAccessMask = [BitConverter]::ToUInt32(
   [BitConverter]::GetBytes([int32]$mutationRights),
   0
@@ -584,7 +586,9 @@ foreach ($rule in $rules) {
     [BitConverter]::GetBytes([int32]$rule.FileSystemRights),
     0
   )
+  $appliesToDirectory = ($rule.PropagationFlags -band $inheritOnly) -eq 0
   if (
+    $appliesToDirectory -and
     $rule.AccessControlType -eq [System.Security.AccessControl.AccessControlType]::Allow -and
     $trustedSids -notcontains $rule.IdentityReference.Value -and
     ($ruleAccessMask -band ($mutationAccessMask -bor $genericMutationRights)) -ne 0
@@ -599,6 +603,8 @@ export type WindowsAclRunner = (
   args: string[],
   options: {
     env: NodeJS.ProcessEnv;
+    killSignal: NodeJS.Signals;
+    timeout: number;
     windowsHide: boolean;
   },
 ) => Promise<string>;
@@ -637,6 +643,8 @@ export async function createOwnerOnlyWindowsFile(
           ...process.env,
           CRABLINE_PRIVATE_FILE_PATH: path.resolve(filePath),
         },
+        killSignal: "SIGKILL",
+        timeout: WINDOWS_ACL_COMMAND_TIMEOUT_MS,
         windowsHide: true,
       },
     );
@@ -681,6 +689,8 @@ export async function applyOwnerOnlyWindowsDirectoryAcl(
           ...process.env,
           CRABLINE_PRIVATE_DIRECTORY_PATH: path.resolve(directoryPath),
         },
+        killSignal: "SIGKILL",
+        timeout: WINDOWS_ACL_COMMAND_TIMEOUT_MS,
         windowsHide: true,
       },
     );
@@ -713,6 +723,8 @@ export async function createOwnerOnlyWindowsDirectoryAncestry(
           ...process.env,
           CRABLINE_PRIVATE_DIRECTORY_PATH: path.resolve(directoryPath),
         },
+        killSignal: "SIGKILL",
+        timeout: WINDOWS_ACL_COMMAND_TIMEOUT_MS,
         windowsHide: true,
       },
     );
@@ -747,6 +759,8 @@ export async function verifyOwnerOnlyWindowsDirectoryAcl(
           ...process.env,
           CRABLINE_PRIVATE_DIRECTORY_PATH: path.resolve(directoryPath),
         },
+        killSignal: "SIGKILL",
+        timeout: WINDOWS_ACL_COMMAND_TIMEOUT_MS,
         windowsHide: true,
       },
     );
@@ -778,6 +792,8 @@ export async function verifyOwnerOnlyWindowsFileAcl(
           ...process.env,
           CRABLINE_PRIVATE_FILE_PATH: path.resolve(filePath),
         },
+        killSignal: "SIGKILL",
+        timeout: WINDOWS_ACL_COMMAND_TIMEOUT_MS,
         windowsHide: true,
       },
     );
@@ -809,6 +825,8 @@ export async function verifySafeWindowsDirectoryEntryParent(
           ...process.env,
           CRABLINE_PRIVATE_DIRECTORY_PATH: path.resolve(directoryPath),
         },
+        killSignal: "SIGKILL",
+        timeout: WINDOWS_ACL_COMMAND_TIMEOUT_MS,
         windowsHide: true,
       },
     );
@@ -840,6 +858,8 @@ export async function verifySafeWindowsDirectoryMutationBoundary(
           ...process.env,
           CRABLINE_PRIVATE_DIRECTORY_PATH: path.resolve(directoryPath),
         },
+        killSignal: "SIGKILL",
+        timeout: WINDOWS_ACL_COMMAND_TIMEOUT_MS,
         windowsHide: true,
       },
     );

--- a/src/platform/windows-acl.ts
+++ b/src/platform/windows-acl.ts
@@ -31,7 +31,9 @@ public static class CrablineWindowsDirectoryHandle
     private const uint FileOpenReparsePoint = 0x00200000;
     private const uint ObjectCaseInsensitive = 0x00000040;
     private const uint FileAttributeNormal = 0x00000080;
+    private const uint DirectoryAttribute = 0x00000010;
     private const uint ReparsePointAttribute = 0x00000400;
+    private const int FileIdInfoClass = 18;
     private const uint OwnerSecurityInformation = 0x00000001;
     private const uint DaclSecurityInformation = 0x00000004;
     private const uint ProtectedDaclSecurityInformation = 0x80000000;
@@ -57,6 +59,20 @@ public static class CrablineWindowsDirectoryHandle
         public uint NumberOfLinks;
         public uint FileIndexHigh;
         public uint FileIndexLow;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct FileId128
+    {
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)]
+        public byte[] Identifier;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct FileIdInfo
+    {
+        public ulong VolumeSerialNumber;
+        public FileId128 FileId;
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -123,6 +139,15 @@ public static class CrablineWindowsDirectoryHandle
     private static extern bool GetFileInformationByHandle(
         SafeFileHandle file,
         out ByHandleFileInformation information
+    );
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetFileInformationByHandleEx(
+        SafeFileHandle file,
+        int informationClass,
+        out FileIdInfo information,
+        uint bufferSize
     );
 
     [DllImport("advapi32.dll")]
@@ -303,19 +328,40 @@ public static class CrablineWindowsDirectoryHandle
                 "Private directory must not be a reparse point."
             );
         }
-        ulong fileIndex =
-            ((ulong)information.FileIndexHigh << 32) |
-            information.FileIndexLow;
-        if (fileIndex == 0) {
+        if ((information.FileAttributes & DirectoryAttribute) == 0) {
+            throw new InvalidOperationException(
+                "Private directory handle does not reference a directory."
+            );
+        }
+        FileIdInfo identity;
+        uint identitySize = (uint)Marshal.SizeOf(typeof(FileIdInfo));
+        if (!GetFileInformationByHandleEx(
+            file,
+            FileIdInfoClass,
+            out identity,
+            identitySize
+        )) {
+            throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+        byte[] identifier = identity.FileId.Identifier;
+        bool hasIdentity = identifier != null && identifier.Length == 16;
+        if (hasIdentity) {
+            hasIdentity = false;
+            foreach (byte value in identifier) {
+                if (value != 0) {
+                    hasIdentity = true;
+                    break;
+                }
+            }
+        }
+        if (!hasIdentity) {
             throw new InvalidOperationException(
                 "Windows did not return a stable directory identity."
             );
         }
-        return information.VolumeSerialNumber.ToString(
+        return identity.VolumeSerialNumber.ToString(
             System.Globalization.CultureInfo.InvariantCulture
-        ) + ":" + fileIndex.ToString(
-            System.Globalization.CultureInfo.InvariantCulture
-        );
+        ) + ":" + BitConverter.ToString(identifier).Replace("-", String.Empty);
     }
 
     public static byte[] ReadSecurityDescriptor(SafeFileHandle file)

--- a/src/platform/windows-acl.ts
+++ b/src/platform/windows-acl.ts
@@ -4,12 +4,446 @@ import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 
+const WINDOWS_ACL_COMMAND_TIMEOUT_MS = 15_000;
+const WINDOWS_DIRECTORY_HANDLE_HELPER = String.raw`
+Add-Type -TypeDefinition @"
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+public static class CrablineWindowsDirectoryHandle
+{
+    private const uint FileReadAttributes = 0x00000080;
+    private const uint ReadControl = 0x00020000;
+    private const uint WriteDac = 0x00040000;
+    private const uint WriteOwner = 0x00080000;
+    private const uint ShareRead = 0x00000001;
+    private const uint ShareWrite = 0x00000002;
+    private const uint Synchronize = 0x00100000;
+    private const uint OpenExisting = 3;
+    private const uint FileFlagBackupSemantics = 0x02000000;
+    private const uint FileFlagOpenReparsePoint = 0x00200000;
+    private const uint FileCreate = 2;
+    private const uint FileDirectoryFile = 0x00000001;
+    private const uint FileSynchronousIoNonAlert = 0x00000020;
+    private const uint FileOpenReparsePoint = 0x00200000;
+    private const uint ObjectCaseInsensitive = 0x00000040;
+    private const uint FileAttributeNormal = 0x00000080;
+    private const uint ReparsePointAttribute = 0x00000400;
+    private const uint OwnerSecurityInformation = 0x00000001;
+    private const uint DaclSecurityInformation = 0x00000004;
+    private const uint ProtectedDaclSecurityInformation = 0x80000000;
+    private const int SeFileObject = 1;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct FileTime
+    {
+        public uint Low;
+        public uint High;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct ByHandleFileInformation
+    {
+        public uint FileAttributes;
+        public FileTime CreationTime;
+        public FileTime LastAccessTime;
+        public FileTime LastWriteTime;
+        public uint VolumeSerialNumber;
+        public uint FileSizeHigh;
+        public uint FileSizeLow;
+        public uint NumberOfLinks;
+        public uint FileIndexHigh;
+        public uint FileIndexLow;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct IoStatusBlock
+    {
+        public IntPtr Status;
+        public UIntPtr Information;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct UnicodeString
+    {
+        public ushort Length;
+        public ushort MaximumLength;
+        public IntPtr Buffer;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct ObjectAttributes
+    {
+        public int Length;
+        public IntPtr RootDirectory;
+        public IntPtr ObjectName;
+        public uint Attributes;
+        public IntPtr SecurityDescriptor;
+        public IntPtr SecurityQualityOfService;
+    }
+
+    [DllImport(
+        "kernel32.dll",
+        CharSet = CharSet.Unicode,
+        SetLastError = true
+    )]
+    private static extern SafeFileHandle CreateFile(
+        string fileName,
+        uint desiredAccess,
+        uint shareMode,
+        IntPtr securityAttributes,
+        uint creationDisposition,
+        uint flagsAndAttributes,
+        IntPtr templateFile
+    );
+
+    [DllImport("ntdll.dll")]
+    private static extern int NtCreateFile(
+        out SafeFileHandle file,
+        uint desiredAccess,
+        ref ObjectAttributes objectAttributes,
+        out IoStatusBlock ioStatus,
+        IntPtr allocationSize,
+        uint fileAttributes,
+        uint shareAccess,
+        uint createDisposition,
+        uint createOptions,
+        IntPtr eaBuffer,
+        uint eaLength
+    );
+
+    [DllImport("ntdll.dll")]
+    private static extern uint RtlNtStatusToDosError(int status);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetFileInformationByHandle(
+        SafeFileHandle file,
+        out ByHandleFileInformation information
+    );
+
+    [DllImport("advapi32.dll")]
+    private static extern uint GetSecurityInfo(
+        SafeFileHandle file,
+        int objectType,
+        uint securityInformation,
+        out IntPtr owner,
+        out IntPtr group,
+        out IntPtr dacl,
+        out IntPtr sacl,
+        out IntPtr securityDescriptor
+    );
+
+    [DllImport("advapi32.dll")]
+    private static extern uint SetSecurityInfo(
+        SafeFileHandle file,
+        int objectType,
+        uint securityInformation,
+        IntPtr owner,
+        IntPtr group,
+        IntPtr dacl,
+        IntPtr sacl
+    );
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetSecurityDescriptorOwner(
+        IntPtr securityDescriptor,
+        out IntPtr owner,
+        [MarshalAs(UnmanagedType.Bool)] out bool ownerDefaulted
+    );
+
+    [DllImport("advapi32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetSecurityDescriptorDacl(
+        IntPtr securityDescriptor,
+        [MarshalAs(UnmanagedType.Bool)] out bool daclPresent,
+        out IntPtr dacl,
+        [MarshalAs(UnmanagedType.Bool)] out bool daclDefaulted
+    );
+
+    [DllImport("advapi32.dll")]
+    private static extern uint GetSecurityDescriptorLength(
+        IntPtr securityDescriptor
+    );
+
+    [DllImport("kernel32.dll")]
+    private static extern IntPtr LocalFree(
+        IntPtr memory
+    );
+
+    public static SafeFileHandle Open(string path, bool writable)
+    {
+        uint access = FileReadAttributes | ReadControl;
+        if (writable) {
+            access |= WriteDac | WriteOwner;
+        }
+        SafeFileHandle file = CreateFile(
+            path,
+            access,
+            ShareRead | ShareWrite,
+            IntPtr.Zero,
+            OpenExisting,
+            FileFlagBackupSemantics | FileFlagOpenReparsePoint,
+            IntPtr.Zero
+        );
+        if (file.IsInvalid) {
+            throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+        try {
+            ReadIdentity(file);
+            return file;
+        } catch {
+            file.Dispose();
+            throw;
+        }
+    }
+
+    public static SafeFileHandle Create(string path, byte[] securityDescriptor)
+    {
+        string fullPath = Path.GetFullPath(path);
+        string nativePath;
+        if (fullPath.StartsWith(@"\\?\", StringComparison.Ordinal)) {
+            nativePath = @"\??\" + fullPath.Substring(4);
+        } else if (fullPath.StartsWith(@"\\", StringComparison.Ordinal)) {
+            nativePath = @"\??\UNC\" + fullPath.Substring(2);
+        } else {
+            nativePath = @"\??\" + fullPath;
+        }
+        int pathBytes = nativePath.Length * 2;
+        if (pathBytes > UInt16.MaxValue - 2) {
+            throw new PathTooLongException();
+        }
+
+        GCHandle descriptorHandle = GCHandle.Alloc(
+            securityDescriptor,
+            GCHandleType.Pinned
+        );
+        IntPtr pathBuffer = IntPtr.Zero;
+        IntPtr objectNameBuffer = IntPtr.Zero;
+        try {
+            pathBuffer = Marshal.StringToHGlobalUni(nativePath);
+            UnicodeString objectName = new UnicodeString {
+                Length = (ushort)pathBytes,
+                MaximumLength = (ushort)(pathBytes + 2),
+                Buffer = pathBuffer
+            };
+            objectNameBuffer = Marshal.AllocHGlobal(
+                Marshal.SizeOf(typeof(UnicodeString))
+            );
+            Marshal.StructureToPtr(objectName, objectNameBuffer, false);
+            ObjectAttributes attributes = new ObjectAttributes {
+                Length = Marshal.SizeOf(typeof(ObjectAttributes)),
+                RootDirectory = IntPtr.Zero,
+                ObjectName = objectNameBuffer,
+                Attributes = ObjectCaseInsensitive,
+                SecurityDescriptor = descriptorHandle.AddrOfPinnedObject(),
+                SecurityQualityOfService = IntPtr.Zero
+            };
+            IoStatusBlock ioStatus;
+            SafeFileHandle file;
+            int status = NtCreateFile(
+                out file,
+                FileReadAttributes |
+                    ReadControl |
+                    WriteDac |
+                    WriteOwner |
+                    Synchronize,
+                ref attributes,
+                out ioStatus,
+                IntPtr.Zero,
+                FileAttributeNormal,
+                ShareRead | ShareWrite,
+                FileCreate,
+                FileDirectoryFile |
+                    FileSynchronousIoNonAlert |
+                    FileOpenReparsePoint,
+                IntPtr.Zero,
+                0
+            );
+            if (status < 0) {
+                throw new Win32Exception(
+                    unchecked((int)RtlNtStatusToDosError(status))
+                );
+            }
+            if (file == null || file.IsInvalid) {
+                throw new InvalidOperationException(
+                    "Windows did not return the created directory handle."
+                );
+            }
+            try {
+                ReadIdentity(file);
+                return file;
+            } catch {
+                file.Dispose();
+                throw;
+            }
+        } finally {
+            if (objectNameBuffer != IntPtr.Zero) {
+                Marshal.FreeHGlobal(objectNameBuffer);
+            }
+            if (pathBuffer != IntPtr.Zero) {
+                Marshal.FreeHGlobal(pathBuffer);
+            }
+            descriptorHandle.Free();
+        }
+    }
+
+    public static string ReadIdentity(SafeFileHandle file)
+    {
+        ByHandleFileInformation information;
+        if (!GetFileInformationByHandle(file, out information)) {
+            throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+        if ((information.FileAttributes & ReparsePointAttribute) != 0) {
+            throw new InvalidOperationException(
+                "Private directory must not be a reparse point."
+            );
+        }
+        ulong fileIndex =
+            ((ulong)information.FileIndexHigh << 32) |
+            information.FileIndexLow;
+        if (fileIndex == 0) {
+            throw new InvalidOperationException(
+                "Windows did not return a stable directory identity."
+            );
+        }
+        return information.VolumeSerialNumber.ToString(
+            System.Globalization.CultureInfo.InvariantCulture
+        ) + ":" + fileIndex.ToString(
+            System.Globalization.CultureInfo.InvariantCulture
+        );
+    }
+
+    public static byte[] ReadSecurityDescriptor(SafeFileHandle file)
+    {
+        IntPtr owner;
+        IntPtr group;
+        IntPtr dacl;
+        IntPtr sacl;
+        IntPtr securityDescriptor;
+        uint error = GetSecurityInfo(
+            file,
+            SeFileObject,
+            OwnerSecurityInformation | DaclSecurityInformation,
+            out owner,
+            out group,
+            out dacl,
+            out sacl,
+            out securityDescriptor
+        );
+        if (error != 0) {
+            throw new Win32Exception((int)error);
+        }
+        try {
+            uint length = GetSecurityDescriptorLength(securityDescriptor);
+            if (length == 0 || length > Int32.MaxValue) {
+                throw new InvalidOperationException(
+                    "Windows returned an invalid directory security descriptor."
+                );
+            }
+            byte[] descriptor = new byte[(int)length];
+            Marshal.Copy(securityDescriptor, descriptor, 0, descriptor.Length);
+            return descriptor;
+        } finally {
+            LocalFree(securityDescriptor);
+        }
+    }
+
+    public static void WriteSecurityDescriptor(
+        SafeFileHandle file,
+        byte[] securityDescriptor
+    )
+    {
+        GCHandle descriptorHandle = GCHandle.Alloc(
+            securityDescriptor,
+            GCHandleType.Pinned
+        );
+        try {
+            IntPtr descriptor = descriptorHandle.AddrOfPinnedObject();
+            IntPtr owner;
+            bool ownerDefaulted;
+            if (!GetSecurityDescriptorOwner(
+                descriptor,
+                out owner,
+                out ownerDefaulted
+            )) {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+            bool daclPresent;
+            IntPtr dacl;
+            bool daclDefaulted;
+            if (!GetSecurityDescriptorDacl(
+                descriptor,
+                out daclPresent,
+                out dacl,
+                out daclDefaulted
+            )) {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+            if (!daclPresent) {
+                throw new InvalidOperationException(
+                    "Private directory security descriptor has no DACL."
+                );
+            }
+            uint error = SetSecurityInfo(
+                file,
+                SeFileObject,
+                OwnerSecurityInformation |
+                    DaclSecurityInformation |
+                    ProtectedDaclSecurityInformation,
+                owner,
+                IntPtr.Zero,
+                dacl,
+                IntPtr.Zero
+            );
+            if (error != 0) {
+                throw new Win32Exception((int)error);
+            }
+        } finally {
+            descriptorHandle.Free();
+        }
+    }
+
+    public static void AssertSamePathIdentity(string path, string expected)
+    {
+        using (SafeFileHandle current = Open(path, false)) {
+            if (!String.Equals(
+                ReadIdentity(current),
+                expected,
+                StringComparison.Ordinal
+            )) {
+                throw new InvalidOperationException(
+                    "Private directory identity changed during ACL mutation."
+                );
+            }
+        }
+    }
+}
+"@
+`;
+
 const WINDOWS_OWNER_ONLY_DIRECTORY_ACL_SCRIPT = String.raw`
 $ErrorActionPreference = "Stop"
 $directoryPath = $env:CRABLINE_PRIVATE_DIRECTORY_PATH
 if ([string]::IsNullOrWhiteSpace($directoryPath)) {
   throw "CRABLINE_PRIVATE_DIRECTORY_PATH is required."
 }
+$directoryPath = [System.IO.Path]::GetFullPath($directoryPath)
+$rootPath = [System.IO.Path]::GetPathRoot($directoryPath)
+if ($directoryPath.Length -gt $rootPath.Length) {
+  $directoryPath = $directoryPath.TrimEnd(
+    [char[]]@(
+      [System.IO.Path]::DirectorySeparatorChar,
+      [System.IO.Path]::AltDirectorySeparatorChar
+    )
+  )
+}
+
+${WINDOWS_DIRECTORY_HANDLE_HELPER}
 
 $identity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
 $sid = $identity.User
@@ -17,60 +451,79 @@ if ($null -eq $sid) {
   throw "Could not resolve the current Windows user SID."
 }
 
-$acl = Get-Acl -LiteralPath $directoryPath
-$acl.SetOwner($sid)
-$acl.SetAccessRuleProtection($true, $false)
-$existingRules = @($acl.GetAccessRules(
-  $true,
-  $false,
-  [System.Security.Principal.SecurityIdentifier]
-))
-foreach ($existingRule in $existingRules) {
-  [void]$acl.RemoveAccessRuleSpecific($existingRule)
-}
-$inheritance = (
-  [System.Security.AccessControl.InheritanceFlags]::ContainerInherit -bor
-  [System.Security.AccessControl.InheritanceFlags]::ObjectInherit
-)
-$rule = [System.Security.AccessControl.FileSystemAccessRule]::new(
-  $sid,
-  [System.Security.AccessControl.FileSystemRights]::FullControl,
-  $inheritance,
-  [System.Security.AccessControl.PropagationFlags]::None,
-  [System.Security.AccessControl.AccessControlType]::Allow
-)
-$acl.SetAccessRule($rule)
-Set-Acl -LiteralPath $directoryPath -AclObject $acl
+$directory = [CrablineWindowsDirectoryHandle]::Open($directoryPath, $true)
+try {
+  $directoryIdentity = [CrablineWindowsDirectoryHandle]::ReadIdentity($directory)
+  $acl = [System.Security.AccessControl.DirectorySecurity]::new()
+  $acl.SetSecurityDescriptorBinaryForm(
+    [CrablineWindowsDirectoryHandle]::ReadSecurityDescriptor($directory)
+  )
+  $acl.SetOwner($sid)
+  $acl.SetAccessRuleProtection($true, $false)
+  $existingRules = @($acl.GetAccessRules(
+    $true,
+    $false,
+    [System.Security.Principal.SecurityIdentifier]
+  ))
+  foreach ($existingRule in $existingRules) {
+    [void]$acl.RemoveAccessRuleSpecific($existingRule)
+  }
+  $inheritance = (
+    [System.Security.AccessControl.InheritanceFlags]::ContainerInherit -bor
+    [System.Security.AccessControl.InheritanceFlags]::ObjectInherit
+  )
+  $rule = [System.Security.AccessControl.FileSystemAccessRule]::new(
+    $sid,
+    [System.Security.AccessControl.FileSystemRights]::FullControl,
+    $inheritance,
+    [System.Security.AccessControl.PropagationFlags]::None,
+    [System.Security.AccessControl.AccessControlType]::Allow
+  )
+  $acl.SetAccessRule($rule)
+  [CrablineWindowsDirectoryHandle]::WriteSecurityDescriptor(
+    $directory,
+    $acl.GetSecurityDescriptorBinaryForm()
+  )
 
-$actual = Get-Acl -LiteralPath $directoryPath
-$ownerSid = $actual.GetOwner([System.Security.Principal.SecurityIdentifier])
-$rules = @($actual.GetAccessRules(
-  $true,
-  $true,
-  [System.Security.Principal.SecurityIdentifier]
-))
-if (-not $actual.AreAccessRulesProtected) {
-  throw "Private directory DACL still inherits permissions."
-}
-if ($ownerSid.Value -ne $sid.Value) {
-  throw "Private directory owner SID does not match the current user."
-}
-if ($rules.Count -ne 1) {
-  throw "Private directory DACL must contain exactly one access rule."
-}
-$actualRule = $rules[0]
-$requiredInheritance = (
-  [System.Security.AccessControl.InheritanceFlags]::ContainerInherit -bor
-  [System.Security.AccessControl.InheritanceFlags]::ObjectInherit
-)
-if (
-  $actualRule.IsInherited -or
-  $actualRule.IdentityReference.Value -ne $sid.Value -or
-  $actualRule.AccessControlType -ne [System.Security.AccessControl.AccessControlType]::Allow -or
-  (($actualRule.FileSystemRights -band [System.Security.AccessControl.FileSystemRights]::FullControl) -ne [System.Security.AccessControl.FileSystemRights]::FullControl) -or
-  (($actualRule.InheritanceFlags -band $requiredInheritance) -ne $requiredInheritance)
-) {
-  throw "Private directory DACL is not owner-only inheritable full control."
+  $actual = [System.Security.AccessControl.DirectorySecurity]::new()
+  $actual.SetSecurityDescriptorBinaryForm(
+    [CrablineWindowsDirectoryHandle]::ReadSecurityDescriptor($directory)
+  )
+  $ownerSid = $actual.GetOwner([System.Security.Principal.SecurityIdentifier])
+  $rules = @($actual.GetAccessRules(
+    $true,
+    $true,
+    [System.Security.Principal.SecurityIdentifier]
+  ))
+  if (-not $actual.AreAccessRulesProtected) {
+    throw "Private directory DACL still inherits permissions."
+  }
+  if ($ownerSid.Value -ne $sid.Value) {
+    throw "Private directory owner SID does not match the current user."
+  }
+  if ($rules.Count -ne 1) {
+    throw "Private directory DACL must contain exactly one access rule."
+  }
+  $actualRule = $rules[0]
+  $requiredInheritance = (
+    [System.Security.AccessControl.InheritanceFlags]::ContainerInherit -bor
+    [System.Security.AccessControl.InheritanceFlags]::ObjectInherit
+  )
+  if (
+    $actualRule.IsInherited -or
+    $actualRule.IdentityReference.Value -ne $sid.Value -or
+    $actualRule.AccessControlType -ne [System.Security.AccessControl.AccessControlType]::Allow -or
+    (($actualRule.FileSystemRights -band [System.Security.AccessControl.FileSystemRights]::FullControl) -ne [System.Security.AccessControl.FileSystemRights]::FullControl) -or
+    (($actualRule.InheritanceFlags -band $requiredInheritance) -ne $requiredInheritance)
+  ) {
+    throw "Private directory DACL is not owner-only inheritable full control."
+  }
+  [CrablineWindowsDirectoryHandle]::AssertSamePathIdentity(
+    $directoryPath,
+    $directoryIdentity
+  )
+} finally {
+  $directory.Dispose()
 }
 `;
 
@@ -80,6 +533,18 @@ $directoryPath = $env:CRABLINE_PRIVATE_DIRECTORY_PATH
 if ([string]::IsNullOrWhiteSpace($directoryPath)) {
   throw "CRABLINE_PRIVATE_DIRECTORY_PATH is required."
 }
+$directoryPath = [System.IO.Path]::GetFullPath($directoryPath)
+$rootPath = [System.IO.Path]::GetPathRoot($directoryPath)
+if ($directoryPath.Length -gt $rootPath.Length) {
+  $directoryPath = $directoryPath.TrimEnd(
+    [char[]]@(
+      [System.IO.Path]::DirectorySeparatorChar,
+      [System.IO.Path]::AltDirectorySeparatorChar
+    )
+  )
+}
+
+${WINDOWS_DIRECTORY_HANDLE_HELPER}
 
 $identity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
 $sid = $identity.User
@@ -103,14 +568,12 @@ $rule = [System.Security.AccessControl.FileSystemAccessRule]::new(
 )
 $acl.SetAccessRule($rule)
 
-# Apply the final security descriptor atomically for new directories, while
-# migrating roots created by older Crabline versions before validation.
 if ([System.IO.Directory]::Exists($directoryPath)) {
-  $directory = [System.IO.DirectoryInfo]::new($directoryPath)
-  if (($directory.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -ne 0) {
-    throw "Private directory must not be a reparse point."
-  }
-  $acl = $directory.GetAccessControl()
+  $directory = [CrablineWindowsDirectoryHandle]::Open($directoryPath, $true)
+  $acl = [System.Security.AccessControl.DirectorySecurity]::new()
+  $acl.SetSecurityDescriptorBinaryForm(
+    [CrablineWindowsDirectoryHandle]::ReadSecurityDescriptor($directory)
+  )
   $acl.SetOwner($sid)
   $acl.SetAccessRuleProtection($true, $false)
   $existingRules = @($acl.GetAccessRules(
@@ -122,35 +585,60 @@ if ([System.IO.Directory]::Exists($directoryPath)) {
     [void]$acl.RemoveAccessRuleSpecific($existingRule)
   }
   $acl.SetAccessRule($rule)
-  $directory.SetAccessControl($acl)
+  [CrablineWindowsDirectoryHandle]::WriteSecurityDescriptor(
+    $directory,
+    $acl.GetSecurityDescriptorBinaryForm()
+  )
 } else {
-  $directory = [System.IO.Directory]::CreateDirectory($directoryPath, $acl)
+  $parent = [System.IO.Directory]::GetParent(
+    $directoryPath
+  )
+  if ($null -eq $parent) {
+    throw "Private directory must have a parent."
+  }
+  [void][System.IO.Directory]::CreateDirectory($parent.FullName)
+  $directory = [CrablineWindowsDirectoryHandle]::Create(
+    $directoryPath,
+    $acl.GetSecurityDescriptorBinaryForm()
+  )
 }
-$actual = $directory.GetAccessControl()
-$ownerSid = $actual.GetOwner([System.Security.Principal.SecurityIdentifier])
-$rules = @($actual.GetAccessRules(
-  $true,
-  $true,
-  [System.Security.Principal.SecurityIdentifier]
-))
-if (-not $actual.AreAccessRulesProtected) {
-  throw "Private directory DACL still inherits permissions."
-}
-if ($ownerSid.Value -ne $sid.Value) {
-  throw "Private directory owner SID does not match the current user."
-}
-if ($rules.Count -ne 1) {
-  throw "Private directory DACL must contain exactly one access rule."
-}
-$actualRule = $rules[0]
-if (
-  $actualRule.IsInherited -or
-  $actualRule.IdentityReference.Value -ne $sid.Value -or
-  $actualRule.AccessControlType -ne [System.Security.AccessControl.AccessControlType]::Allow -or
-  (($actualRule.FileSystemRights -band [System.Security.AccessControl.FileSystemRights]::FullControl) -ne [System.Security.AccessControl.FileSystemRights]::FullControl) -or
-  (($actualRule.InheritanceFlags -band $inheritance) -ne $inheritance)
-) {
-  throw "Private directory DACL is not owner-only inheritable full control."
+try {
+  $directoryIdentity = [CrablineWindowsDirectoryHandle]::ReadIdentity($directory)
+  $actual = [System.Security.AccessControl.DirectorySecurity]::new()
+  $actual.SetSecurityDescriptorBinaryForm(
+    [CrablineWindowsDirectoryHandle]::ReadSecurityDescriptor($directory)
+  )
+  $ownerSid = $actual.GetOwner([System.Security.Principal.SecurityIdentifier])
+  $rules = @($actual.GetAccessRules(
+    $true,
+    $true,
+    [System.Security.Principal.SecurityIdentifier]
+  ))
+  if (-not $actual.AreAccessRulesProtected) {
+    throw "Private directory DACL still inherits permissions."
+  }
+  if ($ownerSid.Value -ne $sid.Value) {
+    throw "Private directory owner SID does not match the current user."
+  }
+  if ($rules.Count -ne 1) {
+    throw "Private directory DACL must contain exactly one access rule."
+  }
+  $actualRule = $rules[0]
+  if (
+    $actualRule.IsInherited -or
+    $actualRule.IdentityReference.Value -ne $sid.Value -or
+    $actualRule.AccessControlType -ne [System.Security.AccessControl.AccessControlType]::Allow -or
+    (($actualRule.FileSystemRights -band [System.Security.AccessControl.FileSystemRights]::FullControl) -ne [System.Security.AccessControl.FileSystemRights]::FullControl) -or
+    (($actualRule.InheritanceFlags -band $inheritance) -ne $inheritance)
+  ) {
+    throw "Private directory DACL is not owner-only inheritable full control."
+  }
+  [CrablineWindowsDirectoryHandle]::AssertSamePathIdentity(
+    $directoryPath,
+    $directoryIdentity
+  )
+} finally {
+  $directory.Dispose()
 }
 `;
 
@@ -203,6 +691,8 @@ export type WindowsAclRunner = (
   args: string[],
   options: {
     env: NodeJS.ProcessEnv;
+    killSignal: NodeJS.Signals;
+    timeout: number;
     windowsHide: boolean;
   },
 ) => Promise<string>;
@@ -241,12 +731,14 @@ export async function applyOwnerOnlyWindowsDirectoryAcl(
           ...process.env,
           CRABLINE_PRIVATE_DIRECTORY_PATH: path.resolve(directoryPath),
         },
+        killSignal: "SIGKILL",
+        timeout: WINDOWS_ACL_COMMAND_TIMEOUT_MS,
         windowsHide: true,
       },
     );
   } catch (error) {
     throw new Error(
-      "Could not apply and verify an owner-only Windows directory ACL; powershell.exe with Set-Acl is required.",
+      "Could not apply and verify an owner-only Windows directory ACL; Windows PowerShell ACL support is required.",
       { cause: error },
     );
   }
@@ -273,6 +765,8 @@ export async function createOwnerOnlyWindowsDirectory(
           ...process.env,
           CRABLINE_PRIVATE_DIRECTORY_PATH: path.resolve(directoryPath),
         },
+        killSignal: "SIGKILL",
+        timeout: WINDOWS_ACL_COMMAND_TIMEOUT_MS,
         windowsHide: true,
       },
     );
@@ -305,6 +799,8 @@ export async function readWindowsDirectorySecurityDescriptor(
           ...process.env,
           CRABLINE_PRIVATE_DIRECTORY_PATH: path.resolve(directoryPath),
         },
+        killSignal: "SIGKILL",
+        timeout: WINDOWS_ACL_COMMAND_TIMEOUT_MS,
         windowsHide: true,
       },
     );

--- a/src/platform/windows-lock-root.ts
+++ b/src/platform/windows-lock-root.ts
@@ -111,7 +111,15 @@ export async function secureCachedWindowsLockRoot(options: {
         }
       });
     }
-    const expected = await secured;
+    let expected: WindowsLockRootIdentity;
+    try {
+      expected = await secured;
+    } catch (error) {
+      if (options.cache.get(options.cacheKey) === secured) {
+        options.cache.delete(options.cacheKey);
+      }
+      throw error;
+    }
     let current: WindowsLockRootIdentity;
     try {
       current = await readStableWindowsLockRootIdentity(options);

--- a/src/providers/builtin/script.ts
+++ b/src/providers/builtin/script.ts
@@ -258,7 +258,7 @@ const WINDOWS_PROCESS_TERMINATOR_SOURCE = [
   "}",
 ].join("");
 
-let windowsJobHelperPath: string | null | undefined;
+let windowsJobHelperPath: string | undefined;
 let windowsJobHelperPromise: Promise<string | undefined> | undefined;
 
 function removeWindowsJobHelper(directory: string): void {
@@ -291,13 +291,12 @@ function runWindowsJobHelperCommand(
 
 async function createWindowsJobHelper(): Promise<string | undefined> {
   if (windowsJobHelperPath !== undefined) {
-    return windowsJobHelperPath ?? undefined;
+    return windowsJobHelperPath;
   }
   let directory: string;
   try {
     directory = mkdtempSync(path.join(tmpdir(), "crabline-script-job-"));
   } catch {
-    windowsJobHelperPath = null;
     return undefined;
   }
   const helperPath = path.join(directory, "crabline-script-job.exe");
@@ -333,7 +332,6 @@ async function createWindowsJobHelper(): Promise<string | undefined> {
     });
   } catch {
     removeWindowsJobHelper(directory);
-    windowsJobHelperPath = null;
     return undefined;
   }
   windowsJobHelperPath = helperPath;
@@ -343,7 +341,7 @@ async function createWindowsJobHelper(): Promise<string | undefined> {
 
 function ensureWindowsJobHelper(): Promise<string | undefined> {
   if (windowsJobHelperPath !== undefined) {
-    return Promise.resolve(windowsJobHelperPath ?? undefined);
+    return Promise.resolve(windowsJobHelperPath);
   }
   windowsJobHelperPromise ??= createWindowsJobHelper().finally(() => {
     windowsJobHelperPromise = undefined;
@@ -351,12 +349,16 @@ function ensureWindowsJobHelper(): Promise<string | undefined> {
   return windowsJobHelperPromise;
 }
 
-function waitForPromiseOrAbort<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+function waitForPromiseOrAbort<T>(
+  createPromise: () => Promise<T>,
+  signal?: AbortSignal,
+): Promise<T> {
+  if (signal?.aborted) {
+    return Promise.reject(signal.reason ?? new Error("Script command aborted."));
+  }
+  const promise = createPromise();
   if (!signal) {
     return promise;
-  }
-  if (signal.aborted) {
-    return Promise.reject(signal.reason ?? new Error("Script command aborted."));
   }
   return new Promise((resolve, reject) => {
     const abort = () => {
@@ -432,7 +434,7 @@ async function spawnScriptChild(
   let startedAtMs: number;
   let child: SpawnedScriptChild;
   if (process.platform === "win32") {
-    const helperPath = await waitForPromiseOrAbort(ensureWindowsJobHelper(), signal);
+    const helperPath = await waitForPromiseOrAbort(ensureWindowsJobHelper, signal);
     if (signal?.aborted) {
       throw signal.reason ?? new Error("Script command aborted.");
     }

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -409,10 +409,12 @@ async function resolveRecorderPublicationPath(filePath: string): Promise<string>
 async function openRecorderForAppend(
   filePath: string,
 ): Promise<{ created: boolean; handle: Awaited<ReturnType<typeof open>> }> {
+  const createFlags = process.platform === "win32" ? "wx+" : "ax+";
+  const existingFlags = process.platform === "win32" ? "r+" : "a+";
   try {
     return {
       created: true,
-      handle: await open(filePath, "ax+", 0o600),
+      handle: await open(filePath, createFlags, 0o600),
     };
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
@@ -420,8 +422,34 @@ async function openRecorderForAppend(
     }
     return {
       created: false,
-      handle: await open(filePath, "a+", 0o600),
+      handle: await open(filePath, existingFlags, 0o600),
     };
+  }
+}
+
+async function appendRecorderData(
+  handle: Awaited<ReturnType<typeof open>>,
+  data: string,
+): Promise<void> {
+  if (process.platform !== "win32") {
+    await handle.writeFile(data, "utf8");
+    return;
+  }
+
+  const bytes = Buffer.from(data, "utf8");
+  const position = (await handle.stat()).size;
+  let offset = 0;
+  while (offset < bytes.length) {
+    const { bytesWritten } = await handle.write(
+      bytes,
+      offset,
+      bytes.length - offset,
+      position + offset,
+    );
+    if (bytesWritten === 0) {
+      throw new Error("Could not append recorder data.");
+    }
+    offset += bytesWritten;
   }
 }
 
@@ -499,7 +527,7 @@ async function prepareRecorderTailForAppend(
   const tail = tailWindow.subarray(lastNewline + 1).toString("utf8");
   try {
     parseRecordedLine(tail);
-    await handle.writeFile("\n", "utf8");
+    await appendRecorderData(handle, "\n");
     return true;
   } catch (error) {
     if (!(error instanceof SyntaxError)) {
@@ -581,7 +609,7 @@ async function appendCommittedLine(
     }
     await prepareRecorderTailForAppend(handle);
     published = true;
-    await handle.writeFile(line, "utf8");
+    await appendRecorderData(handle, line);
     if (durable) {
       await handle.sync();
     }

--- a/test/openclaw-private-file.test.ts
+++ b/test/openclaw-private-file.test.ts
@@ -2292,6 +2292,8 @@ describe("OpenClaw private file publication", () => {
     expect(script).toContain("AreAccessRulesProtected");
     expect(script).toContain("$rules.Count -ne 1");
     expect(options.env.CRABLINE_PRIVATE_FILE_PATH).toBe(path.resolve(filePath));
+    expect(options.killSignal).toBe("SIGKILL");
+    expect(options.timeout).toBe(15_000);
     expect(options.windowsHide).toBe(true);
   });
 
@@ -2330,6 +2332,8 @@ describe("OpenClaw private file publication", () => {
     expect(script).toContain("SetAccessRuleProtection($true, $false)");
     expect(script).toContain("owner-only inheritable full control");
     expect(options.env.CRABLINE_PRIVATE_DIRECTORY_PATH).toBe(path.resolve(directoryPath));
+    expect(options.killSignal).toBe("SIGKILL");
+    expect(options.timeout).toBe(15_000);
   });
 
   it("uses CreateDirectoryW with a protected ACL for every missing Windows ancestor", async () => {
@@ -2354,6 +2358,8 @@ describe("OpenClaw private file publication", () => {
     expect(script).toContain("New private directory was populated during creation.");
     expect(script).not.toContain("Set-Acl");
     expect(options.env.CRABLINE_PRIVATE_DIRECTORY_PATH).toBe(path.resolve(directoryPath));
+    expect(options.killSignal).toBe("SIGKILL");
+    expect(options.timeout).toBe(15_000);
   });
 
   it("fails closed when a Windows ancestry component wins the CreateNew race", async () => {
@@ -2462,6 +2468,9 @@ describe("OpenClaw private file publication", () => {
     expect(script).toContain(
       "$ruleAccessMask -band ($mutationAccessMask -bor $genericMutationRights)",
     );
+    expect(script).toContain("$inheritOnly");
+    expect(script).toContain("$appliesToDirectory");
+    expect(script).toContain("$appliesToDirectory -and");
   });
 
   it("checks Windows delete-child rights when verifying mutation boundary ancestry", async () => {
@@ -2523,8 +2532,32 @@ describe("OpenClaw private file publication", () => {
     },
   );
 
+  it.skipIf(process.platform !== "win32")(
+    "allows inherit-only mutation rights that do not apply to the Windows boundary",
+    async () => {
+      const directory = await createTempDir();
+      try {
+        execFileSync(
+          "icacls.exe",
+          [directory, "/inheritance:r", "/grant", "*S-1-1-0:(OI)(CI)(IO)(GW)"],
+          { stdio: "ignore" },
+        );
+
+        await expect(
+          verifySafeWindowsDirectoryMutationBoundary(directory),
+        ).resolves.toBeUndefined();
+      } finally {
+        await disposeTempDir(directory);
+      }
+    },
+  );
+
   it("reports Windows ACL tooling failures with their cause", async () => {
-    const cause = new Error("powershell.exe missing");
+    const cause = Object.assign(new Error("PowerShell ACL command timed out"), {
+      code: "ETIMEDOUT",
+      killed: true,
+      signal: "SIGKILL",
+    });
     await expect(
       createOwnerOnlyWindowsFile(
         "manifest.json",

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -55,6 +55,58 @@ function runAfterDelay<T>(operation: () => Promise<T>, delayMs = 25): Promise<T>
   });
 }
 
+type RecorderFileHandlePrototype = {
+  write(
+    buffer: Uint8Array,
+    offset: number,
+    length: number,
+    position: number,
+  ): Promise<{ buffer: Uint8Array; bytesWritten: number }>;
+  writeFile(data: string, encoding: BufferEncoding): Promise<void>;
+};
+
+function interceptRecorderWrites(
+  prototype: RecorderFileHandlePrototype,
+  intercept: (data: string, write: () => Promise<void>) => Promise<void>,
+): () => void {
+  const originalWrite = prototype.write;
+  const originalWriteFile = prototype.writeFile;
+  if (process.platform === "win32") {
+    prototype.write = async function (
+      this: FileHandle,
+      buffer: Uint8Array,
+      offset: number,
+      length: number,
+      position: number,
+    ) {
+      let result: { buffer: Uint8Array; bytesWritten: number } | undefined;
+      await intercept(
+        Buffer.from(buffer)
+          .subarray(offset, offset + length)
+          .toString("utf8"),
+        async () => {
+          result = await originalWrite.call(this, buffer, offset, length, position);
+        },
+      );
+      return result!;
+    };
+  } else {
+    prototype.writeFile = async function (
+      this: FileHandle,
+      data: string,
+      encoding: BufferEncoding,
+    ) {
+      await intercept(data, async () => {
+        await originalWriteFile.call(this, data, encoding);
+      });
+    };
+  }
+  return () => {
+    prototype.write = originalWrite;
+    prototype.writeFile = originalWriteFile;
+  };
+}
+
 describe("recorder", () => {
   it("returns an empty list for a missing recorder file", async () => {
     const filePath = await createRecorderPath();
@@ -990,11 +1042,8 @@ describe("recorder", () => {
     await appendRecordedInboundBatch(filePath, [{ ...event, id: "existing", text: "existing" }]);
 
     const probeHandle = await open(filePath, "a+");
-    const fileHandlePrototype = Object.getPrototypeOf(probeHandle) as {
-      writeFile(data: string, encoding: BufferEncoding): Promise<void>;
-    };
+    const fileHandlePrototype = Object.getPrototypeOf(probeHandle) as RecorderFileHandlePrototype;
     await probeHandle.close();
-    const originalWriteFile = fileHandlePrototype.writeFile;
     let releaseWrite!: () => void;
     let reportWrite!: () => void;
     const writeReported = new Promise<void>((resolve) => {
@@ -1004,18 +1053,14 @@ describe("recorder", () => {
       releaseWrite = resolve;
     });
     let interceptBatch = true;
-    fileHandlePrototype.writeFile = async function (
-      this: FileHandle,
-      data: string,
-      encoding: BufferEncoding,
-    ) {
-      await originalWriteFile.call(this, data, encoding);
+    const restoreWrites = interceptRecorderWrites(fileHandlePrototype, async (data, write) => {
+      await write();
       if (interceptBatch && data.includes('"recorderBatchVersion"')) {
         interceptBatch = false;
         reportWrite();
         await writeReleased;
       }
-    };
+    });
 
     const append = appendRecordedInboundBatch(filePath, [event]);
     try {
@@ -1026,7 +1071,7 @@ describe("recorder", () => {
       await expect(append).resolves.toEqual([expect.objectContaining({ id: "rotated-batch" })]);
     } finally {
       releaseWrite();
-      fileHandlePrototype.writeFile = originalWriteFile;
+      restoreWrites();
     }
 
     await expect(readRecordedInbound(filePath)).resolves.toEqual([
@@ -1051,11 +1096,8 @@ describe("recorder", () => {
     };
 
     const probeHandle = await open(filePath, "a+");
-    const fileHandlePrototype = Object.getPrototypeOf(probeHandle) as {
-      writeFile(data: string, encoding: BufferEncoding): Promise<void>;
-    };
+    const fileHandlePrototype = Object.getPrototypeOf(probeHandle) as RecorderFileHandlePrototype;
     await probeHandle.close();
-    const originalWriteFile = fileHandlePrototype.writeFile;
     let releaseWrite!: () => void;
     let reportWrite!: () => void;
     const writeReported = new Promise<void>((resolve) => {
@@ -1065,18 +1107,14 @@ describe("recorder", () => {
       releaseWrite = resolve;
     });
     let interceptAppend = true;
-    fileHandlePrototype.writeFile = async function (
-      this: FileHandle,
-      data: string,
-      encoding: BufferEncoding,
-    ) {
-      await originalWriteFile.call(this, data, encoding);
+    const restoreWrites = interceptRecorderWrites(fileHandlePrototype, async (data, write) => {
+      await write();
       if (interceptAppend && data.includes('"id":"rotated-single"')) {
         interceptAppend = false;
         reportWrite();
         await writeReleased;
       }
-    };
+    });
 
     const append = appendRecordedInbound(filePath, event);
     try {
@@ -1087,7 +1125,7 @@ describe("recorder", () => {
       await expect(append).resolves.toMatchObject({ id: event.id });
     } finally {
       releaseWrite();
-      fileHandlePrototype.writeFile = originalWriteFile;
+      restoreWrites();
     }
 
     await expect(readRecordedInbound(filePath)).resolves.toEqual([
@@ -1115,11 +1153,8 @@ describe("recorder", () => {
     };
 
     const probeHandle = await open(firstTarget, "a+");
-    const fileHandlePrototype = Object.getPrototypeOf(probeHandle) as {
-      writeFile(data: string, encoding: BufferEncoding): Promise<void>;
-    };
+    const fileHandlePrototype = Object.getPrototypeOf(probeHandle) as RecorderFileHandlePrototype;
     await probeHandle.close();
-    const originalWriteFile = fileHandlePrototype.writeFile;
     let releaseWrite!: () => void;
     let reportWrite!: () => void;
     const writeReported = new Promise<void>((resolve) => {
@@ -1129,18 +1164,14 @@ describe("recorder", () => {
       releaseWrite = resolve;
     });
     let interceptBatch = true;
-    fileHandlePrototype.writeFile = async function (
-      this: FileHandle,
-      data: string,
-      encoding: BufferEncoding,
-    ) {
-      await originalWriteFile.call(this, data, encoding);
+    const restoreWrites = interceptRecorderWrites(fileHandlePrototype, async (data, write) => {
+      await write();
       if (interceptBatch && data.includes('"recorderBatchVersion"')) {
         interceptBatch = false;
         reportWrite();
         await writeReleased;
       }
-    };
+    });
 
     const append = appendRecordedInboundBatch(filePath, [event]);
     try {
@@ -1151,7 +1182,7 @@ describe("recorder", () => {
       await expect(append).resolves.toEqual([expect.objectContaining({ id: "symlink-batch" })]);
     } finally {
       releaseWrite();
-      fileHandlePrototype.writeFile = originalWriteFile;
+      restoreWrites();
     }
 
     await expect(readRecordedInbound(filePath)).resolves.toEqual([
@@ -1176,11 +1207,8 @@ describe("recorder", () => {
     };
 
     const probeHandle = await open(path.dirname(filePath), "r");
-    const fileHandlePrototype = Object.getPrototypeOf(probeHandle) as {
-      writeFile(data: string, encoding: BufferEncoding): Promise<void>;
-    };
+    const fileHandlePrototype = Object.getPrototypeOf(probeHandle) as RecorderFileHandlePrototype;
     await probeHandle.close();
-    const originalWriteFile = fileHandlePrototype.writeFile;
     let releaseFirstWrite!: () => void;
     let reportFirstWrite!: () => void;
     const firstWriteReported = new Promise<void>((resolve) => {
@@ -1190,18 +1218,14 @@ describe("recorder", () => {
       releaseFirstWrite = resolve;
     });
     let pauseFirstBatch = true;
-    fileHandlePrototype.writeFile = async function (
-      this: FileHandle,
-      data: string,
-      encoding: BufferEncoding,
-    ) {
+    const restoreWrites = interceptRecorderWrites(fileHandlePrototype, async (data, write) => {
       if (pauseFirstBatch && data.includes('"recorderBatchVersion"')) {
         pauseFirstBatch = false;
         reportFirstWrite();
         await firstWriteReleased;
       }
-      await originalWriteFile.call(this, data, encoding);
-    };
+      await write();
+    });
 
     const first = appendRecordedInboundBatch(filePath, [event]);
     try {
@@ -1213,7 +1237,7 @@ describe("recorder", () => {
       expect(results.map((result) => result.length).toSorted()).toEqual([0, 1]);
     } finally {
       releaseFirstWrite();
-      fileHandlePrototype.writeFile = originalWriteFile;
+      restoreWrites();
     }
 
     await expect(readRecordedInbound(filePath)).resolves.toEqual([

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -17,6 +17,7 @@ import {
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  applyOwnerOnlyWindowsDirectoryAcl,
   createOwnerOnlyWindowsDirectory,
   readWindowsDirectorySecurityDescriptor,
   type WindowsAclRunner,
@@ -246,6 +247,39 @@ describe("recorder", () => {
     await expect(stat(lockRoot)).resolves.toBeDefined();
   });
 
+  it("retries Windows recorder lock-root creation after a cached promise rejects", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const lockRoot = path.join(directory, "retried-locks");
+    const timeout = Object.assign(new Error("PowerShell ACL command timed out"), {
+      code: "ETIMEDOUT",
+      killed: true,
+      signal: "SIGKILL",
+    });
+    let createCount = 0;
+    const createWindowsDirectory = async (directoryPath: string) => {
+      createCount += 1;
+      if (createCount === 1) {
+        throw timeout;
+      }
+      await mkdir(directoryPath);
+    };
+    const options = {
+      createWindowsDirectory,
+      platform: "win32" as const,
+      readWindowsDirectorySecurityDescriptor: readOwnerOnlyWindowsDirectorySecurityDescriptor,
+    };
+
+    await expect(secureProviderRecorderLockRoot(lockRoot, undefined, options)).rejects.toBe(
+      timeout,
+    );
+    await expect(secureProviderRecorderLockRoot(lockRoot, undefined, options)).resolves.toBe(
+      lockRoot,
+    );
+
+    expect(createCount).toBe(2);
+  });
+
   it("deduplicates concurrent Windows recorder lock-root replacement recovery", async () => {
     const directory = await createTempDir();
     directories.push(directory);
@@ -411,13 +445,48 @@ describe("recorder", () => {
 
     expect(calls).toHaveLength(1);
     const [, args, options] = calls[0]!;
-    const script = args.at(-1);
+    const script = args.at(-1)!;
     expect(script).toContain("[System.Security.AccessControl.DirectorySecurity]::new()");
-    expect(script).toContain("[System.IO.Directory]::CreateDirectory($directoryPath, $acl)");
     expect(script).toContain("[System.IO.Directory]::Exists($directoryPath)");
-    expect(script).toContain("$directory.SetAccessControl($acl)");
-    expect(script).toContain("[System.IO.FileAttributes]::ReparsePoint");
+    expect(script).toContain("$directoryPath.TrimEnd(");
+    expect(script).toContain("NtCreateFile(");
+    expect(script).toContain("FileCreate");
+    expect(script).toContain("FileDirectoryFile");
+    expect(script).toContain("FileOpenReparsePoint");
+    expect(script).toContain("[CrablineWindowsDirectoryHandle]::Create(");
+    expect(script.indexOf('StartsWith(@"\\\\?\\",')).toBeLessThan(
+      script.indexOf('StartsWith(@"\\\\",'),
+    );
+    expect(script).toContain("FileFlagOpenReparsePoint");
+    expect(script).toContain("ReparsePointAttribute");
+    expect(script).toContain("GetSecurityInfo(");
+    expect(script).toContain("SetSecurityInfo(");
+    expect(script).toContain("AssertSamePathIdentity");
+    expect(script).not.toContain("$directory.SetAccessControl($acl)");
     expect(options.env.CRABLINE_PRIVATE_DIRECTORY_PATH).toBe(path.resolve(directoryPath));
+    expect(options.killSignal).toBe("SIGKILL");
+    expect(options.timeout).toBe(15_000);
+  });
+
+  it("applies Windows recorder ACLs through a no-follow identity-bound handle", async () => {
+    const calls: Parameters<WindowsAclRunner>[] = [];
+    const run: WindowsAclRunner = async (...args) => {
+      calls.push(args);
+      return "";
+    };
+    const directoryPath = String.raw`C:\Temp\crabline-recorder-locks`;
+
+    await applyOwnerOnlyWindowsDirectoryAcl(directoryPath, run, String.raw`C:\Windows`);
+
+    const [, args, options] = calls[0]!;
+    const script = args.at(-1);
+    expect(script).toContain("FileFlagOpenReparsePoint");
+    expect(script).toContain("[CrablineWindowsDirectoryHandle]::Open($directoryPath, $true)");
+    expect(script).toContain("[CrablineWindowsDirectoryHandle]::WriteSecurityDescriptor(");
+    expect(script).toContain("[CrablineWindowsDirectoryHandle]::AssertSamePathIdentity(");
+    expect(script).not.toContain("Set-Acl");
+    expect(options.killSignal).toBe("SIGKILL");
+    expect(options.timeout).toBe(15_000);
   });
 
   it("reads a stable Windows directory security descriptor fingerprint", async () => {
@@ -439,7 +508,55 @@ describe("recorder", () => {
     expect(script).toContain("GetSecurityDescriptorBinaryForm()");
     expect(script).toContain("[Convert]::ToBase64String($descriptor)");
     expect(options.env.CRABLINE_PRIVATE_DIRECTORY_PATH).toBe(path.resolve(directoryPath));
+    expect(options.killSignal).toBe("SIGKILL");
+    expect(options.timeout).toBe(15_000);
   });
+
+  it.runIf(process.platform === "win32")(
+    "creates missing Windows recorder lock roots with an identity-bound handle",
+    async () => {
+      const directory = await createTempDir();
+      directories.push(directory);
+      const lockRoot = path.join(directory, "new-lock-root");
+
+      await expect(createOwnerOnlyWindowsDirectory(lockRoot)).resolves.toBeUndefined();
+      await expect(stat(lockRoot)).resolves.toMatchObject({
+        isDirectory: expect.any(Function),
+      });
+    },
+  );
+
+  it.runIf(process.platform === "win32")(
+    "creates missing Windows recorder lock roots through extended-length paths",
+    async () => {
+      const directory = await createTempDir();
+      directories.push(directory);
+      const lockRoot = path.join(directory, "extended-lock-root");
+
+      await expect(
+        createOwnerOnlyWindowsDirectory(path.toNamespacedPath(lockRoot)),
+      ).resolves.toBeUndefined();
+      await expect(stat(lockRoot)).resolves.toMatchObject({
+        isDirectory: expect.any(Function),
+      });
+    },
+  );
+
+  it.runIf(process.platform === "win32")(
+    "creates missing Windows recorder lock roots with trailing separators",
+    async () => {
+      const directory = await createTempDir();
+      directories.push(directory);
+      const lockRoot = path.join(directory, "trailing-separator-lock-root");
+
+      await expect(
+        createOwnerOnlyWindowsDirectory(`${lockRoot}${path.sep}`),
+      ).resolves.toBeUndefined();
+      await expect(stat(lockRoot)).resolves.toMatchObject({
+        isDirectory: expect.any(Function),
+      });
+    },
+  );
 
   it.runIf(process.platform === "win32")(
     "migrates existing Windows recorder lock roots to owner-only ACLs",
@@ -453,6 +570,38 @@ describe("recorder", () => {
       await expect(stat(lockRoot)).resolves.toMatchObject({
         isDirectory: expect.any(Function),
       });
+    },
+  );
+
+  it.runIf(process.platform === "win32")(
+    "rejects Windows recorder lock-root junctions without following their targets",
+    async () => {
+      const directory = await createTempDir();
+      directories.push(directory);
+      const target = path.join(directory, "target");
+      const junction = path.join(directory, "junction");
+      await mkdir(target);
+      await symlink(target, junction, "junction");
+
+      await expect(createOwnerOnlyWindowsDirectory(junction)).rejects.toThrow(
+        "Could not atomically create or verify an owner-only Windows directory",
+      );
+    },
+  );
+
+  it.runIf(process.platform === "win32")(
+    "does not create through dangling Windows recorder lock-root junctions",
+    async () => {
+      const directory = await createTempDir();
+      directories.push(directory);
+      const missingTarget = path.join(directory, "missing-target");
+      const junction = path.join(directory, "dangling-junction");
+      await symlink(missingTarget, junction, "junction");
+
+      await expect(createOwnerOnlyWindowsDirectory(junction)).rejects.toThrow(
+        "Could not atomically create or verify an owner-only Windows directory",
+      );
+      await expect(stat(missingTarget)).rejects.toMatchObject({ code: "ENOENT" });
     },
   );
 

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -735,14 +735,23 @@ describe("recorder", () => {
 
     const probeHandle = await open(filePath, "a+");
     const fileHandlePrototype = Object.getPrototypeOf(probeHandle) as {
+      write(
+        buffer: Uint8Array,
+        offset: number,
+        length: number,
+        position: number,
+      ): Promise<{ buffer: Uint8Array; bytesWritten: number }>;
       writeFile(data: string, encoding: BufferEncoding): Promise<void>;
     };
     await probeHandle.close();
+    const originalWrite = fileHandlePrototype.write;
     const originalWriteFile = fileHandlePrototype.writeFile;
+    const appendPosition = (await stat(filePath)).size;
     const partialAppendError = Object.assign(new Error("simulated partial append"), {
       code: "ENOSPC",
     });
     let failNextWrite = true;
+    let partialWritePosition: number | undefined;
     let releasePartialWrite!: () => void;
     let reportPartialWrite!: () => void;
     const partialWriteReported = new Promise<void>((resolve) => {
@@ -751,20 +760,40 @@ describe("recorder", () => {
     const partialWriteReleased = new Promise<void>((resolve) => {
       releasePartialWrite = resolve;
     });
-    fileHandlePrototype.writeFile = async function (
-      this: FileHandle,
-      data: string,
-      encoding: BufferEncoding,
-    ) {
-      if (failNextWrite) {
-        failNextWrite = false;
-        await originalWriteFile.call(this, data.slice(0, Math.ceil(data.length / 2)), encoding);
-        reportPartialWrite();
-        await partialWriteReleased;
-        throw partialAppendError;
-      }
-      await originalWriteFile.call(this, data, encoding);
-    };
+    if (process.platform === "win32") {
+      fileHandlePrototype.write = async function (
+        this: FileHandle,
+        buffer: Uint8Array,
+        offset: number,
+        length: number,
+        position: number,
+      ) {
+        if (failNextWrite) {
+          failNextWrite = false;
+          partialWritePosition = position;
+          await originalWrite.call(this, buffer, offset, Math.ceil(length / 2), position);
+          reportPartialWrite();
+          await partialWriteReleased;
+          throw partialAppendError;
+        }
+        return originalWrite.call(this, buffer, offset, length, position);
+      };
+    } else {
+      fileHandlePrototype.writeFile = async function (
+        this: FileHandle,
+        data: string,
+        encoding: BufferEncoding,
+      ) {
+        if (failNextWrite) {
+          failNextWrite = false;
+          await originalWriteFile.call(this, data.slice(0, Math.ceil(data.length / 2)), encoding);
+          reportPartialWrite();
+          await partialWriteReleased;
+          throw partialAppendError;
+        }
+        await originalWriteFile.call(this, data, encoding);
+      };
+    }
 
     const batch = [event("retry-1"), event("retry-2")];
     const failedAppend = appendRecordedInboundBatch(filePath, batch);
@@ -780,8 +809,10 @@ describe("recorder", () => {
         indeterminate: true,
         name: "ProviderRecorderCommittedError",
       });
+      expect(partialWritePosition).toBe(process.platform === "win32" ? appendPosition : undefined);
     } finally {
       releasePartialWrite();
+      fileHandlePrototype.write = originalWrite;
       fileHandlePrototype.writeFile = originalWriteFile;
     }
 

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -510,7 +510,10 @@ describe("recorder", () => {
       script.indexOf('StartsWith(@"\\\\",'),
     );
     expect(script).toContain("FileFlagOpenReparsePoint");
+    expect(script).toContain("DirectoryAttribute");
     expect(script).toContain("ReparsePointAttribute");
+    expect(script).toContain("GetFileInformationByHandleEx(");
+    expect(script).toContain("FileIdInfoClass");
     expect(script).toContain("GetSecurityInfo(");
     expect(script).toContain("SetSecurityInfo(");
     expect(script).toContain("AssertSamePathIdentity");
@@ -533,6 +536,9 @@ describe("recorder", () => {
     const [, args, options] = calls[0]!;
     const script = args.at(-1);
     expect(script).toContain("FileFlagOpenReparsePoint");
+    expect(script).toContain("DirectoryAttribute");
+    expect(script).toContain("GetFileInformationByHandleEx(");
+    expect(script).toContain("FileIdInfoClass");
     expect(script).toContain("[CrablineWindowsDirectoryHandle]::Open($directoryPath, $true)");
     expect(script).toContain("[CrablineWindowsDirectoryHandle]::WriteSecurityDescriptor(");
     expect(script).toContain("[CrablineWindowsDirectoryHandle]::AssertSamePathIdentity(");
@@ -622,6 +628,21 @@ describe("recorder", () => {
       await expect(stat(lockRoot)).resolves.toMatchObject({
         isDirectory: expect.any(Function),
       });
+    },
+  );
+
+  it.runIf(process.platform === "win32")(
+    "rejects regular files before applying a Windows directory ACL",
+    async () => {
+      const directory = await createTempDir();
+      directories.push(directory);
+      const filePath = path.join(directory, "not-a-directory");
+      await writeFile(filePath, "contents", "utf8");
+
+      await expect(applyOwnerOnlyWindowsDirectoryAcl(filePath)).rejects.toThrow(
+        "Could not apply and verify an owner-only Windows directory ACL",
+      );
+      await expect(readFile(filePath, "utf8")).resolves.toBe("contents");
     },
   );
 

--- a/test/script-provider-windows.test.ts
+++ b/test/script-provider-windows.test.ts
@@ -169,6 +169,71 @@ describe("script provider Windows cleanup", () => {
     },
   );
 
+  it("retries Job Object helper bootstrap after a transient failure", async () => {
+    vi.resetModules();
+    execFileMock.mockImplementationOnce(() => {
+      throw new Error("transient bootstrap failure");
+    });
+    const firstScriptChild = createFakeChild(1110);
+    const secondScriptChild = createFakeChild(1111);
+    spawnMock.mockReturnValueOnce(firstScriptChild).mockReturnValueOnce(secondScriptChild);
+    const { ScriptProviderAdapter: IsolatedScriptProviderAdapter } =
+      await import("../src/providers/builtin/script.js");
+    const context = createContext();
+    const provider = new IsolatedScriptProviderAdapter(context);
+
+    const firstFailure = provider
+      .send({
+        ...context,
+        mode: "send",
+        nonce: "nonce-1",
+        text: "payload",
+      })
+      .catch((error: unknown) => error);
+    await flushScriptSpawn();
+    firstScriptChild.emit("close", 7, null);
+    await firstFailure;
+
+    const secondFailure = provider
+      .send({
+        ...context,
+        mode: "send",
+        nonce: "nonce-2",
+        text: "payload",
+      })
+      .catch((error: unknown) => error);
+    await flushScriptSpawn();
+    secondScriptChild.emit("close", 7, null);
+    await secondFailure;
+
+    expect(execFileMock).toHaveBeenCalledTimes(3);
+    expect(spawnMock.mock.calls[0]?.[0]).toBe("node send.mjs");
+    expect(spawnMock.mock.calls[1]?.[0]).toMatch(/crabline-script-job\.exe$/u);
+  });
+
+  it("does not bootstrap the Job Object helper for an already-aborted spawn", async () => {
+    vi.resetModules();
+    const { ScriptProviderAdapter: IsolatedScriptProviderAdapter } =
+      await import("../src/providers/builtin/script.js");
+    const context = createContext();
+    const controller = new AbortController();
+    const cancellation = new Error("watch cancelled");
+    context.signal = controller.signal;
+    Object.defineProperty(context.fixture.target, "id", {
+      configurable: true,
+      get() {
+        controller.abort(cancellation);
+        return "thread-1";
+      },
+    });
+    const provider = new IsolatedScriptProviderAdapter(context);
+
+    await expect(provider.watch(context).next()).rejects.toBe(cancellation);
+
+    expect(execFileMock).not.toHaveBeenCalled();
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
   it("counts Job Object helper bootstrap against the command timeout", async () => {
     vi.resetModules();
     execFileMock.mockReset();


### PR DESCRIPTION
## What Problem This Solves

Closes the remaining native Windows audit gaps in helper bootstrap, recorder tail repair, and private-directory ACL handling.

## Why This Change Was Made

- Avoid Job Object bootstrap after cancellation and retry transient helper setup failures.
- Use truncation-capable recorder handles while preserving serialized append behavior.
- Reject reparse-point and non-directory substitutions, compare full 128-bit Windows file identities, bound PowerShell ACL subprocesses, and accept harmless inherit-only ACEs.

## User Impact

Windows provider processes retain tree-kill isolation after transient failures, recorder repair works with native file semantics, and private-directory hardening fails closed without rejecting valid inherited ACLs.

## Evidence

- Focused local Windows-path suites, format, typecheck, and lint passed on each source commit.
- Grouped exact-head `gpt-5.6-sol` high autoreview passed with no actionable findings.
- Native Windows Crabbox run `run_2d050bf91faa` passed 138 tests with 39 platform skips plus typecheck; its lease was released.
