### PR TITLE
fix(recorder): stabilize cross-platform locking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - Recursively inspect referenced local actions, include Go manifests in dependency review, and allow production package source-map checks to complete under load.
 - Cryptographically verify npm provenance and bind existing releases to the expected package digest, repository, workflow, tag, and commit.
 - Keep server recorder hardlink transitions on compatible identity locks and reject non-regular recorder handles before publication.
-- Bind Windows recorder lock-root ACL checks to one no-follow handle and secure their parent namespace.
+- Bind Windows recorder and lock-root ACL checks to validated no-follow namespaces, with owner-only ACLs for Crabline-managed directories.
 - Fail closed when Windows script Job Object containment is unavailable.
 - Stream Telegram multipart uploads with bounded parser metadata instead of copying complete files through `FormData`.
 - Keep Unix recorder identity locks in one validated private per-user namespace across processes and recorder path changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Recursively inspect referenced local actions, include Go manifests in dependency review, and allow production package source-map checks to complete under load.
 - Cryptographically verify npm provenance and bind existing releases to the expected package digest, repository, workflow, tag, and commit.
 - Keep server recorder hardlink transitions on compatible identity locks and reject non-regular recorder handles before publication.
+- Bind Windows recorder lock-root ACL checks to one no-follow handle and secure their parent namespace.
 - Fail closed when Windows script Job Object containment is unavailable.
 - Stream Telegram multipart uploads with bounded parser metadata instead of copying complete files through `FormData`.
 - Keep Unix recorder identity locks in one validated private per-user namespace across processes and recorder path changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Recursively inspect referenced local actions, include Go manifests in dependency review, and allow production package source-map checks to complete under load.
 - Cryptographically verify npm provenance and bind existing releases to the expected package digest, repository, workflow, tag, and commit.
 - Keep server recorder hardlink transitions on compatible identity locks and reject non-regular recorder handles before publication.
+- Fail closed when Windows script Job Object containment is unavailable.
 - Stream Telegram multipart uploads with bounded parser metadata instead of copying complete files through `FormData`.
 - Keep Unix recorder identity locks in one validated private per-user namespace across processes and recorder path changes.
 - Reject non-positive Telegram admin message IDs and enforce native Mattermost channel types and unique normalized usernames.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Reject corrupt retained capability matrices before artifact rotation and cancel failed OpenClaw probe response bodies.
 - Recursively inspect referenced local actions, include Go manifests in dependency review, and allow production package source-map checks to complete under load.
 - Cryptographically verify npm provenance and bind existing releases to the expected package digest, repository, workflow, tag, and commit.
+- Keep server recorder hardlink transitions on compatible identity locks and reject non-regular recorder handles before publication.
 - Stream Telegram multipart uploads with bounded parser metadata instead of copying complete files through `FormData`.
 - Keep Unix recorder identity locks in one validated private per-user namespace across processes and recorder path changes.
 - Reject non-positive Telegram admin message IDs and enforce native Mattermost channel types and unique normalized usernames.

--- a/src/platform/recorder-directory.ts
+++ b/src/platform/recorder-directory.ts
@@ -1,0 +1,19 @@
+import path from "node:path";
+
+export function isManagedRecorderDirectory(
+  directory: string,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  const resolved = path.resolve(directory);
+  const managedDirectories = [
+    path.resolve(".crabline", "servers"),
+    path.resolve("artifacts", "crabline"),
+  ];
+  if (platform !== "win32") {
+    return managedDirectories.includes(resolved);
+  }
+  const key = path.win32.normalize(resolved).toLowerCase();
+  return managedDirectories.some(
+    (candidate) => path.win32.normalize(candidate).toLowerCase() === key,
+  );
+}

--- a/src/platform/windows-acl.ts
+++ b/src/platform/windows-acl.ts
@@ -573,6 +573,109 @@ try {
 }
 `;
 
+const WINDOWS_SAFE_PARENT_NAMESPACE_HELPER = String.raw`
+$trustedSids = [System.Collections.Generic.HashSet[string]]::new(
+  [System.StringComparer]::OrdinalIgnoreCase
+)
+[void]$trustedSids.Add($sid.Value)
+[void]$trustedSids.Add("S-1-5-18")
+[void]$trustedSids.Add("S-1-5-32-544")
+[void]$trustedSids.Add(
+  "S-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464"
+)
+$replacementRights = (
+  [int64][System.Security.AccessControl.FileSystemRights]::WriteData -bor
+  [int64][System.Security.AccessControl.FileSystemRights]::WriteAttributes -bor
+  [int64][System.Security.AccessControl.FileSystemRights]::DeleteSubdirectoriesAndFiles -bor
+  [int64][System.Security.AccessControl.FileSystemRights]::Delete -bor
+  [int64][System.Security.AccessControl.FileSystemRights]::ChangePermissions -bor
+  [int64][System.Security.AccessControl.FileSystemRights]::TakeOwnership -bor
+  [int64]0x40000000 -bor
+  [int64]0x10000000
+)
+
+function Assert-SafeParentNamespace(
+  [string]$candidate,
+  [bool]$rejectChildCreation
+) {
+  $parentDirectory = [CrablineWindowsDirectoryHandle]::Open($candidate, $false)
+  try {
+    # ReadIdentity rejects reparse points, so the lexical walk cannot cross a junction.
+    $parentIdentity = [CrablineWindowsDirectoryHandle]::ReadIdentity($parentDirectory)
+    $parentDescriptor = [CrablineWindowsDirectoryHandle]::ReadSecurityDescriptor(
+      $parentDirectory
+    )
+    $parentRawDescriptor = [System.Security.AccessControl.RawSecurityDescriptor]::new(
+      $parentDescriptor,
+      0
+    )
+    if (
+      (($parentRawDescriptor.ControlFlags -band
+        [System.Security.AccessControl.ControlFlags]::DiscretionaryAclPresent) -eq 0) -or
+      $null -eq $parentRawDescriptor.DiscretionaryAcl
+    ) {
+      throw "Private directory parent namespace has a null DACL."
+    }
+    $parentAcl = [System.Security.AccessControl.DirectorySecurity]::new()
+    $parentAcl.SetSecurityDescriptorBinaryForm($parentDescriptor)
+    $parentOwner = $parentAcl.GetOwner(
+      [System.Security.Principal.SecurityIdentifier]
+    )
+    if (-not $trustedSids.Contains($parentOwner.Value)) {
+      throw "Private directory parent namespace has an untrusted owner."
+    }
+    $parentRules = @($parentAcl.GetAccessRules(
+      $true,
+      $true,
+      [System.Security.Principal.SecurityIdentifier]
+    ))
+    $unsafeRights = $replacementRights
+    if ($rejectChildCreation) {
+      $unsafeRights = (
+        $unsafeRights -bor
+        [int64][System.Security.AccessControl.FileSystemRights]::CreateDirectories
+      )
+    }
+    foreach ($parentRule in $parentRules) {
+      if (
+        $parentRule.AccessControlType -ne
+          [System.Security.AccessControl.AccessControlType]::Allow -or
+        $trustedSids.Contains($parentRule.IdentityReference.Value) -or
+        (
+          -not $rejectChildCreation -and
+          (($parentRule.PropagationFlags -band
+            [System.Security.AccessControl.PropagationFlags]::InheritOnly) -ne 0)
+        )
+      ) {
+        continue
+      }
+      if (([int64]$parentRule.FileSystemRights -band $unsafeRights) -ne 0) {
+        throw "Private directory parent namespace permits untrusted replacement."
+      }
+    }
+    [CrablineWindowsDirectoryHandle]::AssertSamePathIdentity(
+      $candidate,
+      $parentIdentity
+    )
+  } finally {
+    $parentDirectory.Dispose()
+  }
+}
+
+function Assert-SafeNamespaceChain(
+  [string]$candidate,
+  [bool]$rejectChildCreationAtCandidate
+) {
+  $current = $candidate
+  while ($null -ne $current) {
+    Assert-SafeParentNamespace $current $rejectChildCreationAtCandidate
+    $rejectChildCreationAtCandidate = $false
+    $parent = [System.IO.Directory]::GetParent($current)
+    $current = if ($null -eq $parent) { $null } else { $parent.FullName }
+  }
+}
+`;
+
 const WINDOWS_CREATE_OWNER_ONLY_DIRECTORY_SCRIPT = String.raw`
 $ErrorActionPreference = "Stop"
 $directoryPath = $env:CRABLINE_PRIVATE_DIRECTORY_PATH
@@ -615,76 +718,7 @@ $rule = [System.Security.AccessControl.FileSystemAccessRule]::new(
 $acl.SetAccessRule($rule)
 $descriptor = $acl.GetSecurityDescriptorBinaryForm()
 
-$trustedSids = [System.Collections.Generic.HashSet[string]]::new(
-  [System.StringComparer]::OrdinalIgnoreCase
-)
-[void]$trustedSids.Add($sid.Value)
-[void]$trustedSids.Add("S-1-5-18")
-[void]$trustedSids.Add("S-1-5-32-544")
-[void]$trustedSids.Add(
-  "S-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464"
-)
-$replacementRights = (
-  [int64][System.Security.AccessControl.FileSystemRights]::DeleteSubdirectoriesAndFiles -bor
-  [int64][System.Security.AccessControl.FileSystemRights]::Delete -bor
-  [int64][System.Security.AccessControl.FileSystemRights]::ChangePermissions -bor
-  [int64][System.Security.AccessControl.FileSystemRights]::TakeOwnership -bor
-  [int64]0x10000000
-)
-
-function Assert-SafeParentNamespace([string]$candidate) {
-  $parentDirectory = [CrablineWindowsDirectoryHandle]::Open($candidate, $false)
-  try {
-    $parentIdentity = [CrablineWindowsDirectoryHandle]::ReadIdentity($parentDirectory)
-    $parentDescriptor = [CrablineWindowsDirectoryHandle]::ReadSecurityDescriptor(
-      $parentDirectory
-    )
-    $parentRawDescriptor = [System.Security.AccessControl.RawSecurityDescriptor]::new(
-      $parentDescriptor,
-      0
-    )
-    if (
-      (($parentRawDescriptor.ControlFlags -band
-        [System.Security.AccessControl.ControlFlags]::DiscretionaryAclPresent) -eq 0) -or
-      $null -eq $parentRawDescriptor.DiscretionaryAcl
-    ) {
-      throw "Private directory parent namespace has a null DACL."
-    }
-    $parentAcl = [System.Security.AccessControl.DirectorySecurity]::new()
-    $parentAcl.SetSecurityDescriptorBinaryForm($parentDescriptor)
-    $parentOwner = $parentAcl.GetOwner(
-      [System.Security.Principal.SecurityIdentifier]
-    )
-    if (-not $trustedSids.Contains($parentOwner.Value)) {
-      throw "Private directory parent namespace has an untrusted owner."
-    }
-    $parentRules = @($parentAcl.GetAccessRules(
-      $true,
-      $true,
-      [System.Security.Principal.SecurityIdentifier]
-    ))
-    foreach ($parentRule in $parentRules) {
-      if (
-        $parentRule.AccessControlType -ne
-          [System.Security.AccessControl.AccessControlType]::Allow -or
-        $trustedSids.Contains($parentRule.IdentityReference.Value) -or
-        (($parentRule.PropagationFlags -band
-          [System.Security.AccessControl.PropagationFlags]::InheritOnly) -ne 0)
-      ) {
-        continue
-      }
-      if (([int64]$parentRule.FileSystemRights -band $replacementRights) -ne 0) {
-        throw "Private directory parent namespace permits untrusted replacement."
-      }
-    }
-    [CrablineWindowsDirectoryHandle]::AssertSamePathIdentity(
-      $candidate,
-      $parentIdentity
-    )
-  } finally {
-    $parentDirectory.Dispose()
-  }
-}
+${WINDOWS_SAFE_PARENT_NAMESPACE_HELPER}
 
 $missing = [System.Collections.Generic.List[string]]::new()
 $current = $directoryPath
@@ -707,11 +741,7 @@ if ($missing.Count -eq 0) {
   }
   $current = $parent.FullName
 }
-while ($null -ne $current) {
-  Assert-SafeParentNamespace($current)
-  $parent = [System.IO.Directory]::GetParent($current)
-  $current = if ($null -eq $parent) { $null } else { $parent.FullName }
-}
+Assert-SafeNamespaceChain $current ($missing.Count -gt 0)
 
 $directory = $null
 if ($missing.Count -eq 0) {
@@ -739,10 +769,26 @@ if ($missing.Count -eq 0) {
   $paths = $missing.ToArray()
   [Array]::Reverse($paths)
   foreach ($candidate in $paths) {
-    $createdDirectory = [CrablineWindowsDirectoryHandle]::Create(
-      $candidate,
-      $descriptor
-    )
+    $createdDirectory = $null
+    try {
+      $createdDirectory = [CrablineWindowsDirectoryHandle]::Create(
+        $candidate,
+        $descriptor
+      )
+    } catch [System.ComponentModel.Win32Exception] {
+      if (
+        $_.Exception.NativeErrorCode -ne 80 -and
+        $_.Exception.NativeErrorCode -ne 183
+      ) {
+        throw
+      }
+      $createdDirectory = [CrablineWindowsDirectoryHandle]::Open($candidate, $true)
+      [void][CrablineWindowsDirectoryHandle]::ReadIdentity($createdDirectory)
+      [CrablineWindowsDirectoryHandle]::WriteSecurityDescriptor(
+        $createdDirectory,
+        $descriptor
+      )
+    }
     if ($candidate -eq $directoryPath) {
       $directory = $createdDirectory
     } else {
@@ -818,6 +864,14 @@ if ($null -eq $sid) {
   throw "Could not resolve the current Windows user SID."
 }
 
+${WINDOWS_SAFE_PARENT_NAMESPACE_HELPER}
+
+$parent = [System.IO.Directory]::GetParent($directoryPath)
+if ($null -eq $parent) {
+  throw "Private directory must have a parent."
+}
+Assert-SafeNamespaceChain $parent.FullName $false
+
 $directory = [CrablineWindowsDirectoryHandle]::Open($directoryPath, $false)
 try {
   $directoryIdentity = [CrablineWindowsDirectoryHandle]::ReadIdentity($directory)
@@ -851,6 +905,51 @@ try {
   ) {
     throw "Windows directory security descriptor is not owner-only."
   }
+  [CrablineWindowsDirectoryHandle]::AssertSamePathIdentity(
+    $directoryPath,
+    $directoryIdentity
+  )
+  [Console]::Out.Write($directoryIdentity)
+  [Console]::Out.Write([Environment]::NewLine)
+  [Console]::Out.Write([Convert]::ToBase64String($descriptor))
+} finally {
+  $directory.Dispose()
+}
+`;
+
+const WINDOWS_DIRECTORY_NAMESPACE_SECURITY_DESCRIPTOR_SCRIPT = String.raw`
+$ErrorActionPreference = "Stop"
+$directoryPath = $env:CRABLINE_PRIVATE_DIRECTORY_PATH
+if ([string]::IsNullOrWhiteSpace($directoryPath)) {
+  throw "CRABLINE_PRIVATE_DIRECTORY_PATH is required."
+}
+$directoryPath = [System.IO.Path]::GetFullPath($directoryPath)
+$rootPath = [System.IO.Path]::GetPathRoot($directoryPath)
+if ($directoryPath.Length -gt $rootPath.Length) {
+  $directoryPath = $directoryPath.TrimEnd(
+    [char[]]@(
+      [System.IO.Path]::DirectorySeparatorChar,
+      [System.IO.Path]::AltDirectorySeparatorChar
+    )
+  )
+}
+
+${WINDOWS_DIRECTORY_HANDLE_HELPER}
+
+$identity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+$sid = $identity.User
+if ($null -eq $sid) {
+  throw "Could not resolve the current Windows user SID."
+}
+
+${WINDOWS_SAFE_PARENT_NAMESPACE_HELPER}
+
+Assert-SafeNamespaceChain $directoryPath $true
+
+$directory = [CrablineWindowsDirectoryHandle]::Open($directoryPath, $false)
+try {
+  $directoryIdentity = [CrablineWindowsDirectoryHandle]::ReadIdentity($directory)
+  $descriptor = [CrablineWindowsDirectoryHandle]::ReadSecurityDescriptor($directory)
   [CrablineWindowsDirectoryHandle]::AssertSamePathIdentity(
     $directoryPath,
     $directoryIdentity
@@ -999,6 +1098,50 @@ export async function readWindowsDirectorySecuritySnapshot(
   } catch (error) {
     throw new Error(
       "Could not read the Windows directory security descriptor through a stable no-follow handle; Windows PowerShell ACL support is required.",
+      { cause: error },
+    );
+  }
+}
+
+export async function readWindowsDirectoryNamespaceSecuritySnapshot(
+  directoryPath: string,
+  run: WindowsAclRunner = runWindowsAclCommand,
+  systemRoot: string | null | undefined = process.env.SystemRoot,
+): Promise<WindowsDirectorySecuritySnapshot> {
+  try {
+    const powershellPath = resolveWindowsPowerShellPath(systemRoot);
+    const output = await run(
+      powershellPath,
+      [
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        WINDOWS_DIRECTORY_NAMESPACE_SECURITY_DESCRIPTOR_SCRIPT,
+      ],
+      {
+        env: {
+          ...process.env,
+          CRABLINE_PRIVATE_DIRECTORY_PATH: path.resolve(directoryPath),
+        },
+        killSignal: "SIGKILL",
+        timeout: WINDOWS_ACL_COMMAND_TIMEOUT_MS,
+        windowsHide: true,
+      },
+    );
+    const [identity, securityDescriptor, ...extraLines] = output.trim().split(/\r?\n/u);
+    if (
+      !identity ||
+      !/^\d+:[0-9A-F]{32}$/u.test(identity) ||
+      !securityDescriptor ||
+      extraLines.length > 0
+    ) {
+      throw new Error("Windows directory namespace security descriptor was empty.");
+    }
+    return { identity, securityDescriptor };
+  } catch (error) {
+    throw new Error(
+      "Could not validate the Windows directory namespace through stable no-follow handles; Windows PowerShell ACL support is required.",
       { cause: error },
     );
   }

--- a/src/platform/windows-acl.ts
+++ b/src/platform/windows-acl.ts
@@ -636,10 +636,22 @@ function Assert-SafeParentNamespace([string]$candidate) {
   $parentDirectory = [CrablineWindowsDirectoryHandle]::Open($candidate, $false)
   try {
     $parentIdentity = [CrablineWindowsDirectoryHandle]::ReadIdentity($parentDirectory)
-    $parentAcl = [System.Security.AccessControl.DirectorySecurity]::new()
-    $parentAcl.SetSecurityDescriptorBinaryForm(
-      [CrablineWindowsDirectoryHandle]::ReadSecurityDescriptor($parentDirectory)
+    $parentDescriptor = [CrablineWindowsDirectoryHandle]::ReadSecurityDescriptor(
+      $parentDirectory
     )
+    $parentRawDescriptor = [System.Security.AccessControl.RawSecurityDescriptor]::new(
+      $parentDescriptor,
+      0
+    )
+    if (
+      (($parentRawDescriptor.ControlFlags -band
+        [System.Security.AccessControl.ControlFlags]::DiscretionaryAclPresent) -eq 0) -or
+      $null -eq $parentRawDescriptor.DiscretionaryAcl
+    ) {
+      throw "Private directory parent namespace has a null DACL."
+    }
+    $parentAcl = [System.Security.AccessControl.DirectorySecurity]::new()
+    $parentAcl.SetSecurityDescriptorBinaryForm($parentDescriptor)
     $parentOwner = $parentAcl.GetOwner(
       [System.Security.Principal.SecurityIdentifier]
     )

--- a/src/platform/windows-acl.ts
+++ b/src/platform/windows-acl.ts
@@ -613,8 +613,96 @@ $rule = [System.Security.AccessControl.FileSystemAccessRule]::new(
   [System.Security.AccessControl.AccessControlType]::Allow
 )
 $acl.SetAccessRule($rule)
+$descriptor = $acl.GetSecurityDescriptorBinaryForm()
 
-if ([System.IO.Directory]::Exists($directoryPath)) {
+$trustedSids = [System.Collections.Generic.HashSet[string]]::new(
+  [System.StringComparer]::OrdinalIgnoreCase
+)
+[void]$trustedSids.Add($sid.Value)
+[void]$trustedSids.Add("S-1-5-18")
+[void]$trustedSids.Add("S-1-5-32-544")
+[void]$trustedSids.Add(
+  "S-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464"
+)
+$replacementRights = (
+  [int64][System.Security.AccessControl.FileSystemRights]::DeleteSubdirectoriesAndFiles -bor
+  [int64][System.Security.AccessControl.FileSystemRights]::Delete -bor
+  [int64][System.Security.AccessControl.FileSystemRights]::ChangePermissions -bor
+  [int64][System.Security.AccessControl.FileSystemRights]::TakeOwnership -bor
+  [int64]0x10000000
+)
+
+function Assert-SafeParentNamespace([string]$candidate) {
+  $parentDirectory = [CrablineWindowsDirectoryHandle]::Open($candidate, $false)
+  try {
+    $parentIdentity = [CrablineWindowsDirectoryHandle]::ReadIdentity($parentDirectory)
+    $parentAcl = [System.Security.AccessControl.DirectorySecurity]::new()
+    $parentAcl.SetSecurityDescriptorBinaryForm(
+      [CrablineWindowsDirectoryHandle]::ReadSecurityDescriptor($parentDirectory)
+    )
+    $parentOwner = $parentAcl.GetOwner(
+      [System.Security.Principal.SecurityIdentifier]
+    )
+    if (-not $trustedSids.Contains($parentOwner.Value)) {
+      throw "Private directory parent namespace has an untrusted owner."
+    }
+    $parentRules = @($parentAcl.GetAccessRules(
+      $true,
+      $true,
+      [System.Security.Principal.SecurityIdentifier]
+    ))
+    foreach ($parentRule in $parentRules) {
+      if (
+        $parentRule.AccessControlType -ne
+          [System.Security.AccessControl.AccessControlType]::Allow -or
+        $trustedSids.Contains($parentRule.IdentityReference.Value) -or
+        (($parentRule.PropagationFlags -band
+          [System.Security.AccessControl.PropagationFlags]::InheritOnly) -ne 0)
+      ) {
+        continue
+      }
+      if (([int64]$parentRule.FileSystemRights -band $replacementRights) -ne 0) {
+        throw "Private directory parent namespace permits untrusted replacement."
+      }
+    }
+    [CrablineWindowsDirectoryHandle]::AssertSamePathIdentity(
+      $candidate,
+      $parentIdentity
+    )
+  } finally {
+    $parentDirectory.Dispose()
+  }
+}
+
+$missing = [System.Collections.Generic.List[string]]::new()
+$current = $directoryPath
+while (-not [System.IO.Directory]::Exists($current)) {
+  if ([System.IO.File]::Exists($current)) {
+    throw "Private directory ancestry contains a non-directory entry."
+  }
+  $missing.Add($current)
+  $parent = [System.IO.Directory]::GetParent($current)
+  if ($null -eq $parent) {
+    throw "Private directory ancestry has no existing parent."
+  }
+  $current = $parent.FullName
+}
+
+if ($missing.Count -eq 0) {
+  $parent = [System.IO.Directory]::GetParent($directoryPath)
+  if ($null -eq $parent) {
+    throw "Private directory must have a parent."
+  }
+  $current = $parent.FullName
+}
+while ($null -ne $current) {
+  Assert-SafeParentNamespace($current)
+  $parent = [System.IO.Directory]::GetParent($current)
+  $current = if ($null -eq $parent) { $null } else { $parent.FullName }
+}
+
+$directory = $null
+if ($missing.Count -eq 0) {
   $directory = [CrablineWindowsDirectoryHandle]::Open($directoryPath, $true)
   $acl = [System.Security.AccessControl.DirectorySecurity]::new()
   $acl.SetSecurityDescriptorBinaryForm(
@@ -636,17 +724,22 @@ if ([System.IO.Directory]::Exists($directoryPath)) {
     $acl.GetSecurityDescriptorBinaryForm()
   )
 } else {
-  $parent = [System.IO.Directory]::GetParent(
-    $directoryPath
-  )
-  if ($null -eq $parent) {
-    throw "Private directory must have a parent."
+  $paths = $missing.ToArray()
+  [Array]::Reverse($paths)
+  foreach ($candidate in $paths) {
+    $createdDirectory = [CrablineWindowsDirectoryHandle]::Create(
+      $candidate,
+      $descriptor
+    )
+    if ($candidate -eq $directoryPath) {
+      $directory = $createdDirectory
+    } else {
+      $createdDirectory.Dispose()
+    }
   }
-  [void][System.IO.Directory]::CreateDirectory($parent.FullName)
-  $directory = [CrablineWindowsDirectoryHandle]::Create(
-    $directoryPath,
-    $acl.GetSecurityDescriptorBinaryForm()
-  )
+}
+if ($null -eq $directory) {
+  throw "Windows did not return the private directory handle."
 }
 try {
   $directoryIdentity = [CrablineWindowsDirectoryHandle]::ReadIdentity($directory)
@@ -694,42 +787,68 @@ $directoryPath = $env:CRABLINE_PRIVATE_DIRECTORY_PATH
 if ([string]::IsNullOrWhiteSpace($directoryPath)) {
   throw "CRABLINE_PRIVATE_DIRECTORY_PATH is required."
 }
+$directoryPath = [System.IO.Path]::GetFullPath($directoryPath)
+$rootPath = [System.IO.Path]::GetPathRoot($directoryPath)
+if ($directoryPath.Length -gt $rootPath.Length) {
+  $directoryPath = $directoryPath.TrimEnd(
+    [char[]]@(
+      [System.IO.Path]::DirectorySeparatorChar,
+      [System.IO.Path]::AltDirectorySeparatorChar
+    )
+  )
+}
 
-$acl = Get-Acl -LiteralPath $directoryPath
+${WINDOWS_DIRECTORY_HANDLE_HELPER}
+
 $identity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
 $sid = $identity.User
 if ($null -eq $sid) {
   throw "Could not resolve the current Windows user SID."
 }
-$ownerSid = $acl.GetOwner([System.Security.Principal.SecurityIdentifier])
-$rules = @($acl.GetAccessRules(
-  $true,
-  $true,
-  [System.Security.Principal.SecurityIdentifier]
-))
-$requiredInheritance = (
-  [System.Security.AccessControl.InheritanceFlags]::ContainerInherit -bor
-  [System.Security.AccessControl.InheritanceFlags]::ObjectInherit
-)
-if (
-  -not $acl.AreAccessRulesProtected -or
-  $ownerSid.Value -ne $sid.Value -or
-  $rules.Count -ne 1
-) {
-  throw "Windows directory security descriptor is not owner-only."
+
+$directory = [CrablineWindowsDirectoryHandle]::Open($directoryPath, $false)
+try {
+  $directoryIdentity = [CrablineWindowsDirectoryHandle]::ReadIdentity($directory)
+  $descriptor = [CrablineWindowsDirectoryHandle]::ReadSecurityDescriptor($directory)
+  $acl = [System.Security.AccessControl.DirectorySecurity]::new()
+  $acl.SetSecurityDescriptorBinaryForm($descriptor)
+  $ownerSid = $acl.GetOwner([System.Security.Principal.SecurityIdentifier])
+  $rules = @($acl.GetAccessRules(
+    $true,
+    $true,
+    [System.Security.Principal.SecurityIdentifier]
+  ))
+  $requiredInheritance = (
+    [System.Security.AccessControl.InheritanceFlags]::ContainerInherit -bor
+    [System.Security.AccessControl.InheritanceFlags]::ObjectInherit
+  )
+  if (
+    -not $acl.AreAccessRulesProtected -or
+    $ownerSid.Value -ne $sid.Value -or
+    $rules.Count -ne 1
+  ) {
+    throw "Windows directory security descriptor is not owner-only."
+  }
+  $rule = $rules[0]
+  if (
+    $rule.IsInherited -or
+    $rule.IdentityReference.Value -ne $sid.Value -or
+    $rule.AccessControlType -ne [System.Security.AccessControl.AccessControlType]::Allow -or
+    (($rule.FileSystemRights -band [System.Security.AccessControl.FileSystemRights]::FullControl) -ne [System.Security.AccessControl.FileSystemRights]::FullControl) -or
+    (($rule.InheritanceFlags -band $requiredInheritance) -ne $requiredInheritance)
+  ) {
+    throw "Windows directory security descriptor is not owner-only."
+  }
+  [CrablineWindowsDirectoryHandle]::AssertSamePathIdentity(
+    $directoryPath,
+    $directoryIdentity
+  )
+  [Console]::Out.Write($directoryIdentity)
+  [Console]::Out.Write([Environment]::NewLine)
+  [Console]::Out.Write([Convert]::ToBase64String($descriptor))
+} finally {
+  $directory.Dispose()
 }
-$rule = $rules[0]
-if (
-  $rule.IsInherited -or
-  $rule.IdentityReference.Value -ne $sid.Value -or
-  $rule.AccessControlType -ne [System.Security.AccessControl.AccessControlType]::Allow -or
-  (($rule.FileSystemRights -band [System.Security.AccessControl.FileSystemRights]::FullControl) -ne [System.Security.AccessControl.FileSystemRights]::FullControl) -or
-  (($rule.InheritanceFlags -band $requiredInheritance) -ne $requiredInheritance)
-) {
-  throw "Windows directory security descriptor is not owner-only."
-}
-$descriptor = $acl.GetSecurityDescriptorBinaryForm()
-[Convert]::ToBase64String($descriptor)
 `;
 
 export type WindowsAclRunner = (
@@ -742,6 +861,11 @@ export type WindowsAclRunner = (
     windowsHide: boolean;
   },
 ) => Promise<string>;
+
+export type WindowsDirectorySecuritySnapshot = {
+  identity: string;
+  securityDescriptor: string;
+};
 
 const runWindowsAclCommand: WindowsAclRunner = async (command, args, options) => {
   const result = await execFileAsync(command, args, { ...options, encoding: "utf8" });
@@ -824,14 +948,14 @@ export async function createOwnerOnlyWindowsDirectory(
   }
 }
 
-export async function readWindowsDirectorySecurityDescriptor(
+export async function readWindowsDirectorySecuritySnapshot(
   directoryPath: string,
   run: WindowsAclRunner = runWindowsAclCommand,
   systemRoot: string | null | undefined = process.env.SystemRoot,
-): Promise<string> {
+): Promise<WindowsDirectorySecuritySnapshot> {
   try {
     const powershellPath = resolveWindowsPowerShellPath(systemRoot);
-    const descriptor = await run(
+    const output = await run(
       powershellPath,
       [
         "-NoLogo",
@@ -850,15 +974,29 @@ export async function readWindowsDirectorySecurityDescriptor(
         windowsHide: true,
       },
     );
-    const normalized = descriptor.trim();
-    if (!normalized) {
+    const [identity, securityDescriptor, ...extraLines] = output.trim().split(/\r?\n/u);
+    if (
+      !identity ||
+      !/^\d+:[0-9A-F]{32}$/u.test(identity) ||
+      !securityDescriptor ||
+      extraLines.length > 0
+    ) {
       throw new Error("Windows directory security descriptor was empty.");
     }
-    return normalized;
+    return { identity, securityDescriptor };
   } catch (error) {
     throw new Error(
-      "Could not read the Windows directory security descriptor; powershell.exe with Get-Acl is required.",
+      "Could not read the Windows directory security descriptor through a stable no-follow handle; Windows PowerShell ACL support is required.",
       { cause: error },
     );
   }
+}
+
+export async function readWindowsDirectorySecurityDescriptor(
+  directoryPath: string,
+  run: WindowsAclRunner = runWindowsAclCommand,
+  systemRoot: string | null | undefined = process.env.SystemRoot,
+): Promise<string> {
+  return (await readWindowsDirectorySecuritySnapshot(directoryPath, run, systemRoot))
+    .securityDescriptor;
 }

--- a/src/platform/windows-lock-root.ts
+++ b/src/platform/windows-lock-root.ts
@@ -1,9 +1,11 @@
 import type { BigIntStats } from "node:fs";
 import { lstat } from "node:fs/promises";
+import type { WindowsDirectorySecuritySnapshot } from "./windows-acl.js";
 
 export type WindowsLockRootIdentity = {
   birthtimeNs: bigint;
   dev: bigint;
+  handleIdentity: string;
   ino: bigint;
   securityDescriptor: string;
 };
@@ -33,7 +35,7 @@ function isSameWindowsLockRoot(
 
 async function readStableWindowsLockRootIdentity(options: {
   errorPrefix: string;
-  readSecurityDescriptor: () => Promise<string>;
+  readSecuritySnapshot: () => Promise<WindowsDirectorySecuritySnapshot>;
   root: string;
 }): Promise<WindowsLockRootIdentity> {
   for (let attempt = 0; attempt < MAX_WINDOWS_LOCK_ROOT_SNAPSHOT_ATTEMPTS; attempt += 1) {
@@ -49,9 +51,9 @@ async function readStableWindowsLockRootIdentity(options: {
     if (!before.isDirectory() || before.isSymbolicLink()) {
       throw new Error(`${options.errorPrefix} is not a private directory.`);
     }
-    let securityDescriptor: string;
+    let securitySnapshot: WindowsDirectorySecuritySnapshot;
     try {
-      securityDescriptor = await options.readSecurityDescriptor();
+      securitySnapshot = await options.readSecuritySnapshot();
     } catch (error) {
       let afterFailure: WindowsLockRootStats;
       try {
@@ -80,8 +82,9 @@ async function readStableWindowsLockRootIdentity(options: {
       return {
         birthtimeNs: before.birthtimeNs,
         dev: before.dev,
+        handleIdentity: securitySnapshot.identity,
         ino: before.ino,
-        securityDescriptor,
+        securityDescriptor: securitySnapshot.securityDescriptor,
       };
     }
   }
@@ -93,7 +96,7 @@ export async function secureCachedWindowsLockRoot(options: {
   cacheKey: string;
   createDirectory: () => Promise<void>;
   errorPrefix: string;
-  readSecurityDescriptor: () => Promise<string>;
+  readSecuritySnapshot: () => Promise<WindowsDirectorySecuritySnapshot>;
   root: string;
 }): Promise<string> {
   let recoveryAttempts = 0;
@@ -137,6 +140,7 @@ export async function secureCachedWindowsLockRoot(options: {
       current.dev === expected.dev &&
       current.ino === expected.ino &&
       current.birthtimeNs === expected.birthtimeNs &&
+      current.handleIdentity === expected.handleIdentity &&
       current.securityDescriptor === expected.securityDescriptor
     ) {
       return options.root;

--- a/src/providers/builtin/script.ts
+++ b/src/providers/builtin/script.ts
@@ -259,7 +259,7 @@ const WINDOWS_PROCESS_TERMINATOR_SOURCE = [
 ].join("");
 
 let windowsJobHelperPath: string | undefined;
-let windowsJobHelperPromise: Promise<string | undefined> | undefined;
+let windowsJobHelperPromise: Promise<string> | undefined;
 
 function removeWindowsJobHelper(directory: string): void {
   try {
@@ -289,15 +289,17 @@ function runWindowsJobHelperCommand(
   });
 }
 
-async function createWindowsJobHelper(): Promise<string | undefined> {
+async function createWindowsJobHelper(): Promise<string> {
   if (windowsJobHelperPath !== undefined) {
     return windowsJobHelperPath;
   }
   let directory: string;
   try {
     directory = mkdtempSync(path.join(tmpdir(), "crabline-script-job-"));
-  } catch {
-    return undefined;
+  } catch (error) {
+    throw new Error("Could not create the Windows script Job Object helper directory.", {
+      cause: error,
+    });
   }
   const helperPath = path.join(directory, "crabline-script-job.exe");
   try {
@@ -330,16 +332,18 @@ async function createWindowsJobHelper(): Promise<string | undefined> {
       timeout: 5_000,
       windowsHide: true,
     });
-  } catch {
+  } catch (error) {
     removeWindowsJobHelper(directory);
-    return undefined;
+    throw new Error("Could not initialize the Windows script Job Object helper.", {
+      cause: error,
+    });
   }
   windowsJobHelperPath = helperPath;
   process.once("exit", () => removeWindowsJobHelper(directory));
   return helperPath;
 }
 
-function ensureWindowsJobHelper(): Promise<string | undefined> {
+function ensureWindowsJobHelper(): Promise<string> {
   if (windowsJobHelperPath !== undefined) {
     return Promise.resolve(windowsJobHelperPath);
   }
@@ -439,28 +443,18 @@ async function spawnScriptChild(
       throw signal.reason ?? new Error("Script command aborted.");
     }
     startedAtMs = Date.now();
-    if (helperPath) {
-      const shellCommand = windowsShellCommand(params.command, params.shell);
-      child = spawn(helperPath, [], {
-        cwd,
-        env: {
-          ...process.env,
-          [WINDOWS_JOB_COMMAND_ENV]: Buffer.from(shellCommand.commandLine).toString("base64"),
-          [WINDOWS_JOB_SHELL_ENV]: Buffer.from(shellCommand.shell).toString("base64"),
-        },
-        shell: false,
-        stdio: ["pipe", "pipe", "pipe"],
-        windowsHide: true,
-      });
-    } else {
-      child = spawn(params.command, {
-        cwd,
-        env: process.env,
-        shell: params.shell ?? true,
-        stdio: ["pipe", "pipe", "pipe"],
-        windowsHide: true,
-      });
-    }
+    const shellCommand = windowsShellCommand(params.command, params.shell);
+    child = spawn(helperPath, [], {
+      cwd,
+      env: {
+        ...process.env,
+        [WINDOWS_JOB_COMMAND_ENV]: Buffer.from(shellCommand.commandLine).toString("base64"),
+        [WINDOWS_JOB_SHELL_ENV]: Buffer.from(shellCommand.shell).toString("base64"),
+      },
+      shell: false,
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
+    });
   } else {
     startedAtMs = Date.now();
     child = spawn(params.command, {

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -6,7 +6,8 @@ import { lock } from "proper-lockfile";
 import { createProcessOwnedLockFileSystem } from "../platform/process-owned-lock.js";
 import {
   createOwnerOnlyWindowsDirectory,
-  readWindowsDirectorySecurityDescriptor,
+  readWindowsDirectorySecuritySnapshot,
+  type WindowsDirectorySecuritySnapshot,
 } from "../platform/windows-acl.js";
 import {
   secureCachedWindowsLockRoot,
@@ -779,7 +780,9 @@ export async function secureProviderRecorderLockRoot(
   options: {
     platform?: NodeJS.Platform;
     createWindowsDirectory?: (directoryPath: string) => Promise<void>;
-    readWindowsDirectorySecurityDescriptor?: (directoryPath: string) => Promise<string>;
+    readWindowsDirectorySecuritySnapshot?: (
+      directoryPath: string,
+    ) => Promise<WindowsDirectorySecuritySnapshot>;
   } = {},
 ): Promise<string> {
   if ((options.platform ?? process.platform) === "win32") {
@@ -787,13 +790,11 @@ export async function secureProviderRecorderLockRoot(
     return secureCachedWindowsLockRoot({
       cache: securedWindowsLockRoots,
       cacheKey,
-      createDirectory: async () => {
-        await mkdir(path.dirname(root), { recursive: true });
-        await (options.createWindowsDirectory ?? createOwnerOnlyWindowsDirectory)(root);
-      },
+      createDirectory: () =>
+        (options.createWindowsDirectory ?? createOwnerOnlyWindowsDirectory)(root),
       errorPrefix: "Provider recorder lock directory",
-      readSecurityDescriptor: () =>
-        (options.readWindowsDirectorySecurityDescriptor ?? readWindowsDirectorySecurityDescriptor)(
+      readSecuritySnapshot: () =>
+        (options.readWindowsDirectorySecuritySnapshot ?? readWindowsDirectorySecuritySnapshot)(
           root,
         ),
       root,

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -383,6 +383,22 @@ function sameRecorderLockIdentity(
   return sameRecorderFileIdentity(left, right) && left?.nlink === right?.nlink;
 }
 
+function requireRecorderHandleIdentity(stats: {
+  dev: bigint;
+  ino: bigint;
+  isFile?: () => boolean;
+  nlink: bigint;
+}): RecorderFileIdentity {
+  if (stats.isFile?.() === false) {
+    throw new Error("Recorder path is not a regular file.");
+  }
+  return {
+    dev: stats.dev,
+    ino: stats.ino,
+    nlink: stats.nlink,
+  };
+}
+
 async function resolveRecorderPublicationPath(filePath: string): Promise<string> {
   try {
     return await realpath(filePath);
@@ -546,8 +562,7 @@ async function prepareRecorderPathForAppend(
 ): Promise<{ created: boolean; identity: RecorderFileIdentity }> {
   const opened = await openRecorderForAppend(publicationPath);
   const { handle } = opened;
-  const identity = await handle.stat({ bigint: true });
-  const recorderIdentity = { dev: identity.dev, ino: identity.ino, nlink: identity.nlink };
+  const recorderIdentity = requireRecorderHandleIdentity(await handle.stat({ bigint: true }));
   try {
     if (
       expectedIdentity !== undefined &&
@@ -596,8 +611,7 @@ async function appendCommittedLine(
 ): Promise<void> {
   const opened = await openRecorderForAppend(publicationPath);
   const { handle } = opened;
-  const identity = await handle.stat({ bigint: true });
-  const recorderIdentity = { dev: identity.dev, ino: identity.ino, nlink: identity.nlink };
+  const recorderIdentity = requireRecorderHandleIdentity(await handle.stat({ bigint: true }));
   let published = false;
   let operationError: unknown;
   try {

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -4,8 +4,10 @@ import { userInfo } from "node:os";
 import path from "node:path";
 import { lock } from "proper-lockfile";
 import { createProcessOwnedLockFileSystem } from "../platform/process-owned-lock.js";
+import { isManagedRecorderDirectory } from "../platform/recorder-directory.js";
 import {
   createOwnerOnlyWindowsDirectory,
+  readWindowsDirectoryNamespaceSecuritySnapshot,
   readWindowsDirectorySecuritySnapshot,
   type WindowsDirectorySecuritySnapshot,
 } from "../platform/windows-acl.js";
@@ -41,6 +43,7 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
 const pendingAppends = new Map<string, Promise<void>>();
 const recordIdentityIndexes = new Map<string, RecordIdentityIndex>();
 const securedWindowsLockRoots = new Map<string, Promise<WindowsLockRootIdentity>>();
+const securedWindowsRecorderDirectories = new Map<string, Promise<WindowsLockRootIdentity>>();
 const MAX_RECORD_IDENTITY_INDEXES = 128;
 const MAX_RECENT_RECORD_KEYS = 4096;
 const RECORDER_BATCH_VERSION = 1;
@@ -837,6 +840,43 @@ export async function secureProviderRecorderLockRoot(
   return canonicalRoot;
 }
 
+async function secureProviderRecorderWindowsDirectory(root: string): Promise<string> {
+  const cacheKey = path.win32.normalize(path.resolve(root)).toLowerCase();
+  return secureCachedWindowsLockRoot({
+    cache: securedWindowsRecorderDirectories,
+    cacheKey,
+    createDirectory: async () => {
+      try {
+        const identity = await lstat(root);
+        if (!identity.isDirectory() || identity.isSymbolicLink()) {
+          throw new Error("Provider recorder Windows directory is not a private directory.");
+        }
+        if (isManagedRecorderDirectory(root)) {
+          await createOwnerOnlyWindowsDirectory(root);
+        }
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw error;
+        }
+        await createOwnerOnlyWindowsDirectory(root);
+      }
+    },
+    errorPrefix: "Provider recorder Windows directory",
+    readSecuritySnapshot: () => readWindowsDirectoryNamespaceSecuritySnapshot(root),
+    root,
+  });
+}
+
+async function prepareRecorderDirectory(filePath: string): Promise<string | undefined> {
+  const directory = path.dirname(filePath);
+  if (process.platform === "win32") {
+    await secureProviderRecorderWindowsDirectory(directory);
+    return undefined;
+  }
+  const createdDirectory = await mkdir(directory, { recursive: true });
+  return createdDirectory === undefined ? undefined : await realpath(createdDirectory);
+}
+
 function recorderLockRootUnavailable(error: unknown): boolean {
   const code = (error as NodeJS.ErrnoException).code;
   return (
@@ -1158,9 +1198,7 @@ export async function appendRecordedInbound(
   filePath: string,
   event: RecordableInboundEnvelope,
 ): Promise<RecordedInboundEnvelope> {
-  const createdDirectory = await mkdir(path.dirname(filePath), { recursive: true });
-  const firstCreatedDirectory =
-    createdDirectory === undefined ? undefined : await realpath(createdDirectory);
+  const firstCreatedDirectory = await prepareRecorderDirectory(filePath);
 
   const recorded = {
     ...event,
@@ -1184,9 +1222,7 @@ export async function appendRecordedInboundBatch(
   if (events.length === 0) {
     return [];
   }
-  const createdDirectory = await mkdir(path.dirname(filePath), { recursive: true });
-  const firstCreatedDirectory =
-    createdDirectory === undefined ? undefined : await realpath(createdDirectory);
+  const firstCreatedDirectory = await prepareRecorderDirectory(filePath);
   for (let attempt = 0; ; attempt++) {
     try {
       return await serializeAppend(

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -358,6 +358,17 @@ function recorderLockAcquisitionReleaseError(
   );
 }
 
+function recorderIdentityLockAcquisitionReleaseError(
+  acquisitionError: unknown,
+  releaseErrors: unknown[],
+): AggregateError {
+  return new AggregateError(
+    [acquisitionError, ...releaseErrors],
+    "Server recorder identity lock acquisition and cleanup both failed.",
+    { cause: acquisitionError },
+  );
+}
+
 function isRecorderLockContention(error: unknown): boolean {
   return (
     typeof error === "object" &&
@@ -691,11 +702,7 @@ async function acquireRecorderIdentityLock(
       .filter((result): result is PromiseRejectedResult => result.status === "rejected")
       .map((result) => result.reason);
     if (releaseErrors.length > 0) {
-      throw new AggregateError(
-        [error, ...releaseErrors],
-        "Server recorder identity lock acquisition and cleanup both failed.",
-        { cause: error },
-      );
+      throw recorderIdentityLockAcquisitionReleaseError(error, releaseErrors);
     }
     throw error;
   }

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -891,6 +891,7 @@ async function appendRecorderAttempt(params: {
           }
         }
         if (result === undefined) {
+          // Repair and truncation change EOF; refresh it before a positional Windows append.
           stats = await file.stat({ bigint: true });
           identity = requireRecorderIdentity(stats);
         }

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -7,9 +7,11 @@ import { lock } from "proper-lockfile";
 import { createProcessOwnedLockFileSystem } from "../platform/process-owned-lock.js";
 import {
   createOwnerOnlyWindowsDirectory,
+  readWindowsDirectoryNamespaceSecuritySnapshot,
   readWindowsDirectorySecuritySnapshot,
   type WindowsDirectorySecuritySnapshot,
 } from "../platform/windows-acl.js";
+import { isManagedRecorderDirectory } from "../platform/recorder-directory.js";
 import {
   secureCachedWindowsLockRoot,
   type WindowsLockRootIdentity,
@@ -63,6 +65,7 @@ const pendingAdmissions = new Map<string, Promise<void>>();
 const pendingLogicalObservers = new Map<string, ObserverTask>();
 const pendingPublicationObservers = new Map<string, ObserverTask>();
 const securedWindowsLockRoots = new Map<string, Promise<WindowsLockRootIdentity>>();
+const securedWindowsRecorderDirectories = new Map<string, Promise<WindowsLockRootIdentity>>();
 const MAX_RECOVERY_VALIDATION_BYTES = 64 * 1024 * 1024;
 const MAX_RECOVERY_SCAN_BYTES = MAX_RECOVERY_VALIDATION_BYTES + 1;
 const RECORDER_LOCK_RETRY_MS = 100;
@@ -73,13 +76,6 @@ const RECORDER_LOCK_DIRECTORY_ENV = "CRABLINE_RECORDER_LOCK_DIR";
 const RECORDER_PATH_ATTEMPTS = 3;
 const RECORDER_ROTATION_ATTEMPTS = 3;
 const TAIL_SCAN_CHUNK_BYTES = 64 * 1024;
-
-function isManagedRecorderDirectory(directory: string): boolean {
-  return (
-    directory === path.resolve(".crabline", "servers") ||
-    directory === path.resolve("artifacts", "crabline")
-  );
-}
 
 async function readBufferAt(
   file: Awaited<ReturnType<typeof open>>,
@@ -173,7 +169,7 @@ async function openRecorderFile(
       created: false,
       file: await open(
         filePath,
-        // A non-creating Windows open cannot materialize a dangling reparse target.
+        // Windows callers secure the publication directory before reaching this open.
         process.platform === "win32"
           ? "r+"
           : fsConstants.O_RDWR |
@@ -596,6 +592,33 @@ export async function secureServerRecorderWindowsLockRoot(
     errorPrefix: "Server recorder Windows lock root",
     readSecuritySnapshot: () =>
       (options.readWindowsDirectorySecuritySnapshot ?? readWindowsDirectorySecuritySnapshot)(root),
+    root,
+  });
+}
+
+async function secureServerRecorderWindowsDirectory(root: string): Promise<string> {
+  const cacheKey = path.win32.normalize(path.resolve(root)).toLowerCase();
+  return secureCachedWindowsLockRoot({
+    cache: securedWindowsRecorderDirectories,
+    cacheKey,
+    createDirectory: async () => {
+      try {
+        const identity = await lstat(root);
+        if (!identity.isDirectory() || identity.isSymbolicLink()) {
+          throw new Error("Server recorder Windows directory is not a private directory.");
+        }
+        if (isManagedRecorderDirectory(root)) {
+          await createOwnerOnlyWindowsDirectory(root);
+        }
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw error;
+        }
+        await createOwnerOnlyWindowsDirectory(root);
+      }
+    },
+    errorPrefix: "Server recorder Windows directory",
+    readSecuritySnapshot: () => readWindowsDirectoryNamespaceSecuritySnapshot(root),
     root,
   });
 }
@@ -1087,9 +1110,14 @@ async function appendResolvedJsonLine(params: {
       let observerActivated = false;
       try {
         const directory = path.dirname(key);
-        const createdDirectory = await mkdir(directory, { mode: 0o700, recursive: true });
-        if (createdDirectory !== undefined || isManagedRecorderDirectory(directory)) {
-          await chmod(directory, 0o700);
+        let createdDirectory: string | undefined;
+        if (process.platform === "win32") {
+          await secureServerRecorderWindowsDirectory(directory);
+        } else {
+          createdDirectory = await mkdir(directory, { mode: 0o700, recursive: true });
+          if (createdDirectory !== undefined || isManagedRecorderDirectory(directory)) {
+            await chmod(directory, 0o700);
+          }
         }
         // Keep the cross-process lock through append verification.
         const committed = await withRecorderLock(key, logicalPath, async () => {

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -604,22 +604,23 @@ async function recorderLocalIdentityLockTarget(
 
 async function recorderIdentityLockTargets(fileIdentity: RecorderFileIdentity): Promise<string[]> {
   const configuredRoot = process.env[RECORDER_LOCK_DIRECTORY_ENV]?.trim();
-  if (!configuredRoot) {
-    if (fileIdentity.nlink > 1n) {
-      throw new Error(
-        `Server recorder hardlinks require ${RECORDER_LOCK_DIRECTORY_ENV} to name one shared writable lock directory for every writer.`,
-      );
+  if (configuredRoot) {
+    if (!path.isAbsolute(configuredRoot)) {
+      throw new Error(`${RECORDER_LOCK_DIRECTORY_ENV} must be an absolute path.`);
     }
-    return [await recorderLocalIdentityLockTarget(fileIdentity)];
+    const sharedRoot = await secureRecorderLockRoot(configuredRoot);
+    // Lock every configured writer in the shared namespace before a first hardlink can appear.
+    return [
+      await recorderLocalIdentityLockTarget(fileIdentity),
+      recorderSharedIdentityLockPath(sharedRoot, fileIdentity),
+    ];
   }
-  if (!path.isAbsolute(configuredRoot)) {
-    throw new Error(`${RECORDER_LOCK_DIRECTORY_ENV} must be an absolute path.`);
+  if (fileIdentity.nlink > 1n) {
+    throw new Error(
+      `Server recorder hardlinks require ${RECORDER_LOCK_DIRECTORY_ENV} to name one shared writable lock directory for every writer.`,
+    );
   }
-  const sharedRoot = await secureRecorderLockRoot(configuredRoot);
-  return [
-    await recorderLocalIdentityLockTarget(fileIdentity),
-    recorderSharedIdentityLockPath(sharedRoot, fileIdentity),
-  ];
+  return [await recorderLocalIdentityLockTarget(fileIdentity)];
 }
 
 async function acquireSingleRecorderLock(filePath: string): Promise<() => Promise<void>> {

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -574,6 +574,20 @@ function recorderSharedIdentityLockPath(root: string, identity: RecorderFileIden
   return path.join(root, `recorder-${identity.ino}`);
 }
 
+function deduplicateRecorderLockTargets(targets: string[]): string[] {
+  const seen = new Set<string>();
+  return targets.filter((target) => {
+    const resolved = path.resolve(target);
+    const key =
+      process.platform === "win32" ? path.win32.normalize(resolved).toLowerCase() : resolved;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
 export async function secureServerRecorderWindowsLockRoot(
   root: string,
   options: {
@@ -668,17 +682,17 @@ async function recorderIdentityLockTargets(fileIdentity: RecorderFileIdentity): 
     }
     const sharedRoot = await secureRecorderLockRoot(configuredRoot);
     // Lock every configured writer in the shared namespace before a first hardlink can appear.
-    return [
+    return deduplicateRecorderLockTargets([
       await recorderLocalIdentityLockTarget(fileIdentity),
       recorderSharedIdentityLockPath(sharedRoot, fileIdentity),
-    ];
+    ]);
   }
   if (fileIdentity.nlink > 1n) {
     throw new Error(
       `Server recorder hardlinks require ${RECORDER_LOCK_DIRECTORY_ENV} to name one shared writable lock directory for every writer.`,
     );
   }
-  return [await recorderLocalIdentityLockTarget(fileIdentity)];
+  return deduplicateRecorderLockTargets([await recorderLocalIdentityLockTarget(fileIdentity)]);
 }
 
 async function acquireSingleRecorderLock(filePath: string): Promise<() => Promise<void>> {

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -7,7 +7,8 @@ import { lock } from "proper-lockfile";
 import { createProcessOwnedLockFileSystem } from "../platform/process-owned-lock.js";
 import {
   createOwnerOnlyWindowsDirectory,
-  readWindowsDirectorySecurityDescriptor,
+  readWindowsDirectorySecuritySnapshot,
+  type WindowsDirectorySecuritySnapshot,
 } from "../platform/windows-acl.js";
 import {
   secureCachedWindowsLockRoot,
@@ -535,7 +536,9 @@ export async function secureServerRecorderWindowsLockRoot(
   root: string,
   options: {
     createWindowsDirectory?: (directoryPath: string) => Promise<void>;
-    readWindowsDirectorySecurityDescriptor?: (directoryPath: string) => Promise<string>;
+    readWindowsDirectorySecuritySnapshot?: (
+      directoryPath: string,
+    ) => Promise<WindowsDirectorySecuritySnapshot>;
   } = {},
 ): Promise<string> {
   const cacheKey = path.win32.normalize(path.resolve(root)).toLowerCase();
@@ -545,10 +548,8 @@ export async function secureServerRecorderWindowsLockRoot(
     createDirectory: () =>
       (options.createWindowsDirectory ?? createOwnerOnlyWindowsDirectory)(root),
     errorPrefix: "Server recorder Windows lock root",
-    readSecurityDescriptor: () =>
-      (options.readWindowsDirectorySecurityDescriptor ?? readWindowsDirectorySecurityDescriptor)(
-        root,
-      ),
+    readSecuritySnapshot: () =>
+      (options.readWindowsDirectorySecuritySnapshot ?? readWindowsDirectorySecuritySnapshot)(root),
     root,
   });
 }

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -98,6 +98,26 @@ async function readBufferAt(
   return buffer.subarray(0, bytesRead);
 }
 
+async function appendRecorderText(
+  file: Awaited<ReturnType<typeof open>>,
+  contents: string,
+  position: number,
+): Promise<void> {
+  if (process.platform !== "win32") {
+    await file.appendFile(contents, { encoding: "utf8" });
+    return;
+  }
+  const buffer = Buffer.from(contents, "utf8");
+  let written = 0;
+  while (written < buffer.length) {
+    const result = await file.write(buffer, written, buffer.length - written, position + written);
+    if (result.bytesWritten === 0) {
+      throw new Error("Server recorder append made no progress.");
+    }
+    written += result.bytesWritten;
+  }
+}
+
 async function findIncompleteTailStart(
   file: Awaited<ReturnType<typeof open>>,
   fileSize: number,
@@ -141,16 +161,6 @@ async function openRecorderFile(
   filePath: string,
 ): Promise<{ created: boolean; file: Awaited<ReturnType<typeof open>> }> {
   try {
-    const existing = await lstat(filePath);
-    if (existing.isFile?.() === false) {
-      throw new Error(`Server recorder path is not a regular file: ${filePath}`);
-    }
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-      throw error;
-    }
-  }
-  try {
     return {
       created: true,
       file: await open(filePath, "ax+", 0o600),
@@ -161,7 +171,17 @@ async function openRecorderFile(
     }
     return {
       created: false,
-      file: await open(filePath, "a+", 0o600),
+      file: await open(
+        filePath,
+        // A non-creating Windows open cannot materialize a dangling reparse target.
+        process.platform === "win32"
+          ? "r+"
+          : fsConstants.O_RDWR |
+              fsConstants.O_APPEND |
+              fsConstants.O_NONBLOCK |
+              fsConstants.O_NOFOLLOW,
+        0o600,
+      ),
     };
   }
 }
@@ -310,6 +330,21 @@ async function recorderPathHasIdentity(
       throw new Error(`Server recorder path is not a regular file: ${filePath}`);
     }
     return recorderIdentity(stats) === expectedIdentity;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function recorderWindowsPathIsRegular(filePath: string): Promise<boolean> {
+  try {
+    const stats = await lstat(filePath, { bigint: true });
+    if (stats.isSymbolicLink() || !stats.isFile()) {
+      throw new Error(`Server recorder path is not a regular file: ${filePath}`);
+    }
+    return true;
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
       return false;
@@ -797,15 +832,20 @@ async function appendRecorderAttempt(params: {
   let releaseIdentityLock: (() => Promise<void>) | undefined;
   let result: "committed" | "retargeted" | "retry" | undefined;
   try {
+    const openedStats = await file.stat({ bigint: true });
+    const lockedIdentity = requireRecorderFileIdentity(openedStats);
+    let identity = `${lockedIdentity.dev}:${lockedIdentity.ino}`;
     if (opened.created) {
       await file.chmod(0o600);
     }
-    const openedStats = await file.stat({ bigint: true });
-    let identity = requireRecorderIdentity(openedStats);
-    if (!(await recorderPathHasIdentity(params.publicationPath, identity))) {
+    if (
+      process.platform === "win32" &&
+      !(await recorderWindowsPathIsRegular(params.publicationPath))
+    ) {
+      result = "retry";
+    } else if (!(await recorderPathHasIdentity(params.publicationPath, identity))) {
       result = "retry";
     } else {
-      const lockedIdentity = requireRecorderFileIdentity(openedStats);
       releaseIdentityLock = await acquireRecorderIdentityLock(lockedIdentity);
       // Lock acquisition may have blocked while another writer repaired or appended.
       let stats = await file.stat({ bigint: true });
@@ -837,7 +877,7 @@ async function appendRecorderAttempt(params: {
             }
             try {
               JSON.parse(tail.toString("utf8"));
-              await file.appendFile("\n", { encoding: "utf8" });
+              await appendRecorderText(file, "\n", fileSize);
             } catch (error) {
               if (!(error instanceof SyntaxError)) {
                 throw error;
@@ -861,7 +901,7 @@ async function appendRecorderAttempt(params: {
           result = "retry";
         } else if (result === undefined) {
           try {
-            await file.appendFile(params.line, { encoding: "utf8" });
+            await appendRecorderText(file, params.line, recorderFileSize(stats.size));
             await file.sync();
             if (
               !(await recorderPathHasIdentity(params.publicationPath, identity)) ||

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -140,6 +140,16 @@ async function openRecorderFile(
   filePath: string,
 ): Promise<{ created: boolean; file: Awaited<ReturnType<typeof open>> }> {
   try {
+    const existing = await lstat(filePath);
+    if (existing.isFile?.() === false) {
+      throw new Error(`Server recorder path is not a regular file: ${filePath}`);
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
+  try {
     return {
       created: true,
       file: await open(filePath, "ax+", 0o600),
@@ -270,8 +280,12 @@ function recorderIdentity(stats: { dev?: bigint; ino?: bigint }): string | undef
 function requireRecorderFileIdentity(stats: {
   dev?: bigint;
   ino?: bigint;
+  isFile?: () => boolean;
   nlink?: bigint;
 }): RecorderFileIdentity {
+  if (stats.isFile?.() === false) {
+    throw new Error("Server recorder path is not a regular file.");
+  }
   if (stats.dev === undefined || stats.ino === undefined) {
     throw new Error("Server recorder file identity is unavailable.");
   }
@@ -290,7 +304,11 @@ async function recorderPathHasIdentity(
   expectedIdentity: string,
 ): Promise<boolean> {
   try {
-    return recorderIdentity(await statPath(filePath, { bigint: true })) === expectedIdentity;
+    const stats = await statPath(filePath, { bigint: true });
+    if (stats.isFile?.() === false) {
+      throw new Error(`Server recorder path is not a regular file: ${filePath}`);
+    }
+    return recorderIdentity(stats) === expectedIdentity;
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
       return false;
@@ -558,7 +576,21 @@ async function recorderProcessLockTarget(filePath: string): Promise<string> {
   return serverRecorderWindowsLockPath(root, filePath);
 }
 
-async function recorderIdentityLockTarget(fileIdentity: RecorderFileIdentity): Promise<string> {
+async function recorderLocalIdentityLockTarget(
+  fileIdentity: RecorderFileIdentity,
+): Promise<string> {
+  if (process.platform === "win32") {
+    const root = await secureServerRecorderWindowsLockRoot(serverRecorderWindowsLockRoot());
+    return recorderIdentityLockPath(root, fileIdentity);
+  }
+  const currentUserId = process.geteuid?.();
+  if (currentUserId === undefined) {
+    throw new Error("Server recorder identity locking requires a current user id.");
+  }
+  return recorderIdentityLockPath(await serverRecorderUnixLockRoot(currentUserId), fileIdentity);
+}
+
+async function recorderIdentityLockTargets(fileIdentity: RecorderFileIdentity): Promise<string[]> {
   const configuredRoot = process.env[RECORDER_LOCK_DIRECTORY_ENV]?.trim();
   if (!configuredRoot) {
     if (fileIdentity.nlink > 1n) {
@@ -566,21 +598,16 @@ async function recorderIdentityLockTarget(fileIdentity: RecorderFileIdentity): P
         `Server recorder hardlinks require ${RECORDER_LOCK_DIRECTORY_ENV} to name one shared writable lock directory for every writer.`,
       );
     }
-    if (process.platform === "win32") {
-      const root = await secureServerRecorderWindowsLockRoot(serverRecorderWindowsLockRoot());
-      return recorderIdentityLockPath(root, fileIdentity);
-    }
-    const currentUserId = process.geteuid?.();
-    if (currentUserId === undefined) {
-      throw new Error("Server recorder identity locking requires a current user id.");
-    }
-    return recorderIdentityLockPath(await serverRecorderUnixLockRoot(currentUserId), fileIdentity);
+    return [await recorderLocalIdentityLockTarget(fileIdentity)];
   }
   if (!path.isAbsolute(configuredRoot)) {
     throw new Error(`${RECORDER_LOCK_DIRECTORY_ENV} must be an absolute path.`);
   }
   const sharedRoot = await secureRecorderLockRoot(configuredRoot);
-  return recorderSharedIdentityLockPath(sharedRoot, fileIdentity);
+  return [
+    await recorderLocalIdentityLockTarget(fileIdentity),
+    recorderSharedIdentityLockPath(sharedRoot, fileIdentity),
+  ];
 }
 
 async function acquireSingleRecorderLock(filePath: string): Promise<() => Promise<void>> {
@@ -650,7 +677,28 @@ async function acquireRecorderLock(
 async function acquireRecorderIdentityLock(
   identity: RecorderFileIdentity,
 ): Promise<() => Promise<void>> {
-  return await acquireRecorderLock(await recorderIdentityLockTarget(identity), false);
+  const releases: Array<() => Promise<void>> = [];
+  try {
+    for (const target of await recorderIdentityLockTargets(identity)) {
+      releases.push(await acquireRecorderLock(target, false));
+    }
+  } catch (error) {
+    const releaseResults = await Promise.allSettled(
+      releases.reverse().map(async (release) => release()),
+    );
+    const releaseErrors = releaseResults
+      .filter((result): result is PromiseRejectedResult => result.status === "rejected")
+      .map((result) => result.reason);
+    if (releaseErrors.length > 0) {
+      throw new AggregateError(
+        [error, ...releaseErrors],
+        "Server recorder identity lock acquisition and cleanup both failed.",
+        { cause: error },
+      );
+    }
+    throw error;
+  }
+  return async () => await releaseRecorderLockSet(releases);
 }
 
 async function withRecorderLock(
@@ -752,9 +800,12 @@ async function appendRecorderAttempt(params: {
       releaseIdentityLock = await acquireRecorderIdentityLock(lockedIdentity);
       // Lock acquisition may have blocked while another writer repaired or appended.
       let stats = await file.stat({ bigint: true });
+      const currentIdentity = requireRecorderFileIdentity(stats);
       identity = requireRecorderIdentity(stats);
       if (
-        identity !== `${lockedIdentity.dev}:${lockedIdentity.ino}` ||
+        currentIdentity.dev !== lockedIdentity.dev ||
+        currentIdentity.ino !== lockedIdentity.ino ||
+        currentIdentity.nlink !== lockedIdentity.nlink ||
         !(await recorderPathHasIdentity(params.publicationPath, identity))
       ) {
         result = "retry";

--- a/test/recorder-concurrency.test.ts
+++ b/test/recorder-concurrency.test.ts
@@ -570,6 +570,54 @@ describe("recorder append serialization", () => {
     },
   );
 
+  it.skipIf(process.platform === "win32")(
+    "keeps configured and local identity locks distinct when their roots match",
+    async () => {
+      const homeDirectory = await mkdtemp(path.join(tmpdir(), "crabline-server-lock-home-"));
+      const lockRoot = path.join(homeDirectory, ".cache", "crabline", "locks", "server-recorder");
+      await mkdir(lockRoot, { mode: 0o700, recursive: true });
+      const canonicalLockRoot = await realpath(lockRoot);
+      const recorderPath = path.join(
+        "/tmp",
+        `crabline-server-recorder-aliased-lock-root-${process.pid}-${Date.now()}.jsonl`,
+      );
+      const actualOs = await vi.importActual<typeof import("node:os")>("node:os");
+      osMocks.userInfo.mockImplementationOnce(() => ({
+        ...actualOs.userInfo(),
+        homedir: homeDirectory,
+      }));
+      fsMocks.serverDirectory = await realpath(path.dirname(recorderPath));
+      fsMocks.serverWrite.mockResolvedValue(undefined);
+      fsMocks.serverFileStat.mockResolvedValue({ dev: 1, ino: 2, nlink: 1, size: 0 });
+      fsMocks.serverStat.mockResolvedValue({ dev: 1, ino: 2, size: 0 });
+      vi.stubEnv("CRABLINE_RECORDER_LOCK_DIR", canonicalLockRoot);
+
+      try {
+        await expect(
+          recordServerEvent({
+            event: {
+              at: "2026-07-12T10:00:00.000Z",
+              method: "POST",
+              path: "/aliased-lock-root",
+              query: {},
+              type: "api",
+            },
+            onEvent: undefined,
+            recorderPath,
+          }),
+        ).resolves.toBeUndefined();
+
+        expect(fsMocks.lock.mock.calls.map(([lockPath]) => String(lockPath))).toEqual([
+          path.join(fsMocks.serverDirectory, path.basename(recorderPath)),
+          path.join(canonicalLockRoot, "recorder-1-2"),
+          path.join(canonicalLockRoot, "recorder-2"),
+        ]);
+      } finally {
+        await rm(homeDirectory, { force: true, recursive: true });
+      }
+    },
+  );
+
   it("rejects hardlinked server recorders without a shared lock namespace", async () => {
     const recorderPath = path.join(
       "/tmp",

--- a/test/recorder-concurrency.test.ts
+++ b/test/recorder-concurrency.test.ts
@@ -509,6 +509,46 @@ describe("recorder append serialization", () => {
     },
   );
 
+  it.skipIf(process.platform === "win32")(
+    "locks single-link recorders in the configured shared namespace",
+    async () => {
+      const lockRoot = await mkdtemp(path.join(tmpdir(), "crabline-server-shared-lock-"));
+      const canonicalLockRoot = await realpath(lockRoot);
+      const recorderPath = path.join(
+        "/tmp",
+        `crabline-server-recorder-single-link-${process.pid}-${Date.now()}.jsonl`,
+      );
+      fsMocks.serverDirectory = await realpath(path.dirname(recorderPath));
+      fsMocks.serverWrite.mockResolvedValue(undefined);
+      fsMocks.serverFileStat.mockResolvedValue({ dev: 1, ino: 2, nlink: 1, size: 0 });
+      fsMocks.serverStat.mockResolvedValue({ dev: 1, ino: 2, size: 0 });
+      vi.stubEnv("CRABLINE_RECORDER_LOCK_DIR", canonicalLockRoot);
+
+      try {
+        await expect(
+          recordServerEvent({
+            event: {
+              at: "2026-07-12T10:00:00.000Z",
+              method: "POST",
+              path: "/single-link-shared-lock",
+              query: {},
+              type: "api",
+            },
+            onEvent: undefined,
+            recorderPath,
+          }),
+        ).resolves.toBeUndefined();
+
+        expect(fsMocks.lock).toHaveBeenCalledTimes(3);
+        expect(fsMocks.lock.mock.calls.map(([lockPath]) => String(lockPath))).toContain(
+          path.join(canonicalLockRoot, "recorder-2"),
+        );
+      } finally {
+        await rm(lockRoot, { force: true, recursive: true });
+      }
+    },
+  );
+
   it("rejects hardlinked server recorders without a shared lock namespace", async () => {
     const recorderPath = path.join(
       "/tmp",

--- a/test/recorder-concurrency.test.ts
+++ b/test/recorder-concurrency.test.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { constants as fsConstants } from "node:fs";
 import {
   chmod,
   link,
@@ -40,11 +41,14 @@ const fsMocks = vi.hoisted(() => ({
   serverFileExists: false,
   serverFileStat:
     vi.fn<() => Promise<{ dev: number; ino: number; nlink?: number; size: number }>>(),
-  serverOpen: vi.fn<(filePath: string, flags: string) => void>(),
+  serverOpen: vi.fn<(filePath: string, flags: number | string) => void>(),
   serverStat: vi.fn<(filePath: string) => Promise<{ dev: number; ino: number; size: number }>>(),
   serverSync: vi.fn<(filePath: string) => Promise<void>>(),
   serverWrite: vi.fn<(filePath: string, data: string) => Promise<void>>(),
 }));
+
+const serverRecorderExistingOpenFlags =
+  fsConstants.O_RDWR | fsConstants.O_APPEND | fsConstants.O_NONBLOCK | fsConstants.O_NOFOLLOW;
 
 const osMocks = vi.hoisted(() => ({
   userInfo: vi.fn<typeof import("node:os").userInfo>(),
@@ -72,6 +76,12 @@ vi.mock("node:fs/promises", async (importOriginal) => {
   return {
     ...actual,
     lstat: async (...args: Parameters<typeof actual.lstat>) => {
+      if (process.platform === "win32" && String(args[0]).includes("crabline-server-recorder")) {
+        return {
+          isFile: () => true,
+          isSymbolicLink: () => false,
+        } as Awaited<ReturnType<typeof actual.lstat>>;
+      }
       if (
         String(args[0]) === fsMocks.providerRecorderPath &&
         fsMocks.providerLstatFailure &&
@@ -103,7 +113,7 @@ vi.mock("node:fs/promises", async (importOriginal) => {
         } as unknown as Awaited<ReturnType<typeof actual.open>>;
       }
       if (
-        (args[1] === "a+" || args[1] === "ax+") &&
+        (args[1] === "a+" || args[1] === "ax+" || args[1] === serverRecorderExistingOpenFlags) &&
         filePath.includes("crabline-server-recorder")
       ) {
         fsMocks.serverOpen(filePath, args[1]);
@@ -119,6 +129,13 @@ vi.mock("node:fs/promises", async (importOriginal) => {
           stat: async () => await fsMocks.serverFileStat(),
           sync: async () => await fsMocks.serverSync(filePath),
           truncate: async () => {},
+          write: async (buffer: Buffer, offset: number, length: number) => {
+            await fsMocks.serverWrite(
+              filePath,
+              buffer.subarray(offset, offset + length).toString("utf8"),
+            );
+            return { buffer, bytesWritten: length };
+          },
         } as unknown as Awaited<ReturnType<typeof actual.open>>;
       }
       if (
@@ -301,7 +318,11 @@ describe("recorder append serialization", () => {
     expect(unixIdentityLockPaths).toEqual(
       process.platform === "win32" ? [] : [unixIdentityLockPaths[0]!, unixIdentityLockPaths[0]!],
     );
-    expect(fsMocks.serverOpen.mock.calls.map(([, flags]) => flags)).toEqual(["ax+", "ax+", "a+"]);
+    expect(fsMocks.serverOpen.mock.calls.map(([, flags]) => flags)).toEqual([
+      "ax+",
+      "ax+",
+      process.platform === "win32" ? "r+" : serverRecorderExistingOpenFlags,
+    ]);
   });
 
   it.skipIf(process.platform === "win32")(

--- a/test/recorder-concurrency.test.ts
+++ b/test/recorder-concurrency.test.ts
@@ -428,11 +428,15 @@ describe("recorder append serialization", () => {
       fsMocks.serverFileStat.mockResolvedValue({ dev: 1, ino: 1, nlink: 2, size: 0 });
       vi.stubEnv("CRABLINE_RECORDER_LOCK_DIR", await realpath(tmpdir()));
       const pathRelease = vi.fn(async () => {});
+      const localIdentityRelease = vi.fn(async () => {});
       const releaseFailure = new Error("identity lock cleanup failed");
-      const identityRelease = vi.fn(async () => {
+      const sharedIdentityRelease = vi.fn(async () => {
         throw releaseFailure;
       });
-      fsMocks.lock.mockResolvedValueOnce(pathRelease).mockResolvedValueOnce(identityRelease);
+      fsMocks.lock
+        .mockResolvedValueOnce(pathRelease)
+        .mockResolvedValueOnce(localIdentityRelease)
+        .mockResolvedValueOnce(sharedIdentityRelease);
       const observer = vi.fn();
 
       await expect(
@@ -455,7 +459,8 @@ describe("recorder append serialization", () => {
       });
       expect(observer).not.toHaveBeenCalled();
       expect(pathRelease).toHaveBeenCalledOnce();
-      expect(identityRelease).toHaveBeenCalledOnce();
+      expect(localIdentityRelease).toHaveBeenCalledOnce();
+      expect(sharedIdentityRelease).toHaveBeenCalledOnce();
       expect(
         fsMocks.lock.mock.calls.some(([lockPath]) =>
           path.basename(String(lockPath)).startsWith("recorder-"),
@@ -479,7 +484,11 @@ describe("recorder append serialization", () => {
         code: "ENOSPC",
       });
       const pathRelease = vi.fn(async () => {});
-      fsMocks.lock.mockResolvedValueOnce(pathRelease).mockRejectedValueOnce(sharedFailure);
+      const localIdentityRelease = vi.fn(async () => {});
+      fsMocks.lock
+        .mockResolvedValueOnce(pathRelease)
+        .mockResolvedValueOnce(localIdentityRelease)
+        .mockRejectedValueOnce(sharedFailure);
 
       await expect(
         recordServerEvent({
@@ -496,6 +505,7 @@ describe("recorder append serialization", () => {
       ).rejects.toBe(sharedFailure);
       expect(fsMocks.serverWrite).not.toHaveBeenCalled();
       expect(pathRelease).toHaveBeenCalledOnce();
+      expect(localIdentityRelease).toHaveBeenCalledOnce();
     },
   );
 

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -19,10 +19,12 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   applyOwnerOnlyWindowsDirectoryAcl,
   createOwnerOnlyWindowsDirectory,
+  readWindowsDirectoryNamespaceSecuritySnapshot,
   readWindowsDirectorySecurityDescriptor,
   readWindowsDirectorySecuritySnapshot,
   type WindowsAclRunner,
 } from "../src/platform/windows-acl.js";
+import { isManagedRecorderDirectory } from "../src/platform/recorder-directory.js";
 import {
   appendRecordedInbound,
   appendRecordedInboundBatch,
@@ -568,9 +570,21 @@ describe("recorder", () => {
     expect(script).toContain("RawSecurityDescriptor");
     expect(script).toContain("DiscretionaryAclPresent");
     expect(script).toContain("Private directory parent namespace has a null DACL.");
+    expect(script).toContain("CreateDirectories");
+    expect(script).toContain("WriteData");
+    expect(script).toContain("WriteAttributes");
+    expect(script).toContain("[int64]0x40000000");
     expect(script).toContain("DeleteSubdirectoriesAndFiles");
+    expect(script).toContain("Assert-SafeNamespaceChain $current ($missing.Count -gt 0)");
     expect(script).toContain("Private directory parent namespace permits untrusted replacement.");
-    expect(script).toContain("[CrablineWindowsDirectoryHandle]::Create(\n      $candidate,");
+    expect(script).toContain("[CrablineWindowsDirectoryHandle]::Create(");
+    expect(script).toContain("catch [System.ComponentModel.Win32Exception]");
+    expect(script).toContain("$_.Exception.NativeErrorCode -ne 80");
+    expect(script).toContain("$_.Exception.NativeErrorCode -ne 183");
+    expect(script).toContain(
+      "[void][CrablineWindowsDirectoryHandle]::ReadIdentity($createdDirectory)",
+    );
+    expect(script).toContain("[CrablineWindowsDirectoryHandle]::WriteSecurityDescriptor(");
     expect(script).toContain("AssertSamePathIdentity");
     expect(script).not.toContain("[System.IO.Directory]::CreateDirectory(");
     expect(script).not.toContain("$directory.SetAccessControl($acl)");
@@ -629,10 +643,45 @@ describe("recorder", () => {
     );
     expect(script).toContain("[CrablineWindowsDirectoryHandle]::AssertSamePathIdentity(");
     expect(script).toContain("[Convert]::ToBase64String($descriptor)");
+    expect(script).toContain("Assert-SafeNamespaceChain $parent.FullName $false");
+    expect(script).toContain("RawSecurityDescriptor");
+    expect(script).toContain("Private directory must not be a reparse point.");
+    expect(script).toContain("Private directory parent namespace has a null DACL.");
+    expect(script).toContain("$rejectChildCreationAtCandidate = $false");
+    expect(script).toContain("Private directory parent namespace permits untrusted replacement.");
     expect(script).not.toContain("Get-Acl");
     expect(options.env.CRABLINE_PRIVATE_DIRECTORY_PATH).toBe(path.resolve(directoryPath));
     expect(options.killSignal).toBe("SIGKILL");
     expect(options.timeout).toBe(15_000);
+  });
+
+  it("validates a Windows directory namespace without requiring an owner-only ACL", async () => {
+    const calls: Parameters<WindowsAclRunner>[] = [];
+    const run: WindowsAclRunner = async (...args) => {
+      calls.push(args);
+      return `${stableWindowsDirectoryIdentity}\r\ndescriptor-base64`;
+    };
+    const directoryPath = String.raw`C:\Temp\custom-recorder`;
+
+    await expect(
+      readWindowsDirectoryNamespaceSecuritySnapshot(directoryPath, run, String.raw`C:\Windows`),
+    ).resolves.toEqual({
+      identity: stableWindowsDirectoryIdentity,
+      securityDescriptor: "descriptor-base64",
+    });
+
+    const [, args, options] = calls[0]!;
+    const script = args.at(-1);
+    expect(script).toContain("Assert-SafeNamespaceChain $directoryPath $true");
+    expect(script).toContain("[CrablineWindowsDirectoryHandle]::Open($directoryPath, $false)");
+    expect(script).toContain("[CrablineWindowsDirectoryHandle]::AssertSamePathIdentity(");
+    expect(script).not.toContain("[CrablineWindowsDirectoryHandle]::WriteSecurityDescriptor(");
+    expect(options.env.CRABLINE_PRIVATE_DIRECTORY_PATH).toBe(path.resolve(directoryPath));
+  });
+
+  it("matches managed Windows recorder directories case-insensitively", () => {
+    expect(isManagedRecorderDirectory(path.resolve("ARTIFACTS", "CRABLINE"), "win32")).toBe(true);
+    expect(isManagedRecorderDirectory(path.resolve(".CRABLINE", "SERVERS"), "win32")).toBe(true);
   });
 
   it.runIf(process.platform === "win32")(
@@ -643,6 +692,25 @@ describe("recorder", () => {
       const lockRoot = path.join(directory, "new-lock-root");
 
       await expect(createOwnerOnlyWindowsDirectory(lockRoot)).resolves.toBeUndefined();
+      await expect(stat(lockRoot)).resolves.toMatchObject({
+        isDirectory: expect.any(Function),
+      });
+    },
+  );
+
+  it.runIf(process.platform === "win32")(
+    "handles concurrent Windows recorder lock-root creation",
+    async () => {
+      const directory = await createTempDir();
+      directories.push(directory);
+      const lockRoot = path.join(directory, "concurrent-lock-root");
+
+      await expect(
+        Promise.all([
+          createOwnerOnlyWindowsDirectory(lockRoot),
+          createOwnerOnlyWindowsDirectory(lockRoot),
+        ]),
+      ).resolves.toEqual([undefined, undefined]);
       await expect(stat(lockRoot)).resolves.toMatchObject({
         isDirectory: expect.any(Function),
       });
@@ -744,6 +812,26 @@ describe("recorder", () => {
   );
 
   it.runIf(process.platform === "win32")(
+    "does not create Windows recorder lock roots through intermediate junctions",
+    async () => {
+      const directory = await createTempDir();
+      directories.push(directory);
+      const target = path.join(directory, "target");
+      const junction = path.join(directory, "junction");
+      const lockRoot = path.join(junction, "lock-root");
+      await mkdir(target);
+      await symlink(target, junction, "junction");
+
+      await expect(createOwnerOnlyWindowsDirectory(lockRoot)).rejects.toThrow(
+        "Could not atomically create or verify an owner-only Windows directory",
+      );
+      await expect(stat(path.join(target, "lock-root"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    },
+  );
+
+  it.runIf(process.platform === "win32")(
     "rejects Windows recorder lock roots beneath a null-DACL parent",
     async () => {
       const directory = await createTempDir();
@@ -808,6 +896,176 @@ describe("recorder", () => {
 
       await expect(secureProviderRecorderLockRoot(lockRoot, undefined)).resolves.toBe(lockRoot);
       await expect(readWindowsDirectorySecurityDescriptor(lockRoot)).resolves.toEqual(
+        expect.any(String),
+      );
+    },
+  );
+
+  it.runIf(process.platform === "win32")(
+    "rejects cached Windows recorder lock roots after their parent becomes replaceable",
+    async () => {
+      const directory = await createTempDir();
+      directories.push(directory);
+      const parent = path.join(directory, "replaceable-parent");
+      const lockRoot = path.join(parent, "lock-root");
+      await mkdir(parent);
+
+      await expect(secureProviderRecorderLockRoot(lockRoot, undefined)).resolves.toBe(lockRoot);
+      execFileSync("icacls.exe", [parent, "/grant", "*S-1-1-0:(OI)(CI)(F)"], { windowsHide: true });
+
+      try {
+        await expect(secureProviderRecorderLockRoot(lockRoot, undefined)).rejects.toThrow(
+          "Could not atomically create or verify an owner-only Windows directory",
+        );
+      } finally {
+        execFileSync("icacls.exe", [parent, "/remove:g", "*S-1-1-0"], {
+          windowsHide: true,
+        });
+      }
+    },
+  );
+
+  it.runIf(process.platform === "win32")(
+    "rejects Windows recorder lock-root parents with untrusted child-creation rights",
+    async () => {
+      const directory = await createTempDir();
+      directories.push(directory);
+      const parent = path.join(directory, "creatable-parent");
+      const lockRoot = path.join(parent, "lock-root");
+      await mkdir(parent);
+      execFileSync("icacls.exe", [parent, "/grant", "*S-1-1-0:(AD)"], {
+        windowsHide: true,
+      });
+
+      try {
+        await expect(createOwnerOnlyWindowsDirectory(lockRoot)).rejects.toThrow(
+          "Could not atomically create or verify an owner-only Windows directory",
+        );
+        await expect(stat(lockRoot)).rejects.toMatchObject({ code: "ENOENT" });
+      } finally {
+        execFileSync("icacls.exe", [parent, "/remove:g", "*S-1-1-0"], {
+          windowsHide: true,
+        });
+      }
+    },
+  );
+
+  it.runIf(process.platform === "win32")(
+    "rejects Windows recorder lock-root parents with untrusted reparse mutation rights",
+    async () => {
+      const directory = await createTempDir();
+      directories.push(directory);
+      for (const [name, rights] of [
+        ["specific", "WD,WA"],
+        ["generic", "GW"],
+      ] as const) {
+        const parent = path.join(directory, `${name}-mutable-parent`);
+        const lockRoot = path.join(parent, "lock-root");
+        await mkdir(parent);
+        execFileSync("icacls.exe", [parent, "/grant", `*S-1-1-0:(${rights})`], {
+          windowsHide: true,
+        });
+
+        try {
+          await expect(createOwnerOnlyWindowsDirectory(lockRoot)).rejects.toThrow(
+            "Could not atomically create or verify an owner-only Windows directory",
+          );
+          await expect(stat(lockRoot)).rejects.toMatchObject({ code: "ENOENT" });
+        } finally {
+          execFileSync("icacls.exe", [parent, "/remove:g", "*S-1-1-0"], {
+            windowsHide: true,
+          });
+        }
+      }
+    },
+  );
+
+  it.runIf(process.platform === "win32")(
+    "rejects unsafe Windows provider recorder parents without changing their ACLs",
+    async () => {
+      const directory = await createTempDir();
+      directories.push(directory);
+      const filePath = path.join(directory, "provider.jsonl");
+      execFileSync("icacls.exe", [directory, "/grant", "*S-1-1-0:(OI)(CI)(F)"], {
+        windowsHide: true,
+      });
+      const before = execFileSync("icacls.exe", [directory], {
+        encoding: "utf8",
+        windowsHide: true,
+      });
+
+      await expect(
+        appendRecordedInbound(filePath, {
+          author: "assistant",
+          id: "unsafe-parent",
+          provider: "slack",
+          sentAt: new Date().toISOString(),
+          text: "private",
+          threadId: "slack:C123",
+        }),
+      ).rejects.toThrow("Could not validate the Windows directory namespace");
+
+      const after = execFileSync("icacls.exe", [directory], {
+        encoding: "utf8",
+        windowsHide: true,
+      });
+      expect(after).toBe(before);
+      await expect(stat(filePath)).rejects.toMatchObject({ code: "ENOENT" });
+    },
+  );
+
+  it.runIf(process.platform === "win32")(
+    "rejects child-inheritable Windows recorder ACLs without changing them",
+    async () => {
+      const directory = await createTempDir();
+      directories.push(directory);
+      const filePath = path.join(directory, "provider.jsonl");
+      execFileSync("icacls.exe", [directory, "/grant", "*S-1-1-0:(OI)(IO)(M)"], {
+        windowsHide: true,
+      });
+      const before = execFileSync("icacls.exe", [directory], {
+        encoding: "utf8",
+        windowsHide: true,
+      });
+
+      await expect(
+        appendRecordedInbound(filePath, {
+          author: "assistant",
+          id: "inherited-unsafe-parent",
+          provider: "slack",
+          sentAt: new Date().toISOString(),
+          text: "private",
+          threadId: "slack:C123",
+        }),
+      ).rejects.toThrow("Could not validate the Windows directory namespace");
+
+      const after = execFileSync("icacls.exe", [directory], {
+        encoding: "utf8",
+        windowsHide: true,
+      });
+      expect(after).toBe(before);
+      await expect(stat(filePath)).rejects.toMatchObject({ code: "ENOENT" });
+    },
+  );
+
+  it.runIf(process.platform === "win32")(
+    "creates missing Windows provider recorder parents with owner-only ACLs",
+    async () => {
+      const directory = await createTempDir();
+      directories.push(directory);
+      const parent = path.join(directory, "private-recorder");
+      const filePath = path.join(parent, "provider.jsonl");
+
+      await appendRecordedInbound(filePath, {
+        author: "assistant",
+        id: "private-parent",
+        provider: "slack",
+        sentAt: new Date().toISOString(),
+        text: "private",
+        threadId: "slack:C123",
+      });
+
+      await expect(readWindowsDirectorySecurityDescriptor(parent)).resolves.toEqual(
         expect.any(String),
       );
     },

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -20,6 +20,7 @@ import {
   applyOwnerOnlyWindowsDirectoryAcl,
   createOwnerOnlyWindowsDirectory,
   readWindowsDirectorySecurityDescriptor,
+  readWindowsDirectorySecuritySnapshot,
   type WindowsAclRunner,
 } from "../src/platform/windows-acl.js";
 import {
@@ -35,7 +36,11 @@ import {
 import { createTempDir, disposeTempDir } from "./test-helpers.js";
 
 const directories: string[] = [];
-const readOwnerOnlyWindowsDirectorySecurityDescriptor = async (): Promise<string> => "owner-only";
+const stableWindowsDirectoryIdentity = "10:00000000000000000000000000000014";
+const readOwnerOnlyWindowsDirectorySecuritySnapshot = async () => ({
+  identity: stableWindowsDirectoryIdentity,
+  securityDescriptor: "owner-only",
+});
 
 afterEach(async () => {
   await Promise.all(directories.splice(0).map(disposeTempDir));
@@ -258,7 +263,7 @@ describe("recorder", () => {
           await mkdir(directoryPath);
           secured.push(directoryPath);
         },
-        readWindowsDirectorySecurityDescriptor: readOwnerOnlyWindowsDirectorySecurityDescriptor,
+        readWindowsDirectorySecuritySnapshot: readOwnerOnlyWindowsDirectorySecuritySnapshot,
       }),
     ).resolves.toBe(lockRoot);
     await mkdir(path.join(lockRoot, "active-lock"));
@@ -268,7 +273,7 @@ describe("recorder", () => {
         createWindowsDirectory: async () => {
           throw new Error("cached Windows lock root was re-secured");
         },
-        readWindowsDirectorySecurityDescriptor: readOwnerOnlyWindowsDirectorySecurityDescriptor,
+        readWindowsDirectorySecuritySnapshot: readOwnerOnlyWindowsDirectorySecuritySnapshot,
       }),
     ).resolves.toBe(lockRoot);
 
@@ -286,14 +291,14 @@ describe("recorder", () => {
     await secureProviderRecorderLockRoot(lockRoot, undefined, {
       createWindowsDirectory,
       platform: "win32",
-      readWindowsDirectorySecurityDescriptor: readOwnerOnlyWindowsDirectorySecurityDescriptor,
+      readWindowsDirectorySecuritySnapshot: readOwnerOnlyWindowsDirectorySecuritySnapshot,
     });
     await rm(lockRoot, { force: true, recursive: true });
     await expect(
       secureProviderRecorderLockRoot(lockRoot, undefined, {
         createWindowsDirectory,
         platform: "win32",
-        readWindowsDirectorySecurityDescriptor: readOwnerOnlyWindowsDirectorySecurityDescriptor,
+        readWindowsDirectorySecuritySnapshot: readOwnerOnlyWindowsDirectorySecuritySnapshot,
       }),
     ).resolves.toBe(lockRoot);
     await expect(stat(lockRoot)).resolves.toBeDefined();
@@ -319,7 +324,7 @@ describe("recorder", () => {
     const options = {
       createWindowsDirectory,
       platform: "win32" as const,
-      readWindowsDirectorySecurityDescriptor: readOwnerOnlyWindowsDirectorySecurityDescriptor,
+      readWindowsDirectorySecuritySnapshot: readOwnerOnlyWindowsDirectorySecuritySnapshot,
     };
 
     await expect(secureProviderRecorderLockRoot(lockRoot, undefined, options)).rejects.toBe(
@@ -345,7 +350,7 @@ describe("recorder", () => {
     await secureProviderRecorderLockRoot(lockRoot, undefined, {
       createWindowsDirectory,
       platform: "win32",
-      readWindowsDirectorySecurityDescriptor: readOwnerOnlyWindowsDirectorySecurityDescriptor,
+      readWindowsDirectorySecuritySnapshot: readOwnerOnlyWindowsDirectorySecuritySnapshot,
     });
     await rm(lockRoot, { force: true, recursive: true });
     await mkdir(lockRoot);
@@ -353,12 +358,12 @@ describe("recorder", () => {
       secureProviderRecorderLockRoot(lockRoot, undefined, {
         createWindowsDirectory,
         platform: "win32",
-        readWindowsDirectorySecurityDescriptor: readOwnerOnlyWindowsDirectorySecurityDescriptor,
+        readWindowsDirectorySecuritySnapshot: readOwnerOnlyWindowsDirectorySecuritySnapshot,
       }),
       secureProviderRecorderLockRoot(lockRoot, undefined, {
         createWindowsDirectory,
         platform: "win32",
-        readWindowsDirectorySecurityDescriptor: readOwnerOnlyWindowsDirectorySecurityDescriptor,
+        readWindowsDirectorySecuritySnapshot: readOwnerOnlyWindowsDirectorySecuritySnapshot,
       }),
     ]);
 
@@ -376,7 +381,7 @@ describe("recorder", () => {
         createWindowsDirectory: async (directoryPath) => {
           await writeFile(directoryPath, "not a directory");
         },
-        readWindowsDirectorySecurityDescriptor: readOwnerOnlyWindowsDirectorySecurityDescriptor,
+        readWindowsDirectorySecuritySnapshot: readOwnerOnlyWindowsDirectorySecuritySnapshot,
       }),
     ).rejects.toThrow("Provider recorder lock directory is not a private directory.");
   });
@@ -392,12 +397,15 @@ describe("recorder", () => {
       await mkdir(directoryPath, { recursive: true });
       securityDescriptor = "owner-only";
     };
-    const readSecurityDescriptor = async () => securityDescriptor;
+    const readSecuritySnapshot = async () => ({
+      identity: stableWindowsDirectoryIdentity,
+      securityDescriptor,
+    });
 
     await secureProviderRecorderLockRoot(lockRoot, undefined, {
       createWindowsDirectory,
       platform: "win32",
-      readWindowsDirectorySecurityDescriptor: readSecurityDescriptor,
+      readWindowsDirectorySecuritySnapshot: readSecuritySnapshot,
     });
     await mkdir(path.join(lockRoot, "acl-change-trigger"));
     securityDescriptor = "unsafe";
@@ -406,7 +414,41 @@ describe("recorder", () => {
       secureProviderRecorderLockRoot(lockRoot, undefined, {
         createWindowsDirectory,
         platform: "win32",
-        readWindowsDirectorySecurityDescriptor: readSecurityDescriptor,
+        readWindowsDirectorySecuritySnapshot: readSecuritySnapshot,
+      }),
+    ).resolves.toBe(lockRoot);
+
+    expect(createCount).toBe(2);
+  });
+
+  it("re-secures a cached Windows recorder lock root when its handle identity changes", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const lockRoot = path.join(directory, "handle-replaced-locks");
+    let createCount = 0;
+    let handleIdentity = stableWindowsDirectoryIdentity;
+    const createWindowsDirectory = async (directoryPath: string) => {
+      createCount += 1;
+      await mkdir(directoryPath, { recursive: true });
+      handleIdentity = stableWindowsDirectoryIdentity;
+    };
+    const readSecuritySnapshot = async () => ({
+      identity: handleIdentity,
+      securityDescriptor: "owner-only",
+    });
+
+    await secureProviderRecorderLockRoot(lockRoot, undefined, {
+      createWindowsDirectory,
+      platform: "win32",
+      readWindowsDirectorySecuritySnapshot: readSecuritySnapshot,
+    });
+    handleIdentity = "10:00000000000000000000000000000015";
+
+    await expect(
+      secureProviderRecorderLockRoot(lockRoot, undefined, {
+        createWindowsDirectory,
+        platform: "win32",
+        readWindowsDirectorySecuritySnapshot: readSecuritySnapshot,
       }),
     ).resolves.toBe(lockRoot);
 
@@ -418,12 +460,15 @@ describe("recorder", () => {
     directories.push(directory);
     const lockRoot = path.join(directory, "active-locks");
     let descriptorReads = 0;
-    const readSecurityDescriptor = async () => {
+    const readSecuritySnapshot = async () => {
       descriptorReads += 1;
       if (descriptorReads === 2) {
         await mkdir(path.join(lockRoot, "concurrent-lock"));
       }
-      return "owner-only";
+      return {
+        identity: stableWindowsDirectoryIdentity,
+        securityDescriptor: "owner-only",
+      };
     };
     const createWindowsDirectory = async (directoryPath: string) => {
       await mkdir(directoryPath, { recursive: true });
@@ -432,7 +477,7 @@ describe("recorder", () => {
     await secureProviderRecorderLockRoot(lockRoot, undefined, {
       createWindowsDirectory,
       platform: "win32",
-      readWindowsDirectorySecurityDescriptor: readSecurityDescriptor,
+      readWindowsDirectorySecuritySnapshot: readSecuritySnapshot,
     });
     await mkdir(path.join(lockRoot, "acl-check-trigger"));
 
@@ -440,7 +485,7 @@ describe("recorder", () => {
       secureProviderRecorderLockRoot(lockRoot, undefined, {
         createWindowsDirectory,
         platform: "win32",
-        readWindowsDirectorySecurityDescriptor: readSecurityDescriptor,
+        readWindowsDirectorySecuritySnapshot: readSecuritySnapshot,
       }),
     ).resolves.toBe(lockRoot);
 
@@ -457,19 +502,22 @@ describe("recorder", () => {
       createCount += 1;
       await mkdir(directoryPath, { recursive: true });
     };
-    const readSecurityDescriptor = async () => {
+    const readSecuritySnapshot = async () => {
       descriptorReads += 1;
       if (descriptorReads === 3) {
         await rm(lockRoot, { force: true, recursive: true });
         throw Object.assign(new Error("lock root removed during Get-Acl"), { code: "ENOENT" });
       }
-      return "owner-only";
+      return {
+        identity: stableWindowsDirectoryIdentity,
+        securityDescriptor: "owner-only",
+      };
     };
 
     await secureProviderRecorderLockRoot(lockRoot, undefined, {
       createWindowsDirectory,
       platform: "win32",
-      readWindowsDirectorySecurityDescriptor: readSecurityDescriptor,
+      readWindowsDirectorySecuritySnapshot: readSecuritySnapshot,
     });
     await mkdir(path.join(lockRoot, "acl-check-trigger"));
 
@@ -477,7 +525,7 @@ describe("recorder", () => {
       secureProviderRecorderLockRoot(lockRoot, undefined, {
         createWindowsDirectory,
         platform: "win32",
-        readWindowsDirectorySecurityDescriptor: readSecurityDescriptor,
+        readWindowsDirectorySecuritySnapshot: readSecuritySnapshot,
       }),
     ).resolves.toBe(lockRoot);
 
@@ -499,7 +547,7 @@ describe("recorder", () => {
     const [, args, options] = calls[0]!;
     const script = args.at(-1)!;
     expect(script).toContain("[System.Security.AccessControl.DirectorySecurity]::new()");
-    expect(script).toContain("[System.IO.Directory]::Exists($directoryPath)");
+    expect(script).toContain("[System.IO.Directory]::Exists($current)");
     expect(script).toContain("$directoryPath.TrimEnd(");
     expect(script).toContain("NtCreateFile(");
     expect(script).toContain("FileCreate");
@@ -516,7 +564,12 @@ describe("recorder", () => {
     expect(script).toContain("FileIdInfoClass");
     expect(script).toContain("GetSecurityInfo(");
     expect(script).toContain("SetSecurityInfo(");
+    expect(script).toContain("Assert-SafeParentNamespace");
+    expect(script).toContain("DeleteSubdirectoriesAndFiles");
+    expect(script).toContain("Private directory parent namespace permits untrusted replacement.");
+    expect(script).toContain("[CrablineWindowsDirectoryHandle]::Create(\n      $candidate,");
     expect(script).toContain("AssertSamePathIdentity");
+    expect(script).not.toContain("[System.IO.Directory]::CreateDirectory(");
     expect(script).not.toContain("$directory.SetAccessControl($acl)");
     expect(options.env.CRABLINE_PRIVATE_DIRECTORY_PATH).toBe(path.resolve(directoryPath));
     expect(options.killSignal).toBe("SIGKILL");
@@ -547,24 +600,33 @@ describe("recorder", () => {
     expect(options.timeout).toBe(15_000);
   });
 
-  it("reads a stable Windows directory security descriptor fingerprint", async () => {
+  it("reads Windows directory identity and ACL from one no-follow handle", async () => {
     const calls: Parameters<WindowsAclRunner>[] = [];
     const run: WindowsAclRunner = async (...args) => {
       calls.push(args);
-      return "descriptor-base64\r\n";
+      return `${stableWindowsDirectoryIdentity}\r\ndescriptor-base64`;
     };
     const directoryPath = String.raw`C:\Temp\crabline-recorder-locks`;
 
     await expect(
-      readWindowsDirectorySecurityDescriptor(directoryPath, run, String.raw`C:\Windows`),
-    ).resolves.toBe("descriptor-base64");
+      readWindowsDirectorySecuritySnapshot(directoryPath, run, String.raw`C:\Windows`),
+    ).resolves.toEqual({
+      identity: stableWindowsDirectoryIdentity,
+      securityDescriptor: "descriptor-base64",
+    });
 
     const [, args, options] = calls[0]!;
     const script = args.at(-1);
     expect(script).toContain("AreAccessRulesProtected");
     expect(script).toContain("$rules.Count -ne 1");
-    expect(script).toContain("GetSecurityDescriptorBinaryForm()");
+    expect(script).toContain("[CrablineWindowsDirectoryHandle]::Open($directoryPath, $false)");
+    expect(script).toContain("[CrablineWindowsDirectoryHandle]::ReadIdentity($directory)");
+    expect(script).toContain(
+      "[CrablineWindowsDirectoryHandle]::ReadSecurityDescriptor($directory)",
+    );
+    expect(script).toContain("[CrablineWindowsDirectoryHandle]::AssertSamePathIdentity(");
     expect(script).toContain("[Convert]::ToBase64String($descriptor)");
+    expect(script).not.toContain("Get-Acl");
     expect(options.env.CRABLINE_PRIVATE_DIRECTORY_PATH).toBe(path.resolve(directoryPath));
     expect(options.killSignal).toBe("SIGKILL");
     expect(options.timeout).toBe(15_000);

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -1783,7 +1783,7 @@ describe("recorder", () => {
         cursor,
         filePath,
         matches: (event) => event.id === `bounded-${eventCount - 1}`,
-        timeoutMs: 30,
+        timeoutMs: 500,
       }),
     ).resolves.toMatchObject({ id: `bounded-${eventCount - 1}` });
     await expect(

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -565,6 +565,9 @@ describe("recorder", () => {
     expect(script).toContain("GetSecurityInfo(");
     expect(script).toContain("SetSecurityInfo(");
     expect(script).toContain("Assert-SafeParentNamespace");
+    expect(script).toContain("RawSecurityDescriptor");
+    expect(script).toContain("DiscretionaryAclPresent");
+    expect(script).toContain("Private directory parent namespace has a null DACL.");
     expect(script).toContain("DeleteSubdirectoriesAndFiles");
     expect(script).toContain("Private directory parent namespace permits untrusted replacement.");
     expect(script).toContain("[CrablineWindowsDirectoryHandle]::Create(\n      $candidate,");
@@ -737,6 +740,54 @@ describe("recorder", () => {
         "Could not atomically create or verify an owner-only Windows directory",
       );
       await expect(stat(missingTarget)).rejects.toMatchObject({ code: "ENOENT" });
+    },
+  );
+
+  it.runIf(process.platform === "win32")(
+    "rejects Windows recorder lock roots beneath a null-DACL parent",
+    async () => {
+      const directory = await createTempDir();
+      directories.push(directory);
+      const parent = path.join(directory, "null-dacl-parent");
+      const lockRoot = path.join(parent, "lock-root");
+      await mkdir(parent);
+
+      const powershellPath = path.join(
+        process.env.SystemRoot ?? String.raw`C:\Windows`,
+        "System32",
+        "WindowsPowerShell",
+        "v1.0",
+        "powershell.exe",
+      );
+      execFileSync(
+        powershellPath,
+        [
+          "-NoLogo",
+          "-NoProfile",
+          "-NonInteractive",
+          "-Command",
+          [
+            "$acl = Get-Acl -LiteralPath $env:CRABLINE_TEST_NULL_DACL",
+            [
+              '$acl.SetSecurityDescriptorSddlForm("D:NO_ACCESS_CONTROL",',
+              "[System.Security.AccessControl.AccessControlSections]::Access)",
+            ].join(" "),
+            "Set-Acl -LiteralPath $env:CRABLINE_TEST_NULL_DACL -AclObject $acl",
+          ].join("; "),
+        ],
+        {
+          env: {
+            ...process.env,
+            CRABLINE_TEST_NULL_DACL: parent,
+          },
+          windowsHide: true,
+        },
+      );
+
+      await expect(createOwnerOnlyWindowsDirectory(lockRoot)).rejects.toThrow(
+        "Could not atomically create or verify an owner-only Windows directory",
+      );
+      await expect(stat(lockRoot)).rejects.toMatchObject({ code: "ENOENT" });
     },
   );
 

--- a/test/script-provider-windows.test.ts
+++ b/test/script-provider-windows.test.ts
@@ -124,7 +124,7 @@ afterEach(() => {
 
 describe("script provider Windows cleanup", () => {
   it.each(["temp", "compile", "probe"] as const)(
-    "falls back to direct shell execution when Job Object helper %s is blocked",
+    "fails closed when Job Object helper %s is blocked",
     async (blockedStage) => {
       vi.resetModules();
       if (blockedStage === "temp") {
@@ -142,14 +142,12 @@ describe("script provider Windows cleanup", () => {
             throw new Error("blocked");
           });
       }
-      const scriptChild = createFakeChild(1110);
-      spawnMock.mockReturnValueOnce(scriptChild);
       const { ScriptProviderAdapter: IsolatedScriptProviderAdapter } =
         await import("../src/providers/builtin/script.js");
       const context = createContext();
       const provider = new IsolatedScriptProviderAdapter(context);
 
-      const failurePromise = provider
+      const failure = await provider
         .send({
           ...context,
           mode: "send",
@@ -157,15 +155,11 @@ describe("script provider Windows cleanup", () => {
           text: "payload",
         })
         .catch((error: unknown) => error);
-      await flushScriptSpawn();
-      scriptChild.emit("close", 7, null);
-      await failurePromise;
 
-      expect(spawnMock.mock.calls[0]?.[0]).toBe("node send.mjs");
-      expect(spawnMock.mock.calls[0]?.[1]).toMatchObject({
-        shell: true,
-        windowsHide: true,
-      });
+      expect(ensureErrorMessage(failure)).toContain("Script command failed to start.");
+      expect(ensureErrorMessage(failure)).toContain("Windows script Job Object helper");
+      expect(spawnMock).not.toHaveBeenCalled();
+      expect(rmSyncMock).toHaveBeenCalledTimes(blockedStage === "temp" ? 0 : 1);
     },
   );
 
@@ -174,15 +168,14 @@ describe("script provider Windows cleanup", () => {
     execFileMock.mockImplementationOnce(() => {
       throw new Error("transient bootstrap failure");
     });
-    const firstScriptChild = createFakeChild(1110);
     const secondScriptChild = createFakeChild(1111);
-    spawnMock.mockReturnValueOnce(firstScriptChild).mockReturnValueOnce(secondScriptChild);
+    spawnMock.mockReturnValueOnce(secondScriptChild);
     const { ScriptProviderAdapter: IsolatedScriptProviderAdapter } =
       await import("../src/providers/builtin/script.js");
     const context = createContext();
     const provider = new IsolatedScriptProviderAdapter(context);
 
-    const firstFailure = provider
+    const firstFailure = await provider
       .send({
         ...context,
         mode: "send",
@@ -190,9 +183,8 @@ describe("script provider Windows cleanup", () => {
         text: "payload",
       })
       .catch((error: unknown) => error);
-    await flushScriptSpawn();
-    firstScriptChild.emit("close", 7, null);
-    await firstFailure;
+    expect(ensureErrorMessage(firstFailure)).toContain("Windows script Job Object helper");
+    expect(spawnMock).not.toHaveBeenCalled();
 
     const secondFailure = provider
       .send({
@@ -207,8 +199,7 @@ describe("script provider Windows cleanup", () => {
     await secondFailure;
 
     expect(execFileMock).toHaveBeenCalledTimes(3);
-    expect(spawnMock.mock.calls[0]?.[0]).toBe("node send.mjs");
-    expect(spawnMock.mock.calls[1]?.[0]).toMatch(/crabline-script-job\.exe$/u);
+    expect(spawnMock.mock.calls[0]?.[0]).toMatch(/crabline-script-job\.exe$/u);
   });
 
   it("does not bootstrap the Job Object helper for an already-aborted spawn", async () => {

--- a/test/server-recorder-filesystem.test.ts
+++ b/test/server-recorder-filesystem.test.ts
@@ -16,6 +16,7 @@ import {
 import path from "node:path";
 import { lock } from "proper-lockfile";
 import { afterEach, expect, it, vi } from "vitest";
+import { readWindowsDirectorySecurityDescriptor } from "../src/platform/windows-acl.js";
 import type { ServerRequestEvent } from "../src/servers/http.js";
 import { recordServerEvent } from "../src/servers/recorder.js";
 import { createTempDir, disposeTempDir } from "./test-helpers.js";
@@ -63,7 +64,7 @@ it.skipIf(process.platform === "win32")(
       }),
     ).rejects.toThrow("Server recorder path is not a regular file.");
   },
-  1_000,
+  2_000,
 );
 
 it.runIf(process.platform === "win32")(
@@ -89,6 +90,60 @@ it.runIf(process.platform === "win32")(
       .split("\n")
       .map((line) => JSON.parse(line) as { path: string });
     expect(events.map((event) => event.path)).toEqual(["/existing", "/appended"]);
+  },
+);
+
+it.runIf(process.platform === "win32")(
+  "rejects an unsafe Windows recorder parent without changing its ACLs",
+  async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const recorderPath = path.join(directory, "server.jsonl");
+    await writeFile(recorderPath, `${JSON.stringify(serverEvent("/existing"))}\n`, "utf8");
+    execFileSync("icacls.exe", [directory, "/grant", "*S-1-1-0:(OI)(CI)(F)"], {
+      windowsHide: true,
+    });
+    const before = execFileSync("icacls.exe", [directory], {
+      encoding: "utf8",
+      windowsHide: true,
+    });
+
+    await expect(
+      recordServerEvent({
+        event: serverEvent("/appended"),
+        onEvent: undefined,
+        recorderPath,
+      }),
+    ).rejects.toThrow("Could not validate the Windows directory namespace");
+
+    const after = execFileSync("icacls.exe", [directory], {
+      encoding: "utf8",
+      windowsHide: true,
+    });
+    expect(after).toBe(before);
+    await expect(readFile(recorderPath, "utf8")).resolves.toBe(
+      `${JSON.stringify(serverEvent("/existing"))}\n`,
+    );
+  },
+);
+
+it.runIf(process.platform === "win32")(
+  "creates a missing Windows recorder parent with an owner-only ACL",
+  async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const parent = path.join(directory, "private-recorder");
+    const recorderPath = path.join(parent, "server.jsonl");
+
+    await recordServerEvent({
+      event: serverEvent("/created"),
+      onEvent: undefined,
+      recorderPath,
+    });
+
+    await expect(readWindowsDirectorySecurityDescriptor(parent)).resolves.toEqual(
+      expect.any(String),
+    );
   },
 );
 

--- a/test/server-recorder-filesystem.test.ts
+++ b/test/server-recorder-filesystem.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import {
   appendFile,
   chmod,
@@ -15,6 +16,7 @@ import {
 import path from "node:path";
 import { lock } from "proper-lockfile";
 import { afterEach, expect, it, vi } from "vitest";
+import type { ServerRequestEvent } from "../src/servers/http.js";
 import { recordServerEvent } from "../src/servers/recorder.js";
 import { createTempDir, disposeTempDir } from "./test-helpers.js";
 
@@ -28,6 +30,63 @@ afterEach(async () => {
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+function serverEvent(pathname: string): ServerRequestEvent {
+  return {
+    at: "2026-07-14T12:00:00.000Z",
+    method: "POST",
+    path: pathname,
+    query: {},
+    type: "api",
+  };
+}
+
+it.skipIf(process.platform === "win32")(
+  "rejects a FIFO recorder without waiting for a writer",
+  async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const recorderPath = path.join(directory, "server.jsonl");
+    execFileSync("mkfifo", [recorderPath]);
+
+    await expect(
+      recordServerEvent({
+        event: {
+          at: new Date().toISOString(),
+          method: "POST",
+          path: "/fifo",
+          query: {},
+          type: "api",
+        },
+        onEvent: undefined,
+        recorderPath,
+      }),
+    ).rejects.toThrow("Server recorder path is not a regular file.");
+  },
+  1_000,
+);
+
+it.runIf(process.platform === "win32")(
+  "appends through a validated existing Windows handle",
+  async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const recorderPath = path.join(directory, "server.jsonl");
+    await writeFile(recorderPath, JSON.stringify(serverEvent("/existing")), "utf8");
+
+    await recordServerEvent({
+      event: serverEvent("/appended"),
+      onEvent: undefined,
+      recorderPath,
+    });
+
+    const events = (await readFile(recorderPath, "utf8"))
+      .trimEnd()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { path: string });
+    expect(events.map((event) => event.path)).toEqual(["/existing", "/appended"]);
+  },
+);
 
 it.skipIf(process.platform === "win32")(
   "reacquires the matching lock when a recorder symlink is retargeted",

--- a/test/server-recorder-filesystem.test.ts
+++ b/test/server-recorder-filesystem.test.ts
@@ -67,12 +67,14 @@ it.skipIf(process.platform === "win32")(
 );
 
 it.runIf(process.platform === "win32")(
-  "appends through a validated existing Windows handle",
+  "repairs a missing newline before appending through a validated Windows handle",
   async () => {
     const directory = await createTempDir();
     directories.push(directory);
     const recorderPath = path.join(directory, "server.jsonl");
-    await writeFile(recorderPath, JSON.stringify(serverEvent("/existing")), "utf8");
+    const existingLine = JSON.stringify(serverEvent("/existing"));
+    const appendedLine = JSON.stringify(serverEvent("/appended"));
+    await writeFile(recorderPath, existingLine, "utf8");
 
     await recordServerEvent({
       event: serverEvent("/appended"),
@@ -80,7 +82,9 @@ it.runIf(process.platform === "win32")(
       recorderPath,
     });
 
-    const events = (await readFile(recorderPath, "utf8"))
+    const contents = await readFile(recorderPath, "utf8");
+    expect(contents).toBe(`${existingLine}\n${appendedLine}\n`);
+    const events = contents
       .trimEnd()
       .split("\n")
       .map((line) => JSON.parse(line) as { path: string });

--- a/test/server-recorder.test.ts
+++ b/test/server-recorder.test.ts
@@ -56,6 +56,7 @@ const fsMocks = vi.hoisted(() => {
       (options?: { bigint?: boolean }) => Promise<{
         dev?: bigint | number;
         ino?: bigint | number;
+        isFile?: () => boolean;
         nlink?: bigint | number;
         size: bigint | number;
       }>
@@ -101,6 +102,7 @@ const fsMocks = vi.hoisted(() => {
       ) => Promise<{
         dev?: bigint | number;
         ino?: bigint | number;
+        isFile?: () => boolean;
         nlink?: bigint | number;
         size: bigint | number;
       }>
@@ -1024,6 +1026,49 @@ describe("server recorder", () => {
 
     expect(fsMocks.file.appendFile).not.toHaveBeenCalled();
     expect(fsMocks.file.close).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a non-regular recorder handle before append or observer notification", async () => {
+    const observer = vi.fn<(event: ServerRequestEvent) => void>();
+    fsMocks.file.stat.mockResolvedValue({
+      dev: 1,
+      ino: 1,
+      isFile: () => false,
+      nlink: 1,
+      size: 0,
+    });
+
+    await expect(
+      recordServerEvent({
+        event: serverEvent("/non-regular"),
+        onEvent: observer,
+        recorderPath: path.join("/tmp", "crabline-server-recorder-special.jsonl"),
+      }),
+    ).rejects.toThrow("Server recorder path is not a regular file.");
+
+    expect(fsMocks.file.appendFile).not.toHaveBeenCalled();
+    expect(fsMocks.file.sync).not.toHaveBeenCalled();
+    expect(observer).not.toHaveBeenCalled();
+  });
+
+  it("rejects a recorder whose link count changes while acquiring its identity lock", async () => {
+    fsMocks.file.stat
+      .mockResolvedValueOnce({ dev: 1, ino: 1, nlink: 1, size: 0 })
+      .mockResolvedValue({ dev: 1, ino: 1, nlink: 2, size: 0 });
+
+    await expect(
+      recordServerEvent({
+        event: serverEvent("/hardlink-transition"),
+        onEvent: undefined,
+        recorderPath: path.join("/tmp", "crabline-server-recorder-hardlink-transition.jsonl"),
+      }),
+    ).rejects.toThrow(
+      "Server recorder hardlinks require CRABLINE_RECORDER_LOCK_DIR to name one shared writable lock directory for every writer.",
+    );
+
+    expect(fsMocks.file.appendFile).not.toHaveBeenCalled();
+    expect(lockMocks.lock).toHaveBeenCalledTimes(2);
+    expect(lockMocks.release).toHaveBeenCalledTimes(2);
   });
 
   it("reports a committed append without truncating a rotated inode", async () => {

--- a/test/server-recorder.test.ts
+++ b/test/server-recorder.test.ts
@@ -23,7 +23,10 @@ const lockMocks = vi.hoisted(() => {
   };
 });
 
-const readWindowsDirectorySecurityDescriptor = vi.fn(async () => "owner-only");
+const readWindowsDirectorySecuritySnapshot = vi.fn(async () => ({
+  identity: "10:00000000000000000000000000000014",
+  securityDescriptor: "owner-only",
+}));
 
 const fsMocks = vi.hoisted(() => {
   const directory = {
@@ -205,7 +208,7 @@ function serverEvent(pathname: string): ServerRequestEvent {
 }
 
 beforeEach(() => {
-  readWindowsDirectorySecurityDescriptor.mockClear();
+  readWindowsDirectorySecuritySnapshot.mockClear();
   lockMocks.release.mockReset();
   lockMocks.release.mockResolvedValue();
   lockMocks.lock.mockReset();
@@ -275,13 +278,13 @@ describe("server recorder", () => {
     await expect(
       secureServerRecorderWindowsLockRoot(lockRoot, {
         createWindowsDirectory,
-        readWindowsDirectorySecurityDescriptor,
+        readWindowsDirectorySecuritySnapshot,
       }),
     ).resolves.toBe(lockRoot);
     await expect(
       secureServerRecorderWindowsLockRoot(lockRoot, {
         createWindowsDirectory,
-        readWindowsDirectorySecurityDescriptor,
+        readWindowsDirectorySecuritySnapshot,
       }),
     ).resolves.toBe(lockRoot);
 
@@ -298,13 +301,13 @@ describe("server recorder", () => {
 
     await secureServerRecorderWindowsLockRoot(lockRoot, {
       createWindowsDirectory,
-      readWindowsDirectorySecurityDescriptor,
+      readWindowsDirectorySecuritySnapshot,
     });
     fsMocks.lstat.mockRejectedValueOnce(missing).mockRejectedValueOnce(missing);
     await expect(
       secureServerRecorderWindowsLockRoot(lockRoot, {
         createWindowsDirectory,
-        readWindowsDirectorySecurityDescriptor,
+        readWindowsDirectorySecuritySnapshot,
       }),
     ).resolves.toBe(lockRoot);
 
@@ -317,7 +320,7 @@ describe("server recorder", () => {
 
     await secureServerRecorderWindowsLockRoot(lockRoot, {
       createWindowsDirectory,
-      readWindowsDirectorySecurityDescriptor,
+      readWindowsDirectorySecuritySnapshot,
     });
     fsMocks.lstat.mockResolvedValue({
       dev: 10n,
@@ -330,11 +333,11 @@ describe("server recorder", () => {
     await Promise.all([
       secureServerRecorderWindowsLockRoot(lockRoot, {
         createWindowsDirectory,
-        readWindowsDirectorySecurityDescriptor,
+        readWindowsDirectorySecuritySnapshot,
       }),
       secureServerRecorderWindowsLockRoot(lockRoot, {
         createWindowsDirectory,
-        readWindowsDirectorySecurityDescriptor,
+        readWindowsDirectorySecuritySnapshot,
       }),
     ]);
 
@@ -413,7 +416,7 @@ describe("server recorder", () => {
     await expect(
       secureServerRecorderWindowsLockRoot(lockRoot, {
         createWindowsDirectory,
-        readWindowsDirectorySecurityDescriptor,
+        readWindowsDirectorySecuritySnapshot,
       }),
     ).rejects.toThrow("Server recorder Windows lock root could not be stabilized.");
     expect(createWindowsDirectory).toHaveBeenCalledTimes(2);
@@ -493,7 +496,7 @@ describe("server recorder", () => {
     await expect(
       secureServerRecorderWindowsLockRoot(lockRoot, {
         createWindowsDirectory,
-        readWindowsDirectorySecurityDescriptor,
+        readWindowsDirectorySecuritySnapshot,
       }),
     ).resolves.toBe(lockRoot);
 

--- a/test/server-recorder.test.ts
+++ b/test/server-recorder.test.ts
@@ -1,5 +1,6 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { once } from "node:events";
+import { constants as fsConstants } from "node:fs";
 import { realpath } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -27,6 +28,13 @@ const readWindowsDirectorySecuritySnapshot = vi.fn(async () => ({
   identity: "10:00000000000000000000000000000014",
   securityDescriptor: "owner-only",
 }));
+
+const serverRecorderExistingOpenFlags =
+  fsConstants.O_RDWR | fsConstants.O_APPEND | fsConstants.O_NONBLOCK | fsConstants.O_NOFOLLOW;
+
+function isServerRecorderExistingOpen(flags: number | string): boolean {
+  return flags === "a+" || flags === "r+" || flags === serverRecorderExistingOpenFlags;
+}
 
 const fsMocks = vi.hoisted(() => {
   const directory = {
@@ -66,11 +74,21 @@ const fsMocks = vi.hoisted(() => {
     >(),
     sync: vi.fn<() => Promise<void>>(),
     truncate: vi.fn<(length: number) => Promise<void>>(),
+    write:
+      vi.fn<
+        (
+          buffer: Buffer,
+          offset: number,
+          length: number,
+          position: number,
+        ) => Promise<{ buffer: Buffer; bytesWritten: number }>
+      >(),
   };
   return {
     chmod: vi.fn<(filePath: string, mode: number) => Promise<void>>(),
     directory,
     file,
+    recordedWrite: vi.fn<(data: string) => Promise<void>>(),
     lstat: vi.fn<
       (
         filePath: string,
@@ -79,6 +97,7 @@ const fsMocks = vi.hoisted(() => {
         dev: bigint;
         ino: bigint;
         isDirectory(): boolean;
+        isFile?(): boolean;
         isSymbolicLink(): boolean;
         mode: bigint;
         uid: bigint;
@@ -229,8 +248,12 @@ beforeEach(() => {
   });
   fsMocks.directory.sync.mockReset();
   fsMocks.directory.sync.mockResolvedValue();
+  fsMocks.recordedWrite.mockReset();
+  fsMocks.recordedWrite.mockResolvedValue();
   fsMocks.file.appendFile.mockReset();
-  fsMocks.file.appendFile.mockResolvedValue();
+  fsMocks.file.appendFile.mockImplementation(async (data) => {
+    await fsMocks.recordedWrite(data);
+  });
   fsMocks.file.chmod.mockReset();
   fsMocks.file.chmod.mockResolvedValue();
   fsMocks.file.close.mockReset();
@@ -243,14 +266,26 @@ beforeEach(() => {
   fsMocks.file.sync.mockResolvedValue();
   fsMocks.file.truncate.mockReset();
   fsMocks.file.truncate.mockResolvedValue();
+  fsMocks.file.write.mockReset();
+  fsMocks.file.write.mockImplementation(async (buffer, offset, length) => {
+    await fsMocks.recordedWrite(buffer.subarray(offset, offset + length).toString("utf8"));
+    return {
+      buffer,
+      bytesWritten: length,
+    };
+  });
   fsMocks.lstat.mockReset();
-  fsMocks.lstat.mockResolvedValue({
-    dev: 10n,
-    ino: 20n,
-    isDirectory: () => true,
-    isSymbolicLink: () => false,
-    mode: 0o700n,
-    uid: BigInt(process.geteuid?.() ?? 0),
+  fsMocks.lstat.mockImplementation(async (filePath) => {
+    const isRecorderFile = String(filePath).endsWith(".jsonl");
+    return {
+      dev: isRecorderFile ? 1n : 10n,
+      ino: isRecorderFile ? 1n : 20n,
+      isDirectory: () => !isRecorderFile,
+      isFile: () => isRecorderFile,
+      isSymbolicLink: () => false,
+      mode: isRecorderFile ? 0o600n : 0o700n,
+      uid: BigInt(process.geteuid?.() ?? 0),
+    };
   });
   fsMocks.mkdir.mockReset();
   fsMocks.mkdir.mockResolvedValue(undefined);
@@ -258,6 +293,9 @@ beforeEach(() => {
   fsMocks.open.mockImplementation(async (_filePath, flags) => {
     if (flags === "ax+") {
       throw Object.assign(new Error("Recorder already exists"), { code: "EEXIST" });
+    }
+    if (isServerRecorderExistingOpen(flags)) {
+      return fsMocks.file;
     }
     return typeof flags === "number" || flags === "r" ? fsMocks.directory : fsMocks.file;
   });
@@ -524,7 +562,11 @@ describe("server recorder", () => {
       return filePath === canonicalFinalParent ? canonicalFirstParent : undefined;
     });
     fsMocks.open.mockImplementation(async (_filePath, flags) =>
-      typeof flags === "number" || flags === "r" ? fsMocks.directory : fsMocks.file,
+      isServerRecorderExistingOpen(flags)
+        ? fsMocks.file
+        : typeof flags === "number" || flags === "r"
+          ? fsMocks.directory
+          : fsMocks.file,
     );
     await recordServerEvent({
       event: serverEvent("/private"),
@@ -544,9 +586,7 @@ describe("server recorder", () => {
       [path.dirname(canonicalFirstParent), "r"],
     ]);
     expect(fsMocks.file.chmod).toHaveBeenCalledWith(0o600);
-    expect(fsMocks.file.appendFile).toHaveBeenCalledWith(expect.any(String), {
-      encoding: "utf8",
-    });
+    expect(fsMocks.recordedWrite).toHaveBeenCalledWith(expect.any(String));
     expect(fsMocks.file.sync).toHaveBeenCalledOnce();
     expect(fsMocks.directory.sync).toHaveBeenCalledTimes(3);
     expect(fsMocks.file.sync.mock.invocationCallOrder[0]).toBeLessThan(
@@ -574,7 +614,7 @@ describe("server recorder", () => {
     ).toBe(true);
     expect(lockMocks.release).toHaveBeenCalledTimes(2);
     expect(fsMocks.file.chmod.mock.invocationCallOrder[0]).toBeLessThan(
-      fsMocks.file.appendFile.mock.invocationCallOrder[0]!,
+      fsMocks.recordedWrite.mock.invocationCallOrder[0]!,
     );
     expect(fsMocks.file.close).toHaveBeenCalledOnce();
     expect(fsMocks.directory.close.mock.calls.length).toBeGreaterThanOrEqual(3);
@@ -595,7 +635,7 @@ describe("server recorder", () => {
     fsMocks.directory.sync.mockRejectedValueOnce(ancestrySyncFailure).mockResolvedValue(undefined);
     fsMocks.open.mockImplementation(async (openedPath, flags) => {
       if (typeof flags === "number") {
-        return fsMocks.directory;
+        return isServerRecorderExistingOpen(flags) ? fsMocks.file : fsMocks.directory;
       }
       if (flags === "r") {
         if (openedPath === canonicalRoot) {
@@ -633,7 +673,7 @@ describe("server recorder", () => {
       recorderPath,
     });
 
-    expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(2);
+    expect(fsMocks.recordedWrite).toHaveBeenCalledTimes(2);
     expect(fsMocks.file.sync).toHaveBeenCalledTimes(2);
     expect(fsMocks.directory.sync).toHaveBeenCalledTimes(2);
     expect(fsMocks.open).not.toHaveBeenCalledWith(path.parse(recorderPath).root, "r");
@@ -656,7 +696,7 @@ describe("server recorder", () => {
     fsMocks.stat.mockResolvedValue({ dev: 61, ino: 62, nlink: 1, size: 0 });
     fsMocks.open.mockImplementation(async (openedPath, flags) => {
       if (typeof flags === "number") {
-        return fsMocks.directory;
+        return isServerRecorderExistingOpen(flags) ? fsMocks.file : fsMocks.directory;
       }
       if (flags === "ax+") {
         throw Object.assign(new Error("Recorder already exists"), { code: "EEXIST" });
@@ -718,7 +758,7 @@ describe("server recorder", () => {
     fsMocks.stat.mockResolvedValue({ dev: 71, ino: 72, nlink: 1, size: 0 });
     fsMocks.open.mockImplementation(async (openedPath, flags) => {
       if (typeof flags === "number") {
-        return fsMocks.directory;
+        return isServerRecorderExistingOpen(flags) ? fsMocks.file : fsMocks.directory;
       }
       if (flags === "ax+") {
         if (recorderExists) {
@@ -780,7 +820,7 @@ describe("server recorder", () => {
     });
 
     expect(lockMocks.lock).toHaveBeenCalledTimes(3);
-    expect(fsMocks.file.appendFile).toHaveBeenCalledOnce();
+    expect(fsMocks.recordedWrite).toHaveBeenCalledOnce();
     expect(lockMocks.release).toHaveBeenCalledTimes(2);
   });
 
@@ -832,13 +872,13 @@ describe("server recorder", () => {
     });
 
     await vi.waitFor(() => expect(recorderMkdirCalls()).toHaveLength(1));
-    expect(fsMocks.file.appendFile).not.toHaveBeenCalled();
+    expect(fsMocks.recordedWrite).not.toHaveBeenCalled();
 
     releaseFirstMkdir?.();
     await Promise.all([first, second]);
 
     expect(recorderMkdirCalls()).toHaveLength(2);
-    expect(fsMocks.file.appendFile.mock.calls.map(([line]) => JSON.parse(line).path)).toEqual([
+    expect(fsMocks.recordedWrite.mock.calls.map(([line]) => JSON.parse(line).path)).toEqual([
       "/first",
       "/second",
     ]);
@@ -847,7 +887,7 @@ describe("server recorder", () => {
       fsMocks.mkdir.mock.invocationCallOrder[
         fsMocks.mkdir.mock.calls.indexOf(recorderMkdirCalls()[1]!)
       ],
-    ).toBeGreaterThan(fsMocks.file.appendFile.mock.invocationCallOrder[0]!);
+    ).toBeGreaterThan(fsMocks.recordedWrite.mock.invocationCallOrder[0]!);
   });
 
   it("snapshots events before waiting for recorder admission", async () => {
@@ -862,14 +902,14 @@ describe("server recorder", () => {
 
     await recording;
 
-    expect(JSON.parse(fsMocks.file.appendFile.mock.calls[0]![0]).path).toBe("/original");
+    expect(JSON.parse(fsMocks.recordedWrite.mock.calls[0]![0]).path).toBe("/original");
     expect(observer).toHaveBeenCalledWith(serverEvent("/original"));
   });
 
   it("recovers serialization after an append failure", async () => {
     const recorderPath = path.join("/tmp", "crabline-server-recorder-recovery.jsonl");
     const appendFailure = new Error("disk unavailable");
-    fsMocks.file.appendFile.mockRejectedValueOnce(appendFailure).mockResolvedValueOnce();
+    fsMocks.recordedWrite.mockRejectedValueOnce(appendFailure).mockResolvedValueOnce();
 
     await expect(
       recordServerEvent({
@@ -891,7 +931,7 @@ describe("server recorder", () => {
       }),
     ).resolves.toBeUndefined();
 
-    expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(2);
+    expect(fsMocks.recordedWrite).toHaveBeenCalledTimes(2);
     expect(fsMocks.file.truncate).not.toHaveBeenCalled();
     expect(fsMocks.file.sync).toHaveBeenCalledOnce();
   });
@@ -903,7 +943,7 @@ describe("server recorder", () => {
       recorderPath: path.join("/tmp", "crabline-server-recorder-durable.jsonl"),
     });
 
-    expect(fsMocks.file.appendFile).toHaveBeenCalledOnce();
+    expect(fsMocks.recordedWrite).toHaveBeenCalledOnce();
     expect(fsMocks.file.sync).toHaveBeenCalledOnce();
   });
 
@@ -918,7 +958,11 @@ describe("server recorder", () => {
       if (flags === "r" && openedPath !== canonicalParent) {
         throw Object.assign(new Error("execute-only ancestor"), { code: "EACCES" });
       }
-      return typeof flags === "number" || flags === "r" ? fsMocks.directory : fsMocks.file;
+      return isServerRecorderExistingOpen(flags)
+        ? fsMocks.file
+        : typeof flags === "number" || flags === "r"
+          ? fsMocks.directory
+          : fsMocks.file;
     });
 
     await recordServerEvent({
@@ -997,7 +1041,7 @@ describe("server recorder", () => {
     });
 
     expect(fsMocks.file.close).toHaveBeenCalledTimes(2);
-    expect(fsMocks.file.appendFile).toHaveBeenCalledOnce();
+    expect(fsMocks.recordedWrite).toHaveBeenCalledOnce();
     expect(fsMocks.file.sync).toHaveBeenCalledOnce();
   });
 
@@ -1012,7 +1056,7 @@ describe("server recorder", () => {
       }),
     ).rejects.toThrow("Server recorder file identity is unavailable.");
 
-    expect(fsMocks.file.appendFile).not.toHaveBeenCalled();
+    expect(fsMocks.recordedWrite).not.toHaveBeenCalled();
     expect(fsMocks.file.close).toHaveBeenCalledOnce();
   });
 
@@ -1027,7 +1071,7 @@ describe("server recorder", () => {
       }),
     ).rejects.toThrow("Server recorder file link count is unavailable.");
 
-    expect(fsMocks.file.appendFile).not.toHaveBeenCalled();
+    expect(fsMocks.recordedWrite).not.toHaveBeenCalled();
     expect(fsMocks.file.close).toHaveBeenCalledOnce();
   });
 
@@ -1049,7 +1093,7 @@ describe("server recorder", () => {
       }),
     ).rejects.toThrow("Server recorder path is not a regular file.");
 
-    expect(fsMocks.file.appendFile).not.toHaveBeenCalled();
+    expect(fsMocks.recordedWrite).not.toHaveBeenCalled();
     expect(fsMocks.file.sync).not.toHaveBeenCalled();
     expect(observer).not.toHaveBeenCalled();
   });
@@ -1069,7 +1113,7 @@ describe("server recorder", () => {
       "Server recorder hardlinks require CRABLINE_RECORDER_LOCK_DIR to name one shared writable lock directory for every writer.",
     );
 
-    expect(fsMocks.file.appendFile).not.toHaveBeenCalled();
+    expect(fsMocks.recordedWrite).not.toHaveBeenCalled();
     expect(lockMocks.lock).toHaveBeenCalledTimes(2);
     expect(lockMocks.release).toHaveBeenCalledTimes(2);
   });
@@ -1095,7 +1139,7 @@ describe("server recorder", () => {
       }),
     ).rejects.toMatchObject({ committed: true, name: "ServerRecorderCommittedError" });
 
-    expect(fsMocks.file.appendFile).toHaveBeenCalledOnce();
+    expect(fsMocks.recordedWrite).toHaveBeenCalledOnce();
     expect(fsMocks.file.truncate).not.toHaveBeenCalled();
     expect(fsMocks.file.sync).toHaveBeenCalledOnce();
     expect(fsMocks.file.close).toHaveBeenCalledOnce();
@@ -1123,7 +1167,7 @@ describe("server recorder", () => {
       }),
     ).rejects.toMatchObject({ committed: true, name: "ServerRecorderCommittedError" });
 
-    expect(fsMocks.file.appendFile).toHaveBeenCalledOnce();
+    expect(fsMocks.recordedWrite).toHaveBeenCalledOnce();
     expect(fsMocks.file.truncate).not.toHaveBeenCalled();
     expect(fsMocks.file.sync).toHaveBeenCalledOnce();
     expect(fsMocks.directory.sync).toHaveBeenCalledOnce();
@@ -1178,7 +1222,7 @@ describe("server recorder", () => {
 
   it("exposes an indeterminate result when an append fails", async () => {
     const appendFailure = new Error("simulated append failure");
-    fsMocks.file.appendFile.mockRejectedValueOnce(appendFailure);
+    fsMocks.recordedWrite.mockRejectedValueOnce(appendFailure);
 
     const recording = recordServerEvent({
       event: serverEvent("/append-failed"),
@@ -1261,7 +1305,7 @@ describe("server recorder", () => {
         recorderPath,
       }),
     ).resolves.toBeUndefined();
-    expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(2);
+    expect(fsMocks.recordedWrite).toHaveBeenCalledTimes(2);
   });
 
   it("fills short tail reads before repairing a torn final append", async () => {
@@ -1286,9 +1330,8 @@ describe("server recorder", () => {
 
     expect(fsMocks.file.truncate).toHaveBeenCalledWith(Buffer.byteLength(completed));
     expect(fsMocks.file.read.mock.calls.length).toBeGreaterThan(3);
-    expect(fsMocks.file.appendFile).toHaveBeenLastCalledWith(
+    expect(fsMocks.recordedWrite).toHaveBeenLastCalledWith(
       `${JSON.stringify(serverEvent("/after-recovery"))}\n`,
-      { encoding: "utf8" },
     );
     expect(fsMocks.file.sync).toHaveBeenCalledOnce();
   });
@@ -1300,6 +1343,7 @@ describe("server recorder", () => {
       const completed = `${JSON.stringify(serverEvent("/completed"))}\n`;
       const contents = Buffer.from(`${completed}{"type":"api","path":"/torn"`);
       let repairAttempts = 0;
+      let existingOpen = true;
       fsMocks.file.stat.mockResolvedValue({
         dev: 1,
         ino: 1,
@@ -1315,10 +1359,18 @@ describe("server recorder", () => {
         if (flags === "ax+") {
           throw Object.assign(new Error("Recorder already exists"), { code: "EEXIST" });
         }
-        if (flags === "r+" && repairAttempts++ === 0) {
-          throw Object.assign(new Error("Recorder rotated"), { code: "ENOENT" });
+        if (flags === "r+") {
+          if (existingOpen) {
+            existingOpen = false;
+          } else if (repairAttempts++ === 0) {
+            throw Object.assign(new Error("Recorder rotated"), { code: "ENOENT" });
+          }
         }
-        return typeof flags === "number" || flags === "r" ? fsMocks.directory : fsMocks.file;
+        return isServerRecorderExistingOpen(flags)
+          ? fsMocks.file
+          : typeof flags === "number" || flags === "r"
+            ? fsMocks.directory
+            : fsMocks.file;
       });
 
       await expect(
@@ -1331,7 +1383,7 @@ describe("server recorder", () => {
 
       expect(repairAttempts).toBe(2);
       expect(fsMocks.file.truncate).toHaveBeenCalledWith(Buffer.byteLength(completed));
-      expect(fsMocks.file.appendFile).toHaveBeenCalledOnce();
+      expect(fsMocks.recordedWrite).toHaveBeenCalledOnce();
     },
   );
 
@@ -1370,7 +1422,7 @@ describe("server recorder", () => {
       ).rejects.toThrow("Server recorder rotation retries exhausted");
 
       expect(fsMocks.file.truncate).not.toHaveBeenCalled();
-      expect(fsMocks.file.appendFile).not.toHaveBeenCalled();
+      expect(fsMocks.recordedWrite).not.toHaveBeenCalled();
     },
   );
 
@@ -1388,7 +1440,7 @@ describe("server recorder", () => {
       }),
     ).resolves.toBeUndefined();
 
-    const recordedLine = fsMocks.file.appendFile.mock.calls[0]?.[0];
+    const recordedLine = fsMocks.recordedWrite.mock.calls[0]?.[0];
     expect(recordedLine).toBeDefined();
     expect(Buffer.byteLength(recordedLine!)).toBeGreaterThan(4 * 1024 * 1024);
     expect(JSON.parse(recordedLine!).query.payload).toHaveLength(4 * 1024 * 1024);
@@ -1420,9 +1472,9 @@ describe("server recorder", () => {
     ).resolves.toBeUndefined();
 
     expect(fsMocks.file.truncate).not.toHaveBeenCalled();
-    expect(fsMocks.file.appendFile.mock.calls).toEqual([
-      ["\n", { encoding: "utf8" }],
-      [`${JSON.stringify(serverEvent("/after-valid-oversized-tail"))}\n`, { encoding: "utf8" }],
+    expect(fsMocks.recordedWrite.mock.calls).toEqual([
+      ["\n"],
+      [`${JSON.stringify(serverEvent("/after-valid-oversized-tail"))}\n`],
     ]);
   });
 
@@ -1475,9 +1527,9 @@ describe("server recorder", () => {
       tailStart,
     );
     expect(fsMocks.file.truncate).not.toHaveBeenCalled();
-    expect(fsMocks.file.appendFile.mock.calls).toEqual([
-      ["\n", { encoding: "utf8" }],
-      [`${JSON.stringify(serverEvent("/after-valid-boundary-tail"))}\n`, { encoding: "utf8" }],
+    expect(fsMocks.recordedWrite.mock.calls).toEqual([
+      ["\n"],
+      [`${JSON.stringify(serverEvent("/after-valid-boundary-tail"))}\n`],
     ]);
   });
 
@@ -1503,9 +1555,8 @@ describe("server recorder", () => {
     ).resolves.toBeUndefined();
 
     expect(fsMocks.file.truncate).toHaveBeenCalledWith(Buffer.byteLength(completed));
-    expect(fsMocks.file.appendFile).toHaveBeenLastCalledWith(
+    expect(fsMocks.recordedWrite).toHaveBeenLastCalledWith(
       `${JSON.stringify(serverEvent("/after-oversized-tail"))}\n`,
-      { encoding: "utf8" },
     );
   });
 
@@ -1548,7 +1599,7 @@ describe("server recorder", () => {
       fileSize - validationBudget - 1,
     );
     expect(fsMocks.file.truncate).not.toHaveBeenCalled();
-    expect(fsMocks.file.appendFile).not.toHaveBeenCalled();
+    expect(fsMocks.recordedWrite).not.toHaveBeenCalled();
   });
 
   it("serializes torn-tail recovery and append across recorder processes", async () => {
@@ -1834,7 +1885,7 @@ describe("server recorder", () => {
       },
       recorderPath,
     });
-    await vi.waitFor(() => expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(fsMocks.recordedWrite).toHaveBeenCalledTimes(2));
     await vi.waitFor(() => expect(order).toEqual(["first:start", "second"]));
 
     releaseFirst?.();
@@ -1857,7 +1908,7 @@ describe("server recorder", () => {
       },
       recorderPath,
     });
-    await vi.waitFor(() => expect(fsMocks.file.appendFile).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(fsMocks.recordedWrite).toHaveBeenCalledOnce());
 
     second = recordServerEvent({
       event: serverEvent("/second"),
@@ -1867,7 +1918,7 @@ describe("server recorder", () => {
     allowFirstToWait();
 
     await expect(Promise.all([first, second])).resolves.toEqual([undefined, undefined]);
-    expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(2);
+    expect(fsMocks.recordedWrite).toHaveBeenCalledTimes(2);
   });
 
   it("allows observers to append reentrantly to the same recorder", async () => {
@@ -1885,7 +1936,7 @@ describe("server recorder", () => {
       recorderPath,
     });
 
-    expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(2);
+    expect(fsMocks.recordedWrite).toHaveBeenCalledTimes(2);
     expect(fsMocks.file.sync).toHaveBeenCalledTimes(2);
   });
 
@@ -1906,7 +1957,7 @@ describe("server recorder", () => {
     });
 
     expect(nestedObserver).toHaveBeenCalledWith(serverEvent("/nested"));
-    expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(2);
+    expect(fsMocks.recordedWrite).toHaveBeenCalledTimes(2);
   });
 
   it("allows nested observers for independent recorder paths", async () => {
@@ -1925,7 +1976,7 @@ describe("server recorder", () => {
     });
 
     expect(nestedObserver).toHaveBeenCalledWith(serverEvent("/nested"));
-    expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(2);
+    expect(fsMocks.recordedWrite).toHaveBeenCalledTimes(2);
   });
 
   it("starts nested observers after prior invocation without waiting for completion", async () => {
@@ -1961,7 +2012,7 @@ describe("server recorder", () => {
       },
       recorderPath: secondPath,
     });
-    await vi.waitFor(() => expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(3));
+    await vi.waitFor(() => expect(fsMocks.recordedWrite).toHaveBeenCalledTimes(3));
     await vi.waitFor(() =>
       expect(nestedObserver).toHaveBeenCalledWith(serverEvent("/nested-on-first")),
     );
@@ -2012,7 +2063,7 @@ describe("server recorder", () => {
     });
 
     await expect(Promise.all([first, second])).resolves.toEqual([undefined, undefined]);
-    expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(4);
+    expect(fsMocks.recordedWrite).toHaveBeenCalledTimes(4);
   });
 
   it("keeps later appends available after an observer failure", async () => {
@@ -2040,7 +2091,7 @@ describe("server recorder", () => {
       }),
     ).resolves.toBeUndefined();
 
-    expect(fsMocks.file.appendFile).toHaveBeenCalledTimes(2);
+    expect(fsMocks.recordedWrite).toHaveBeenCalledTimes(2);
     expect(fsMocks.file.truncate).not.toHaveBeenCalled();
     expect(fsMocks.file.sync).toHaveBeenCalledTimes(2);
   });
@@ -2060,7 +2111,7 @@ describe("server recorder", () => {
       committed: true,
       name: "ServerRecorderCommittedError",
     });
-    expect(fsMocks.file.appendFile).toHaveBeenCalledOnce();
+    expect(fsMocks.recordedWrite).toHaveBeenCalledOnce();
     expect(fsMocks.file.truncate).not.toHaveBeenCalled();
   });
 
@@ -2089,6 +2140,6 @@ describe("server recorder", () => {
         recorderPath: path.join("/tmp", "crabline-server-recorder-committed-cycle.jsonl"),
       }),
     ).resolves.toBeUndefined();
-    expect(fsMocks.file.appendFile).not.toHaveBeenCalled();
+    expect(fsMocks.recordedWrite).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- stabilize recorder identity locking and preserve cleanup causes
- require Windows job containment and bind recorder namespaces to no-follow ACL validation
- preserve custom Windows directory ACLs while hardening Crabline-managed directories
- add cross-platform regressions and changelog entries

## Validation
- `gpt-5.6-sol` high autoreview: clean on `cd72de966a7f480eb651c6e96d36bc22543d4f2f`
- hosted CI `verify`: passed on the exact PR head
- Linux Crabbox `pnpm verify`: `run_ea82b2c3a0cd`
  - 64 test files passed
  - 1,621 tests passed; 34 skipped
- native Windows Crabbox: `run_a35abb56cb0a`
  - 16 selected tests passed; 133 skipped
  - Windows typecheck passed
