### PR TITLE
fix(openclaw): reject invalid validation metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Reject blank Mattermost readiness usernames and non-native Matrix thread IDs while preserving valid legacy smoke-only artifact generations.
 - Provision CI Go from the tools module, lint both workflow YAML extensions, and build distributable output before package verification.
 - Give the recorder-scan roundtrip regression enough time to complete on loaded CI workers.
 - Reject invalid shared HTTP body limits, webhook deadlines, and signed-JWT cache timings before starting I/O.

--- a/src/openclaw/artifact-generation.ts
+++ b/src/openclaw/artifact-generation.ts
@@ -232,7 +232,7 @@ function isSuccessfulProbe(
       return (
         value.id === manifest.botUserId &&
         typeof value.username === "string" &&
-        value.username.length > 0 &&
+        value.username.trim().length > 0 &&
         typeof value.update_at === "number" &&
         Number.isSafeInteger(value.update_at) &&
         value.update_at >= 0
@@ -554,15 +554,18 @@ async function assertCurrentGenerationExists(
     ? readNestedRecorderPath(providerReadiness)
     : undefined;
   const smokeRecorderPath = readNestedRecorderPath(smoke);
-  const recorderPaths = [manifestRecorderPath, providerReadinessRecorderPath, smokeRecorderPath];
+  const readinessRecorderPaths = [
+    ...(isRecord(providerReadiness) ? [providerReadinessRecorderPath] : []),
+    smokeRecorderPath,
+  ];
+  const recorderPaths = [manifestRecorderPath, ...readinessRecorderPaths];
   if (manifest.recorderPath !== undefined && typeof manifest.recorderPath !== "string") {
     throw new Error("OpenClaw Crabline current artifact generation is incomplete.");
   }
   // The artifact store is owner-only; v1 compatibility covers historical layouts, not hostile same-owner rewrites.
   if (
     pointer.version === 1 &&
-    providerReadinessRecorderPath === undefined &&
-    smokeRecorderPath === undefined &&
+    readinessRecorderPaths.every((recorderPath) => recorderPath === undefined) &&
     (manifestRecorderPath === undefined ||
       path.dirname(path.resolve(outputDir, manifestRecorderPath)) !== generationDirectory)
   ) {

--- a/src/openclaw/bridges/matrix.ts
+++ b/src/openclaw/bridges/matrix.ts
@@ -1,4 +1,5 @@
 import { isIP } from "node:net";
+import { isMatrixEventId } from "../../matrix-ids.js";
 import {
   canonicalConversationIdForInbound,
   createAdminInboundRequest,
@@ -88,9 +89,21 @@ function targetKey(roomId: string, threadId?: string): string {
   return threadId ? `${roomId}:thread:${threadId}` : roomId;
 }
 
-function eventThreadId(content: Record<string, unknown>): string | undefined {
+function matrixThreadId(value: string): string {
+  const trimmed = value.trim();
+  if (!isMatrixEventId(trimmed)) {
+    throw new Error("Matrix thread IDs must be native event IDs.");
+  }
+  return trimmed;
+}
+
+function eventThreadId(content: Record<string, unknown>): string | null | undefined {
   const relation = isRecord(content["m.relates_to"]) ? content["m.relates_to"] : undefined;
-  return relation?.rel_type === "m.thread" ? readString(relation.event_id) : undefined;
+  if (relation?.rel_type !== "m.thread") {
+    return undefined;
+  }
+  const eventId = readString(relation.event_id);
+  return eventId && isMatrixEventId(eventId) ? eventId : null;
 }
 
 const MAX_DELIVERED_MATRIX_TRANSACTIONS = 1_000;
@@ -171,7 +184,8 @@ export const MATRIX_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablinePr
       },
       createInbound(input) {
         const roomId = matrixRoomId(canonicalConversationIdForInbound(input));
-        const threadId = input.threadId?.trim() || undefined;
+        const rawThreadId = input.threadId?.trim();
+        const threadId = rawThreadId ? matrixThreadId(rawThreadId) : undefined;
         const direct = input.conversation.kind === "direct";
         return {
           ...createAdminInboundRequest(matrix),
@@ -231,6 +245,9 @@ export const MATRIX_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablinePr
           return null;
         }
         const threadId = eventThreadId(event.body);
+        if (threadId === null) {
+          return null;
+        }
         deliveredTransactions.add(transactionKey);
         if (deliveredTransactions.size > MAX_DELIVERED_MATRIX_TRANSACTIONS) {
           deliveredTransactions.delete(deliveredTransactions.values().next().value!);

--- a/test/openclaw-artifact-generation.test.ts
+++ b/test/openclaw-artifact-generation.test.ts
@@ -33,6 +33,25 @@ const manifest: CrablineServerManifest = {
   version: 1,
 };
 
+const mattermostManifest = {
+  adminToken: "sample",
+  baseUrl: "http://127.0.0.1:9753",
+  botToken: "sample",
+  botUserId: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+  endpoints: {
+    adminInboundUrl: "http://127.0.0.1:9753/crabline/mattermost/inbound",
+    apiRoot: "http://127.0.0.1:9753/api/v4",
+    websocketUrl: "ws://127.0.0.1:9753/api/v4/websocket",
+  },
+  env: {
+    MATTERMOST_BOT_TOKEN: "sample",
+    MATTERMOST_URL: "http://127.0.0.1:9753",
+  },
+  provider: "mattermost",
+  recorderPath: "/tmp/crabline/mattermost.jsonl",
+  version: 1,
+} satisfies CrablineServerManifest;
+
 function createLock(): OpenClawCrablineSmokeRunLock & {
   assertOwned: ReturnType<typeof vi.fn<() => Promise<void>>>;
   commitFileAtomically: ReturnType<
@@ -90,6 +109,30 @@ function publishParamsWithRecorderSnapshot(outputDir: string, lock = createLock(
   };
 }
 
+function mattermostPublishParams(outputDir: string) {
+  return {
+    capabilityReport: { result: { selectedChannel: "mattermost" } },
+    lock: createLock(),
+    manifest: mattermostManifest,
+    outputDir,
+    selection: resolveOpenClawCrablineChannelDriverSelection({ channel: "mattermost" }),
+    providerReadiness: {
+      result: {
+        endpoints: mattermostManifest.endpoints,
+        ok: true,
+        probe: {
+          id: mattermostManifest.botUserId,
+          update_at: 0,
+          username: " \n\t",
+        },
+        proof: "provider-api-probe",
+        provider: "mattermost",
+        ready: true,
+      },
+    },
+  };
+}
+
 describe("OpenClaw artifact generation publication", () => {
   it("documents runtime pruning of abandoned artifact generations", async () => {
     const channelSetup = await fs.readFile(
@@ -124,6 +167,66 @@ describe("OpenClaw artifact generation publication", () => {
         smokeArtifactPath: result.smokeArtifactPath,
         version: 1,
       });
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
+  it("validates every existing section in legacy smoke-only generations", async () => {
+    const outputDir = await createTempDir();
+    try {
+      const first = await publishOpenClawCrablineArtifactGeneration(
+        publishParamsWithRecorderSnapshot(outputDir),
+        { createGenerationId: () => "11111111-1111-4111-8111-111111111111" },
+      );
+      const pointerPath = path.join(outputDir, OPENCLAW_CRABLINE_ARTIFACT_POINTER_PATH);
+      const pointer = JSON.parse(await fs.readFile(pointerPath, "utf8")) as Record<string, unknown>;
+      delete pointer.providerReadinessArtifactPath;
+      delete pointer.recorderSnapshotPath;
+      pointer.version = 1;
+      await fs.writeFile(pointerPath, `${JSON.stringify(pointer, null, 2)}\n`);
+
+      const readinessPath = path.join(outputDir, first.smokeArtifactPath);
+      const readiness = JSON.parse(await fs.readFile(readinessPath, "utf8")) as {
+        providerReadiness?: unknown;
+        smoke: { result: Record<string, unknown> };
+      };
+      delete readiness.providerReadiness;
+      delete readiness.smoke.result.proof;
+      delete readiness.smoke.result.ready;
+      const validSmokeOnlyReadiness = `${JSON.stringify(readiness, null, 2)}\n`;
+      readiness.smoke.result.endpoints = {};
+      await fs.writeFile(readinessPath, `${JSON.stringify(readiness, null, 2)}\n`);
+
+      await expect(
+        publishOpenClawCrablineArtifactGeneration(publishParams(outputDir), {
+          createGenerationId: () => "22222222-2222-4222-8222-222222222222",
+        }),
+      ).rejects.toThrow("OpenClaw Crabline current artifact generation is incomplete.");
+
+      await fs.writeFile(readinessPath, validSmokeOnlyReadiness);
+      await expect(
+        publishOpenClawCrablineArtifactGeneration(publishParams(outputDir), {
+          createGenerationId: () => "22222222-2222-4222-8222-222222222222",
+        }),
+      ).resolves.toMatchObject({
+        previousGeneration: first.generation,
+        version: 2,
+      });
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
+  it("rejects whitespace-only Mattermost usernames in readiness evidence", async () => {
+    const outputDir = await createTempDir();
+    try {
+      await expect(
+        publishOpenClawCrablineArtifactGeneration(mattermostPublishParams(outputDir), {
+          createGenerationId: () => "11111111-1111-4111-8111-111111111111",
+        }),
+      ).rejects.toThrow("OpenClaw Crabline current artifact generation is incomplete.");
+      await expect(readOpenClawCrablineArtifactPointer(outputDir)).resolves.toBeNull();
     } finally {
       await disposeTempDir(outputDir);
     }

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -2863,6 +2863,17 @@ describe("OpenClaw local provider bridge", () => {
       },
       threadId: "$root:matrix.test",
     });
+    expect(() =>
+      createOpenClawCrablineInbound({
+        manifest: matrixManifest,
+        input: {
+          conversation: { id: roomId, kind: "group" },
+          senderId: "@alice:matrix.test",
+          text: "invalid thread id",
+          threadId: "root",
+        },
+      }),
+    ).toThrow("Matrix thread IDs must be native event IDs.");
     expect(
       createOpenClawCrablineOutboundFromRecorderEvent({
         manifest: matrixManifest,
@@ -2885,6 +2896,25 @@ describe("OpenClaw local provider bridge", () => {
       text: "unmapped thread reply",
       to: `${roomId}:thread:$root:matrix.test`,
     });
+    expect(
+      createOpenClawCrablineOutboundFromRecorderEvent({
+        manifest: matrixManifest,
+        targetByProviderTarget: new Map(),
+        event: {
+          body: {
+            body: "invalid thread reply",
+            msgtype: "m.text",
+            "m.relates_to": {
+              event_id: "root",
+              rel_type: "m.thread",
+            },
+          },
+          method: "PUT",
+          path: `/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/send/m.room.message/invalid-thread`,
+          type: "api",
+        },
+      }),
+    ).toBeNull();
 
     expect(() =>
       createOpenClawCrablineInbound({


### PR DESCRIPTION
## What Problem This Solves

Fixes issues where OpenClaw validation could accept blank Mattermost identities or non-native Matrix thread identifiers, while legacy smoke-only artifacts could be rejected despite containing no readiness recorder path.

## Why This Change Was Made

Tightens provider-native identifier checks at the OpenClaw bridge boundary and preserves the version 1 smoke-only artifact contract while continuing to validate any sections that are present.

## User Impact

Operators get fail-closed readiness and thread correlation validation without breaking valid legacy smoke-only artifacts.

## Evidence

- Sol-high autoreview on exact commit `dd196cab33257ba9f703a0abe7b2666aa48efbda`: clean, confidence 0.90
- Crabbox Linux `pnpm verify`: run `run_5f20ad9b98a0`, 65 files passed, 1,699 tests passed, 34 platform skips
- Changelog entry included