### PR TITLE
fix(openclaw): validate generated artifact schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Clarify that WhatsApp group targets are available through the OpenClaw bridge rather than the built-in Cloud API adapter.
 - Bound rejected webhook bodies, validate body limits before listening, parse JWT cache directives by name, and fully drain lazy watch returns.
 - Bound deferred WhatsApp startup cleanup, avoid retrying ambiguous timed-out sends, and defer OpenClaw readiness cleanup until aborted probes settle.
+- Validate generated OpenClaw manifest and readiness schemas and cross-references before publication.
 - Bound shared HTTP responses, Matrix sync payloads, stalled webhook DNS recovery, unmatched request bodies, and admitted local-mock hook cleanup.
 - Reject Signal JSON-RPC integral IDs that cannot round-trip safely while preserving fractional and string IDs, and register SSE clients before exposing connected response headers.
 - Keep Telegram multipart fields prototype-safe, synthetic chat IDs within 52 significant bits, and topic identities scoped to their chats.

--- a/src/openclaw/artifact-generation.ts
+++ b/src/openclaw/artifact-generation.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
 import type { CrablineServerManifest } from "../servers/index.js";
 import {
   captureDirectoryIdentity,
@@ -81,6 +82,215 @@ function isMissingPathError(error: unknown): boolean {
   return (error as NodeJS.ErrnoException).code === "ENOENT";
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasNonEmptyStringFields(
+  value: Record<string, unknown>,
+  fields: readonly string[],
+): boolean {
+  return fields.every((field) => typeof value[field] === "string" && value[field].length > 0);
+}
+
+function isGeneratedManifest(value: Record<string, unknown>): boolean {
+  if (
+    value.version !== 1 ||
+    !hasNonEmptyStringFields(value, ["adminToken", "baseUrl", "provider"]) ||
+    !isRecord(value.endpoints) ||
+    !isRecord(value.env)
+  ) {
+    return false;
+  }
+  const endpoints = value.endpoints;
+  const env = value.env;
+  const baseUrl = value.baseUrl as string;
+  switch (value.provider) {
+    case "mattermost":
+      return (
+        hasNonEmptyStringFields(value, ["botToken", "botUserId"]) &&
+        hasNonEmptyStringFields(endpoints, ["adminInboundUrl", "apiRoot", "websocketUrl"]) &&
+        hasNonEmptyStringFields(env, ["MATTERMOST_BOT_TOKEN", "MATTERMOST_URL"]) &&
+        endpoints.adminInboundUrl === `${baseUrl}/crabline/mattermost/inbound` &&
+        endpoints.apiRoot === `${baseUrl}/api/v4` &&
+        endpoints.websocketUrl === `${baseUrl.replace(/^http/u, "ws")}/api/v4/websocket` &&
+        env.MATTERMOST_BOT_TOKEN === value.botToken &&
+        env.MATTERMOST_URL === baseUrl
+      );
+    case "matrix":
+      return (
+        hasNonEmptyStringFields(value, ["accessToken", "botUserId", "deviceId"]) &&
+        hasNonEmptyStringFields(endpoints, ["adminInboundUrl", "clientApiRoot", "syncUrl"]) &&
+        hasNonEmptyStringFields(env, [
+          "MATRIX_ACCESS_TOKEN",
+          "MATRIX_BASE_URL",
+          "MATRIX_USER_ID",
+        ]) &&
+        endpoints.adminInboundUrl === `${baseUrl}/crabline/matrix/inbound` &&
+        endpoints.clientApiRoot === `${baseUrl}/_matrix/client/v3` &&
+        endpoints.syncUrl === `${endpoints.clientApiRoot as string}/sync` &&
+        env.MATRIX_ACCESS_TOKEN === value.accessToken &&
+        env.MATRIX_BASE_URL === baseUrl &&
+        env.MATRIX_USER_ID === value.botUserId
+      );
+    case "signal":
+      return (
+        hasNonEmptyStringFields(value, ["account"]) &&
+        hasNonEmptyStringFields(endpoints, ["adminInboundUrl", "apiRoot", "eventsUrl", "rpcUrl"]) &&
+        endpoints.adminInboundUrl === `${baseUrl}/crabline/signal/inbound` &&
+        endpoints.apiRoot === baseUrl &&
+        endpoints.eventsUrl === `${baseUrl}/api/v1/events` &&
+        endpoints.rpcUrl === `${baseUrl}/api/v1/rpc` &&
+        Object.keys(env).length === 0
+      );
+    case "slack":
+      return (
+        hasNonEmptyStringFields(value, ["botToken", "signingSecret"]) &&
+        hasNonEmptyStringFields(endpoints, ["adminInboundUrl", "apiRoot", "eventsUrl"]) &&
+        hasNonEmptyStringFields(env, [
+          "SLACK_API_URL",
+          "SLACK_BOT_TOKEN",
+          "SLACK_SIGNING_SECRET",
+        ]) &&
+        endpoints.adminInboundUrl === `${baseUrl}/crabline/slack/inbound` &&
+        endpoints.apiRoot === `${baseUrl}/api/` &&
+        endpoints.eventsUrl === `${baseUrl}/slack/events` &&
+        env.SLACK_API_URL === endpoints.apiRoot &&
+        env.SLACK_BOT_TOKEN === value.botToken &&
+        env.SLACK_SIGNING_SECRET === value.signingSecret
+      );
+    case "telegram":
+      return (
+        hasNonEmptyStringFields(value, ["botToken"]) &&
+        hasNonEmptyStringFields(endpoints, ["adminInboundUrl", "apiRoot"]) &&
+        hasNonEmptyStringFields(env, ["TELEGRAM_BOT_TOKEN"]) &&
+        endpoints.adminInboundUrl === `${baseUrl}/crabline/telegram/inbound` &&
+        endpoints.apiRoot === baseUrl &&
+        env.TELEGRAM_BOT_TOKEN === value.botToken
+      );
+    case "whatsapp":
+      return (
+        hasNonEmptyStringFields(value, [
+          "accessToken",
+          "graphVersion",
+          "phoneNumberId",
+          "selfJid",
+        ]) &&
+        hasNonEmptyStringFields(endpoints, [
+          "adminInboundUrl",
+          "apiRoot",
+          "baileysWebSocketUrl",
+          "messagesUrl",
+          "phoneNumberUrl",
+          "statusUrl",
+        ]) &&
+        hasNonEmptyStringFields(env, [
+          "CLOUD_API_ACCESS_TOKEN",
+          "CLOUD_API_VERSION",
+          "WA_BASE_URL",
+          "WA_PHONE_NUMBER_ID",
+        ]) &&
+        endpoints.adminInboundUrl === `${baseUrl}/_crabline/admin/whatsapp/inbound` &&
+        endpoints.apiRoot === `${baseUrl}/${value.graphVersion as string}` &&
+        endpoints.phoneNumberUrl ===
+          `${endpoints.apiRoot as string}/${value.phoneNumberId as string}` &&
+        endpoints.messagesUrl === `${endpoints.phoneNumberUrl as string}/messages` &&
+        endpoints.statusUrl === endpoints.messagesUrl &&
+        endpoints.baileysWebSocketUrl ===
+          `${baseUrl.replace(/^http/u, "ws")}/ws/chat?access_token=${encodeURIComponent(
+            value.accessToken as string,
+          )}` &&
+        env.CLOUD_API_ACCESS_TOKEN === value.accessToken &&
+        env.CLOUD_API_VERSION === value.graphVersion &&
+        env.WA_BASE_URL === baseUrl &&
+        env.WA_PHONE_NUMBER_ID === value.phoneNumberId
+      );
+    case "zalo":
+      return (
+        hasNonEmptyStringFields(value, ["botId", "botToken"]) &&
+        hasNonEmptyStringFields(endpoints, ["adminInboundUrl", "apiRoot"]) &&
+        hasNonEmptyStringFields(env, ["ZALO_API_URL", "ZALO_BOT_TOKEN"]) &&
+        endpoints.adminInboundUrl === `${baseUrl}/crabline/zalo/inbound` &&
+        endpoints.apiRoot === baseUrl &&
+        env.ZALO_API_URL === baseUrl &&
+        env.ZALO_BOT_TOKEN === value.botToken
+      );
+    default:
+      return false;
+  }
+}
+
+function isSuccessfulProbe(
+  value: unknown,
+  manifest: Record<string, unknown>,
+): value is Record<string, unknown> {
+  if (!isRecord(value)) {
+    return false;
+  }
+  switch (manifest.provider) {
+    case "mattermost":
+      return (
+        value.id === manifest.botUserId &&
+        typeof value.username === "string" &&
+        value.username.length > 0 &&
+        typeof value.update_at === "number" &&
+        Number.isSafeInteger(value.update_at) &&
+        value.update_at >= 0
+      );
+    case "matrix":
+      return value.user_id === manifest.botUserId;
+    case "signal":
+      return (
+        value.ok === true &&
+        typeof value.status === "number" &&
+        Number.isInteger(value.status) &&
+        value.status >= 200 &&
+        value.status < 300
+      );
+    case "slack":
+      return value.ok === true;
+    case "telegram": {
+      const result = value.result;
+      return (
+        value.ok === true &&
+        isRecord(result) &&
+        typeof result.id === "number" &&
+        Number.isSafeInteger(result.id) &&
+        result.id > 0 &&
+        result.is_bot === true &&
+        typeof result.first_name === "string" &&
+        result.first_name.length > 0
+      );
+    }
+    case "whatsapp":
+      return value.id === manifest.phoneNumberId;
+    case "zalo":
+      return value.ok === true && isRecord(value.result) && value.result.id === manifest.botId;
+    default:
+      return false;
+  }
+}
+
+function isReadinessSection(
+  value: unknown,
+  manifest: Record<string, unknown>,
+  manifestPath: string,
+  requireCurrentFields: boolean,
+): value is Record<string, unknown> {
+  if (!isRecord(value) || value.manifestPath !== manifestPath || !isRecord(value.result)) {
+    return false;
+  }
+  const result = value.result;
+  return (
+    result.ok === true &&
+    result.provider === manifest.provider &&
+    isRecord(result.endpoints) &&
+    isDeepStrictEqual(result.endpoints, manifest.endpoints) &&
+    isSuccessfulProbe(result.probe, manifest) &&
+    (!requireCurrentFields || (result.proof === "provider-api-probe" && result.ready === true))
+  );
+}
+
 function assertGenerationName(value: unknown, field: string): asserts value is string {
   if (typeof value !== "string" || !GENERATION_NAME_PATTERN.test(value)) {
     throw new Error(`OpenClaw Crabline artifact pointer ${field} is malformed.`);
@@ -128,7 +338,7 @@ function parseArtifactPointer(contents: string): OpenClawCrablineArtifactPointer
   } catch (error) {
     throw new Error("OpenClaw Crabline artifact pointer is malformed.", { cause: error });
   }
-  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+  if (!isRecord(parsed)) {
     throw new Error("OpenClaw Crabline artifact pointer is malformed.");
   }
   const value = parsed as Partial<OpenClawCrablineArtifactPointerBase> & {
@@ -280,25 +490,19 @@ async function assertCurrentGenerationExists(
       await assertGenerationIdentity();
       const value = JSON.parse(await fs.readFile(path.join(outputDir, artifactPath), "utf8"));
       await assertGenerationIdentity();
-      if (value === null || typeof value !== "object" || Array.isArray(value)) {
+      if (!isRecord(value)) {
         throw new Error("artifact is not an object");
       }
-      return value as Record<string, unknown>;
+      return value;
     } catch (error) {
       throw new Error("OpenClaw Crabline current artifact generation is incomplete.", {
         cause: error,
       });
     }
   };
-  const readNestedRecorderPath = (value: unknown): string | undefined => {
-    if (value === null || typeof value !== "object" || Array.isArray(value)) {
-      return undefined;
-    }
-    const result = (value as Record<string, unknown>).result;
-    if (result === null || typeof result !== "object" || Array.isArray(result)) {
-      return undefined;
-    }
-    const recorderPath = (result as Record<string, unknown>).recorderPath;
+  const readNestedRecorderPath = (value: Record<string, unknown>): string | undefined => {
+    const result = value.result as Record<string, unknown>;
+    const recorderPath = result.recorderPath;
     if (recorderPath !== undefined && typeof recorderPath !== "string") {
       throw new Error("OpenClaw Crabline current artifact generation is incomplete.");
     }
@@ -308,7 +512,10 @@ async function assertCurrentGenerationExists(
   const manifest = await readArtifactObject(pointer.manifestPath);
   const capabilityMatrix = await readArtifactObject(pointer.capabilityMatrixPath);
   const readiness = await readArtifactObject(pointer.providerReadinessArtifactPath);
+  const providerReadiness = readiness.providerReadiness;
+  const smoke = readiness.smoke;
   if (
+    !isGeneratedManifest(manifest) ||
     capabilityMatrix.version !== 1 ||
     capabilityMatrix.source !== "openclaw/crabline" ||
     capabilityMatrix.manifestPath !== pointer.manifestPath ||
@@ -318,14 +525,35 @@ async function assertCurrentGenerationExists(
     capabilityMatrix.selectedChannel.length === 0 ||
     capabilityMatrix.report === null ||
     typeof capabilityMatrix.report !== "object" ||
-    Array.isArray(capabilityMatrix.report)
+    Array.isArray(capabilityMatrix.report) ||
+    readiness.version !== 1 ||
+    readiness.source !== "openclaw/crabline" ||
+    readiness.manifestPath !== pointer.manifestPath ||
+    readiness.channelDriver !== capabilityMatrix.channelDriver ||
+    readiness.selectedChannel !== capabilityMatrix.selectedChannel ||
+    manifest.provider !== readiness.selectedChannel ||
+    !isReadinessSection(
+      smoke,
+      manifest,
+      pointer.manifestPath,
+      pointer.version === 2 || providerReadiness !== undefined,
+    ) ||
+    (pointer.version === 2 &&
+      (!isReadinessSection(providerReadiness, manifest, pointer.manifestPath, true) ||
+        !isDeepStrictEqual(providerReadiness, smoke))) ||
+    (pointer.version === 1 &&
+      providerReadiness !== undefined &&
+      (!isReadinessSection(providerReadiness, manifest, pointer.manifestPath, true) ||
+        !isDeepStrictEqual(providerReadiness, smoke)))
   ) {
     throw new Error("OpenClaw Crabline current artifact generation is incomplete.");
   }
   const manifestRecorderPath =
     typeof manifest.recorderPath === "string" ? manifest.recorderPath : undefined;
-  const providerReadinessRecorderPath = readNestedRecorderPath(readiness.providerReadiness);
-  const smokeRecorderPath = readNestedRecorderPath(readiness.smoke);
+  const providerReadinessRecorderPath = isRecord(providerReadiness)
+    ? readNestedRecorderPath(providerReadiness)
+    : undefined;
+  const smokeRecorderPath = readNestedRecorderPath(smoke);
   const recorderPaths = [manifestRecorderPath, providerReadinessRecorderPath, smokeRecorderPath];
   if (manifest.recorderPath !== undefined && typeof manifest.recorderPath !== "string") {
     throw new Error("OpenClaw Crabline current artifact generation is incomplete.");
@@ -602,6 +830,10 @@ export async function publishOpenClawCrablineArtifactGeneration(
     await store.assertIdentityAt();
 
     await dependencies.beforePointerSwitch?.(pointer);
+    await output.assertIdentityAt();
+    await store.assertIdentityAt();
+    await staging.assertIdentityAt(generationPath);
+    await assertCurrentGenerationExists(outputDir, pointer);
     await output.assertIdentityAt();
     await store.assertIdentityAt();
     await staging.assertIdentityAt(generationPath);

--- a/test/openclaw-artifact-generation.test.ts
+++ b/test/openclaw-artifact-generation.test.ts
@@ -56,8 +56,27 @@ function publishParams(outputDir: string, lock = createLock()) {
     outputDir,
     selection: resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" }),
     providerReadiness: {
-      result: { proof: "provider-api-probe", provider: "telegram", ready: true },
+      result: providerReadinessResult(),
     },
+  };
+}
+
+function providerReadinessResult(extra: Record<string, unknown> = {}) {
+  return {
+    endpoints: manifest.endpoints,
+    ok: true,
+    probe: {
+      ok: true,
+      result: {
+        first_name: "Crabline",
+        id: 424_242,
+        is_bot: true,
+      },
+    },
+    proof: "provider-api-probe",
+    provider: "telegram",
+    ready: true,
+    ...extra,
   };
 }
 
@@ -244,12 +263,9 @@ describe("OpenClaw artifact generation publication", () => {
     const paramsWithRecorderReference = {
       ...params,
       providerReadiness: {
-        result: {
-          proof: "provider-api-probe",
-          provider: "telegram",
-          ready: true,
+        result: providerReadinessResult({
           recorderPath: "/tmp/crabline/telegram.jsonl",
-        },
+        }),
       },
     };
     try {
@@ -496,6 +512,131 @@ describe("OpenClaw artifact generation publication", () => {
       await disposeTempDir(outputDir);
     }
   });
+
+  it.each([
+    {
+      label: "empty manifest",
+      path: "manifestPath",
+      corrupt: () => ({}),
+    },
+    {
+      label: "empty readiness artifact",
+      path: "providerReadinessArtifactPath",
+      corrupt: () => ({}),
+    },
+    {
+      label: "manifest with empty endpoint metadata",
+      path: "manifestPath",
+      corrupt: (artifact: Record<string, unknown>) => ({
+        ...artifact,
+        endpoints: {},
+      }),
+    },
+    {
+      label: "manifest with mismatched environment credentials",
+      path: "manifestPath",
+      corrupt: (artifact: Record<string, unknown>) => ({
+        ...artifact,
+        env: {
+          ...(artifact.env as Record<string, unknown>),
+          TELEGRAM_BOT_TOKEN: "placeholder",
+        },
+      }),
+    },
+    {
+      label: "readiness artifact with an empty result",
+      path: "providerReadinessArtifactPath",
+      corrupt: (artifact: Record<string, unknown>) => ({
+        ...artifact,
+        providerReadiness: {
+          ...(artifact.providerReadiness as Record<string, unknown>),
+          result: {},
+        },
+      }),
+    },
+    {
+      label: "readiness artifact with a malformed probe",
+      path: "providerReadinessArtifactPath",
+      corrupt: (artifact: Record<string, unknown>) => {
+        const providerReadiness = artifact.providerReadiness as Record<string, unknown>;
+        return {
+          ...artifact,
+          providerReadiness: {
+            ...providerReadiness,
+            result: {
+              ...(providerReadiness.result as Record<string, unknown>),
+              probe: null,
+            },
+          },
+        };
+      },
+    },
+    {
+      label: "readiness artifact with the wrong source",
+      path: "providerReadinessArtifactPath",
+      corrupt: (artifact: Record<string, unknown>) => ({
+        ...artifact,
+        source: "other/source",
+      }),
+    },
+    {
+      label: "readiness artifact with a mismatched manifest path",
+      path: "providerReadinessArtifactPath",
+      corrupt: (artifact: Record<string, unknown>) => ({
+        ...artifact,
+        manifestPath: "other-manifest.json",
+      }),
+    },
+    {
+      label: "provider readiness with a mismatched manifest reference",
+      path: "providerReadinessArtifactPath",
+      corrupt: (artifact: Record<string, unknown>) => ({
+        ...artifact,
+        providerReadiness: {
+          ...(artifact.providerReadiness as Record<string, unknown>),
+          manifestPath: "other-manifest.json",
+        },
+      }),
+    },
+    {
+      label: "smoke readiness with a mismatched manifest reference",
+      path: "providerReadinessArtifactPath",
+      corrupt: (artifact: Record<string, unknown>) => ({
+        ...artifact,
+        smoke: {
+          ...(artifact.smoke as Record<string, unknown>),
+          manifestPath: "other-manifest.json",
+        },
+      }),
+    },
+  ] as const)(
+    "rejects a generated $label before pointer publication",
+    async ({ corrupt, path: field }) => {
+      const outputDir = await createTempDir();
+      try {
+        await expect(
+          publishOpenClawCrablineArtifactGeneration(publishParams(outputDir), {
+            beforePointerSwitch: async (pointer) => {
+              const artifactPath = path.join(outputDir, pointer[field]);
+              const artifact = JSON.parse(await fs.readFile(artifactPath, "utf8")) as Record<
+                string,
+                unknown
+              >;
+              await fs.writeFile(artifactPath, `${JSON.stringify(corrupt(artifact), null, 2)}\n`);
+            },
+            createGenerationId: () => "11111111-1111-4111-8111-111111111111",
+          }),
+        ).rejects.toThrow("OpenClaw Crabline current artifact generation is incomplete.");
+
+        await expect(readOpenClawCrablineArtifactPointer(outputDir)).resolves.toBeNull();
+        await expect(
+          fs.readdir(path.join(outputDir, OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY)),
+        ).resolves.toEqual([]);
+      } finally {
+        await disposeTempDir(outputDir);
+      }
+    },
+  );
 
   it("rejects publication when current recorder references are removed", async () => {
     const outputDir = await createTempDir();
@@ -795,7 +936,7 @@ describe("OpenClaw artifact generation publication", () => {
           manifest,
           outputDir,
           selection,
-          providerReadiness: { result: { generation: "successor" } },
+          providerReadiness: { result: providerReadinessResult({ generation: "successor" }) },
         },
         {
           beforePointerSwitch: async () => {
@@ -816,7 +957,7 @@ describe("OpenClaw artifact generation publication", () => {
             manifest,
             outputDir,
             selection,
-            providerReadiness: { result: { generation: "expired" } },
+            providerReadiness: { result: providerReadinessResult({ generation: "expired" }) },
           },
           { createGenerationId: () => "11111111-1111-4111-8111-111111111111" },
         ),
@@ -880,7 +1021,7 @@ describe("OpenClaw artifact generation publication", () => {
           manifest,
           outputDir,
           selection,
-          providerReadiness: { result: { generation: "old" } },
+          providerReadiness: { result: providerReadinessResult({ generation: "old" }) },
         },
         { createGenerationId: () => "11111111-1111-4111-8111-111111111111" },
       );
@@ -905,7 +1046,7 @@ describe("OpenClaw artifact generation publication", () => {
           manifest,
           outputDir,
           selection,
-          providerReadiness: { result: { generation: "successor" } },
+          providerReadiness: { result: providerReadinessResult({ generation: "successor" }) },
         },
         { createGenerationId: () => "22222222-2222-4222-8222-222222222222" },
       );
@@ -997,7 +1138,7 @@ describe("OpenClaw artifact generation publication", () => {
           outputDir,
           selection: resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" }),
           providerReadiness: {
-            result: { proof: "provider-api-probe", ready: true },
+            result: providerReadinessResult(),
           },
         }),
       ).rejects.toMatchObject({ code: "ENOENT" });

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -163,6 +163,18 @@ function recorderProbeLine(extra: Record<string, unknown> = {}): string {
   })}\n`;
 }
 
+function telegramProbeResult(extra: Record<string, unknown> = {}) {
+  return {
+    ok: true,
+    result: {
+      first_name: "Crabline",
+      id: 424_242,
+      is_bot: true,
+    },
+    ...extra,
+  };
+}
+
 const manifest: CrablineServerManifest = {
   adminToken: "crabline-admin-token",
   baseUrl: "http://127.0.0.1:1234",
@@ -2982,8 +2994,10 @@ describe("OpenClaw local provider bridge", () => {
               probe: async () => {
                 await fs.writeFile(params.recorderPath!, recorderProbeLine());
                 return {
-                  ok: true,
+                  ...telegramProbeResult(),
                   result: {
+                    first_name: "Crabline",
+                    id: 424_242,
                     is_bot: true,
                     username: "crabline_bot",
                   },
@@ -3164,7 +3178,7 @@ describe("OpenClaw local provider bridge", () => {
                   if (outcome === "failed") {
                     throw probeFailure;
                   }
-                  return { ok: true };
+                  return telegramProbeResult();
                 },
               } as Awaited<ReturnType<typeof startOpenClawCrablineAdapter>>;
             },
@@ -3290,7 +3304,7 @@ describe("OpenClaw local provider bridge", () => {
               return {
                 close: async () => await close(),
                 manifest: { ...manifest, recorderPath: recorderPath! },
-                probe: async () => ({ ok: true }),
+                probe: async () => telegramProbeResult(),
               } as Awaited<ReturnType<typeof startOpenClawCrablineAdapter>>;
             },
             syncParent,
@@ -3340,7 +3354,7 @@ describe("OpenClaw local provider bridge", () => {
               return {
                 close,
                 manifest: { ...manifest, recorderPath: params.recorderPath! },
-                probe: async () => ({ ok: true }),
+                probe: async () => telegramProbeResult(),
               } as unknown as Awaited<ReturnType<typeof startOpenClawCrablineAdapter>>;
             },
             syncParent,
@@ -3373,7 +3387,7 @@ describe("OpenClaw local provider bridge", () => {
           ...manifest,
           recorderPath: params.recorderPath!,
         },
-        probe: async () => ({ currentRun }),
+        probe: async () => telegramProbeResult({ currentRun }),
       } as Awaited<ReturnType<typeof startOpenClawCrablineAdapter>>;
     };
     try {
@@ -3481,7 +3495,7 @@ describe("OpenClaw local provider bridge", () => {
             return {
               close: async () => undefined,
               manifest: { ...manifest, recorderPath: params.recorderPath! },
-              probe: async () => ({ ok: true }),
+              probe: async () => telegramProbeResult(),
             } as Awaited<ReturnType<typeof startOpenClawCrablineAdapter>>;
           },
         },
@@ -3532,7 +3546,7 @@ describe("OpenClaw local provider bridge", () => {
       return {
         close: async () => undefined,
         manifest: { ...manifest, recorderPath: params.recorderPath! },
-        probe: async () => ({ ok: true }),
+        probe: async () => telegramProbeResult(),
       } as Awaited<ReturnType<typeof startOpenClawCrablineAdapter>>;
     };
     try {
@@ -3604,7 +3618,7 @@ describe("OpenClaw local provider bridge", () => {
               return {
                 close: async () => undefined,
                 manifest: { ...manifest, recorderPath: params.recorderPath! },
-                probe: async () => ({ ok: true }),
+                probe: async () => telegramProbeResult(),
               } as Awaited<ReturnType<typeof startOpenClawCrablineAdapter>>;
             },
           },


### PR DESCRIPTION
## Summary
- validate generated manifest, readiness, and probe artifact schemas before publication
- enforce artifact cross-references and directory identities
- reject corrupt and empty generation artifacts before they become current
- use protocol-valid Telegram readiness fixtures across lifecycle coverage
- add focused regression coverage and changelog entry

## Validation
- 99 focused OpenClaw tests
- TypeScript, type-aware oxlint, format, and `git diff --check`
- Linux Crabbox `pnpm verify`: 1,631 passed, 34 skipped (`run_c1038144c8cf`)
- hosted CI verify: passed
- GPT-5.6 Sol high autoreview: clean (0.92)