### PR TITLE
fix(locking): fence cleanup and removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Bound rejected webhook bodies, validate body limits before listening, parse JWT cache directives by name, and fully drain lazy watch returns.
 - Bound deferred WhatsApp startup cleanup, avoid retrying ambiguous timed-out sends, and defer OpenClaw readiness cleanup until aborted probes settle.
 - Validate generated OpenClaw manifest and readiness schemas and cross-references before publication.
+- Fence smoke-lock release cleanup to verified lock artifacts and nonrecursive directory removal.
 - Bound shared HTTP responses, Matrix sync payloads, stalled webhook DNS recovery, unmatched request bodies, and admitted local-mock hook cleanup.
 - Reject Signal JSON-RPC integral IDs that cannot round-trip safely while preserving fractional and string IDs, and register SSE clients before exposing connected response headers.
 - Keep Telegram multipart fields prototype-safe, synthetic chat IDs within 52 significant bits, and topic identities scoped to their chats.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Bound rejected webhook bodies, validate body limits before listening, parse JWT cache directives by name, and fully drain lazy watch returns.
 - Bound deferred WhatsApp startup cleanup, avoid retrying ambiguous timed-out sends, and defer OpenClaw readiness cleanup until aborted probes settle.
 - Validate generated OpenClaw manifest and readiness schemas and cross-references before publication.
+- Quarantine verified recorder lock directories before final removal so path replacements are preserved.
 - Fence smoke-lock release cleanup to verified lock artifacts and nonrecursive directory removal.
 - Bound shared HTTP responses, Matrix sync payloads, stalled webhook DNS recovery, unmatched request bodies, and admitted local-mock hook cleanup.
 - Reject Signal JSON-RPC integral IDs that cannot round-trip safely while preserving fractional and string IDs, and register SSE clients before exposing connected response headers.

--- a/src/openclaw/smoke-lock.ts
+++ b/src/openclaw/smoke-lock.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import fsSync, { readFileSync } from "node:fs";
 import fs, { type FileHandle } from "node:fs/promises";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
@@ -62,6 +62,7 @@ type BeforeRecoveryDeleteClaim = () => Promise<void>;
 type BeforeCompatibilityMarkerRenew = () => Promise<void>;
 type BeforeReleaseClaim = () => Promise<void>;
 type BeforeReleaseRename = () => Promise<void>;
+type BeforeReleaseRemove = () => Promise<void>;
 type BeforeCommitClaim = () => Promise<void>;
 type BeforeCommitFileRename = () => Promise<void>;
 type BeforeCommitRename = () => Promise<void>;
@@ -93,6 +94,8 @@ type SmokeLockRuntime = {
 
 const LOCK_OWNER_FILE = "owner.json";
 const LOCK_LEASE_FILE_PREFIX = "lease.";
+const LOCK_COMMIT_STAGE_FILE_PREFIX = "commit-stage.";
+const LOCK_STAGED_FILE_PREFIX = ".commit-file.";
 const LEGACY_RECOVERY_SUFFIX = ".recovering";
 const COMMIT_CLAIM_SUFFIX = ".commit";
 const OWNED_CLAIM_SUFFIX = ".owned";
@@ -113,10 +116,6 @@ export function processStartedAtMsFromTimeOrigin(timeOrigin: number): number {
   }
   return Math.trunc(timeOrigin);
 }
-
-const removeLockDirectory: RemoveLockDirectory = async (lockDirectory) => {
-  await fs.rm(lockDirectory, { force: true, recursive: true });
-};
 
 const sleep: Sleep = async (delayMs) => {
   await new Promise<void>((resolve) => setTimeout(resolve, delayMs));
@@ -222,6 +221,101 @@ function hasSameDirectoryIdentity(
   return (
     left !== null && right !== null && left.device === right.device && left.inode === right.inode
   );
+}
+
+function isOwnedLockArtifactName(name: string, token: string): boolean {
+  const leaseName = leaseFileName(token);
+  const commitStageName = `${LOCK_COMMIT_STAGE_FILE_PREFIX}${token}.json`;
+  return (
+    name === LOCK_OWNER_FILE ||
+    name === leaseName ||
+    (name.startsWith(`.${leaseName}.`) && name.endsWith(".tmp")) ||
+    name === commitStageName ||
+    (name.startsWith(`.${LOCK_COMMIT_STAGE_FILE_PREFIX}${token}.`) && name.endsWith(".tmp")) ||
+    (name.startsWith(`${LOCK_STAGED_FILE_PREFIX}${token}.`) && name.endsWith(".tmp"))
+  );
+}
+
+async function removeVerifiedLockDirectory(params: {
+  beforeRemove?: BeforeReleaseRemove;
+  directoryPath: string;
+  expectedIdentity: DirectoryIdentity;
+  token: string;
+}): Promise<void> {
+  if (
+    !hasSameDirectoryIdentity(
+      params.expectedIdentity,
+      await readDirectoryIdentity(params.directoryPath),
+    )
+  ) {
+    throw new Error("OpenClaw Crabline smoke lock cleanup target changed.");
+  }
+  await params.beforeRemove?.();
+  const quarantinePath = `${params.directoryPath}.cleanup.${randomUUID()}`;
+  fsSync.renameSync(params.directoryPath, quarantinePath);
+  let quarantinedIdentity: DirectoryIdentity | null = null;
+  const stats = fsSync.lstatSync(quarantinePath, { bigint: true });
+  if (stats.isDirectory() && !stats.isSymbolicLink() && stats.ino > 0n) {
+    quarantinedIdentity = { device: stats.dev, inode: stats.ino };
+  }
+  if (!hasSameDirectoryIdentity(params.expectedIdentity, quarantinedIdentity)) {
+    throw new Error("OpenClaw Crabline smoke lock cleanup target changed.");
+  }
+
+  const entries = fsSync.readdirSync(quarantinePath);
+  const artifacts: Array<{ identity: FileIdentity; path: string }> = [];
+  for (const entry of entries) {
+    if (!isOwnedLockArtifactName(entry, params.token)) {
+      throw new Error("OpenClaw Crabline smoke lock cleanup found an unexpected artifact.");
+    }
+    const artifactPath = path.join(quarantinePath, entry);
+    const artifactStats = fsSync.lstatSync(artifactPath, { bigint: true });
+    if (
+      !artifactStats.isFile() ||
+      artifactStats.isSymbolicLink() ||
+      artifactStats.nlink !== 1n ||
+      artifactStats.ino <= 0n
+    ) {
+      throw new Error("OpenClaw Crabline smoke lock cleanup found an unsafe artifact.");
+    }
+    artifacts.push({
+      identity: { device: artifactStats.dev, inode: artifactStats.ino },
+      path: artifactPath,
+    });
+  }
+  artifacts.sort(
+    (left, right) =>
+      Number(path.basename(left.path) === LOCK_OWNER_FILE) -
+      Number(path.basename(right.path) === LOCK_OWNER_FILE),
+  );
+  for (const artifact of artifacts) {
+    const directoryStats = fsSync.lstatSync(quarantinePath, { bigint: true });
+    const artifactStats = fsSync.lstatSync(artifact.path, { bigint: true });
+    if (
+      !directoryStats.isDirectory() ||
+      directoryStats.isSymbolicLink() ||
+      directoryStats.dev !== params.expectedIdentity.device ||
+      directoryStats.ino !== params.expectedIdentity.inode ||
+      !artifactStats.isFile() ||
+      artifactStats.isSymbolicLink() ||
+      artifactStats.nlink !== 1n ||
+      artifactStats.dev !== artifact.identity.device ||
+      artifactStats.ino !== artifact.identity.inode
+    ) {
+      throw new Error("OpenClaw Crabline smoke lock cleanup artifact changed.");
+    }
+    fsSync.unlinkSync(artifact.path);
+  }
+  const finalStats = fsSync.lstatSync(quarantinePath, { bigint: true });
+  if (
+    !finalStats.isDirectory() ||
+    finalStats.isSymbolicLink() ||
+    finalStats.dev !== params.expectedIdentity.device ||
+    finalStats.ino !== params.expectedIdentity.inode
+  ) {
+    throw new Error("OpenClaw Crabline smoke lock cleanup target changed.");
+  }
+  fsSync.rmdirSync(quarantinePath);
 }
 
 function isPositiveSafeInteger(value: unknown): value is number {
@@ -682,6 +776,7 @@ async function resolveConfinedPath(
 async function removeOwnedLock(params: {
   beforeClaim?: () => Promise<void>;
   beforeRename?: () => Promise<void>;
+  beforeRemove?: BeforeReleaseRemove;
   lockDirectory: string;
   onOwnedDirectoryChange?: (directoryPath: string) => void;
   ownedDirectory: string;
@@ -742,7 +837,16 @@ async function removeOwnedLock(params: {
     return false;
   }
 
-  await (params.removeDirectory ?? removeLockDirectory)(releaseClaim);
+  if (params.removeDirectory) {
+    await params.removeDirectory(releaseClaim);
+  } else {
+    await removeVerifiedLockDirectory({
+      ...(params.beforeRemove ? { beforeRemove: params.beforeRemove } : {}),
+      directoryPath: releaseClaim,
+      expectedIdentity: observedIdentity,
+      token: params.token,
+    });
+  }
   return true;
 }
 
@@ -1162,6 +1266,7 @@ export async function acquireOpenClawCrablineSmokeRunLock(
     beforeRecoveryClaim?: BeforeRecoveryClaim;
     beforeReleaseClaim?: BeforeReleaseClaim;
     beforeReleaseRename?: BeforeReleaseRename;
+    beforeReleaseRemove?: BeforeReleaseRemove;
     removeDirectory?: RemoveLockDirectory;
     sleep?: Sleep;
     startHeartbeat?: StartHeartbeat;
@@ -1729,6 +1834,9 @@ export async function acquireOpenClawCrablineSmokeRunLock(
             : {}),
           ...(dependencies.beforeReleaseRename
             ? { beforeRename: dependencies.beforeReleaseRename }
+            : {}),
+          ...(dependencies.beforeReleaseRemove
+            ? { beforeRemove: dependencies.beforeReleaseRemove }
             : {}),
           lockDirectory,
           onOwnedDirectoryChange: (directoryPath) => {

--- a/src/platform/process-owned-lock.ts
+++ b/src/platform/process-owned-lock.ts
@@ -453,6 +453,7 @@ function removeVerifiedLockDirectorySync(
   directoryPath: fs.PathLike,
   expectedIdentity: DirectoryIdentity,
   expectedMtimeMs?: bigint,
+  beforeRemove?: (directoryPath: string) => void,
 ): void {
   if (!verifiedLockDirectoryStats(directoryPath, expectedIdentity, expectedMtimeMs)) {
     return;
@@ -493,12 +494,19 @@ function removeVerifiedLockDirectorySync(
   if (!verifiedLockDirectoryStats(directoryPath, expectedIdentity)) {
     return;
   }
+  const sourcePath = String(directoryPath);
+  const quarantinePath = `${sourcePath}.cleanup.${randomUUID()}`;
+  beforeRemove?.(sourcePath);
+  fs.renameSync(directoryPath, quarantinePath);
+  if (!verifiedLockDirectoryStats(quarantinePath, expectedIdentity)) {
+    throw lockCleanupError("Recorder lock cleanup target disappeared.");
+  }
   try {
-    fs.rmdirSync(directoryPath);
+    fs.rmdirSync(quarantinePath);
   } catch (error) {
     try {
-      if (verifiedLockDirectoryStats(directoryPath, expectedIdentity)) {
-        fs.utimesSync(directoryPath, new Date(0), new Date(0));
+      if (verifiedLockDirectoryStats(quarantinePath, expectedIdentity)) {
+        fs.utimesSync(quarantinePath, new Date(0), new Date(0));
       }
     } catch {
       // Do not mutate a replacement directory after cleanup loses its identity fence.
@@ -897,6 +905,7 @@ function isRecoverableUnknownOwner(
 
 export function createProcessOwnedLockFileSystem(
   options: {
+    beforeDirectoryRemoval?: (directoryPath: string) => void;
     machineIdentityReader?: () => string | null;
     processIdentityReader?: (pid: number) => string | null;
   } = {},
@@ -909,6 +918,18 @@ export function createProcessOwnedLockFileSystem(
     return fs;
   }
   const token = randomUUID();
+  const removeLockDirectorySync = (
+    directoryPath: fs.PathLike,
+    expectedIdentity: DirectoryIdentity,
+    expectedMtimeMs?: bigint,
+  ): void => {
+    removeVerifiedLockDirectorySync(
+      directoryPath,
+      expectedIdentity,
+      expectedMtimeMs,
+      options.beforeDirectoryRemoval,
+    );
+  };
   const identityReader = options.processIdentityReader ?? readProcessIdentity;
   let currentProcessIdentity: string | null;
   if (options.processIdentityReader) {
@@ -1175,7 +1196,7 @@ export function createProcessOwnedLockFileSystem(
         } catch (ownerError) {
           if (createdIdentity) {
             try {
-              removeVerifiedLockDirectorySync(claimPath, createdIdentity);
+              removeLockDirectorySync(claimPath, createdIdentity);
             } catch {
               // Preserve an unverified replacement instead of deleting it by pathname.
             }
@@ -1284,7 +1305,7 @@ export function createProcessOwnedLockFileSystem(
     const removeActiveClaim = (): void => {
       let activeError: NodeJS.ErrnoException | null = null;
       try {
-        removeVerifiedLockDirectorySync(claim.activePath, claim.activeIdentity);
+        removeLockDirectorySync(claim.activePath, claim.activeIdentity);
       } catch (error) {
         activeError = error as NodeJS.ErrnoException;
       }
@@ -1365,11 +1386,7 @@ export function createProcessOwnedLockFileSystem(
         return;
       }
       try {
-        removeVerifiedLockDirectorySync(
-          superseded.path,
-          superseded.identity,
-          superseded.identity.mtimeMs,
-        );
+        removeLockDirectorySync(superseded.path, superseded.identity, superseded.identity.mtimeMs);
       } catch {
         if (!removedSupersededPath) {
           preserveActiveClaim();
@@ -1510,7 +1527,7 @@ export function createProcessOwnedLockFileSystem(
             }
           } else if (createdIdentity) {
             try {
-              removeVerifiedLockDirectorySync(directoryPath, createdIdentity);
+              removeLockDirectorySync(directoryPath, createdIdentity);
             } catch {
               // Preserve an unverified replacement instead of deleting it by pathname.
             }
@@ -1662,7 +1679,7 @@ export function createProcessOwnedLockFileSystem(
             abandonedDirectoryIdentities.delete(coordinationKey);
             abandonedOwnerKeys.delete(abandonedOwnerKey(directory, token));
             try {
-              removeVerifiedLockDirectorySync(tombstonePath, directoryIdentity(initialStats));
+              removeLockDirectorySync(tombstonePath, directoryIdentity(initialStats));
               finish(null);
             } catch (error) {
               finish(error as NodeJS.ErrnoException);
@@ -1831,7 +1848,7 @@ export function createProcessOwnedLockFileSystem(
             return;
           }
           try {
-            removeVerifiedLockDirectorySync(tombstonePath, directoryIdentity(initialStats));
+            removeLockDirectorySync(tombstonePath, directoryIdentity(initialStats));
             if (candidate) {
               abandonedOwnerKeys.delete(
                 abandonedOwnerKey(candidate.lockDirectory, candidate.owner.token),
@@ -1894,14 +1911,11 @@ export function createProcessOwnedLockFileSystem(
       }
       const tombstonePath = `${claimPath}.${token}.release`;
       fs.renameSync(directoryPath, tombstonePath);
-      removeVerifiedLockDirectorySync(tombstonePath, directoryIdentity(ownedDirectory));
+      removeLockDirectorySync(tombstonePath, directoryIdentity(ownedDirectory));
       ownedDirectories.delete(canonicalLockDirectoryPath(directory));
     } finally {
       try {
-        removeVerifiedLockDirectorySync(
-          coordinationClaim.activePath,
-          coordinationClaim.activeIdentity,
-        );
+        removeLockDirectorySync(coordinationClaim.activePath, coordinationClaim.activeIdentity);
       } catch {
         // Exit cleanup is best-effort; a live coordination claim is safer than an ABA race.
       }

--- a/test/openclaw-smoke-lock.test.ts
+++ b/test/openclaw-smoke-lock.test.ts
@@ -1972,9 +1972,34 @@ describe("OpenClaw smoke lock cleanup", () => {
   it("fails pointer fencing after a heartbeat renewal error", async () => {
     const outputDir = await createTempDir();
     const params = { channel: "telegram" as const, outputDir };
+    let runHeartbeat: (() => Promise<void>) | undefined;
     try {
       const lock = await acquireOpenClawCrablineSmokeRunLock(params, {
-        leaseMs: 30,
+        startHeartbeat: (renew) => {
+          let failure: unknown;
+          let pending: Promise<void> | undefined;
+          runHeartbeat = async () => {
+            pending = renew().catch((error: unknown) => {
+              failure ??= error;
+            });
+            await pending;
+          };
+          return {
+            assertHealthy() {
+              if (failure !== undefined) {
+                throw new Error("OpenClaw Crabline smoke lock heartbeat failed.", {
+                  cause: failure,
+                });
+              }
+            },
+            async settle() {
+              await pending;
+            },
+            async stop() {
+              await pending;
+            },
+          };
+        },
       });
       const ownerPath = path.join(await findOwnedLockDirectory(outputDir), "owner.json");
       const owner = await fs.readFile(ownerPath, "utf8");
@@ -1982,7 +2007,7 @@ describe("OpenClaw smoke lock cleanup", () => {
         ownerPath,
         `${JSON.stringify({ ...JSON.parse(owner), token: "replacement-owner" })}\n`,
       );
-      await new Promise((resolve) => setTimeout(resolve, 25));
+      await runHeartbeat?.();
 
       await expect(
         lock.commitFileAtomically({

--- a/test/openclaw-smoke-lock.test.ts
+++ b/test/openclaw-smoke-lock.test.ts
@@ -755,6 +755,114 @@ describe("OpenClaw smoke lock cleanup", () => {
     }
   });
 
+  it("preserves a replacement tree substituted after release validation", async () => {
+    const outputDir = await createTempDir();
+    const params = { channel: "telegram" as const, outputDir };
+    let sentinelPath: string | undefined;
+    try {
+      const lock = await acquireOpenClawCrablineSmokeRunLock(params, {
+        beforeReleaseRemove: async () => {
+          const releaseDirectory = (await fs.readdir(outputDir))
+            .filter((entry) => entry.includes(".lock.release."))
+            .map((entry) => path.join(outputDir, entry))[0];
+          if (!releaseDirectory) {
+            throw new Error("Expected a smoke lock release directory.");
+          }
+          await fs.rename(releaseDirectory, `${releaseDirectory}.original`);
+          const replacementTree = path.join(releaseDirectory, "replacement");
+          await fs.mkdir(replacementTree, { recursive: true });
+          sentinelPath = path.join(replacementTree, "sentinel");
+          await fs.writeFile(sentinelPath, "preserve\n");
+        },
+        startHeartbeat: disableHeartbeat,
+      });
+
+      await expect(lock.release()).rejects.toThrow(
+        "OpenClaw Crabline smoke lock cleanup target changed.",
+      );
+      expect(sentinelPath).toBeDefined();
+      const quarantineDirectory = (await fs.readdir(outputDir))
+        .filter((entry) => entry.includes(".lock.release.") && entry.includes(".cleanup."))
+        .map((entry) => path.join(outputDir, entry))[0];
+      expect(quarantineDirectory).toBeDefined();
+      await expect(
+        fs.readFile(path.join(quarantineDirectory!, "replacement", "sentinel"), "utf8"),
+      ).resolves.toBe("preserve\n");
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
+  it("restores an empty replacement directory substituted after release validation", async () => {
+    const outputDir = await createTempDir();
+    const params = { channel: "telegram" as const, outputDir };
+    let releaseDirectory: string | undefined;
+    let replacementIdentity: { dev: bigint; ino: bigint } | undefined;
+    try {
+      const lock = await acquireOpenClawCrablineSmokeRunLock(params, {
+        beforeReleaseRemove: async () => {
+          releaseDirectory = (await fs.readdir(outputDir))
+            .filter((entry) => entry.includes(".lock.release."))
+            .map((entry) => path.join(outputDir, entry))[0];
+          if (!releaseDirectory) {
+            throw new Error("Expected a smoke lock release directory.");
+          }
+          await fs.rename(releaseDirectory, `${releaseDirectory}.original`);
+          await fs.mkdir(releaseDirectory);
+          const stats = await fs.lstat(releaseDirectory, { bigint: true });
+          replacementIdentity = { dev: stats.dev, ino: stats.ino };
+        },
+        startHeartbeat: disableHeartbeat,
+      });
+
+      await expect(lock.release()).rejects.toThrow(
+        "OpenClaw Crabline smoke lock cleanup target changed.",
+      );
+      const quarantineDirectory = (await fs.readdir(outputDir))
+        .filter((entry) => entry.includes(".lock.release.") && entry.includes(".cleanup."))
+        .map((entry) => path.join(outputDir, entry))[0];
+      expect(quarantineDirectory).toBeDefined();
+      const retained = await fs.lstat(quarantineDirectory!, { bigint: true });
+      expect({ device: retained.dev, inode: retained.ino }).toEqual({
+        device: replacementIdentity?.dev,
+        inode: replacementIdentity?.ino,
+      });
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
+  it("does not unlink through a release directory symlink substituted after validation", async () => {
+    const outputDir = await createTempDir();
+    const outsideDir = await createTempDir();
+    const outsideOwnerPath = path.join(outsideDir, "owner.json");
+    const params = { channel: "telegram" as const, outputDir };
+    try {
+      await fs.writeFile(outsideOwnerPath, "preserve\n");
+      const lock = await acquireOpenClawCrablineSmokeRunLock(params, {
+        beforeReleaseRemove: async () => {
+          const releaseDirectory = (await fs.readdir(outputDir))
+            .filter((entry) => entry.includes(".lock.release."))
+            .map((entry) => path.join(outputDir, entry))[0];
+          if (!releaseDirectory) {
+            throw new Error("Expected a smoke lock release directory.");
+          }
+          await fs.rename(releaseDirectory, `${releaseDirectory}.original`);
+          await fs.symlink(outsideDir, releaseDirectory, "dir");
+        },
+        startHeartbeat: disableHeartbeat,
+      });
+
+      await expect(lock.release()).rejects.toThrow(
+        "OpenClaw Crabline smoke lock cleanup target changed.",
+      );
+      await expect(fs.readFile(outsideOwnerPath, "utf8")).resolves.toBe("preserve\n");
+    } finally {
+      await disposeTempDir(outsideDir);
+      await disposeTempDir(outputDir);
+    }
+  });
+
   it("does not transiently relocate a successor while its heartbeat runs", async () => {
     const outputDir = await createTempDir();
     const params = { channel: "telegram" as const, outputDir };

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -3236,28 +3236,18 @@ describe("OpenClaw local provider bridge", () => {
             }) as unknown as Awaited<ReturnType<typeof startOpenClawCrablineAdapter>>,
         },
       );
-      let readinessSettled = false;
       const outcome = readiness.then(
-        (result) => {
-          readinessSettled = true;
-          return { kind: "resolved" as const, result };
-        },
-        (error: unknown) => {
-          readinessSettled = true;
-          return { error, kind: "rejected" as const };
-        },
+        (result) => ({ kind: "resolved" as const, result }),
+        (error: unknown) => ({ error, kind: "rejected" as const }),
       );
 
       await probeStarted;
       expect(timeoutMock).toHaveBeenCalledWith(5_000);
       controller.abort(new DOMException("probe deadline", "TimeoutError"));
       await abortObserved;
-      await new Promise((resolve) => setTimeout(resolve, 300));
-
-      expect(readinessSettled).toBe(true);
-      expect(close).not.toHaveBeenCalled();
 
       const result = await outcome;
+      expect(close).not.toHaveBeenCalled();
       expect(result.kind).toBe("rejected");
       expect(result).toMatchObject({
         error: expect.objectContaining({

--- a/test/process-owned-lock.test.ts
+++ b/test/process-owned-lock.test.ts
@@ -323,7 +323,7 @@ describe("process-owned lock filesystem", () => {
     const removeDirectory = fs.rmdirSync.bind(fs);
     let failedBaseCleanup = false;
     const removeSpy = vi.spyOn(fs, "rmdirSync").mockImplementation(((targetPath: fs.PathLike) => {
-      if (String(targetPath) === baseClaim && !failedBaseCleanup) {
+      if (String(targetPath).startsWith(`${baseClaim}.cleanup.`) && !failedBaseCleanup) {
         failedBaseCleanup = true;
         throw Object.assign(new Error("base claim cleanup failed"), { code: "EACCES" });
       }
@@ -332,7 +332,11 @@ describe("process-owned lock filesystem", () => {
 
     try {
       await expect(acquire(target)).rejects.toMatchObject({ code: "ELOCKED" });
-      expect(fs.existsSync(baseClaim)).toBe(true);
+      expect(
+        fs
+          .readdirSync(path.dirname(baseClaim))
+          .some((entry) => entry.startsWith(`${path.basename(baseClaim)}.cleanup.`)),
+      ).toBe(true);
       expect(fs.existsSync(takeoverClaim)).toBe(false);
       expect(fs.existsSync(activeClaim)).toBe(false);
     } finally {
@@ -487,9 +491,9 @@ describe("process-owned lock filesystem", () => {
       const removeDirectory = fs.rmdirSync.bind(fs);
       let claimCleanupCount = 0;
       const removeSpy = vi.spyOn(fs, "rmdirSync").mockImplementation(((targetPath: fs.PathLike) => {
-        const claimCleanup = /^\.crabline-reclaim-[0-9a-f]{64}$/u.test(
-          path.basename(String(targetPath)),
-        );
+        const claimCleanup =
+          path.basename(String(targetPath)).startsWith(".crabline-reclaim-") &&
+          String(targetPath).includes(".cleanup.");
         if (claimCleanup && ++claimCleanupCount === 3) {
           throw Object.assign(new Error("claim cleanup failed"), { code: "EACCES" });
         }
@@ -807,6 +811,43 @@ describe("process-owned lock filesystem", () => {
     } finally {
       renameSpy.mockRestore();
     }
+  });
+
+  it("quarantines an empty replacement substituted immediately before removal", async () => {
+    const target = await createLockTarget();
+    let removalPath: string | undefined;
+    let replacementIdentity: fs.BigIntStats | undefined;
+    const lockFileSystem = createProcessOwnedLockFileSystem({
+      beforeDirectoryRemoval: (directoryPath) => {
+        if (removalPath || !directoryPath.endsWith(".release")) {
+          return;
+        }
+        removalPath = directoryPath;
+        fs.renameSync(directoryPath, `${directoryPath}.original`);
+        fs.mkdirSync(directoryPath);
+        replacementIdentity = fs.lstatSync(directoryPath, { bigint: true });
+      },
+    });
+    const release = await lock(target, {
+      fs: lockFileSystem,
+      realpath: false,
+      retries: 0,
+      stale: 2000,
+      update: 1000,
+    });
+
+    await expect(release()).rejects.toMatchObject({ code: "ELOCKED" });
+    expect(removalPath).toBeDefined();
+    const quarantinePath = fs
+      .readdirSync(path.dirname(removalPath!))
+      .filter((entry) => entry.startsWith(`${path.basename(removalPath!)}.cleanup.`))
+      .map((entry) => path.join(path.dirname(removalPath!), entry))[0];
+    expect(quarantinePath).toBeDefined();
+    const retained = fs.lstatSync(quarantinePath!, { bigint: true });
+    expect({ dev: retained.dev, ino: retained.ino }).toEqual({
+      dev: replacementIdentity?.dev,
+      ino: replacementIdentity?.ino,
+    });
   });
 
   it("removes an empty lock directory after owner publication fails", async () => {


### PR DESCRIPTION
## Summary
- fence OpenClaw smoke lock release cleanup against recursive replacement removal
- quarantine process-owned lock directories before deletion
- close cleanup TOCTOU windows without removing successor-owned state
- add focused regression coverage and changelog entries

## Validation
- 102 focused tests, 3 platform skips
- TypeScript, type-aware oxlint, format, and diff checks
- Linux Crabbox `pnpm verify`: 1,625 passed, 34 skipped (`run_1a1b967ac16d`)
- hosted CI verify: passed
- GPT-5.6 Sol high autoreview: clean (0.86)