### PR TITLE
test(runtime): stabilize recorder scan regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Give the recorder-scan roundtrip regression enough time to complete on loaded CI workers.
 - Reject invalid shared HTTP body limits, webhook deadlines, and signed-JWT cache timings before starting I/O.
 - Parse Google signing certificates as X.509 and redact Discord and Slack webhook tokens before recorder persistence.
 - Contain WhatsApp acceptance timeout cleanup failures, enforce compressed binary-node payload limits, and require explicit interop JID server tokens.

--- a/test/local-mock-provider.test.ts
+++ b/test/local-mock-provider.test.ts
@@ -1147,7 +1147,7 @@ describe("local mock provider", () => {
       retries: 0,
       tags: [],
       target: { behavior: "echo", id: "C1234567890", metadata: {} },
-      timeoutMs: 100,
+      timeoutMs: 500,
     };
     const manifest: ManifestDefinition = {
       configVersion: 1,


### PR DESCRIPTION
## Summary
- raise the recorder-scan roundtrip regression timeout from 100 ms to the suite-standard 500 ms
- document the loaded-CI stabilization in the changelog

## Verification
- `vitest run test/local-mock-provider.test.ts` (39 passed)
- `tsc -p tsconfig.test.json --noEmit`
- Sol-high autoreview: clean (0.99 confidence)
- Crabbox `pnpm verify`: 1,695 passed, 34 skipped (`run_8f2f5368957a`)

This isolates the repeated hosted CI failure seen on PR #219 without changing runtime behavior.