### PR TITLE
docs: clarify WhatsApp target support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Preserve class-based OpenClaw bridge adapters, reject non-native Mattermost target identifiers, and close successful Signal probe bodies.
 - Harden autoreview Python requirements, Vitest config checks, local workflow pin validation, and release changelog date validation.
 - Ship only the runnable example fixture and include skipped fixtures in inferred suite totals.
+- Clarify that WhatsApp group targets are available through the OpenClaw bridge rather than the built-in Cloud API adapter.
 - Bound shared HTTP responses, Matrix sync payloads, stalled webhook DNS recovery, unmatched request bodies, and admitted local-mock hook cleanup.
 - Reject Signal JSON-RPC integral IDs that cannot round-trip safely while preserving fractional and string IDs, and register SSE clients before exposing connected response headers.
 - Keep Telegram multipart fields prototype-safe, synthetic chat IDs within 52 significant bits, and topic identities scoped to their chats.

--- a/README.md
+++ b/README.md
@@ -437,8 +437,11 @@ Examples:
 - Telegram username targets require `@`, contain 4-32 letters, digits, or
   underscores, and normalize to lowercase. Numeric chat IDs must be nonzero and
   have an absolute value no greater than `2^52 - 1`.
-- WhatsApp Cloud API users: digits-only `wa_id` values such as `15551234567`
-- WhatsApp groups: `120363001234567890@g.us`
+- Built-in WhatsApp Cloud API users: digits-only `wa_id` values such as
+  `15551234567`
+- OpenClaw WhatsApp bridge users: `15551234567@s.whatsapp.net`
+  (legacy `15551234567@c.us` inputs are accepted and canonicalized)
+- OpenClaw WhatsApp bridge groups: `120363001234567890@g.us`
 - Discord channels and threads: Discord snowflake ids such as
   `123456789012345678`
 - iMessage recipients: E.164 phone numbers such as `+15551234567`, email

--- a/test/package-production.test.ts
+++ b/test/package-production.test.ts
@@ -490,8 +490,9 @@ describe("production package", () => {
       "Matrix webhook ingress currently has no provider-native authentication mode",
     );
     expect(readme).toContain(
-      "WhatsApp Cloud API users: digits-only `wa_id` values such as `15551234567`",
+      "Built-in WhatsApp Cloud API users: digits-only `wa_id` values such as",
     );
+    expect(readme).toContain("OpenClaw WhatsApp bridge groups: `120363001234567890@g.us`");
     expect(readme).not.toContain("WhatsApp users: `+15551234567`");
   });
 


### PR DESCRIPTION
## Summary
- distinguish built-in WhatsApp Cloud API user targets from OpenClaw bridge targets
- document bridge user and group JID forms
- keep the production documentation contract aligned
- add the clarification to the changelog

## Validation
- `vitest run test/package-production.test.ts` (10 passed)
- `tsc -p tsconfig.test.json --noEmit`
- targeted type-aware oxlint and format checks
- Linux Crabbox `pnpm verify`: `run_81a82e0c2ab1` (1,621 passed, 34 skipped)
- GPT-5.6 Sol high autoreview: clean (0.95)