### PR TITLE
fix(openclaw): preserve adapter contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Parse Google signing certificates as X.509 and redact Discord and Slack webhook tokens before recorder persistence.
 - Contain WhatsApp acceptance timeout cleanup failures, enforce compressed binary-node payload limits, and require explicit interop JID server tokens.
+- Preserve class-based OpenClaw bridge adapters and reject non-native Mattermost target identifiers.
 - Bound shared HTTP responses, Matrix sync payloads, stalled webhook DNS recovery, unmatched request bodies, and admitted local-mock hook cleanup.
 - Reject Signal JSON-RPC integral IDs that cannot round-trip safely while preserving fractional and string IDs, and register SSE clients before exposing connected response headers.
 - Keep Telegram multipart fields prototype-safe, synthetic chat IDs within 52 significant bits, and topic identities scoped to their chats.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Parse Google signing certificates as X.509 and redact Discord and Slack webhook tokens before recorder persistence.
 - Contain WhatsApp acceptance timeout cleanup failures, enforce compressed binary-node payload limits, and require explicit interop JID server tokens.
-- Preserve class-based OpenClaw bridge adapters and reject non-native Mattermost target identifiers.
+- Preserve class-based OpenClaw bridge adapters, reject non-native Mattermost target identifiers, and close successful Signal probe bodies.
 - Bound shared HTTP responses, Matrix sync payloads, stalled webhook DNS recovery, unmatched request bodies, and admitted local-mock hook cleanup.
 - Reject Signal JSON-RPC integral IDs that cannot round-trip safely while preserving fractional and string IDs, and register SSE clients before exposing connected response headers.
 - Keep Telegram multipart fields prototype-safe, synthetic chat IDs within 52 significant bits, and topic identities scoped to their chats.

--- a/src/openclaw/bridges/mattermost.ts
+++ b/src/openclaw/bridges/mattermost.ts
@@ -11,12 +11,12 @@ import {
 import { mattermostId } from "../../servers/mattermost.js";
 import { throwProbeHttpError } from "./probe-response.js";
 
-function nativeId(value: string): string {
+function nativeId(value: string, label = "Mattermost target"): string {
   const trimmed = value.trim();
-  if (!trimmed) {
-    throw new Error("Mattermost target is required.");
+  if (!/^[a-z0-9]{26}$/u.test(trimmed)) {
+    throw new Error(`${label} must be exactly 26 lowercase alphanumeric characters.`);
   }
-  return /^[a-z0-9]{26}$/u.test(trimmed) ? trimmed : mattermostId(trimmed);
+  return trimmed;
 }
 
 function directChannelId(botUserId: string, userId: string): string {
@@ -28,8 +28,7 @@ function targetKey(channelId: string, rootId?: string): string {
 }
 
 function threadRootId(channelId: string, value: string): string {
-  const trimmed = value.trim();
-  return /^[a-z0-9]{26}$/u.test(trimmed) ? trimmed : mattermostId(`thread:${channelId}:${trimmed}`);
+  return nativeId(value, `Mattermost root post for channel ${channelId}`);
 }
 
 export const MATTERMOST_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablineProviderBridge({

--- a/src/openclaw/bridges/signal.ts
+++ b/src/openclaw/bridges/signal.ts
@@ -84,6 +84,7 @@ export const SIGNAL_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablinePr
             `Crabline Signal check probe failed with HTTP ${response.status}.`,
           );
         }
+        await response.body?.cancel();
         return { ok: true, status: response.status };
       },
       createBinding() {

--- a/src/openclaw/shared.ts
+++ b/src/openclaw/shared.ts
@@ -161,7 +161,12 @@ export function createOpenClawCrablineProviderBridge<
   const createAdapter = (manifest: ProviderManifest): OpenClawCrablineProviderAdapter => {
     const adapter = params.createAdapter(manifest);
     return {
-      ...adapter,
+      createAgentDelivery(parsed) {
+        return adapter.createAgentDelivery(parsed);
+      },
+      createBinding() {
+        return adapter.createBinding();
+      },
       createInbound(input) {
         if (!readNonBlankString(input.text)) {
           throw new Error("OpenClaw Crabline inbound message text is required.");
@@ -170,6 +175,12 @@ export function createOpenClawCrablineProviderBridge<
           throw new Error("OpenClaw Crabline inbound conversation kind must be direct or group.");
         }
         return adapter.createInbound(input);
+      },
+      createOutboundFromRecorderEvent(outboundParams) {
+        return adapter.createOutboundFromRecorderEvent(outboundParams);
+      },
+      probe(signal) {
+        return adapter.probe(signal);
       },
     };
   };

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -40,7 +40,12 @@ import {
 } from "../src/openclaw/artifact-generation.js";
 import { MATRIX_OPENCLAW_CRABLINE_PROVIDER_BRIDGE } from "../src/openclaw/bridges/matrix.js";
 import { SIGNAL_OPENCLAW_CRABLINE_PROVIDER_BRIDGE } from "../src/openclaw/bridges/signal.js";
-import { isRecord, parseQaTarget } from "../src/openclaw/shared.js";
+import {
+  createOpenClawCrablineProviderBridge,
+  isRecord,
+  parseQaTarget,
+  type OpenClawCrablineProviderAdapter,
+} from "../src/openclaw/shared.js";
 
 type ProviderReadinessTestDependencies = {
   acquireLock?: () => Promise<{
@@ -294,6 +299,69 @@ const zaloManifest: CrablineServerManifest = {
 };
 
 describe("OpenClaw local provider bridge", () => {
+  it("preserves prototype methods and receivers on class-based adapters", async () => {
+    class ClassAdapter implements OpenClawCrablineProviderAdapter {
+      readonly label = "class-adapter";
+
+      createAgentDelivery() {
+        return {
+          channel: this.label,
+          replyChannel: this.label,
+          replyTo: this.label,
+          to: this.label,
+        };
+      }
+
+      createBinding() {
+        return {
+          accountId: this.label,
+          channel: this.label,
+          createChannelDriverSmokeEnv: (env: NodeJS.ProcessEnv) => env,
+          createGatewayConfig: () => ({}),
+          requiredPluginIds: [],
+        };
+      }
+
+      createInbound(input: Parameters<OpenClawCrablineProviderAdapter["createInbound"]>[0]) {
+        return {
+          providerBody: {},
+          providerHeaders: {},
+          providerTargetKey: this.label,
+          providerUrl: `https://${this.label}.test`,
+          qaTarget: `dm:${input.conversation.id}`,
+          stateConversation: input.conversation,
+        };
+      }
+
+      createOutboundFromRecorderEvent() {
+        return null;
+      }
+
+      async probe() {
+        return this.label;
+      }
+    }
+
+    const bridge = createOpenClawCrablineProviderBridge({
+      provider: "mattermost",
+      createAdapter: () => new ClassAdapter(),
+    });
+    const adapter = bridge.createAdapter(mattermostManifest);
+
+    await expect(adapter.probe()).resolves.toBe("class-adapter");
+    expect(adapter.createAgentDelivery({ id: "target", kind: "direct", native: true }).to).toBe(
+      "class-adapter",
+    );
+    expect(adapter.createBinding().channel).toBe("class-adapter");
+    expect(
+      adapter.createInbound({
+        conversation: { id: "target", kind: "direct" },
+        senderId: "sender",
+        text: "hello",
+      }).providerTargetKey,
+    ).toBe("class-adapter");
+  });
+
   it.each([
     ["mattermost", mattermostManifest],
     ["matrix", matrixManifest],
@@ -2417,28 +2485,43 @@ describe("OpenClaw local provider bridge", () => {
   });
 
   it("maps Mattermost QA targets, inbound messages, and recorder events", () => {
+    const userId = "bbbbbbbbbbbbbbbbbbbbbbbbbb";
+    const otherUserId = "cccccccccccccccccccccccccc";
+    const channelId = "dddddddddddddddddddddddddd";
+    const otherChannelId = "eeeeeeeeeeeeeeeeeeeeeeeeee";
+    const rootId = "ffffffffffffffffffffffffff";
     const delivery = createOpenClawCrablineAgentDelivery({
       manifest: mattermostManifest,
-      target: "dm:alice",
+      target: `dm:${userId}`,
     });
-    expect(delivery).toMatchObject({
+    expect(delivery).toEqual({
       channel: "mattermost",
       replyChannel: "mattermost",
+      replyTo: `user:${userId}`,
+      to: `user:${userId}`,
     });
-    expect(delivery.to).toMatch(/^user:[a-z0-9]{26}$/u);
+
+    for (const target of ["dm:alice", "group:UPPERCASEIDENTIFIER123456"]) {
+      expect(() =>
+        createOpenClawCrablineAgentDelivery({
+          manifest: mattermostManifest,
+          target,
+        }),
+      ).toThrow("must be exactly 26 lowercase alphanumeric characters");
+    }
 
     expect(() =>
       createOpenClawCrablineAgentDelivery({
         manifest: mattermostManifest,
-        target: "thread:general/parent",
+        target: `thread:${channelId}/${rootId}`,
       }),
     ).toThrow("Mattermost thread targets require OpenClaw QA thread forwarding.");
 
     const inbound = createOpenClawCrablineInbound({
       manifest: mattermostManifest,
       input: {
-        conversation: { id: " alice ", kind: "direct" },
-        senderId: "alice",
+        conversation: { id: ` ${userId} `, kind: "direct" },
+        senderId: userId,
         senderName: "Alice",
         text: "hello",
       },
@@ -2450,19 +2533,19 @@ describe("OpenClaw local provider bridge", () => {
         text: "hello",
       },
       providerUrl: "http://127.0.0.1:9753/crabline/mattermost/inbound",
-      qaTarget: "dm:alice",
+      qaTarget: `dm:${userId}`,
       stateConversation: {
-        id: "alice",
+        id: userId,
         kind: "direct",
       },
     });
-    expect(inbound.providerBody.senderId).toBe(delivery.to.slice("user:".length));
+    expect(inbound.providerBody.senderId).toBe(userId);
     expect(() =>
       createOpenClawCrablineInbound({
         manifest: mattermostManifest,
         input: {
-          conversation: { id: "alice", kind: "direct" },
-          senderId: "bob",
+          conversation: { id: userId, kind: "direct" },
+          senderId: otherUserId,
           text: "hello",
         },
       }),
@@ -2473,7 +2556,7 @@ describe("OpenClaw local provider bridge", () => {
           manifest: mattermostManifest,
           input: {
             conversation: { id: conversationId, kind: "direct" },
-            senderId: "alice",
+            senderId: userId,
             text: "hello",
           },
         }),
@@ -2483,7 +2566,7 @@ describe("OpenClaw local provider bridge", () => {
     expect(
       createOpenClawCrablineOutboundFromRecorderEvent({
         manifest: mattermostManifest,
-        targetByProviderTarget: new Map([[inbound.providerTargetKey, "dm:alice"]]),
+        targetByProviderTarget: new Map([[inbound.providerTargetKey, `dm:${userId}`]]),
         event: {
           body: { channel_id: inbound.providerTargetKey, message: "hello from openclaw" },
           method: "POST",
@@ -2496,7 +2579,7 @@ describe("OpenClaw local provider bridge", () => {
       senderId: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
       senderName: "OpenClaw QA",
       text: "hello from openclaw",
-      to: "dm:alice",
+      to: `dm:${userId}`,
     });
     expect(
       createOpenClawCrablineOutboundFromRecorderEvent({
@@ -2523,29 +2606,29 @@ describe("OpenClaw local provider bridge", () => {
     const threadInbound = createOpenClawCrablineInbound({
       manifest: mattermostManifest,
       input: {
-        conversation: { id: "general", kind: "group" },
-        senderId: "alice",
+        conversation: { id: channelId, kind: "group" },
+        senderId: userId,
         text: "thread reply",
-        threadId: "parent",
+        threadId: rootId,
       },
     });
-    expect(threadInbound.providerTargetKey).toMatch(/:thread:[a-z0-9]{26}$/u);
-    expect(threadInbound.threadId).toBe(threadInbound.providerBody.rootId);
+    expect(threadInbound.providerTargetKey).toBe(`${channelId}:thread:${rootId}`);
+    expect(threadInbound.threadId).toBe(rootId);
     const otherThreadInbound = createOpenClawCrablineInbound({
       manifest: mattermostManifest,
       input: {
-        conversation: { id: "random", kind: "group" },
-        senderId: "alice",
-        text: "same symbolic thread in another channel",
-        threadId: "parent",
+        conversation: { id: otherChannelId, kind: "group" },
+        senderId: userId,
+        text: "same root in another channel",
+        threadId: rootId,
       },
     });
-    expect(otherThreadInbound.providerBody.rootId).not.toBe(threadInbound.providerBody.rootId);
+    expect(otherThreadInbound.providerBody.rootId).toBe(rootId);
     const blankThreadInbound = createOpenClawCrablineInbound({
       manifest: mattermostManifest,
       input: {
-        conversation: { id: "general", kind: "group" },
-        senderId: "alice",
+        conversation: { id: channelId, kind: "group" },
+        senderId: userId,
         text: "top-level reply",
         threadId: " \n\t",
       },
@@ -2555,7 +2638,9 @@ describe("OpenClaw local provider bridge", () => {
     expect(
       createOpenClawCrablineOutboundFromRecorderEvent({
         manifest: mattermostManifest,
-        targetByProviderTarget: new Map([[blankThreadInbound.providerTargetKey, "group:general"]]),
+        targetByProviderTarget: new Map([
+          [blankThreadInbound.providerTargetKey, `group:${channelId}`],
+        ]),
         event: {
           body: {
             channel_id: blankThreadInbound.providerBody.channelId,
@@ -2567,24 +2652,23 @@ describe("OpenClaw local provider bridge", () => {
           type: "api",
         },
       }),
-    ).toMatchObject({ to: "group:general" });
-    const nativeRootId = "bbbbbbbbbbbbbbbbbbbbbbbbbb";
-    expect(
+    ).toMatchObject({ to: `group:${channelId}` });
+    expect(() =>
       createOpenClawCrablineInbound({
         manifest: mattermostManifest,
         input: {
-          conversation: { id: "general", kind: "group" },
-          senderId: "alice",
-          text: "real root",
-          threadId: nativeRootId,
+          conversation: { id: channelId, kind: "group" },
+          senderId: userId,
+          text: "invalid root",
+          threadId: "parent",
         },
-      }).providerBody.rootId,
-    ).toBe(nativeRootId);
+      }),
+    ).toThrow("must be exactly 26 lowercase alphanumeric characters");
     expect(
       createOpenClawCrablineOutboundFromRecorderEvent({
         manifest: mattermostManifest,
         targetByProviderTarget: new Map([
-          [threadInbound.providerTargetKey, "thread:general/parent"],
+          [threadInbound.providerTargetKey, `thread:${channelId}/${rootId}`],
         ]),
         event: {
           body: {
@@ -2597,7 +2681,7 @@ describe("OpenClaw local provider bridge", () => {
           type: "api",
         },
       }),
-    ).toMatchObject({ to: "thread:general/parent" });
+    ).toMatchObject({ to: `thread:${channelId}/${rootId}` });
   });
 
   it("maps Matrix native rooms, inbound messages, and recorder events", () => {

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -470,6 +470,22 @@ describe("OpenClaw local provider bridge", () => {
     }
   });
 
+  it("cancels successful Signal probe response bodies", async () => {
+    const cancel = vi.fn();
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(new ReadableStream({ cancel }), { status: 200 }));
+    try {
+      await expect(probeOpenClawCrablineProvider(signalManifest)).resolves.toEqual({
+        ok: true,
+        status: 200,
+      });
+      expect(cancel).toHaveBeenCalledOnce();
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
   it.each([null, {}, { id: "999999999999999" }])(
     "requires WhatsApp to return the configured phone resource: %j",
     async (payload) => {


### PR DESCRIPTION
## Summary
- delegate OpenClaw bridge methods without dropping class prototype methods or receivers
- require native 26-character Mattermost identifiers instead of hashing invalid labels
- cancel successful Signal probe response bodies
- update focused bridge coverage and changelog

## Validation
- `vitest run test/openclaw.test.ts` (101 passed)
- `tsc -p tsconfig.test.json --noEmit`
- targeted type-aware oxlint
- Linux Crabbox `pnpm verify`: `run_4b7fcc89a0fe` (1,623 passed, 34 skipped)
- GPT-5.6 Sol high autoreview: clean (0.91)