### PR TITLE
fix(ci): harden build verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,14 +29,21 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          cache-dependency-path: tools/go.sum
+          go-version-file: tools/go.mod
+
       - name: Validate workflows
         # actionlint's schema does not yet include GitHub's concurrency.queue key.
         run: >-
           cd tools &&
-          go run github.com/rhysd/actionlint/cmd/actionlint
+          find ../.github/workflows -type f
+          \( -name '*.yml' -o -name '*.yaml' \)
+          -exec go run github.com/rhysd/actionlint/cmd/actionlint
           -config-file ../.github/actionlint.yaml
           -ignore 'unexpected key "queue" for "concurrency" section'
-          ../.github/workflows/*.yml
+          {} +
 
       - name: Verify
         run: pnpm verify

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Provision CI Go from the tools module, lint both workflow YAML extensions, and build distributable output before package verification.
 - Give the recorder-scan roundtrip regression enough time to complete on loaded CI workers.
 - Reject invalid shared HTTP body limits, webhook deadlines, and signed-JWT cache timings before starting I/O.
 - Cancel provider-created webhook responses when recorder persistence fails before delivery.

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "typecheck": "tsc -p tsconfig.test.json",
-    "verify": "pnpm lint && pnpm test:autoreview && pnpm test:coverage",
+    "verify": "pnpm lint && pnpm test:autoreview && pnpm build && pnpm test:coverage",
     "check": "pnpm verify"
   },
   "dependencies": {

--- a/test/ci-workflow.test.ts
+++ b/test/ci-workflow.test.ts
@@ -42,16 +42,29 @@ async function readWorkflow(filePath: string): Promise<Workflow> {
 describe("CI workflow hardening", () => {
   it("runs actionlint in the primary CI gate", async () => {
     const workflow = await readWorkflow(".github/workflows/ci.yml");
-    const commands = Object.values(workflow.jobs ?? {}).flatMap(
-      (job) => job.steps?.map((step) => step.run).filter(Boolean) ?? [],
+    const steps = workflow.jobs?.verify?.steps ?? [];
+    const setupGoIndex = steps.findIndex((step) => step.uses?.startsWith("actions/setup-go@"));
+    const actionlintIndex = steps.findIndex((step) =>
+      step.run?.includes("github.com/rhysd/actionlint/cmd/actionlint"),
     );
 
-    expect(commands).toContain(
+    expect(steps[setupGoIndex]).toEqual({
+      uses: "actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16",
+      with: {
+        "cache-dependency-path": "tools/go.sum",
+        "go-version-file": "tools/go.mod",
+      },
+    });
+    expect(setupGoIndex).toBeLessThan(actionlintIndex);
+    expect(steps[actionlintIndex]?.run).toBe(
       "cd tools && " +
+        "find ../.github/workflows -type f " +
+        "\\( -name '*.yml' -o -name '*.yaml' \\) " +
+        "-exec " +
         "go run github.com/rhysd/actionlint/cmd/actionlint " +
         "-config-file ../.github/actionlint.yaml " +
         '-ignore \'unexpected key "queue" for "concurrency" section\' ' +
-        "../.github/workflows/*.yml",
+        "{} +",
     );
   });
 

--- a/test/package-production.test.ts
+++ b/test/package-production.test.ts
@@ -139,6 +139,18 @@ const IMPORT_PATTERNS = DEV_ONLY_RUNTIME_PACKAGES.map(
 );
 
 describe("production package", () => {
+  it("builds distributable output before running package verification", async () => {
+    const pkg = JSON.parse(await fs.readFile("package.json", "utf8")) as {
+      scripts?: Record<string, string>;
+    };
+    const verifySteps = pkg.scripts?.verify?.split(" && ") ?? [];
+
+    expect(verifySteps).toContain("pnpm build");
+    expect(verifySteps.indexOf("pnpm build")).toBeLessThan(
+      verifySteps.indexOf("pnpm test:coverage"),
+    );
+  });
+
   it("ships its public entry points and CLI without dev-only dependencies", async () => {
     const root = process.cwd();
     const pkg = JSON.parse(await fs.readFile(path.join(root, "package.json"), "utf8")) as {


### PR DESCRIPTION
## Summary
- provision Go from `tools/go.mod` before workflow validation
- lint both `.yml` and `.yaml` workflows without masking actionlint failures
- build distributable output before production package verification
- add regression coverage and a changelog entry

## Verification
- focused CI/package tests: 18 passed
- typecheck and diff check
- actionlint: clean in worker validation
- Sol-high autoreview: clean (0.93 confidence)
- Crabbox `pnpm verify`: 1,697 passed, 34 skipped (`run_7c4ce518dd2b`)

The Crabbox run exercised the newly inserted build phase before coverage.