### PR TITLE
fix(whatsapp): harden wire boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Parse Google signing certificates as X.509 and redact Discord and Slack webhook tokens before recorder persistence.
+- Contain WhatsApp acceptance timeout cleanup failures, enforce compressed binary-node payload limits, and require explicit interop JID server tokens.
 - Bound shared HTTP responses, Matrix sync payloads, stalled webhook DNS recovery, unmatched request bodies, and admitted local-mock hook cleanup.
 - Reject Signal JSON-RPC integral IDs that cannot round-trip safely while preserving fractional and string IDs, and register SSE clients before exposing connected response headers.
 - Keep Telegram multipart fields prototype-safe, synthetic chat IDs within 52 significant bits, and topic identities scoped to their chats.

--- a/src/servers/whatsapp-baileys-websocket.ts
+++ b/src/servers/whatsapp-baileys-websocket.ts
@@ -347,7 +347,9 @@ export class WhatsAppSignalBundleStore {
     const timeout = setTimeout(() => {
       const error = new Error("WhatsApp message acceptance timed out.");
       fenceTerminalAcceptance(error);
-      options.onTerminalTimeout?.();
+      try {
+        options.onTerminalTimeout?.();
+      } catch {}
     }, timeoutMs);
     timeout.unref();
     let pendingAcknowledgement: PendingWhatsAppAcknowledgement;

--- a/src/servers/whatsapp-wire/binary-node.ts
+++ b/src/servers/whatsapp-wire/binary-node.ts
@@ -399,12 +399,14 @@ function decodeDecompressedBinaryNode(
     const user = readString(readByte());
     const device = readInt(2);
     const integrator = readInt(2);
-    const beforeServer = indexRef.index;
-    let server = "interop";
+    let server: string;
     try {
       server = readString(readByte());
-    } catch {
-      indexRef.index = beforeServer;
+    } catch (error) {
+      throw new Error("Invalid WhatsApp interop JID server.", { cause: error });
+    }
+    if (server !== "interop") {
+      throw new Error(`Invalid WhatsApp interop JID server: ${server}.`);
     }
     return `${integrator}-${user}:${device}@${server}`;
   };

--- a/src/servers/whatsapp-wire/binary-node.ts
+++ b/src/servers/whatsapp-wire/binary-node.ts
@@ -173,11 +173,11 @@ async function decompressIfRequired(buffer: Buffer): Promise<Buffer> {
   }
   const flag = buffer.readUInt8();
   if ((flag & 2) !== 0) {
-    if (buffer.length > WHATSAPP_BINARY_NODE_MAX_COMPRESSED_BYTES) {
-      throw new Error(`Compressed WhatsApp binary node frame is too large: ${buffer.length}.`);
+    const compressed = buffer.subarray(1);
+    if (compressed.length > WHATSAPP_BINARY_NODE_MAX_COMPRESSED_BYTES) {
+      throw new Error(`Compressed WhatsApp binary node frame is too large: ${compressed.length}.`);
     }
     try {
-      const compressed = buffer.subarray(1);
       const inflated = await inflateWithInfo(compressed);
       if (inflated.engine.bytesWritten !== compressed.length) {
         throw new Error("Compressed WhatsApp binary node frame contains trailing data.");

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -1371,6 +1371,32 @@ describe("whatsapp local provider server", () => {
     }
   });
 
+  it("preserves the acceptance timeout when terminal timeout cleanup throws", async () => {
+    vi.useFakeTimers();
+    try {
+      const receiver = new WhatsAppSignalBundleStore(1, 1, 1, undefined, undefined, {
+        messageAcceptanceTimeoutMs: 100,
+      });
+      const stalled = receiver.acceptMessageOnce(
+        "peer\0throwing-timeout-cleanup",
+        async () => await new Promise<boolean>(() => undefined),
+        {
+          onTerminalTimeout: () => {
+            throw new Error("timeout cleanup failed");
+          },
+        },
+      );
+      const rejection = expect(stalled).rejects.toThrow(
+        "WhatsApp message acceptance timed out.",
+      );
+
+      await vi.advanceTimersByTimeAsync(100);
+      await rejection;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("fences duplicate persistence until timed-out recorder work settles", async () => {
     const receiver = new WhatsAppSignalBundleStore(1, 1, undefined, undefined, undefined, {
       messageAcceptanceTimeoutMs: 100,

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -1386,10 +1386,10 @@ describe("whatsapp local provider server", () => {
           },
         },
       );
-      const rejection = expect(stalled).rejects.toThrow("WhatsApp message acceptance timed out.");
-
-      await vi.advanceTimersByTimeAsync(100);
-      await rejection;
+      await Promise.all([
+        expect(stalled).rejects.toThrow("WhatsApp message acceptance timed out."),
+        vi.advanceTimersByTimeAsync(100),
+      ]);
     } finally {
       vi.useRealTimers();
     }

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -1386,9 +1386,7 @@ describe("whatsapp local provider server", () => {
           },
         },
       );
-      const rejection = expect(stalled).rejects.toThrow(
-        "WhatsApp message acceptance timed out.",
-      );
+      const rejection = expect(stalled).rejects.toThrow("WhatsApp message acceptance timed out.");
 
       await vi.advanceTimersByTimeAsync(100);
       await rejection;

--- a/test/whatsapp-wire.test.ts
+++ b/test/whatsapp-wire.test.ts
@@ -646,7 +646,7 @@ describe("WhatsApp binary nodes", () => {
         WHATSAPP_BINARY_NODE_MAX_COMPRESSED_BYTES + 1
       }.`,
     );
-  });
+  }, 60_000);
 
   it("round trips the largest decodable frame and rejects one byte more", async () => {
     const payloadBytes = WHATSAPP_BINARY_NODE_MAX_DECOMPRESSED_BYTES - 16;

--- a/test/whatsapp-wire.test.ts
+++ b/test/whatsapp-wire.test.ts
@@ -739,6 +739,42 @@ describe("WhatsApp binary nodes", () => {
     expect(decoded.attrs["__proto__"]).toBe("polluted");
     expect(({} as Record<string, unknown>).polluted).toBeUndefined();
   });
+
+  it("decodes an explicit interop JID server before the next attribute", async () => {
+    const frame = Buffer.concat([
+      Buffer.from([0, 248, 5, 19, 6, 245, 252, 4]),
+      Buffer.from("user"),
+      Buffer.from([0, 7, 0, 42, 252, 7]),
+      Buffer.from("interop"),
+      Buffer.from([8, 252, 10]),
+      Buffer.from("message-id"),
+    ]);
+
+    await expect(decodeBinaryNode(frame)).resolves.toMatchObject({
+      attrs: {
+        from: "42-user:7@interop",
+        id: "message-id",
+      },
+      tag: "message",
+    });
+  });
+
+  it.each([
+    ["omitted", Buffer.alloc(0)],
+    [
+      "invalid",
+      Buffer.concat([Buffer.from([252, 11]), Buffer.from("not-interop")]),
+    ],
+  ])("rejects an %s interop JID server", async (_label, serverToken) => {
+    const frame = Buffer.concat([
+      Buffer.from([0, 248, 3, 19, 6, 245, 252, 4]),
+      Buffer.from("user"),
+      Buffer.from([0, 7, 0, 42]),
+      serverToken,
+    ]);
+
+    await expect(decodeBinaryNode(frame)).rejects.toThrow("Invalid WhatsApp interop JID server");
+  });
 });
 
 describe("WhatsApp signal bundle store", () => {

--- a/test/whatsapp-wire.test.ts
+++ b/test/whatsapp-wire.test.ts
@@ -5,6 +5,7 @@ import { WebSocket } from "ws";
 import {
   decodeBinaryNode,
   encodeBinaryNode,
+  WHATSAPP_BINARY_NODE_MAX_COMPRESSED_BYTES,
   WHATSAPP_BINARY_NODE_MAX_DEPTH,
   WHATSAPP_BINARY_NODE_MAX_DECOMPRESSED_BYTES,
   WHATSAPP_BINARY_NODE_MAX_FRAME_BYTES,
@@ -626,6 +627,26 @@ describe("WhatsApp binary nodes", () => {
 
     await expect(decodeBinaryNode(Buffer.concat([Buffer.from([2]), compressed]))).rejects.toThrow(
       "WhatsApp binary node expands beyond",
+    );
+  });
+
+  it("enforces the compressed payload limit after the frame flag", async () => {
+    const node = {
+      attrs: {},
+      content: Buffer.alloc(WHATSAPP_BINARY_NODE_MAX_COMPRESSED_BYTES - 176),
+      tag: "message",
+    };
+    const compressed = deflateSync(encodeBinaryNode(node).subarray(1), { level: 0 });
+    const frame = Buffer.concat([Buffer.from([2]), compressed]);
+
+    expect(compressed).toHaveLength(WHATSAPP_BINARY_NODE_MAX_COMPRESSED_BYTES);
+    await expect(decodeBinaryNode(frame)).resolves.toEqual(node);
+    await expect(
+      decodeBinaryNode(Buffer.concat([frame, Buffer.from([0])])),
+    ).rejects.toThrow(
+      `Compressed WhatsApp binary node frame is too large: ${
+        WHATSAPP_BINARY_NODE_MAX_COMPRESSED_BYTES + 1
+      }.`,
     );
   });
 

--- a/test/whatsapp-wire.test.ts
+++ b/test/whatsapp-wire.test.ts
@@ -641,9 +641,7 @@ describe("WhatsApp binary nodes", () => {
 
     expect(compressed).toHaveLength(WHATSAPP_BINARY_NODE_MAX_COMPRESSED_BYTES);
     await expect(decodeBinaryNode(frame)).resolves.toEqual(node);
-    await expect(
-      decodeBinaryNode(Buffer.concat([frame, Buffer.from([0])])),
-    ).rejects.toThrow(
+    await expect(decodeBinaryNode(Buffer.concat([frame, Buffer.from([0])]))).rejects.toThrow(
       `Compressed WhatsApp binary node frame is too large: ${
         WHATSAPP_BINARY_NODE_MAX_COMPRESSED_BYTES + 1
       }.`,
@@ -761,10 +759,7 @@ describe("WhatsApp binary nodes", () => {
 
   it.each([
     ["omitted", Buffer.alloc(0)],
-    [
-      "invalid",
-      Buffer.concat([Buffer.from([252, 11]), Buffer.from("not-interop")]),
-    ],
+    ["invalid", Buffer.concat([Buffer.from([252, 11]), Buffer.from("not-interop")])],
   ])("rejects an %s interop JID server", async (_label, serverToken) => {
     const frame = Buffer.concat([
       Buffer.from([0, 248, 3, 19, 6, 245, 252, 4]),


### PR DESCRIPTION
## Summary
- contain terminal timeout cleanup failures without replacing the acceptance timeout
- count compressed WhatsApp payload bytes after the frame flag
- require the explicit `interop` server token for interop JIDs
- add focused regression coverage and changelog entries

## Validation
- 94 focused tests
- full type-aware oxlint, typecheck, and format checks
- Linux Crabbox `pnpm verify`: `run_30384e67579b` (1,626 passed, 34 skipped)
- GPT-5.6 Sol high autoreview: clean (0.95)