### PR TITLE
fix(providers): preserve native protocol identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Bound shared HTTP responses, Matrix sync payloads, stalled webhook DNS recovery, unmatched request bodies, and admitted local-mock hook cleanup.
+- Reject Signal JSON-RPC numeric IDs that cannot round-trip as safe integers while preserving string IDs.
 - Keep Telegram multipart fields prototype-safe, synthetic chat IDs within 52 significant bits, and topic identities scoped to their chats.
 - Preserve opaque Mattermost identifiers exactly instead of trimming REST and WebSocket inputs.
 - Preserve Zalo polling arrival order until each older HTTP response commits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Bound shared HTTP responses, Matrix sync payloads, stalled webhook DNS recovery, unmatched request bodies, and admitted local-mock hook cleanup.
+- Preserve opaque Mattermost identifiers exactly instead of trimming REST and WebSocket inputs.
 - Preserve Zalo polling arrival order until each older HTTP response commits.
 - Stream Telegram multipart uploads with bounded parser metadata instead of copying complete files through `FormData`.
 - Keep Unix recorder identity locks in one validated private per-user namespace across processes and recorder path changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Bound shared HTTP responses, Matrix sync payloads, stalled webhook DNS recovery, unmatched request bodies, and admitted local-mock hook cleanup.
-- Reject Signal JSON-RPC numeric IDs that cannot round-trip as safe integers while preserving string IDs.
+- Reject Signal JSON-RPC integral IDs that cannot round-trip safely while preserving fractional and string IDs.
 - Keep Telegram multipart fields prototype-safe, synthetic chat IDs within 52 significant bits, and topic identities scoped to their chats.
 - Preserve opaque Mattermost identifiers exactly instead of trimming REST and WebSocket inputs.
 - Preserve Zalo polling arrival order until each older HTTP response commits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Bound shared HTTP responses, Matrix sync payloads, stalled webhook DNS recovery, unmatched request bodies, and admitted local-mock hook cleanup.
+- Preserve Zalo polling arrival order until each older HTTP response commits.
 - Stream Telegram multipart uploads with bounded parser metadata instead of copying complete files through `FormData`.
 - Keep Unix recorder identity locks in one validated private per-user namespace across processes and recorder path changes.
 - Reject non-positive Telegram admin message IDs and enforce native Mattermost channel types and unique normalized usernames.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Bound shared HTTP responses, Matrix sync payloads, stalled webhook DNS recovery, unmatched request bodies, and admitted local-mock hook cleanup.
+- Keep Telegram multipart fields prototype-safe, synthetic chat IDs within 52 significant bits, and topic identities scoped to their chats.
 - Preserve opaque Mattermost identifiers exactly instead of trimming REST and WebSocket inputs.
 - Preserve Zalo polling arrival order until each older HTTP response commits.
 - Stream Telegram multipart uploads with bounded parser metadata instead of copying complete files through `FormData`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Bound shared HTTP responses, Matrix sync payloads, stalled webhook DNS recovery, unmatched request bodies, and admitted local-mock hook cleanup.
-- Reject Signal JSON-RPC integral IDs that cannot round-trip safely while preserving fractional and string IDs.
+- Reject Signal JSON-RPC integral IDs that cannot round-trip safely while preserving fractional and string IDs, and register SSE clients before exposing connected response headers.
 - Keep Telegram multipart fields prototype-safe, synthetic chat IDs within 52 significant bits, and topic identities scoped to their chats.
 - Preserve opaque Mattermost identifiers exactly instead of trimming REST and WebSocket inputs.
 - Preserve Zalo polling arrival order until each older HTTP response commits.

--- a/src/providers/builtin/telegram.ts
+++ b/src/providers/builtin/telegram.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
 import { LocalMockProviderAdapter } from "../local-mock.js";
+import { matchesNativeId } from "../native-ids.js";
 import {
   getBuiltinTargetCodec,
   parseCanonicalTelegramInboundTopic,
@@ -60,17 +61,24 @@ function normalizeGenericTelegramPayload(payload: Record<string, unknown>) {
   const threadId =
     (message ? optionalString(message, "threadId") : undefined) ??
     optionalString(payload, "threadId");
-  const canonicalTopic = threadId ? parseCanonicalTelegramInboundTopic(threadId) : undefined;
+  let canonicalTopic = threadId ? parseCanonicalTelegramInboundTopic(threadId) : undefined;
   const channelIds = [
     optionalString(payload, "channelId"),
     ...(message ? [optionalString(message, "channelId")] : []),
-  ].filter((value): value is string => value !== undefined);
+  ]
+    .filter((value): value is string => value !== undefined)
+    .map((channelId) =>
+      requireNativeInboundId(channelId, TELEGRAM_INBOUND_CHAT_ID_RULE, "Telegram channelId"),
+    );
+  const channelId = channelIds[0];
+  if (channelIds.some((candidate) => candidate !== channelId)) {
+    throw new CrablineError("Telegram inbound channelId values must match.", {
+      kind: "inbound",
+    });
+  }
   if (canonicalTopic) {
-    for (const channelId of channelIds) {
-      if (
-        requireNativeInboundId(channelId, TELEGRAM_INBOUND_CHAT_ID_RULE, "Telegram channelId") !==
-        canonicalTopic.chatId
-      ) {
+    for (const candidate of channelIds) {
+      if (candidate !== canonicalTopic.chatId) {
         throw new CrablineError(
           "Telegram canonical topic chat_id must match the inbound channelId.",
           {
@@ -78,6 +86,15 @@ function normalizeGenericTelegramPayload(payload: Record<string, unknown>) {
           },
         );
       }
+    }
+  } else if (threadId && matchesNativeId(threadId, TELEGRAM_MESSAGE_THREAD_ID_RULE)) {
+    if (!channelId) {
+      throw new CrablineError("Telegram bare topic IDs require an inbound channelId.", {
+        kind: "inbound",
+      });
+    }
+    if (threadId !== channelId) {
+      canonicalTopic = { chatId: channelId, topicId: threadId };
     }
   }
   const genericPayload = canonicalTopic

--- a/src/servers/mattermost.ts
+++ b/src/servers/mattermost.ts
@@ -13,7 +13,6 @@ import {
   jsonResponse,
   parseUnknownRequestBody,
   queryRecord,
-  readTrimmedString,
   RequestBodyTooLargeError,
   startHttpJsonServer,
   type ServerRequestEvent,

--- a/src/servers/mattermost.ts
+++ b/src/servers/mattermost.ts
@@ -616,7 +616,7 @@ async function handleApi(params: {
     return channel ? jsonResponse(channel) : mattermostError("Channel not found", 404);
   }
   if (method === "POST" && apiPath === "/channels/direct") {
-    const userIds = Array.isArray(body) ? body.map(readMattermostString) : [];
+    const userIds = Array.isArray(body) ? body.map(readMattermostId) : [];
     if (userIds.length !== 2 || userIds.some((value) => !value)) {
       return mattermostError("Two user IDs are required", 400);
     }
@@ -644,7 +644,7 @@ async function handleApi(params: {
     return mattermostError("Request body must be a JSON object", 400);
   }
   if (method === "POST" && apiPath === "/users/me/typing") {
-    const channelId = readMattermostString(body.channel_id);
+    const channelId = readMattermostId(body.channel_id);
     if (!channelId) {
       return mattermostError("channel_id is required", 400);
     }
@@ -654,6 +654,7 @@ async function handleApi(params: {
     if (!state.channels.has(channelId)) {
       return mattermostError("Channel not found", 404);
     }
+    const parentId = readMattermostId(body.parent_id);
     broadcast(
       state,
       {
@@ -663,9 +664,7 @@ async function handleApi(params: {
         }),
         data: {
           channel_id: channelId,
-          ...(readMattermostString(body.parent_id)
-            ? { parent_id: readMattermostString(body.parent_id) }
-            : {}),
+          ...(parentId ? { parent_id: parentId } : {}),
           user_id: state.botUserId,
         },
         event: "typing",
@@ -675,12 +674,12 @@ async function handleApi(params: {
     return jsonResponse({ status: "OK" });
   }
   if (method === "POST" && apiPath === "/posts") {
-    const channelId = readMattermostString(body.channel_id);
+    const channelId = readMattermostId(body.channel_id);
     const message = readMattermostMessage(body.message);
     if (!channelId || !message) {
       return mattermostError("channel_id and message are required", 400);
     }
-    const rootId = readMattermostString(body.root_id);
+    const rootId = readMattermostId(body.root_id);
     if (body.root_id !== undefined && typeof body.root_id !== "string") {
       return mattermostError("root_id must be a string", 400);
     }
@@ -945,7 +944,7 @@ function attachWebSocketServer(params: {
         return;
       }
       if (message.action === "user_typing") {
-        const channelId = readTrimmedString(message.data?.channel_id);
+        const channelId = readMattermostId(message.data?.channel_id);
         if (!channelId || !params.state.channels.has(channelId)) {
           sendControlMessage(params.state, client, {
             error: {
@@ -966,7 +965,7 @@ function attachWebSocketServer(params: {
             }),
             data: {
               channel_id: channelId,
-              parent_id: readTrimmedString(message.data?.parent_id) ?? "",
+              parent_id: readMattermostId(message.data?.parent_id) ?? "",
               user_id: params.state.botUserId,
             },
             event: "typing",

--- a/src/servers/signal.ts
+++ b/src/servers/signal.ts
@@ -806,7 +806,6 @@ async function handleRequest(params: {
       connection: "keep-alive",
       "content-type": "text/event-stream",
     });
-    params.response.flushHeaders();
     params.response.once("close", () => {
       removeSignalClient(params.state, params.response, false);
     });
@@ -817,6 +816,7 @@ async function handleRequest(params: {
       events: [],
       inFlight: [],
     });
+    params.response.flushHeaders();
     replayExclusiveSignalEvents(params.state, params.response);
     if (params.state.clients.has(params.response)) {
       flushPendingSignalEvents(params.state);

--- a/src/servers/signal.ts
+++ b/src/servers/signal.ts
@@ -498,7 +498,9 @@ async function handleRpc(params: {
     !hasId ||
     id === null ||
     typeof id === "string" ||
-    (typeof id === "number" && Number.isSafeInteger(id));
+    (typeof id === "number" &&
+      Number.isFinite(id) &&
+      (!Number.isInteger(id) || Number.isSafeInteger(id)));
   const method = params.body.method;
   if (typeof method !== "string" || !validId) {
     return {

--- a/src/servers/signal.ts
+++ b/src/servers/signal.ts
@@ -498,7 +498,7 @@ async function handleRpc(params: {
     !hasId ||
     id === null ||
     typeof id === "string" ||
-    (typeof id === "number" && Number.isFinite(id));
+    (typeof id === "number" && Number.isSafeInteger(id));
   const method = params.body.method;
   if (typeof method !== "string" || !validId) {
     return {

--- a/src/servers/telegram-identity.ts
+++ b/src/servers/telegram-identity.ts
@@ -5,7 +5,7 @@ export const TELEGRAM_BOT_USERNAME_PATTERN = /^@[A-Za-z][A-Za-z0-9_]{4,31}$/u;
 export const TELEGRAM_CHAT_USERNAME_PATTERN = /^@[A-Za-z][A-Za-z0-9_]{3,31}$/u;
 
 const TELEGRAM_SYNTHETIC_ID_RANGE = 1n << 50n;
-const TELEGRAM_USERNAME_ID_BASE = (1n << 52n) + TELEGRAM_SYNTHETIC_ID_RANGE;
+const TELEGRAM_USERNAME_ID_BASE = TELEGRAM_NATIVE_CHAT_ID_MAX - TELEGRAM_SYNTHETIC_ID_RANGE + 1n;
 
 export function canonicalizeTelegramUsername(value: string): string | undefined {
   const username = value.trim();
@@ -21,4 +21,12 @@ export function telegramUsernameChatId(value: string): number | undefined {
   return Number(
     -(TELEGRAM_USERNAME_ID_BASE + (hash.readBigUInt64BE() % TELEGRAM_SYNTHETIC_ID_RANGE)),
   );
+}
+
+export function isTelegramUsernameChatId(value: number): boolean {
+  if (!Number.isSafeInteger(value) || value >= 0) {
+    return false;
+  }
+  const magnitude = BigInt(-value);
+  return magnitude >= TELEGRAM_USERNAME_ID_BASE && magnitude <= TELEGRAM_NATIVE_CHAT_ID_MAX;
 }

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -28,6 +28,7 @@ import {
 } from "./webhook-target.js";
 import {
   canonicalizeTelegramUsername,
+  isTelegramUsernameChatId,
   TELEGRAM_BOT_USERNAME_PATTERN,
   TELEGRAM_NATIVE_CHAT_ID_MAX,
   telegramUsernameChatId,
@@ -752,7 +753,7 @@ async function parseMultipartFormDataRequest(
     const boundary = parseTelegramMultipartBoundary(contentType);
     const bodyBoundary = Buffer.concat([Buffer.from("\r\n"), boundary]);
     const reader = new TelegramMultipartReader(request, TELEGRAM_MAX_REQUEST_BODY_BYTES);
-    const fields: Record<string, unknown> = {};
+    const fields = Object.create(null) as Record<string, unknown>;
     let retainedTextBytes = 0;
     let partCount = 0;
     let boundaryKind = await reader.readInitialBoundary(
@@ -899,7 +900,7 @@ function createBotUser(state: TelegramServerState) {
 function inferTelegramChatType(chatId: number): TelegramChat["type"] {
   return chatId >= 0
     ? "private"
-    : String(chatId).startsWith("-100") || BigInt(chatId) < -TELEGRAM_NATIVE_CHAT_ID_MAX
+    : String(chatId).startsWith("-100") || isTelegramUsernameChatId(chatId)
       ? "supergroup"
       : "group";
 }

--- a/src/servers/zalo.ts
+++ b/src/servers/zalo.ts
@@ -82,7 +82,6 @@ type ZaloServerState = {
   botName: string;
   botToken: string;
   closing: boolean;
-  failedUpdateOrders: Set<number>;
   inboundAdmission: Promise<void>;
   maxPendingInboundEvents: number;
   nextMessage: number;
@@ -433,11 +432,7 @@ function nextUpdate(
   if (!update) {
     return undefined;
   }
-  const order = pollingUpdateOrder(state, update);
-  if (
-    state.failedUpdateOrders.has(order) &&
-    [...state.reservedUpdateOrders].some((reservedOrder) => reservedOrder < order)
-  ) {
+  if (hasEarlierReservedPollingUpdate(state, update)) {
     return undefined;
   }
   state.updates.shift();
@@ -467,9 +462,13 @@ function queuePollingUpdate(state: ZaloServerState, update: ZaloUpdate): void {
   }
 }
 
+function hasEarlierReservedPollingUpdate(state: ZaloServerState, update: ZaloUpdate): boolean {
+  const order = pollingUpdateOrder(state, update);
+  return [...state.reservedUpdateOrders].some((reservedOrder) => reservedOrder < order);
+}
+
 function reservePollingUpdate(state: ZaloServerState, update: ZaloUpdate): void {
   const order = pollingUpdateOrder(state, update);
-  state.failedUpdateOrders.delete(order);
   state.reservedUpdateOrders.add(order);
 }
 
@@ -483,11 +482,7 @@ function flushPendingPollingUpdate(state: ZaloServerState): void {
     settlePendingUpdate(state, pending, { kind: "disconnect" });
     return;
   }
-  const order = pollingUpdateOrder(state, update);
-  if (
-    state.failedUpdateOrders.has(order) &&
-    [...state.reservedUpdateOrders].some((reservedOrder) => reservedOrder < order)
-  ) {
+  if (hasEarlierReservedPollingUpdate(state, update)) {
     return;
   }
   state.updates.shift();
@@ -510,7 +505,6 @@ function reservedUpdateResponse(state: ZaloServerState, update: ZaloUpdate): Htt
       if (!release()) {
         return;
       }
-      state.failedUpdateOrders.add(pollingUpdateOrder(state, update));
       queuePollingUpdate(state, update);
       flushPendingPollingUpdate(state);
     },
@@ -610,7 +604,7 @@ async function waitForUpdate(
 
 function deliverPollingUpdate(state: ZaloServerState, update: ZaloUpdate): boolean {
   pollingUpdateOrder(state, update);
-  if (state.updates.length > 0) {
+  if (state.updates.length > 0 || hasEarlierReservedPollingUpdate(state, update)) {
     if (state.updates.length + state.reservedUpdateOrders.size >= state.maxPendingInboundEvents) {
       return false;
     }
@@ -943,7 +937,6 @@ export async function startZaloServer(
       params.botToken ??
       (isLoopbackHost(host) ? "crabline-zalo-bot-token" : randomBytes(32).toString("base64url")),
     closing: false,
-    failedUpdateOrders: new Set(),
     inboundAdmission: Promise.resolve(),
     maxPendingInboundEvents: resolveMaxPendingInboundEvents(params.maxPendingInboundEvents),
     nextMessage: 1,

--- a/test/mattermost-server.test.ts
+++ b/test/mattermost-server.test.ts
@@ -955,6 +955,76 @@ describe("Mattermost local provider server", () => {
     expect(rootMutation.status).toBe(403);
   });
 
+  it("does not trim opaque REST identifiers", async () => {
+    const server = await startMattermostServer({ adminToken: "admin", botToken: "fake" });
+    servers.push(server);
+    const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({ channelId: CHANNEL_ID, senderId: USER_ID, text: "root" }),
+      headers: {
+        "content-type": "application/json",
+        "x-crabline-admin-token": "admin",
+      },
+      method: "POST",
+    });
+    const root = (await inbound.json()) as { post: { id: string } };
+
+    const paddedChannel = await fetch(`${server.manifest.endpoints.apiRoot}/posts`, {
+      body: JSON.stringify({
+        channel_id: ` ${CHANNEL_ID} `,
+        message: "padded channel",
+      }),
+      headers: {
+        authorization: "Bearer fake",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+    expect(paddedChannel.status).toBe(404);
+    await expect(paddedChannel.json()).resolves.toMatchObject({ message: "Channel not found" });
+
+    const paddedRoot = await fetch(`${server.manifest.endpoints.apiRoot}/posts`, {
+      body: JSON.stringify({
+        channel_id: CHANNEL_ID,
+        message: "padded root",
+        root_id: ` ${root.post.id} `,
+      }),
+      headers: {
+        authorization: "Bearer fake",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+    expect(paddedRoot.status).toBe(404);
+    await expect(paddedRoot.json()).resolves.toMatchObject({ message: "Root post not found" });
+
+    const paddedParticipant = await fetch(`${server.manifest.endpoints.apiRoot}/channels/direct`, {
+      body: JSON.stringify([server.manifest.botUserId, ` ${USER_ID} `]),
+      headers: {
+        authorization: "Bearer fake",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+    expect(paddedParticipant.status).toBe(404);
+    await expect(paddedParticipant.json()).resolves.toMatchObject({ message: "User not found" });
+
+    const paddedTypingChannel = await fetch(
+      `${server.manifest.endpoints.apiRoot}/users/me/typing`,
+      {
+        body: JSON.stringify({ channel_id: ` ${CHANNEL_ID} ` }),
+        headers: {
+          authorization: "Bearer fake",
+          "content-type": "application/json",
+        },
+        method: "POST",
+      },
+    );
+    expect(paddedTypingChannel.status).toBe(404);
+    await expect(paddedTypingChannel.json()).resolves.toMatchObject({
+      message: "Channel not found",
+    });
+  });
+
   it("keeps typing channel-scoped, omitted from the sender, and ephemeral", async () => {
     const server = await startMattermostServer({ adminToken: "admin", botToken: "fake" });
     servers.push(server);

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -1098,9 +1098,9 @@ describe("OpenClaw local provider bridge", () => {
       },
     });
     expect(usernameGroupInbound.providerBody.chatId).not.toBe("@channelusername");
-    expect(BigInt(String(usernameGroupInbound.providerBody.chatId))).toBeLessThan(
-      -((1n << 52n) + (1n << 50n)),
-    );
+    const usernameGroupChatId = BigInt(String(usernameGroupInbound.providerBody.chatId));
+    expect(usernameGroupChatId).toBeLessThan(0n);
+    expect(-usernameGroupChatId).toBeLessThanOrEqual((1n << 52n) - 1n);
     expect(usernameGroupInbound.providerBody.chatId).not.toBe(symbolicGroupDelivery.to);
     expect(
       createOpenClawCrablineInbound({

--- a/test/signal-server.test.ts
+++ b/test/signal-server.test.ts
@@ -447,7 +447,6 @@ describe("signal local provider server", () => {
     for (const body of [
       { id: true, jsonrpc: "2.0", method: "version" },
       { id: {}, jsonrpc: "2.0", method: "version" },
-      { id: 1.5, jsonrpc: "2.0", method: "version" },
       { id: 1, jsonrpc: "2.0", method: 42 },
       { id: 1, method: "version" },
       { id: 1, jsonrpc: "2.0", method: "sendTyping", params: null },
@@ -464,6 +463,17 @@ describe("signal local provider server", () => {
         jsonrpc: "2.0",
       });
     }
+
+    const fractionalId = await fetch(server.manifest.endpoints.rpcUrl, {
+      body: JSON.stringify({ id: 1.5, jsonrpc: "2.0", method: "version" }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    expect(fractionalId.status).toBe(200);
+    await expect(fractionalId.json()).resolves.toMatchObject({
+      id: 1.5,
+      jsonrpc: "2.0",
+    });
 
     const unsafeId = await fetch(server.manifest.endpoints.rpcUrl, {
       body: '{"jsonrpc":"2.0","id":9007199254740993,"method":"version"}',

--- a/test/signal-server.test.ts
+++ b/test/signal-server.test.ts
@@ -447,6 +447,7 @@ describe("signal local provider server", () => {
     for (const body of [
       { id: true, jsonrpc: "2.0", method: "version" },
       { id: {}, jsonrpc: "2.0", method: "version" },
+      { id: 1.5, jsonrpc: "2.0", method: "version" },
       { id: 1, jsonrpc: "2.0", method: 42 },
       { id: 1, method: "version" },
       { id: 1, jsonrpc: "2.0", method: "sendTyping", params: null },
@@ -463,6 +464,18 @@ describe("signal local provider server", () => {
         jsonrpc: "2.0",
       });
     }
+
+    const unsafeId = await fetch(server.manifest.endpoints.rpcUrl, {
+      body: '{"jsonrpc":"2.0","id":9007199254740993,"method":"version"}',
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    });
+    expect(unsafeId.status).toBe(400);
+    await expect(unsafeId.json()).resolves.toEqual({
+      error: { code: -32600, message: "Invalid Request" },
+      id: null,
+      jsonrpc: "2.0",
+    });
 
     const malformedNotification = await fetch(server.manifest.endpoints.rpcUrl, {
       body: JSON.stringify({ jsonrpc: "2.0", method: "version", params: 42 }),

--- a/test/telegram-provider.test.ts
+++ b/test/telegram-provider.test.ts
@@ -248,6 +248,40 @@ describe("telegram provider", () => {
       message: { threadId: "-100123:44" },
     });
 
+    const bareTopLevel = {
+      channelId: "-100123",
+      text: "bare top-level topic",
+      threadId: "46",
+    };
+    expect(normalizeTelegramWebhookPayload(bareTopLevel)).toMatchObject({
+      raw: bareTopLevel,
+      text: "bare top-level topic",
+      threadId: "-100123:46",
+    });
+
+    const bareNested = {
+      message: {
+        channelId: "-100124",
+        text: "bare nested topic",
+        threadId: "46",
+      },
+    };
+    expect(normalizeTelegramWebhookPayload(bareNested)).toMatchObject({
+      raw: bareNested,
+      threadId: "-100124:46",
+      message: {
+        text: "bare nested topic",
+        threadId: "-100124:46",
+      },
+    });
+
+    expect(() =>
+      normalizeTelegramWebhookPayload({
+        text: "ambiguous bare topic",
+        threadId: "46",
+      }),
+    ).toThrow(/bare topic IDs require an inbound channelId/u);
+
     expect(() =>
       normalizeTelegramWebhookPayload({
         channelId: "-100999",
@@ -266,6 +300,16 @@ describe("telegram provider", () => {
         },
       }),
     ).toThrow(/must match the inbound channelId/u);
+    expect(() =>
+      normalizeTelegramWebhookPayload({
+        channelId: "-100998",
+        message: {
+          channelId: "-100999",
+          text: "conflicting channels",
+          threadId: "42",
+        },
+      }),
+    ).toThrow(/channelId values must match/u);
   });
 
   it("normalizes edited channel posts", () => {

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -5,6 +5,10 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { startTelegramServer, type StartedTelegramServer } from "../src/index.js";
 import { handleTelegramGetUpdates, withTelegramWebhookDeadline } from "../src/servers/telegram.js";
+import {
+  TELEGRAM_NATIVE_CHAT_ID_MAX,
+  telegramUsernameChatId,
+} from "../src/servers/telegram-identity.js";
 import { createTempDir, disposeTempDir, requestHttp } from "./test-helpers.js";
 
 const servers: StartedTelegramServer[] = [];
@@ -218,6 +222,16 @@ describe("telegram local provider server", () => {
     });
     expect(secondPayload.result).toMatchObject({ message_id: 2 });
     expect(secondPayload.result.chat.id).toBe(firstPayload.result.chat.id);
+
+    for (const username of ["@Crabline_Channel", "@another_channel", "@collectible"]) {
+      const chatId = telegramUsernameChatId(username);
+      expect(chatId).toBeDefined();
+      expect(Number.isSafeInteger(chatId)).toBe(true);
+      expect(BigInt(Math.abs(chatId!)) <= TELEGRAM_NATIVE_CHAT_ID_MAX).toBe(true);
+    }
+    expect(telegramUsernameChatId("@Crabline_Channel")).toBe(
+      telegramUsernameChatId("@crabline_channel"),
+    );
   });
 
   it("preserves registered channel and supergroup types for username destinations", async () => {
@@ -2234,6 +2248,39 @@ describe("telegram local provider server", () => {
         },
       },
     });
+  });
+
+  it("keeps prototype-special multipart fields as own request properties", async () => {
+    let recordedBody: unknown;
+    const server = await startTelegramServer({
+      botToken: "test-token-placeholder",
+      onEvent(event) {
+        if (event.path === "/bot<redacted>/sendMessage") {
+          recordedBody = event.body;
+        }
+      },
+    });
+    servers.push(server);
+    const body = new FormData();
+    body.set("chat_id", "100");
+    body.set("text", "prototype-safe");
+    body.set(
+      "__proto__",
+      new Blob(["prototype bytes"], { type: "application/octet-stream" }),
+      "prototype.bin",
+    );
+
+    const response = await fetch(
+      `${server.manifest.baseUrl}/bottest-token-placeholder/sendMessage`,
+      {
+        body,
+        method: "POST",
+      },
+    );
+    expect(response.status).toBe(200);
+    expect(recordedBody).toBeTypeOf("object");
+    expect(Object.hasOwn(recordedBody as object, "__proto__")).toBe(true);
+    expect((recordedBody as Record<string, unknown>).__proto__).toBe("prototype.bin");
   });
 
   it("streams multipart files across chunk-split boundaries without retaining upload bytes", async () => {

--- a/test/zalo-server.test.ts
+++ b/test/zalo-server.test.ts
@@ -857,15 +857,25 @@ describe("Zalo local provider server", () => {
 
         if (firstOutcome === "success") {
           Reflect.apply(originalEnd, heldResponse!, heldArgs!) as ServerResponse;
-          const firstResponse = await firstPoll;
-          expect(JSON.parse(firstResponse.body)).toMatchObject({
-            ok: true,
-            result: { message: { text: "first" } },
-          });
         } else {
           heldResponse!.destroy(new Error("simulated response failure"));
-          await expect(firstPoll).rejects.toThrow();
         }
+
+        const firstResult = await firstPoll.then(
+          (response) => ({ body: JSON.parse(response.body) as unknown, kind: "success" as const }),
+          () => ({ body: undefined, kind: "failure" as const }),
+        );
+        expect(firstResult).toMatchObject(
+          firstOutcome === "success"
+            ? {
+                body: {
+                  ok: true,
+                  result: { message: { text: "first" } },
+                },
+                kind: "success",
+              }
+            : { body: undefined, kind: "failure" },
+        );
 
         const secondResponse = await secondPoll;
         expect(JSON.parse(secondResponse.body)).toMatchObject({
@@ -876,13 +886,19 @@ describe("Zalo local provider server", () => {
         responsePrototype.end = originalEnd;
       }
 
-      if (firstOutcome === "failure") {
-        const update = await fetch(`${server.manifest.baseUrl}/botsample/getUpdates?timeout=0`);
-        await expect(update.json()).resolves.toMatchObject({
-          ok: true,
-          result: { message: { text: "second" } },
-        });
-      }
+      const remaining = await fetch(`${server.manifest.baseUrl}/botsample/getUpdates?timeout=0`);
+      await expect(remaining.json()).resolves.toMatchObject(
+        firstOutcome === "failure"
+          ? {
+              ok: true,
+              result: { message: { text: "second" } },
+            }
+          : {
+              description: "Request timeout",
+              error_code: 408,
+              ok: false,
+            },
+      );
     },
   );
 

--- a/test/zalo-server.test.ts
+++ b/test/zalo-server.test.ts
@@ -792,82 +792,99 @@ describe("Zalo local provider server", () => {
     });
   });
 
-  it("restores reverse-order poll failures ahead of a waiting poll", async () => {
-    const server = await startZaloServer({ botToken: "sample" });
-    servers.push(server);
-    for (const text of ["first", "second"]) {
-      const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
-        body: JSON.stringify({ chatId: "chat-1", senderId: "user-1", text }),
-        headers: adminHeaders(server),
-        method: "POST",
+  it.each(["success", "failure"] as const)(
+    "waits for an older poll response to commit before %s delivery",
+    async (firstOutcome) => {
+      let polls = 0;
+      let reportSecondPoll!: () => void;
+      const secondPollObserved = new Promise<void>((resolve) => {
+        reportSecondPoll = resolve;
       });
-      expect(inbound.status).toBe(200);
-    }
-
-    const responsePrototype = ServerResponse.prototype as unknown as {
-      end: (...args: unknown[]) => ServerResponse;
-    };
-    const originalEnd = responsePrototype.end;
-    let failedResponses = 0;
-    let reportLaterFailure!: () => void;
-    const laterFailureReported = new Promise<void>((resolve) => {
-      reportLaterFailure = resolve;
-    });
-    responsePrototype.end = function (this: ServerResponse, ...args: unknown[]) {
-      if (this.req?.url?.includes("/getUpdates") && failedResponses < 2) {
-        const responseIndex = failedResponses++;
-        const delayMs = responseIndex === 0 ? 100 : 10;
-        setTimeout(() => {
-          if (responseIndex === 1) {
-            reportLaterFailure();
+      const server = await startZaloServer({
+        botToken: "sample",
+        onEvent(event) {
+          if (event.path === "/bot<redacted>/getUpdates" && ++polls === 2) {
+            reportSecondPoll();
           }
-          this.destroy(new Error("simulated response failure"));
-        }, delayMs);
-        return this;
+        },
+      });
+      servers.push(server);
+      for (const text of ["first", "second"]) {
+        const inbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
+          body: JSON.stringify({ chatId: "chat-1", senderId: "user-1", text }),
+          headers: adminHeaders(server),
+          method: "POST",
+        });
+        expect(inbound.status).toBe(200);
       }
-      return Reflect.apply(originalEnd, this, args) as ServerResponse;
-    };
 
-    try {
-      const failedPolls = Promise.allSettled([
-        requestHttp({
+      const responsePrototype = ServerResponse.prototype as unknown as {
+        end: (...args: unknown[]) => ServerResponse;
+      };
+      const originalEnd = responsePrototype.end;
+      let heldResponse: ServerResponse | undefined;
+      let heldArgs: unknown[] | undefined;
+      let reportHeldResponse!: () => void;
+      const heldResponseObserved = new Promise<void>((resolve) => {
+        reportHeldResponse = resolve;
+      });
+      responsePrototype.end = function (this: ServerResponse, ...args: unknown[]) {
+        if (this.req?.url?.includes("/getUpdates") && !heldResponse) {
+          heldResponse = this;
+          heldArgs = args;
+          reportHeldResponse();
+          return this;
+        }
+        return Reflect.apply(originalEnd, this, args) as ServerResponse;
+      };
+
+      try {
+        const firstPoll = requestHttp({
           method: "GET",
           url: `${server.manifest.baseUrl}/botsample/getUpdates?timeout=0`,
-        }),
-        requestHttp({
+        });
+        await heldResponseObserved;
+        let secondSettled = false;
+        const secondPoll = requestHttp({
           method: "GET",
-          url: `${server.manifest.baseUrl}/botsample/getUpdates?timeout=0`,
-        }),
-      ]);
-      const waitingPoll = requestHttp({
-        method: "GET",
-        url: `${server.manifest.baseUrl}/botsample/getUpdates?timeout=1`,
-      });
-      await laterFailureReported;
-      const thirdInbound = await fetch(server.manifest.endpoints.adminInboundUrl, {
-        body: JSON.stringify({ chatId: "chat-1", senderId: "user-1", text: "third" }),
-        headers: adminHeaders(server),
-        method: "POST",
-      });
-      expect(thirdInbound.status).toBe(200);
-      const waitingResponse = await waitingPoll;
-      expect(JSON.parse(waitingResponse.body)).toMatchObject({
-        ok: true,
-        result: { message: { text: "first" } },
-      });
-      await failedPolls;
-    } finally {
-      responsePrototype.end = originalEnd;
-    }
+          url: `${server.manifest.baseUrl}/botsample/getUpdates?timeout=2`,
+        }).finally(() => {
+          secondSettled = true;
+        });
+        await secondPollObserved;
+        await new Promise((resolve) => setTimeout(resolve, 25));
+        expect(secondSettled).toBe(false);
 
-    for (const text of ["second", "third"]) {
-      const update = await fetch(`${server.manifest.baseUrl}/botsample/getUpdates?timeout=0`);
-      await expect(update.json()).resolves.toMatchObject({
-        ok: true,
-        result: { message: { text } },
-      });
-    }
-  });
+        if (firstOutcome === "success") {
+          Reflect.apply(originalEnd, heldResponse!, heldArgs!) as ServerResponse;
+          const firstResponse = await firstPoll;
+          expect(JSON.parse(firstResponse.body)).toMatchObject({
+            ok: true,
+            result: { message: { text: "first" } },
+          });
+        } else {
+          heldResponse!.destroy(new Error("simulated response failure"));
+          await expect(firstPoll).rejects.toThrow();
+        }
+
+        const secondResponse = await secondPoll;
+        expect(JSON.parse(secondResponse.body)).toMatchObject({
+          ok: true,
+          result: { message: { text: firstOutcome === "success" ? "second" : "first" } },
+        });
+      } finally {
+        responsePrototype.end = originalEnd;
+      }
+
+      if (firstOutcome === "failure") {
+        const update = await fetch(`${server.manifest.baseUrl}/botsample/getUpdates?timeout=0`);
+        await expect(update.json()).resolves.toMatchObject({
+          ok: true,
+          result: { message: { text: "second" } },
+        });
+      }
+    },
+  );
 
   it("rejects webhook activation while a poll delivery is reserved", async () => {
     const webhook = createServer((_request, response) => {


### PR DESCRIPTION
## Summary
- serialize Zalo polling commits and preserve opaque Mattermost identifiers
- constrain Telegram synthetic identities and preserve valid Signal JSON-RPC IDs
- close the Signal SSE registration race and add protocol regressions
- include changelog entries

## Validation
- gpt-5.6-sol high autoreview: clean
- Crabbox Linux `pnpm verify`: `run_8d4ef93f4ae5`
- 64 test files passed; 1,571 tests passed; 22 skipped
