### PR TITLE
fix(cli): bound backpressured watch shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - Verify downloaded npm tarball integrity, retry transient provenance lookups, and revalidate release tags immediately before publication mutations.
 - Validate effective fixture mode overrides and stop retrying permanent provider send failures.
 - Bound watch iterator return and provider cleanup during CLI shutdown, forcing process exit after deadline failures.
+- Apply the watch shutdown deadline to backpressured CLI output writes.
 - Correct provider-native channel target examples, admin-ingress setup, and contract maintenance coverage.
 - Document the complete ready and script-bridge channel matrix and validate the shipped example against the manifest schema.
 - Preserve native Slack rich text and block fallbacks, isolate Feishu replay identities, ignore non-message Google Chat interactions, and fail closed on invalid Zalo adapter inputs.

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -223,28 +223,54 @@ async function print(value: string): Promise<boolean> {
 
 class WatchShutdownDeadlineError extends CrablineError {}
 
-async function withWatchShutdownDeadline<T>(
-  operation: PromiseLike<T>,
-  operationName: string,
-): Promise<T> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  const deadline = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => {
-      reject(
-        new WatchShutdownDeadlineError(
-          `Provider ${operationName} did not settle within ${WATCH_SHUTDOWN_GRACE_MS}ms during watch shutdown.`,
-          { kind: "timeout" },
-        ),
-      );
-    }, WATCH_SHUTDOWN_GRACE_MS);
-  });
-  try {
-    return await Promise.race([Promise.resolve(operation), deadline]);
-  } finally {
-    if (timer) {
-      clearTimeout(timer);
-    }
-  }
+function createWatchShutdownDeadline(): {
+  race<T>(operation: PromiseLike<T>, operationName: string): Promise<T>;
+  start(): void;
+} {
+  let deadlineAt: number | undefined;
+  const controller = new AbortController();
+  return {
+    async race<T>(operation: PromiseLike<T>, operationName: string): Promise<T> {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      let removeStartListener: (() => void) | undefined;
+      const deadline = new Promise<never>((_, reject) => {
+        const arm = () => {
+          timer = setTimeout(
+            () => {
+              reject(
+                new WatchShutdownDeadlineError(
+                  `Provider ${operationName} did not settle within ${WATCH_SHUTDOWN_GRACE_MS}ms during watch shutdown.`,
+                  { kind: "timeout" },
+                ),
+              );
+            },
+            Math.max(0, deadlineAt! - Date.now()),
+          );
+        };
+        if (controller.signal.aborted) {
+          arm();
+          return;
+        }
+        controller.signal.addEventListener("abort", arm, { once: true });
+        removeStartListener = () => controller.signal.removeEventListener("abort", arm);
+      });
+      try {
+        return await Promise.race([Promise.resolve(operation), deadline]);
+      } finally {
+        removeStartListener?.();
+        if (timer) {
+          clearTimeout(timer);
+        }
+      }
+    },
+    start() {
+      if (deadlineAt !== undefined) {
+        return;
+      }
+      deadlineAt = Date.now() + WATCH_SHUTDOWN_GRACE_MS;
+      controller.abort();
+    },
+  };
 }
 
 function containsWatchShutdownDeadline(error: unknown, seen = new Set<object>()): boolean {
@@ -520,14 +546,16 @@ export function createProgram(
         }
 
         const controller = new AbortController();
+        const shutdownDeadline = createWatchShutdownDeadline();
         let iterator:
           | AsyncIterator<NonNullable<Awaited<ReturnType<typeof provider.waitForInbound>>>>
           | undefined;
         const stopWatch = onceAsync(async () => {
+          shutdownDeadline.start();
           controller.abort();
           const returnResult = iterator?.return?.();
           if (returnResult) {
-            await withWatchShutdownDeadline(returnResult, "watch iterator return");
+            await shutdownDeadline.race(returnResult, "watch iterator return");
           }
         });
         const shutdown = installShutdownHandler(stopWatch);
@@ -566,10 +594,13 @@ export function createProgram(
               break;
             }
             const message = result.value;
-            const written = await print(
-              options.json
-                ? formatCliJson(message)
-                : `${sanitizeTerminalText(message.sentAt, true)} ${sanitizeTerminalText(message.author, true)} ${sanitizeTerminalText(message.text, true)}`,
+            const written = await shutdownDeadline.race(
+              print(
+                options.json
+                  ? formatCliJson(message)
+                  : `${sanitizeTerminalText(message.sentAt, true)} ${sanitizeTerminalText(message.author, true)} ${sanitizeTerminalText(message.text, true)}`,
+              ),
+              "watch output write",
             );
             if (!written) {
               break;
@@ -588,7 +619,7 @@ export function createProgram(
         try {
           const cleanup = provider.cleanup?.();
           if (cleanup) {
-            await withWatchShutdownDeadline(cleanup, "cleanup");
+            await shutdownDeadline.race(cleanup, "cleanup");
           }
         } catch (error) {
           if (!lifecycleErrors.includes(error)) {

--- a/test/cli-shutdown-subprocess.test.ts
+++ b/test/cli-shutdown-subprocess.test.ts
@@ -11,6 +11,124 @@ afterEach(async () => {
 });
 
 describe.skipIf(process.platform === "win32")("CLI shutdown subprocess", () => {
+  it("forces exit when watch stdout remains backpressured during shutdown", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const configPath = path.join(directory, "crabline.yaml");
+    await writeText(
+      configPath,
+      [
+        "configVersion: 1",
+        "providers:",
+        "  local:",
+        "    adapter: loopback",
+        "fixtures:",
+        "  - id: watched",
+        "    provider: local",
+        "    mode: agent",
+        "    target:",
+        "      id: echo-bot",
+      ].join("\n"),
+    );
+
+    const programUrl = new URL("../src/cli/program.ts", import.meta.url).href;
+    const script = `
+      import { runCli } from ${JSON.stringify(programUrl)};
+      setInterval(() => undefined, 1_000);
+      const iterator = {
+        next() {
+          return Promise.resolve({
+            done: false,
+            value: {
+              author: "assistant",
+              id: "message",
+              provider: "local",
+              sentAt: new Date().toISOString(),
+              text: "payload",
+              threadId: "thread",
+            },
+          });
+        },
+        return() {
+          return Promise.resolve({ done: true });
+        },
+      };
+      const provider = {
+        cleanup() {
+          return Promise.resolve();
+        },
+        watch() {
+          return {
+            [Symbol.asyncIterator]() {
+              return iterator;
+            },
+          };
+        },
+      };
+      let announced = false;
+      process.stdout.write = () => {
+        if (!announced) {
+          announced = true;
+          process.stderr.write("ready\\n");
+        }
+        return false;
+      };
+      await runCli(
+        ["node", "crabline", "--config", ${JSON.stringify(configPath)}, "watch", "watched"],
+        {
+          dependencies: {
+            createRegistry: () => ({
+              resolve: () => provider,
+            }),
+          },
+          forceExit: (code) => process.exit(code),
+        },
+      );
+    `;
+    const child = spawn(
+      process.execPath,
+      ["--import", "tsx", "--input-type=module", "--eval", script],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+    let stderr = "";
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+
+    let exitTimeout: NodeJS.Timeout | undefined;
+    try {
+      await expect.poll(() => stderr, { interval: 10, timeout: 2_000 }).toContain("ready\n");
+      child.kill("SIGTERM");
+      const [code, signal] = (await Promise.race([
+        once(child, "exit"),
+        new Promise<never>((_, reject) => {
+          exitTimeout = setTimeout(
+            () =>
+              reject(
+                new Error(
+                  `CLI did not exit after backpressured shutdown; stderr: ${JSON.stringify(stderr)}`,
+                ),
+              ),
+            2_000,
+          );
+        }),
+      ])) as [number | null, NodeJS.Signals | null];
+
+      expect(signal).toBeNull();
+      expect(code).toBe(15);
+      expect(stderr).toContain(
+        "Provider watch output write did not settle within 250ms during watch shutdown.",
+      );
+    } finally {
+      clearTimeout(exitTimeout);
+      if (child.exitCode === null && child.signalCode === null) {
+        child.kill("SIGKILL");
+        await once(child, "exit");
+      }
+    }
+  }, 10_000);
+
   it("forces exit after a watch shutdown deadline with a ref'd handle", async () => {
     const directory = await createTempDir();
     directories.push(directory);


### PR DESCRIPTION
## Summary
- share one watch shutdown deadline across iterator return, output writes, and provider cleanup
- force a bounded exit when stdout remains backpressured during signal shutdown
- add a focused subprocess regression test and changelog entry

## Validation
- 60 focused tests
- typecheck, full type-aware lint, and format
- Linux Crabbox `pnpm verify`: `run_4efc4673a34a` (1,622 passed, 34 skipped)
- GPT-5.6 Sol high autoreview: clean