### PR TITLE
fix(auth): reject unsafe provider credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Reject blank Slack and Feishu ingress secrets, confine generated Telegram recorder paths, and compare WhatsApp and Mattermost bearer tokens in constant time.
 - Reject blank Mattermost readiness usernames and non-native Matrix thread IDs while preserving valid legacy smoke-only artifact generations.
 - Provision CI Go from the tools module, lint both workflow YAML extensions, and build distributable output before package verification.
 - Give the recorder-scan roundtrip regression enough time to complete on loaded CI workers.

--- a/src/providers/builtin/feishu.ts
+++ b/src/providers/builtin/feishu.ts
@@ -50,9 +50,19 @@ export function resolveFeishuAdapterConfig(
   config: ProviderConfig,
   env: FeishuEnvironment = process.env,
 ) {
+  const configuredEncryptKey = config.feishu?.encryptKey;
+  const encryptKey = configuredEncryptKey ?? env.FEISHU_ENCRYPT_KEY;
+  if (encryptKey !== undefined && !encryptKey.trim()) {
+    throw new CrablineError(
+      configuredEncryptKey === undefined
+        ? "FEISHU_ENCRYPT_KEY must not be empty or whitespace-only."
+        : "Feishu encryptKey must not be empty or whitespace-only.",
+      { kind: "config" },
+    );
+  }
   return {
     appId: config.feishu?.appId ?? "local-mock-feishu-app",
-    encryptKey: config.feishu?.encryptKey ?? env.FEISHU_ENCRYPT_KEY,
+    encryptKey,
     userName: config.feishu?.userName,
     verificationToken: config.feishu?.verificationToken ?? env.FEISHU_VERIFICATION_TOKEN,
   };

--- a/src/providers/builtin/slack.ts
+++ b/src/providers/builtin/slack.ts
@@ -22,8 +22,18 @@ export function resolveSlackAdapterConfig(
   config: ProviderConfig,
   env: SlackEnvironment = process.env,
 ) {
+  const configuredSigningSecret = config.slack?.signingSecret;
+  const signingSecret = configuredSigningSecret ?? env.SLACK_SIGNING_SECRET;
+  if (signingSecret !== undefined && !signingSecret.trim()) {
+    throw new CrablineError(
+      configuredSigningSecret === undefined
+        ? "SLACK_SIGNING_SECRET must not be empty or whitespace-only."
+        : "Slack signingSecret must not be empty or whitespace-only.",
+      { kind: "config" },
+    );
+  }
   return {
-    signingSecret: config.slack?.signingSecret ?? env.SLACK_SIGNING_SECRET,
+    signingSecret,
   };
 }
 

--- a/src/providers/builtin/telegram.ts
+++ b/src/providers/builtin/telegram.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
-import { LocalMockProviderAdapter } from "../local-mock.js";
+import { LocalMockProviderAdapter, resolveGeneratedLocalMockRecorderPath } from "../local-mock.js";
 import { matchesNativeId } from "../native-ids.js";
 import {
   getBuiltinTargetCodec,
@@ -53,7 +53,7 @@ function toRecorderPath(providerId: string, config: ProviderConfig): string {
   const configuredPath = config.telegram?.recorder.path;
   return configuredPath
     ? path.resolve(configuredPath)
-    : path.resolve(".crabline", "recorders", `${providerId}.jsonl`);
+    : resolveGeneratedLocalMockRecorderPath(providerId);
 }
 
 function normalizeGenericTelegramPayload(payload: Record<string, unknown>) {

--- a/src/servers/mattermost.ts
+++ b/src/servers/mattermost.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { WebSocket, WebSocketServer, type RawData } from "ws";
 import {
   adminAuthError,
+  constantTimeTokenEqual,
   drainRequestBody,
   hasAdminToken,
   InvalidJsonBodyError,
@@ -159,7 +160,8 @@ async function appendEvent(
 }
 
 function authorized(request: IncomingMessage, token: string): boolean {
-  return /^Bearer ([^\s]+)$/iu.exec(request.headers.authorization ?? "")?.[1] === token;
+  const providedToken = /^Bearer ([^\s]+)$/iu.exec(request.headers.authorization ?? "")?.[1];
+  return providedToken ? constantTimeTokenEqual(providedToken, token) : false;
 }
 
 function mattermostError(
@@ -909,7 +911,8 @@ function attachWebSocketServer(params: {
         }
         if (
           message.action !== "authentication_challenge" ||
-          message.data?.token !== params.state.botToken
+          typeof message.data?.token !== "string" ||
+          !constantTimeTokenEqual(message.data.token, params.state.botToken)
         ) {
           sendControlMessage(params.state, client, {
             error: { id: "api.context.unauthorized", message: "Authentication failed" },

--- a/src/servers/whatsapp.ts
+++ b/src/servers/whatsapp.ts
@@ -3,6 +3,7 @@ import { randomBytes } from "node:crypto";
 import path from "node:path";
 import {
   adminAuthError,
+  constantTimeTokenEqual,
   drainRequestBody,
   hasAdminToken,
   InvalidJsonBodyError,
@@ -209,7 +210,8 @@ function requireAuth(request: IncomingMessage, state: WhatsAppServerState): bool
     return false;
   }
   const match = /^Bearer +(.+)$/iu.exec(authorization.trimStart());
-  return match?.[1] === state.accessToken;
+  const providedToken = match?.[1];
+  return providedToken ? constantTimeTokenEqual(providedToken, state.accessToken) : false;
 }
 
 type WhatsAppMessageIdReservation = {

--- a/test/feishu-provider.test.ts
+++ b/test/feishu-provider.test.ts
@@ -7,6 +7,7 @@ import {
   FeishuProviderAdapter,
   handleFeishuWebhookPayload,
   normalizeFeishuWebhookPayload,
+  resolveFeishuAdapterConfig,
 } from "../src/providers/builtin/feishu.js";
 import {
   createLocalMockConfig,
@@ -41,6 +42,19 @@ describe("Feishu webhook normalizer", () => {
     expect(
       () => new FeishuProviderAdapter("feishu", config, "crabline", { env: {} }),
     ).not.toThrow();
+  });
+
+  it("rejects whitespace-only encryption keys from config and env", async () => {
+    const config = await createLocalMockConfig("feishu", "/feishu/webhook");
+    config.feishu!.encryptKey = " \t ";
+    expect(() => resolveFeishuAdapterConfig(config, {})).toThrow(
+      "Feishu encryptKey must not be empty or whitespace-only.",
+    );
+
+    delete config.feishu!.encryptKey;
+    expect(() => resolveFeishuAdapterConfig(config, { FEISHU_ENCRYPT_KEY: "\n" })).toThrow(
+      "FEISHU_ENCRYPT_KEY must not be empty or whitespace-only.",
+    );
   });
 
   it("answers URL verification challenges", async () => {

--- a/test/mattermost-server.test.ts
+++ b/test/mattermost-server.test.ts
@@ -313,7 +313,13 @@ describe("Mattermost local provider server", () => {
     const server = await startMattermostServer({ botToken: "fake" });
     servers.push(server);
 
-    for (const authorization of ["Bearer  fake", "Bearer\tfake", "Basic fake"]) {
+    for (const authorization of [
+      "Bearer  fake",
+      "Bearer\tfake",
+      "Basic fake",
+      "Bearer fakf",
+      "Bearer short-token",
+    ]) {
       const response = await fetch(`${server.manifest.endpoints.apiRoot}/users/me`, {
         headers: { authorization },
       });
@@ -641,22 +647,24 @@ describe("Mattermost local provider server", () => {
       reason: "authentication timeout",
     });
 
-    const invalid = new WebSocket(server.manifest.endpoints.websocketUrl);
-    const invalidClosed = waitForSocketClose(invalid);
-    await waitForSocketOpen(invalid);
-    const failure = nextMessage(invalid);
-    invalid.send(
-      JSON.stringify({
-        action: "authentication_challenge",
-        data: { token: "not-a-real" },
-        seq: 1,
-      }),
-    );
-    await expect(failure).resolves.toMatchObject({ seq_reply: 1, status: "FAIL" });
-    await expect(invalidClosed).resolves.toEqual({
-      code: 4001,
-      reason: "authentication failed",
-    });
+    for (const token of ["fakf", "not-a-real"]) {
+      const invalid = new WebSocket(server.manifest.endpoints.websocketUrl);
+      const invalidClosed = waitForSocketClose(invalid);
+      await waitForSocketOpen(invalid);
+      const failure = nextMessage(invalid);
+      invalid.send(
+        JSON.stringify({
+          action: "authentication_challenge",
+          data: { token },
+          seq: 1,
+        }),
+      );
+      await expect(failure).resolves.toMatchObject({ seq_reply: 1, status: "FAIL" });
+      await expect(invalidClosed).resolves.toEqual({
+        code: 4001,
+        reason: "authentication failed",
+      });
+    }
   });
 
   it("rejects admin inbound when the disconnected event queue is full", async () => {

--- a/test/slack-provider.test.ts
+++ b/test/slack-provider.test.ts
@@ -6,6 +6,7 @@ import type { ProviderConfig } from "../src/config/schema.js";
 import {
   handleSlackWebhookPayload,
   normalizeSlackEventsPayload,
+  resolveSlackAdapterConfig,
   SlackProviderAdapter,
 } from "../src/providers/builtin/slack.js";
 import { appendRecordedInbound } from "../src/providers/recorder.js";
@@ -127,6 +128,19 @@ describe("slack provider", () => {
     config.slack!.signingSecret = "test-token-placeholder";
     const provider = new SlackProviderAdapter("slack", config, "crabline");
     providers.push(provider);
+  });
+
+  it("rejects whitespace-only signing secrets from config and env", async () => {
+    const config = await createSlackConfig(0);
+    config.slack!.signingSecret = " \t ";
+    expect(() => resolveSlackAdapterConfig(config, {})).toThrow(
+      "Slack signingSecret must not be empty or whitespace-only.",
+    );
+
+    delete config.slack!.signingSecret;
+    expect(() => resolveSlackAdapterConfig(config, { SLACK_SIGNING_SECRET: "\n" })).toThrow(
+      "SLACK_SIGNING_SECRET must not be empty or whitespace-only.",
+    );
   });
 
   it("keeps native Slack conversation and thread timestamp ids", async () => {

--- a/test/telegram-provider.test.ts
+++ b/test/telegram-provider.test.ts
@@ -93,6 +93,15 @@ describe("telegram provider", () => {
     });
   });
 
+  it("confines generated recorder paths for provider IDs", async () => {
+    const config = await createTelegramConfig(0);
+    config.telegram!.recorder = {};
+
+    expect(() => new TelegramProviderAdapter("../escape", config, "crabline")).toThrow(
+      /Provider ID cannot contain absolute or parent-directory paths/u,
+    );
+  });
+
   it("normalizes chat and topic targets", async () => {
     const config = await createTelegramConfig(0);
     const provider = new TelegramProviderAdapter("telegram", config, "crabline");

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -255,6 +255,23 @@ afterEach(async () => {
 });
 
 describe("whatsapp local provider server", () => {
+  it("accepts only the exact Cloud API bearer token", async () => {
+    const server = await startWhatsAppServer({ accessToken: "fake" });
+    servers.push(server);
+
+    for (const token of ["fakf", "x"]) {
+      const rejected = await fetch(server.manifest.endpoints.phoneNumberUrl, {
+        headers: { authorization: `Bearer ${token}` },
+      });
+      expect(rejected.status).toBe(401);
+    }
+
+    const accepted = await fetch(server.manifest.endpoints.phoneNumberUrl, {
+      headers: { authorization: "Bearer fake" },
+    });
+    expect(accepted.status).toBe(200);
+  });
+
   it("validates inbound queue limits before binding the HTTP port", async () => {
     await expect(startWhatsAppServer({ accessToken: "" })).rejects.toThrow(
       "accessToken must not be empty",


### PR DESCRIPTION
## What Problem This Solves

Fixes issues where blank Slack or Feishu ingress secrets could pass configuration, generated Telegram recorder paths could escape the recorder directory, and provider bearer-token checks used variable-time comparisons.

## Why This Change Was Made

Rejects whitespace-only credentials, routes generated recorder paths through the existing confinement helper, and uses constant-time comparisons with malformed-token guards for Mattermost and WhatsApp.

## User Impact

Provider ingress fails closed for invalid credentials and generated artifacts remain confined to their expected directory.

## Evidence

- Sol-high autoreview on exact commit `911cecf2c55b508e471d2d7f8a5a7064840417dc`: clean, confidence 0.91
- Crabbox Linux `pnpm verify`: run `run_bb9c0fd48e9b`, 65 files passed, 1,703 tests passed, 34 platform skips
- Changelog entry included