### PR TITLE
fix(tooling): harden artifacts, CI, and release provenance

### DIFF
--- a/.agents/skills/autoreview/scripts/autoreview
+++ b/.agents/skills/autoreview/scripts/autoreview
@@ -275,6 +275,7 @@ SECRET_PLACEHOLDER_VALUES = {
     "example",
     "fake",
     "gateway-token",
+    "local-mock-imessage-api-key",
     "not-a-real",
     "placeholder",
     "redacted",

--- a/.agents/skills/autoreview/scripts/autoreview_test.py
+++ b/.agents/skills/autoreview/scripts/autoreview_test.py
@@ -47,6 +47,22 @@ DRAFT_REPORT = {
 }
 
 
+class AutoreviewSecretTests(unittest.TestCase):
+    def test_allows_the_static_local_imessage_mock_key(self) -> None:
+        assignment = (
+            'apiKey: config.imessage?.apiKey ?? env.IMESSAGE_API_KEY ?? '
+            '"local-mock-imessage-api-key",'
+        )
+
+        self.assertFalse(AUTOREVIEW.secret_text_risk(assignment))
+        unsafe_value = "-".join(("live-looking", "imessage", "api-key"))
+        unsafe_assignment = "api" + (
+            'Key: config.imessage?.apiKey ?? env.IMESSAGE_API_KEY ?? '
+            f'"{unsafe_value}",'
+        )
+        self.assertTrue(AUTOREVIEW.secret_text_risk(unsafe_assignment))
+
+
 class AutoreviewCursorTests(unittest.TestCase):
     def test_extract_json_prefers_terminal_result_event(self) -> None:
         stream = "\n".join(

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -7,6 +7,8 @@ on:
       - package.json
       - pnpm-lock.yaml
       - pnpm-workspace.yaml
+      - tools/go.mod
+      - tools/go.sum
       - ".github/actions/**"
       - ".github/workflows/**"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,11 +296,16 @@ jobs:
 
             const packageName = process.env.PACKAGE_NAME;
             const releaseVersion = process.env.RELEASE_VERSION;
-            const releaseRef = `refs/tags/${process.env.RELEASE_TAG}`;
-            const repository = `${process.env.GITHUB_SERVER_URL.replace(/\/$/u, "")}/${process.env.GITHUB_REPOSITORY}`;
-            const expectedSubject = `pkg:npm/${
-              packageName.startsWith("@") ? `%40${packageName.slice(1)}` : packageName
-            }@${releaseVersion}`;
+            const releaseRef = "refs/tags/" + process.env.RELEASE_TAG;
+            const repository =
+              process.env.GITHUB_SERVER_URL.replace(/\/$/u, "") +
+              "/" +
+              process.env.GITHUB_REPOSITORY;
+            const expectedSubject =
+              "pkg:npm/" +
+              (packageName.startsWith("@") ? "%40" + packageName.slice(1) : packageName) +
+              "@" +
+              releaseVersion;
             const integrityMatch = /^sha512-([A-Za-z0-9+/]+={0,2})$/u.exec(
               process.env.PACKAGE_INTEGRITY,
             );
@@ -346,7 +351,7 @@ jobs:
                   Array.isArray(dependencies) &&
                   dependencies.some(
                     (dependency) =>
-                      dependency?.uri === `git+${repository}@${releaseRef}` &&
+                      dependency?.uri === "git+" + repository + "@" + releaseRef &&
                       dependency?.digest?.gitCommit === process.env.VERIFIED_COMMIT,
                   )
                 );

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,16 +279,98 @@ jobs:
           }
           NODE
 
+          verify_package_provenance() {
+            local audit_dir audit_path
+            audit_dir="$(mktemp -d "$RUNNER_TEMP/crabline-provenance.XXXXXX")"
+            audit_path="$audit_dir/audit.json"
+            if ! (
+              cd "$audit_dir"
+              npm install --ignore-scripts --no-audit --no-fund "$PACKAGE_NAME@$RELEASE_VERSION" >/dev/null 2>&1
+              npm audit signatures --json --include-attestations=true > "$audit_path" 2>/dev/null
+            ); then
+              rm -rf "$audit_dir"
+              return 3
+            fi
+            if ! PACKAGE_AUDIT_PATH="$audit_path" node --input-type=module 2>/dev/null -e '
+            import fs from "node:fs";
+
+            const packageName = process.env.PACKAGE_NAME;
+            const releaseVersion = process.env.RELEASE_VERSION;
+            const releaseRef = `refs/tags/${process.env.RELEASE_TAG}`;
+            const repository = `${process.env.GITHUB_SERVER_URL.replace(/\/$/u, "")}/${process.env.GITHUB_REPOSITORY}`;
+            const expectedSubject = `pkg:npm/${
+              packageName.startsWith("@") ? `%40${packageName.slice(1)}` : packageName
+            }@${releaseVersion}`;
+            const integrityMatch = /^sha512-([A-Za-z0-9+/]+={0,2})$/u.exec(
+              process.env.PACKAGE_INTEGRITY,
+            );
+            if (!integrityMatch) {
+              process.exit(1);
+            }
+            const expectedDigest = Buffer.from(integrityMatch[1], "base64").toString("hex");
+            const audit = JSON.parse(fs.readFileSync(process.env.PACKAGE_AUDIT_PATH, "utf8"));
+            const verified = Array.isArray(audit.verified)
+              ? audit.verified.find(
+                  (entry) => entry?.name === packageName && entry?.version === releaseVersion,
+                )
+              : undefined;
+            const bundles = Array.isArray(verified?.attestationBundles)
+              ? verified.attestationBundles
+              : [];
+            const valid = bundles.some((attestation) => {
+              if (attestation?.predicateType !== "https://slsa.dev/provenance/v1") {
+                return false;
+              }
+              try {
+                const statement = JSON.parse(
+                  Buffer.from(attestation.bundle.dsseEnvelope.payload, "base64").toString("utf8"),
+                );
+                const workflow =
+                  statement.predicate?.buildDefinition?.externalParameters?.workflow;
+                const dependencies =
+                  statement.predicate?.buildDefinition?.resolvedDependencies;
+                return (
+                  statement._type === "https://in-toto.io/Statement/v1" &&
+                  statement.predicateType === "https://slsa.dev/provenance/v1" &&
+                  statement.predicate?.buildDefinition?.buildType ===
+                    "https://slsa-framework.github.io/github-actions-buildtypes/workflow/v1" &&
+                  Array.isArray(statement.subject) &&
+                  statement.subject.some(
+                    (subject) =>
+                      subject?.name === expectedSubject &&
+                      subject?.digest?.sha512 === expectedDigest,
+                  ) &&
+                  workflow?.repository === repository &&
+                  workflow?.path === ".github/workflows/release.yml" &&
+                  workflow?.ref === releaseRef &&
+                  Array.isArray(dependencies) &&
+                  dependencies.some(
+                    (dependency) =>
+                      dependency?.uri === `git+${repository}@${releaseRef}` &&
+                      dependency?.digest?.gitCommit === process.env.VERIFIED_COMMIT,
+                  )
+                );
+              } catch {
+                return false;
+              }
+            });
+            process.exit(valid ? 0 : 1);
+            '; then
+              rm -rf "$audit_dir"
+              echo "::error::Published $PACKAGE_NAME@$RELEASE_VERSION has provenance that does not match the repository, workflow, tag, commit, or package integrity."
+              return 2
+            fi
+            rm -rf "$audit_dir"
+            return 0
+          }
+
           check_existing_package() {
-            local actual_integrity actual_provenance actual_version
+            local actual_integrity actual_version provenance_status
             if ! actual_integrity="$(npm view "$PACKAGE_NAME@$RELEASE_VERSION" dist.integrity 2>/dev/null)"; then
               return 1
             fi
             if ! actual_version="$(npm view "$PACKAGE_NAME@$RELEASE_VERSION" version 2>/dev/null)"; then
               return 1
-            fi
-            if ! actual_provenance="$(npm view "$PACKAGE_NAME@$RELEASE_VERSION" dist.attestations.provenance.predicateType 2>/dev/null)"; then
-              return 3
             fi
             if [[ "$actual_version" != "$RELEASE_VERSION" ]]; then
               echo "::error::Published $PACKAGE_NAME@$RELEASE_VERSION reports version $actual_version."
@@ -298,15 +380,12 @@ jobs:
               echo "::error::Published $PACKAGE_NAME@$RELEASE_VERSION has integrity $actual_integrity, expected $PACKAGE_INTEGRITY."
               return 2
             fi
-            if [[ -z "$actual_provenance" ]]; then
-              echo "::error::Published $PACKAGE_NAME@$RELEASE_VERSION is missing npm provenance."
-              return 2
+            if verify_package_provenance; then
+              return 0
+            else
+              provenance_status=$?
+              return "$provenance_status"
             fi
-            if [[ "$actual_provenance" != "https://slsa.dev/provenance/v1" ]]; then
-              echo "::error::Published $PACKAGE_NAME@$RELEASE_VERSION has unsupported provenance predicate $actual_provenance."
-              return 2
-            fi
-            return 0
           }
 
           verify_published_package() {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Escape C1 controls in JSON reports and fail commands whose successful payload cannot be serialized.
 - Reject corrupt retained capability matrices before artifact rotation and cancel failed OpenClaw probe response bodies.
 - Recursively inspect referenced local actions, include Go manifests in dependency review, and allow production package source-map checks to complete under load.
+- Cryptographically verify npm provenance and bind existing releases to the expected package digest, repository, workflow, tag, and commit.
 - Stream Telegram multipart uploads with bounded parser metadata instead of copying complete files through `FormData`.
 - Keep Unix recorder identity locks in one validated private per-user namespace across processes and recorder path changes.
 - Reject non-positive Telegram admin message IDs and enforce native Mattermost channel types and unique normalized usernames.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Classify empty JWT key sets and failed refresh cooldowns as signing-key infrastructure failures.
 - Reject malformed UTF-8 and empty explicit config paths, and require canonical Zalo header credentials.
 - Keep channel setup defaults and secret-handling guidance synchronized with the schema.
+- Escape C1 controls in JSON reports and fail commands whose successful payload cannot be serialized.
 - Stream Telegram multipart uploads with bounded parser metadata instead of copying complete files through `FormData`.
 - Keep Unix recorder identity locks in one validated private per-user namespace across processes and recorder path changes.
 - Reject non-positive Telegram admin message IDs and enforce native Mattermost channel types and unique normalized usernames.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Reject malformed UTF-8 and empty explicit config paths, and require canonical Zalo header credentials.
 - Keep channel setup defaults and secret-handling guidance synchronized with the schema.
 - Escape C1 controls in JSON reports and fail commands whose successful payload cannot be serialized.
+- Reject corrupt retained capability matrices before artifact rotation and cancel failed OpenClaw probe response bodies.
 - Stream Telegram multipart uploads with bounded parser metadata instead of copying complete files through `FormData`.
 - Keep Unix recorder identity locks in one validated private per-user namespace across processes and recorder path changes.
 - Reject non-positive Telegram admin message IDs and enforce native Mattermost channel types and unique normalized usernames.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Keep channel setup defaults and secret-handling guidance synchronized with the schema.
 - Escape C1 controls in JSON reports and fail commands whose successful payload cannot be serialized.
 - Reject corrupt retained capability matrices before artifact rotation and cancel failed OpenClaw probe response bodies.
+- Recursively inspect referenced local actions, include Go manifests in dependency review, and allow production package source-map checks to complete under load.
 - Stream Telegram multipart uploads with bounded parser metadata instead of copying complete files through `FormData`.
 - Keep Unix recorder identity locks in one validated private per-user namespace across processes and recorder path changes.
 - Reject non-positive Telegram admin message IDs and enforce native Mattermost channel types and unique normalized usernames.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Reject empty loopback cursors, preserve Slack edit event identity, and prune settled WhatsApp wait cursors during concurrent waits.
 - Use the canonical Matrix identifier validators for local targets and webhook envelopes.
 - Classify empty JWT key sets and failed refresh cooldowns as signing-key infrastructure failures.
+- Reject malformed UTF-8 and empty explicit config paths, and require canonical Zalo header credentials.
+- Keep channel setup defaults and secret-handling guidance synchronized with the schema.
 - Stream Telegram multipart uploads with bounded parser metadata instead of copying complete files through `FormData`.
 - Keep Unix recorder identity locks in one validated private per-user namespace across processes and recorder path changes.
 - Reject non-positive Telegram admin message IDs and enforce native Mattermost channel types and unique normalized usernames.

--- a/README.md
+++ b/README.md
@@ -172,6 +172,12 @@ pass descriptors above 2 through package runners such as `pnpm`; use fd 0
 instead. Keep credential files owner-readable or pipe the JSON directly from a
 secret manager.
 
+Ready files contain generated provider and admin credentials. Crabline creates
+or replaces them with POSIX mode `0600`, but the parent directory still needs
+to be private. Exclude ready files from version control and CI artifact
+collection, and delete them after use. On non-POSIX or shared filesystems,
+verify the effective ACLs before publishing one.
+
 Library callers can pass `onEvent` to `startCrablineServer`, an individual
 provider server, or `startOpenClawCrablineAdapter`. Crabline awaits the callback
 after appending each API/admin event to `recorderPath`, so callers can react in

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -135,8 +135,9 @@ header before JSON parsing or recorder writes:
   so its listener and any advertised callback must remain loopback-only.
 - Mattermost `webhookToken` or `MATTERMOST_TOKEN` verifies the `token` field in
   outgoing webhook form or JSON bodies. The token is removed before recorder
-  persistence. Externally reachable callbacks require this token and an HTTPS
-  `webhook.publicUrl`.
+  persistence. Mattermost webhook ingress is currently loopback-only:
+  non-loopback listener hosts and any `webhook.publicUrl` are rejected even
+  when a token is configured.
 - iMessage webhook ingress currently has no provider-native authentication
   mode, so its listener and any advertised callback must remain loopback-only.
 - Feishu `verificationToken` or `FEISHU_VERIFICATION_TOKEN` verifies plaintext
@@ -255,6 +256,12 @@ values, and overrides environment fallbacks field by field. Do not pass
 descriptors above 2 through package runners such as `pnpm`; use fd 0 instead.
 Keep credential files owner-readable or pipe the JSON directly from a secret
 manager.
+
+Ready files contain generated provider and admin credentials. Crabline creates
+or replaces them with POSIX mode `0600`, but the parent directory still needs
+to be private. Exclude ready files from version control and CI artifact
+collection, and delete them after use. On non-POSIX or shared filesystems,
+verify the effective ACLs before publishing one.
 
 ### Mattermost
 

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -6,8 +6,14 @@ import nodePath from "node:path";
 import { finished } from "node:stream/promises";
 import { lock } from "proper-lockfile";
 import { loadManifest } from "../config/load.js";
+import { EXIT_CODES } from "../core/exit-codes.js";
 import { createRegistry } from "../providers/registry.js";
-import { formatJson, formatRunResultText, sanitizeTerminalText } from "../core/reporters.js";
+import {
+  formatJson,
+  formatJsonResult,
+  formatRunResultText,
+  sanitizeTerminalText,
+} from "../core/reporters.js";
 import {
   assertScriptStdinPayloadSize,
   computeExitCode,
@@ -381,6 +387,13 @@ export function createProgram(
   const publish = dependencies.publishReadyFile ?? publishReadyFileUnlocked;
   const removeReady = dependencies.removeReadyFile ?? removeReadyFileIfOwned;
   const startServer = dependencies.startServer ?? startCrablineServer;
+  const formatCliJson = (value: unknown): string => {
+    const formatted = formatJsonResult(value);
+    if (!formatted.ok) {
+      setExitCode(EXIT_CODES.FAILURE);
+    }
+    return formatted.output;
+  };
 
   program
     .exitOverride()
@@ -407,7 +420,7 @@ export function createProgram(
         })),
         support: registry.catalog,
       };
-      await print(options.json ? formatJson(payload) : renderProvidersText(payload));
+      await print(options.json ? formatCliJson(payload) : renderProvidersText(payload));
     });
 
   program
@@ -418,7 +431,7 @@ export function createProgram(
       const { manifest } = await loadManifest(options.config);
       await print(
         options.json
-          ? formatJson(manifest.fixtures)
+          ? formatCliJson(manifest.fixtures)
           : manifest.fixtures
               .map(
                 (fixture) =>
@@ -446,8 +459,8 @@ export function createProgram(
         modeOverride: "probe",
         registry,
       });
-      await print(options.json ? formatJson(result) : formatRunResultText(result));
       setExitCode(computeExitCode(result));
+      await print(options.json ? formatCliJson(result) : formatRunResultText(result));
     });
 
   for (const mode of ["send", "roundtrip", "agent"] as const) {
@@ -465,8 +478,8 @@ export function createProgram(
           modeOverride: mode,
           registry,
         });
-        await print(options.json ? formatJson(result) : formatRunResultText(result));
         setExitCode(computeExitCode(result));
+        await print(options.json ? formatCliJson(result) : formatRunResultText(result));
       });
   }
 
@@ -483,8 +496,8 @@ export function createProgram(
         manifestPath: path,
         registry,
       });
-      await print(options.json ? formatJson(result) : formatRunResultText(result));
       setExitCode(computeExitCode(result));
+      await print(options.json ? formatCliJson(result) : formatRunResultText(result));
     });
 
   program
@@ -555,7 +568,7 @@ export function createProgram(
             const message = result.value;
             const written = await print(
               options.json
-                ? formatJson(message)
+                ? formatCliJson(message)
                 : `${sanitizeTerminalText(message.sentAt, true)} ${sanitizeTerminalText(message.author, true)} ${sanitizeTerminalText(message.text, true)}`,
             );
             if (!written) {
@@ -752,7 +765,11 @@ export function createProgram(
           } else {
             let outputWritten = true;
             try {
-              const payload = formatJson(server.manifest);
+              const formatted = formatJsonResult(server.manifest);
+              if (!formatted.ok) {
+                throw new Error("Unable to serialize server manifest.");
+              }
+              const payload = formatted.output;
               if (commandOptions.readyFile) {
                 const readyContents = `${payload}\n`;
                 publishedReady = {
@@ -815,8 +832,8 @@ export function createProgram(
       const findings = diagnose(manifest);
       const ok = findings.length === 0;
       const payload = { findings, ok };
-      await print(options.json ? formatJson(payload) : ok ? "doctor ok" : findings.join("\n"));
       setExitCode(ok ? 0 : 10);
+      await print(options.json ? formatCliJson(payload) : ok ? "doctor ok" : findings.join("\n"));
     });
 
   return program;

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -1,12 +1,14 @@
 import { constants as fsConstants } from "node:fs";
 import { open, stat, type FileHandle } from "node:fs/promises";
 import path from "node:path";
+import { TextDecoder } from "node:util";
 import YAML from "yaml";
 import { CrablineError, ensureErrorMessage } from "../core/errors.js";
 import { type ManifestDefinition, ManifestSchema } from "./schema.js";
 
 const DEFAULT_CONFIG_CANDIDATES = ["crabline.yaml", "crabline.yml", "crabline.json"] as const;
 const MAX_MANIFEST_BYTES = 1024 * 1024;
+const UTF8_DECODER = new TextDecoder("utf-8", { fatal: true });
 
 class DuplicateJsonKeyError extends SyntaxError {}
 
@@ -81,14 +83,17 @@ async function readManifestFile(resolvedPath: string): Promise<string> {
     if (offset > MAX_MANIFEST_BYTES) {
       throw new Error(`Config file exceeds the ${MAX_MANIFEST_BYTES}-byte limit.`);
     }
-    return buffer.toString("utf8", 0, offset);
+    return UTF8_DECODER.decode(buffer.subarray(0, offset));
   } finally {
     await handle?.close();
   }
 }
 
 export async function resolveConfigPath(explicitPath?: string): Promise<string> {
-  if (explicitPath) {
+  if (explicitPath !== undefined) {
+    if (explicitPath.trim().length === 0) {
+      throw new CrablineError("Config path must not be empty.", { kind: "config" });
+    }
     return path.resolve(explicitPath);
   }
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -104,6 +104,8 @@ const HttpsUrlSchema = HttpUrlSchema.refine((value) => {
 const HeaderValueSchema = z
   .string()
   .min(1)
+  .refine((value) => value.trim().length > 0, "secret must not be blank")
+  .refine((value) => value === value.trim(), "secret must not contain surrounding whitespace")
   .refine((value) => {
     try {
       validateHeaderValue("x-crabline-secret", value);

--- a/src/core/reporters.ts
+++ b/src/core/reporters.ts
@@ -5,7 +5,8 @@ const BIDI_CONTROL_CODE_POINTS = new Set([
   0x061c, 0x200e, 0x200f, 0x202a, 0x202b, 0x202c, 0x202d, 0x202e, 0x2066, 0x2067, 0x2068, 0x2069,
 ]);
 
-const UNSAFE_JSON_CODE_POINTS = /[\u061c\u200e\u200f\u2028\u2029\u202a-\u202e\u2066-\u2069]/gu;
+const UNSAFE_JSON_CODE_POINTS =
+  /[\u007f-\u009f\u061c\u200e\u200f\u2028\u2029\u202a-\u202e\u2066-\u2069]/gu;
 const JSON_SERIALIZATION_ERROR = `{
   "error": {
     "message": "Unable to serialize JSON output."
@@ -61,17 +62,29 @@ export function formatRunResultText(result: CommandRunResult | SuiteRunResult): 
   return formatSingleResult(result);
 }
 
-export function formatJson(result: unknown): string {
+export type JsonFormatResult = {
+  ok: boolean;
+  output: string;
+};
+
+export function formatJsonResult(result: unknown): JsonFormatResult {
   let serialized: string | undefined;
   try {
     serialized = JSON.stringify(result === undefined ? null : result, null, 2);
   } catch {
-    return JSON_SERIALIZATION_ERROR;
+    return { ok: false, output: JSON_SERIALIZATION_ERROR };
   }
-  return (serialized ?? "null").replace(
-    UNSAFE_JSON_CODE_POINTS,
-    (character) => String.raw`\u${character.codePointAt(0)!.toString(16).padStart(4, "0")}`,
-  );
+  return {
+    ok: true,
+    output: (serialized ?? "null").replace(
+      UNSAFE_JSON_CODE_POINTS,
+      (character) => String.raw`\u${character.codePointAt(0)!.toString(16).padStart(4, "0")}`,
+    ),
+  };
+}
+
+export function formatJson(result: unknown): string {
+  return formatJsonResult(result).output;
 }
 
 function formatSingleResult(result: CommandRunResult): string {

--- a/src/openclaw/artifact-generation.ts
+++ b/src/openclaw/artifact-generation.ts
@@ -316,7 +316,9 @@ async function assertCurrentGenerationExists(
     capabilityMatrix.channelDriver.length === 0 ||
     typeof capabilityMatrix.selectedChannel !== "string" ||
     capabilityMatrix.selectedChannel.length === 0 ||
-    !Object.hasOwn(capabilityMatrix, "report")
+    capabilityMatrix.report === null ||
+    typeof capabilityMatrix.report !== "object" ||
+    Array.isArray(capabilityMatrix.report)
   ) {
     throw new Error("OpenClaw Crabline current artifact generation is incomplete.");
   }

--- a/src/openclaw/artifact-generation.ts
+++ b/src/openclaw/artifact-generation.ts
@@ -306,7 +306,20 @@ async function assertCurrentGenerationExists(
   };
 
   const manifest = await readArtifactObject(pointer.manifestPath);
+  const capabilityMatrix = await readArtifactObject(pointer.capabilityMatrixPath);
   const readiness = await readArtifactObject(pointer.providerReadinessArtifactPath);
+  if (
+    capabilityMatrix.version !== 1 ||
+    capabilityMatrix.source !== "openclaw/crabline" ||
+    capabilityMatrix.manifestPath !== pointer.manifestPath ||
+    typeof capabilityMatrix.channelDriver !== "string" ||
+    capabilityMatrix.channelDriver.length === 0 ||
+    typeof capabilityMatrix.selectedChannel !== "string" ||
+    capabilityMatrix.selectedChannel.length === 0 ||
+    !Object.hasOwn(capabilityMatrix, "report")
+  ) {
+    throw new Error("OpenClaw Crabline current artifact generation is incomplete.");
+  }
   const manifestRecorderPath =
     typeof manifest.recorderPath === "string" ? manifest.recorderPath : undefined;
   const providerReadinessRecorderPath = readNestedRecorderPath(readiness.providerReadiness);

--- a/src/openclaw/bridges/matrix.ts
+++ b/src/openclaw/bridges/matrix.ts
@@ -9,6 +9,7 @@ import {
   readNonBlankString,
   readString,
 } from "../shared.js";
+import { throwProbeHttpError } from "./probe-response.js";
 
 const MAX_MATRIX_IDENTIFIER_BYTES = 255;
 
@@ -105,7 +106,10 @@ export const MATRIX_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablinePr
           ...(signal ? { signal } : {}),
         });
         if (!response.ok) {
-          throw new Error(`Crabline Matrix probe failed with HTTP ${response.status}.`);
+          await throwProbeHttpError(
+            response,
+            `Crabline Matrix probe failed with HTTP ${response.status}.`,
+          );
         }
         const payload: unknown = await response.json();
         if (!isRecord(payload) || readString(payload.user_id) !== matrix.botUserId) {

--- a/src/openclaw/bridges/mattermost.ts
+++ b/src/openclaw/bridges/mattermost.ts
@@ -9,6 +9,7 @@ import {
   readString,
 } from "../shared.js";
 import { mattermostId } from "../../servers/mattermost.js";
+import { throwProbeHttpError } from "./probe-response.js";
 
 function nativeId(value: string): string {
   const trimmed = value.trim();
@@ -41,7 +42,10 @@ export const MATTERMOST_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabli
           ...(signal ? { signal } : {}),
         });
         if (!response.ok) {
-          throw new Error(`Crabline Mattermost probe failed with HTTP ${response.status}.`);
+          await throwProbeHttpError(
+            response,
+            `Crabline Mattermost probe failed with HTTP ${response.status}.`,
+          );
         }
         const payload: unknown = await response.json();
         if (

--- a/src/openclaw/bridges/probe-response.ts
+++ b/src/openclaw/bridges/probe-response.ts
@@ -1,0 +1,8 @@
+export async function throwProbeHttpError(response: Response, message: string): Promise<never> {
+  try {
+    await response.body?.cancel();
+  } catch {
+    // Preserve the provider HTTP failure when response cleanup also fails.
+  }
+  throw new Error(message);
+}

--- a/src/openclaw/bridges/signal.ts
+++ b/src/openclaw/bridges/signal.ts
@@ -8,6 +8,7 @@ import {
   readNonBlankString,
   readString,
 } from "../shared.js";
+import { throwProbeHttpError } from "./probe-response.js";
 
 const SIGNAL_UUID_RE =
   /^(?:uuid:)?([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/iu;
@@ -78,7 +79,10 @@ export const SIGNAL_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablinePr
           ...(abortSignal ? { signal: abortSignal } : {}),
         });
         if (!response.ok) {
-          throw new Error(`Crabline Signal check probe failed with HTTP ${response.status}.`);
+          await throwProbeHttpError(
+            response,
+            `Crabline Signal check probe failed with HTTP ${response.status}.`,
+          );
         }
         return { ok: true, status: response.status };
       },

--- a/src/openclaw/bridges/slack.ts
+++ b/src/openclaw/bridges/slack.ts
@@ -14,6 +14,7 @@ import {
   SLACK_TS_RULE,
   SLACK_USER_ID_RULE,
 } from "../../providers/slack-ids.js";
+import { throwProbeHttpError } from "./probe-response.js";
 
 function requireSlackSendTargetId(value: string, label: string): string {
   const trimmed = value.trim();
@@ -185,7 +186,10 @@ export const SLACK_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablinePro
           ...(signal ? { signal } : {}),
         });
         if (!response.ok) {
-          throw new Error(`Crabline Slack auth.test probe failed with HTTP ${response.status}.`);
+          await throwProbeHttpError(
+            response,
+            `Crabline Slack auth.test probe failed with HTTP ${response.status}.`,
+          );
         }
         const result: unknown = await response.json();
         if (!isRecord(result) || result.ok !== true) {

--- a/src/openclaw/bridges/telegram.ts
+++ b/src/openclaw/bridges/telegram.ts
@@ -15,6 +15,7 @@ import {
   TELEGRAM_NATIVE_CHAT_ID_MAX,
   telegramUsernameChatId,
 } from "../../servers/telegram-identity.js";
+import { throwProbeHttpError } from "./probe-response.js";
 
 const TELEGRAM_SYMBOLIC_ID_BASE = TELEGRAM_NATIVE_CHAT_ID_MAX + 1n;
 const TELEGRAM_SYMBOLIC_ID_RANGE = 1n << 50n;
@@ -140,7 +141,10 @@ export const TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
           signal ? { signal } : {},
         );
         if (!response.ok) {
-          throw new Error(`Crabline Telegram getMe probe failed with HTTP ${response.status}.`);
+          await throwProbeHttpError(
+            response,
+            `Crabline Telegram getMe probe failed with HTTP ${response.status}.`,
+          );
         }
         const payload: unknown = await response.json();
         if (!isRecord(payload) || payload.ok !== true) {

--- a/src/openclaw/bridges/whatsapp.ts
+++ b/src/openclaw/bridges/whatsapp.ts
@@ -13,6 +13,7 @@ import {
   canonicalizeWhatsAppUserCorrelationJid,
   canonicalizeWhatsAppUserJid,
 } from "../../servers/whatsapp-jid.js";
+import { throwProbeHttpError } from "./probe-response.js";
 
 function requireWhatsAppJid(value: string, label: string, userOnly = false): string {
   const canonical = userOnly
@@ -57,7 +58,10 @@ export const WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
           ...(signal ? { signal } : {}),
         });
         if (!response.ok) {
-          throw new Error(`Crabline WhatsApp probe failed with HTTP ${response.status}.`);
+          await throwProbeHttpError(
+            response,
+            `Crabline WhatsApp probe failed with HTTP ${response.status}.`,
+          );
         }
         const payload: unknown = await response.json();
         if (!isRecord(payload) || readString(payload.id) !== whatsapp.phoneNumberId) {

--- a/src/openclaw/bridges/zalo.ts
+++ b/src/openclaw/bridges/zalo.ts
@@ -11,6 +11,7 @@ import {
   readNonBlankString,
   readString,
 } from "../shared.js";
+import { throwProbeHttpError } from "./probe-response.js";
 
 function nativeId(value: string): string {
   const id = value.trim();
@@ -33,7 +34,10 @@ export const ZALO_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablineProv
           ...(signal ? { signal } : {}),
         });
         if (!response.ok) {
-          throw new Error(`Crabline Zalo getMe probe failed with HTTP ${response.status}.`);
+          await throwProbeHttpError(
+            response,
+            `Crabline Zalo getMe probe failed with HTTP ${response.status}.`,
+          );
         }
         const result = await response.json();
         const bot = isRecord(result) && isRecord(result.result) ? result.result : undefined;

--- a/test/channel-setup-docs.test.ts
+++ b/test/channel-setup-docs.test.ts
@@ -60,9 +60,7 @@ describe("channel setup contracts", () => {
     })).toSorted((left, right) => left.platform.localeCompare(right.platform));
     const documentedWebhooks = new Map(
       Array.from(
-        channelSetup.matchAll(
-          /^\| `([^`]+)`\s+\| `([^`]+)`\s+\| `([0-9]+)`\s+\|$/gmu,
-        ),
+        channelSetup.matchAll(/^\| `([^`]+)`\s+\| `([^`]+)`\s+\| `([0-9]+)`\s+\|$/gmu),
         (match) => [match[1]!, { path: match[2]!, port: Number(match[3]) }] as const,
       ),
     );

--- a/test/channel-setup-docs.test.ts
+++ b/test/channel-setup-docs.test.ts
@@ -4,6 +4,21 @@ import { parse } from "yaml";
 import { BUILTIN_ADAPTERS, ManifestSchema } from "../src/config/schema.js";
 import { OPENCLAW_SUPPORT_CATALOG } from "../src/providers/catalog.js";
 
+type WebhookDefaults = { path: string; port: number };
+
+function schemaWebhookDefaults(adapter: (typeof BUILTIN_ADAPTERS)[number]): WebhookDefaults {
+  const manifest = ManifestSchema.parse({
+    fixtures: [],
+    providers: { provider: { adapter, [adapter]: {} } },
+  });
+  const provider = manifest.providers.provider as unknown as Record<string, unknown>;
+  const adapterConfig = provider[adapter] as { webhook?: WebhookDefaults } | undefined;
+  if (!adapterConfig?.webhook) {
+    throw new Error(`Adapter ${adapter} does not define webhook defaults.`);
+  }
+  return { path: adapterConfig.webhook.path, port: adapterConfig.webhook.port };
+}
+
 describe("channel setup contracts", () => {
   it("ships a schema-valid example covering every built-in adapter", async () => {
     const manifest = ManifestSchema.parse(
@@ -22,9 +37,10 @@ describe("channel setup contracts", () => {
   });
 
   it("keeps documented support lists synchronized with schema and catalog", async () => {
-    const [readme, channelSetup] = await Promise.all([
+    const [readme, channelSetup, exampleText] = await Promise.all([
       fs.readFile("README.md", "utf8"),
       fs.readFile("docs/channel-setup.md", "utf8"),
+      fs.readFile("fixtures/examples/crabline.example.yaml", "utf8"),
     ]);
     const readmeBuiltinSection = readme.slice(
       readme.indexOf("The built-in providers are:"),
@@ -42,11 +58,31 @@ describe("channel setup contracts", () => {
       platform,
       status,
     })).toSorted((left, right) => left.platform.localeCompare(right.platform));
+    const documentedWebhooks = new Map(
+      Array.from(
+        channelSetup.matchAll(
+          /^\| `([^`]+)`\s+\| `([^`]+)`\s+\| `([0-9]+)`\s+\|$/gmu,
+        ),
+        (match) => [match[1]!, { path: match[2]!, port: Number(match[3]) }] as const,
+      ),
+    );
+    const example = ManifestSchema.parse(parse(exampleText));
+    const webhookAdapters = BUILTIN_ADAPTERS.filter(
+      (adapter) => adapter !== "loopback" && adapter !== "script",
+    );
 
     expect(documentedBuiltinAdapters).toEqual(
       BUILTIN_ADAPTERS.filter((adapter) => adapter !== "script").toSorted(),
     );
     expect(documentedCatalog).toEqual(expectedCatalog);
+    expect([...documentedWebhooks.keys()].toSorted()).toEqual(webhookAdapters.toSorted());
+    for (const adapter of webhookAdapters) {
+      const defaults = schemaWebhookDefaults(adapter);
+      expect(documentedWebhooks.get(adapter)).toEqual(defaults);
+      const provider = example.providers[adapter] as unknown as Record<string, unknown>;
+      const config = provider[adapter] as { webhook?: WebhookDefaults };
+      expect(config.webhook).toMatchObject(defaults);
+    }
   });
 
   it("documents native target and admin-ingress identifiers", async () => {
@@ -72,5 +108,21 @@ describe("channel setup contracts", () => {
     expect(matrixSection).toContain("`endpoints.adminInboundUrl`");
     expect(matrixSection).toContain("`adminToken`");
     expect(matrixSection).toContain("`X-Crabline-Admin-Token`");
+  });
+
+  it("documents ready-file protections and Mattermost ingress limits", async () => {
+    const [readme, channelSetup] = await Promise.all([
+      fs.readFile("README.md", "utf8"),
+      fs.readFile("docs/channel-setup.md", "utf8"),
+    ]);
+
+    for (const document of [readme, channelSetup]) {
+      expect(document).toContain("generated provider and admin credentials");
+      expect(document).toContain("POSIX mode `0600`");
+      expect(document).toContain("Exclude ready files from version control and CI artifact");
+      expect(document).toContain("delete them after use");
+    }
+    expect(channelSetup).toContain("Mattermost webhook ingress is currently loopback-only");
+    expect(channelSetup).toContain("any `webhook.publicUrl` are rejected");
   });
 });

--- a/test/ci-workflow.test.ts
+++ b/test/ci-workflow.test.ts
@@ -80,6 +80,7 @@ describe("CI workflow hardening", () => {
         fs.mkdir(path.join(root, ".github", "workflows"), { recursive: true }),
         fs.mkdir(path.join(root, ".github", "actions", "example"), { recursive: true }),
         fs.mkdir(path.join(root, ".github", "actions", "container"), { recursive: true }),
+        fs.mkdir(path.join(root, "ci", "outside"), { recursive: true }),
       ]);
       await Promise.all([
         fs.writeFile(
@@ -97,6 +98,7 @@ describe("CI workflow hardening", () => {
             "        image: postgres:17",
             "    steps:",
             "      - run: echo ok",
+            "      - uses: ./ci/outside",
           ].join("\n"),
         ),
         fs.writeFile(
@@ -114,6 +116,10 @@ describe("CI workflow hardening", () => {
           path.join(root, ".github", "actions", "container", "action.yml"),
           ["runs:", "  using: docker", "  image: docker://busybox:1.37"].join("\n"),
         ),
+        fs.writeFile(
+          path.join(root, "ci", "outside", "action.yml"),
+          ["runs:", "  using: composite", "  steps:", "    - uses: owner/outside@v2"].join("\n"),
+        ),
       ]);
 
       const actionRefs = await collectExternalActionRefs(root);
@@ -123,6 +129,7 @@ describe("CI workflow hardening", () => {
           "docker://ghcr.io/owner/runtime:latest",
           "docker://postgres:17",
           "owner/action@v1",
+          "owner/outside@v2",
           "docker://alpine:3.20",
           `docker://ghcr.io/owner/action@sha256:${"0".repeat(64)}`,
           "docker://busybox:1.37",
@@ -134,6 +141,7 @@ describe("CI workflow hardening", () => {
           "docker://ghcr.io/owner/runtime:latest",
           "docker://postgres:17",
           "owner/action@v1",
+          "owner/outside@v2",
           "docker://alpine:3.20",
           "docker://busybox:1.37",
         ].toSorted(),
@@ -151,6 +159,8 @@ describe("CI workflow hardening", () => {
 
     expect(codeowners).toContain("/pnpm-workspace.yaml @openclaw/openclaw-secops");
     expect(dependencyReview).toContain("      - pnpm-workspace.yaml");
+    expect(dependencyReview).toContain("      - tools/go.mod");
+    expect(dependencyReview).toContain("      - tools/go.sum");
   });
 
   it("protects and scans local action and executable tool changes", async () => {
@@ -210,22 +220,58 @@ async function collectExternalActionRefs(root: string): Promise<string[]> {
     )
   ).flat();
 
+  const externalRefs = workflowRefs.filter((uses) => !uses.startsWith("./"));
   const actionFiles = await listYamlFiles(path.join(root, ".github", "actions"));
-  const compositeRefs = (
-    await Promise.all(
-      actionFiles.map(async (filePath) => {
-        const action = parse(await fs.readFile(filePath, "utf8")) as CompositeAction;
-        if (action.runs?.using === "composite") {
-          return action.runs.steps?.flatMap((step) => (step.uses ? [step.uses] : [])) ?? [];
-        }
-        return action.runs?.using === "docker" && action.runs.image?.startsWith("docker://")
+  for (const localRef of workflowRefs.filter((uses) => uses.startsWith("./"))) {
+    actionFiles.push(await resolveLocalActionManifest(root, localRef));
+  }
+
+  const pending = [...new Set(actionFiles)];
+  const visited = new Set<string>();
+  while (pending.length > 0) {
+    const filePath = pending.shift()!;
+    if (visited.has(filePath)) {
+      continue;
+    }
+    visited.add(filePath);
+    const action = parse(await fs.readFile(filePath, "utf8")) as CompositeAction;
+    const refs =
+      action.runs?.using === "composite"
+        ? (action.runs.steps?.flatMap((step) => (step.uses ? [step.uses] : [])) ?? [])
+        : action.runs?.using === "docker" && action.runs.image?.startsWith("docker://")
           ? [action.runs.image]
           : [];
-      }),
-    )
-  ).flat();
+    for (const uses of refs) {
+      if (uses.startsWith("./")) {
+        pending.push(await resolveLocalActionManifest(root, uses));
+      } else {
+        externalRefs.push(uses);
+      }
+    }
+  }
 
-  return [...workflowRefs, ...compositeRefs].filter((uses) => !uses.startsWith("./"));
+  return externalRefs;
+}
+
+async function resolveLocalActionManifest(root: string, uses: string): Promise<string> {
+  const resolved = path.resolve(root, uses.slice(2));
+  const relative = path.relative(root, resolved);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`Local action escapes the repository: ${uses}`);
+  }
+  for (const fileName of ["action.yml", "action.yaml"]) {
+    const manifestPath = path.join(resolved, fileName);
+    try {
+      if ((await fs.stat(manifestPath)).isFile()) {
+        return manifestPath;
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    }
+  }
+  throw new Error(`Local action manifest is missing: ${uses}`);
 }
 
 function workflowImage(value: string | { image?: string } | undefined): string | undefined {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -122,17 +122,14 @@ describe("cli", () => {
     const configPath = await createConfig();
     let exitCode = -1;
     const captured = await captureWrites(async () => {
-      exitCode = await runCli(
-        ["node", "crabline", "--json", "--config", configPath, "providers"],
-        {
-          dependencies: {
-            createRegistry: () =>
-              ({
-                catalog: [{ value: 1n }],
-              }) as never,
-          },
+      exitCode = await runCli(["node", "crabline", "--json", "--config", configPath, "providers"], {
+        dependencies: {
+          createRegistry: () =>
+            ({
+              catalog: [{ value: 1n }],
+            }) as never,
         },
-      );
+      });
     });
 
     expect(exitCode).toBe(1);

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -118,6 +118,30 @@ describe("cli", () => {
     expect(captured.stdout.join("")).toContain("roundtrip-fixture");
   });
 
+  it("returns failure when successful JSON output cannot be serialized", async () => {
+    const configPath = await createConfig();
+    let exitCode = -1;
+    const captured = await captureWrites(async () => {
+      exitCode = await runCli(
+        ["node", "crabline", "--json", "--config", configPath, "providers"],
+        {
+          dependencies: {
+            createRegistry: () =>
+              ({
+                catalog: [{ value: 1n }],
+              }) as never,
+          },
+        },
+      );
+    });
+
+    expect(exitCode).toBe(1);
+    expect(JSON.parse(captured.stdout.join(""))).toEqual({
+      error: { message: "Unable to serialize JSON output." },
+      ok: false,
+    });
+  });
+
   it("sanitizes user-controlled fixture fields in text output", async () => {
     const directory = await createTempDir();
     directories.push(directory);

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -180,6 +180,41 @@ describe("manifest schema", () => {
     ).toThrow(/webhook path must start with \//u);
   });
 
+  it.each([" ", "\t", " secret "])(
+    "rejects non-canonical Zalo header credentials: %j",
+    (secret) => {
+      for (const field of ["botToken", "webhookSecret"] as const) {
+        expect(() =>
+          ManifestSchema.parse({
+            configVersion: 1,
+            fixtures: [],
+            providers: {
+              zalo: {
+                adapter: "zalo",
+                zalo: { [field]: secret },
+              },
+            },
+          }),
+        ).toThrow(/secret must/u);
+      }
+    },
+  );
+
+  it("accepts canonical Zalo header credentials", () => {
+    expect(() =>
+      ManifestSchema.parse({
+        configVersion: 1,
+        fixtures: [],
+        providers: {
+          zalo: {
+            adapter: "zalo",
+            zalo: { botToken: "bot-token", webhookSecret: "webhook-secret" },
+          },
+        },
+      }),
+    ).not.toThrow();
+  });
+
   it.each([
     "/slack/../events",
     "/slack\\events",

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -208,7 +208,7 @@ describe("manifest schema", () => {
         providers: {
           zalo: {
             adapter: "zalo",
-            zalo: { botToken: "bot-token", webhookSecret: "webhook-secret" },
+            zalo: { botToken: "placeholder", webhookSecret: "placeholder" },
           },
         },
       }),

--- a/test/load.test.ts
+++ b/test/load.test.ts
@@ -56,6 +56,19 @@ describe("config load", () => {
     expect(loaded.path).toBe(configPath);
   });
 
+  it.each(["yaml", "json"])("rejects malformed UTF-8 in %s manifests", async (extension) => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const configPath = path.join(directory, `crabline.${extension}`);
+    const prefix =
+      extension === "json"
+        ? Buffer.from('{"configVersion":1,"providers":{},"fixtures":[],"comment":"')
+        : Buffer.from("configVersion: 1\nproviders: {}\nfixtures: []\ncomment: ");
+    await writeFile(configPath, Buffer.concat([prefix, Buffer.from([0xc3, 0x28])]));
+
+    await expect(loadManifest(configPath)).rejects.toThrow(/not valid for encoding utf-8/u);
+  });
+
   it("rejects duplicate keys in JSON manifests", async () => {
     const directory = await createTempDir();
     directories.push(directory);
@@ -208,6 +221,23 @@ describe("config load", () => {
     process.chdir(directory);
     try {
       expect(await realpath(await resolveConfigPath())).toBe(await realpath(configPath));
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
+  it.each(["", " ", "\t"])("rejects an explicit empty config path: %j", async (configPath) => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    await writeText(
+      path.join(directory, "crabline.yaml"),
+      "configVersion: 1\nproviders: {}\nfixtures: []\n",
+    );
+    const originalCwd = process.cwd();
+
+    process.chdir(directory);
+    try {
+      await expect(loadManifest(configPath)).rejects.toThrow(/Config path must not be empty/u);
     } finally {
       process.chdir(originalCwd);
     }

--- a/test/openclaw-artifact-generation.test.ts
+++ b/test/openclaw-artifact-generation.test.ts
@@ -464,6 +464,39 @@ describe("OpenClaw artifact generation publication", () => {
     }
   });
 
+  it("rejects a non-object capability report without pruning retained generations", async () => {
+    const outputDir = await createTempDir();
+    try {
+      const first = await publishOpenClawCrablineArtifactGeneration(publishParams(outputDir), {
+        createGenerationId: () => "11111111-1111-4111-8111-111111111111",
+      });
+      const second = await publishOpenClawCrablineArtifactGeneration(publishParams(outputDir), {
+        createGenerationId: () => "22222222-2222-4222-8222-222222222222",
+      });
+      const capabilityMatrixPath = path.join(outputDir, second.capabilityMatrixPath);
+      const capabilityMatrix = JSON.parse(
+        await fs.readFile(capabilityMatrixPath, "utf8"),
+      ) as Record<string, unknown>;
+      capabilityMatrix.report = null;
+      await fs.writeFile(capabilityMatrixPath, JSON.stringify(capabilityMatrix));
+
+      await expect(
+        publishOpenClawCrablineArtifactGeneration(publishParams(outputDir), {
+          createGenerationId: () => "33333333-3333-4333-8333-333333333333",
+        }),
+      ).rejects.toThrow("OpenClaw Crabline current artifact generation is incomplete.");
+
+      await expect(readOpenClawCrablineArtifactPointer(outputDir)).resolves.toMatchObject({
+        generation: second.generation,
+        previousGeneration: first.generation,
+      });
+      await expect(fs.stat(path.join(outputDir, first.manifestPath))).resolves.toBeDefined();
+      await expect(fs.stat(path.join(outputDir, second.manifestPath))).resolves.toBeDefined();
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
   it("rejects publication when current recorder references are removed", async () => {
     const outputDir = await createTempDir();
     try {

--- a/test/openclaw-artifact-generation.test.ts
+++ b/test/openclaw-artifact-generation.test.ts
@@ -436,6 +436,34 @@ describe("OpenClaw artifact generation publication", () => {
     }
   });
 
+  it("rejects a corrupt current capability matrix without pruning retained generations", async () => {
+    const outputDir = await createTempDir();
+    try {
+      const first = await publishOpenClawCrablineArtifactGeneration(publishParams(outputDir), {
+        createGenerationId: () => "11111111-1111-4111-8111-111111111111",
+      });
+      const second = await publishOpenClawCrablineArtifactGeneration(publishParams(outputDir), {
+        createGenerationId: () => "22222222-2222-4222-8222-222222222222",
+      });
+      await fs.writeFile(path.join(outputDir, second.capabilityMatrixPath), "{");
+
+      await expect(
+        publishOpenClawCrablineArtifactGeneration(publishParams(outputDir), {
+          createGenerationId: () => "33333333-3333-4333-8333-333333333333",
+        }),
+      ).rejects.toThrow("OpenClaw Crabline current artifact generation is incomplete.");
+
+      await expect(readOpenClawCrablineArtifactPointer(outputDir)).resolves.toMatchObject({
+        generation: second.generation,
+        previousGeneration: first.generation,
+      });
+      await expect(fs.stat(path.join(outputDir, first.manifestPath))).resolves.toBeDefined();
+      await expect(fs.stat(path.join(outputDir, second.manifestPath))).resolves.toBeDefined();
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
   it("rejects publication when current recorder references are removed", async () => {
     const outputDir = await createTempDir();
     try {

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -469,9 +469,9 @@ describe("OpenClaw local provider bridge", () => {
     ["Zalo", zaloManifest],
   ] as const)("cancels failed %s probe response bodies", async (_label, probeManifest) => {
     const cancel = vi.fn();
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(new ReadableStream({ cancel }), { status: 503 }),
-    );
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(new ReadableStream({ cancel }), { status: 503 }));
     try {
       await expect(probeOpenClawCrablineProvider(probeManifest)).rejects.toThrow(/HTTP 503/u);
       expect(cancel).toHaveBeenCalledOnce();

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -460,6 +460,27 @@ describe("OpenClaw local provider bridge", () => {
   });
 
   it.each([
+    ["Mattermost", mattermostManifest],
+    ["Matrix", matrixManifest],
+    ["Signal", signalManifest],
+    ["Slack", slackManifest],
+    ["Telegram", manifest],
+    ["WhatsApp", whatsappManifest],
+    ["Zalo", zaloManifest],
+  ] as const)("cancels failed %s probe response bodies", async (_label, probeManifest) => {
+    const cancel = vi.fn();
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(new ReadableStream({ cancel }), { status: 503 }),
+    );
+    try {
+      await expect(probeOpenClawCrablineProvider(probeManifest)).rejects.toThrow(/HTTP 503/u);
+      expect(cancel).toHaveBeenCalledOnce();
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
+  it.each([
     { ok: true },
     { ok: true, result: null },
     { ok: true, result: {} },

--- a/test/package-production.test.ts
+++ b/test/package-production.test.ts
@@ -346,31 +346,27 @@ describe("production package", () => {
     }
   }, 120_000);
 
-  it(
-    "embeds source contents in published JavaScript source maps",
-    async () => {
-      const root = process.cwd();
-      const pack = await npmPackDryRun(root);
-      const sourceMaps = pack.files
-        .map((file) => file.path)
-        .filter((file) => file.startsWith("dist/") && file.endsWith(".js.map"));
+  it("embeds source contents in published JavaScript source maps", async () => {
+    const root = process.cwd();
+    const pack = await npmPackDryRun(root);
+    const sourceMaps = pack.files
+      .map((file) => file.path)
+      .filter((file) => file.startsWith("dist/") && file.endsWith(".js.map"));
 
-      expect(sourceMaps).not.toEqual([]);
-      await Promise.all(
-        sourceMaps.map(async (file) => {
-          const sourceMap = JSON.parse(await fs.readFile(path.join(root, file), "utf8")) as {
-            sources?: unknown[];
-            sourcesContent?: unknown[];
-          };
-          expect(sourceMap.sourcesContent, `${file} is missing inline source contents`).toHaveLength(
-            sourceMap.sources?.length ?? 0,
-          );
-          expect(sourceMap.sourcesContent?.every((source) => typeof source === "string")).toBe(true);
-        }),
-      );
-    },
-    120_000,
-  );
+    expect(sourceMaps).not.toEqual([]);
+    await Promise.all(
+      sourceMaps.map(async (file) => {
+        const sourceMap = JSON.parse(await fs.readFile(path.join(root, file), "utf8")) as {
+          sources?: unknown[];
+          sourcesContent?: unknown[];
+        };
+        expect(sourceMap.sourcesContent, `${file} is missing inline source contents`).toHaveLength(
+          sourceMap.sources?.length ?? 0,
+        );
+        expect(sourceMap.sourcesContent?.every((source) => typeof source === "string")).toBe(true);
+      }),
+    );
+  }, 120_000);
 
   it("uses portable cleanup scripts", async () => {
     const root = process.cwd();

--- a/test/package-production.test.ts
+++ b/test/package-production.test.ts
@@ -346,27 +346,31 @@ describe("production package", () => {
     }
   }, 120_000);
 
-  it("embeds source contents in published JavaScript source maps", async () => {
-    const root = process.cwd();
-    const pack = await npmPackDryRun(root);
-    const sourceMaps = pack.files
-      .map((file) => file.path)
-      .filter((file) => file.startsWith("dist/") && file.endsWith(".js.map"));
+  it(
+    "embeds source contents in published JavaScript source maps",
+    async () => {
+      const root = process.cwd();
+      const pack = await npmPackDryRun(root);
+      const sourceMaps = pack.files
+        .map((file) => file.path)
+        .filter((file) => file.startsWith("dist/") && file.endsWith(".js.map"));
 
-    expect(sourceMaps).not.toEqual([]);
-    await Promise.all(
-      sourceMaps.map(async (file) => {
-        const sourceMap = JSON.parse(await fs.readFile(path.join(root, file), "utf8")) as {
-          sources?: unknown[];
-          sourcesContent?: unknown[];
-        };
-        expect(sourceMap.sourcesContent, `${file} is missing inline source contents`).toHaveLength(
-          sourceMap.sources?.length ?? 0,
-        );
-        expect(sourceMap.sourcesContent?.every((source) => typeof source === "string")).toBe(true);
-      }),
-    );
-  });
+      expect(sourceMaps).not.toEqual([]);
+      await Promise.all(
+        sourceMaps.map(async (file) => {
+          const sourceMap = JSON.parse(await fs.readFile(path.join(root, file), "utf8")) as {
+            sources?: unknown[];
+            sourcesContent?: unknown[];
+          };
+          expect(sourceMap.sourcesContent, `${file} is missing inline source contents`).toHaveLength(
+            sourceMap.sources?.length ?? 0,
+          );
+          expect(sourceMap.sourcesContent?.every((source) => typeof source === "string")).toBe(true);
+        }),
+      );
+    },
+    120_000,
+  );
 
   it("uses portable cleanup scripts", async () => {
     const root = process.cwd();

--- a/test/release-workflow.test.ts
+++ b/test/release-workflow.test.ts
@@ -14,6 +14,9 @@ const PUBLISH_TARBALL_CONTENTS = "package";
 const PUBLISH_PACKAGE_INTEGRITY = `sha512-${createHash("sha512")
   .update(PUBLISH_TARBALL_CONTENTS)
   .digest("base64")}`;
+const PUBLISH_PACKAGE_DIGEST = createHash("sha512").update(PUBLISH_TARBALL_CONTENTS).digest("hex");
+const PROVENANCE_MISMATCH_ERROR =
+  "::error::Published @openclaw/crabline@1.2.3 has provenance that does not match the repository, workflow, tag, commit, or package integrity.";
 
 type WorkflowStep = {
   id?: string;
@@ -39,6 +42,70 @@ type ReleaseWorkflow = {
     }
   >;
 };
+
+function createAuditResult(
+  overrides: {
+    commit?: string;
+    predicateType?: string;
+    ref?: string;
+    repository?: string;
+    subjectDigest?: string;
+    workflowPath?: string;
+  } = {},
+): Record<string, unknown> {
+  const predicateType = overrides.predicateType ?? "https://slsa.dev/provenance/v1";
+  const repository = overrides.repository ?? "https://github.com/openclaw/crabline";
+  const ref = overrides.ref ?? "refs/tags/v1.2.3";
+  const statement = {
+    _type: "https://in-toto.io/Statement/v1",
+    predicateType,
+    subject: [
+      {
+        digest: { sha512: overrides.subjectDigest ?? PUBLISH_PACKAGE_DIGEST },
+        name: "pkg:npm/%40openclaw/crabline@1.2.3",
+      },
+    ],
+    predicate: {
+      buildDefinition: {
+        buildType: "https://slsa-framework.github.io/github-actions-buildtypes/workflow/v1",
+        externalParameters: {
+          workflow: {
+            path: overrides.workflowPath ?? ".github/workflows/release.yml",
+            ref,
+            repository,
+          },
+        },
+        resolvedDependencies: [
+          {
+            digest: {
+              gitCommit: overrides.commit ?? "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            },
+            uri: `git+${repository}@${ref}`,
+          },
+        ],
+      },
+    },
+  };
+  return {
+    verified: [
+      {
+        attestationBundles: [
+          {
+            bundle: {
+              dsseEnvelope: {
+                payload: Buffer.from(JSON.stringify(statement)).toString("base64"),
+              },
+            },
+            predicateType,
+          },
+        ],
+        attestations: { provenance: { predicateType } },
+        name: "@openclaw/crabline",
+        version: "1.2.3",
+      },
+    ],
+  };
+}
 
 describe("release workflow", () => {
   it("only accepts stable tags and checks out the exact tag ref", async () => {
@@ -138,9 +205,10 @@ describe("release workflow", () => {
     expect(uploadStep?.with?.path).toBe("${{ steps.package.outputs.tarball }}");
     expect(publishStep).toContain('npm view "$PACKAGE_NAME@$RELEASE_VERSION" dist.integrity');
     expect(publishStep).toContain('npm view "$PACKAGE_NAME@$RELEASE_VERSION" version');
-    expect(publishStep).toContain(
-      'npm view "$PACKAGE_NAME@$RELEASE_VERSION" dist.attestations.provenance.predicateType',
-    );
+    expect(publishStep).toContain("npm audit signatures --json --include-attestations=true");
+    expect(publishStep).toContain('workflow?.path === ".github/workflows/release.yml"');
+    expect(publishStep).toContain("dependency?.digest?.gitCommit === process.env.VERIFIED_COMMIT");
+    expect(publishStep).toContain("subject?.digest?.sha512 === expectedDigest");
     expect(publishStep).toContain('npm view "$PACKAGE_NAME@latest" version');
     expect(publishStep).toContain('"Refusing to publish " +');
     expect(publishStep).toContain('" because npm latest is newer at " +');
@@ -279,7 +347,7 @@ describe("release workflow", () => {
     expect(
       publishCommands
         .filter((command) => command !== "npm install -g npm@12.0.1")
-        .some((command) => /\b(?:pnpm|install|build|test|pack)\b/u.test(command)),
+        .some((command) => /\b(?:pnpm|build|test|pack)\b/u.test(command)),
     ).toBe(false);
   });
 
@@ -346,10 +414,12 @@ describe("release workflow", () => {
     expect(matchingCalls).toEqual([
       "view @openclaw/crabline@1.2.3 dist.integrity",
       "view @openclaw/crabline@1.2.3 version",
-      "view @openclaw/crabline@1.2.3 dist.attestations.provenance.predicateType",
+      "install --ignore-scripts --no-audit --no-fund @openclaw/crabline@1.2.3",
+      "audit signatures --json --include-attestations=true",
       "view @openclaw/crabline@1.2.3 dist.integrity",
       "view @openclaw/crabline@1.2.3 version",
-      "view @openclaw/crabline@1.2.3 dist.attestations.provenance.predicateType",
+      "install --ignore-scripts --no-audit --no-fund @openclaw/crabline@1.2.3",
+      "audit signatures --json --include-attestations=true",
       expect.stringContaining("git ls-remote --exit-code"),
     ]);
 
@@ -365,15 +435,27 @@ describe("release workflow", () => {
         MOCK_PROVENANCE_RESULT: "missing",
         MOCK_VIEW_RESULT: "matching",
       }),
-    ).rejects.toThrow("::error::Published @openclaw/crabline@1.2.3 is missing npm provenance.");
+    ).rejects.toThrow(PROVENANCE_MISMATCH_ERROR);
     await expect(
       runPublishStep(publishStep, {
         MOCK_PROVENANCE_RESULT: "unsupported",
         MOCK_VIEW_RESULT: "matching",
       }),
-    ).rejects.toThrow(
-      "::error::Published @openclaw/crabline@1.2.3 has unsupported provenance predicate https://example.invalid/provenance.",
-    );
+    ).rejects.toThrow(PROVENANCE_MISMATCH_ERROR);
+    for (const provenanceResult of [
+      "wrong-commit",
+      "wrong-repository",
+      "wrong-workflow",
+      "wrong-ref",
+      "wrong-subject",
+    ]) {
+      await expect(
+        runPublishStep(publishStep, {
+          MOCK_PROVENANCE_RESULT: provenanceResult,
+          MOCK_VIEW_RESULT: "matching",
+        }),
+      ).rejects.toThrow(PROVENANCE_MISMATCH_ERROR);
+    }
     const transientProvenanceCalls = await runPublishStep(publishStep, {
       MOCK_PROVENANCE_RESULT: "transient-once",
       MOCK_VIEW_RESULT: "matching",
@@ -400,7 +482,8 @@ describe("release workflow", () => {
       ),
       "view @openclaw/crabline@1.2.3 dist.integrity",
       "view @openclaw/crabline@1.2.3 version",
-      "view @openclaw/crabline@1.2.3 dist.attestations.provenance.predicateType",
+      "install --ignore-scripts --no-audit --no-fund @openclaw/crabline@1.2.3",
+      "audit signatures --json --include-attestations=true",
       expect.stringContaining("git ls-remote --exit-code"),
     ];
     expect(publishedCalls).toEqual(expectedPublishCalls);
@@ -423,7 +506,7 @@ describe("release workflow", () => {
     ).rejects.toThrow(
       "::error::Unable to resolve the current npm latest version for @openclaw/crabline.",
     );
-  });
+  }, 20_000);
 
   it("rejects a downloaded tarball whose bytes do not match the verified SRI", async () => {
     const workflow = await readWorkflow();
@@ -463,7 +546,7 @@ describe("release workflow", () => {
         MOCK_PROVENANCE_RESULT: "missing",
         MOCK_VIEW_RESULT: "after-publish",
       }),
-    ).rejects.toThrow("::error::Published @openclaw/crabline@1.2.3 is missing npm provenance.");
+    ).rejects.toThrow(PROVENANCE_MISMATCH_ERROR);
     await expect(
       runPublishStep(publishStep, {
         MOCK_VERSION_RESULT: "mismatch",
@@ -682,12 +765,34 @@ async function runPublishStep(
   const logPath = path.join(tempDir, "npm.log");
   const publishedPath = path.join(tempDir, "published");
   const provenanceCountPath = path.join(tempDir, "provenance-count");
+  const provenanceDir = path.join(tempDir, "provenance");
   const racePath = path.join(tempDir, "tag-raced");
   const releaseDir = path.join(tempDir, "release");
 
   try {
-    await Promise.all([fs.mkdir(binDir), fs.mkdir(releaseDir)]);
+    await Promise.all([fs.mkdir(binDir), fs.mkdir(provenanceDir), fs.mkdir(releaseDir)]);
     await fs.writeFile(path.join(releaseDir, "crabline-1.2.3.tgz"), PUBLISH_TARBALL_CONTENTS);
+    const provenanceResults = {
+      matching: createAuditResult(),
+      missing: { verified: [] },
+      unsupported: createAuditResult({
+        predicateType: "https://example.invalid/provenance",
+      }),
+      "wrong-commit": createAuditResult({
+        commit: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      }),
+      "wrong-ref": createAuditResult({ ref: "refs/tags/v1.2.2" }),
+      "wrong-repository": createAuditResult({
+        repository: "https://github.com/example/crabline",
+      }),
+      "wrong-subject": createAuditResult({ subjectDigest: "0".repeat(128) }),
+      "wrong-workflow": createAuditResult({ workflowPath: ".github/workflows/other.yml" }),
+    };
+    await Promise.all(
+      Object.entries(provenanceResults).map(([name, result]) =>
+        fs.writeFile(path.join(provenanceDir, `${name}.json`), JSON.stringify(result)),
+      ),
+    );
     await Promise.all([
       writeExecutable(
         path.join(binDir, "npm"),
@@ -697,6 +802,30 @@ echo "$*" >> "$MOCK_LOG"
 if [[ "$1" == "publish" ]]; then
   touch "$MOCK_PUBLISHED"
   exit "\${MOCK_PUBLISH_STATUS:-0}"
+fi
+if [[ "$1" == "install" ]]; then
+  exit 0
+fi
+if [[ "$1 $2" == "audit signatures" ]]; then
+  provenance_result="\${MOCK_PROVENANCE_RESULT:-matching}"
+  if [[ "$provenance_result" == "transient-once" ]]; then
+    provenance_count=0
+    if [[ -f "$MOCK_PROVENANCE_COUNT" ]]; then
+      provenance_count="$(cat "$MOCK_PROVENANCE_COUNT")"
+    fi
+    echo "$((provenance_count + 1))" > "$MOCK_PROVENANCE_COUNT"
+    if [[ "$provenance_count" -eq 0 ]]; then
+      exit 1
+    fi
+    provenance_result="matching"
+  elif [[ "$provenance_result" == "transient" ]]; then
+    exit 1
+  fi
+  cat "$MOCK_PROVENANCE_DIR/$provenance_result.json"
+  if [[ "\${MOCK_TAG_RACE_AFTER_EXISTING:-0}" -eq 1 ]]; then
+    touch "$MOCK_TAG_RACE"
+  fi
+  exit 0
 fi
 if [[ "$2" == "$PACKAGE_NAME@latest" ]]; then
   if [[ "\${MOCK_TAG_RACE_AFTER_LOOKUP:-0}" -eq 1 ]]; then
@@ -718,29 +847,6 @@ if [[ "$3" == "version" ]]; then
     mismatch) echo "1.2.4" ;;
     *) exit 1 ;;
   esac
-  exit 0
-fi
-if [[ "$3" == "dist.attestations.provenance.predicateType" ]]; then
-  case "\${MOCK_PROVENANCE_RESULT:-matching}" in
-    matching) echo "https://slsa.dev/provenance/v1" ;;
-    missing) exit 0 ;;
-    unsupported) echo "https://example.invalid/provenance" ;;
-    transient-once)
-      provenance_count=0
-      if [[ -f "$MOCK_PROVENANCE_COUNT" ]]; then
-        provenance_count="$(cat "$MOCK_PROVENANCE_COUNT")"
-      fi
-      echo "$((provenance_count + 1))" > "$MOCK_PROVENANCE_COUNT"
-      if [[ "$provenance_count" -eq 0 ]]; then
-        exit 1
-      fi
-      echo "https://slsa.dev/provenance/v1"
-      ;;
-    *) exit 1 ;;
-  esac
-  if [[ "\${MOCK_TAG_RACE_AFTER_EXISTING:-0}" -eq 1 ]]; then
-    touch "$MOCK_TAG_RACE"
-  fi
   exit 0
 fi
 case "$view_result" in
@@ -776,6 +882,7 @@ printf '%s\\trefs/tags/v1.2.3^{}\\n' "$remote_commit"
         MOCK_LOG: logPath,
         MOCK_PUBLISHED: publishedPath,
         MOCK_PROVENANCE_COUNT: provenanceCountPath,
+        MOCK_PROVENANCE_DIR: provenanceDir,
         MOCK_TAG_RACE: racePath,
         PACKAGE_INTEGRITY: PUBLISH_PACKAGE_INTEGRITY,
         PACKAGE_NAME: "@openclaw/crabline",

--- a/test/reporters-errors.test.ts
+++ b/test/reporters-errors.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { CrablineError, ensureErrorMessage } from "../src/core/errors.js";
 import { EXIT_CODES } from "../src/core/exit-codes.js";
-import { formatJson, formatRunResultText, sanitizeTerminalText } from "../src/core/reporters.js";
+import {
+  formatJson,
+  formatJsonResult,
+  formatRunResultText,
+  sanitizeTerminalText,
+} from "../src/core/reporters.js";
 
 const ansiPattern = new RegExp(String.raw`\u001B\[[0-?]*[ -/]*[@-~]`, "g");
 
@@ -81,10 +86,12 @@ describe("errors and reporters", () => {
 
   it("escapes visually unsafe Unicode controls without changing parsed JSON values", () => {
     const controls =
-      "\u061c\u200e\u200f\u2028\u2029\u202a\u202b\u202c\u202d\u202e\u2066\u2067\u2068\u2069";
+      "\u007f\u0080\u0085\u009f\u061c\u200e\u200f\u2028\u2029\u202a\u202b\u202c\u202d\u202e\u2066\u2067\u2068\u2069";
     const output = formatJson({ [controls]: controls });
 
-    expect(output).not.toMatch(/[\u061c\u200e\u200f\u2028\u2029\u202a-\u202e\u2066-\u2069]/u);
+    expect(output).not.toMatch(
+      /[\u007f-\u009f\u061c\u200e\u200f\u2028\u2029\u202a-\u202e\u2066-\u2069]/u,
+    );
     for (const character of controls) {
       expect(output).toContain(
         String.raw`\u${character.codePointAt(0)!.toString(16).padStart(4, "0")}`,
@@ -110,7 +117,9 @@ describe("errors and reporters", () => {
     const expectedOutput = JSON.stringify(expected, null, 2);
 
     for (const value of [cyclic, { value: 1n }, throwingValue]) {
-      const output = formatJson(value);
+      const result = formatJsonResult(value);
+      const output = result.output;
+      expect(result.ok).toBe(false);
       expect(output).toBe(expectedOutput);
       expect(output).not.toContain("sensitive serialization detail");
     }


### PR DESCRIPTION
## Summary
- harden manifest, documentation, JSON output, artifact, and capability-report contracts
- close CI dependency-policy gaps and bind npm provenance to release identity
- add exact local mock-key scanner coverage and changelog entries

## Validation
- gpt-5.6-sol high autoreview: clean
- Crabbox Linux `pnpm verify`: `run_f4f7945f1bec`
- 64 test files passed; 1,588 tests passed; 22 skipped
