### PR TITLE
fix(runtime): harden body and iterator cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Harden autoreview Python requirements, Vitest config checks, local workflow pin validation, and release changelog date validation.
 - Ship only the runnable example fixture and include skipped fixtures in inferred suite totals.
 - Clarify that WhatsApp group targets are available through the OpenClaw bridge rather than the built-in Cloud API adapter.
-- Bound rejected webhook bodies and validate body size limits before listening.
+- Bound rejected webhook bodies, validate body size limits before listening, and parse JWT cache directives by name.
 - Bound shared HTTP responses, Matrix sync payloads, stalled webhook DNS recovery, unmatched request bodies, and admitted local-mock hook cleanup.
 - Reject Signal JSON-RPC integral IDs that cannot round-trip safely while preserving fractional and string IDs, and register SSE clients before exposing connected response headers.
 - Keep Telegram multipart fields prototype-safe, synthetic chat IDs within 52 significant bits, and topic identities scoped to their chats.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Harden autoreview Python requirements, Vitest config checks, local workflow pin validation, and release changelog date validation.
 - Ship only the runnable example fixture and include skipped fixtures in inferred suite totals.
 - Clarify that WhatsApp group targets are available through the OpenClaw bridge rather than the built-in Cloud API adapter.
-- Bound rejected webhook bodies, validate body size limits before listening, and parse JWT cache directives by name.
+- Bound rejected webhook bodies, validate body limits before listening, parse JWT cache directives by name, and fully drain lazy watch returns.
 - Bound shared HTTP responses, Matrix sync payloads, stalled webhook DNS recovery, unmatched request bodies, and admitted local-mock hook cleanup.
 - Reject Signal JSON-RPC integral IDs that cannot round-trip safely while preserving fractional and string IDs, and register SSE clients before exposing connected response headers.
 - Keep Telegram multipart fields prototype-safe, synthetic chat IDs within 52 significant bits, and topic identities scoped to their chats.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Harden autoreview Python requirements, Vitest config checks, local workflow pin validation, and release changelog date validation.
 - Ship only the runnable example fixture and include skipped fixtures in inferred suite totals.
 - Clarify that WhatsApp group targets are available through the OpenClaw bridge rather than the built-in Cloud API adapter.
+- Bound rejected webhook bodies and validate body size limits before listening.
 - Bound shared HTTP responses, Matrix sync payloads, stalled webhook DNS recovery, unmatched request bodies, and admitted local-mock hook cleanup.
 - Reject Signal JSON-RPC integral IDs that cannot round-trip safely while preserving fractional and string IDs, and register SSE clients before exposing connected response headers.
 - Keep Telegram multipart fields prototype-safe, synthetic chat IDs within 52 significant bits, and topic identities scoped to their chats.

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -225,7 +225,7 @@ export class LazyProviderAdapter implements ProviderAdapter {
           }
           let result = await source.return();
           while (!result.done) {
-            result = await source.return();
+            result = await source.next();
           }
           finish();
           return result;

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -219,12 +219,15 @@ export class LazyProviderAdapter implements ProviderAdapter {
       closePromise ??= (async () => {
         controller.abort();
         try {
-          const result = source.return
-            ? await source.return()
-            : { done: true as const, value: undefined as never };
-          if (result.done) {
+          if (!source.return) {
             finish();
+            return { done: true as const, value: undefined as never };
           }
+          let result = await source.return();
+          while (!result.done) {
+            result = await source.return();
+          }
+          finish();
           return result;
         } catch (error) {
           finish();

--- a/src/providers/signed-jwt.ts
+++ b/src/providers/signed-jwt.ts
@@ -137,7 +137,12 @@ export function resolveHttpCacheExpiry(response: Response, requestTime: number):
   if (!cacheControlDirectives) {
     return requestTime;
   }
-  if (/(?:^|,)\s*(?:no-cache|no-store)(?:\s*(?:=|,|$))/iu.test(cacheControl ?? "")) {
+  if (
+    cacheControlDirectives.some((directive) => {
+      const name = cacheControlDirectiveName(directive);
+      return name === "no-cache" || name === "no-store";
+    })
+  ) {
     return requestTime;
   }
   const ageHeader = response.headers.get("age");

--- a/src/providers/webhook-server.ts
+++ b/src/providers/webhook-server.ts
@@ -47,7 +47,7 @@ async function readRequestBody(
       }
       settled = true;
       cleanup();
-      drainRequestBody(request);
+      drainRequestBodyWithDeadline(request, bodyTimeoutMs);
       reject(error);
     };
     const onData = (chunk: Buffer | string) => {
@@ -87,7 +87,7 @@ async function readRequestBody(
   });
 }
 
-function drainIgnoredRequestBody(request: IncomingMessage, bodyTimeoutMs: number): void {
+function drainRequestBodyWithDeadline(request: IncomingMessage, bodyTimeoutMs: number): void {
   if (request.destroyed || request.readableEnded) {
     return;
   }
@@ -245,12 +245,15 @@ export async function startWebhookServer(params: {
   }
   const methods = new Set(params.methods ?? ["POST"]);
   const maxBodyBytes = params.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES;
+  if (!Number.isSafeInteger(maxBodyBytes) || maxBodyBytes <= 0) {
+    throw new Error("Webhook maxBodyBytes must be a positive safe integer.");
+  }
   const bodyTimeoutMs = params.bodyTimeoutMs ?? DEFAULT_BODY_TIMEOUT_MS;
   let closing = false;
   const server = createServer(async (request, response) => {
     try {
       if (closing) {
-        drainIgnoredRequestBody(request, bodyTimeoutMs);
+        drainRequestBodyWithDeadline(request, bodyTimeoutMs);
         await writeFetchResponse(
           response,
           new Response("provider is shutting down", {
@@ -264,7 +267,7 @@ export async function startWebhookServer(params: {
       const host = request.headers.host ?? "127.0.0.1";
       const url = new URL(request.url ?? "/", `http://${host}`);
       if (!methods.has(method) || url.pathname !== params.path) {
-        drainIgnoredRequestBody(request, bodyTimeoutMs);
+        drainRequestBodyWithDeadline(request, bodyTimeoutMs);
         await writeFetchResponse(response, new Response("not found", { status: 404 }));
         return;
       }
@@ -304,7 +307,7 @@ export async function startWebhookServer(params: {
                 ? "request body timeout"
                 : "internal server error",
             {
-              ...(status === 408 ? { headers: { connection: "close" } } : {}),
+              ...(status === 408 || status === 413 ? { headers: { connection: "close" } } : {}),
               status,
             },
           ),

--- a/test/registry-lifecycle.test.ts
+++ b/test/registry-lifecycle.test.ts
@@ -998,7 +998,7 @@ describe("lazy provider lifecycle", () => {
       text: id,
       threadId: "thread",
     });
-    let returnCalls = 0;
+    const cleanupSteps: string[] = [];
     const concrete: ProviderAdapter = {
       id: "test",
       platform: "loopback",
@@ -1016,22 +1016,14 @@ describe("lazy provider lifecycle", () => {
       async waitForInbound() {
         return null;
       },
-      watch() {
-        return {
-          [Symbol.asyncIterator]() {
-            return {
-              async next() {
-                return { done: false as const, value: event("watch-event") };
-              },
-              async return() {
-                returnCalls += 1;
-                return returnCalls === 1
-                  ? { done: false as const, value: event("return-value") }
-                  : { done: true as const, value: undefined };
-              },
-            };
-          },
-        };
+      async *watch() {
+        try {
+          yield event("watch-event");
+        } finally {
+          cleanupSteps.push("before-yield");
+          yield event("cleanup-yield");
+          cleanupSteps.push("after-yield");
+        }
       },
     };
     const provider = new LazyProviderAdapter({
@@ -1048,7 +1040,7 @@ describe("lazy provider lifecycle", () => {
       break;
     }
 
-    expect(returnCalls).toBe(2);
+    expect(cleanupSteps).toEqual(["before-yield", "after-yield"]);
     await provider.cleanup();
   });
 
@@ -1063,7 +1055,7 @@ describe("lazy provider lifecycle", () => {
       text: "watch event",
       threadId: "thread",
     };
-    let returnCalls = 0;
+    const cleanupSteps: string[] = [];
     const concrete: ProviderAdapter = {
       id: "test",
       platform: "loopback",
@@ -1081,23 +1073,16 @@ describe("lazy provider lifecycle", () => {
       async waitForInbound() {
         return null;
       },
-      watch() {
-        return {
-          [Symbol.asyncIterator]() {
-            return {
-              async next() {
-                return { done: false as const, value: event };
-              },
-              async return() {
-                returnCalls += 1;
-                if (returnCalls === 1) {
-                  return { done: false as const, value: event };
-                }
-                throw cleanupError;
-              },
-            };
-          },
-        };
+      async *watch() {
+        try {
+          yield event;
+        } finally {
+          cleanupSteps.push("before-yield");
+          yield { ...event, id: "cleanup-yield" };
+          cleanupSteps.push("after-yield");
+          // oxlint-disable-next-line no-unsafe-finally -- This intentionally models a failing generator cleanup.
+          throw cleanupError;
+        }
       },
     };
     const provider = new LazyProviderAdapter({
@@ -1118,7 +1103,7 @@ describe("lazy provider lifecycle", () => {
         }
       })(),
     ).rejects.toBe(cleanupError);
-    expect(returnCalls).toBe(2);
+    expect(cleanupSteps).toEqual(["before-yield", "after-yield"]);
     await provider.cleanup();
   });
 

--- a/test/registry-lifecycle.test.ts
+++ b/test/registry-lifecycle.test.ts
@@ -988,7 +988,7 @@ describe("lazy provider lifecycle", () => {
     expect(cleanup).toHaveBeenCalledOnce();
   });
 
-  it("keeps a lazy watch active when the source return reports done false", async () => {
+  it("drains lazy watch cleanup yields when a for-await loop breaks", async () => {
     const { context } = createTelegramManifest("/tmp/unused.jsonl");
     const event = (id: string) => ({
       author: "assistant" as const,
@@ -1043,17 +1043,81 @@ describe("lazy provider lifecycle", () => {
       status: "ready",
       supports: ["agent"],
     });
-    const iterator = provider.watch(context)[Symbol.asyncIterator]();
+    for await (const value of provider.watch(context)) {
+      expect(value.id).toBe("watch-event");
+      break;
+    }
 
-    await expect(iterator.next()).resolves.toMatchObject({
-      done: false,
-      value: { id: "watch-event" },
+    expect(returnCalls).toBe(2);
+    await provider.cleanup();
+  });
+
+  it("preserves lazy watch errors after cleanup yields on for-await break", async () => {
+    const { context } = createTelegramManifest("/tmp/unused.jsonl");
+    const cleanupError = new Error("watch cleanup failed");
+    const event = {
+      author: "assistant" as const,
+      id: "watch-event",
+      provider: "test",
+      sentAt: new Date().toISOString(),
+      text: "watch event",
+      threadId: "thread",
+    };
+    let returnCalls = 0;
+    const concrete: ProviderAdapter = {
+      id: "test",
+      platform: "loopback",
+      status: "ready",
+      supports: ["agent"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      async probe() {
+        return { details: [], healthy: true };
+      },
+      async send() {
+        return { accepted: true, messageId: "sent", threadId: "thread" };
+      },
+      async waitForInbound() {
+        return null;
+      },
+      watch() {
+        return {
+          [Symbol.asyncIterator]() {
+            return {
+              async next() {
+                return { done: false as const, value: event };
+              },
+              async return() {
+                returnCalls += 1;
+                if (returnCalls === 1) {
+                  return { done: false as const, value: event };
+                }
+                throw cleanupError;
+              },
+            };
+          },
+        };
+      },
+    };
+    const provider = new LazyProviderAdapter({
+      adapterName: "test",
+      factory: async () => concrete,
+      id: "test",
+      normalizeTarget: concrete.normalizeTarget.bind(concrete),
+      platform: "loopback",
+      status: "ready",
+      supports: ["agent"],
     });
-    await expect(iterator.return!()).resolves.toMatchObject({
-      done: false,
-      value: { id: "return-value" },
-    });
-    await expect(iterator.return!()).resolves.toEqual({ done: true, value: undefined });
+
+    await expect(
+      (async () => {
+        for await (const value of provider.watch(context)) {
+          expect(value.id).toBe("watch-event");
+          break;
+        }
+      })(),
+    ).rejects.toBe(cleanupError);
     expect(returnCalls).toBe(2);
     await provider.cleanup();
   });

--- a/test/signed-jwt.test.ts
+++ b/test/signed-jwt.test.ts
@@ -183,6 +183,22 @@ describe("signed JWT remote key cache", () => {
     ).toBe(now);
   });
 
+  it("does not treat quoted no-cache or no-store values as directives", () => {
+    const now = 1_700_000_000_000;
+
+    for (const cacheControl of [
+      'private="authorization, no-cache", max-age=3600',
+      'x-metadata="quoted, no-store", max-age=3600',
+    ]) {
+      expect(
+        resolveHttpCacheExpiry(
+          new Response(null, { headers: { "cache-control": cacheControl } }),
+          now,
+        ),
+      ).toBe(now + 3_600_000);
+    }
+  });
+
   it("subtracts response Age from cache freshness", () => {
     const now = 1_700_000_000_000;
 

--- a/test/webhook-server.test.ts
+++ b/test/webhook-server.test.ts
@@ -91,6 +91,21 @@ describe("webhook server", () => {
     ).rejects.toThrow(/canonical URL pathname/u);
   });
 
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, 0, -1, 1.5])(
+    "rejects invalid maxBodyBytes before listening: %s",
+    async (maxBodyBytes) => {
+      await expect(
+        startWebhookServer({
+          handle: async () => new Response("ok"),
+          host: "127.0.0.1",
+          maxBodyBytes,
+          path: "/slack/events",
+          port: -1,
+        }),
+      ).rejects.toThrow(/maxBodyBytes must be a positive safe integer/u);
+    },
+  );
+
   it("can serve explicit GET webhook routes", async () => {
     const server = await startWebhookServer({
       async handle(request) {
@@ -351,6 +366,44 @@ describe("webhook server", () => {
     const healthy = await fetch(server.endpointUrl, { body: "1234", method: "POST" });
     expect(healthy.status).toBe(200);
     expect(handlerInvoked).toBe(true);
+  });
+
+  it("closes oversized request bodies that stall after rejection", async () => {
+    let handlerInvoked = false;
+    const server = await startWebhookServer({
+      bodyTimeoutMs: 20,
+      async handle() {
+        handlerInvoked = true;
+        return new Response("ok");
+      },
+      host: "127.0.0.1",
+      maxBodyBytes: 4,
+      path: "/slack/events",
+      port: 0,
+    });
+    cleanups.push(() => server.close());
+    const endpoint = new URL(server.endpointUrl);
+    const socket = connect(Number(endpoint.port), endpoint.hostname);
+    let response = "";
+    const closed = once(socket, "close");
+    socket.setEncoding("utf8");
+    socket.on("data", (chunk) => {
+      response += chunk;
+    });
+    await once(socket, "connect");
+    socket.write(
+      "POST /slack/events HTTP/1.1\r\nHost: 127.0.0.1\r\nContent-Length: 10\r\n\r\n12345",
+    );
+
+    await vi.waitFor(() => expect(response).toContain("HTTP/1.1 413"));
+    expect(response).toMatch(/\r\nconnection: close\r\n/iu);
+    await expect(
+      Promise.race([
+        closed.then(() => "closed"),
+        new Promise<string>((resolve) => setTimeout(() => resolve("timed out"), 500)),
+      ]),
+    ).resolves.toBe("closed");
+    expect(handlerInvoked).toBe(false);
   });
 
   it("rejects a wrong route before reading an oversized body", async () => {


### PR DESCRIPTION
## Summary
- bound and close oversized rejected webhook request bodies
- require positive safe integer body limits
- parse exact cache-control directive names
- fully drain async generator cleanup yields through completion
- add focused regression coverage and changelog entries

## Validation
- 45 focused tests
- `tsc -p tsconfig.test.json --noEmit`
- targeted type-aware oxlint and format checks
- Linux Crabbox `pnpm verify`: `run_db80f96dbaca` (1,630 passed, 34 skipped)
- GPT-5.6 Sol high autoreview: clean (0.91)