### PR TITLE
fix(http): harden bounded transport lifecycles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Bound shared HTTP responses, Matrix sync payloads, stalled webhook DNS recovery, unmatched request bodies, and admitted local-mock hook cleanup.
 - Stream Telegram multipart uploads with bounded parser metadata instead of copying complete files through `FormData`.
 - Keep Unix recorder identity locks in one validated private per-user namespace across processes and recorder path changes.
 - Reject non-positive Telegram admin message IDs and enforce native Mattermost channel types and unique normalized usernames.

--- a/src/providers/local-mock.ts
+++ b/src/providers/local-mock.ts
@@ -57,9 +57,11 @@ export type LocalMockAdapterOptions = {
   recorderPath?: string | undefined;
   settleWebhookRequest?: (params: { accepted: boolean; payload: unknown; rawBody: string }) => void;
   webhook?: LocalMockWebhookConfig | undefined;
+  webhookCleanupGraceMs?: number | undefined;
 };
 
 const MAX_WAIT_CURSORS = 64;
+const DEFAULT_WEBHOOK_CLEANUP_GRACE_MS = 250;
 
 type WaitCursorState = {
   active: number;
@@ -265,6 +267,32 @@ function reportPostCommitWebhookSettlementFailure(providerId: string, error: unk
   }
 }
 
+async function settleWebhookHandlers(
+  providerId: string,
+  handlers: readonly Promise<Response>[],
+  graceMs: number,
+): Promise<void> {
+  if (handlers.length === 0) {
+    return;
+  }
+  let timer: NodeJS.Timeout | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(
+        new CrablineError(
+          `Provider "${providerId}" webhook handlers did not settle within ${graceMs}ms after cleanup.`,
+          { kind: "timeout" },
+        ),
+      );
+    }, graceMs);
+  });
+  try {
+    await Promise.race([Promise.allSettled(handlers).then(() => undefined), deadline]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 export class LocalMockProviderAdapter implements ProviderAdapter {
   readonly id;
   readonly platform;
@@ -276,6 +304,7 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
   readonly #options: LocalMockAdapterOptions;
   readonly #publicUrl: string | undefined;
   readonly #recorderPath: string;
+  readonly #webhookCleanupGraceMs: number;
   readonly #activeSends = new Set<Promise<SendResult>>();
   readonly #activeWebhookHandlers = new Set<Promise<Response>>();
   readonly #cleanupController = new AbortController();
@@ -300,6 +329,14 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
     this.#options = params.options;
     this.#publicUrl = params.options.publicUrl ?? params.options.webhook?.publicUrl;
     this.#recorderPath = toRecorderPath(params.id, params.options.recorderPath);
+    const webhookCleanupGraceMs =
+      params.options.webhookCleanupGraceMs ?? DEFAULT_WEBHOOK_CLEANUP_GRACE_MS;
+    if (!Number.isSafeInteger(webhookCleanupGraceMs) || webhookCleanupGraceMs < 1) {
+      throw new CrablineError("Webhook cleanup grace must be a positive safe integer.", {
+        kind: "config",
+      });
+    }
+    this.#webhookCleanupGraceMs = webhookCleanupGraceMs;
     this.#installCleanupFence();
   }
 
@@ -498,13 +535,18 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
     this.#cleanupPromise ??= (async () => {
       const sends = [...this.#activeSends];
       const webhookHandlers = [...this.#activeWebhookHandlers];
-      const [serverResult] = await Promise.allSettled([
+      const results = await Promise.allSettled([
         this.#serverClosing,
         ...sends,
-        ...webhookHandlers,
+        settleWebhookHandlers(this.id, webhookHandlers, this.#webhookCleanupGraceMs),
       ]);
+      const serverResult = results[0];
       if (serverResult?.status === "rejected") {
         throw serverResult.reason;
+      }
+      const webhookResult = results.at(-1);
+      if (webhookResult?.status === "rejected") {
+        throw webhookResult.reason;
       }
     })();
     await this.#cleanupPromise;
@@ -514,7 +556,10 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
     if (this.#cleanupBegun) {
       return Promise.resolve(new Response("provider is shutting down", { status: 503 }));
     }
-    const handling = this.#handleAdmittedWebhook(request);
+    const admittedRequest = new Request(request, {
+      signal: this.#signalFor(request.signal),
+    });
+    const handling = this.#handleAdmittedWebhook(admittedRequest);
     this.#activeWebhookHandlers.add(handling);
     void handling.then(
       () => this.#activeWebhookHandlers.delete(handling),

--- a/src/providers/webhook-server.ts
+++ b/src/providers/webhook-server.ts
@@ -4,6 +4,7 @@ import {
   advertisedHostForBindAddress,
   assertLoopbackBindAddress,
   closeServer,
+  drainRequestBody,
   formatUrlHost,
   writeFetchResponseHeaders,
 } from "../servers/http.js";
@@ -25,18 +26,19 @@ async function readRequestBody(
   maxBodyBytes: number,
   bodyTimeoutMs: number,
 ): Promise<Buffer> {
+  if (request.aborted) {
+    throw new Error("request body aborted");
+  }
   return await new Promise<Buffer>((resolve, reject) => {
     const chunks: Buffer[] = [];
     let bodyBytes = 0;
     let settled = false;
 
-    const cleanup = (preserveErrorListener = false) => {
+    const cleanup = () => {
       clearTimeout(timeout);
       request.off("data", onData);
       request.off("end", onEnd);
-      if (!preserveErrorListener) {
-        request.off("error", onError);
-      }
+      request.off("error", onError);
       request.off("aborted", onAborted);
     };
     const fail = (error: unknown) => {
@@ -44,7 +46,8 @@ async function readRequestBody(
         return;
       }
       settled = true;
-      cleanup(true);
+      cleanup();
+      drainRequestBody(request);
       reject(error);
     };
     const onData = (chunk: Buffer | string) => {
@@ -55,7 +58,6 @@ async function readRequestBody(
       const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
       bodyBytes += buffer.length;
       if (bodyBytes > maxBodyBytes) {
-        request.resume();
         fail(new RequestBodyTooLargeError());
         return;
       }
@@ -72,7 +74,6 @@ async function readRequestBody(
     const onError = (error: Error) => fail(error);
     const onAborted = () => fail(new Error("request body aborted"));
     const timeout = setTimeout(() => {
-      request.resume();
       fail(new RequestBodyTimeoutError());
     }, bodyTimeoutMs);
 
@@ -80,7 +81,27 @@ async function readRequestBody(
     request.once("end", onEnd);
     request.once("error", onError);
     request.once("aborted", onAborted);
+    if (request.aborted) {
+      onAborted();
+    }
   });
+}
+
+function drainIgnoredRequestBody(request: IncomingMessage, bodyTimeoutMs: number): void {
+  if (request.destroyed || request.readableEnded) {
+    return;
+  }
+  const socket = request.socket;
+  const timeout = setTimeout(() => socket.destroy(), bodyTimeoutMs);
+  timeout.unref();
+  const cleanup = () => {
+    clearTimeout(timeout);
+    request.off("end", cleanup);
+    socket.off("close", cleanup);
+  };
+  request.once("end", cleanup);
+  socket.once("close", cleanup);
+  drainRequestBody(request);
 }
 
 async function toFetchRequest(
@@ -229,7 +250,7 @@ export async function startWebhookServer(params: {
   const server = createServer(async (request, response) => {
     try {
       if (closing) {
-        request.resume();
+        drainIgnoredRequestBody(request, bodyTimeoutMs);
         await writeFetchResponse(
           response,
           new Response("provider is shutting down", {
@@ -243,7 +264,7 @@ export async function startWebhookServer(params: {
       const host = request.headers.host ?? "127.0.0.1";
       const url = new URL(request.url ?? "/", `http://${host}`);
       if (!methods.has(method) || url.pathname !== params.path) {
-        request.resume();
+        drainIgnoredRequestBody(request, bodyTimeoutMs);
         await writeFetchResponse(response, new Response("not found", { status: 404 }));
         return;
       }

--- a/src/servers/http.ts
+++ b/src/servers/http.ts
@@ -77,6 +77,7 @@ export function drainRequestBody(request: IncomingMessage): void {
   const ignoreError = () => {};
   request.on("error", ignoreError);
   if (request.destroyed) {
+    // IncomingMessage may emit its terminal error after destroyed becomes true.
     return;
   }
   const cleanup = () => {
@@ -299,6 +300,7 @@ export async function writeResponse(
   fetchResponse: Response,
   maxBytes = DEFAULT_MAX_RESPONSE_BODY_BYTES,
 ): Promise<void> {
+  requirePositiveSafeInteger(maxBytes, "maxResponseBodyBytes");
   const reader = fetchResponse.body?.getReader();
   let cancellation: Promise<void> | undefined;
   let rejectStopped!: (error: Error) => void;
@@ -418,13 +420,17 @@ export async function startHttpJsonServer(params: {
   port: number;
   serverName: string;
 }): Promise<{ baseUrl: string; close(): Promise<void>; server: Server }> {
+  const maxResponseBodyBytes = requirePositiveSafeInteger(
+    params.maxResponseBodyBytes ?? DEFAULT_MAX_RESPONSE_BODY_BYTES,
+    "maxResponseBodyBytes",
+  );
   const handleRequest = async (request: IncomingMessage, response: ServerResponse) => {
     try {
       const result = await params.handle(request, response);
       drainRequestBody(request);
       const handled = result instanceof Response ? { response: result } : result;
       try {
-        await writeResponse(response, handled.response, params.maxResponseBodyBytes);
+        await writeResponse(response, handled.response, maxResponseBodyBytes);
       } catch (error) {
         await handled.onWriteFailure?.();
         throw error;
@@ -453,7 +459,7 @@ export async function startHttpJsonServer(params: {
               },
               500,
             ),
-          params.maxResponseBodyBytes,
+          maxResponseBodyBytes,
         );
       } catch {
         response.destroy();
@@ -490,6 +496,13 @@ export async function startHttpJsonServer(params: {
     },
     server,
   };
+}
+
+function requirePositiveSafeInteger(value: number, name: string): number {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new RangeError(`${name} must be a positive safe integer.`);
+  }
+  return value;
 }
 
 export function readString(value: unknown): string | undefined {

--- a/src/servers/http.ts
+++ b/src/servers/http.ts
@@ -1,5 +1,5 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
-import { timingSafeEqual } from "node:crypto";
+import { createHash, timingSafeEqual } from "node:crypto";
 import { BlockList, isIP } from "node:net";
 import { CrablineError } from "../core/errors.js";
 
@@ -22,7 +22,9 @@ export type HttpJsonHandlerResult =
 
 export const ADMIN_TOKEN_HEADER = "x-crabline-admin-token";
 export const DEFAULT_MAX_REQUEST_BODY_BYTES = 1024 * 1024;
+export const DEFAULT_MAX_RESPONSE_BODY_BYTES = 8 * 1024 * 1024;
 export const DEFAULT_SERVER_SHUTDOWN_GRACE_MS = 250;
+const DRAINING_REQUESTS = new WeakSet<IncomingMessage>();
 const LOOPBACK_ADDRESSES = new BlockList();
 LOOPBACK_ADDRESSES.addSubnet("127.0.0.0", 8, "ipv4");
 LOOPBACK_ADDRESSES.addAddress("::1", "ipv6");
@@ -56,17 +58,29 @@ export class RequestBodyTooLargeError extends Error {
   }
 }
 
+export class ResponseBodyTooLargeError extends Error {
+  constructor(readonly maxBytes: number) {
+    super(`Response body exceeds the ${maxBytes} byte limit.`);
+    this.name = "ResponseBodyTooLargeError";
+  }
+}
+
 export function jsonResponse(value: unknown, status = 200): Response {
   return Response.json(value, { status });
 }
 
 export function drainRequestBody(request: IncomingMessage): void {
+  if (request.readableEnded || DRAINING_REQUESTS.has(request)) {
+    return;
+  }
+  DRAINING_REQUESTS.add(request);
   const ignoreError = () => {};
   request.on("error", ignoreError);
-  if (request.destroyed || request.readableEnded) {
+  if (request.destroyed) {
     return;
   }
   const cleanup = () => {
+    DRAINING_REQUESTS.delete(request);
     request.off("close", cleanup);
     request.off("end", cleanup);
     request.off("error", ignoreError);
@@ -81,6 +95,9 @@ export async function readBody(
   request: IncomingMessage,
   maxBytes = DEFAULT_MAX_REQUEST_BODY_BYTES,
 ): Promise<Buffer> {
+  if (request.aborted) {
+    throw new Error("Request body stream was aborted.");
+  }
   const contentLengthHeader = request.headers["content-length"];
   const contentLengthValue = Array.isArray(contentLengthHeader)
     ? contentLengthHeader[0]
@@ -137,6 +154,9 @@ export async function readBody(
     request.on("data", onData);
     request.on("end", onEnd);
     request.on("error", onError);
+    if (request.aborted) {
+      onAborted();
+    }
   });
 }
 
@@ -277,6 +297,7 @@ export function writeFetchResponseHeaders(response: ServerResponse, fetchRespons
 export async function writeResponse(
   response: ServerResponse,
   fetchResponse: Response,
+  maxBytes = DEFAULT_MAX_RESPONSE_BODY_BYTES,
 ): Promise<void> {
   const reader = fetchResponse.body?.getReader();
   let cancellation: Promise<void> | undefined;
@@ -331,6 +352,9 @@ export async function writeResponse(
           break;
         }
         if (chunk.value.byteLength > 0) {
+          if (bodyLength + chunk.value.byteLength > maxBytes) {
+            throw new ResponseBodyTooLargeError(maxBytes);
+          }
           const buffer = Buffer.from(chunk.value);
           chunks.push(buffer);
           bodyLength += buffer.length;
@@ -390,15 +414,17 @@ export async function startHttpJsonServer(params: {
   handle: (request: IncomingMessage, response: ServerResponse) => Promise<HttpJsonHandlerResult>;
   handleError?: (error: unknown, request: IncomingMessage) => Response | undefined;
   host: string;
+  maxResponseBodyBytes?: number | undefined;
   port: number;
   serverName: string;
 }): Promise<{ baseUrl: string; close(): Promise<void>; server: Server }> {
   const handleRequest = async (request: IncomingMessage, response: ServerResponse) => {
     try {
       const result = await params.handle(request, response);
+      drainRequestBody(request);
       const handled = result instanceof Response ? { response: result } : result;
       try {
-        await writeResponse(response, handled.response);
+        await writeResponse(response, handled.response, params.maxResponseBodyBytes);
       } catch (error) {
         await handled.onWriteFailure?.();
         throw error;
@@ -409,6 +435,7 @@ export async function startHttpJsonServer(params: {
         // Delivery is already committed; lifecycle failures must not trigger another response.
       }
     } catch (error) {
+      drainRequestBody(request);
       let handled: Response | undefined;
       try {
         handled = params.handleError?.(error, request);
@@ -426,6 +453,7 @@ export async function startHttpJsonServer(params: {
               },
               500,
             ),
+          params.maxResponseBodyBytes,
         );
       } catch {
         response.destroy();
@@ -499,6 +527,12 @@ function readBearerToken(authorization: string | undefined): string | undefined 
   return trimmed.slice(7);
 }
 
+export function constantTimeTokenEqual(providedToken: string, expectedToken: string): boolean {
+  const provided = createHash("sha256").update(providedToken).digest();
+  const expected = createHash("sha256").update(expectedToken).digest();
+  return timingSafeEqual(provided, expected);
+}
+
 export function hasAdminToken(request: IncomingMessage, expectedToken: string): boolean {
   const header = request.headers[ADMIN_TOKEN_HEADER];
   const directToken = Array.isArray(header) ? header[0] : header;
@@ -507,9 +541,7 @@ export function hasAdminToken(request: IncomingMessage, expectedToken: string): 
     return false;
   }
 
-  const provided = Buffer.from(providedToken);
-  const expected = Buffer.from(expectedToken);
-  return provided.length === expected.length && timingSafeEqual(provided, expected);
+  return constantTimeTokenEqual(providedToken, expectedToken);
 }
 
 export function adminAuthError(): Response {

--- a/src/servers/matrix.ts
+++ b/src/servers/matrix.ts
@@ -501,7 +501,11 @@ function createSyncRoom(
 function jsonItemsByteLength(items: readonly unknown[], maxBytes: number): number | undefined {
   let bytes = 0;
   for (const item of items) {
-    bytes += Buffer.byteLength(JSON.stringify(item), "utf8");
+    const serialized = JSON.stringify(item);
+    if (serialized === undefined) {
+      return undefined;
+    }
+    bytes += Buffer.byteLength(serialized, "utf8");
     if (bytes > maxBytes) {
       return undefined;
     }
@@ -536,7 +540,11 @@ function boundedSyncRoom(
       break;
     }
     const entry = requestedTimeline[index]!;
-    const eventBytes = Buffer.byteLength(JSON.stringify(entry.event), "utf8");
+    const serializedEvent = JSON.stringify(entry.event);
+    if (serializedEvent === undefined) {
+      return undefined;
+    }
+    const eventBytes = Buffer.byteLength(serializedEvent, "utf8");
     if (timelineBytes + ephemeralBytes + eventBytes > maxBytes) {
       break;
     }
@@ -560,7 +568,11 @@ function boundedSyncRoom(
     if (!dropped) {
       return undefined;
     }
-    timelineBytes -= Buffer.byteLength(JSON.stringify(dropped.event), "utf8");
+    const serializedDropped = JSON.stringify(dropped.event);
+    if (serializedDropped === undefined) {
+      return undefined;
+    }
+    timelineBytes -= Buffer.byteLength(serializedDropped, "utf8");
   }
 }
 

--- a/src/servers/matrix.ts
+++ b/src/servers/matrix.ts
@@ -514,6 +514,7 @@ function boundedSyncRoom(
   since: number | undefined,
   timelineLimit: number | undefined,
   maxBytes: number,
+  maxTimelineEvents = Number.POSITIVE_INFINITY,
 ): string | undefined {
   const available = room.timeline.filter((entry) => since === undefined || entry.sequence > since);
   const requestedTimeline =
@@ -531,6 +532,9 @@ function boundedSyncRoom(
   const timeline: Array<{ sequence: number; event: MatrixEvent }> = [];
   let timelineBytes = 0;
   for (let index = requestedTimeline.length - 1; index >= 0; index -= 1) {
+    if (timeline.length >= maxTimelineEvents) {
+      break;
+    }
     const entry = requestedTimeline[index]!;
     const eventBytes = Buffer.byteLength(JSON.stringify(entry.event), "utf8");
     if (timelineBytes + ephemeralBytes + eventBytes > maxBytes) {
@@ -607,26 +611,50 @@ async function handleSync(url: URL, state: MatrixServerState): Promise<Response>
     `s${state.nextSequence - 1}`,
   )},"presence":{"events":[]},"rooms":{"invite":{},"join":{`;
   const suffix = '},"knock":{},"leave":{}},"to_device":{"events":[]}}';
-  const parts: string[] = [];
   let responseBytes = Buffer.byteLength(prefix, "utf8") + Buffer.byteLength(suffix, "utf8");
-  for (const room of state.rooms.values()) {
-    if (!roomHasSyncUpdates(room, since)) {
-      continue;
-    }
-    const separator = parts.length === 0 ? "" : ",";
+  const rooms = [...state.rooms.values()].filter((room) => roomHasSyncUpdates(room, since));
+  const minimumEntries: Array<{
+    framingBytes: number;
+    minimumBytes: number;
+    room: MatrixRoom;
+    roomKey: string;
+    separator: string;
+  }> = [];
+  for (const [index, room] of rooms.entries()) {
+    const separator = index === 0 ? "" : ",";
     const roomKey = JSON.stringify(room.id);
     const framingBytes = Buffer.byteLength(`${separator}${roomKey}:`, "utf8");
-    const roomBody = boundedSyncRoom(
+    const roomBody = boundedSyncRoom(room, since, timelineLimit, state.maxSyncResponseBytes, 1);
+    if (!roomBody) {
+      return matrixResourceLimitError("Sync response exceeds the configured byte limit");
+    }
+    minimumEntries.push({
+      framingBytes,
+      minimumBytes: framingBytes + Buffer.byteLength(roomBody, "utf8"),
       room,
+      roomKey,
+      separator,
+    });
+  }
+  let reservedBytes = minimumEntries.reduce((total, entry) => total + entry.minimumBytes, 0);
+  if (responseBytes + reservedBytes > state.maxSyncResponseBytes) {
+    return matrixResourceLimitError("Sync response exceeds the configured byte limit");
+  }
+
+  const parts: string[] = [];
+  for (const entry of minimumEntries) {
+    reservedBytes -= entry.minimumBytes;
+    const roomBody = boundedSyncRoom(
+      entry.room,
       since,
       timelineLimit,
-      state.maxSyncResponseBytes - responseBytes - framingBytes,
+      state.maxSyncResponseBytes - responseBytes - entry.framingBytes - reservedBytes,
     );
     if (!roomBody) {
       return matrixResourceLimitError("Sync response exceeds the configured byte limit");
     }
-    parts.push(`${separator}${roomKey}:${roomBody}`);
-    responseBytes += framingBytes + Buffer.byteLength(roomBody, "utf8");
+    parts.push(`${entry.separator}${entry.roomKey}:${roomBody}`);
+    responseBytes += entry.framingBytes + Buffer.byteLength(roomBody, "utf8");
   }
   const body = `${prefix}${parts.join("")}${suffix}`;
   if (Buffer.byteLength(body, "utf8") > state.maxSyncResponseBytes) {

--- a/src/servers/matrix.ts
+++ b/src/servers/matrix.ts
@@ -9,6 +9,8 @@ import {
 } from "../matrix-ids.js";
 import {
   adminAuthError,
+  constantTimeTokenEqual,
+  DEFAULT_MAX_RESPONSE_BODY_BYTES,
   hasAdminToken,
   InvalidJsonBodyError,
   isJsonObject,
@@ -72,6 +74,7 @@ type MatrixServerState = {
   filters: Map<string, { body: Record<string, unknown>; bytes: number }>;
   maxCommittedRooms: number;
   maxCommittedUsers: number;
+  maxSyncResponseBytes: number;
   nextEvent: number;
   nextFilter: number;
   nextSequence: number;
@@ -96,6 +99,7 @@ const MATRIX_TRANSACTION_RETENTION_MS = 10 * 60_000;
 const MAX_NODE_TIMER_DELAY_MS = 2_147_483_647;
 const DEFAULT_MAX_MATRIX_COMMITTED_ROOMS = 1_000;
 const DEFAULT_MAX_MATRIX_COMMITTED_USERS = 1_000;
+const DEFAULT_MAX_MATRIX_SYNC_RESPONSE_BYTES = 4 * 1024 * 1024;
 
 class InvalidMatrixPathEncodingError extends Error {
   constructor() {
@@ -138,6 +142,7 @@ export type StartMatrixServerParams = {
   host?: string | undefined;
   maxCommittedRooms?: number | undefined;
   maxCommittedUsers?: number | undefined;
+  maxSyncResponseBytes?: number | undefined;
   onEvent?: ServerEventObserver | undefined;
   port?: number | undefined;
   recorderPath?: string | undefined;
@@ -161,7 +166,8 @@ async function appendEvent(
 
 function authorized(request: IncomingMessage, token: string): boolean {
   const match = /^Bearer\s+(\S+)$/iu.exec(request.headers.authorization ?? "");
-  return match?.[1] === token;
+  const providedToken = match?.[1];
+  return providedToken ? constantTimeTokenEqual(providedToken, token) : false;
 }
 
 function matrixError(errcode: string, error: string, status: number): Response {
@@ -352,21 +358,40 @@ function publishDirectRoom(state: MatrixServerState, userId: string, roomId: str
   state.directRoomsSequence = state.nextSequence++;
 }
 
-function syncAccountData(state: MatrixServerState, since: number | undefined) {
+function serializeSyncAccountData(
+  state: MatrixServerState,
+  since: number | undefined,
+  maxBytes: number,
+): string | undefined {
   const sequence = state.directRoomsSequence;
   if (sequence === undefined || (since !== undefined && sequence <= since)) {
-    return { events: [] };
+    return '{"events":[]}';
   }
-  return {
-    events: [
-      {
-        content: Object.fromEntries(
-          [...state.directRooms].map(([userId, roomIds]) => [userId, [...roomIds]]),
-        ),
-        type: "m.direct",
-      },
-    ],
-  };
+  const prefix = '{"events":[{"content":{';
+  const suffix = '},"type":"m.direct"}]}';
+  const parts: string[] = [];
+  let bytes = Buffer.byteLength(prefix, "utf8") + Buffer.byteLength(suffix, "utf8");
+  for (const [userId, roomIds] of state.directRooms) {
+    const roomParts: string[] = [];
+    let roomBytes = 2;
+    for (const roomId of roomIds) {
+      const separator = roomParts.length === 0 ? "" : ",";
+      const roomPart = `${separator}${JSON.stringify(roomId)}`;
+      roomBytes += Buffer.byteLength(roomPart, "utf8");
+      if (bytes + roomBytes > maxBytes) {
+        return undefined;
+      }
+      roomParts.push(roomPart);
+    }
+    const separator = parts.length === 0 ? "" : ",";
+    const part = `${separator}${JSON.stringify(userId)}:[${roomParts.join("")}]`;
+    bytes += Buffer.byteLength(part, "utf8");
+    if (bytes > maxBytes) {
+      return undefined;
+    }
+    parts.push(part);
+  }
+  return `${prefix}${parts.join("")}${suffix}`;
 }
 
 function rememberTransaction(
@@ -429,12 +454,12 @@ function resolveSyncFilter(
   }
 }
 
-function syncRoom(room: MatrixRoom, since: number | undefined, timelineLimit: number | undefined) {
-  const available = room.timeline.filter((entry) => since === undefined || entry.sequence > since);
-  const timeline =
-    timelineLimit === undefined
-      ? available
-      : available.slice(Math.max(0, available.length - timelineLimit));
+function createSyncRoom(
+  room: MatrixRoom,
+  since: number | undefined,
+  available: Array<{ sequence: number; event: MatrixEvent }>,
+  timeline: Array<{ sequence: number; event: MatrixEvent }>,
+) {
   const firstSequence = timeline[0]?.sequence;
   const historyWasTrimmed =
     room.lastDroppedTimelineSequence !== undefined &&
@@ -471,6 +496,68 @@ function syncRoom(room: MatrixRoom, since: number | undefined, timelineLimit: nu
     },
     unread_notifications: { highlight_count: 0, notification_count: 0 },
   };
+}
+
+function jsonItemsByteLength(items: readonly unknown[], maxBytes: number): number | undefined {
+  let bytes = 0;
+  for (const item of items) {
+    bytes += Buffer.byteLength(JSON.stringify(item), "utf8");
+    if (bytes > maxBytes) {
+      return undefined;
+    }
+  }
+  return bytes;
+}
+
+function boundedSyncRoom(
+  room: MatrixRoom,
+  since: number | undefined,
+  timelineLimit: number | undefined,
+  maxBytes: number,
+): string | undefined {
+  const available = room.timeline.filter((entry) => since === undefined || entry.sequence > since);
+  const requestedTimeline =
+    timelineLimit === undefined
+      ? available
+      : available.slice(Math.max(0, available.length - timelineLimit));
+  const ephemeral = room.ephemeral
+    .filter((entry) => since === undefined || entry.sequence > since)
+    .map((entry) => entry.event);
+  const ephemeralBytes = jsonItemsByteLength(ephemeral, maxBytes);
+  if (ephemeralBytes === undefined) {
+    return undefined;
+  }
+
+  const timeline: Array<{ sequence: number; event: MatrixEvent }> = [];
+  let timelineBytes = 0;
+  for (let index = requestedTimeline.length - 1; index >= 0; index -= 1) {
+    const entry = requestedTimeline[index]!;
+    const eventBytes = Buffer.byteLength(JSON.stringify(entry.event), "utf8");
+    if (timelineBytes + ephemeralBytes + eventBytes > maxBytes) {
+      break;
+    }
+    timeline.unshift(entry);
+    timelineBytes += eventBytes;
+  }
+  if (requestedTimeline.length > 0 && timelineLimit !== 0 && timeline.length === 0) {
+    return undefined;
+  }
+
+  while (true) {
+    const body = createSyncRoom(room, since, available, timeline);
+    const stateBytes = jsonItemsByteLength(body.state.events, maxBytes);
+    if (stateBytes !== undefined && stateBytes + ephemeralBytes + timelineBytes <= maxBytes) {
+      const serialized = JSON.stringify(body);
+      if (Buffer.byteLength(serialized, "utf8") <= maxBytes) {
+        return serialized;
+      }
+    }
+    const dropped = timeline.shift();
+    if (!dropped) {
+      return undefined;
+    }
+    timelineBytes -= Buffer.byteLength(JSON.stringify(dropped.event), "utf8");
+  }
 }
 
 function roomHasSyncUpdates(room: MatrixRoom, since: number | undefined): boolean {
@@ -512,19 +599,42 @@ async function handleSync(url: URL, state: MatrixServerState): Promise<Response>
   if (since !== undefined && !hasNewEvents && timeout > 0) {
     await waitForSyncEvent(state, timeout);
   }
-  const join = Object.fromEntries(
-    [...state.rooms.values()]
-      .filter((room) => roomHasSyncUpdates(room, since))
-      .map((room) => [room.id, syncRoom(room, since, timelineLimit)]),
-  );
-  return jsonResponse({
-    account_data: syncAccountData(state, since),
-    device_lists: { changed: [], left: [] },
-    device_one_time_keys_count: {},
-    next_batch: `s${state.nextSequence - 1}`,
-    presence: { events: [] },
-    rooms: { invite: {}, join, knock: {}, leave: {} },
-    to_device: { events: [] },
+  const accountData = serializeSyncAccountData(state, since, state.maxSyncResponseBytes);
+  if (!accountData) {
+    return matrixResourceLimitError("Sync response exceeds the configured byte limit");
+  }
+  const prefix = `{"account_data":${accountData},"device_lists":{"changed":[],"left":[]},"device_one_time_keys_count":{},"next_batch":${JSON.stringify(
+    `s${state.nextSequence - 1}`,
+  )},"presence":{"events":[]},"rooms":{"invite":{},"join":{`;
+  const suffix = '},"knock":{},"leave":{}},"to_device":{"events":[]}}';
+  const parts: string[] = [];
+  let responseBytes = Buffer.byteLength(prefix, "utf8") + Buffer.byteLength(suffix, "utf8");
+  for (const room of state.rooms.values()) {
+    if (!roomHasSyncUpdates(room, since)) {
+      continue;
+    }
+    const separator = parts.length === 0 ? "" : ",";
+    const roomKey = JSON.stringify(room.id);
+    const framingBytes = Buffer.byteLength(`${separator}${roomKey}:`, "utf8");
+    const roomBody = boundedSyncRoom(
+      room,
+      since,
+      timelineLimit,
+      state.maxSyncResponseBytes - responseBytes - framingBytes,
+    );
+    if (!roomBody) {
+      return matrixResourceLimitError("Sync response exceeds the configured byte limit");
+    }
+    parts.push(`${separator}${roomKey}:${roomBody}`);
+    responseBytes += framingBytes + Buffer.byteLength(roomBody, "utf8");
+  }
+  const body = `${prefix}${parts.join("")}${suffix}`;
+  if (Buffer.byteLength(body, "utf8") > state.maxSyncResponseBytes) {
+    return matrixResourceLimitError("Sync response exceeds the configured byte limit");
+  }
+  return new Response(body, {
+    headers: { "content-type": "application/json" },
+    status: 200,
   });
 }
 
@@ -924,6 +1034,11 @@ export async function startMatrixServer(
       "maxCommittedUsers",
       DEFAULT_MAX_MATRIX_COMMITTED_USERS,
     ),
+    maxSyncResponseBytes: resolvePositiveLimit(
+      params.maxSyncResponseBytes,
+      "maxSyncResponseBytes",
+      DEFAULT_MAX_MATRIX_SYNC_RESPONSE_BYTES,
+    ),
     nextEvent: 1,
     nextFilter: 1,
     nextSequence: 1,
@@ -962,6 +1077,7 @@ export async function startMatrixServer(
       return matrixError("M_UNKNOWN", "Internal server error", 500);
     },
     host,
+    maxResponseBodyBytes: Math.max(DEFAULT_MAX_RESPONSE_BODY_BYTES, state.maxSyncResponseBytes),
     port: params.port ?? 0,
     serverName: "Matrix",
     async handle(request) {

--- a/src/servers/matrix.ts
+++ b/src/servers/matrix.ts
@@ -564,6 +564,9 @@ function boundedSyncRoom(
         return serialized;
       }
     }
+    if (timeline.length === 1 && requestedTimeline.length > 0 && timelineLimit !== 0) {
+      return undefined;
+    }
     const dropped = timeline.shift();
     if (!dropped) {
       return undefined;

--- a/src/servers/webhook-target.ts
+++ b/src/servers/webhook-target.ts
@@ -56,8 +56,11 @@ type Nat64Prefix = {
 };
 
 type PendingWebhookDnsLookup = {
+  detached: boolean;
   hostname: string;
   onAbort: () => void;
+  recoveryReady: boolean;
+  recoveryTimer: NodeJS.Timeout | undefined;
   reject(error: unknown): void;
   resolve(addresses: WebhookDnsLookupResult): void;
   settled: boolean;
@@ -68,21 +71,28 @@ type PendingWebhookDnsLookup = {
 
 export class WebhookDnsLookupPool {
   readonly #pending: PendingWebhookDnsLookup[] = [];
+  readonly #recoverable = new Set<PendingWebhookDnsLookup>();
   #active = 0;
+  #detached = 0;
 
   constructor(
     private readonly maxConcurrent: number,
     private readonly lookupHostname: WebhookDnsLookup = async (hostname) =>
       await lookup(hostname, { all: true, verbatim: true }),
+    private readonly abortedLookupRecoveryMs = 5_000,
   ) {
     if (!Number.isSafeInteger(maxConcurrent) || maxConcurrent < 1) {
       throw new Error("Webhook DNS lookup concurrency must be a positive safe integer.");
+    }
+    if (!Number.isSafeInteger(abortedLookupRecoveryMs) || abortedLookupRecoveryMs < 1) {
+      throw new Error("Webhook DNS lookup recovery must be a positive safe integer.");
     }
   }
 
   resolve(hostname: string, signal?: AbortSignal): Promise<WebhookDnsLookupResult> {
     return new Promise<WebhookDnsLookupResult>((resolve, reject) => {
       const pending: PendingWebhookDnsLookup = {
+        detached: false,
         hostname,
         onAbort: () => {
           if (pending.settled) {
@@ -94,12 +104,16 @@ export class WebhookDnsLookupPool {
             if (index >= 0) {
               this.#pending.splice(index, 1);
             }
+          } else {
+            this.#scheduleRecovery(pending);
           }
           signal?.removeEventListener("abort", pending.onAbort);
           reject(abortSignalError(signal));
           this.#pump();
         },
         reject,
+        recoveryReady: false,
+        recoveryTimer: undefined,
         resolve,
         settled: false,
         signal,
@@ -150,9 +164,52 @@ export class WebhookDnsLookupPool {
           },
         )
         .finally(() => {
+          if (pending.recoveryTimer) {
+            clearTimeout(pending.recoveryTimer);
+            pending.recoveryTimer = undefined;
+          }
+          this.#recoverable.delete(pending);
           pending.signal?.removeEventListener("abort", pending.onAbort);
-          this.#releaseSlot(pending);
+          if (pending.detached) {
+            pending.detached = false;
+            this.#detached -= 1;
+            this.#recoverSlots();
+            this.#pump();
+          } else {
+            this.#releaseSlot(pending);
+          }
         });
+    }
+  }
+
+  #scheduleRecovery(pending: PendingWebhookDnsLookup): void {
+    if (pending.recoveryTimer || pending.detached || !pending.slotHeld) {
+      return;
+    }
+    pending.recoveryTimer = setTimeout(() => {
+      pending.recoveryTimer = undefined;
+      if (!pending.slotHeld) {
+        return;
+      }
+      pending.recoveryReady = true;
+      this.#recoverable.add(pending);
+      this.#recoverSlots();
+    }, this.abortedLookupRecoveryMs);
+    pending.recoveryTimer.unref();
+  }
+
+  #recoverSlots(): void {
+    for (const pending of this.#recoverable) {
+      if (this.#detached >= this.maxConcurrent) {
+        return;
+      }
+      this.#recoverable.delete(pending);
+      if (!pending.recoveryReady || !pending.slotHeld) {
+        continue;
+      }
+      pending.detached = true;
+      this.#detached += 1;
+      this.#releaseSlot(pending);
     }
   }
 

--- a/test/http-server.test.ts
+++ b/test/http-server.test.ts
@@ -5,6 +5,7 @@ import {
   adminAuthError,
   ADMIN_TOKEN_HEADER,
   assertLoopbackBindAddress,
+  constantTimeTokenEqual,
   DEFAULT_MAX_REQUEST_BODY_BYTES,
   drainRequestBody,
   hasAdminToken,
@@ -16,6 +17,7 @@ import {
   readBody,
   readInteger,
   RequestBodyTooLargeError,
+  ResponseBodyTooLargeError,
   startHttpJsonServer,
 } from "../src/servers/http.js";
 
@@ -49,6 +51,12 @@ describe("server admin authentication", () => {
     expect(hasAdminToken(createRequest(headers), expectedToken)).toBe(expected);
   });
 
+  it("compares tokens through a fixed-length digest", () => {
+    expect(constantTimeTokenEqual("same-token", "same-token")).toBe(true);
+    expect(constantTimeTokenEqual("short", "a-much-longer-token")).toBe(false);
+    expect(constantTimeTokenEqual("token-a", "token-b")).toBe(false);
+  });
+
   it("gives the custom header precedence over Bearer authorization", () => {
     expect(
       hasAdminToken(
@@ -80,6 +88,12 @@ describe("server admin authentication", () => {
 });
 
 describe("server HTTP body reader", () => {
+  it("rejects requests that were already aborted before reading began", async () => {
+    const request = Object.assign(createRequest(), { aborted: true });
+
+    await expect(readBody(request)).rejects.toThrow("Request body stream was aborted");
+  });
+
   it("keeps rejected request streams error-handled until close", async () => {
     const aborted = createRequest();
     const abortedRead = readBody(aborted);
@@ -397,6 +411,70 @@ describe("server HTTP body reader", () => {
         error: "internal server error",
         ok: false,
       });
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("bounds buffered response bodies before staging status and headers", async () => {
+    let cancelled = false;
+    const server = await startHttpJsonServer({
+      async handle() {
+        return new Response(
+          new ReadableStream({
+            cancel() {
+              cancelled = true;
+            },
+            start(controller) {
+              controller.enqueue(Buffer.alloc(65, 0x78));
+            },
+          }),
+          { headers: { "x-uncommitted": "true" }, status: 201 },
+        );
+      },
+      handleError(error) {
+        expect(error).toBeInstanceOf(ResponseBodyTooLargeError);
+        return Response.json({ error: "response too large", ok: false }, { status: 500 });
+      },
+      host: "127.0.0.1",
+      maxResponseBodyBytes: 64,
+      port: 0,
+      serverName: "test",
+    });
+
+    try {
+      const response = await fetch(server.baseUrl);
+      expect(response.status).toBe(500);
+      expect(response.headers.get("x-uncommitted")).toBeNull();
+      await expect(response.json()).resolves.toEqual({
+        error: "response too large",
+        ok: false,
+      });
+      expect(cancelled).toBe(true);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("drains request bodies that handlers ignore", async () => {
+    let observedRequest: IncomingMessage | undefined;
+    const server = await startHttpJsonServer({
+      async handle(request) {
+        observedRequest = request;
+        return Response.json({ ok: true });
+      },
+      host: "127.0.0.1",
+      port: 0,
+      serverName: "test",
+    });
+
+    try {
+      const response = await fetch(server.baseUrl, {
+        body: "ignored request body",
+        method: "POST",
+      });
+      expect(response.status).toBe(200);
+      await expect.poll(() => observedRequest?.readableEnded).toBe(true);
     } finally {
       await server.close();
     }

--- a/test/http-server.test.ts
+++ b/test/http-server.test.ts
@@ -1,4 +1,4 @@
-import { get, type IncomingMessage } from "node:http";
+import { get, type IncomingMessage, type ServerResponse } from "node:http";
 import { PassThrough } from "node:stream";
 import { describe, expect, it } from "vitest";
 import {
@@ -19,6 +19,7 @@ import {
   RequestBodyTooLargeError,
   ResponseBodyTooLargeError,
   startHttpJsonServer,
+  writeResponse,
 } from "../src/servers/http.js";
 
 type TestRequest = IncomingMessage & PassThrough;
@@ -454,6 +455,33 @@ describe("server HTTP body reader", () => {
     } finally {
       await server.close();
     }
+  });
+
+  it("rejects response body limits that cannot enforce a finite byte bound", async () => {
+    for (const maxResponseBodyBytes of [
+      0,
+      -1,
+      1.5,
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      Number.MAX_SAFE_INTEGER + 1,
+    ]) {
+      await expect(
+        startHttpJsonServer({
+          async handle() {
+            return Response.json({ ok: true });
+          },
+          host: "127.0.0.1",
+          maxResponseBodyBytes,
+          port: 0,
+          serverName: "test",
+        }),
+      ).rejects.toThrow("maxResponseBodyBytes must be a positive safe integer.");
+    }
+
+    await expect(
+      writeResponse({} as ServerResponse, Response.json({ ok: true }), Number.NaN),
+    ).rejects.toThrow("maxResponseBodyBytes must be a positive safe integer.");
   });
 
   it("drains request bodies that handlers ignore", async () => {

--- a/test/local-mock-provider.test.ts
+++ b/test/local-mock-provider.test.ts
@@ -950,6 +950,107 @@ describe("local mock provider", () => {
     await expect(cleanup).resolves.toBeUndefined();
   });
 
+  it("aborts admitted webhook hooks when provider cleanup begins", async () => {
+    let handleRequest: ((request: Request) => Promise<Response>) | undefined;
+    let observedSignal: AbortSignal | undefined;
+    let reportAdmission!: () => void;
+    const admitted = new Promise<void>((resolve) => {
+      reportAdmission = resolve;
+    });
+    webhookMocks.startWebhookServer.mockImplementationOnce(async (params) => {
+      handleRequest = params.handle;
+      return {
+        async close() {},
+        endpointUrl: "http://127.0.0.1:43210/slack/events",
+      };
+    });
+    const config = createConfig();
+    const provider = new LocalMockProviderAdapter({
+      codec: createGenericLocalMockTargetCodec("slack"),
+      config,
+      id: "provider-a",
+      options: {
+        defaultWebhook: { host: "127.0.0.1", path: "/slack/events", port: 0 },
+        endpointLabel: "events endpoint",
+        async handleWebhookPayload(_payload, request) {
+          observedSignal = request.signal;
+          reportAdmission();
+          await new Promise<void>((resolve, reject) => {
+            const abort = () => reject(request.signal.reason);
+            if (request.signal.aborted) {
+              abort();
+              return;
+            }
+            request.signal.addEventListener("abort", abort, { once: true });
+          });
+          return new Response("unreachable");
+        },
+        platform: "slack",
+      },
+    });
+    providers.push(provider);
+    await provider.probe(createContext(config));
+    const handling = handleRequest!(
+      new Request("http://127.0.0.1:43210/slack/events", {
+        body: "{}",
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      }),
+    );
+    await admitted;
+
+    const cleanup = provider.cleanup();
+
+    expect(observedSignal?.aborted).toBe(true);
+    await expect(handling).rejects.toThrow(/cleaned up/u);
+    await expect(cleanup).resolves.toBeUndefined();
+  });
+
+  it("bounds cleanup when an admitted webhook hook ignores cancellation", async () => {
+    let handleRequest: ((request: Request) => Promise<Response>) | undefined;
+    let reportAdmission!: () => void;
+    const admitted = new Promise<void>((resolve) => {
+      reportAdmission = resolve;
+    });
+    webhookMocks.startWebhookServer.mockImplementationOnce(async (params) => {
+      handleRequest = params.handle;
+      return {
+        async close() {},
+        endpointUrl: "http://127.0.0.1:43210/slack/events",
+      };
+    });
+    const config = createConfig();
+    const provider = new LocalMockProviderAdapter({
+      codec: createGenericLocalMockTargetCodec("slack"),
+      config,
+      id: "provider-a",
+      options: {
+        defaultWebhook: { host: "127.0.0.1", path: "/slack/events", port: 0 },
+        endpointLabel: "events endpoint",
+        async handleWebhookPayload() {
+          reportAdmission();
+          return await new Promise<Response>(() => {});
+        },
+        platform: "slack",
+        webhookCleanupGraceMs: 20,
+      },
+    });
+    await provider.probe(createContext(config));
+    void handleRequest!(
+      new Request("http://127.0.0.1:43210/slack/events", {
+        body: "{}",
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      }),
+    );
+    await admitted;
+
+    await expect(provider.cleanup()).rejects.toMatchObject({
+      kind: "timeout",
+      message: expect.stringContaining("did not settle within 20ms"),
+    });
+  });
+
   it("does not watch events from another provider sharing its recorder", async () => {
     const directory = await createTempDir();
     directories.push(directory);

--- a/test/matrix-server.test.ts
+++ b/test/matrix-server.test.ts
@@ -1559,6 +1559,37 @@ describe("Matrix local provider server", () => {
     });
   });
 
+  it("does not advance past the sole deliverable event when room framing exceeds the limit", async () => {
+    const server = await startMatrixServer({
+      accessToken: "test-token-placeholder",
+      maxSyncResponseBytes: 1_200,
+      roomId: "!sync-framing-limit:matrix.test",
+    });
+    servers.push(server);
+    const sent = await fetch(
+      `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!sync-framing-limit:matrix.test")}/send/m.room.message/framing-limit`,
+      {
+        body: JSON.stringify({ body: "x".repeat(100), msgtype: "m.text" }),
+        headers: {
+          ...auth("test-token-placeholder"),
+          "content-type": "application/json",
+        },
+        method: "PUT",
+      },
+    );
+    expect(sent.status).toBe(200);
+
+    const response = await fetch(server.manifest.endpoints.syncUrl, {
+      headers: auth("test-token-placeholder"),
+    });
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      admin_contact: "mailto:admin@localhost",
+      errcode: "M_RESOURCE_LIMIT_EXCEEDED",
+      error: "Sync response exceeds the configured byte limit",
+    });
+  });
+
   it("reserves sync capacity for later rooms before adding optional history", async () => {
     const server = await startMatrixServer({
       accessToken: "test-token-placeholder",

--- a/test/matrix-server.test.ts
+++ b/test/matrix-server.test.ts
@@ -1558,4 +1558,67 @@ describe("Matrix local provider server", () => {
       error: "Sync response exceeds the configured byte limit",
     });
   });
+
+  it("reserves sync capacity for later rooms before adding optional history", async () => {
+    const server = await startMatrixServer({
+      accessToken: "test-token-placeholder",
+      adminToken: "test-auth-token",
+      maxSyncResponseBytes: 4_000,
+      roomId: "!first-budget:matrix.test",
+    });
+    servers.push(server);
+    for (let index = 0; index < 8; index += 1) {
+      const sent = await fetch(
+        `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!first-budget:matrix.test")}/send/m.room.message/first-${index}`,
+        {
+          body: JSON.stringify({ body: `${index}:${"x".repeat(300)}`, msgtype: "m.text" }),
+          headers: {
+            ...auth("test-token-placeholder"),
+            "content-type": "application/json",
+          },
+          method: "PUT",
+        },
+      );
+      expect(sent.status).toBe(200);
+    }
+    const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({
+        roomId: "!second-budget:matrix.test",
+        senderId: "@alice:matrix.test",
+        text: "later room event",
+      }),
+      headers: {
+        "content-type": "application/json",
+        [ADMIN_TOKEN_HEADER]: "test-auth-token",
+      },
+      method: "POST",
+    });
+    expect(inbound.status).toBe(200);
+
+    const response = await fetch(server.manifest.endpoints.syncUrl, {
+      headers: auth("test-token-placeholder"),
+    });
+    const rawBody = await response.text();
+    const body = JSON.parse(rawBody) as {
+      rooms: {
+        join: Record<
+          string,
+          { timeline: { events: Array<{ content: { body?: string } }>; limited: boolean } }
+        >;
+      };
+    };
+
+    expect(response.status).toBe(200);
+    expect(Buffer.byteLength(rawBody, "utf8")).toBeLessThanOrEqual(4_000);
+    expect(Object.keys(body.rooms.join).sort()).toEqual([
+      "!first-budget:matrix.test",
+      "!second-budget:matrix.test",
+    ]);
+    expect(body.rooms.join["!first-budget:matrix.test"]?.timeline.limited).toBe(true);
+    expect(
+      body.rooms.join["!second-budget:matrix.test"]?.timeline.events.some(
+        (event) => event.content.body === "later room event",
+      ),
+    ).toBe(true);
+  });
 });

--- a/test/matrix-server.test.ts
+++ b/test/matrix-server.test.ts
@@ -1480,4 +1480,82 @@ describe("Matrix local provider server", () => {
     );
     await expect(untouchedRetry.json()).resolves.toEqual({ event_id: secondEventId });
   }, 15_000);
+
+  it("bounds sync responses without skipping the newest deliverable event", async () => {
+    const server = await startMatrixServer({
+      accessToken: "test-token-placeholder",
+      maxSyncResponseBytes: 2_500,
+      roomId: "!sync-budget:matrix.test",
+    });
+    servers.push(server);
+    for (let index = 0; index < 12; index += 1) {
+      const response = await fetch(
+        `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!sync-budget:matrix.test")}/send/m.room.message/budget-${index}`,
+        {
+          body: JSON.stringify({
+            body: `${index}:${"x".repeat(300)}`,
+            msgtype: "m.text",
+          }),
+          headers: {
+            ...auth("test-token-placeholder"),
+            "content-type": "application/json",
+          },
+          method: "PUT",
+        },
+      );
+      expect(response.status).toBe(200);
+    }
+
+    const response = await fetch(server.manifest.endpoints.syncUrl, {
+      headers: auth("test-token-placeholder"),
+    });
+    const rawBody = await response.text();
+    const body = JSON.parse(rawBody) as {
+      rooms: {
+        join: Record<
+          string,
+          { timeline: { events: Array<{ content: { body: string } }>; limited: boolean } }
+        >;
+      };
+    };
+    const timeline = body.rooms.join["!sync-budget:matrix.test"]?.timeline;
+
+    expect(response.status).toBe(200);
+    expect(Buffer.byteLength(rawBody, "utf8")).toBeLessThanOrEqual(2_500);
+    expect(timeline?.limited).toBe(true);
+    expect(timeline?.events.length).toBeGreaterThan(0);
+    expect(timeline?.events.length).toBeLessThan(12);
+    expect(timeline?.events.at(-1)?.content.body).toBe(`11:${"x".repeat(300)}`);
+  });
+
+  it("returns a native resource-limit error when the newest sync event cannot fit", async () => {
+    const server = await startMatrixServer({
+      accessToken: "test-token-placeholder",
+      maxSyncResponseBytes: 1_500,
+      roomId: "!sync-too-large:matrix.test",
+    });
+    servers.push(server);
+    const sent = await fetch(
+      `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent("!sync-too-large:matrix.test")}/send/m.room.message/oversized-sync`,
+      {
+        body: JSON.stringify({ body: "x".repeat(3_000), msgtype: "m.text" }),
+        headers: {
+          ...auth("test-token-placeholder"),
+          "content-type": "application/json",
+        },
+        method: "PUT",
+      },
+    );
+    expect(sent.status).toBe(200);
+
+    const response = await fetch(server.manifest.endpoints.syncUrl, {
+      headers: auth("test-token-placeholder"),
+    });
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      admin_contact: "mailto:admin@localhost",
+      errcode: "M_RESOURCE_LIMIT_EXCEEDED",
+      error: "Sync response exceeds the configured byte limit",
+    });
+  });
 });

--- a/test/webhook-server.test.ts
+++ b/test/webhook-server.test.ts
@@ -371,6 +371,39 @@ describe("webhook server", () => {
     expect(response.status).toBe(404);
   });
 
+  it("closes unmatched routes whose request bodies stall", async () => {
+    let handlerInvoked = false;
+    const server = await startWebhookServer({
+      bodyTimeoutMs: 20,
+      async handle() {
+        handlerInvoked = true;
+        return new Response("ok");
+      },
+      host: "127.0.0.1",
+      path: "/slack/events",
+      port: 0,
+    });
+    cleanups.push(() => server.close());
+    const endpoint = new URL(server.endpointUrl);
+    const socket = connect(Number(endpoint.port), endpoint.hostname);
+    let response = "";
+    const closed = once(socket, "close");
+    socket.setEncoding("utf8");
+    socket.on("data", (chunk) => {
+      response += chunk;
+    });
+    await once(socket, "connect");
+    socket.write("POST /wrong HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: 5\r\n\r\n1");
+    await vi.waitFor(() => expect(response).toContain("HTTP/1.1 404"));
+    await expect(
+      Promise.race([
+        closed.then(() => "closed"),
+        new Promise<string>((resolve) => setTimeout(() => resolve("timed out"), 500)),
+      ]),
+    ).resolves.toBe("closed");
+    expect(handlerInvoked).toBe(false);
+  });
+
   it("times out slow request bodies before invoking the handler", async () => {
     let handlerInvoked = false;
     const server = await startWebhookServer({

--- a/test/webhook-target.test.ts
+++ b/test/webhook-target.test.ts
@@ -343,6 +343,44 @@ describe("webhook target validation", () => {
     await expect(fourth).resolves.toEqual([{ address: "93.184.216.37", family: 4 }]);
   });
 
+  it("recovers bounded capacity when aborted DNS lookups never settle", async () => {
+    const started: string[] = [];
+    const releases = new Map<
+      string,
+      (addresses: Array<{ address: string; family: number }>) => void
+    >();
+    const pool = new WebhookDnsLookupPool(
+      1,
+      async (hostname) =>
+        await new Promise((resolve) => {
+          started.push(hostname);
+          releases.set(hostname, resolve);
+        }),
+      20,
+    );
+    const firstController = new AbortController();
+    const first = pool.resolve("first.test", firstController.signal);
+    const secondController = new AbortController();
+    const second = pool.resolve("second.test", secondController.signal);
+    const third = pool.resolve("third.test");
+
+    firstController.abort();
+    await expect(first).rejects.toMatchObject({ name: "AbortError" });
+    await vi.waitFor(() => expect(started).toEqual(["first.test", "second.test"]));
+
+    secondController.abort();
+    await expect(second).rejects.toMatchObject({ name: "AbortError" });
+    await new Promise<void>((resolve) => setTimeout(resolve, 50));
+    expect(started).toEqual(["first.test", "second.test"]);
+
+    releases.get("first.test")?.([{ address: "93.184.216.34", family: 4 }]);
+    await vi.waitFor(() => expect(started).toEqual(["first.test", "second.test", "third.test"]));
+
+    releases.get("second.test")?.([{ address: "93.184.216.35", family: 4 }]);
+    releases.get("third.test")?.([{ address: "93.184.216.36", family: 4 }]);
+    await expect(third).resolves.toEqual([{ address: "93.184.216.36", family: 4 }]);
+  });
+
   it("does not reuse sockets for DNS-pinned webhook delivery", async () => {
     const remotePorts: number[] = [];
     const receiver = createServer((request, response) => {


### PR DESCRIPTION
## Summary
- bound HTTP request, response, DNS lookup, webhook cleanup, and Matrix sync lifecycles
- preserve Matrix cursor/event integrity under serialization and response limits
- add regression coverage and changelog entries

## Validation
- gpt-5.6-sol high autoreview: clean
- Crabbox Linux `pnpm verify`: `run_af92b0910106`
- 64 test files passed; 1,581 tests passed; 22 skipped
