### PR TITLE
fix(runtime): bound provider lifecycle cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Ship only the runnable example fixture and include skipped fixtures in inferred suite totals.
 - Clarify that WhatsApp group targets are available through the OpenClaw bridge rather than the built-in Cloud API adapter.
 - Bound rejected webhook bodies, validate body limits before listening, parse JWT cache directives by name, and fully drain lazy watch returns.
+- Bound deferred WhatsApp startup cleanup, avoid retrying ambiguous timed-out sends, and defer OpenClaw readiness cleanup until aborted probes settle.
 - Bound shared HTTP responses, Matrix sync payloads, stalled webhook DNS recovery, unmatched request bodies, and admitted local-mock hook cleanup.
 - Reject Signal JSON-RPC integral IDs that cannot round-trip safely while preserving fractional and string IDs, and register SSE clients before exposing connected response headers.
 - Keep Telegram multipart fields prototype-safe, synthetic chat IDs within 52 significant bits, and topic identities scoped to their chats.

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -51,6 +51,15 @@ class UnsettledProviderOperationError extends CrablineError {
   }
 }
 
+class ProviderOperationTimeoutError extends CrablineError {
+  constructor(
+    message: string,
+    readonly retryable: boolean,
+  ) {
+    super(message, { kind: "timeout" });
+  }
+}
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -93,6 +102,7 @@ async function withFixtureDeadline<T>(
   operation: (signal: AbortSignal) => Promise<T>,
   timeoutMs: number,
   operationName: string,
+  retryableAfterTimeout = true,
 ): Promise<T> {
   const controller = new AbortController();
   const pending = observeProviderOperation(
@@ -100,11 +110,9 @@ async function withFixtureDeadline<T>(
   );
   const result = await raceInboundDeadline(pending.promise, timeoutMs);
   if (result === INBOUND_DEADLINE_REACHED) {
-    const timeoutError = new CrablineError(
+    const timeoutError = new ProviderOperationTimeoutError(
       `Provider ${operationName} timed out after ${timeoutMs}ms.`,
-      {
-        kind: "timeout",
-      },
+      retryableAfterTimeout,
     );
     controller.abort(timeoutError);
     if (
@@ -451,12 +459,16 @@ export async function runFixtureCommand(params: {
               async (signal) => await provider.send({ ...sendContext, signal }),
               fixture.timeoutMs,
               "send",
+              false,
             );
           } catch (error) {
             lastFailure = toFailure(fixture.id, fixture.provider, mode, error, "outbound", nonce);
             if (error instanceof UnsettledProviderOperationError) {
               abortDrainFailed = true;
               unsettledProviderOperations.push(error.operation);
+              break;
+            }
+            if (error instanceof ProviderOperationTimeoutError && !error.retryable) {
               break;
             }
             if (isPermanentFailure(lastFailure)) {

--- a/src/openclaw.ts
+++ b/src/openclaw.ts
@@ -24,6 +24,7 @@ import {
   OPENCLAW_CRABLINE_ARTIFACT_POINTER_PATH,
   OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY,
   OPENCLAW_CRABLINE_MANIFEST_PATH,
+  getUnsettledOpenClawCrablineProviderProbe,
   isRecord,
   parseQaTarget,
   runOpenClawCrablineProviderProbe,
@@ -94,6 +95,7 @@ const RECORDER_TEMP_NAME_PATTERN =
   /^\.([a-z]+)-fake-provider\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl\.tmp$/iu;
 const RECORDER_LOCK_REMOVAL_TOMBSTONE_PATTERN =
   /^\.(.+)\.\d+\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.remove$/iu;
+const OPENCLAW_CRABLINE_PROVIDER_PROBE_CLEANUP_GRACE_MS = 250;
 
 function isOpenClawCrablineRecorderTemporary(name: string): boolean {
   const channel = RECORDER_TEMP_NAME_PATTERN.exec(name)?.[1]?.toLowerCase();
@@ -516,6 +518,43 @@ type ProviderReadinessDependencies = {
   syncParent?: typeof syncParentDirectory;
 };
 
+function attachOpenClawCrablineProbeCleanupFailure(
+  probeFailure: Error,
+  cleanupError: unknown,
+): void {
+  const existingCause = probeFailure.cause;
+  try {
+    Object.defineProperty(probeFailure, "cause", {
+      configurable: true,
+      value:
+        existingCause === undefined
+          ? cleanupError
+          : new AggregateError(
+              [existingCause, cleanupError],
+              "OpenClaw Crabline provider probe cleanup also failed.",
+            ),
+    });
+  } catch {
+    // Some provider errors are frozen; preserving the primary failure is authoritative.
+  }
+}
+
+async function waitForOpenClawCrablineProbeCleanup(probeSettlement: Promise<void>): Promise<void> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      probeSettlement,
+      new Promise<void>((resolve) => {
+        timeout = setTimeout(resolve, OPENCLAW_CRABLINE_PROVIDER_PROBE_CLEANUP_GRACE_MS);
+      }),
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
 export function runOpenClawCrablineProviderReadiness(params: {
   outputDir: string;
   selection: OpenClawCrablineChannelDriverSelection;
@@ -561,43 +600,47 @@ export async function runOpenClawCrablineProviderReadiness(
     let probe: unknown;
     let probeFailed = false;
     let probeFailure: unknown;
+    let probeSettlement: Promise<void> | undefined;
     try {
       probe = await adapter.probe();
     } catch (error) {
       probeFailed = true;
       probeFailure = error;
+      probeSettlement = getUnsettledOpenClawCrablineProviderProbe(error);
     }
-    try {
-      await adapter.close();
-    } catch (cleanupError) {
-      if (!probeFailed) {
-        throw cleanupError;
-      }
-      if (probeFailure instanceof Error) {
-        const existingCause = probeFailure.cause;
+    if (probeSettlement) {
+      const primaryFailure = probeFailure;
+      void waitForOpenClawCrablineProbeCleanup(probeSettlement).then(async () => {
         try {
-          Object.defineProperty(probeFailure, "cause", {
-            configurable: true,
-            value:
-              existingCause === undefined
-                ? cleanupError
-                : new AggregateError(
-                    [existingCause, cleanupError],
-                    "OpenClaw Crabline provider probe cleanup also failed.",
-                  ),
-          });
-        } catch {
-          // Some provider errors are frozen; preserving the primary failure is authoritative.
+          await adapter.close();
+        } catch (cleanupError) {
+          if (primaryFailure instanceof Error) {
+            attachOpenClawCrablineProbeCleanupFailure(primaryFailure, cleanupError);
+          }
         }
-        throw probeFailure;
+      });
+    } else {
+      try {
+        await adapter.close();
+      } catch (cleanupError) {
+        if (!probeFailed) {
+          throw cleanupError;
+        }
+        if (probeFailure instanceof Error) {
+          attachOpenClawCrablineProbeCleanupFailure(probeFailure, cleanupError);
+          throw probeFailure;
+        }
+        const combinedError = new Error(
+          "OpenClaw Crabline provider probe and cleanup both failed.",
+          {
+            cause: cleanupError,
+          },
+        );
+        Object.defineProperty(combinedError, "errors", {
+          value: [probeFailure, cleanupError],
+        });
+        throw combinedError;
       }
-      const combinedError = new Error("OpenClaw Crabline provider probe and cleanup both failed.", {
-        cause: cleanupError,
-      });
-      Object.defineProperty(combinedError, "errors", {
-        value: [probeFailure, cleanupError],
-      });
-      throw combinedError;
     }
     if (probeFailed) {
       throw probeFailure;

--- a/src/openclaw/shared.ts
+++ b/src/openclaw/shared.ts
@@ -14,6 +14,7 @@ export const OPENCLAW_CRABLINE_ARTIFACT_POINTER_PATH = `${OPENCLAW_CRABLINE_ARTI
 export const OPENCLAW_CRABLINE_DEFAULT_CHANNEL = "telegram";
 
 const OPENCLAW_CRABLINE_PROVIDER_PROBE_TIMEOUT_MS = 5_000;
+const OPENCLAW_CRABLINE_PROVIDER_PROBE_ABORT_GRACE_MS = 250;
 const OPENCLAW_CRABLINE_PROVIDER_PROBE_LABELS = {
   mattermost: "Mattermost users.me",
   matrix: "Matrix whoami",
@@ -23,6 +24,7 @@ const OPENCLAW_CRABLINE_PROVIDER_PROBE_LABELS = {
   whatsapp: "WhatsApp phone number",
   zalo: "Zalo getMe",
 } satisfies Record<CrablineServerManifest["provider"], string>;
+const unsettledProviderProbeSettlements = new WeakMap<Error, Promise<void>>();
 
 export type OpenClawCrablineChannelDriverSelection = {
   channel: CrablineServerChannel;
@@ -209,30 +211,64 @@ export async function runOpenClawCrablineProviderProbe<T>(
       `Crabline ${OPENCLAW_CRABLINE_PROVIDER_PROBE_LABELS[provider]} probe timed out after ${OPENCLAW_CRABLINE_PROVIDER_PROBE_TIMEOUT_MS} ms.`,
       { cause },
     );
+  const operation = Promise.resolve().then(() => probe(signal));
+  const settled = operation.then(
+    () => undefined,
+    () => undefined,
+  );
   let onAbort: (() => void) | undefined;
-  const timeout = new Promise<never>((_, reject) => {
-    onAbort = () => reject(timeoutError(signal.reason));
+  const timeout = new Promise<{ kind: "timeout" }>((resolve) => {
+    onAbort = () => resolve({ kind: "timeout" });
     if (signal.aborted) {
       onAbort();
       return;
     }
     signal.addEventListener("abort", onAbort, { once: true });
   });
-  const probeResult = Promise.resolve()
-    .then(() => probe(signal))
-    .catch((error: unknown) => {
-      if (signal.aborted) {
-        throw timeoutError(error);
-      }
-      throw error;
-    });
   try {
-    return await Promise.race([probeResult, timeout]);
+    const outcome = await Promise.race([
+      operation.then(
+        (value) => ({ kind: "result" as const, value }),
+        (error: unknown) => ({ error, kind: "error" as const }),
+      ),
+      timeout,
+    ]);
+    if (outcome.kind === "result") {
+      return outcome.value;
+    }
+    if (outcome.kind === "error" && !signal.aborted) {
+      throw outcome.error;
+    }
+
+    const failure = timeoutError(outcome.kind === "error" ? outcome.error : signal.reason);
+    let abortGrace: ReturnType<typeof setTimeout> | undefined;
+    const drained = await Promise.race([
+      settled.then(() => true as const),
+      new Promise<false>((resolve) => {
+        abortGrace = setTimeout(
+          () => resolve(false),
+          OPENCLAW_CRABLINE_PROVIDER_PROBE_ABORT_GRACE_MS,
+        );
+      }),
+    ]);
+    if (abortGrace) {
+      clearTimeout(abortGrace);
+    }
+    if (!drained) {
+      unsettledProviderProbeSettlements.set(failure, settled);
+    }
+    throw failure;
   } finally {
     if (onAbort) {
       signal.removeEventListener("abort", onAbort);
     }
   }
+}
+
+export function getUnsettledOpenClawCrablineProviderProbe(
+  error: unknown,
+): Promise<void> | undefined {
+  return error instanceof Error ? unsettledProviderProbeSettlements.get(error) : undefined;
 }
 
 export function readString(value: unknown): string | undefined {

--- a/src/providers/builtin/whatsapp.ts
+++ b/src/providers/builtin/whatsapp.ts
@@ -72,6 +72,48 @@ const DEFAULT_WHATSAPP_WEBHOOK = {
 const MAX_WAIT_CURSORS = 64;
 const MAX_WHATSAPP_WEBHOOK_BODY_BYTES = 1024 * 1024;
 const WHATSAPP_WEBHOOK_BODY_TIMEOUT_MS = 5_000;
+const WHATSAPP_WEBHOOK_STARTUP_CLEANUP_GRACE_MS = 250;
+
+function abortableOperation<T>(operation: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) {
+    return Promise.reject(signal.reason);
+  }
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(signal.reason);
+    signal.addEventListener("abort", onAbort, { once: true });
+    void operation.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error: unknown) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      },
+    );
+  });
+}
+
+async function settlesWithin(operation: Promise<unknown>, timeoutMs: number): Promise<boolean> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<false>((resolve) => {
+    timeout = setTimeout(() => resolve(false), timeoutMs);
+    timeout.unref();
+  });
+  try {
+    return await Promise.race([
+      operation.then(
+        () => true as const,
+        () => true as const,
+      ),
+      deadline,
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
 
 class WhatsAppWebhookBodyError extends Error {
   constructor(
@@ -227,6 +269,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
   readonly #inFlightWebhookRequests = new Set<Promise<Response>>();
   readonly #waitCursors = new Map<string, WaitCursorState>();
   #server: StartedWebhookServer | null = null;
+  #serverClosePromise: Promise<void> | null = null;
   #serverClosing: Promise<void> | null = null;
   #serverStarting: Promise<StartedWebhookServer> | null = null;
 
@@ -257,12 +300,13 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
   }
 
   override async probe(context: ProviderContext): Promise<ProbeResult> {
-    context.signal?.throwIfAborted();
-    const server = await this.#ensureWebhookServer();
+    const signal = this.#operationSignal(context.signal);
+    signal.throwIfAborted();
+    const server = await this.#ensureWebhookServer(signal);
     if (this.#cleanupBegun || this.#cleanedUp) {
       throw this.#cleanedUpError();
     }
-    context.signal?.throwIfAborted();
+    signal.throwIfAborted();
     const target = this.normalizeTarget(context.fixture.target);
     const details = [
       "whatsapp local mock ready",
@@ -299,10 +343,11 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
     if (context.signal?.aborted) {
       return null;
     }
+    const signal = this.#operationSignal(context.signal);
     try {
-      await this.#ensureWebhookServer();
+      await this.#ensureWebhookServer(signal);
     } catch (error) {
-      if (this.#cleanupBegun) {
+      if (this.#cleanupBegun || signal.aborted) {
         return null;
       }
       throw error;
@@ -336,7 +381,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
           isAddressInChannel(candidate.threadId, channelId) &&
           matchesInbound(candidate, context.fixture.inboundMatch, context.nonce),
         since: context.since,
-        signal: this.#operationSignal(context.signal),
+        signal,
         timeoutMs: context.timeoutMs,
       });
       if (
@@ -363,10 +408,11 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
     if (context.signal?.aborted) {
       return;
     }
+    const signal = this.#operationSignal(context.signal);
     try {
-      await this.#ensureWebhookServer();
+      await this.#ensureWebhookServer(signal);
     } catch (error) {
-      if (this.#cleanupBegun) {
+      if (this.#cleanupBegun || signal.aborted) {
         return;
       }
       throw error;
@@ -381,7 +427,7 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
         entry.provider === this.id &&
         !isOutboundRecord(entry) &&
         isAddressInChannel(entry.threadId, target.threadId ?? target.channelId ?? target.id),
-      signal: this.#operationSignal(context.signal),
+      signal,
       since: context.since,
     })) {
       yield event;
@@ -528,15 +574,16 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
     );
   }
 
-  async #ensureWebhookServer(): Promise<StartedWebhookServer> {
+  async #ensureWebhookServer(signal: AbortSignal): Promise<StartedWebhookServer> {
     if (this.#cleanupBegun) {
       throw this.#cleanedUpError();
     }
+    signal.throwIfAborted();
     if (this.#server) {
       return this.#server;
     }
     if (this.#serverStarting) {
-      return await this.#serverStarting;
+      return await abortableOperation(this.#serverStarting, signal);
     }
 
     const resolvedConfig = resolveWhatsAppAdapterConfig(this.#config, this.#env);
@@ -562,39 +609,54 @@ export class WhatsAppProviderAdapter extends LocalMockProviderAdapter implements
 
       this.#server = server;
       if (this.#cleanupBegun) {
-        throw this.#cleanedUpError();
+        void this.#closeStartedWebhookServer(server).catch(() => undefined);
       }
       return server;
     })();
     this.#serverStarting = starting;
+    void starting.then(
+      () => {
+        if (this.#serverStarting === starting) {
+          this.#serverStarting = null;
+        }
+      },
+      () => {
+        if (this.#serverStarting === starting) {
+          this.#serverStarting = null;
+        }
+      },
+    );
 
-    try {
-      return await starting;
-    } finally {
-      if (this.#serverStarting === starting) {
-        this.#serverStarting = null;
-      }
+    const server = await abortableOperation(starting, signal);
+    if (this.#cleanupBegun) {
+      throw this.#cleanedUpError();
     }
+    return server;
+  }
+
+  async #closeStartedWebhookServer(server: StartedWebhookServer): Promise<void> {
+    if (this.#server === server) {
+      this.#server = null;
+    }
+    if (!this.#serverClosePromise) {
+      this.#serverClosePromise = server.close();
+    }
+    await this.#serverClosePromise;
   }
 
   async #closeWebhookServer(): Promise<void> {
     const starting = this.#serverStarting;
     if (starting) {
-      try {
-        await starting;
-      } catch {
-        // A failed startup has no listener; a cleanup race publishes one below.
-      }
+      await settlesWithin(starting, WHATSAPP_WEBHOOK_STARTUP_CLEANUP_GRACE_MS);
     }
     const server = this.#server;
-    if (!server) {
+    if (server) {
+      await this.#closeStartedWebhookServer(server);
       return;
     }
-
-    if (this.#server === server) {
-      this.#server = null;
+    if (this.#serverClosePromise) {
+      await this.#serverClosePromise;
     }
-    await server.close();
   }
 
   #cleanedUpError(): CrablineError {

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -44,6 +44,7 @@ import {
   createOpenClawCrablineProviderBridge,
   isRecord,
   parseQaTarget,
+  runOpenClawCrablineProviderProbe,
   type OpenClawCrablineProviderAdapter,
 } from "../src/openclaw/shared.js";
 
@@ -3184,6 +3185,87 @@ describe("OpenClaw local provider bridge", () => {
       }
     },
   );
+
+  it("defers readiness cleanup while an aborted provider probe remains unsettled", async () => {
+    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-probe-drain-"));
+    const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
+    const controller = new AbortController();
+    const timeoutMock = vi.spyOn(AbortSignal, "timeout").mockReturnValue(controller.signal);
+    const cleanupFailure = new Error("deferred adapter close failed");
+    const close = vi.fn(async () => {
+      throw cleanupFailure;
+    });
+    let reportAbort: (() => void) | undefined;
+    let reportProbeStart: (() => void) | undefined;
+    const abortObserved = new Promise<void>((resolve) => {
+      reportAbort = resolve;
+    });
+    const probeStarted = new Promise<void>((resolve) => {
+      reportProbeStart = resolve;
+    });
+
+    try {
+      const readiness = runProviderReadinessWithDependencies(
+        { outputDir, selection },
+        {
+          startAdapter: async (params) =>
+            ({
+              close,
+              manifest: { ...manifest, recorderPath: params.recorderPath! },
+              probe: async () =>
+                await runOpenClawCrablineProviderProbe("telegram", async (signal) => {
+                  reportProbeStart?.();
+                  return await new Promise<never>(() => {
+                    signal.addEventListener("abort", () => reportAbort?.(), { once: true });
+                  });
+                }),
+            }) as unknown as Awaited<ReturnType<typeof startOpenClawCrablineAdapter>>,
+        },
+      );
+      let readinessSettled = false;
+      const outcome = readiness.then(
+        (result) => {
+          readinessSettled = true;
+          return { kind: "resolved" as const, result };
+        },
+        (error: unknown) => {
+          readinessSettled = true;
+          return { error, kind: "rejected" as const };
+        },
+      );
+
+      await probeStarted;
+      expect(timeoutMock).toHaveBeenCalledWith(5_000);
+      controller.abort(new DOMException("probe deadline", "TimeoutError"));
+      await abortObserved;
+      await new Promise((resolve) => setTimeout(resolve, 300));
+
+      expect(readinessSettled).toBe(true);
+      expect(close).not.toHaveBeenCalled();
+
+      const result = await outcome;
+      expect(result.kind).toBe("rejected");
+      expect(result).toMatchObject({
+        error: expect.objectContaining({
+          message: "Crabline Telegram getMe probe timed out after 5000 ms.",
+        }),
+      });
+
+      await vi.waitFor(() => expect(close).toHaveBeenCalledTimes(1));
+      await vi.waitFor(() =>
+        expect(result).toMatchObject({
+          error: expect.objectContaining({
+            cause: expect.objectContaining({
+              errors: expect.arrayContaining([cleanupFailure]),
+            }),
+          }),
+        }),
+      );
+    } finally {
+      timeoutMock.mockRestore();
+      await fs.rm(outputDir, { recursive: true, force: true });
+    }
+  }, 5_000);
 
   it("fails closed when a successful probe produces no recorder evidence", async () => {
     const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-recorder-missing-"));

--- a/test/run.retry-timeout.test.ts
+++ b/test/run.retry-timeout.test.ts
@@ -329,6 +329,66 @@ describe("runFixtureCommand retries", () => {
     expect(cleanupCalls).toBe(1);
   });
 
+  it("does not retry an accepted send that settles during abort grace", async () => {
+    let cleanupCalls = 0;
+    let sendCalls = 0;
+    const provider: ProviderAdapter = {
+      id: "mock",
+      platform: "loopback",
+      status: "ready",
+      supports: ["send"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      async probe() {
+        return { details: [], healthy: true };
+      },
+      async send(context) {
+        sendCalls += 1;
+        return await new Promise((resolve) => {
+          context.signal?.addEventListener(
+            "abort",
+            () => {
+              setTimeout(() => {
+                resolve({
+                  accepted: true,
+                  messageId: "accepted-after-deadline",
+                  threadId: "thread-1",
+                });
+              }, 25);
+            },
+            { once: true },
+          );
+        });
+      },
+      async waitForInbound() {
+        throw new Error("wait must not run");
+      },
+      async cleanup() {
+        cleanupCalls += 1;
+      },
+    };
+    const registry: Registry = {
+      catalog: OPENCLAW_SUPPORT_CATALOG,
+      resolve() {
+        return provider;
+      },
+    };
+
+    const result = await runFixtureCommand({
+      fixtureId: "fixture",
+      manifest,
+      manifestPath: "/tmp/crabline.yaml",
+      modeOverride: "send",
+      registry,
+    });
+
+    expect(result).toMatchObject({ failureKind: "timeout", ok: false });
+    expect(result.diagnostics).toContain("Provider send timed out after 10ms.");
+    expect(sendCalls).toBe(1);
+    expect(cleanupCalls).toBe(1);
+  });
+
   it("bounds cleanup after an inbound wait ignores cancellation", async () => {
     let releaseWait: (() => void) | undefined;
     const provider: ProviderAdapter = {

--- a/test/whatsapp-provider-lifecycle.test.ts
+++ b/test/whatsapp-provider-lifecycle.test.ts
@@ -256,6 +256,41 @@ describe("WhatsApp provider lifecycle", () => {
     expect(close).toHaveBeenCalledTimes(1);
   });
 
+  it("cancels operations and bounds cleanup when listener startup never settles", async () => {
+    webhookMocks.startWebhookServer.mockReturnValueOnce(new Promise(() => undefined));
+    const config = createConfig();
+    const provider = new WhatsAppProviderAdapter("whatsapp", config, "crabline");
+    const context = createContext(config);
+    const probeController = new AbortController();
+    const inboundController = new AbortController();
+    const probeFailure = new Error("probe deadline reached");
+
+    const probe = provider.probe({ ...context, signal: probeController.signal });
+    const waiting = provider.waitForInbound({
+      ...context,
+      nonce: "never-started-wait",
+      signal: inboundController.signal,
+      since: new Date(0).toISOString(),
+      timeoutMs: 30_000,
+    });
+    const stream = provider.watch({
+      ...context,
+      signal: inboundController.signal,
+      since: new Date(0).toISOString(),
+    });
+    const watching = stream[Symbol.asyncIterator]();
+    const next = watching.next();
+    await vi.waitFor(() => expect(webhookMocks.startWebhookServer).toHaveBeenCalledTimes(1));
+
+    probeController.abort(probeFailure);
+    inboundController.abort(new Error("inbound deadline reached"));
+
+    await expect(probe).rejects.toBe(probeFailure);
+    await expect(waiting).resolves.toBeNull();
+    await expect(next).resolves.toEqual({ done: true, value: undefined });
+    await expect(provider.cleanup()).resolves.toBeUndefined();
+  }, 1_000);
+
   it("rechecks cleanup after awaiting an existing listener", async () => {
     const close = vi.fn(async () => undefined);
     webhookMocks.startWebhookServer.mockResolvedValueOnce({
@@ -367,7 +402,9 @@ describe("WhatsApp provider lifecycle", () => {
         nonce: "whatsapp-cleanup-race",
         text: "finish before cleanup",
       });
-      await vi.waitFor(() => expect(recorderMocks.appendRecordedInbound).toHaveBeenCalledTimes(2));
+      await vi.waitFor(() => expect(recorderMocks.appendRecordedInbound).toHaveBeenCalledTimes(2), {
+        timeout: 5_000,
+      });
 
       let cleanupResolved = false;
       cleanup = provider.cleanup().then(() => {


### PR DESCRIPTION
## Summary
- bound deferred WhatsApp webhook startup and cancel it on shutdown
- avoid retrying sends after ambiguous timeout outcomes
- drain timed-out provider probes without masking primary readiness failures
- add focused regression coverage and changelog entries

## Validation
- 30 focused tests
- full type-aware oxlint, typecheck, and repository format check
- Linux Crabbox `pnpm verify`: 1,624 passed, 34 skipped (`run_c87476115f8e`)
- hosted CI verify: passed
- GPT-5.6 Sol high autoreview: clean (0.87)