### PR TITLE
fix(adapters): harden auth and native inbound handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Classify empty Zalo and Mattermost webhook credentials as configuration failures.
 - Confine Discord's generated recorder path to Crabline's recorder directory.
 - Isolate the local iMessage adapter from ambient gateway environment variables and accept native nested `imsg` notifications.
+- Reject empty loopback cursors, preserve Slack edit event identity, and prune settled WhatsApp wait cursors during concurrent waits.
 - Stream Telegram multipart uploads with bounded parser metadata instead of copying complete files through `FormData`.
 - Keep Unix recorder identity locks in one validated private per-user namespace across processes and recorder path changes.
 - Reject non-positive Telegram admin message IDs and enforce native Mattermost channel types and unique normalized usernames.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Preserve opaque Mattermost identifiers exactly instead of trimming REST and WebSocket inputs.
 - Preserve Zalo polling arrival order until each older HTTP response commits.
 - Classify empty Zalo and Mattermost webhook credentials as configuration failures.
+- Confine Discord's generated recorder path to Crabline's recorder directory.
 - Stream Telegram multipart uploads with bounded parser metadata instead of copying complete files through `FormData`.
 - Keep Unix recorder identity locks in one validated private per-user namespace across processes and recorder path changes.
 - Reject non-positive Telegram admin message IDs and enforce native Mattermost channel types and unique normalized usernames.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Confine Discord's generated recorder path to Crabline's recorder directory.
 - Isolate the local iMessage adapter from ambient gateway environment variables and accept native nested `imsg` notifications.
 - Reject empty loopback cursors, preserve Slack edit event identity, and prune settled WhatsApp wait cursors during concurrent waits.
+- Use the canonical Matrix identifier validators for local targets and webhook envelopes.
 - Stream Telegram multipart uploads with bounded parser metadata instead of copying complete files through `FormData`.
 - Keep Unix recorder identity locks in one validated private per-user namespace across processes and recorder path changes.
 - Reject non-positive Telegram admin message IDs and enforce native Mattermost channel types and unique normalized usernames.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Preserve Zalo polling arrival order until each older HTTP response commits.
 - Classify empty Zalo and Mattermost webhook credentials as configuration failures.
 - Confine Discord's generated recorder path to Crabline's recorder directory.
+- Isolate the local iMessage adapter from ambient gateway environment variables and accept native nested `imsg` notifications.
 - Stream Telegram multipart uploads with bounded parser metadata instead of copying complete files through `FormData`.
 - Keep Unix recorder identity locks in one validated private per-user namespace across processes and recorder path changes.
 - Reject non-positive Telegram admin message IDs and enforce native Mattermost channel types and unique normalized usernames.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Keep Telegram multipart fields prototype-safe, synthetic chat IDs within 52 significant bits, and topic identities scoped to their chats.
 - Preserve opaque Mattermost identifiers exactly instead of trimming REST and WebSocket inputs.
 - Preserve Zalo polling arrival order until each older HTTP response commits.
+- Classify empty Zalo and Mattermost webhook credentials as configuration failures.
 - Stream Telegram multipart uploads with bounded parser metadata instead of copying complete files through `FormData`.
 - Keep Unix recorder identity locks in one validated private per-user namespace across processes and recorder path changes.
 - Reject non-positive Telegram admin message IDs and enforce native Mattermost channel types and unique normalized usernames.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Isolate the local iMessage adapter from ambient gateway environment variables and accept native nested `imsg` notifications.
 - Reject empty loopback cursors, preserve Slack edit event identity, and prune settled WhatsApp wait cursors during concurrent waits.
 - Use the canonical Matrix identifier validators for local targets and webhook envelopes.
+- Classify empty JWT key sets and failed refresh cooldowns as signing-key infrastructure failures.
 - Stream Telegram multipart uploads with bounded parser metadata instead of copying complete files through `FormData`.
 - Keep Unix recorder identity locks in one validated private per-user namespace across processes and recorder path changes.
 - Reject non-positive Telegram admin message IDs and enforce native Mattermost channel types and unique normalized usernames.

--- a/src/providers/builtin/discord.ts
+++ b/src/providers/builtin/discord.ts
@@ -2,7 +2,7 @@ import { createPublicKey, verify, type KeyObject } from "node:crypto";
 import path from "node:path";
 import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
-import { LocalMockProviderAdapter } from "../local-mock.js";
+import { LocalMockProviderAdapter, resolveGeneratedLocalMockRecorderPath } from "../local-mock.js";
 import type { ProviderAdapter } from "../types.js";
 import { DISCORD_SNOWFLAKE_RULE, getBuiltinTargetCodec } from "../target-normalizers.js";
 import {
@@ -172,7 +172,7 @@ function toRecorderPath(providerId: string, config: ProviderConfig): string {
   const configuredPath = config.discord?.recorder.path;
   return configuredPath
     ? path.resolve(configuredPath)
-    : path.resolve(".crabline", "recorders", `${providerId}.jsonl`);
+    : resolveGeneratedLocalMockRecorderPath(providerId);
 }
 
 export function normalizeDiscordWebhookPayload(payload: unknown) {

--- a/src/providers/builtin/imessage.ts
+++ b/src/providers/builtin/imessage.ts
@@ -14,15 +14,42 @@ import {
 } from "./native-local-mock.js";
 import { requireExternalWebhookAuthentication } from "./external-webhook-auth.js";
 
-export function resolveIMessageAdapterConfig(
-  config: ProviderConfig,
-  env: NodeJS.ProcessEnv = process.env,
-) {
+export function resolveIMessageAdapterConfig(config: ProviderConfig, env: NodeJS.ProcessEnv = {}) {
   return {
     apiKey: config.imessage?.apiKey ?? env.IMESSAGE_API_KEY ?? "local-mock-imessage-api-key",
     local: config.imessage?.local ?? true,
     serverUrl: config.imessage?.serverUrl ?? env.IMESSAGE_SERVER_URL,
   };
+}
+
+function isNativeIMessageData(data: Record<string, unknown>): boolean {
+  return [
+    "chat_guid",
+    "chat_identifier",
+    "chatGuid",
+    "chatIdentifier",
+    "guid",
+    "is_from_me",
+    "isFromMe",
+  ].some((key) => key in data);
+}
+
+function iMessageNativeData(payload: Record<string, unknown>): Record<string, unknown> {
+  const data = optionalRecord(payload, "data") ?? payload;
+  const message = optionalRecord(data, "message");
+  if (message && isNativeIMessageData(message)) {
+    return message;
+  }
+  return data;
+}
+
+function iMessageThreadIdentifiers(data: Record<string, unknown>): string[] {
+  return [
+    optionalString(data, "chatGuid"),
+    optionalString(data, "chatIdentifier"),
+    optionalString(data, "chat_guid"),
+    optionalString(data, "chat_identifier"),
+  ].filter((value): value is string => value !== undefined);
 }
 
 export class IMessageProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
@@ -61,15 +88,15 @@ export function matchesIMessageThread(
   raw?: unknown,
 ): boolean {
   const rawPayload = isRecord(raw) ? raw : undefined;
-  const data = rawPayload ? (optionalRecord(rawPayload, "data") ?? rawPayload) : undefined;
-  const recipientAlias = data ? optionalString(data, "chatIdentifier") : undefined;
+  const data = rawPayload ? iMessageNativeData(rawPayload) : undefined;
+  const aliases = data ? iMessageThreadIdentifiers(data) : [];
   const expectedIdentifiers = new Set([target.channelId ?? target.id]);
   if (expectedThreadId !== undefined) {
     expectedIdentifiers.add(expectedThreadId);
   }
   return (
     expectedIdentifiers.has(candidateThreadId) ||
-    (recipientAlias !== undefined && expectedIdentifiers.has(recipientAlias))
+    aliases.some((alias) => expectedIdentifiers.has(alias))
   );
 }
 
@@ -78,7 +105,8 @@ function normalizeIMessageWebhookPayload(payload: unknown) {
     throw new CrablineError("iMessage webhook payload must be an object", { kind: "inbound" });
   }
 
-  if (optionalRecord(payload, "message")) {
+  const message = optionalRecord(payload, "message");
+  if (message && !isNativeIMessageData(message)) {
     return genericMockPayloadWithNativeThread({
       channelRule: IMESSAGE_THREAD_RULE,
       payload,
@@ -86,12 +114,12 @@ function normalizeIMessageWebhookPayload(payload: unknown) {
     });
   }
 
-  const data = optionalRecord(payload, "data") ?? payload;
-  const threadId = optionalString(data, "chatGuid") ?? optionalString(data, "chatIdentifier");
+  const data = iMessageNativeData(payload);
+  const threadId = iMessageThreadIdentifiers(data)[0];
   const text = optionalString(data, "text") ?? optionalString(data, "message");
   if (!threadId || !text) {
     throw new CrablineError(
-      "iMessage webhook payload requires chatGuid or chatIdentifier and text",
+      "iMessage webhook payload requires chatGuid or chatIdentifier (including native snake_case aliases) and text",
       {
         kind: "inbound",
       },
@@ -99,7 +127,7 @@ function normalizeIMessageWebhookPayload(payload: unknown) {
   }
 
   return {
-    author: authorFromBotFlag(data.isFromMe === true),
+    author: authorFromBotFlag(data.isFromMe === true || data.is_from_me === true),
     ...(optionalString(data, "guid") ? { id: optionalString(data, "guid") } : {}),
     raw: payload,
     text,

--- a/src/providers/builtin/imessage.ts
+++ b/src/providers/builtin/imessage.ts
@@ -16,12 +16,11 @@ import { requireExternalWebhookAuthentication } from "./external-webhook-auth.js
 
 export function resolveIMessageAdapterConfig(config: ProviderConfig, env?: NodeJS.ProcessEnv) {
   const local = config.imessage?.local ?? true;
-  const resolvedEnv = env ?? (local ? {} : process.env);
+  env ??= local ? {} : process.env;
   return {
-    apiKey:
-      config.imessage?.apiKey ?? resolvedEnv.IMESSAGE_API_KEY ?? "local-mock-imessage-api-key",
+    apiKey: config.imessage?.apiKey ?? env.IMESSAGE_API_KEY ?? "local-mock-imessage-api-key",
     local,
-    serverUrl: config.imessage?.serverUrl ?? resolvedEnv.IMESSAGE_SERVER_URL,
+    serverUrl: config.imessage?.serverUrl ?? env.IMESSAGE_SERVER_URL,
   };
 }
 

--- a/src/providers/builtin/imessage.ts
+++ b/src/providers/builtin/imessage.ts
@@ -38,7 +38,8 @@ function isNativeIMessageData(data: Record<string, unknown>): boolean {
 
 function iMessageNativeData(payload: Record<string, unknown>): Record<string, unknown> {
   const data = optionalRecord(payload, "data") ?? payload;
-  const message = optionalRecord(data, "message");
+  const params = optionalRecord(data, "params");
+  const message = optionalRecord(params ?? {}, "message") ?? optionalRecord(data, "message");
   if (message && isNativeIMessageData(message)) {
     return message;
   }

--- a/src/providers/builtin/imessage.ts
+++ b/src/providers/builtin/imessage.ts
@@ -14,11 +14,14 @@ import {
 } from "./native-local-mock.js";
 import { requireExternalWebhookAuthentication } from "./external-webhook-auth.js";
 
-export function resolveIMessageAdapterConfig(config: ProviderConfig, env: NodeJS.ProcessEnv = {}) {
+export function resolveIMessageAdapterConfig(config: ProviderConfig, env?: NodeJS.ProcessEnv) {
+  const local = config.imessage?.local ?? true;
+  const resolvedEnv = env ?? (local ? {} : process.env);
   return {
-    apiKey: config.imessage?.apiKey ?? env.IMESSAGE_API_KEY ?? "local-mock-imessage-api-key",
-    local: config.imessage?.local ?? true,
-    serverUrl: config.imessage?.serverUrl ?? env.IMESSAGE_SERVER_URL,
+    apiKey:
+      config.imessage?.apiKey ?? resolvedEnv.IMESSAGE_API_KEY ?? "local-mock-imessage-api-key",
+    local,
+    serverUrl: config.imessage?.serverUrl ?? resolvedEnv.IMESSAGE_SERVER_URL,
   };
 }
 

--- a/src/providers/builtin/loopback.ts
+++ b/src/providers/builtin/loopback.ts
@@ -212,7 +212,7 @@ export class LoopbackChatAdapter {
     }
     const limit = options?.limit ?? storedMessages.length;
     let cursor: number | undefined;
-    if (options?.cursor) {
+    if (options?.cursor !== undefined) {
       if (!/^[1-9]\d*$/u.test(options.cursor)) {
         throw new CrablineError("Loopback message cursor must be a positive safe integer.", {
           kind: "config",

--- a/src/providers/builtin/mattermost.ts
+++ b/src/providers/builtin/mattermost.ts
@@ -51,18 +51,21 @@ export function resolveMattermostAdapterConfig(
       { kind: "config" },
     );
   }
-  if (
-    config.mattermost?.webhookToken === undefined &&
-    env.MATTERMOST_TOKEN !== undefined &&
-    !env.MATTERMOST_TOKEN.trim()
-  ) {
-    throw new Error("MATTERMOST_TOKEN must not be empty or whitespace-only.");
+  const configuredWebhookToken = config.mattermost?.webhookToken;
+  const webhookToken = configuredWebhookToken ?? env.MATTERMOST_TOKEN;
+  if (webhookToken !== undefined && !webhookToken.trim()) {
+    throw new CrablineError(
+      configuredWebhookToken === undefined
+        ? "MATTERMOST_TOKEN must not be empty or whitespace-only."
+        : "Mattermost webhookToken must not be empty or whitespace-only.",
+      { kind: "config" },
+    );
   }
   return {
     baseUrl,
     botToken: config.mattermost?.botToken ?? env.MATTERMOST_BOT_TOKEN ?? "local-mock-token",
     userName: config.mattermost?.userName,
-    webhookToken: config.mattermost?.webhookToken ?? env.MATTERMOST_TOKEN,
+    webhookToken,
   };
 }
 

--- a/src/providers/builtin/slack.ts
+++ b/src/providers/builtin/slack.ts
@@ -240,7 +240,9 @@ function normalizeSlackEventsPayload(payload: unknown) {
       });
     }
     const threadTs = message.thread_ts;
-    const eventId = optionalString(message, "ts");
+    const eventId = isMessageChanged
+      ? optionalString(event, "event_ts")
+      : optionalString(message, "ts");
     return {
       author: slackAuthorFromEvent(message),
       ...(eventId

--- a/src/providers/builtin/whatsapp.ts
+++ b/src/providers/builtin/whatsapp.ts
@@ -203,13 +203,6 @@ function pruneInactiveWaitCursors(cursors: Map<string, WaitCursorState>): void {
   }
 }
 
-function pruneSettledWaitCursors(cursors: Map<string, WaitCursorState>): void {
-  if ([...cursors.values()].some((state) => state.active > 0)) {
-    return;
-  }
-  pruneInactiveWaitCursors(cursors);
-}
-
 export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   readonly #config: ProviderConfig;
   readonly #env: WhatsAppEnvironment;
@@ -352,7 +345,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
       ) {
         this.#waitCursors.delete(cursorKey);
       }
-      pruneSettledWaitCursors(this.#waitCursors);
+      pruneInactiveWaitCursors(this.#waitCursors);
     }
   }
 

--- a/src/providers/builtin/whatsapp.ts
+++ b/src/providers/builtin/whatsapp.ts
@@ -193,12 +193,22 @@ function cursorHasAdvanced(
 }
 
 function pruneInactiveWaitCursors(cursors: Map<string, WaitCursorState>): void {
-  for (const [key, state] of cursors) {
-    if (cursors.size <= MAX_WAIT_CURSORS) {
-      return;
+  let inactiveCount = 0;
+  for (const state of cursors.values()) {
+    if (state.active === 0) {
+      inactiveCount++;
     }
+  }
+  if (inactiveCount <= MAX_WAIT_CURSORS) {
+    return;
+  }
+  for (const [key, state] of cursors) {
     if (state.active === 0) {
       cursors.delete(key);
+      inactiveCount--;
+      if (inactiveCount <= MAX_WAIT_CURSORS) {
+        return;
+      }
     }
   }
 }

--- a/src/providers/builtin/zalo.ts
+++ b/src/providers/builtin/zalo.ts
@@ -23,10 +23,11 @@ export function resolveZaloAdapterConfig(
   const configuredWebhookSecret = config.zalo?.webhookSecret;
   const webhookSecret = configuredWebhookSecret ?? env.ZALO_WEBHOOK_SECRET;
   if (webhookSecret !== undefined && !webhookSecret.trim()) {
-    throw new Error(
+    throw new CrablineError(
       configuredWebhookSecret === undefined
         ? "ZALO_WEBHOOK_SECRET must not be empty or whitespace-only."
         : "Zalo webhookSecret must not be empty or whitespace-only.",
+      { kind: "config" },
     );
   }
   return {

--- a/src/providers/signed-jwt.ts
+++ b/src/providers/signed-jwt.ts
@@ -26,6 +26,12 @@ const MAX_NEGATIVE_KEY_IDS = 128;
 const MAX_REMOTE_KEY_SET_SIZE = 128;
 const UTF8_DECODER = new TextDecoder("utf-8", { fatal: true });
 
+function jwtKeyInfrastructureError(error: unknown): JwtKeyInfrastructureError {
+  return error instanceof JwtKeyInfrastructureError
+    ? error
+    : new JwtKeyInfrastructureError("JWT signing key fetch failed.", { cause: error });
+}
+
 function decodeBase64UrlPart(value: string, label: string): Buffer {
   if (!/^[A-Za-z0-9_-]+$/u.test(value)) {
     throw new Error(`${label} must use unpadded base64url encoding.`);
@@ -191,6 +197,9 @@ function validateRemoteJwtKeySet<T>(
   if (!Array.isArray(keySet.values)) {
     throw new JwtKeyInfrastructureError("JWT signing key set values must be an array.");
   }
+  if (keySet.values.length === 0) {
+    throw new JwtKeyInfrastructureError("JWT signing key set must include at least one key.");
+  }
   if (keySet.values.length > MAX_REMOTE_KEY_SET_SIZE) {
     throw new JwtKeyInfrastructureError(
       `JWT signing key set exceeds the ${MAX_REMOTE_KEY_SET_SIZE}-key limit.`,
@@ -293,11 +302,12 @@ export function createCachedJwtKeyResolver<T>(params: {
             return keySet;
           },
           (error: unknown) => {
+            const infrastructureError = jwtKeyInfrastructureError(error);
             if (fetchInFlight?.generation === generation) {
               fetchFailureCooldownUntil = now() + refreshCooldownMs;
-              fetchFailureError = error;
+              fetchFailureError = infrastructureError;
             }
-            throw error;
+            throw infrastructureError;
           },
         )
         .finally(() => {
@@ -368,6 +378,9 @@ export function createCachedJwtKeyResolver<T>(params: {
       refreshed = await refreshInFlight;
     } else {
       if (refreshCooldownUntil > now()) {
+        if (fetchFailureCooldownUntil > now() && fetchFailureError) {
+          throw fetchFailureError;
+        }
         return rejectUnknownKey(header.kid, refreshCooldownUntil);
       }
       refreshInFlight = Promise.resolve()

--- a/src/providers/target-normalizers.ts
+++ b/src/providers/target-normalizers.ts
@@ -53,13 +53,15 @@ export const IMESSAGE_THREAD_RULE: NativeIdRule = {
 export const MATRIX_ROOM_ID_RULE: NativeIdRule = {
   example: "!abcdef:matrix.org",
   name: "Matrix room id",
-  pattern: /^!(?:[^:\s]+:[^\s]+|[A-Za-z0-9_-]{43})$/u,
+  pattern: /^!/u,
+  validate: isMatrixRoomId,
 };
 
 export const MATRIX_EVENT_ID_RULE: NativeIdRule = {
   example: "$eventid:matrix.org",
   name: "Matrix event id",
-  pattern: /^\$[^\s]+(?::[^\s]+)?$/u,
+  pattern: /^\$/u,
+  validate: isMatrixEventId,
 };
 
 export { isMatrixEventId, isMatrixRoomId } from "../matrix-ids.js";

--- a/test/discord-provider.test.ts
+++ b/test/discord-provider.test.ts
@@ -219,6 +219,15 @@ function createContext(config: ProviderConfig): ProviderContext {
 }
 
 describe("discord provider", () => {
+  it("confines generated recorder paths to the recorder directory", async () => {
+    const config = await createDiscordConfig(0);
+    config.discord!.recorder = {};
+
+    expect(() => new DiscordProviderAdapter("../escaped", config, "crabline", { env: {} })).toThrow(
+      /Provider ID cannot contain absolute or parent-directory paths/u,
+    );
+  });
+
   it("requires signatures for externally reachable interaction endpoints", async () => {
     const config = await createDiscordConfig(0);
     config.discord!.webhook.host = "0.0.0.0";

--- a/test/imessage-provider.default-runtime.test.ts
+++ b/test/imessage-provider.default-runtime.test.ts
@@ -68,11 +68,11 @@ describe("imessage provider default runtime", () => {
   });
 
   it("uses ambient gateway metadata for remote mode", () => {
-    vi.stubEnv("IMESSAGE_API_KEY", "ambient-api-key");
+    vi.stubEnv("IMESSAGE_API_KEY", "sample");
     vi.stubEnv("IMESSAGE_SERVER_URL", "https://ambient-imessage.example.com");
 
     expect(resolveIMessageAdapterConfig(createConfig({ local: false }))).toEqual({
-      apiKey: "ambient-api-key",
+      apiKey: "sample",
       local: false,
       serverUrl: "https://ambient-imessage.example.com",
     });

--- a/test/imessage-provider.default-runtime.test.ts
+++ b/test/imessage-provider.default-runtime.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveIMessageAdapterConfig } from "../src/providers/builtin/imessage.js";
 import type { ProviderConfig } from "../src/config/schema.js";
 
@@ -23,11 +23,31 @@ function createConfig(imessage?: Partial<NonNullable<ProviderConfig["imessage"]>
 }
 
 describe("imessage provider default runtime", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("keeps remote gateway metadata optional for the local mock", () => {
+    vi.stubEnv("IMESSAGE_API_KEY", "ambient-api-key");
+    vi.stubEnv("IMESSAGE_SERVER_URL", "https://ambient-imessage.example.com");
+
     expect(resolveIMessageAdapterConfig(createConfig())).toEqual({
       apiKey: "local-mock-imessage-api-key",
       local: true,
       serverUrl: undefined,
+    });
+  });
+
+  it("accepts an explicitly isolated environment", () => {
+    expect(
+      resolveIMessageAdapterConfig(createConfig(), {
+        IMESSAGE_API_KEY: "isolated-api-key",
+        IMESSAGE_SERVER_URL: "https://isolated-imessage.example.com",
+      }),
+    ).toEqual({
+      apiKey: "isolated-api-key",
+      local: true,
+      serverUrl: "https://isolated-imessage.example.com",
     });
   });
 

--- a/test/imessage-provider.default-runtime.test.ts
+++ b/test/imessage-provider.default-runtime.test.ts
@@ -28,7 +28,7 @@ describe("imessage provider default runtime", () => {
   });
 
   it("keeps remote gateway metadata optional for the local mock", () => {
-    vi.stubEnv("IMESSAGE_API_KEY", "ambient-api-key");
+    vi.stubEnv("IMESSAGE_API_KEY", "sample");
     vi.stubEnv("IMESSAGE_SERVER_URL", "https://ambient-imessage.example.com");
 
     expect(resolveIMessageAdapterConfig(createConfig())).toEqual({
@@ -41,11 +41,11 @@ describe("imessage provider default runtime", () => {
   it("accepts an explicitly isolated environment", () => {
     expect(
       resolveIMessageAdapterConfig(createConfig(), {
-        IMESSAGE_API_KEY: "isolated-api-key",
+        IMESSAGE_API_KEY: "test-token-placeholder",
         IMESSAGE_SERVER_URL: "https://isolated-imessage.example.com",
       }),
     ).toEqual({
-      apiKey: "isolated-api-key",
+      apiKey: "test-token-placeholder",
       local: true,
       serverUrl: "https://isolated-imessage.example.com",
     });

--- a/test/imessage-provider.default-runtime.test.ts
+++ b/test/imessage-provider.default-runtime.test.ts
@@ -66,4 +66,15 @@ describe("imessage provider default runtime", () => {
       serverUrl: "https://imessage.example.com",
     });
   });
+
+  it("uses ambient gateway metadata for remote mode", () => {
+    vi.stubEnv("IMESSAGE_API_KEY", "ambient-api-key");
+    vi.stubEnv("IMESSAGE_SERVER_URL", "https://ambient-imessage.example.com");
+
+    expect(resolveIMessageAdapterConfig(createConfig({ local: false }))).toEqual({
+      apiKey: "ambient-api-key",
+      local: false,
+      serverUrl: "https://ambient-imessage.example.com",
+    });
+  });
 });

--- a/test/imessage-provider.test.ts
+++ b/test/imessage-provider.test.ts
@@ -47,9 +47,14 @@ describe("iMessage thread matching", () => {
         "+15551234567",
         { id: "+15551234567" },
         {
-          message: {
-            chat_guid: "iMessage;-;chat-guid-1",
-            chat_identifier: "+15551234567",
+          jsonrpc: "2.0",
+          method: "message",
+          params: {
+            message: {
+              chat_guid: "iMessage;-;chat-guid-1",
+              chat_identifier: "+15551234567",
+            },
+            subscription: 1,
           },
         },
       ),
@@ -172,12 +177,17 @@ describe("iMessage thread matching", () => {
       });
       const response = await fetch(endpoint!, {
         body: JSON.stringify({
-          message: {
-            chat_guid: "iMessage;-;chat-guid-1",
-            chat_identifier: "+15551234567",
-            guid: "imsg-native-nested",
-            is_from_me: false,
-            text: "native nested envelope",
+          jsonrpc: "2.0",
+          method: "message",
+          params: {
+            message: {
+              chat_guid: "iMessage;-;chat-guid-1",
+              chat_identifier: "+15551234567",
+              guid: "imsg-native-nested",
+              is_from_me: false,
+              text: "native nested envelope",
+            },
+            subscription: 1,
           },
         }),
         headers: { "content-type": "application/json" },

--- a/test/imessage-provider.test.ts
+++ b/test/imessage-provider.test.ts
@@ -40,6 +40,22 @@ describe("iMessage thread matching", () => {
     ).toBe(true);
   });
 
+  it("matches native nested notification aliases", () => {
+    expect(
+      matchesIMessageThread(
+        "iMessage;-;chat-guid-1",
+        "+15551234567",
+        { id: "+15551234567" },
+        {
+          message: {
+            chat_guid: "iMessage;-;chat-guid-1",
+            chat_identifier: "+15551234567",
+          },
+        },
+      ),
+    ).toBe(true);
+  });
+
   it("rejects unrelated GUIDs and recipient aliases", () => {
     expect(
       matchesIMessageThread(
@@ -128,6 +144,51 @@ describe("iMessage thread matching", () => {
       ).resolves.toMatchObject({
         id: "imsg-guid-alias",
         text: "recipient alias",
+        threadId: "iMessage;-;chat-guid-1",
+      });
+    } finally {
+      await provider.cleanup();
+    }
+  });
+
+  it("normalizes native nested imsg notifications", async () => {
+    const config = await createLocalMockConfig("imessage", "/imessage/webhook");
+    const provider = new IMessageProviderAdapter("imessage", config, "crabline");
+    const context = createProviderContext("imessage", config, {
+      id: "+15551234567",
+      metadata: {},
+    });
+    context.fixture.inboundMatch.author = "any";
+
+    try {
+      const endpoint = (await provider.probe(context)).details
+        .find((detail) => detail.startsWith("webhook endpoint "))
+        ?.replace("webhook endpoint ", "");
+      const waiting = provider.waitForInbound({
+        ...context,
+        nonce: "native nested envelope",
+        since: new Date(Date.now() - 1000).toISOString(),
+        timeoutMs: 500,
+      });
+      const response = await fetch(endpoint!, {
+        body: JSON.stringify({
+          message: {
+            chat_guid: "iMessage;-;chat-guid-1",
+            chat_identifier: "+15551234567",
+            guid: "imsg-native-nested",
+            is_from_me: false,
+            text: "native nested envelope",
+          },
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+
+      expect(response.status).toBe(200);
+      await expect(waiting).resolves.toMatchObject({
+        author: "user",
+        id: "imsg-native-nested",
+        text: "native nested envelope",
         threadId: "iMessage;-;chat-guid-1",
       });
     } finally {

--- a/test/loopback-adapter.test.ts
+++ b/test/loopback-adapter.test.ts
@@ -151,7 +151,7 @@ describe("loopback chat adapter", () => {
     expect(() => adapter!.fetchMessages("thread-1", { limit })).toThrow(/positive safe integer/u);
   });
 
-  it.each(["0", "-1", "1.5", "not-a-cursor", "9007199254740992"])(
+  it.each(["", "0", "-1", "1.5", "not-a-cursor", "9007199254740992"])(
     "rejects invalid message cursors: %s",
     (cursor) => {
       adapter = new LoopbackChatAdapter("crabline");

--- a/test/matrix-provider.test.ts
+++ b/test/matrix-provider.test.ts
@@ -57,6 +57,35 @@ describe("Matrix webhook normalizer", () => {
     }
   });
 
+  it("preserves spec-valid whitespace in scoped Matrix identifiers", async () => {
+    const config = await createLocalMockConfig("matrix", "/matrix/webhook");
+    const provider = new MatrixProviderAdapter("matrix", config, "crabline");
+    const roomId = "!room with space:matrix.test";
+    const eventId = "$event with space:matrix.test";
+
+    try {
+      expect(
+        provider.normalizeTarget({
+          channelId: roomId,
+          id: roomId,
+          metadata: {},
+          threadId: eventId,
+        }),
+      ).toMatchObject({ channelId: roomId, threadId: eventId });
+      expect(
+        normalizeMatrixWebhookPayload({
+          message: {
+            id: eventId,
+            text: "whitespace identifiers",
+            threadId: roomId,
+          },
+        }),
+      ).toMatchObject({ message: { id: eventId }, threadId: roomId });
+    } finally {
+      await provider.cleanup();
+    }
+  });
+
   it("rejects externally reachable webhooks without native authentication", async () => {
     const config = await createLocalMockConfig("matrix", "/matrix/webhook");
     config.matrix!.webhook.host = "0.0.0.0";

--- a/test/mattermost-provider.test.ts
+++ b/test/mattermost-provider.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { CrablineError } from "../src/core/errors.js";
 import {
   MattermostProviderAdapter,
   matchesMattermostThread,
@@ -32,7 +33,23 @@ describe("Mattermost webhook normalizer", () => {
       webhookToken: "sample",
     });
     expect(() => resolveMattermostAdapterConfig(config, { MATTERMOST_TOKEN: " \t" })).toThrow(
-      "MATTERMOST_TOKEN must not be empty or whitespace-only.",
+      expect.objectContaining({
+        kind: "config",
+        message: "MATTERMOST_TOKEN must not be empty or whitespace-only.",
+      }),
+    );
+    expect(() => resolveMattermostAdapterConfig(config, { MATTERMOST_TOKEN: " " })).toThrow(
+      CrablineError,
+    );
+
+    config.mattermost!.webhookToken = "\t";
+    expect(() =>
+      resolveMattermostAdapterConfig(config, { MATTERMOST_TOKEN: "environment-token" }),
+    ).toThrow(
+      expect.objectContaining({
+        kind: "config",
+        message: "Mattermost webhookToken must not be empty or whitespace-only.",
+      }),
     );
   });
 

--- a/test/mattermost-provider.test.ts
+++ b/test/mattermost-provider.test.ts
@@ -43,9 +43,7 @@ describe("Mattermost webhook normalizer", () => {
     );
 
     config.mattermost!.webhookToken = "\t";
-    expect(() =>
-      resolveMattermostAdapterConfig(config, { MATTERMOST_TOKEN: "environment-token" }),
-    ).toThrow(
+    expect(() => resolveMattermostAdapterConfig(config, { MATTERMOST_TOKEN: "sample" })).toThrow(
       expect.objectContaining({
         kind: "config",
         message: "Mattermost webhookToken must not be empty or whitespace-only.",

--- a/test/signed-jwt.test.ts
+++ b/test/signed-jwt.test.ts
@@ -694,6 +694,26 @@ describe("signed JWT remote key cache", () => {
     await expect(resolveKey({ alg: "RS256", kid: "key-0" })).rejects.toThrow(/128-key limit/u);
   });
 
+  it("classifies empty remote key sets as infrastructure failures", async () => {
+    const resolveKey = createCachedJwtKeyResolver<string>({
+      async fetchKeys() {
+        return {
+          expiresAt: 1_700_000_060_000,
+          values: [],
+        };
+      },
+      keyId: (value) => value,
+      now: () => 1_700_000_000_000,
+      unknownKeyMessage: "unknown key",
+    });
+
+    const failure = await resolveKey({ alg: "RS256", kid: "missing" }).catch(
+      (error: unknown) => error,
+    );
+    expect(failure).toBeInstanceOf(JwtKeyInfrastructureError);
+    expect(failure).toMatchObject({ message: expect.stringMatching(/at least one key/u) });
+  });
+
   it("backs off failed key fetches", async () => {
     let now = 1_700_000_000_000;
     let fetches = 0;
@@ -709,12 +729,21 @@ describe("signed JWT remote key cache", () => {
       unknownKeyMessage: "unknown key",
     });
 
-    await expect(resolveKey({ alg: "RS256", kid: "missing" })).rejects.toBe(fetchError);
-    await expect(resolveKey({ alg: "RS256", kid: "missing" })).rejects.toBe(fetchError);
+    for (const failure of [
+      await resolveKey({ alg: "RS256", kid: "missing" }).catch((error: unknown) => error),
+      await resolveKey({ alg: "RS256", kid: "missing" }).catch((error: unknown) => error),
+    ]) {
+      expect(failure).toBeInstanceOf(JwtKeyInfrastructureError);
+      expect(failure).toMatchObject({ cause: fetchError });
+    }
     expect(fetches).toBe(1);
 
     now += 10_001;
-    await expect(resolveKey({ alg: "RS256", kid: "missing" })).rejects.toBe(fetchError);
+    const retriedFailure = await resolveKey({ alg: "RS256", kid: "missing" }).catch(
+      (error: unknown) => error,
+    );
+    expect(retriedFailure).toBeInstanceOf(JwtKeyInfrastructureError);
+    expect(retriedFailure).toMatchObject({ cause: fetchError });
     expect(fetches).toBe(2);
   });
 
@@ -735,8 +764,13 @@ describe("signed JWT remote key cache", () => {
         unknownKeyMessage: "unknown key",
       });
 
-      await expect(resolveKey({ alg: "RS256", kid: "missing" })).rejects.toBe(fetchError);
-      await expect(resolveKey({ alg: "RS256", kid: "missing" })).rejects.toBe(fetchError);
+      for (const failure of [
+        await resolveKey({ alg: "RS256", kid: "missing" }).catch((error: unknown) => error),
+        await resolveKey({ alg: "RS256", kid: "missing" }).catch((error: unknown) => error),
+      ]) {
+        expect(failure).toBeInstanceOf(JwtKeyInfrastructureError);
+        expect(failure).toMatchObject({ cause: fetchError });
+      }
       expect(fetches).toBe(1);
       expect(vi.getTimerCount()).toBe(0);
     } finally {
@@ -766,12 +800,19 @@ describe("signed JWT remote key cache", () => {
     });
 
     await expect(resolveKey({ alg: "RS256", kid: "known" })).resolves.toBe("known");
-    await expect(resolveKey({ alg: "RS256", kid: "missing-a" })).rejects.toBe(fetchError);
-    await expect(resolveKey({ alg: "RS256", kid: "missing-b" })).rejects.toThrow("unknown key");
+    for (const kid of ["missing-a", "missing-b"]) {
+      const failure = await resolveKey({ alg: "RS256", kid }).catch((error: unknown) => error);
+      expect(failure).toBeInstanceOf(JwtKeyInfrastructureError);
+      expect(failure).toMatchObject({ cause: fetchError });
+    }
     expect(fetches).toBe(2);
 
     now += 10_001;
-    await expect(resolveKey({ alg: "RS256", kid: "missing-c" })).rejects.toBe(fetchError);
+    const retriedFailure = await resolveKey({ alg: "RS256", kid: "missing-c" }).catch(
+      (error: unknown) => error,
+    );
+    expect(retriedFailure).toBeInstanceOf(JwtKeyInfrastructureError);
+    expect(retriedFailure).toMatchObject({ cause: fetchError });
     expect(fetches).toBe(3);
   });
 

--- a/test/slack-provider.test.ts
+++ b/test/slack-provider.test.ts
@@ -300,7 +300,7 @@ describe("slack provider", () => {
     expect(response.status).toBe(200);
     await expect(waiting).resolves.toMatchObject({
       author: "user",
-      id: "1700000001.000200",
+      id: "1700000002.000300",
       text: "edited ACK edited-nonce",
       threadId: "C1234567890:thread:1700000000.000100",
     });

--- a/test/whatsapp-provider-cursor.test.ts
+++ b/test/whatsapp-provider-cursor.test.ts
@@ -250,7 +250,7 @@ describe("WhatsApp provider recorder cursors", () => {
     await Promise.all(waits.slice(1));
   });
 
-  it("prunes inactive cursor entries after a concurrent burst settles", async () => {
+  it("prunes inactive cursor entries while another wait remains active", async () => {
     const config = await createLocalMockConfig("whatsapp", "/whatsapp/webhook");
     const provider = new WhatsAppProviderAdapter("whatsapp", config, "crabline");
     providers.push(provider);
@@ -259,11 +259,28 @@ describe("WhatsApp provider recorder cursors", () => {
       metadata: {},
     });
     const startingOffsets: number[] = [];
+    let releaseActiveWait!: () => void;
+    const activeWaitBlocked = new Promise<void>((resolve) => {
+      releaseActiveWait = resolve;
+    });
+    let calls = 0;
     recorderMocks.waitForRecordedInbound.mockImplementation(async ({ cursor }) => {
+      calls++;
       startingOffsets.push(cursor!.readState.offset);
       cursor!.readState.offset = 1;
+      if (calls === 1) {
+        await activeWaitBlocked;
+      }
       return null;
     });
+    const activeWait = provider.waitForInbound({
+      ...baseContext,
+      nonce: "active-cursor",
+      since: new Date(0).toISOString(),
+      threadId: "15551234567",
+      timeoutMs: 100,
+    });
+    await vi.waitFor(() => expect(recorderMocks.waitForRecordedInbound).toHaveBeenCalledTimes(1));
     const contexts = Array.from({ length: 65 }, (_, index) => ({
       ...baseContext,
       nonce: `settled-cursor-${index}`,
@@ -274,8 +291,10 @@ describe("WhatsApp provider recorder cursors", () => {
 
     await Promise.all(contexts.map((context) => provider.waitForInbound(context)));
     await provider.waitForInbound(contexts[0]!);
+    releaseActiveWait();
+    await expect(activeWait).resolves.toBeNull();
 
-    expect(startingOffsets).toHaveLength(66);
+    expect(startingOffsets).toHaveLength(67);
     expect(startingOffsets.at(-1)).toBe(0);
   });
 

--- a/test/whatsapp-provider.test.ts
+++ b/test/whatsapp-provider.test.ts
@@ -750,6 +750,55 @@ describe("WhatsApp webhook normalizer", () => {
       await provider.cleanup();
     }
   });
+
+  it("prunes settled wait cursors while another wait remains active", async () => {
+    const config = await createLocalMockConfig("whatsapp", "/whatsapp/webhook");
+    const provider = new WhatsAppProviderAdapter("whatsapp", config, "crabline");
+    const context = createProviderContext("whatsapp", config, {
+      id: "15551234567",
+      metadata: {},
+    });
+    const contexts = Array.from({ length: 65 }, (_, index) => ({
+      ...context,
+      nonce: `mp-whatsapp-cursor-${index}-12345678`,
+      since: new Date(0).toISOString(),
+      timeoutMs: 1_000,
+    }));
+    const controllers = contexts.map(() => new AbortController());
+
+    try {
+      await provider.probe(context);
+      const waits = contexts.map((waitContext, index) =>
+        provider.waitForInbound({ ...waitContext, signal: controllers[index]!.signal }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      await appendRecordedInbound(config.whatsapp!.recorder.path!, {
+        author: "assistant",
+        id: "cursor-prune-0",
+        provider: "whatsapp",
+        sentAt: new Date().toISOString(),
+        text: contexts[0]!.nonce,
+        threadId: "15551234567",
+      });
+
+      await expect(waits[0]).resolves.toMatchObject({ id: "cursor-prune-0" });
+      await expect(provider.waitForInbound(contexts[0]!)).resolves.toMatchObject({
+        id: "cursor-prune-0",
+      });
+
+      for (const controller of controllers.slice(1)) {
+        controller.abort();
+      }
+      await expect(Promise.all(waits.slice(1))).resolves.toEqual(
+        Array.from({ length: 64 }, () => null),
+      );
+    } finally {
+      for (const controller of controllers) {
+        controller.abort();
+      }
+      await provider.cleanup();
+    }
+  });
 });
 
 const contractNonces = {

--- a/test/whatsapp-provider.test.ts
+++ b/test/whatsapp-provider.test.ts
@@ -750,55 +750,6 @@ describe("WhatsApp webhook normalizer", () => {
       await provider.cleanup();
     }
   });
-
-  it("prunes settled wait cursors while another wait remains active", async () => {
-    const config = await createLocalMockConfig("whatsapp", "/whatsapp/webhook");
-    const provider = new WhatsAppProviderAdapter("whatsapp", config, "crabline");
-    const context = createProviderContext("whatsapp", config, {
-      id: "15551234567",
-      metadata: {},
-    });
-    const contexts = Array.from({ length: 65 }, (_, index) => ({
-      ...context,
-      nonce: `mp-whatsapp-cursor-${index}-12345678`,
-      since: new Date(0).toISOString(),
-      timeoutMs: 1_000,
-    }));
-    const controllers = contexts.map(() => new AbortController());
-
-    try {
-      await provider.probe(context);
-      const waits = contexts.map((waitContext, index) =>
-        provider.waitForInbound({ ...waitContext, signal: controllers[index]!.signal }),
-      );
-      await new Promise((resolve) => setTimeout(resolve, 50));
-      await appendRecordedInbound(config.whatsapp!.recorder.path!, {
-        author: "assistant",
-        id: "cursor-prune-0",
-        provider: "whatsapp",
-        sentAt: new Date().toISOString(),
-        text: contexts[0]!.nonce,
-        threadId: "15551234567",
-      });
-
-      await expect(waits[0]).resolves.toMatchObject({ id: "cursor-prune-0" });
-      await expect(provider.waitForInbound(contexts[0]!)).resolves.toMatchObject({
-        id: "cursor-prune-0",
-      });
-
-      for (const controller of controllers.slice(1)) {
-        controller.abort();
-      }
-      await expect(Promise.all(waits.slice(1))).resolves.toEqual(
-        Array.from({ length: 64 }, () => null),
-      );
-    } finally {
-      for (const controller of controllers) {
-        controller.abort();
-      }
-      await provider.cleanup();
-    }
-  });
 });
 
 const contractNonces = {

--- a/test/zalo-provider.test.ts
+++ b/test/zalo-provider.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { CrablineError } from "../src/core/errors.js";
 import {
   normalizeZaloWebhookPayload,
   resolveZaloAdapterConfig,
@@ -245,7 +246,12 @@ describe("Zalo webhook normalizer", () => {
           new ZaloProviderAdapter("zalo", config, "crabline", {
             env: { ZALO_WEBHOOK_SECRET: secret },
           }),
-      ).toThrow(/ZALO_WEBHOOK_SECRET must not be empty/u);
+      ).toThrow(
+        expect.objectContaining({
+          kind: "config",
+          message: expect.stringMatching(/ZALO_WEBHOOK_SECRET must not be empty/u),
+        }),
+      );
     },
   );
 
@@ -260,9 +266,22 @@ describe("Zalo webhook normalizer", () => {
           new ZaloProviderAdapter("zalo", config, "crabline", {
             env: { ZALO_WEBHOOK_SECRET: "test-token-placeholder" },
           }),
-      ).toThrow(/Zalo webhookSecret must not be empty/u);
+      ).toThrow(
+        expect.objectContaining({
+          kind: "config",
+          message: expect.stringMatching(/Zalo webhookSecret must not be empty/u),
+        }),
+      );
     },
   );
+
+  it("uses the shared configuration error type for invalid webhook secrets", async () => {
+    const config = await createLocalMockConfig("zalo", "/zalo/webhook");
+
+    expect(() => resolveZaloAdapterConfig(config, { ZALO_WEBHOOK_SECRET: " " })).toThrow(
+      CrablineError,
+    );
+  });
 
   it("preserves configured webhook secret precedence and environment fallback", async () => {
     const config = await createLocalMockConfig("zalo", "/zalo/webhook");


### PR DESCRIPTION
## Summary
- classify local credential failures without masking infrastructure errors
- preserve native edit, cursor, Matrix, JWT, WhatsApp, Discord, and iMessage semantics
- unwrap native iMessage RPC notifications while retaining remote environment defaults
- include changelog entries

## Validation
- gpt-5.6-sol high autoreview: clean
- Crabbox Linux `pnpm verify`: `run_967997058493`
- 64 test files passed; 1,577 tests passed; 22 skipped
