### PR TITLE
fix(providers): cancel uncommitted webhook responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Give the recorder-scan roundtrip regression enough time to complete on loaded CI workers.
 - Reject invalid shared HTTP body limits, webhook deadlines, and signed-JWT cache timings before starting I/O.
+- Cancel provider-created webhook responses when recorder persistence fails before delivery.
 - Parse Google signing certificates as X.509 and redact Discord and Slack webhook tokens before recorder persistence.
 - Contain WhatsApp acceptance timeout cleanup failures, enforce compressed binary-node payload limits, and require explicit interop JID server tokens.
 - Preserve class-based OpenClaw bridge adapters, reject non-native Mattermost target identifiers, and close successful Signal probe bodies.

--- a/src/providers/local-mock.ts
+++ b/src/providers/local-mock.ts
@@ -605,6 +605,7 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
       settle(response.ok);
       return response;
     };
+    let uncommittedResponse: Response | undefined;
     const settleCommittedAcceptance = () => {
       if (settled) {
         return;
@@ -660,6 +661,7 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
           headers: { "content-type": "application/json" },
           status: 200,
         });
+      uncommittedResponse = successResponse;
       await appendRecordedInbound(this.#recorderPath, {
         author: authorFromPayload(payload),
         id,
@@ -671,8 +673,10 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
         threadId,
       });
       settleCommittedAcceptance();
+      uncommittedResponse = undefined;
       return successResponse;
     } catch (error) {
+      void uncommittedResponse?.body?.cancel(error).catch(() => undefined);
       settle(false);
       throw error;
     }

--- a/test/local-mock-provider.test.ts
+++ b/test/local-mock-provider.test.ts
@@ -667,6 +667,54 @@ describe("local mock provider", () => {
     expect(settleWebhookRequest).toHaveBeenCalledWith(expect.objectContaining({ accepted: false }));
   });
 
+  it("cancels an uncommitted success response when recorder persistence fails", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    let handleRequest: ((request: Request) => Promise<Response>) | undefined;
+    webhookMocks.startWebhookServer.mockImplementationOnce(async (params) => {
+      handleRequest = params.handle;
+      return {
+        async close() {},
+        endpointUrl: "http://127.0.0.1:43210/slack/events",
+      };
+    });
+    const cancelled = vi.fn();
+    const config = createConfig();
+    const provider = new LocalMockProviderAdapter({
+      codec: createGenericLocalMockTargetCodec("slack"),
+      config,
+      id: "provider-a",
+      options: {
+        createWebhookSuccessResponse: () =>
+          new Response(
+            new ReadableStream({
+              cancel: cancelled,
+              start(controller) {
+                controller.enqueue(Buffer.from("uncommitted"));
+              },
+            }),
+          ),
+        defaultWebhook: { host: "127.0.0.1", path: "/slack/events", port: 0 },
+        endpointLabel: "events endpoint",
+        platform: "slack",
+        recorderPath: directory,
+      },
+    });
+    providers.push(provider);
+    await provider.probe(createContext(config));
+
+    await expect(
+      handleRequest!(
+        new Request("http://127.0.0.1:43210/slack/events", {
+          body: JSON.stringify({ id: "event-1", text: "hello", threadId: "C1234567890" }),
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        }),
+      ),
+    ).rejects.toThrow(/not a regular file/u);
+    await vi.waitFor(() => expect(cancelled).toHaveBeenCalledOnce());
+  });
+
   it("preserves accepted webhook success when post-commit settlement fails", async () => {
     const directory = await createTempDir();
     directories.push(directory);


### PR DESCRIPTION
## Summary
- cancel provider-created success response bodies when recorder persistence fails before the response can be committed
- preserve the original recorder error if cancellation itself fails
- add regression coverage and a changelog entry

## Verification
- `vitest run test/local-mock-provider.test.ts` (40 passed)
- `tsc -p tsconfig.test.json --noEmit`
- Sol-high autoreview: clean (0.93 confidence)
- Crabbox `pnpm verify`: 1,696 passed, 34 skipped (`run_a96eab07a465`)

Depends on the CI timing stabilization landed in #220.