### PR TITLE
fix(providers): close remaining protocol fidelity gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Enforce Telegram native identity and UTF-16 entity boundaries without synthetic chat collisions, while accepting four-character collectible chat usernames and scheduled zero message IDs.
 - Randomize WhatsApp server credentials, canonicalize direct delivery JIDs, restrict read receipts to accepted inbound messages, and bound queued, session, and binary-node resources without evicting live Signal sessions.
 - Reject malformed, unencodable, or non-canonical loopback v2 addresses instead of aliasing thread identities.
+- Reject invalid loopback encoder components and history timestamps while preserving lossless address round trips and monotonic message order.
 - Encode generic local-mock target components without channel or thread identity collisions while preserving canonical target idempotence.
 - Keep fixture-local iMessage target IDs separate from provider-native thread aliases.
 - Case-fold Zalo recorder credential keys and fully redact ambiguous malformed URL authorities.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 - Honor HTTP response age when caching JWT keys, reject unsupported critical JWS headers and malformed provider key metadata, preserve signing-service failure status, and protect webhook routing and framing headers.
 - Enforce Telegram destination prefixes, username canonicalization, topic IDs, and signed 52-bit chat identifier boundaries.
 - Bound GET and HEAD webhook bodies, reject invalid loopback callback exposure, and cancel response streams when clients disconnect.
-- Bound stalled WhatsApp acceptance, reserve message IDs and one-time prekeys atomically, align binary-node encode limits, and require native webhook envelopes.
+- Bound stalled WhatsApp acceptance, reserve message IDs and one-time prekeys atomically, enforce Cloud text limits, align binary-node encode limits, and require native webhook envelopes.
 - Verify downloaded npm tarball integrity, retry transient provenance lookups, and revalidate release tags immediately before publication mutations.
 - Validate effective fixture mode overrides and stop retrying permanent provider send failures.
 - Bound watch iterator return and provider cleanup during CLI shutdown, forcing process exit after deadline failures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Preserve local-mock webhook acceptance when clients disconnect or post-commit settlement hooks fail.
 - Scope iMessage direct waits and Matrix and Mattermost thread correlation to their native conversations.
 - Open Windows recorder files with truncation-capable handles while preserving serialized append behavior.
+- Keep Matrix incremental syncs sparse while separating canonical local identities from historical event senders.
 - Coordinate recorder repair by file identity, limit existing-file durability syncs to the immediate parent, and reject provider lock roots beneath unsafe Unix namespaces.
 - Stop retrying and resending accepted outbound messages after permanent inbound authentication or configuration failures.
 - Escape visually unsafe Unicode controls in JSON reports, return a stable error document for unserializable values, and preserve Node write encoding semantics in test captures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Honor HTTP response age when caching JWT keys, reject unsupported critical JWS headers and malformed provider key metadata, preserve signing-service failure status, and protect webhook routing and framing headers.
 - Enforce Telegram destination prefixes, username canonicalization, topic IDs, and signed 52-bit chat identifier boundaries.
 - Bound GET and HEAD webhook bodies, reject invalid loopback callback exposure, and cancel response streams when clients disconnect.
+- Bound stalled WhatsApp acceptance, reserve message IDs and one-time prekeys atomically, align binary-node encode limits, and require native webhook envelopes.
 - Verify downloaded npm tarball integrity, retry transient provenance lookups, and revalidate release tags immediately before publication mutations.
 - Validate effective fixture mode overrides and stop retrying permanent provider send failures.
 - Bound watch iterator return and provider cleanup during CLI shutdown, forcing process exit after deadline failures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Stream Telegram multipart uploads with bounded parser metadata instead of copying complete files through `FormData`.
 - Keep Unix recorder identity locks in one validated private per-user namespace across processes and recorder path changes.
 - Reject non-positive Telegram admin message IDs and enforce native Mattermost channel types and unique normalized usernames.
 - Preserve local-mock webhook acceptance when clients disconnect or post-commit settlement hooks fail.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Scope iMessage direct waits and Matrix and Mattermost thread correlation to their native conversations.
 - Open Windows recorder files with truncation-capable handles while preserving serialized append behavior.
 - Keep Matrix incremental syncs sparse while separating canonical local identities from historical event senders.
+- Reject Signal RPC calls that select an account the local daemon does not serve.
 - Coordinate recorder repair by file identity, limit existing-file durability syncs to the immediate parent, and reject provider lock roots beneath unsafe Unix namespaces.
 - Stop retrying and resending accepted outbound messages after permanent inbound authentication or configuration failures.
 - Escape visually unsafe Unicode controls in JSON reports, return a stable error document for unserializable values, and preserve Node write encoding semantics in test captures.

--- a/src/matrix-ids.ts
+++ b/src/matrix-ids.ts
@@ -44,13 +44,17 @@ function hasLoneSurrogate(value: string): boolean {
   return false;
 }
 
-function isMatrixScopedIdentifier(value: string, sigil: "!" | "$" | "@"): boolean {
+function isMatrixScopedIdentifier(
+  value: string,
+  sigil: "!" | "$" | "@",
+  allowEmptyLocalpart = false,
+): boolean {
   const separator = value.indexOf(":");
   const localpart = value.slice(1, separator);
   return (
     value.startsWith(sigil) &&
     Buffer.byteLength(value, "utf8") <= MAX_MATRIX_IDENTIFIER_BYTES &&
-    separator >= (sigil === "@" ? 1 : 2) &&
+    separator >= (allowEmptyLocalpart ? 1 : 2) &&
     !localpart.includes("\0") &&
     !hasLoneSurrogate(localpart) &&
     isMatrixServerName(value.slice(separator + 1))
@@ -88,5 +92,13 @@ export function isMatrixEventId(value: string): boolean {
 }
 
 export function isMatrixUserId(value: string): boolean {
-  return isMatrixScopedIdentifier(value, "@");
+  if (!isMatrixScopedIdentifier(value, "@")) {
+    return false;
+  }
+  const localpart = value.slice(1, value.indexOf(":"));
+  return /^[a-z0-9._=/+-]+$/u.test(localpart);
+}
+
+export function isHistoricalMatrixUserId(value: string): boolean {
+  return isMatrixScopedIdentifier(value, "@", true);
 }

--- a/src/providers/builtin/loopback.ts
+++ b/src/providers/builtin/loopback.ts
@@ -65,6 +65,17 @@ function malformedThreadAddress(cause?: unknown): CrablineError {
   });
 }
 
+function encodeThreadAddressComponent(value: string): string {
+  if (!value) {
+    throw malformedThreadAddress();
+  }
+  try {
+    return encodeURIComponent(value);
+  } catch (error) {
+    throw malformedThreadAddress(error);
+  }
+}
+
 function decodeThreadAddressComponent(value: string): string {
   let decoded: string;
   let canonical: string;
@@ -87,6 +98,7 @@ export class LoopbackChatAdapter {
 
   readonly #messages = new Map<string, StoredLoopbackMessage[]>();
   readonly #nextSequence = new Map<string, number>();
+  #lastMessageTimestamp = -1;
 
   constructor(userName: string) {
     this.userName = userName;
@@ -169,18 +181,20 @@ export class LoopbackChatAdapter {
     existing.text = text;
     existing.formatted = text;
     existing.metadata.edited = true;
-    existing.metadata.editedAt = new Date();
+    existing.metadata.editedAt = new Date(this.#nextMessageTimestamp());
     existing.raw.text = text;
     return Promise.resolve({ id: existing.id, raw: cloneRawMessage(existing.raw), threadId });
   }
 
   encodeThreadId(platformData: ThreadAddress): string {
-    const address = platformData.channelId
-      ? `${LOOPBACK_V2_PREFIX}${encodeURIComponent(platformData.channelId)}:${encodeURIComponent(platformData.id)}`
-      : `${LOOPBACK_V2_PREFIX}${encodeURIComponent(platformData.id)}`;
-    return platformData.threadId
-      ? `${address}::${encodeURIComponent(platformData.threadId)}`
-      : address;
+    const id = encodeThreadAddressComponent(platformData.id);
+    const address =
+      platformData.channelId === undefined
+        ? `${LOOPBACK_V2_PREFIX}${id}`
+        : `${LOOPBACK_V2_PREFIX}${encodeThreadAddressComponent(platformData.channelId)}:${id}`;
+    return platformData.threadId === undefined
+      ? address
+      : `${address}::${encodeThreadAddressComponent(platformData.threadId)}`;
   }
 
   fetchMessages(
@@ -274,7 +288,7 @@ export class LoopbackChatAdapter {
       id: createMessageId(),
       text,
       threadId,
-      timestamp: new Date().toISOString(),
+      timestamp: this.#nextMessageTimestamp(),
     } satisfies LoopbackRawMessage;
     const parsed = this.parseMessage(raw);
     this.#append(threadId, parsed);
@@ -299,7 +313,7 @@ export class LoopbackChatAdapter {
       id: createMessageId(),
       text,
       threadId,
-      timestamp: new Date().toISOString(),
+      timestamp: this.#nextMessageTimestamp(),
     } satisfies LoopbackRawMessage;
     const parsed = this.parseMessage(raw);
     this.#append(threadId, parsed);
@@ -308,6 +322,11 @@ export class LoopbackChatAdapter {
 
   listSince(threadId: string, since: string): LoopbackMessage[] {
     const sinceTime = new Date(since).getTime();
+    if (!Number.isFinite(sinceTime)) {
+      throw new CrablineError("Loopback since timestamp must be a valid date.", {
+        kind: "config",
+      });
+    }
     return (this.#messages.get(threadId) ?? [])
       .map((entry) => entry.message)
       .filter((message) => message.metadata.dateSent.getTime() >= sinceTime)
@@ -320,6 +339,12 @@ export class LoopbackChatAdapter {
     bucket.push({ message: cloneMessage(message), sequence });
     this.#messages.set(threadId, bucket);
     this.#nextSequence.set(threadId, sequence);
+  }
+
+  #nextMessageTimestamp(): string {
+    const timestamp = Math.max(Date.now(), this.#lastMessageTimestamp + 1);
+    this.#lastMessageTimestamp = timestamp;
+    return new Date(timestamp).toISOString();
   }
 }
 

--- a/src/providers/builtin/whatsapp.ts
+++ b/src/providers/builtin/whatsapp.ts
@@ -619,12 +619,22 @@ export function normalizeWhatsAppWebhookPayload(
 
   const normalized: NormalizedWhatsAppWebhookMessage[] = [];
   if (Array.isArray(payload.entry)) {
+    if (optionalString(payload, "object") !== "whatsapp_business_account") {
+      throw new CrablineError(
+        'WhatsApp webhook entry payloads require object="whatsapp_business_account"',
+        { kind: "inbound" },
+      );
+    }
     for (const entry of payload.entry) {
       if (!isRecord(entry) || !Array.isArray(entry.changes)) {
         continue;
       }
       for (const change of entry.changes) {
         if (!isRecord(change)) {
+          continue;
+        }
+        const field = optionalString(change, "field");
+        if (field !== undefined && field !== "messages") {
           continue;
         }
         const value = optionalRecord(change, "value");

--- a/src/servers/matrix.ts
+++ b/src/servers/matrix.ts
@@ -1,7 +1,12 @@
 import { createHash, randomBytes } from "node:crypto";
 import type { IncomingMessage } from "node:http";
 import path from "node:path";
-import { isMatrixEventId, isMatrixRoomId, isMatrixUserId } from "../matrix-ids.js";
+import {
+  isHistoricalMatrixUserId,
+  isMatrixEventId,
+  isMatrixRoomId,
+  isMatrixUserId,
+} from "../matrix-ids.js";
 import {
   adminAuthError,
   hasAdminToken,
@@ -468,6 +473,15 @@ function syncRoom(room: MatrixRoom, since: number | undefined, timelineLimit: nu
   };
 }
 
+function roomHasSyncUpdates(room: MatrixRoom, since: number | undefined): boolean {
+  return (
+    since === undefined ||
+    room.createdSequence > since ||
+    room.timeline.some((entry) => entry.sequence > since) ||
+    room.ephemeral.some((entry) => entry.sequence > since)
+  );
+}
+
 function parseSyncToken(value: string | null): number | null | undefined {
   if (value === null) {
     return undefined;
@@ -494,16 +508,14 @@ async function handleSync(url: URL, state: MatrixServerState): Promise<Response>
   const hasNewEvents =
     (state.directRoomsSequence !== undefined &&
       (since === undefined || state.directRoomsSequence > since)) ||
-    [...state.rooms.values()].some((room) =>
-      [...room.timeline, ...room.ephemeral].some(
-        (entry) => since === undefined || entry.sequence > since,
-      ),
-    );
+    [...state.rooms.values()].some((room) => roomHasSyncUpdates(room, since));
   if (since !== undefined && !hasNewEvents && timeout > 0) {
     await waitForSyncEvent(state, timeout);
   }
   const join = Object.fromEntries(
-    [...state.rooms.values()].map((room) => [room.id, syncRoom(room, since, timelineLimit)]),
+    [...state.rooms.values()]
+      .filter((room) => roomHasSyncUpdates(room, since))
+      .map((room) => [room.id, syncRoom(room, since, timelineLimit)]),
   );
   return jsonResponse({
     account_data: syncAccountData(state, since),
@@ -533,7 +545,7 @@ async function handleAdminInbound(params: {
   const threadId = readTrimmedString(params.body.threadId);
   if (
     !isMatrixRoomId(roomId) ||
-    !isMatrixUserId(sender) ||
+    !isHistoricalMatrixUserId(sender) ||
     (threadId !== undefined && !isMatrixEventId(threadId))
   ) {
     return jsonResponse({ error: "Invalid Matrix identifier", ok: false }, 400);
@@ -889,10 +901,14 @@ export async function startMatrixServer(
 ): Promise<StartedMatrixServer> {
   const host = params.host ?? "127.0.0.1";
   const serverName = params.serverName ?? "matrix.test";
+  const botUserId = params.botUserId ?? `@openclaw:${serverName}`;
+  if (!isMatrixUserId(botUserId)) {
+    throw new Error("botUserId must be a canonical Matrix user ID.");
+  }
   const state: MatrixServerState = {
     accessToken: params.accessToken ?? `syt_crabline_${randomBytes(12).toString("hex")}`,
     adminToken: params.adminToken ?? randomBytes(24).toString("hex"),
-    botUserId: params.botUserId ?? `@openclaw:${serverName}`,
+    botUserId,
     deviceId: params.deviceId ?? "CRABLINE",
     directRooms: new Map(),
     directRoomsSequence: undefined,
@@ -912,9 +928,7 @@ export async function startMatrixServer(
     nextFilter: 1,
     nextSequence: 1,
     onEvent: params.onEvent,
-    profiles: new Map([
-      [params.botUserId ?? `@openclaw:${serverName}`, { display_name: "OpenClaw QA" }],
-    ]),
+    profiles: new Map([[botUserId, { display_name: "OpenClaw QA" }]]),
     recorderPath: params.recorderPath ?? path.resolve("artifacts/crabline/matrix.jsonl"),
     rooms: new Map(),
     serverName,

--- a/src/servers/signal.ts
+++ b/src/servers/signal.ts
@@ -545,6 +545,16 @@ async function handleRpc(params: {
           : rpcError(-32602, "Invalid params", id),
       };
     }
+    const account = params.body.params.account;
+    if (typeof account === "string" && account !== params.state.account) {
+      return {
+        accepted: false,
+        record: false,
+        response: notification
+          ? new Response(null, { status: 204 })
+          : rpcError(-32602, "Specified account does not exist", id),
+      };
+    }
     const timestamp = nextSignalTimestamp(params.state);
     if (timestamp >= Number.MAX_SAFE_INTEGER) {
       return {
@@ -653,7 +663,7 @@ function hasValidOptionalSignalString(params: Record<string, unknown>, field: st
   return params[field] === undefined || typeof params[field] === "string";
 }
 
-function validSignalRpcParams(method: string, value: unknown): boolean {
+function validSignalRpcParams(method: string, value: unknown): value is Record<string, unknown> {
   if (
     !isJsonObject(value) ||
     !hasValidSignalRecipientFieldTypes(value) ||

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -34,6 +34,9 @@ import {
 } from "./telegram-identity.js";
 
 const TELEGRAM_MAX_REQUEST_BODY_BYTES = 50 * 1024 * 1024;
+const TELEGRAM_MAX_MULTIPART_HEADER_BYTES = 16 * 1024;
+const TELEGRAM_MAX_MULTIPART_PARTS = 128;
+const TELEGRAM_MAX_MULTIPART_TEXT_BYTES = 1024 * 1024;
 const TELEGRAM_WEBHOOK_MAX_BACKOFF_EXPONENT = 5;
 const TELEGRAM_WEBHOOK_RETRY_BASE_MS = 100;
 const TELEGRAM_WEBHOOK_DELIVERY_TIMEOUT_MS = 3_000;
@@ -175,6 +178,16 @@ type TelegramMultipartFile = {
   fileName: string;
 };
 
+type TelegramMultipartDisposition = {
+  fileName?: string | undefined;
+  name: string;
+};
+
+type TelegramMimeParameter = {
+  quoted: boolean;
+  value: string;
+};
+
 type TelegramChat = {
   id: number;
   title?: string;
@@ -290,12 +303,19 @@ function telegramError(description: string, status = 400): Response {
 }
 
 async function parseRequestBody(request: IncomingMessage): Promise<unknown> {
+  const contentType = request.headers["content-type"] ?? "";
+  const contentTypes = Array.isArray(contentType) ? contentType : [contentType];
+  const multipartType = contentTypes.find((entry) =>
+    entry.toLowerCase().includes("multipart/form-data"),
+  );
+  if (multipartType) {
+    return await parseMultipartFormDataRequest(request, multipartType);
+  }
+
   const body = await readBody(request, TELEGRAM_MAX_REQUEST_BODY_BYTES);
   if (body.length === 0) {
     return {};
   }
-  const contentType = request.headers["content-type"] ?? "";
-  const contentTypes = Array.isArray(contentType) ? contentType : [contentType];
   if (contentTypes.some(isJsonMediaType)) {
     try {
       return JSON.parse(body.toString("utf8")) as unknown;
@@ -303,44 +323,476 @@ async function parseRequestBody(request: IncomingMessage): Promise<unknown> {
       throw new InvalidJsonBodyError(error);
     }
   }
-  const multipartType = contentTypes.find((entry) =>
-    entry.toLowerCase().includes("multipart/form-data"),
-  );
-  if (multipartType) {
-    return await parseMultipartFormDataBody(body, multipartType);
-  }
   const params = new URLSearchParams(body.toString("utf8"));
   return Object.fromEntries(params.entries());
 }
 
-async function parseMultipartFormDataBody(
-  body: Buffer,
+function invalidTelegramMultipartBody(message: string): InvalidJsonBodyError {
+  return new InvalidJsonBodyError(new Error(message));
+}
+
+function parseTelegramMimeParameters(
+  value: string,
+  options: { decodeQuotedPairs?: boolean } = {},
+): {
+  parameters: Map<string, TelegramMimeParameter>;
+  type: string;
+} {
+  const separator = value.indexOf(";");
+  const type = value
+    .slice(0, separator < 0 ? value.length : separator)
+    .trim()
+    .toLowerCase();
+  const parameters = new Map<string, TelegramMimeParameter>();
+  let index = separator < 0 ? value.length : separator + 1;
+  while (index < value.length) {
+    while (index < value.length && /[\t ;]/u.test(value[index] ?? "")) {
+      index += 1;
+    }
+    if (index >= value.length) {
+      break;
+    }
+
+    const nameStart = index;
+    while (index < value.length && /[!#$%&'*+\-.^_`|~0-9A-Za-z]/u.test(value[index] ?? "")) {
+      index += 1;
+    }
+    const name = value.slice(nameStart, index).toLowerCase();
+    while (index < value.length && /[\t ]/u.test(value[index] ?? "")) {
+      index += 1;
+    }
+    if (!name || value[index] !== "=") {
+      throw invalidTelegramMultipartBody("Multipart header contains a malformed parameter.");
+    }
+    index += 1;
+    while (index < value.length && /[\t ]/u.test(value[index] ?? "")) {
+      index += 1;
+    }
+
+    let parameterValue = "";
+    let quoted = false;
+    if (value[index] === '"') {
+      quoted = true;
+      index += 1;
+      let closed = false;
+      while (index < value.length) {
+        const character = value[index];
+        index += 1;
+        if (character === "\\" && options.decodeQuotedPairs) {
+          if (index >= value.length) {
+            break;
+          }
+          parameterValue += value[index];
+          index += 1;
+        } else if (character === '"') {
+          closed = true;
+          break;
+        } else if (character === "\r" || character === "\n") {
+          break;
+        } else {
+          parameterValue += character;
+        }
+      }
+      if (!closed) {
+        throw invalidTelegramMultipartBody("Multipart header contains an unterminated quote.");
+      }
+      while (index < value.length && /[\t ]/u.test(value[index] ?? "")) {
+        index += 1;
+      }
+      if (index < value.length && value[index] !== ";") {
+        throw invalidTelegramMultipartBody("Multipart header contains trailing parameter data.");
+      }
+    } else {
+      const parameterStart = index;
+      while (index < value.length && value[index] !== ";") {
+        if (value[index] === "\r" || value[index] === "\n") {
+          throw invalidTelegramMultipartBody("Multipart header contains a line break.");
+        }
+        index += 1;
+      }
+      parameterValue = value.slice(parameterStart, index).trim();
+    }
+    parameters.set(name, { quoted, value: parameterValue });
+    if (value[index] === ";") {
+      index += 1;
+    }
+  }
+  return { parameters, type };
+}
+
+function parseTelegramMultipartBoundary(contentType: string): Buffer {
+  const parsed = parseTelegramMimeParameters(contentType, { decodeQuotedPairs: true });
+  const boundary = parsed.parameters.get("boundary")?.value;
+  if (
+    parsed.type !== "multipart/form-data" ||
+    !boundary ||
+    boundary.length > 70 ||
+    boundary.endsWith(" ") ||
+    !/^[0-9A-Za-z'()+_,./:=? -]+$/u.test(boundary)
+  ) {
+    throw invalidTelegramMultipartBody("Multipart boundary is missing or invalid.");
+  }
+  return Buffer.from(`--${boundary}`, "ascii");
+}
+
+function decodeTelegramMultipartParameter(parameter: TelegramMimeParameter): string {
+  return parameter.quoted
+    ? parameter.value.replace(/%0A/giu, "\n").replace(/%0D/giu, "\r").replace(/%22/giu, '"')
+    : parameter.value;
+}
+
+function decodeTelegramMultipartExtendedParameter(parameter: TelegramMimeParameter): string {
+  const extended = /^([^']*)'[^']*'(.*)$/u.exec(parameter.value);
+  if (!extended) {
+    return decodeTelegramMultipartParameter(parameter);
+  }
+  const charset = extended[1]?.toLowerCase();
+  if (charset !== "utf-8" && charset !== "us-ascii") {
+    return decodeTelegramMultipartParameter(parameter);
+  }
+  try {
+    return decodeURIComponent(extended[2] ?? "");
+  } catch {
+    return extended[2] ?? "";
+  }
+}
+
+function parseTelegramMultipartDisposition(headerBlock: Buffer): TelegramMultipartDisposition {
+  let contentDisposition: string | undefined;
+  for (const line of headerBlock.toString("utf8").split("\r\n")) {
+    const separator = line.indexOf(":");
+    if (separator <= 0) {
+      throw invalidTelegramMultipartBody("Multipart part contains a malformed header.");
+    }
+    if (line.slice(0, separator).trim().toLowerCase() === "content-disposition") {
+      contentDisposition = line.slice(separator + 1).trim();
+    }
+  }
+  if (!contentDisposition) {
+    throw invalidTelegramMultipartBody("Multipart part is missing a form-data disposition.");
+  }
+
+  const parsed = parseTelegramMimeParameters(contentDisposition);
+  if (parsed.type !== "form-data") {
+    throw invalidTelegramMultipartBody("Multipart part is missing a form-data disposition.");
+  }
+  const rawName = parsed.parameters.get("name");
+  if (rawName === undefined) {
+    throw invalidTelegramMultipartBody("Multipart part is missing a field name.");
+  }
+  const rawFileName = parsed.parameters.get("filename");
+  const rawExtendedFileName = parsed.parameters.get("filename*");
+  return {
+    ...(rawExtendedFileName !== undefined
+      ? { fileName: decodeTelegramMultipartExtendedParameter(rawExtendedFileName) }
+      : rawFileName !== undefined
+        ? { fileName: decodeTelegramMultipartParameter(rawFileName) }
+        : {}),
+    name: decodeTelegramMultipartParameter(rawName),
+  };
+}
+
+class TelegramMultipartReader {
+  readonly #iterator: AsyncIterator<Buffer | string>;
+  #buffer: Buffer<ArrayBufferLike> = Buffer.alloc(0);
+  #ended = false;
+  #totalBytes = 0;
+
+  constructor(
+    private readonly request: IncomingMessage,
+    private readonly maxBytes: number,
+  ) {
+    this.#iterator = request[Symbol.asyncIterator]() as AsyncIterator<Buffer | string>;
+  }
+
+  async readUntil(delimiter: Buffer, maxBytes: number): Promise<Buffer> {
+    const chunks: Buffer[] = [];
+    let length = 0;
+    while (true) {
+      const delimiterIndex = this.#buffer.indexOf(delimiter);
+      if (delimiterIndex >= 0) {
+        length += delimiterIndex;
+        if (length > maxBytes) {
+          throw new RequestBodyTooLargeError(maxBytes);
+        }
+        chunks.push(this.#buffer.subarray(0, delimiterIndex));
+        this.#consume(delimiterIndex + delimiter.length);
+        return Buffer.concat(chunks, length);
+      }
+
+      const emitLength = Math.max(0, this.#buffer.length - delimiter.length + 1);
+      if (emitLength > 0) {
+        length += emitLength;
+        if (length > maxBytes) {
+          throw new RequestBodyTooLargeError(maxBytes);
+        }
+        chunks.push(this.#buffer.subarray(0, emitLength));
+        this.#consume(emitLength);
+      }
+      if (!(await this.#readMore())) {
+        throw invalidTelegramMultipartBody("Multipart delimiter is incomplete.");
+      }
+    }
+  }
+
+  async readInitialBoundary(boundary: Buffer, maxPreambleBytes: number): Promise<"final" | "next"> {
+    const lineBoundary = Buffer.concat([Buffer.from("\r\n"), boundary]);
+    let preambleBytes = 0;
+    let checkBodyStart = true;
+    while (true) {
+      if (checkBodyStart) {
+        await this.#ensure(boundary.length + 2);
+        checkBodyStart = false;
+        if (this.#buffer.subarray(0, boundary.length).equals(boundary)) {
+          const suffix = await this.#readBoundarySuffix(boundary.length);
+          if (suffix) {
+            this.#consume(suffix.consumedBytes);
+            return suffix.kind;
+          }
+        }
+      }
+
+      const boundaryIndex = this.#buffer.indexOf(lineBoundary);
+      if (boundaryIndex >= 0) {
+        const suffixOffset = boundaryIndex + lineBoundary.length;
+        if (this.#buffer.length < suffixOffset + 2) {
+          if (boundaryIndex > 0) {
+            preambleBytes += boundaryIndex;
+            if (preambleBytes > maxPreambleBytes) {
+              throw new RequestBodyTooLargeError(maxPreambleBytes);
+            }
+            this.#consume(boundaryIndex);
+          }
+          if (!(await this.#readMore())) {
+            throw invalidTelegramMultipartBody("Multipart boundary is incomplete.");
+          }
+          continue;
+        }
+
+        const suffix = await this.#readBoundarySuffix(suffixOffset);
+        if (suffix) {
+          preambleBytes += boundaryIndex;
+          if (preambleBytes > maxPreambleBytes) {
+            throw new RequestBodyTooLargeError(maxPreambleBytes);
+          }
+          this.#consume(suffix.consumedBytes);
+          return suffix.kind;
+        }
+
+        const emitLength = suffixOffset;
+        preambleBytes += emitLength;
+        if (preambleBytes > maxPreambleBytes) {
+          throw new RequestBodyTooLargeError(maxPreambleBytes);
+        }
+        this.#consume(emitLength);
+        continue;
+      }
+
+      const emitLength = Math.max(0, this.#buffer.length - lineBoundary.length + 1);
+      if (emitLength > 0) {
+        preambleBytes += emitLength;
+        if (preambleBytes > maxPreambleBytes) {
+          throw new RequestBodyTooLargeError(maxPreambleBytes);
+        }
+        this.#consume(emitLength);
+      }
+      if (!(await this.#readMore())) {
+        throw invalidTelegramMultipartBody("Multipart body is missing its initial boundary.");
+      }
+    }
+  }
+
+  async readPartBody(
+    boundaryMarker: Buffer,
+    onChunk: (chunk: Buffer) => void,
+  ): Promise<"final" | "next"> {
+    while (true) {
+      const boundaryIndex = this.#buffer.indexOf(boundaryMarker);
+      if (boundaryIndex >= 0) {
+        const suffixOffset = boundaryIndex + boundaryMarker.length;
+        if (this.#buffer.length < suffixOffset + 2) {
+          if (boundaryIndex > 0) {
+            onChunk(this.#buffer.subarray(0, boundaryIndex));
+            this.#consume(boundaryIndex);
+          }
+          if (!(await this.#readMore())) {
+            throw invalidTelegramMultipartBody("Multipart boundary is incomplete.");
+          }
+          continue;
+        }
+
+        const suffix = await this.#readBoundarySuffix(suffixOffset);
+        if (suffix) {
+          if (boundaryIndex > 0) {
+            onChunk(this.#buffer.subarray(0, boundaryIndex));
+          }
+          this.#consume(suffix.consumedBytes);
+          return suffix.kind;
+        }
+
+        const emitLength = suffixOffset;
+        onChunk(this.#buffer.subarray(0, emitLength));
+        this.#consume(emitLength);
+        continue;
+      }
+
+      const emitLength = Math.max(0, this.#buffer.length - boundaryMarker.length + 1);
+      if (emitLength > 0) {
+        onChunk(this.#buffer.subarray(0, emitLength));
+        this.#consume(emitLength);
+      }
+      if (!(await this.#readMore())) {
+        throw invalidTelegramMultipartBody("Multipart body is missing its closing boundary.");
+      }
+    }
+  }
+
+  async consumeRemainder(): Promise<void> {
+    while (await this.#readMore()) {
+      this.#buffer = Buffer.alloc(0);
+    }
+  }
+
+  #consume(length: number): void {
+    this.#buffer = this.#buffer.subarray(length);
+  }
+
+  async #ensure(length: number): Promise<void> {
+    while (this.#buffer.length < length) {
+      if (!(await this.#readMore())) {
+        throw invalidTelegramMultipartBody("Multipart body ended unexpectedly.");
+      }
+    }
+  }
+
+  async #readBoundarySuffix(
+    suffixOffset: number,
+  ): Promise<{ consumedBytes: number; kind: "final" | "next" } | undefined> {
+    await this.#ensure(suffixOffset + 2);
+    const suffix = this.#buffer.subarray(suffixOffset, suffixOffset + 2);
+    const final = suffix.equals(Buffer.from("--"));
+    let lineEnd = suffixOffset + (final ? 2 : 0);
+    while (true) {
+      while (
+        lineEnd < this.#buffer.length &&
+        (this.#buffer[lineEnd] === 0x20 || this.#buffer[lineEnd] === 0x09)
+      ) {
+        lineEnd += 1;
+        if (lineEnd - suffixOffset > TELEGRAM_MAX_MULTIPART_HEADER_BYTES) {
+          return undefined;
+        }
+      }
+      if (lineEnd >= this.#buffer.length) {
+        if (await this.#readMore()) {
+          continue;
+        }
+        return final ? { consumedBytes: lineEnd, kind: "final" } : undefined;
+      }
+      if (this.#buffer[lineEnd] !== 0x0d) {
+        return undefined;
+      }
+      if (lineEnd + 1 >= this.#buffer.length) {
+        if (await this.#readMore()) {
+          continue;
+        }
+        return undefined;
+      }
+      return this.#buffer[lineEnd + 1] === 0x0a
+        ? { consumedBytes: lineEnd + 2, kind: final ? "final" : "next" }
+        : undefined;
+    }
+  }
+
+  async #readMore(): Promise<boolean> {
+    if (this.#ended) {
+      return false;
+    }
+    const next = await this.#iterator.next();
+    if (next.done) {
+      this.#ended = true;
+      return false;
+    }
+    const chunk = Buffer.isBuffer(next.value) ? next.value : Buffer.from(next.value);
+    this.#totalBytes += chunk.length;
+    if (this.#totalBytes > this.maxBytes) {
+      throw new RequestBodyTooLargeError(this.maxBytes);
+    }
+    this.#buffer =
+      this.#buffer.length === 0
+        ? chunk
+        : Buffer.concat([this.#buffer, chunk], this.#buffer.length + chunk.length);
+    return true;
+  }
+}
+
+function enforceTelegramMultipartContentLength(request: IncomingMessage): void {
+  const contentLengthHeader = request.headers["content-length"];
+  const contentLength = Array.isArray(contentLengthHeader)
+    ? contentLengthHeader[0]
+    : contentLengthHeader;
+  if (contentLength && /^\d+$/u.test(contentLength)) {
+    const bytes = Number(contentLength);
+    if (!Number.isSafeInteger(bytes) || bytes > TELEGRAM_MAX_REQUEST_BODY_BYTES) {
+      drainRequestBody(request);
+      throw new RequestBodyTooLargeError(TELEGRAM_MAX_REQUEST_BODY_BYTES);
+    }
+  }
+}
+
+async function parseMultipartFormDataRequest(
+  request: IncomingMessage,
   contentType: string,
 ): Promise<Record<string, unknown>> {
-  let form: FormData;
+  enforceTelegramMultipartContentLength(request);
   try {
-    form = await new Request("http://localhost", {
-      body,
-      headers: { "content-type": contentType },
-      method: "POST",
-    }).formData();
+    const boundary = parseTelegramMultipartBoundary(contentType);
+    const bodyBoundary = Buffer.concat([Buffer.from("\r\n"), boundary]);
+    const reader = new TelegramMultipartReader(request, TELEGRAM_MAX_REQUEST_BODY_BYTES);
+    const fields: Record<string, unknown> = {};
+    let retainedTextBytes = 0;
+    let partCount = 0;
+    let boundaryKind = await reader.readInitialBoundary(
+      boundary,
+      TELEGRAM_MAX_MULTIPART_HEADER_BYTES,
+    );
+    while (boundaryKind !== "final") {
+      partCount += 1;
+      if (partCount > TELEGRAM_MAX_MULTIPART_PARTS) {
+        throw new RequestBodyTooLargeError(TELEGRAM_MAX_MULTIPART_PARTS);
+      }
+      const disposition = parseTelegramMultipartDisposition(
+        await reader.readUntil(Buffer.from("\r\n\r\n"), TELEGRAM_MAX_MULTIPART_HEADER_BYTES),
+      );
+      const digest = disposition.fileName === undefined ? undefined : createHash("sha256");
+      const textChunks: Buffer[] = [];
+      let textLength = 0;
+      boundaryKind = await reader.readPartBody(bodyBoundary, (chunk) => {
+        if (digest) {
+          digest.update(chunk);
+          return;
+        }
+        retainedTextBytes += chunk.length;
+        textLength += chunk.length;
+        if (retainedTextBytes > TELEGRAM_MAX_MULTIPART_TEXT_BYTES) {
+          throw new RequestBodyTooLargeError(TELEGRAM_MAX_MULTIPART_TEXT_BYTES);
+        }
+        textChunks.push(Buffer.from(chunk));
+      });
+      fields[disposition.name] =
+        digest && disposition.fileName !== undefined
+          ? ({
+              [TELEGRAM_MULTIPART_FILE]: true,
+              contentDigest: digest.digest("base64url"),
+              fileName: disposition.fileName,
+            } satisfies TelegramMultipartFile)
+          : Buffer.concat(textChunks, textLength).toString("utf8");
+    }
+    await reader.consumeRemainder();
+    return fields;
   } catch (error) {
-    throw new InvalidJsonBodyError(error);
+    drainRequestBody(request);
+    throw error;
   }
-  const fields: Record<string, unknown> = {};
-  for (const [name, value] of form) {
-    fields[name] =
-      typeof value === "string"
-        ? value
-        : ({
-            [TELEGRAM_MULTIPART_FILE]: true,
-            contentDigest: createHash("sha256")
-              .update(Buffer.from(await value.arrayBuffer()))
-              .digest("base64url"),
-            fileName: value.name,
-          } satisfies TelegramMultipartFile);
-  }
-  return fields;
 }
 
 function requireTelegramBotPath(pathname: string): { method: string; token: string } | undefined {

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -382,7 +382,11 @@ function parseTelegramMimeParameters(
           if (index >= value.length) {
             break;
           }
-          parameterValue += value[index];
+          const quotedCharacter = value[index];
+          if (quotedCharacter === "\r" || quotedCharacter === "\n") {
+            break;
+          }
+          parameterValue += quotedCharacter;
           index += 1;
         } else if (character === '"') {
           closed = true;
@@ -472,7 +476,7 @@ function parseTelegramMultipartDisposition(headerBlock: Buffer): TelegramMultipa
     throw invalidTelegramMultipartBody("Multipart part is missing a form-data disposition.");
   }
 
-  const parsed = parseTelegramMimeParameters(contentDisposition);
+  const parsed = parseTelegramMimeParameters(contentDisposition, { decodeQuotedPairs: true });
   if (parsed.type !== "form-data") {
     throw invalidTelegramMultipartBody("Multipart part is missing a form-data disposition.");
   }

--- a/src/servers/whatsapp-baileys-websocket.ts
+++ b/src/servers/whatsapp-baileys-websocket.ts
@@ -47,10 +47,14 @@ const MAX_PENDING_WEBSOCKET_MESSAGES = 32;
 const MAX_WHATSAPP_PENDING_ACKNOWLEDGEMENTS = 10_000;
 const MAX_WHATSAPP_PENDING_ACKNOWLEDGEMENT_AGE_MS = 5 * 60 * 1_000;
 const MAX_WHATSAPP_RECENT_ACKNOWLEDGEMENTS = 10_000;
+const MAX_NODE_TIMER_DELAY_MS = 2_147_483_647;
 export const MAX_WHATSAPP_WEBSOCKET_FRAGMENTS = 1_024;
 export const MAX_WHATSAPP_SIGNAL_BUNDLES = 1_024;
+export const MAX_WHATSAPP_SIGNAL_PREKEYS_PER_BUNDLE = 32;
 export const MAX_WHATSAPP_SIGNAL_SESSIONS_PER_BUNDLE = 32;
 export const MAX_WHATSAPP_WEBSOCKET_CLOSE_REASON_BYTES = 123;
+export const WHATSAPP_MESSAGE_ACCEPTANCE_TIMEOUT_MS = 5_000;
+export const WHATSAPP_SIGNAL_PREKEY_RESERVATION_TTL_MS = 5 * 60 * 1_000;
 type NodeBuffer = Buffer<ArrayBufferLike>;
 type WhatsAppWebSocketRawData = NodeBuffer | ArrayBuffer | NodeBuffer[];
 type WhatsAppWebSocketSendTarget = {
@@ -76,6 +80,7 @@ export type WhatsAppBaileysWebSocketServerParams = {
   appendEvent(event: ServerRequestEvent): Promise<void>;
   httpServer: Server;
   maxPendingInboundMessages?: number | undefined;
+  messageAcceptanceTimeoutMs?: number | undefined;
   path: string;
   selfJid: string;
 };
@@ -122,7 +127,10 @@ export type WhatsAppSignalDecryptResult<T> =
   | { status: "rejected" };
 
 export type WhatsAppSignalBundleStoreOptions = {
+  maxPreKeysPerBundle?: number | undefined;
   maxSessionsPerBundle?: number | undefined;
+  messageAcceptanceTimeoutMs?: number | undefined;
+  preKeyReservationTtlMs?: number | undefined;
 };
 
 type PendingWhatsAppAcknowledgement = {
@@ -131,14 +139,59 @@ type PendingWhatsAppAcknowledgement = {
   acknowledged: boolean;
 };
 
+type StoredSignalBundle = Omit<MockSignalBundle, "preKey" | "preKeyId"> & {
+  availablePreKeyIds: number[];
+  nextPreKeyId: number;
+  pendingPreKeyIds: Set<number>;
+  preKeyReservations: Map<number, number>;
+  preKeys: Map<number, KeyPair>;
+};
+
+type WhatsAppMessageAcceptanceOptions = {
+  onTerminalTimeout?: (() => void) | undefined;
+  signal?: AbortSignal | undefined;
+  terminalDrain?: (() => Promise<"acknowledged" | "retryable">) | undefined;
+  timeoutMs?: number | undefined;
+};
+
+type TerminalWhatsAppAcceptance = {
+  error: Error;
+};
+
+async function awaitWithAbort<T>(operation: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) {
+    return await operation;
+  }
+  signal.throwIfAborted();
+  return await new Promise<T>((resolve, reject) => {
+    const abort = () => reject(signal.reason);
+    signal.addEventListener("abort", abort, { once: true });
+    void operation.then(
+      (value) => {
+        signal.removeEventListener("abort", abort);
+        resolve(value);
+      },
+      (error) => {
+        signal.removeEventListener("abort", abort);
+        reject(error);
+      },
+    );
+  });
+}
+
 export class WhatsAppSignalBundleStore {
   readonly #acknowledgedMessageIds = new Map<string, true>();
-  readonly #bundles = new Map<string, MockSignalBundle>();
+  readonly #bundles = new Map<string, StoredSignalBundle>();
   readonly #lidByPhoneNumber = new Map<string, string>();
+  readonly #maxPreKeysPerBundle: number;
   readonly #maxSessionsPerBundle: number;
+  readonly #maxTerminalAcceptances: number;
+  readonly #messageAcceptanceTimeoutMs: number;
   readonly #pendingAcknowledgements = new Map<string, PendingWhatsAppAcknowledgement>();
   readonly #pendingTransactions = new Map<string, Promise<void>>();
+  readonly #preKeyReservationTtlMs: number;
   readonly #sessions = new Map<string, Map<string, SessionRecord>>();
+  readonly #terminalAcceptances = new Map<string, TerminalWhatsAppAcceptance>();
 
   constructor(
     private readonly maxBundles = MAX_WHATSAPP_SIGNAL_BUNDLES,
@@ -148,13 +201,34 @@ export class WhatsAppSignalBundleStore {
     private readonly now: () => number = Date.now,
     options: WhatsAppSignalBundleStoreOptions = {},
   ) {
+    const maxPreKeysPerBundle =
+      options.maxPreKeysPerBundle ?? MAX_WHATSAPP_SIGNAL_PREKEYS_PER_BUNDLE;
     const maxSessionsPerBundle =
       options.maxSessionsPerBundle ?? MAX_WHATSAPP_SIGNAL_SESSIONS_PER_BUNDLE;
+    const messageAcceptanceTimeoutMs =
+      options.messageAcceptanceTimeoutMs ?? WHATSAPP_MESSAGE_ACCEPTANCE_TIMEOUT_MS;
+    const preKeyReservationTtlMs =
+      options.preKeyReservationTtlMs ?? WHATSAPP_SIGNAL_PREKEY_RESERVATION_TTL_MS;
     if (!Number.isSafeInteger(maxBundles) || maxBundles < 1) {
       throw new Error("WhatsApp maxSignalBundles must be a positive safe integer.");
     }
     if (!Number.isSafeInteger(maxSessionsPerBundle) || maxSessionsPerBundle < 1) {
       throw new Error("WhatsApp maxSignalSessionsPerBundle must be a positive safe integer.");
+    }
+    if (!Number.isSafeInteger(maxPreKeysPerBundle) || maxPreKeysPerBundle < 1) {
+      throw new Error("WhatsApp maxSignalPreKeysPerBundle must be a positive safe integer.");
+    }
+    if (
+      !Number.isSafeInteger(messageAcceptanceTimeoutMs) ||
+      messageAcceptanceTimeoutMs < 1 ||
+      messageAcceptanceTimeoutMs > MAX_NODE_TIMER_DELAY_MS
+    ) {
+      throw new Error(
+        `WhatsApp messageAcceptanceTimeoutMs must be a positive integer no greater than ${MAX_NODE_TIMER_DELAY_MS}.`,
+      );
+    }
+    if (!Number.isSafeInteger(preKeyReservationTtlMs) || preKeyReservationTtlMs < 1) {
+      throw new Error("WhatsApp preKeyReservationTtlMs must be a positive safe integer.");
     }
     if (!Number.isSafeInteger(maxPendingAcknowledgements) || maxPendingAcknowledgements < 1) {
       throw new Error("WhatsApp maxPendingAcknowledgements must be a positive safe integer.");
@@ -168,7 +242,14 @@ export class WhatsAppSignalBundleStore {
     ) {
       throw new Error("WhatsApp maxPendingAcknowledgementAgeMs must be a positive safe integer.");
     }
+    this.#maxPreKeysPerBundle = maxPreKeysPerBundle;
     this.#maxSessionsPerBundle = maxSessionsPerBundle;
+    this.#maxTerminalAcceptances = Math.min(
+      Number.MAX_SAFE_INTEGER,
+      maxPendingAcknowledgements + maxRecentAcknowledgements,
+    );
+    this.#messageAcceptanceTimeoutMs = messageAcceptanceTimeoutMs;
+    this.#preKeyReservationTtlMs = preKeyReservationTtlMs;
   }
 
   get size(): number {
@@ -187,39 +268,112 @@ export class WhatsAppSignalBundleStore {
     return count;
   }
 
-  async acceptMessageOnce(messageKey: string, operation: () => Promise<boolean>): Promise<boolean> {
+  async acceptMessageOnce(
+    messageKey: string,
+    operation: (signal: AbortSignal) => Promise<boolean>,
+    options: WhatsAppMessageAcceptanceOptions = {},
+  ): Promise<boolean> {
     this.#recoverExpiredPendingAcknowledgements();
     const pendingAcceptance = this.#pendingAcknowledgements.get(messageKey);
     if (pendingAcceptance) {
       return await pendingAcceptance.acceptance;
     }
+    const terminalAcceptance = this.#terminalAcceptances.get(messageKey);
+    if (terminalAcceptance) {
+      this.#terminalAcceptances.delete(messageKey);
+      this.#terminalAcceptances.set(messageKey, terminalAcceptance);
+      throw terminalAcceptance.error;
+    }
     if (this.#acknowledgedMessageIds.delete(messageKey)) {
       this.#acknowledgedMessageIds.set(messageKey, true);
       return true;
+    }
+    if (
+      this.#terminalAcceptances.size + this.#pendingAcknowledgements.size >=
+      this.#maxTerminalAcceptances
+    ) {
+      throw new Error(
+        `WhatsApp terminal acceptance limit exceeded (${this.#maxTerminalAcceptances}).`,
+      );
     }
     if (this.#pendingAcknowledgements.size >= this.maxPendingAcknowledgements) {
       throw new Error(
         `WhatsApp pending acknowledgement limit exceeded (${this.maxPendingAcknowledgements}).`,
       );
     }
+    const timeoutMs = options.timeoutMs ?? this.#messageAcceptanceTimeoutMs;
+    if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > MAX_NODE_TIMER_DELAY_MS) {
+      throw new Error(
+        `WhatsApp message acceptance timeout must be a positive integer no greater than ${MAX_NODE_TIMER_DELAY_MS}.`,
+      );
+    }
+    const controller = new AbortController();
+    const operationPromise = Promise.resolve().then(() => operation(controller.signal));
+    let terminalFenced = false;
+    const fenceTerminalAcceptance = (error: Error) => {
+      if (terminalFenced) {
+        return;
+      }
+      terminalFenced = true;
+      controller.abort(error);
+      const terminalDrain = Promise.all([
+        operationPromise.then(
+          () => undefined,
+          () => undefined,
+        ),
+        Promise.resolve()
+          .then(() => options.terminalDrain?.())
+          .then(
+            (disposition) => disposition ?? "retryable",
+            () => "retryable" as const,
+          ),
+      ]).then(([, disposition]) => disposition);
+      this.#rememberTerminalAcceptance(messageKey, error, terminalDrain);
+    };
+    const abortFromOwner = () => {
+      const reason = options.signal?.reason;
+      fenceTerminalAcceptance(
+        reason instanceof Error ? reason : new Error("WhatsApp message acceptance cancelled."),
+      );
+    };
+    if (options.signal?.aborted) {
+      abortFromOwner();
+    } else {
+      options.signal?.addEventListener("abort", abortFromOwner, { once: true });
+    }
+    const timeout = setTimeout(() => {
+      const error = new Error("WhatsApp message acceptance timed out.");
+      fenceTerminalAcceptance(error);
+      options.onTerminalTimeout?.();
+    }, timeoutMs);
+    timeout.unref();
     let pendingAcknowledgement: PendingWhatsAppAcknowledgement;
     const acceptance = Promise.resolve().then(async () => {
       try {
-        const accepted = await operation();
+        const accepted = await awaitWithAbort(operationPromise, controller.signal);
         if (!accepted) {
-          this.#pendingAcknowledgements.delete(messageKey);
+          if (this.#pendingAcknowledgements.get(messageKey) === pendingAcknowledgement) {
+            this.#pendingAcknowledgements.delete(messageKey);
+          }
           return false;
         }
         if (pendingAcknowledgement.acknowledged) {
-          this.#pendingAcknowledgements.delete(messageKey);
+          if (this.#pendingAcknowledgements.get(messageKey) === pendingAcknowledgement) {
+            this.#pendingAcknowledgements.delete(messageKey);
+          }
           this.#rememberAcknowledgedMessage(messageKey);
         } else {
           pendingAcknowledgement.acceptedAt = this.now();
         }
         return true;
       } catch (error) {
-        this.#pendingAcknowledgements.delete(messageKey);
+        if (this.#pendingAcknowledgements.get(messageKey) === pendingAcknowledgement) {
+          this.#pendingAcknowledgements.delete(messageKey);
+        }
         throw error;
+      } finally {
+        clearTimeout(timeout);
+        options.signal?.removeEventListener("abort", abortFromOwner);
       }
     });
     pendingAcknowledgement = {
@@ -292,7 +446,99 @@ export class WhatsAppSignalBundleStore {
       // Published bundle identities stay stable for the store lifetime.
       throw new Error(`WhatsApp signal bundle limit exceeded (${this.maxBundles}).`);
     }
-    return identityKeys.map((identityKey) => this.#resolve(identityKey));
+    const stagedNewBundles = new Map<string, StoredSignalBundle>();
+    const stagedReservations = new Map<
+      string,
+      {
+        availablePreKeyIds: number[];
+        bundle: StoredSignalBundle;
+        nextPreKeyId: number;
+        preKeyReservations: Map<number, number>;
+        preKeys: Map<number, KeyPair>;
+      }
+    >();
+    const reservationNow = this.now();
+    const stagedForIdentity = (identityKey: string) => {
+      let bundle = this.#bundles.get(identityKey) ?? stagedNewBundles.get(identityKey);
+      if (!bundle) {
+        bundle = this.#createBundle();
+        stagedNewBundles.set(identityKey, bundle);
+      }
+      let staged = stagedReservations.get(identityKey);
+      if (!staged) {
+        const preKeys = new Map(bundle.preKeys);
+        const preKeyReservations = new Map(bundle.preKeyReservations);
+        for (const [preKeyId, reservedAt] of preKeyReservations) {
+          if (reservationNow - reservedAt >= this.#preKeyReservationTtlMs) {
+            preKeyReservations.delete(preKeyId);
+            preKeys.delete(preKeyId);
+          }
+        }
+        staged = {
+          availablePreKeyIds: bundle.availablePreKeyIds.filter((id) => preKeys.has(id)),
+          bundle,
+          nextPreKeyId: bundle.nextPreKeyId,
+          preKeyReservations,
+          preKeys,
+        };
+        stagedReservations.set(identityKey, staged);
+      }
+      return staged;
+    };
+    const requestedPreKeys = new Map<string, number>();
+    for (const identityKey of identityKeys) {
+      requestedPreKeys.set(identityKey, (requestedPreKeys.get(identityKey) ?? 0) + 1);
+    }
+    for (const [identityKey, requested] of requestedPreKeys) {
+      const staged = stagedForIdentity(identityKey);
+      const available = staged.availablePreKeyIds.length;
+      const creatable = Math.max(
+        0,
+        this.#maxPreKeysPerBundle - staged.preKeys.size - staged.bundle.pendingPreKeyIds.size,
+      );
+      if (requested > available + creatable) {
+        throw new Error(
+          `WhatsApp Signal prekey reservation limit exceeded (${this.#maxPreKeysPerBundle}).`,
+        );
+      }
+    }
+    const reservedBundles = identityKeys.map((identityKey) => {
+      const staged = stagedForIdentity(identityKey);
+      const { bundle } = staged;
+      let preKeyId = staged.availablePreKeyIds.shift();
+      if (preKeyId === undefined) {
+        const created = this.#createPreKey(
+          staged.preKeys,
+          staged.nextPreKeyId,
+          staged.bundle.pendingPreKeyIds,
+        );
+        preKeyId = created.id;
+        staged.preKeys.set(created.id, created.keyPair);
+        staged.nextPreKeyId = created.nextPreKeyId;
+      }
+      const preKey = staged.preKeys.get(preKeyId);
+      if (!preKey) {
+        throw new Error("WhatsApp Signal prekey reservation is unavailable.");
+      }
+      staged.preKeyReservations.set(preKeyId, reservationNow);
+      return {
+        identityKey: bundle.identityKey,
+        preKey,
+        preKeyId,
+        registrationId: bundle.registrationId,
+        signedPreKey: bundle.signedPreKey,
+      };
+    });
+    for (const [identityKey, bundle] of stagedNewBundles) {
+      this.#bundles.set(identityKey, bundle);
+    }
+    for (const staged of stagedReservations.values()) {
+      staged.bundle.availablePreKeyIds = staged.availablePreKeyIds;
+      staged.bundle.nextPreKeyId = staged.nextPreKeyId;
+      staged.bundle.preKeyReservations = staged.preKeyReservations;
+      staged.bundle.preKeys = staged.preKeys;
+    }
+    return reservedBundles;
   }
 
   async decryptDirectMessage(params: {
@@ -316,8 +562,10 @@ export class WhatsAppSignalBundleStore {
     ciphertext: Uint8Array;
     recipientJid: string;
     remoteJid: string;
+    signal?: AbortSignal | undefined;
     type: "msg" | "pkmsg";
   }): Promise<WhatsAppSignalDecryptResult<T>> {
+    params.signal?.throwIfAborted();
     const recipientJid = canonicalizeWhatsAppUserCorrelationJid(params.recipientJid);
     const recipientIdentityKey = recipientJid ? signalBundleIdentityKey(recipientJid) : undefined;
     const mappedLidIdentityKey = recipientIdentityKey
@@ -338,6 +586,7 @@ export class WhatsAppSignalBundleStore {
     const address = new ProtocolAddress(remoteAddress.name, remoteAddress.deviceId);
     // Capacity checks, staged writes, and commits stay atomic per recipient bundle.
     return await this.#runTransaction(identityKey, async () => {
+      params.signal?.throwIfAborted();
       const sessions = this.#sessions.get(identityKey) ?? new Map<string, SessionRecord>();
       const sessionLimitError = new Error("WhatsApp Signal session limit exceeded.");
       const maxSessionsPerBundle = this.#maxSessionsPerBundle;
@@ -360,10 +609,8 @@ export class WhatsAppSignalBundleStore {
         },
         isTrustedIdentity: () => true,
         async loadPreKey(id) {
-          if (String(id) !== String(bundle.preKeyId)) {
-            return undefined;
-          }
-          return signalKeyPair(bundle.preKey);
+          const preKey = bundle.preKeys.get(Number(id));
+          return preKey ? signalKeyPair(preKey) : undefined;
         },
         removePreKey(id) {
           stagedPreKeyRemovals.add(id);
@@ -385,45 +632,85 @@ export class WhatsAppSignalBundleStore {
         }
         return { error, status: "decrypt-failed" };
       }
-      const replacementPreKey = stagedPreKeyRemovals.has(bundle.preKeyId)
-        ? {
-            id: bundle.preKeyId === 0xff_ff_ff ? 1 : bundle.preKeyId + 1,
-            keyPair: generateSignalKeyPair(),
-          }
-        : undefined;
-      const accepted = await params.accept(plaintext);
-      if (accepted === undefined) {
-        return { status: "rejected" };
+      params.signal?.throwIfAborted();
+      let stagedNextPreKeyId = bundle.nextPreKeyId;
+      const stagedPreKeyIds = new Set<number>();
+      const replacementPreKeys = [...stagedPreKeyRemovals]
+        .filter((id) => bundle.preKeys.has(id))
+        .map(() => {
+          const unavailableIds = new Set([...bundle.pendingPreKeyIds, ...stagedPreKeyIds]);
+          const created = this.#createPreKey(bundle.preKeys, stagedNextPreKeyId, unavailableIds);
+          stagedNextPreKeyId = created.nextPreKeyId;
+          stagedPreKeyIds.add(created.id);
+          return created;
+        });
+      for (const replacementPreKey of replacementPreKeys) {
+        bundle.pendingPreKeyIds.add(replacementPreKey.id);
       }
-      for (const [id, session] of stagedSessions) {
-        sessions.set(id, session);
+      bundle.nextPreKeyId = stagedNextPreKeyId;
+      try {
+        const accepted = await awaitWithAbort(
+          Promise.resolve().then(() => params.accept(plaintext)),
+          params.signal,
+        );
+        if (accepted === undefined) {
+          return { status: "rejected" };
+        }
+        params.signal?.throwIfAborted();
+        for (const [id, session] of stagedSessions) {
+          sessions.set(id, session);
+        }
+        if (stagedSessions.size > 0) {
+          this.#sessions.set(identityKey, sessions);
+        }
+        for (const id of stagedPreKeyRemovals) {
+          bundle.preKeyReservations.delete(id);
+          bundle.preKeys.delete(id);
+        }
+        for (const replacementPreKey of replacementPreKeys) {
+          bundle.preKeys.set(replacementPreKey.id, replacementPreKey.keyPair);
+          bundle.availablePreKeyIds.push(replacementPreKey.id);
+        }
+        return { status: "accepted", value: accepted };
+      } finally {
+        for (const replacementPreKey of replacementPreKeys) {
+          bundle.pendingPreKeyIds.delete(replacementPreKey.id);
+        }
       }
-      if (stagedSessions.size > 0) {
-        this.#sessions.set(identityKey, sessions);
-      }
-      if (replacementPreKey) {
-        bundle.preKey = replacementPreKey.keyPair;
-        bundle.preKeyId = replacementPreKey.id;
-      }
-      return { status: "accepted", value: accepted };
     });
   }
 
-  #resolve(bundleKey: string): MockSignalBundle {
-    const existing = this.#bundles.get(bundleKey);
-    if (existing) {
-      return existing;
-    }
+  #createBundle(): StoredSignalBundle {
     const identityKey = generateSignalKeyPair();
-    const bundle = {
+    return {
+      availablePreKeyIds: [],
       identityKey,
-      preKey: generateSignalKeyPair(),
-      preKeyId: 1,
+      nextPreKeyId: 1,
+      pendingPreKeyIds: new Set<number>(),
+      preKeyReservations: new Map<number, number>(),
+      preKeys: new Map<number, KeyPair>(),
       registrationId: 1,
       signedPreKey: signedKeyPair(identityKey, 1),
     };
-    this.#bundles.set(bundleKey, bundle);
-    return bundle;
+  }
+
+  #createPreKey(
+    preKeys: ReadonlyMap<number, KeyPair>,
+    startingId: number,
+    stagedIds: ReadonlySet<number> = new Set(),
+  ): { id: number; keyPair: KeyPair; nextPreKeyId: number } {
+    let id = startingId;
+    while (preKeys.has(id) || stagedIds.has(id)) {
+      id = id === 0xff_ff_ff ? 1 : id + 1;
+      if (id === startingId) {
+        throw new Error("WhatsApp Signal prekey identifier space exhausted.");
+      }
+    }
+    return {
+      id,
+      keyPair: generateSignalKeyPair(),
+      nextPreKeyId: id === 0xff_ff_ff ? 1 : id + 1,
+    };
   }
 
   #recoverExpiredPendingAcknowledgements(): void {
@@ -450,6 +737,23 @@ export class WhatsAppSignalBundleStore {
         this.#acknowledgedMessageIds.delete(oldestMessageKey);
       }
     }
+  }
+
+  #rememberTerminalAcceptance(
+    messageKey: string,
+    error: Error,
+    drain: Promise<"acknowledged" | "retryable">,
+  ): void {
+    const terminalAcceptance = { error };
+    this.#terminalAcceptances.set(messageKey, terminalAcceptance);
+    void drain.then((disposition) => {
+      if (this.#terminalAcceptances.get(messageKey) === terminalAcceptance) {
+        this.#terminalAcceptances.delete(messageKey);
+      }
+      if (disposition === "acknowledged") {
+        this.#rememberAcknowledgedMessage(messageKey);
+      }
+    });
   }
 
   async #runTransaction<T>(key: string, operation: () => Promise<T>): Promise<T> {
@@ -772,6 +1076,7 @@ class BaileysNoiseServer {
 }
 
 class WhatsAppBaileysWebSocketSession {
+  readonly #acceptanceAbort = new AbortController();
   #handshakeState: "client-finish" | "client-hello" | "open" = "client-hello";
   readonly #handleSerializedMessage: (data: WhatsAppWebSocketRawData) => Promise<void>;
   readonly #noise = new BaileysNoiseServer();
@@ -804,6 +1109,12 @@ class WhatsAppBaileysWebSocketSession {
 
   handleMessage(data: WhatsAppWebSocketRawData): Promise<void> {
     return this.#handleSerializedMessage(data);
+  }
+
+  abortAcceptance(reason: unknown): void {
+    if (!this.#acceptanceAbort.signal.aborted) {
+      this.#acceptanceAbort.abort(reason);
+    }
   }
 
   async deliverInboundMessage(message: WhatsAppBaileysInboundMessage): Promise<boolean> {
@@ -858,8 +1169,15 @@ class WhatsAppBaileysWebSocketSession {
       const peer = requireAttr(node, "to");
       const messageId = requireAttr(node, "id");
       const accepted = await persistAcceptedBaileysMessage({
+        acceptanceSignal: this.#acceptanceAbort.signal,
         appendEvent: this.params.appendEvent,
         node,
+        onAcceptanceTimeout: () => {
+          const close = resolveWhatsAppWebSocketClose(
+            new Error("WhatsApp message acceptance timed out."),
+          );
+          this.socket.close(close.code, close.reason);
+        },
         path: this.params.path,
         remoteJid: this.params.selfJid,
         signalBundles: this.params.signalBundles,
@@ -1167,7 +1485,14 @@ function truncateWebSocketCloseReason(reason: string): string {
 export function attachWhatsAppBaileysWebSocketServer(
   params: WhatsAppBaileysWebSocketServerParams,
 ): WhatsAppBaileysWebSocketServer {
-  const signalBundles = new WhatsAppSignalBundleStore();
+  const signalBundles = new WhatsAppSignalBundleStore(
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    { messageAcceptanceTimeoutMs: params.messageAcceptanceTimeoutMs },
+  );
   const sessions = new Set<WhatsAppBaileysWebSocketSession>();
   const pendingSessionMessages = new Set<Promise<void>>();
   const pendingMessages: WhatsAppBaileysInboundMessage[] = [];
@@ -1242,8 +1567,12 @@ export function attachWhatsAppBaileysWebSocketServer(
       signalBundles,
     });
     sessions.add(session);
-    socket.once("close", () => sessions.delete(session));
+    socket.once("close", () => {
+      session.abortAcceptance(new Error("WhatsApp WebSocket closed."));
+      sessions.delete(session);
+    });
     socket.on("error", () => {
+      session.abortAcceptance(new Error("WhatsApp WebSocket failed."));
       sessions.delete(session);
       socket.terminate();
     });
@@ -1261,6 +1590,9 @@ export function attachWhatsAppBaileysWebSocketServer(
       closing = true;
       params.httpServer.off("upgrade", handleUpgrade);
       pendingMessages.length = 0;
+      for (const session of sessions) {
+        session.abortAcceptance(new Error("WhatsApp WebSocket server is shutting down."));
+      }
       await closeWebSocketServer(wss);
       const messageResults = await Promise.allSettled([...pendingSessionMessages]);
       await flushPromise;
@@ -1368,8 +1700,10 @@ function children(node: BinaryNode): BinaryNode[] {
 }
 
 export async function persistAcceptedBaileysMessage(params: {
+  acceptanceSignal?: AbortSignal | undefined;
   appendEvent(event: ServerRequestEvent): Promise<void>;
   node: BinaryNode;
+  onAcceptanceTimeout?: (() => void) | undefined;
   path: string;
   remoteJid: string;
   signalBundles: WhatsAppSignalBundleStore;
@@ -1379,70 +1713,124 @@ export async function persistAcceptedBaileysMessage(params: {
   if (!peer || !messageId) {
     return false;
   }
-  return await params.signalBundles.acceptMessageOnce(`${peer}\0${messageId}`, async () => {
-    const candidates = encryptedMessageCandidates(params.node);
-    if (candidates.length === 0) {
-      await params.appendEvent({
-        accepted: true,
-        at: new Date().toISOString(),
-        body: sanitizeNodeForJson(params.node),
-        method: "WEBSOCKET",
-        path: params.path,
-        query: {},
-        type: "api",
-      } as ServerRequestEvent & { accepted: true });
-      return true;
-    }
-    const remoteCorrelationJid = canonicalizeWhatsAppUserCorrelationJid(params.remoteJid);
-    candidates.sort((left, right) => {
-      const leftIsSelf =
-        canonicalizeWhatsAppUserCorrelationJid(left.recipientJid) === remoteCorrelationJid;
-      const rightIsSelf =
-        canonicalizeWhatsAppUserCorrelationJid(right.recipientJid) === remoteCorrelationJid;
-      return Number(leftIsSelf) - Number(rightIsSelf);
-    });
-    for (const candidate of candidates) {
-      const result = await params.signalBundles.transactDirectMessage({
-        accept: async (decrypted) => {
-          let text: string | undefined;
-          try {
-            text = readWhatsAppConversation(unpadRandomMax16(decrypted));
-          } catch {
-            text = undefined;
-          }
-          const message: WhatsAppBaileysInboundMessage | undefined = text
-            ? {
-                key: {
-                  fromMe: true,
-                  id: messageId,
-                  remoteJid: peer,
-                },
-                message: { conversation: text },
-                messageTimestamp: Math.floor(Date.now() / 1000),
-              }
-            : undefined;
-          await params.appendEvent({
-            accepted: true,
-            at: new Date().toISOString(),
-            body: message ?? sanitizeNodeForJson(params.node),
-            method: "WEBSOCKET",
-            path: params.path,
-            query: {},
-            type: "api",
-          } as ServerRequestEvent & { accepted: true });
-          return true;
-        },
-        ciphertext: candidate.ciphertext,
-        recipientJid: candidate.recipientJid,
-        remoteJid: params.remoteJid,
-        type: candidate.type,
-      });
-      if (result.status === "accepted") {
-        return true;
-      }
-    }
-    return false;
+  let persistenceSucceeded = false;
+  let operationSettled!: () => void;
+  const operationSettlement = new Promise<void>((resolve) => {
+    operationSettled = resolve;
   });
+  let requiresSignalCommit = false;
+  let signalCommitSucceeded = false;
+  const pendingAcceptanceOperations = new Set<Promise<unknown>>();
+  const trackAcceptanceOperation = <T>(operation: Promise<T>): Promise<T> => {
+    pendingAcceptanceOperations.add(operation);
+    void operation.then(
+      () => {
+        persistenceSucceeded = true;
+        pendingAcceptanceOperations.delete(operation);
+      },
+      () => pendingAcceptanceOperations.delete(operation),
+    );
+    return operation;
+  };
+  const drainAcceptanceOperations = async (): Promise<"acknowledged" | "retryable"> => {
+    while (pendingAcceptanceOperations.size > 0) {
+      await Promise.allSettled([...pendingAcceptanceOperations]);
+    }
+    await operationSettlement;
+    return persistenceSucceeded && (!requiresSignalCommit || signalCommitSucceeded)
+      ? "acknowledged"
+      : "retryable";
+  };
+  return await params.signalBundles.acceptMessageOnce(
+    `${peer}\0${messageId}`,
+    async (acceptanceSignal) => {
+      try {
+        acceptanceSignal.throwIfAborted();
+        const candidates = encryptedMessageCandidates(params.node);
+        requiresSignalCommit = candidates.length > 0;
+        if (candidates.length === 0) {
+          await awaitWithAbort(
+            trackAcceptanceOperation(
+              params.appendEvent({
+                accepted: true,
+                at: new Date().toISOString(),
+                body: sanitizeNodeForJson(params.node),
+                method: "WEBSOCKET",
+                path: params.path,
+                query: {},
+                type: "api",
+              } as ServerRequestEvent & { accepted: true }),
+            ),
+            acceptanceSignal,
+          );
+          return true;
+        }
+        const remoteCorrelationJid = canonicalizeWhatsAppUserCorrelationJid(params.remoteJid);
+        candidates.sort((left, right) => {
+          const leftIsSelf =
+            canonicalizeWhatsAppUserCorrelationJid(left.recipientJid) === remoteCorrelationJid;
+          const rightIsSelf =
+            canonicalizeWhatsAppUserCorrelationJid(right.recipientJid) === remoteCorrelationJid;
+          return Number(leftIsSelf) - Number(rightIsSelf);
+        });
+        for (const candidate of candidates) {
+          const result = await params.signalBundles.transactDirectMessage({
+            accept: async (decrypted) => {
+              let text: string | undefined;
+              try {
+                text = readWhatsAppConversation(unpadRandomMax16(decrypted));
+              } catch {
+                text = undefined;
+              }
+              const message: WhatsAppBaileysInboundMessage | undefined = text
+                ? {
+                    key: {
+                      fromMe: true,
+                      id: messageId,
+                      remoteJid: peer,
+                    },
+                    message: { conversation: text },
+                    messageTimestamp: Math.floor(Date.now() / 1000),
+                  }
+                : undefined;
+              await awaitWithAbort(
+                trackAcceptanceOperation(
+                  params.appendEvent({
+                    accepted: true,
+                    at: new Date().toISOString(),
+                    body: message ?? sanitizeNodeForJson(params.node),
+                    method: "WEBSOCKET",
+                    path: params.path,
+                    query: {},
+                    type: "api",
+                  } as ServerRequestEvent & { accepted: true }),
+                ),
+                acceptanceSignal,
+              );
+              return true;
+            },
+            ciphertext: candidate.ciphertext,
+            recipientJid: candidate.recipientJid,
+            remoteJid: params.remoteJid,
+            signal: acceptanceSignal,
+            type: candidate.type,
+          });
+          if (result.status === "accepted") {
+            signalCommitSucceeded = true;
+            return true;
+          }
+        }
+        return false;
+      } finally {
+        operationSettled();
+      }
+    },
+    {
+      onTerminalTimeout: params.onAcceptanceTimeout,
+      signal: params.acceptanceSignal,
+      terminalDrain: drainAcceptanceOperations,
+    },
+  );
 }
 
 function encryptedMessageCandidates(node: BinaryNode): Array<{

--- a/src/servers/whatsapp-baileys-websocket.ts
+++ b/src/servers/whatsapp-baileys-websocket.ts
@@ -1797,7 +1797,7 @@ export async function persistAcceptedBaileysMessage(params: {
   const operationSettlement = new Promise<void>((resolve) => {
     operationSettled = resolve;
   });
-  let requiresSignalCommit = false;
+  let requiresSignalCommit = wasPreviouslyPersisted;
   let signalCommitSucceeded = false;
   const pendingAcceptanceOperations = new Set<Promise<unknown>>();
   const trackAcceptanceOperation = <T>(operation: Promise<T>): Promise<T> => {

--- a/src/servers/whatsapp-baileys-websocket.ts
+++ b/src/servers/whatsapp-baileys-websocket.ts
@@ -145,12 +145,13 @@ type StoredSignalBundle = Omit<MockSignalBundle, "preKey" | "preKeyId"> & {
   pendingPreKeyIds: Set<number>;
   preKeyReservations: Map<number, number>;
   preKeys: Map<number, KeyPair>;
+  protectedPreKeyIds: Map<number, number>;
 };
 
 type WhatsAppMessageAcceptanceOptions = {
   onTerminalTimeout?: (() => void) | undefined;
   signal?: AbortSignal | undefined;
-  terminalDrain?: (() => Promise<"acknowledged" | "retryable">) | undefined;
+  terminalDrain?: (() => Promise<"acknowledged" | "persisted" | "retryable">) | undefined;
   timeoutMs?: number | undefined;
 };
 
@@ -186,9 +187,11 @@ export class WhatsAppSignalBundleStore {
   readonly #maxPreKeysPerBundle: number;
   readonly #maxSessionsPerBundle: number;
   readonly #maxTerminalAcceptances: number;
+  readonly #messagePreKeyProtections = new Map<string, Map<string, Set<number>>>();
   readonly #messageAcceptanceTimeoutMs: number;
   readonly #pendingAcknowledgements = new Map<string, PendingWhatsAppAcknowledgement>();
   readonly #pendingTransactions = new Map<string, Promise<void>>();
+  readonly #persistedMessageIds = new Map<string, true>();
   readonly #preKeyReservationTtlMs: number;
   readonly #sessions = new Map<string, Map<string, SessionRecord>>();
   readonly #terminalAcceptances = new Map<string, TerminalWhatsAppAcceptance>();
@@ -403,6 +406,37 @@ export class WhatsAppSignalBundleStore {
     }
   }
 
+  hasPersistedMessage(messageKey: string): boolean {
+    return this.#persistedMessageIds.has(messageKey);
+  }
+
+  clearPersistedMessage(messageKey: string): void {
+    this.#persistedMessageIds.delete(messageKey);
+    this.releaseMessagePreKeyProtection(messageKey);
+  }
+
+  releaseMessagePreKeyProtection(messageKey: string): void {
+    const protections = this.#messagePreKeyProtections.get(messageKey);
+    if (!protections) {
+      return;
+    }
+    this.#messagePreKeyProtections.delete(messageKey);
+    for (const [identityKey, preKeyIds] of protections) {
+      const bundle = this.#bundles.get(identityKey);
+      if (!bundle) {
+        continue;
+      }
+      for (const preKeyId of preKeyIds) {
+        const references = bundle.protectedPreKeyIds.get(preKeyId) ?? 0;
+        if (references <= 1) {
+          bundle.protectedPreKeyIds.delete(preKeyId);
+        } else {
+          bundle.protectedPreKeyIds.set(preKeyId, references - 1);
+        }
+      }
+    }
+  }
+
   associateLid(phoneNumberJid: string, lidJid: string): void {
     const phoneNumber = canonicalizeWhatsAppUserCorrelationJid(phoneNumberJid);
     const lid = canonicalizeWhatsAppUserCorrelationJid(lidJid);
@@ -469,7 +503,10 @@ export class WhatsAppSignalBundleStore {
         const preKeys = new Map(bundle.preKeys);
         const preKeyReservations = new Map(bundle.preKeyReservations);
         for (const [preKeyId, reservedAt] of preKeyReservations) {
-          if (reservationNow - reservedAt >= this.#preKeyReservationTtlMs) {
+          if (
+            reservationNow - reservedAt >= this.#preKeyReservationTtlMs &&
+            !bundle.protectedPreKeyIds.has(preKeyId)
+          ) {
             preKeyReservations.delete(preKeyId);
             preKeys.delete(preKeyId);
           }
@@ -560,6 +597,7 @@ export class WhatsAppSignalBundleStore {
   async transactDirectMessage<T>(params: {
     accept(plaintext: Buffer): Promise<T | undefined>;
     ciphertext: Uint8Array;
+    messageKey?: string | undefined;
     recipientJid: string;
     remoteJid: string;
     signal?: AbortSignal | undefined;
@@ -608,8 +646,11 @@ export class WhatsAppSignalBundleStore {
           stagedSessions.set(id, cloneSignalSession(session));
         },
         isTrustedIdentity: () => true,
-        async loadPreKey(id) {
+        loadPreKey: async (id) => {
           const preKey = bundle.preKeys.get(Number(id));
+          if (preKey && params.messageKey) {
+            this.#protectMessagePreKey(params.messageKey, identityKey, Number(id));
+          }
           return preKey ? signalKeyPair(preKey) : undefined;
         },
         removePreKey(id) {
@@ -689,6 +730,7 @@ export class WhatsAppSignalBundleStore {
       pendingPreKeyIds: new Set<number>(),
       preKeyReservations: new Map<number, number>(),
       preKeys: new Map<number, KeyPair>(),
+      protectedPreKeyIds: new Map<number, number>(),
       registrationId: 1,
       signedPreKey: signedKeyPair(identityKey, 1),
     };
@@ -739,10 +781,43 @@ export class WhatsAppSignalBundleStore {
     }
   }
 
+  #rememberPersistedMessage(messageKey: string): void {
+    this.#persistedMessageIds.delete(messageKey);
+    this.#persistedMessageIds.set(messageKey, true);
+    if (this.#persistedMessageIds.size > this.maxRecentAcknowledgements) {
+      const oldestMessageKey = this.#persistedMessageIds.keys().next().value;
+      if (oldestMessageKey !== undefined) {
+        this.#persistedMessageIds.delete(oldestMessageKey);
+        this.releaseMessagePreKeyProtection(oldestMessageKey);
+      }
+    }
+  }
+
+  #protectMessagePreKey(messageKey: string, identityKey: string, preKeyId: number): void {
+    let protections = this.#messagePreKeyProtections.get(messageKey);
+    if (!protections) {
+      protections = new Map<string, Set<number>>();
+      this.#messagePreKeyProtections.set(messageKey, protections);
+    }
+    let preKeyIds = protections.get(identityKey);
+    if (!preKeyIds) {
+      preKeyIds = new Set<number>();
+      protections.set(identityKey, preKeyIds);
+    }
+    if (preKeyIds.has(preKeyId)) {
+      return;
+    }
+    preKeyIds.add(preKeyId);
+    const bundle = this.#bundles.get(identityKey);
+    if (bundle) {
+      bundle.protectedPreKeyIds.set(preKeyId, (bundle.protectedPreKeyIds.get(preKeyId) ?? 0) + 1);
+    }
+  }
+
   #rememberTerminalAcceptance(
     messageKey: string,
     error: Error,
-    drain: Promise<"acknowledged" | "retryable">,
+    drain: Promise<"acknowledged" | "persisted" | "retryable">,
   ): void {
     const terminalAcceptance = { error };
     this.#terminalAcceptances.set(messageKey, terminalAcceptance);
@@ -752,6 +827,8 @@ export class WhatsAppSignalBundleStore {
       }
       if (disposition === "acknowledged") {
         this.#rememberAcknowledgedMessage(messageKey);
+      } else if (disposition === "persisted") {
+        this.#rememberPersistedMessage(messageKey);
       }
     });
   }
@@ -1713,7 +1790,9 @@ export async function persistAcceptedBaileysMessage(params: {
   if (!peer || !messageId) {
     return false;
   }
-  let persistenceSucceeded = false;
+  const messageKey = `${peer}\0${messageId}`;
+  const wasPreviouslyPersisted = params.signalBundles.hasPersistedMessage(messageKey);
+  let persistenceSucceeded = wasPreviouslyPersisted;
   let operationSettled!: () => void;
   const operationSettlement = new Promise<void>((resolve) => {
     operationSettled = resolve;
@@ -1732,37 +1811,47 @@ export async function persistAcceptedBaileysMessage(params: {
     );
     return operation;
   };
-  const drainAcceptanceOperations = async (): Promise<"acknowledged" | "retryable"> => {
+  const drainAcceptanceOperations = async (): Promise<
+    "acknowledged" | "persisted" | "retryable"
+  > => {
     while (pendingAcceptanceOperations.size > 0) {
       await Promise.allSettled([...pendingAcceptanceOperations]);
     }
     await operationSettlement;
-    return persistenceSucceeded && (!requiresSignalCommit || signalCommitSucceeded)
-      ? "acknowledged"
-      : "retryable";
+    if (!persistenceSucceeded) {
+      params.signalBundles.releaseMessagePreKeyProtection(messageKey);
+      return "retryable";
+    }
+    if (!requiresSignalCommit || signalCommitSucceeded) {
+      params.signalBundles.releaseMessagePreKeyProtection(messageKey);
+      return "acknowledged";
+    }
+    return "persisted";
   };
-  return await params.signalBundles.acceptMessageOnce(
-    `${peer}\0${messageId}`,
+  const accepted = await params.signalBundles.acceptMessageOnce(
+    messageKey,
     async (acceptanceSignal) => {
       try {
         acceptanceSignal.throwIfAborted();
         const candidates = encryptedMessageCandidates(params.node);
         requiresSignalCommit = candidates.length > 0;
         if (candidates.length === 0) {
-          await awaitWithAbort(
-            trackAcceptanceOperation(
-              params.appendEvent({
-                accepted: true,
-                at: new Date().toISOString(),
-                body: sanitizeNodeForJson(params.node),
-                method: "WEBSOCKET",
-                path: params.path,
-                query: {},
-                type: "api",
-              } as ServerRequestEvent & { accepted: true }),
-            ),
-            acceptanceSignal,
-          );
+          if (!wasPreviouslyPersisted) {
+            await awaitWithAbort(
+              trackAcceptanceOperation(
+                params.appendEvent({
+                  accepted: true,
+                  at: new Date().toISOString(),
+                  body: sanitizeNodeForJson(params.node),
+                  method: "WEBSOCKET",
+                  path: params.path,
+                  query: {},
+                  type: "api",
+                } as ServerRequestEvent & { accepted: true }),
+              ),
+              acceptanceSignal,
+            );
+          }
           return true;
         }
         const remoteCorrelationJid = canonicalizeWhatsAppUserCorrelationJid(params.remoteJid);
@@ -1793,23 +1882,26 @@ export async function persistAcceptedBaileysMessage(params: {
                     messageTimestamp: Math.floor(Date.now() / 1000),
                   }
                 : undefined;
-              await awaitWithAbort(
-                trackAcceptanceOperation(
-                  params.appendEvent({
-                    accepted: true,
-                    at: new Date().toISOString(),
-                    body: message ?? sanitizeNodeForJson(params.node),
-                    method: "WEBSOCKET",
-                    path: params.path,
-                    query: {},
-                    type: "api",
-                  } as ServerRequestEvent & { accepted: true }),
-                ),
-                acceptanceSignal,
-              );
+              if (!wasPreviouslyPersisted) {
+                await awaitWithAbort(
+                  trackAcceptanceOperation(
+                    params.appendEvent({
+                      accepted: true,
+                      at: new Date().toISOString(),
+                      body: message ?? sanitizeNodeForJson(params.node),
+                      method: "WEBSOCKET",
+                      path: params.path,
+                      query: {},
+                      type: "api",
+                    } as ServerRequestEvent & { accepted: true }),
+                  ),
+                  acceptanceSignal,
+                );
+              }
               return true;
             },
             ciphertext: candidate.ciphertext,
+            messageKey,
             recipientJid: candidate.recipientJid,
             remoteJid: params.remoteJid,
             signal: acceptanceSignal,
@@ -1822,6 +1914,9 @@ export async function persistAcceptedBaileysMessage(params: {
         }
         return false;
       } finally {
+        if (!acceptanceSignal.aborted && !signalCommitSucceeded) {
+          params.signalBundles.releaseMessagePreKeyProtection(messageKey);
+        }
         operationSettled();
       }
     },
@@ -1831,6 +1926,10 @@ export async function persistAcceptedBaileysMessage(params: {
       terminalDrain: drainAcceptanceOperations,
     },
   );
+  if (accepted) {
+    params.signalBundles.clearPersistedMessage(messageKey);
+  }
+  return accepted;
 }
 
 function encryptedMessageCandidates(node: BinaryNode): Array<{

--- a/src/servers/whatsapp-wire/binary-node.ts
+++ b/src/servers/whatsapp-wire/binary-node.ts
@@ -9,6 +9,7 @@ export type BinaryNode = {
 
 export const WHATSAPP_BINARY_NODE_MAX_COMPRESSED_BYTES = 1024 * 1024;
 export const WHATSAPP_BINARY_NODE_MAX_DECOMPRESSED_BYTES = 8 * 1024 * 1024;
+export const WHATSAPP_BINARY_NODE_MAX_FRAME_BYTES = WHATSAPP_BINARY_NODE_MAX_DECOMPRESSED_BYTES + 1;
 export const WHATSAPP_BINARY_NODE_MAX_DEPTH = 128;
 export const WHATSAPP_BINARY_NODE_MAX_NODES = 32_768;
 export const WHATSAPP_BINARY_NODE_MAX_LIST_ITEMS = 131_072;
@@ -499,12 +500,22 @@ function writeBudgetedListStart(buffer: number[], size: number, budget: BinaryNo
 }
 
 function pushByte(buffer: number[], value: number): void {
+  assertEncodedCapacity(buffer, 1);
   buffer.push(value & 0xff);
 }
 
 function pushBytes(buffer: number[], bytes: Uint8Array): void {
+  assertEncodedCapacity(buffer, bytes.length);
   for (const byte of bytes) {
-    pushByte(buffer, byte);
+    buffer.push(byte & 0xff);
+  }
+}
+
+function assertEncodedCapacity(buffer: number[], additionalBytes: number): void {
+  if (buffer.length + additionalBytes > WHATSAPP_BINARY_NODE_MAX_FRAME_BYTES) {
+    throw new Error(
+      `WhatsApp binary node frame exceeds ${WHATSAPP_BINARY_NODE_MAX_FRAME_BYTES} bytes.`,
+    );
   }
 }
 

--- a/src/servers/whatsapp.ts
+++ b/src/servers/whatsapp.ts
@@ -36,6 +36,7 @@ const WHATSAPP_GENERATED_MESSAGE_ID_RE = /^wamid\.FAKE(\d{8,})$/u;
 const DEFAULT_GRAPH_VERSION = "v25.0";
 const MAX_WHATSAPP_READABLE_MESSAGE_IDS = 10_000;
 const MAX_WHATSAPP_RECENT_MESSAGE_IDS = 10_000;
+const MAX_WHATSAPP_TEXT_MESSAGE_CHARACTERS = 4_096;
 
 function createDefaultAccessToken(): string {
   return `EAA${randomBytes(24).toString("base64url")}`;
@@ -311,6 +312,12 @@ function readTextMessageBody(body: Record<string, unknown>): string | Response {
     return graphParameterError(
       "(#100) Missing required parameter: text.body",
       "A WhatsApp text send requires text.body.",
+    );
+  }
+  if ([...text].length > MAX_WHATSAPP_TEXT_MESSAGE_CHARACTERS) {
+    return graphParameterError(
+      "(#100) Invalid parameter: text.body",
+      `text.body must not exceed ${MAX_WHATSAPP_TEXT_MESSAGE_CHARACTERS} characters.`,
     );
   }
   return text;

--- a/src/servers/whatsapp.ts
+++ b/src/servers/whatsapp.ts
@@ -32,8 +32,10 @@ import {
 
 const WHATSAPP_CLOUD_RECIPIENT_RE = /^\d{7,15}$/u;
 const WHATSAPP_GRAPH_VERSION_RE = /^v\d+\.\d+$/u;
+const WHATSAPP_GENERATED_MESSAGE_ID_RE = /^wamid\.FAKE(\d{8,})$/u;
 const DEFAULT_GRAPH_VERSION = "v25.0";
 const MAX_WHATSAPP_READABLE_MESSAGE_IDS = 10_000;
+const MAX_WHATSAPP_RECENT_MESSAGE_IDS = 10_000;
 
 function createDefaultAccessToken(): string {
   return `EAA${randomBytes(24).toString("base64url")}`;
@@ -48,7 +50,9 @@ type WhatsAppServerState = {
   ): PreparedWhatsAppBaileysInboundDelivery | undefined;
   graphVersion: string;
   inboundMessageIds: Set<string>;
-  nextMessageId: number;
+  pendingMessageIds: Set<string>;
+  recentMessageIds: Map<string, true>;
+  nextMessageId: bigint;
   onEvent: ServerEventObserver | undefined;
   phoneNumberId: string;
   recorderPath: string;
@@ -95,6 +99,7 @@ export type StartWhatsAppServerParams = {
   graphVersion?: string | undefined;
   host?: string | undefined;
   maxPendingInboundMessages?: number | undefined;
+  messageAcceptanceTimeoutMs?: number | undefined;
   onEvent?: ServerEventObserver | undefined;
   phoneNumberId?: string | undefined;
   port?: number | undefined;
@@ -104,6 +109,7 @@ export type StartWhatsAppServerParams = {
 
 type WhatsAppAdminInboundResult = {
   message?: WhatsAppBaileysMessage | undefined;
+  messageIdReservation?: WhatsAppMessageIdReservation | undefined;
   response?: Response | undefined;
   webhook?: Record<string, unknown> | undefined;
 };
@@ -205,8 +211,62 @@ function requireAuth(request: IncomingMessage, state: WhatsAppServerState): bool
   return match?.[1] === state.accessToken;
 }
 
-function nextMessageId(state: WhatsAppServerState): string {
-  return `wamid.FAKE${String(state.nextMessageId++).padStart(8, "0")}`;
+type WhatsAppMessageIdReservation = {
+  cancel(): void;
+  commit(): void;
+  id: string;
+};
+
+function reserveMessageId(
+  state: WhatsAppServerState,
+  requestedId?: string,
+): WhatsAppMessageIdReservation | Response {
+  let id = requestedId;
+  if (id) {
+    if (state.pendingMessageIds.has(id) || state.recentMessageIds.has(id)) {
+      return graphParameterError(
+        "(#100) Invalid parameter: messageId",
+        "messageId must be unique within this WhatsApp server.",
+      );
+    }
+  } else {
+    do {
+      id = `wamid.FAKE${String(state.nextMessageId++).padStart(8, "0")}`;
+    } while (state.pendingMessageIds.has(id) || state.recentMessageIds.has(id));
+  }
+  state.pendingMessageIds.add(id);
+  let settled = false;
+  return {
+    cancel() {
+      if (!settled) {
+        settled = true;
+        state.pendingMessageIds.delete(id);
+      }
+    },
+    commit() {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      state.pendingMessageIds.delete(id);
+      state.recentMessageIds.delete(id);
+      state.recentMessageIds.set(id, true);
+      if (state.recentMessageIds.size > MAX_WHATSAPP_RECENT_MESSAGE_IDS) {
+        const oldestId = state.recentMessageIds.keys().next().value;
+        if (oldestId !== undefined) {
+          state.recentMessageIds.delete(oldestId);
+        }
+      }
+      const generatedSequence = WHATSAPP_GENERATED_MESSAGE_ID_RE.exec(id)?.[1];
+      if (generatedSequence) {
+        const sequence = BigInt(generatedSequence);
+        if (sequence >= state.nextMessageId) {
+          state.nextMessageId = sequence + 1n;
+        }
+      }
+    },
+    id,
+  };
 }
 
 function waIdFromJid(jid: string): string {
@@ -308,9 +368,14 @@ function prepareSendMessage(params: {
   }
   return {
     commit() {
+      const reservation = reserveMessageId(params.state);
+      if (reservation instanceof Response) {
+        return reservation;
+      }
+      reservation.commit();
       const message = createWhatsAppMessage({
         fromMe: true,
-        id: nextMessageId(params.state),
+        id: reservation.id,
         remoteJid: `${to}@s.whatsapp.net`,
         text,
       });
@@ -396,9 +461,16 @@ async function handleAdminInbound(params: {
       ),
     };
   }
+  const messageIdReservation = reserveMessageId(
+    params.state,
+    readTrimmedString(params.body.messageId),
+  );
+  if (messageIdReservation instanceof Response) {
+    return { response: messageIdReservation };
+  }
   const message = createWhatsAppMessage({
     fromMe: false,
-    id: readTrimmedString(params.body.messageId) ?? nextMessageId(params.state),
+    id: messageIdReservation.id,
     pushName: readTrimmedString(params.body.pushName) ?? "Test User",
     remoteJid: isGroupChat ? chatJid : directPeerIdentity(chatJid),
     senderJid: isGroupChat ? senderJid : undefined,
@@ -440,7 +512,7 @@ async function handleAdminInbound(params: {
     ],
     object: "whatsapp_business_account",
   };
-  return { message, webhook };
+  return { message, messageIdReservation, webhook };
 }
 
 async function handleRequest(params: { request: IncomingMessage; state: WhatsAppServerState }) {
@@ -478,6 +550,7 @@ async function handleRequest(params: { request: IncomingMessage; state: WhatsApp
       ? params.state.prepareInboundMessage(result.message)
       : undefined;
     if (result.message && !preparedDelivery) {
+      result.messageIdReservation?.cancel();
       return graphError({
         code: 4,
         details: "The pending WhatsApp inbound queue is full.",
@@ -493,13 +566,21 @@ async function handleRequest(params: { request: IncomingMessage; state: WhatsApp
       await appendEvent(params.state, event);
     } catch (error) {
       preparedDelivery?.cancel();
+      result.messageIdReservation?.cancel();
       throw error;
     }
     if (result.message && preparedDelivery) {
-      const delivery = await preparedDelivery.commit();
-      rememberInboundMessageId(params.state, result.message.key.id);
-      return whatsappOk({ delivery, message: result.message, webhook: result.webhook });
+      try {
+        const delivery = await preparedDelivery.commit();
+        result.messageIdReservation?.commit();
+        rememberInboundMessageId(params.state, result.message.key.id);
+        return whatsappOk({ delivery, message: result.message, webhook: result.webhook });
+      } catch (error) {
+        result.messageIdReservation?.cancel();
+        throw error;
+      }
     }
+    result.messageIdReservation?.cancel();
     return graphParameterError("(#100) Invalid inbound WhatsApp event");
   }
 
@@ -611,7 +692,9 @@ export async function startWhatsAppServer(
     displayPhoneNumber: params.displayPhoneNumber ?? "15550000000",
     graphVersion,
     inboundMessageIds: new Set(),
-    nextMessageId: 1,
+    pendingMessageIds: new Set(),
+    recentMessageIds: new Map(),
+    nextMessageId: 1n,
     onEvent: params.onEvent,
     phoneNumberId,
     recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "whatsapp.jsonl"),
@@ -653,6 +736,7 @@ export async function startWhatsAppServer(
     appendEvent: (event: ServerRequestEvent) => appendEvent(state, event),
     httpServer: httpServer.server,
     maxPendingInboundMessages,
+    messageAcceptanceTimeoutMs: params.messageAcceptanceTimeoutMs,
     path: "/ws/chat",
     selfJid: state.selfJid,
   };

--- a/test/loopback-adapter.test.ts
+++ b/test/loopback-adapter.test.ts
@@ -1,10 +1,11 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { CrablineError } from "../src/core/errors.js";
 import { LoopbackChatAdapter } from "../src/providers/builtin/loopback.js";
 
 let adapter: LoopbackChatAdapter | undefined;
 
 afterEach(() => {
+  vi.useRealTimers();
   adapter = undefined;
 });
 
@@ -15,9 +16,38 @@ describe("loopback chat adapter", () => {
     for (const address of [
       { id: "user:1", threadId: "dm::1" },
       { channelId: "channel:1", id: "user:1", threadId: "topic::1" },
+      {
+        channelId: "channel/%:?#[]@!$&'()*+,;=\u96EA",
+        id: "user/%:?#[]@!$&'()*+,;=\u72D0",
+        threadId: "topic/%:?#[]@!$&'()*+,;=\uD83E\uDD8A",
+      },
     ]) {
       expect(adapter.decodeThreadId(adapter.encodeThreadId(address))).toEqual(address);
     }
+  });
+
+  it.each([
+    { id: "" },
+    { channelId: "", id: "user" },
+    { id: "user", threadId: "" },
+    { id: "\uD800" },
+    { channelId: "\uD800", id: "user" },
+    { id: "user", threadId: "\uD800" },
+  ])("rejects invalid v2 encoder components: %o", (address) => {
+    adapter = new LoopbackChatAdapter("crabline");
+
+    let failure: unknown;
+    try {
+      adapter.encodeThreadId(address);
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(CrablineError);
+    expect(failure).toMatchObject({
+      kind: "inbound",
+      message: "Loopback v2 thread address is malformed.",
+    });
   });
 
   it("recovers delimiter-containing v2 channel ids for thread metadata", async () => {
@@ -132,6 +162,42 @@ describe("loopback chat adapter", () => {
       );
     },
   );
+
+  it("preserves message order with unique timestamps across coarse and regressing clocks", async () => {
+    vi.useFakeTimers();
+    const initialTime = new Date("2026-07-14T07:00:00.000Z");
+    vi.setSystemTime(initialTime);
+    adapter = new LoopbackChatAdapter("crabline");
+    const threadId = adapter.encodeThreadId({ id: "user-1" });
+
+    const first = adapter.ingestUserMessage(threadId, "first");
+    const second = await adapter.postMessage(threadId, "second");
+    vi.setSystemTime(new Date(initialTime.getTime() - 1_000));
+    adapter.ingestUserMessage(threadId, "third");
+    await adapter.editMessage(threadId, second.id, "second edited");
+
+    const messages = adapter.listSince(threadId, first.raw.timestamp);
+    expect(messages.map((message) => message.text)).toEqual(["first", "second edited", "third"]);
+    expect(messages.map((message) => Date.parse(message.raw.timestamp))).toEqual([
+      initialTime.getTime(),
+      initialTime.getTime() + 1,
+      initialTime.getTime() + 2,
+    ]);
+    expect(messages[1]?.metadata.editedAt?.getTime()).toBe(initialTime.getTime() + 3);
+  });
+
+  it("rejects invalid history timestamps instead of reporting empty history", () => {
+    adapter = new LoopbackChatAdapter("crabline");
+    const threadId = adapter.encodeThreadId({ id: "user-1" });
+    adapter.ingestUserMessage(threadId, "first");
+
+    expect(() => adapter!.listSince(threadId, "not-a-date")).toThrow(
+      expect.objectContaining({
+        kind: "config",
+        message: "Loopback since timestamp must be a valid date.",
+      }),
+    );
+  });
 
   it("isolates stored messages from mutable inputs and returns", async () => {
     adapter = new LoopbackChatAdapter("crabline");

--- a/test/matrix-server.test.ts
+++ b/test/matrix-server.test.ts
@@ -478,7 +478,7 @@ describe("Matrix local provider server", () => {
     });
   });
 
-  it("accepts whitespace in domain-scoped identifier localparts", async () => {
+  it("accepts historical user localparts for inbound event senders", async () => {
     const server = await startMatrixServer();
     servers.push(server);
     const roomId = "!room name:matrix.test";
@@ -530,6 +530,23 @@ describe("Matrix local provider server", () => {
       event: { sender: "@:matrix.test" },
       ok: true,
     });
+  });
+
+  it("requires a canonical configured bot user ID", async () => {
+    for (const botUserId of [
+      "@:matrix.test",
+      "@Alice:matrix.test",
+      "@alice smith:matrix.test",
+      "@alice*:matrix.test",
+    ]) {
+      await expect(startMatrixServer({ botUserId })).rejects.toThrow(
+        "botUserId must be a canonical Matrix user ID.",
+      );
+    }
+
+    const server = await startMatrixServer({ botUserId: "@open+claw:matrix.test" });
+    servers.push(server);
+    expect(server.manifest.botUserId).toBe("@open+claw:matrix.test");
   });
 
   it("accepts numeric DNS-form Matrix server names", async () => {
@@ -1275,6 +1292,61 @@ describe("Matrix local provider server", () => {
         type: "m.room.member",
       }),
     );
+  });
+
+  it("omits unchanged rooms from incremental syncs", async () => {
+    const server = await startMatrixServer({
+      accessToken: "test-token-placeholder",
+      adminToken: "test-auth-token",
+      roomId: "!quiet:matrix.test",
+    });
+    servers.push(server);
+    const changedRoomId = "!changed:matrix.test";
+    const sendInbound = (text: string) =>
+      fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({
+          roomId: changedRoomId,
+          senderId: "@alice:matrix.test",
+          text,
+        }),
+        headers: {
+          "content-type": "application/json",
+          [ADMIN_TOKEN_HEADER]: "test-auth-token",
+        },
+        method: "POST",
+      });
+
+    expect((await sendInbound("before initial sync")).status).toBe(200);
+    const initial = (await (
+      await fetch(server.manifest.endpoints.syncUrl, {
+        headers: auth("test-token-placeholder"),
+      })
+    ).json()) as {
+      next_batch: string;
+      rooms: { join: Record<string, unknown> };
+    };
+    expect(Object.keys(initial.rooms.join).sort()).toEqual([
+      "!changed:matrix.test",
+      "!quiet:matrix.test",
+    ]);
+
+    expect((await sendInbound("after initial sync")).status).toBe(200);
+    const incremental = (await (
+      await fetch(`${server.manifest.endpoints.syncUrl}?since=${initial.next_batch}`, {
+        headers: auth("test-token-placeholder"),
+      })
+    ).json()) as {
+      next_batch: string;
+      rooms: { join: Record<string, unknown> };
+    };
+    expect(Object.keys(incremental.rooms.join)).toEqual([changedRoomId]);
+
+    const unchanged = (await (
+      await fetch(`${server.manifest.endpoints.syncUrl}?since=${incremental.next_batch}`, {
+        headers: auth("test-token-placeholder"),
+      })
+    ).json()) as { rooms: { join: Record<string, unknown> } };
+    expect(unchanged.rooms.join).toEqual({});
   });
 
   it("bounds timelines and retains recently replayed transactions", async () => {

--- a/test/signal-server.test.ts
+++ b/test/signal-server.test.ts
@@ -378,6 +378,65 @@ describe("signal local provider server", () => {
     expect(recorded).toContain('"path":"/crabline/signal/inbound"');
   });
 
+  it("rejects outbound RPC calls for accounts the daemon does not serve", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const account = "+15550001111";
+    const recorderPath = path.join(directory, "signal-accounts.jsonl");
+    const server = await startSignalServer({ account, recorderPath });
+    servers.push(server);
+
+    async function send(id: string, rpcAccount?: string) {
+      const response = await fetch(server.manifest.endpoints.rpcUrl, {
+        body: JSON.stringify({
+          id,
+          jsonrpc: "2.0",
+          method: "send",
+          params: {
+            ...(rpcAccount === undefined ? {} : { account: rpcAccount }),
+            message: "hello",
+            recipient: "+15551234567",
+          },
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      return await response.json();
+    }
+
+    await expect(send("omitted")).resolves.toMatchObject({
+      id: "omitted",
+      result: { timestamp: expect.any(Number) },
+    });
+    await expect(send("matching", account)).resolves.toMatchObject({
+      id: "matching",
+      result: { timestamp: expect.any(Number) },
+    });
+    for (const [id, rpcAccount] of [
+      ["blank", ""],
+      ["different", "+15550002222"],
+    ] as const) {
+      await expect(send(id, rpcAccount)).resolves.toEqual({
+        error: { code: -32602, message: "Specified account does not exist" },
+        id,
+        jsonrpc: "2.0",
+      });
+    }
+
+    const records = (await fs.readFile(recorderPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { accepted?: boolean; body?: { id?: string } });
+    expect(records).toHaveLength(2);
+    expect(records).toEqual([
+      expect.objectContaining({ accepted: true, body: expect.objectContaining({ id: "omitted" }) }),
+      expect.objectContaining({
+        accepted: true,
+        body: expect.objectContaining({ id: "matching" }),
+      }),
+    ]);
+  });
+
   it("enforces JSON-RPC envelopes and does not respond to notifications", async () => {
     const directory = await createTempDir();
     directories.push(directory);

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import { createHash } from "node:crypto";
 import { Agent, createServer, request as httpRequest, type IncomingMessage } from "node:http";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -466,6 +467,17 @@ describe("telegram local provider server", () => {
       error_code: 413,
       ok: false,
     });
+    const oversizedMultipart = await requestHttp({
+      agent: new Agent({ keepAlive: false }),
+      headers: {
+        connection: "close",
+        "content-length": String(50 * 1024 * 1024 + 1),
+        "content-type": "multipart/form-data; boundary=CrablineOversizedBoundary",
+      },
+      method: "POST",
+      url: `${server.manifest.baseUrl}/bot123456:fake-token/sendDocument`,
+    });
+    expect(oversizedMultipart.status).toBe(413);
 
     const sendMessage = await fetch(`${server.manifest.baseUrl}/bot123456:fake-token/sendMessage`, {
       body: JSON.stringify({
@@ -2222,6 +2234,149 @@ describe("telegram local provider server", () => {
         },
       },
     });
+  });
+
+  it("streams multipart files across chunk-split boundaries without retaining upload bytes", async () => {
+    const server = await startTelegramServer({ botToken: "test-token-placeholder" });
+    servers.push(server);
+    const boundary = "CrablineStreamingBoundary";
+    const fileBytes = Buffer.from(
+      `binary\0payload\r\n--${boundary}--not-a-boundary\r\n--${boundary}not-a-boundary\r\nwith trailing bytes`,
+      "utf8",
+    );
+    const body = Buffer.concat([
+      Buffer.from(`preamble\r\n--${boundary}--not-a-boundary\r\n`, "utf8"),
+      Buffer.from(
+        [
+          `--${boundary}`,
+          'Content-Disposition: form-data; name="chat_id"',
+          "",
+          "700",
+          `--${boundary} \t`,
+          'Content-Disposition: form-data; name="document"; filename=" split%22name%20\\folder.bin "',
+          "Content-Type: application/octet-stream",
+          "",
+          "",
+        ].join("\r\n"),
+        "utf8",
+      ),
+      fileBytes,
+      Buffer.from(`\r\n--${boundary}--\t \r\n`, "utf8"),
+    ]);
+
+    const response = await new Promise<{ body: string; status: number }>((resolve, reject) => {
+      const request = httpRequest(
+        `${server.manifest.baseUrl}/bottest-token-placeholder/sendDocument`,
+        {
+          headers: {
+            "content-type": `multipart/form-data; note="x; boundary=fake; y=z"; boundary="${boundary}"`,
+            "transfer-encoding": "chunked",
+          },
+          method: "POST",
+        },
+        (incoming) => {
+          const chunks: Buffer[] = [];
+          incoming.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+          incoming.once("end", () => {
+            resolve({
+              body: Buffer.concat(chunks).toString("utf8"),
+              status: incoming.statusCode ?? 0,
+            });
+          });
+        },
+      );
+      request.once("error", reject);
+      let offset = 0;
+      const writeNext = () => {
+        if (offset >= body.length) {
+          request.end();
+          return;
+        }
+        const nextOffset = Math.min(body.length, offset + 7);
+        request.write(body.subarray(offset, nextOffset));
+        offset = nextOffset;
+        setImmediate(writeNext);
+      };
+      writeNext();
+    });
+
+    expect(response.status).toBe(200);
+    const payload = JSON.parse(response.body) as {
+      result: { document: { file_name: string; file_unique_id: string } };
+    };
+    expect(payload.result.document.file_name).toBe(' split"name%20\\folder.bin ');
+    expect(payload.result.document.file_unique_id).toBe(
+      `crabline-document-unique-${createHash("sha256").update(fileBytes).digest("base64url").slice(0, 32)}`,
+    );
+  });
+
+  it("bounds retained multipart text independently of streamed file data", async () => {
+    const server = await startTelegramServer({ botToken: "test-token-placeholder" });
+    servers.push(server);
+    const boundary = "CrablineTextBudgetBoundary";
+    const body = Buffer.from(
+      [
+        `--${boundary}`,
+        'Content-Disposition: form-data; name="chat_id"',
+        "",
+        "800",
+        `--${boundary}`,
+        'Content-Disposition: form-data; name="document"',
+        "",
+        "x".repeat(1024 * 1024),
+        `--${boundary}`,
+        'Content-Disposition: form-data; name="caption"',
+        "",
+        "overflow",
+        `--${boundary}--`,
+        "",
+      ].join("\r\n"),
+      "utf8",
+    );
+    const response = await requestHttp({
+      body,
+      headers: { "content-type": `multipart/form-data; boundary=${boundary}` },
+      method: "POST",
+      timeoutMs: 5_000,
+      url: `${server.manifest.baseUrl}/bottest-token-placeholder/sendDocument`,
+    });
+
+    expect(response.status).toBe(413);
+    expect(JSON.parse(response.body)).toEqual({
+      description: "Request Entity Too Large",
+      error_code: 413,
+      ok: false,
+    });
+  });
+
+  it("drains malformed multipart requests before reusing a keep-alive connection", async () => {
+    const server = await startTelegramServer({ botToken: "test-token-placeholder" });
+    servers.push(server);
+    const agent = new Agent({ keepAlive: true, maxSockets: 1 });
+    try {
+      const malformed = await requestHttp({
+        agent,
+        body: "malformed multipart",
+        headers: { "content-type": "multipart/form-data" },
+        method: "POST",
+        url: `${server.manifest.baseUrl}/bottest-token-placeholder/sendDocument`,
+      });
+      expect(malformed.status).toBe(400);
+
+      const valid = await requestHttp({
+        agent,
+        body: "chat_id=900&text=connection+reused",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        method: "POST",
+        url: `${server.manifest.baseUrl}/bottest-token-placeholder/sendMessage`,
+      });
+      expect(valid.status).toBe(200);
+      expect(JSON.parse(valid.body)).toMatchObject({
+        result: { text: "connection reused" },
+      });
+    } finally {
+      agent.destroy();
+    }
   });
 
   it("tracks explicit message IDs independently per chat", async () => {

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -2249,11 +2249,11 @@ describe("telegram local provider server", () => {
       Buffer.from(
         [
           `--${boundary}`,
-          'Content-Disposition: form-data; name="chat_id"',
+          'Content-Disposition: form-data; name="chat\\_id"',
           "",
           "700",
           `--${boundary} \t`,
-          'Content-Disposition: form-data; name="document"; filename=" split%22name%20\\folder.bin "',
+          'Content-Disposition: form-data; name="document"; filename=" split%22name%20\\\"quoted\\\"\\\\folder.bin "',
           "Content-Type: application/octet-stream",
           "",
           "",
@@ -2304,7 +2304,7 @@ describe("telegram local provider server", () => {
     const payload = JSON.parse(response.body) as {
       result: { document: { file_name: string; file_unique_id: string } };
     };
-    expect(payload.result.document.file_name).toBe(' split"name%20\\folder.bin ');
+    expect(payload.result.document.file_name).toBe(' split"name%20"quoted"\\folder.bin ');
     expect(payload.result.document.file_unique_id).toBe(
       `crabline-document-unique-${createHash("sha256").update(fileBytes).digest("base64url").slice(0, 32)}`,
     );

--- a/test/whatsapp-provider-lifecycle.test.ts
+++ b/test/whatsapp-provider-lifecycle.test.ts
@@ -423,6 +423,7 @@ describe("WhatsApp provider lifecycle", () => {
 
       request = handle!(
         signedWhatsAppRequest({
+          object: "whatsapp_business_account",
           entry: [
             {
               changes: [

--- a/test/whatsapp-provider.test.ts
+++ b/test/whatsapp-provider.test.ts
@@ -26,6 +26,7 @@ describe("WhatsApp webhook normalizer", () => {
       timestamp: "1700000000",
     };
     const payload = {
+      object: "whatsapp_business_account",
       entry: [
         {
           changes: [
@@ -65,6 +66,7 @@ describe("WhatsApp webhook normalizer", () => {
       type: "text",
     };
     const payload = {
+      object: "whatsapp_business_account",
       entry: [{ changes: [{ value: { messages: [first, second] } }] }],
     };
 
@@ -76,6 +78,7 @@ describe("WhatsApp webhook normalizer", () => {
 
   it("does not filter inbound messages when phoneNumberId is omitted", () => {
     const payload = {
+      object: "whatsapp_business_account",
       entry: [
         {
           changes: [
@@ -109,9 +112,16 @@ describe("WhatsApp webhook normalizer", () => {
 
   it.each([
     ["not-an-object", "WhatsApp webhook payload must be an object"],
-    [{ entry: [{ changes: [{ value: { messages: [{ from: "15551234567" }] } }] }] }, "requires"],
     [
       {
+        object: "whatsapp_business_account",
+        entry: [{ changes: [{ value: { messages: [{ from: "15551234567" }] } }] }],
+      },
+      "requires",
+    ],
+    [
+      {
+        object: "whatsapp_business_account",
         entry: [
           {
             changes: [
@@ -133,6 +143,7 @@ describe("WhatsApp webhook normalizer", () => {
   it("requires provider message ids for native webhook deliveries", () => {
     expect(() =>
       normalizeWhatsAppWebhookPayload({
+        object: "whatsapp_business_account",
         entry: [
           {
             changes: [
@@ -146,6 +157,33 @@ describe("WhatsApp webhook normalizer", () => {
         ],
       }),
     ).toThrow("messages[].id");
+  });
+
+  it("requires the native account envelope and skips non-message change fields", () => {
+    expect(() =>
+      normalizeWhatsAppWebhookPayload({
+        entry: [],
+        object: "page",
+      }),
+    ).toThrow('object="whatsapp_business_account"');
+
+    expect(
+      normalizeWhatsAppWebhookPayload({
+        object: "whatsapp_business_account",
+        entry: [
+          {
+            changes: [
+              {
+                field: "statuses",
+                value: {
+                  messages: [{ from: "invalid", text: { body: "must be ignored" } }],
+                },
+              },
+            ],
+          },
+        ],
+      }),
+    ).toEqual([]);
   });
 
   it("preserves generic fallback thread payloads", () => {
@@ -213,6 +251,7 @@ describe("WhatsApp webhook normalizer", () => {
         ?.replace("webhook endpoint ", "");
       expect(endpoint).toBeDefined();
       const body = JSON.stringify({
+        object: "whatsapp_business_account",
         entry: [
           {
             changes: [
@@ -285,6 +324,7 @@ describe("WhatsApp webhook normalizer", () => {
       expect(forbidden.status).toBe(403);
 
       const body = JSON.stringify({
+        object: "whatsapp_business_account",
         entry: [
           {
             changes: [
@@ -312,6 +352,46 @@ describe("WhatsApp webhook normalizer", () => {
         method: "POST",
       });
       expect(unsigned.status).toBe(401);
+      await expect(readFile(config.whatsapp!.recorder.path!, "utf8")).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+
+      const foreignEnvelopeBody = JSON.stringify({ entry: [], object: "page" });
+      const foreignEnvelope = await fetch(endpoint!, {
+        body: foreignEnvelopeBody,
+        headers: {
+          "content-type": "application/json",
+          "x-hub-signature-256": whatsappSignature(foreignEnvelopeBody, signingKey),
+        },
+        method: "POST",
+      });
+      expect(foreignEnvelope.status).toBe(400);
+
+      const nonMessageBody = JSON.stringify({
+        entry: [
+          {
+            changes: [
+              {
+                field: "statuses",
+                value: {
+                  messages: [{ from: "invalid", text: { body: "must be ignored" } }],
+                },
+              },
+            ],
+          },
+        ],
+        object: "whatsapp_business_account",
+      });
+      const nonMessage = await fetch(endpoint!, {
+        body: nonMessageBody,
+        headers: {
+          "content-type": "application/json",
+          "x-hub-signature-256": whatsappSignature(nonMessageBody, signingKey),
+        },
+        method: "POST",
+      });
+      expect(nonMessage.status).toBe(200);
+      await expect(nonMessage.json()).resolves.toEqual({ ids: [], ok: true });
       await expect(readFile(config.whatsapp!.recorder.path!, "utf8")).rejects.toMatchObject({
         code: "ENOENT",
       });
@@ -395,6 +475,7 @@ describe("WhatsApp webhook normalizer", () => {
       );
 
       const body = JSON.stringify({
+        object: "whatsapp_business_account",
         entry: [
           {
             changes: [
@@ -468,6 +549,7 @@ describe("WhatsApp webhook normalizer", () => {
       expect((await fetch(verificationUrl)).status).toBe(200);
 
       const body = JSON.stringify({
+        object: "whatsapp_business_account",
         entry: [
           {
             changes: [
@@ -689,6 +771,7 @@ runLocalMockProviderContract({
     text: `reply ${contractNonces.webhook}`,
   },
   webhookPayload: {
+    object: "whatsapp_business_account",
     entry: [
       {
         changes: [
@@ -720,6 +803,7 @@ runLocalMockProviderContract({
   },
   webhookThreadId: "15551234567",
   userWebhookPayload: (nonce) => ({
+    object: "whatsapp_business_account",
     entry: [
       {
         changes: [

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -501,6 +501,47 @@ describe("whatsapp local provider server", () => {
       messaging_product: "whatsapp",
     });
 
+    const maximumText = await fetch(server.manifest.endpoints.messagesUrl, {
+      body: JSON.stringify({
+        messaging_product: "whatsapp",
+        text: { body: "x".repeat(4_096) },
+        to: "15551234567",
+        type: "text",
+      }),
+      headers: {
+        authorization: "Bearer fake-whatsapp-token",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+    expect(maximumText.status).toBe(200);
+
+    const oversizedText = await fetch(server.manifest.endpoints.messagesUrl, {
+      body: JSON.stringify({
+        messaging_product: "whatsapp",
+        text: { body: "x".repeat(4_097) },
+        to: "15551234567",
+        type: "text",
+      }),
+      headers: {
+        authorization: "Bearer fake-whatsapp-token",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+    expect(oversizedText.status).toBe(400);
+    await expect(oversizedText.json()).resolves.toMatchObject({
+      error: {
+        code: 100,
+        error_data: {
+          details: "text.body must not exceed 4096 characters.",
+          messaging_product: "whatsapp",
+        },
+        message: "(#100) Invalid parameter: text.body",
+        type: "OAuthException",
+      },
+    });
+
     const invalidProduct = await fetch(server.manifest.endpoints.messagesUrl, {
       body: JSON.stringify({
         messaging_product: "messenger",
@@ -1464,8 +1505,10 @@ describe("whatsapp local provider server", () => {
   it("fences late Signal mutation after acceptance timeout", async () => {
     const recipientJid = "15551234567@s.whatsapp.net";
     const senderJid = "15550000001@s.whatsapp.net";
-    const receiver = new WhatsAppSignalBundleStore(1, 1, undefined, undefined, undefined, {
+    let now = 0;
+    const receiver = new WhatsAppSignalBundleStore(1, 1, undefined, undefined, () => now, {
       messageAcceptanceTimeoutMs: 100,
+      preKeyReservationTtlMs: 1,
     });
     const bundle = receiver.resolveMany([recipientJid])[0]!;
     const senderIdentity = Curve.generateKeyPair();
@@ -1519,6 +1562,8 @@ describe("whatsapp local provider server", () => {
       });
       expect(receiver.sessionCount).toBe(0);
 
+      now = 1;
+      receiver.resolveMany([recipientJid]);
       releaseAppend();
       await vi.advanceTimersByTimeAsync(0);
       expect(receiver.sessionCount).toBe(0);
@@ -1532,7 +1577,7 @@ describe("whatsapp local provider server", () => {
           signalBundles: receiver,
         }),
       ).resolves.toBe(true);
-      expect(retryAppend).toHaveBeenCalledOnce();
+      expect(retryAppend).not.toHaveBeenCalled();
       expect(receiver.sessionCount).toBe(1);
       expect(receiver.resolveMany([recipientJid])[0]!.preKeyId).toBeGreaterThan(bundle.preKeyId);
     } finally {

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -1567,6 +1567,23 @@ describe("whatsapp local provider server", () => {
       releaseAppend();
       await vi.advanceTimersByTimeAsync(0);
       expect(receiver.sessionCount).toBe(0);
+      const abortedRetry = new AbortController();
+      abortedRetry.abort(new Error("retry owner already closed"));
+      const abortedRetryAppend = vi.fn(async () => undefined);
+      await expect(
+        persistAcceptedBaileysMessage({
+          acceptanceSignal: abortedRetry.signal,
+          appendEvent: abortedRetryAppend,
+          node,
+          path: "/ws/chat",
+          remoteJid: senderJid,
+          signalBundles: receiver,
+        }),
+      ).rejects.toThrow("retry owner already closed");
+      expect(abortedRetryAppend).not.toHaveBeenCalled();
+      expect(receiver.sessionCount).toBe(0);
+      await vi.advanceTimersByTimeAsync(0);
+
       const retryAppend = vi.fn(async () => undefined);
       await expect(
         persistAcceptedBaileysMessage({

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -367,6 +367,74 @@ describe("whatsapp local provider server", () => {
     }
   });
 
+  it("closes the owning socket and bounds shutdown when acceptance never settles", async () => {
+    let markAcceptanceStarted!: () => void;
+    const acceptanceStarted = new Promise<void>((resolve) => {
+      markAcceptanceStarted = resolve;
+    });
+    const acceptanceBlocked = new Promise<void>(() => undefined);
+    const server = await startWhatsAppServer({
+      messageAcceptanceTimeoutMs: 100,
+      onEvent: async (event) => {
+        if (event.method === "WEBSOCKET" && "accepted" in event && event.accepted === true) {
+          markAcceptanceStarted();
+          await acceptanceBlocked;
+        }
+      },
+      selfJid: "15550000001:0@s.whatsapp.net",
+    });
+    const socket = createBaileysTestSocket(server);
+    const connectionUpdates: unknown[] = [];
+    socket.ev.on("connection.update", (update) => {
+      connectionUpdates.push(update);
+    });
+
+    try {
+      await waitForCondition(
+        () =>
+          connectionUpdates.some(
+            (update) =>
+              !!update &&
+              typeof update === "object" &&
+              (update as { connection?: unknown }).connection === "open",
+          ),
+        "Baileys connection open",
+      );
+      const send = socket
+        .sendMessage("15551234567@s.whatsapp.net", { text: "never settles" })
+        .catch(() => undefined);
+      await acceptanceStarted;
+      await waitForCondition(
+        () =>
+          connectionUpdates.some(
+            (update) =>
+              !!update &&
+              typeof update === "object" &&
+              (update as { connection?: unknown }).connection === "close",
+          ),
+        "acceptance timeout socket close",
+      );
+      expect(
+        connectionUpdates.some(
+          (update) =>
+            !!update &&
+            typeof update === "object" &&
+            (update as { connection?: unknown }).connection === "close",
+        ),
+      ).toBe(true);
+      await Promise.race([
+        server.close(),
+        new Promise<never>((_resolve, reject) => {
+          setTimeout(() => reject(new Error("WhatsApp shutdown exceeded acceptance bound.")), 500);
+        }),
+      ]);
+      await send;
+    } finally {
+      socket.end(undefined);
+      await server.close().catch(() => undefined);
+    }
+  });
+
   it("serves Cloud API sends and injected inbound webhook payloads", async () => {
     const directory = await createTempDir();
     directories.push(directory);
@@ -723,6 +791,90 @@ describe("whatsapp local provider server", () => {
     expect(directBody.message.key).not.toHaveProperty("participant");
   });
 
+  it("reserves explicit and generated message ids atomically", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const server = await startWhatsAppServer({
+      accessToken: "fake",
+      adminToken: "admin",
+      recorderPath: path.join(directory, "whatsapp-message-ids.jsonl"),
+    });
+    servers.push(server);
+    const sendInbound = (messageId: string) =>
+      fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({
+          chatJid: "15551234567@s.whatsapp.net",
+          messageId,
+          senderJid: "15551234567@s.whatsapp.net",
+          text: "reserved inbound",
+        }),
+        headers: {
+          [ADMIN_TOKEN_HEADER]: "admin",
+          "content-type": "application/json",
+        },
+        method: "POST",
+      });
+
+    const duplicateIngress = await Promise.all([
+      sendInbound("wamid.FAKE00000001"),
+      sendInbound("wamid.FAKE00000001"),
+    ]);
+    expect(duplicateIngress.map((response) => response.status).sort()).toEqual([200, 400]);
+
+    const outbound = await fetch(server.manifest.endpoints.messagesUrl, {
+      body: JSON.stringify({
+        messaging_product: "whatsapp",
+        text: { body: "generated outbound" },
+        to: "15551234567",
+        type: "text",
+      }),
+      headers: {
+        authorization: "Bearer fake",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+    await expect(outbound.json()).resolves.toMatchObject({
+      messages: [{ id: "wamid.FAKE00000002" }],
+    });
+    expect((await sendInbound("wamid.FAKE00000002")).status).toBe(400);
+    expect((await sendInbound("wamid.FAKE9007199254740991")).status).toBe(200);
+    const sendGenerated = async () => {
+      const response = await fetch(server.manifest.endpoints.messagesUrl, {
+        body: JSON.stringify({
+          messaging_product: "whatsapp",
+          text: { body: "generated beyond safe integer" },
+          to: "15551234567",
+          type: "text",
+        }),
+        headers: {
+          authorization: "Bearer fake",
+          "content-type": "application/json",
+        },
+        method: "POST",
+      });
+      return (await response.json()) as { messages: Array<{ id: string }> };
+    };
+    await expect(sendGenerated()).resolves.toMatchObject({
+      messages: [{ id: "wamid.FAKE9007199254740992" }],
+    });
+    await expect(sendGenerated()).resolves.toMatchObject({
+      messages: [{ id: "wamid.FAKE9007199254740993" }],
+    });
+
+    const recorderEvents = (await fs.readFile(server.manifest.recorderPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { body?: { messageId?: string }; path?: string });
+    expect(
+      recorderEvents.filter(
+        (event) =>
+          event.path === "/_crabline/admin/whatsapp/inbound" &&
+          event.body?.messageId === "wamid.FAKE00000001",
+      ),
+    ).toHaveLength(1);
+  });
+
   it("separates PN and LID signal bundle/session keys while normalizing devices", () => {
     const phoneNumberKey = signalBundleIdentityKey("15551234567:2@s.whatsapp.net");
     const lidKey = signalBundleIdentityKey("15551234567:3@lid");
@@ -731,11 +883,14 @@ describe("whatsapp local provider server", () => {
     expect(phoneNumberKey).not.toBe(lidKey);
 
     const store = new WhatsAppSignalBundleStore(2);
-    const [phoneNumber, lid] = store.resolveMany(["15551234567@s.whatsapp.net", "15551234567@lid"]);
+    const phoneNumber = store.resolveMany(["15551234567@s.whatsapp.net"])[0]!;
+    const lid = store.resolveMany(["15551234567@lid"])[0]!;
     expect(phoneNumber).not.toBe(lid);
-    expect(store.resolveMany(["15551234567:2@s.whatsapp.net"])[0]).toBe(phoneNumber);
-    expect(store.resolveMany(["15551234567:0@c.us"])[0]).toBe(phoneNumber);
-    expect(store.resolveMany(["15551234567:3@lid"])[0]).toBe(lid);
+    expect(store.resolveMany(["15551234567:2@s.whatsapp.net"])[0]!.identityKey).toBe(
+      phoneNumber.identityKey,
+    );
+    expect(store.resolveMany(["15551234567:0@c.us"])[0]!.identityKey).toBe(phoneNumber.identityKey);
+    expect(store.resolveMany(["15551234567:3@lid"])[0]!.identityKey).toBe(lid.identityKey);
     expect(store.size).toBe(2);
   });
 
@@ -744,8 +899,8 @@ describe("whatsapp local provider server", () => {
     const receiver = new WhatsAppSignalBundleStore(1, undefined, undefined, undefined, undefined, {
       maxSessionsPerBundle: 1,
     });
-    const bundle = receiver.resolveMany([recipientJid])[0]!;
     const createSender = async (senderJid: string, registrationId: number, message: string) => {
+      const bundle = receiver.resolveMany([recipientJid])[0]!;
       const identity = Curve.generateKeyPair();
       const storage = createSignalTestStorage(identity, registrationId);
       const address = new ProtocolAddress("15551234567", 0);
@@ -922,12 +1077,11 @@ describe("whatsapp local provider server", () => {
     ordering.push("ack");
 
     expect(ordering).toEqual(["persist:start", "persist:done", "ack"]);
-    expect(bundle.preKey).not.toBe(originalPreKey);
-    expect(bundle.preKeyId).toBe(originalPreKeyId + 1);
-    expect(receiver.resolveMany([recipientJid])[0]).toMatchObject({
-      preKey: bundle.preKey,
-      preKeyId: originalPreKeyId + 1,
-    });
+    expect(bundle.preKey).toBe(originalPreKey);
+    expect(bundle.preKeyId).toBe(originalPreKeyId);
+    const replacement = receiver.resolveMany([recipientJid])[0]!;
+    expect(replacement.preKey).not.toBe(originalPreKey);
+    expect(replacement.preKeyId).not.toBe(originalPreKeyId);
     await expect(
       receiver.transactDirectMessage({
         accept: async () => true,
@@ -1008,8 +1162,9 @@ describe("whatsapp local provider server", () => {
       status: "accepted",
       value: "retry recorder failure",
     });
-    expect(bundle.preKey).not.toBe(originalPreKey);
-    expect(bundle.preKeyId).toBe(originalPreKeyId + 1);
+    const replacement = receiver.resolveMany([recipientJid])[0]!;
+    expect(replacement.preKey).not.toBe(originalPreKey);
+    expect(replacement.preKeyId).not.toBe(originalPreKeyId);
   });
 
   it("deduplicates accepted evidence across reconnect acknowledgement retries", async () => {
@@ -1058,8 +1213,9 @@ describe("whatsapp local provider server", () => {
       }),
     ).resolves.toBe(true);
     expect(events).toHaveLength(1);
-    expect(bundle.preKey).not.toBe(originalPreKey);
-    expect(bundle.preKeyId).toBe(originalPreKeyId + 1);
+    const replacement = receiver.resolveMany([recipientJid])[0]!;
+    expect(replacement.preKey).not.toBe(originalPreKey);
+    expect(replacement.preKeyId).not.toBe(originalPreKeyId);
 
     await expect(
       persistAcceptedBaileysMessage({
@@ -1079,7 +1235,7 @@ describe("whatsapp local provider server", () => {
         message: { conversation: "retry" },
       },
     });
-    expect(bundle.preKeyId).toBe(originalPreKeyId + 1);
+    expect(replacement.preKeyId).not.toBe(originalPreKeyId);
     receiver.markMessageAcknowledged("15557654321@s.whatsapp.net", "retry-ack");
 
     await expect(
@@ -1124,6 +1280,265 @@ describe("whatsapp local provider server", () => {
     await expect(
       receiver.acceptMessageOnce("15557654321@s.whatsapp.net\0next", async () => true),
     ).resolves.toBe(true);
+  });
+
+  it("times out stalled acceptance and recovers pending acknowledgement capacity", async () => {
+    vi.useFakeTimers();
+    try {
+      const terminalTimeout = vi.fn();
+      const receiver = new WhatsAppSignalBundleStore(1, 1, 1, undefined, undefined, {
+        messageAcceptanceTimeoutMs: 100,
+      });
+      const stalled = receiver
+        .acceptMessageOnce(
+          "peer\0stalled",
+          async () => await new Promise<boolean>(() => undefined),
+          { onTerminalTimeout: terminalTimeout },
+        )
+        .then(
+          () => ({ error: undefined }),
+          (error: unknown) => ({ error }),
+        );
+      await Promise.resolve();
+
+      await vi.advanceTimersByTimeAsync(100);
+      await expect(stalled).resolves.toEqual({
+        error: expect.objectContaining({ message: "WhatsApp message acceptance timed out." }),
+      });
+      expect(terminalTimeout).toHaveBeenCalledOnce();
+      const duplicateOperation = vi.fn(async () => true);
+      await expect(receiver.acceptMessageOnce("peer\0stalled", duplicateOperation)).rejects.toThrow(
+        "message acceptance timed out",
+      );
+      expect(duplicateOperation).not.toHaveBeenCalled();
+      await expect(receiver.acceptMessageOnce("peer\0recovered", async () => true)).resolves.toBe(
+        true,
+      );
+      const secondStalled = receiver
+        .acceptMessageOnce(
+          "peer\0second-stalled",
+          async () => await new Promise<boolean>(() => undefined),
+        )
+        .catch(() => undefined);
+      await vi.advanceTimersByTimeAsync(100);
+      await secondStalled;
+      await expect(
+        receiver.acceptMessageOnce("peer\0backpressure", async () => true),
+      ).rejects.toThrow("terminal acceptance limit exceeded (2)");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("fences duplicate persistence until timed-out recorder work settles", async () => {
+    const receiver = new WhatsAppSignalBundleStore(1, 1, undefined, undefined, undefined, {
+      messageAcceptanceTimeoutMs: 100,
+    });
+    const node: BinaryNode = {
+      attrs: { id: "stalled-recorder", to: "15557654321@s.whatsapp.net" },
+      tag: "message",
+    };
+    let markAppendStarted!: () => void;
+    const appendStarted = new Promise<void>((resolve) => {
+      markAppendStarted = resolve;
+    });
+    let releaseAppend!: () => void;
+    const appendBlocked = new Promise<void>((resolve) => {
+      releaseAppend = resolve;
+    });
+
+    vi.useFakeTimers();
+    try {
+      const stalled = persistAcceptedBaileysMessage({
+        appendEvent: async () => {
+          markAppendStarted();
+          await appendBlocked;
+        },
+        node,
+        path: "/ws/chat",
+        remoteJid: "15550000001@s.whatsapp.net",
+        signalBundles: receiver,
+      }).then(
+        () => ({ error: undefined }),
+        (error: unknown) => ({ error }),
+      );
+      await appendStarted;
+      await vi.advanceTimersByTimeAsync(100);
+      await expect(stalled).resolves.toEqual({
+        error: expect.objectContaining({ message: "WhatsApp message acceptance timed out." }),
+      });
+
+      const duplicateAppend = vi.fn(async () => undefined);
+      await expect(
+        persistAcceptedBaileysMessage({
+          appendEvent: duplicateAppend,
+          node,
+          path: "/ws/chat",
+          remoteJid: "15550000001@s.whatsapp.net",
+          signalBundles: receiver,
+        }),
+      ).rejects.toThrow("message acceptance timed out");
+      expect(duplicateAppend).not.toHaveBeenCalled();
+
+      releaseAppend();
+      await vi.advanceTimersByTimeAsync(0);
+      const retryAppend = vi.fn(async () => undefined);
+      await expect(
+        persistAcceptedBaileysMessage({
+          appendEvent: retryAppend,
+          node,
+          path: "/ws/chat",
+          remoteJid: "15550000001@s.whatsapp.net",
+          signalBundles: receiver,
+        }),
+      ).resolves.toBe(true);
+      expect(retryAppend).not.toHaveBeenCalled();
+    } finally {
+      releaseAppend();
+      vi.useRealTimers();
+    }
+  });
+
+  it("fences recorder persistence after the owning socket aborts", async () => {
+    const receiver = new WhatsAppSignalBundleStore(1, 1);
+    const node: BinaryNode = {
+      attrs: { id: "owner-abort", to: "15557654321@s.whatsapp.net" },
+      tag: "message",
+    };
+    const controller = new AbortController();
+    let markAppendStarted!: () => void;
+    const appendStarted = new Promise<void>((resolve) => {
+      markAppendStarted = resolve;
+    });
+    let releaseAppend!: () => void;
+    const appendBlocked = new Promise<void>((resolve) => {
+      releaseAppend = resolve;
+    });
+    const stalled = persistAcceptedBaileysMessage({
+      acceptanceSignal: controller.signal,
+      appendEvent: async () => {
+        markAppendStarted();
+        await appendBlocked;
+      },
+      node,
+      path: "/ws/chat",
+      remoteJid: "15550000001@s.whatsapp.net",
+      signalBundles: receiver,
+    }).then(
+      () => ({ error: undefined }),
+      (error: unknown) => ({ error }),
+    );
+    await appendStarted;
+
+    controller.abort(new Error("owning socket closed"));
+    await expect(stalled).resolves.toEqual({
+      error: expect.objectContaining({ message: "owning socket closed" }),
+    });
+    const duplicateAppend = vi.fn(async () => undefined);
+    await expect(
+      persistAcceptedBaileysMessage({
+        appendEvent: duplicateAppend,
+        node,
+        path: "/ws/chat",
+        remoteJid: "15550000001@s.whatsapp.net",
+        signalBundles: receiver,
+      }),
+    ).rejects.toThrow("owning socket closed");
+    expect(duplicateAppend).not.toHaveBeenCalled();
+
+    releaseAppend();
+    await new Promise((resolve) => setImmediate(resolve));
+    const retryAppend = vi.fn(async () => undefined);
+    await expect(
+      persistAcceptedBaileysMessage({
+        appendEvent: retryAppend,
+        node,
+        path: "/ws/chat",
+        remoteJid: "15550000001@s.whatsapp.net",
+        signalBundles: receiver,
+      }),
+    ).resolves.toBe(true);
+    expect(retryAppend).not.toHaveBeenCalled();
+  });
+
+  it("fences late Signal mutation after acceptance timeout", async () => {
+    const recipientJid = "15551234567@s.whatsapp.net";
+    const senderJid = "15550000001@s.whatsapp.net";
+    const receiver = new WhatsAppSignalBundleStore(1, 1, undefined, undefined, undefined, {
+      messageAcceptanceTimeoutMs: 100,
+    });
+    const bundle = receiver.resolveMany([recipientJid])[0]!;
+    const senderIdentity = Curve.generateKeyPair();
+    const senderStorage = createSignalTestStorage(senderIdentity, 2);
+    const senderAddress = new ProtocolAddress("15551234567", 0);
+    await new SessionBuilder(senderStorage, senderAddress).initOutgoing({
+      identityKey: signalTestKeyPair(bundle.identityKey).pubKey,
+      preKey: {
+        keyId: bundle.preKeyId,
+        publicKey: signalTestKeyPair(bundle.preKey).pubKey,
+      },
+      registrationId: bundle.registrationId,
+      signedPreKey: {
+        keyId: bundle.signedPreKey.keyId,
+        publicKey: signalTestKeyPair(bundle.signedPreKey.keyPair).pubKey,
+        signature: bundle.signedPreKey.signature,
+      },
+    });
+    const encrypted = await new SessionCipher(senderStorage, senderAddress).encrypt(
+      Buffer.from("late acceptance"),
+    );
+    const node = signalMessageNode({
+      ciphertext: signalCiphertext(encrypted.body),
+      id: "late",
+      recipientJid,
+      type: encrypted.type,
+    });
+    let releaseAppend!: () => void;
+    const appendBlocked = new Promise<void>((resolve) => {
+      releaseAppend = resolve;
+    });
+
+    vi.useFakeTimers();
+    try {
+      const stalled = persistAcceptedBaileysMessage({
+        appendEvent: async () => {
+          await appendBlocked;
+        },
+        node,
+        path: "/ws/chat",
+        remoteJid: senderJid,
+        signalBundles: receiver,
+      }).then(
+        () => ({ error: undefined }),
+        (error: unknown) => ({ error }),
+      );
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(100);
+      await expect(stalled).resolves.toEqual({
+        error: expect.objectContaining({ message: "WhatsApp message acceptance timed out." }),
+      });
+      expect(receiver.sessionCount).toBe(0);
+
+      releaseAppend();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(receiver.sessionCount).toBe(0);
+      const retryAppend = vi.fn(async () => undefined);
+      await expect(
+        persistAcceptedBaileysMessage({
+          appendEvent: retryAppend,
+          node,
+          path: "/ws/chat",
+          remoteJid: senderJid,
+          signalBundles: receiver,
+        }),
+      ).resolves.toBe(true);
+      expect(retryAppend).toHaveBeenCalledOnce();
+      expect(receiver.sessionCount).toBe(1);
+      expect(receiver.resolveMany([recipientJid])[0]!.preKeyId).toBeGreaterThan(bundle.preKeyId);
+    } finally {
+      releaseAppend();
+      vi.useRealTimers();
+    }
   });
 
   it("bounds aggregate acceptance work without blocking unrelated message keys", async () => {
@@ -1418,11 +1833,11 @@ describe("whatsapp local provider server", () => {
     ).rejects.toThrow("simulated recorder failure");
   });
 
-  it("serializes first-contact Signal transactions by recipient bundle", async () => {
+  it("reserves distinct prekeys so two initiators can establish serialized sessions", async () => {
     const recipientJid = "15551234567@s.whatsapp.net";
     const receiver = new WhatsAppSignalBundleStore(1);
-    const bundle = receiver.resolveMany([recipientJid])[0]!;
     const createSender = async (senderJid: string, registrationId: number) => {
+      const bundle = receiver.resolveMany([recipientJid])[0]!;
       const identity = Curve.generateKeyPair();
       const storage = createSignalTestStorage(identity, registrationId);
       const address = new ProtocolAddress("15551234567", 0);
@@ -1482,7 +1897,82 @@ describe("whatsapp local provider server", () => {
     expect(secondStarted).toBe(false);
     releaseFirst();
     await expect(first).resolves.toEqual({ status: "accepted", value: true });
-    await expect(second).resolves.toMatchObject({ status: "decrypt-failed" });
+    await expect(second).resolves.toEqual({ status: "accepted", value: true });
+    expect(receiver.sessionCount).toBe(2);
+  });
+
+  it("keeps replacement prekey reservations distinct from concurrent bundle fetches", async () => {
+    const recipientJid = "15551234567@s.whatsapp.net";
+    const receiver = new WhatsAppSignalBundleStore(1);
+    const createSender = async (
+      bundle: ReturnType<WhatsAppSignalBundleStore["resolveMany"]>[number],
+      senderJid: string,
+      registrationId: number,
+      text: string,
+    ) => {
+      const identity = Curve.generateKeyPair();
+      const storage = createSignalTestStorage(identity, registrationId);
+      const address = new ProtocolAddress("15551234567", 0);
+      await new SessionBuilder(storage, address).initOutgoing({
+        identityKey: signalTestKeyPair(bundle.identityKey).pubKey,
+        preKey: {
+          keyId: bundle.preKeyId,
+          publicKey: signalTestKeyPair(bundle.preKey).pubKey,
+        },
+        registrationId: bundle.registrationId,
+        signedPreKey: {
+          keyId: bundle.signedPreKey.keyId,
+          publicKey: signalTestKeyPair(bundle.signedPreKey.keyPair).pubKey,
+          signature: bundle.signedPreKey.signature,
+        },
+      });
+      const encrypted = await new SessionCipher(storage, address).encrypt(Buffer.from(text));
+      return { ciphertext: signalCiphertext(encrypted.body), senderJid };
+    };
+    const firstBundle = receiver.resolveMany([recipientJid])[0]!;
+    const firstSender = await createSender(firstBundle, "15550000001@s.whatsapp.net", 2, "first");
+    let releaseFirst!: () => void;
+    const firstBlocked = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let firstStarted!: () => void;
+    const firstAcceptanceStarted = new Promise<void>((resolve) => {
+      firstStarted = resolve;
+    });
+    const first = receiver.transactDirectMessage({
+      accept: async () => {
+        firstStarted();
+        await firstBlocked;
+        return true;
+      },
+      ciphertext: firstSender.ciphertext,
+      recipientJid,
+      remoteJid: firstSender.senderJid,
+      type: "pkmsg",
+    });
+    await firstAcceptanceStarted;
+
+    const secondBundle = receiver.resolveMany([recipientJid])[0]!;
+    expect(secondBundle.preKeyId).not.toBe(firstBundle.preKeyId + 1);
+    const secondSender = await createSender(
+      secondBundle,
+      "15550000002@s.whatsapp.net",
+      3,
+      "second",
+    );
+    releaseFirst();
+
+    await expect(first).resolves.toEqual({ status: "accepted", value: true });
+    await expect(
+      receiver.transactDirectMessage({
+        accept: async () => true,
+        ciphertext: secondSender.ciphertext,
+        recipientJid,
+        remoteJid: secondSender.senderJid,
+        type: "pkmsg",
+      }),
+    ).resolves.toEqual({ status: "accepted", value: true });
+    expect(receiver.sessionCount).toBe(2);
   });
 
   it("generates replacement prekeys before accepted evidence persists", async () => {

--- a/test/whatsapp-wire.test.ts
+++ b/test/whatsapp-wire.test.ts
@@ -7,6 +7,7 @@ import {
   encodeBinaryNode,
   WHATSAPP_BINARY_NODE_MAX_DEPTH,
   WHATSAPP_BINARY_NODE_MAX_DECOMPRESSED_BYTES,
+  WHATSAPP_BINARY_NODE_MAX_FRAME_BYTES,
   WHATSAPP_BINARY_NODE_MAX_LIST_ITEMS,
   WHATSAPP_BINARY_NODE_MAX_NODES,
   type BinaryNode,
@@ -628,6 +629,22 @@ describe("WhatsApp binary nodes", () => {
     );
   });
 
+  it("round trips the largest decodable frame and rejects one byte more", async () => {
+    const payloadBytes = WHATSAPP_BINARY_NODE_MAX_DECOMPRESSED_BYTES - 16;
+    const largest = {
+      attrs: {},
+      content: Buffer.alloc(payloadBytes),
+      tag: "message",
+    };
+    const encoded = encodeBinaryNode(largest);
+
+    expect(encoded).toHaveLength(WHATSAPP_BINARY_NODE_MAX_FRAME_BYTES);
+    await expect(decodeBinaryNode(encoded)).resolves.toEqual(largest);
+    expect(() => encodeBinaryNode({ ...largest, content: Buffer.alloc(payloadBytes + 1) })).toThrow(
+      `exceeds ${WHATSAPP_BINARY_NODE_MAX_FRAME_BYTES} bytes`,
+    );
+  }, 20_000);
+
   it("rejects trailing bytes after a compressed node stream", async () => {
     const compressed = deflateSync(encodeBinaryNode({ attrs: {}, tag: "message" }).subarray(1));
 
@@ -708,8 +725,11 @@ describe("WhatsApp signal bundle store", () => {
     const store = new WhatsAppSignalBundleStore(1);
     const first = store.resolveMany(["15551234567@s.whatsapp.net"]);
     expect(first).toHaveLength(1);
-    expect(store.resolveMany(["15551234567@s.whatsapp.net"])[0]).toBe(first[0]);
-    expect(store.resolveMany(["15551234567@c.us"])[0]).toBe(first[0]);
+    const second = store.resolveMany(["15551234567@s.whatsapp.net"])[0]!;
+    const legacy = store.resolveMany(["15551234567@c.us"])[0]!;
+    expect(second.identityKey).toBe(first[0]!.identityKey);
+    expect(legacy.identityKey).toBe(first[0]!.identityKey);
+    expect(new Set([first[0]!.preKeyId, second.preKeyId, legacy.preKeyId]).size).toBe(3);
     expect(first[0]!.identityKey.public).toHaveLength(33);
     expect(first[0]!.identityKey.public[0]).toBe(KEY_BUNDLE_TYPE[0]);
     expect(first[0]!.preKey.public).toHaveLength(33);
@@ -725,9 +745,111 @@ describe("WhatsApp signal bundle store", () => {
     expect(
       () =>
         new WhatsAppSignalBundleStore(undefined, undefined, undefined, undefined, undefined, {
+          maxPreKeysPerBundle: 0,
+        }),
+    ).toThrow(/maxSignalPreKeysPerBundle/u);
+    expect(
+      () =>
+        new WhatsAppSignalBundleStore(undefined, undefined, undefined, undefined, undefined, {
           maxSessionsPerBundle: 0,
         }),
     ).toThrow(/maxSignalSessionsPerBundle/u);
+    expect(
+      () =>
+        new WhatsAppSignalBundleStore(undefined, undefined, undefined, undefined, undefined, {
+          messageAcceptanceTimeoutMs: 2_147_483_648,
+        }),
+    ).toThrow(/no greater than 2147483647/u);
+    expect(
+      () =>
+        new WhatsAppSignalBundleStore(undefined, undefined, undefined, undefined, undefined, {
+          preKeyReservationTtlMs: 0,
+        }),
+    ).toThrow(/preKeyReservationTtlMs/u);
+  });
+
+  it("bounds outstanding one-time prekey reservations per identity", () => {
+    const atomicStore = new WhatsAppSignalBundleStore(
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { maxPreKeysPerBundle: 2 },
+    );
+    expect(() =>
+      atomicStore.resolveMany([
+        "15551234567@c.us",
+        "15551234567:2@s.whatsapp.net",
+        "15551234567@s.whatsapp.net",
+      ]),
+    ).toThrow("prekey reservation limit exceeded (2)");
+    expect(atomicStore.resolveMany(["15551234567@s.whatsapp.net"])[0]!.preKeyId).toBe(1);
+
+    const failureAtomicStore = new WhatsAppSignalBundleStore(
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { maxPreKeysPerBundle: 2 },
+    );
+    const originalGenerateKeyPair = Curve.generateKeyPair.bind(Curve);
+    const generateKeyPair = vi.spyOn(Curve, "generateKeyPair");
+    let keyPairCalls = 0;
+    generateKeyPair.mockImplementation(() => {
+      keyPairCalls += 1;
+      if (keyPairCalls === 3) {
+        throw new Error("simulated prekey generation failure");
+      }
+      return originalGenerateKeyPair();
+    });
+    expect(() =>
+      failureAtomicStore.resolveMany([
+        "15551234567@s.whatsapp.net",
+        "15551234567:2@s.whatsapp.net",
+      ]),
+    ).toThrow("simulated prekey generation failure");
+    generateKeyPair.mockRestore();
+    expect(failureAtomicStore.resolveMany(["15551234567@s.whatsapp.net"])[0]!.preKeyId).toBe(1);
+
+    const store = new WhatsAppSignalBundleStore(
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { maxPreKeysPerBundle: 2 },
+    );
+    const first = store.resolveMany(["15551234567@s.whatsapp.net"])[0]!;
+    const second = store.resolveMany(["15551234567@s.whatsapp.net"])[0]!;
+
+    expect(first.preKeyId).not.toBe(second.preKeyId);
+    expect(() => store.resolveMany(["15551234567@s.whatsapp.net"])).toThrow(
+      "prekey reservation limit exceeded (2)",
+    );
+
+    let now = 0;
+    const expiringStore = new WhatsAppSignalBundleStore(
+      1,
+      undefined,
+      undefined,
+      undefined,
+      () => now,
+      {
+        maxPreKeysPerBundle: 2,
+        preKeyReservationTtlMs: 100,
+      },
+    );
+    const abandoned = expiringStore.resolveMany([
+      "15551234567@s.whatsapp.net",
+      "15551234567@s.whatsapp.net",
+    ]);
+    now = 100;
+    const reclaimed = expiringStore.resolveMany(["15551234567@s.whatsapp.net"])[0]!;
+    expect(abandoned.map((bundle) => bundle.preKeyId)).toEqual([1, 2]);
+    expect(reclaimed.preKeyId).toBe(3);
+    expect(reclaimed.preKey).not.toBe(abandoned[0]!.preKey);
   });
 
   it("bounds PN-to-LID associations and evicts the least recently associated entry", () => {

--- a/test/whatsapp-wire.test.ts
+++ b/test/whatsapp-wire.test.ts
@@ -643,7 +643,7 @@ describe("WhatsApp binary nodes", () => {
     expect(() => encodeBinaryNode({ ...largest, content: Buffer.alloc(payloadBytes + 1) })).toThrow(
       `exceeds ${WHATSAPP_BINARY_NODE_MAX_FRAME_BYTES} bytes`,
     );
-  }, 20_000);
+  }, 60_000);
 
   it("rejects trailing bytes after a compressed node stream", async () => {
     const compressed = deflateSync(encodeBinaryNode({ attrs: {}, tag: "message" }).subarray(1));


### PR DESCRIPTION
## What Problem This Solves

Closes the remaining protocol-fidelity gaps in Loopback, Matrix, Signal, Telegram, and WhatsApp provider behavior.

## Why This Change Was Made

- Preserve lossless Loopback identities, reject invalid history timestamps, and keep message/edit ordering monotonic.
- Emit sparse Matrix incremental syncs while separating canonical local identities from historical event senders.
- Reject Signal RPC account selectors the local daemon does not serve.
- Bound WhatsApp acceptance work, retain one-time prekeys across persisted retries, enforce Cloud text and encoder limits, and validate native webhook discriminators.
- Stream Telegram multipart parsing with bounded metadata and RFC quoted-pair handling.

## User Impact

Compatible clients see provider-native identity, ordering, synchronization, account, multipart, and webhook behavior under malformed input and concurrency instead of mock-specific shortcuts.

## Evidence

- Focused provider suites, format, typecheck, and lint passed on each source commit.
- `gpt-5.6-sol` high autoreview passed on each completed source lane.
- Exact-head grouped `gpt-5.6-sol` high autoreview reported no accepted or actionable findings.
- Linux Crabbox `pnpm verify` passed on `ffe54e6fa0d837e1a52391c45885f79afc0d4011`: 64 files passed, 1,568 tests passed, 22 skipped.
- Crabbox run `run_b097d18c8f16`; lease `cbx_8ba672f42bc9` released automatically.
