### PR TITLE
fix(windows): preserve lock-root identity during ACL checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Ignore inherit-only Windows ACEs for current-directory mutation checks and bind lock-root identity and ACL validation to the same no-follow handle across path replacement.
 - Reject blank Slack and Feishu ingress secrets, confine generated Telegram recorder paths, and compare WhatsApp and Mattermost bearer tokens in constant time.
 - Reject blank Mattermost readiness usernames and non-native Matrix thread IDs while preserving valid legacy smoke-only artifact generations.
 - Provision CI Go from the tools module, lint both workflow YAML extensions, and build distributable output before package verification.

--- a/src/platform/windows-acl.ts
+++ b/src/platform/windows-acl.ts
@@ -456,16 +456,21 @@ public static class CrablineWindowsDirectoryHandle
 
     public static void AssertSamePathIdentity(string path, string expected)
     {
+        if (!String.Equals(
+            ReadPathIdentity(path),
+            expected,
+            StringComparison.Ordinal
+        )) {
+            throw new InvalidOperationException(
+                "Private directory identity changed during ACL mutation."
+            );
+        }
+    }
+
+    public static string ReadPathIdentity(string path)
+    {
         using (SafeFileHandle current = Open(path, false)) {
-            if (!String.Equals(
-                ReadIdentity(current),
-                expected,
-                StringComparison.Ordinal
-            )) {
-                throw new InvalidOperationException(
-                    "Private directory identity changed during ACL mutation."
-                );
-            }
+            return ReadIdentity(current);
         }
     }
 }
@@ -629,6 +634,7 @@ function Assert-SafeParentNamespace(
       $true,
       [System.Security.Principal.SecurityIdentifier]
     ))
+    $inheritOnly = [System.Security.AccessControl.PropagationFlags]::InheritOnly
     $unsafeRights = $replacementRights
     if ($rejectChildCreation) {
       $unsafeRights = (
@@ -641,11 +647,7 @@ function Assert-SafeParentNamespace(
         $parentRule.AccessControlType -ne
           [System.Security.AccessControl.AccessControlType]::Allow -or
         $trustedSids.Contains($parentRule.IdentityReference.Value) -or
-        (
-          -not $rejectChildCreation -and
-          (($parentRule.PropagationFlags -band
-            [System.Security.AccessControl.PropagationFlags]::InheritOnly) -ne 0)
-        )
+        (($parentRule.PropagationFlags -band $inheritOnly) -ne 0)
       ) {
         continue
       }
@@ -905,11 +907,13 @@ try {
   ) {
     throw "Windows directory security descriptor is not owner-only."
   }
-  [CrablineWindowsDirectoryHandle]::AssertSamePathIdentity(
-    $directoryPath,
-    $directoryIdentity
-  )
+  $pathIdentity = [CrablineWindowsDirectoryHandle]::ReadPathIdentity($directoryPath)
+  if ($pathIdentity -ne $directoryIdentity) {
+    throw "Private directory identity changed during security inspection."
+  }
   [Console]::Out.Write($directoryIdentity)
+  [Console]::Out.Write([Environment]::NewLine)
+  [Console]::Out.Write($pathIdentity)
   [Console]::Out.Write([Environment]::NewLine)
   [Console]::Out.Write([Convert]::ToBase64String($descriptor))
 } finally {
@@ -950,11 +954,13 @@ $directory = [CrablineWindowsDirectoryHandle]::Open($directoryPath, $false)
 try {
   $directoryIdentity = [CrablineWindowsDirectoryHandle]::ReadIdentity($directory)
   $descriptor = [CrablineWindowsDirectoryHandle]::ReadSecurityDescriptor($directory)
-  [CrablineWindowsDirectoryHandle]::AssertSamePathIdentity(
-    $directoryPath,
-    $directoryIdentity
-  )
+  $pathIdentity = [CrablineWindowsDirectoryHandle]::ReadPathIdentity($directoryPath)
+  if ($pathIdentity -ne $directoryIdentity) {
+    throw "Private directory identity changed during security inspection."
+  }
   [Console]::Out.Write($directoryIdentity)
+  [Console]::Out.Write([Environment]::NewLine)
+  [Console]::Out.Write($pathIdentity)
   [Console]::Out.Write([Environment]::NewLine)
   [Console]::Out.Write([Convert]::ToBase64String($descriptor))
 } finally {
@@ -975,6 +981,7 @@ export type WindowsAclRunner = (
 
 export type WindowsDirectorySecuritySnapshot = {
   identity: string;
+  pathIdentity: string;
   securityDescriptor: string;
 };
 
@@ -1085,16 +1092,21 @@ export async function readWindowsDirectorySecuritySnapshot(
         windowsHide: true,
       },
     );
-    const [identity, securityDescriptor, ...extraLines] = output.trim().split(/\r?\n/u);
+    const [identity, pathIdentity, securityDescriptor, ...extraLines] = output
+      .trim()
+      .split(/\r?\n/u);
     if (
       !identity ||
       !/^\d+:[0-9A-F]{32}$/u.test(identity) ||
+      !pathIdentity ||
+      !/^\d+:[0-9A-F]{32}$/u.test(pathIdentity) ||
+      pathIdentity !== identity ||
       !securityDescriptor ||
       extraLines.length > 0
     ) {
-      throw new Error("Windows directory security descriptor was empty.");
+      throw new Error("Windows directory security snapshot was invalid.");
     }
-    return { identity, securityDescriptor };
+    return { identity, pathIdentity, securityDescriptor };
   } catch (error) {
     throw new Error(
       "Could not read the Windows directory security descriptor through a stable no-follow handle; Windows PowerShell ACL support is required.",
@@ -1129,16 +1141,21 @@ export async function readWindowsDirectoryNamespaceSecuritySnapshot(
         windowsHide: true,
       },
     );
-    const [identity, securityDescriptor, ...extraLines] = output.trim().split(/\r?\n/u);
+    const [identity, pathIdentity, securityDescriptor, ...extraLines] = output
+      .trim()
+      .split(/\r?\n/u);
     if (
       !identity ||
       !/^\d+:[0-9A-F]{32}$/u.test(identity) ||
+      !pathIdentity ||
+      !/^\d+:[0-9A-F]{32}$/u.test(pathIdentity) ||
+      pathIdentity !== identity ||
       !securityDescriptor ||
       extraLines.length > 0
     ) {
-      throw new Error("Windows directory namespace security descriptor was empty.");
+      throw new Error("Windows directory namespace security snapshot was invalid.");
     }
-    return { identity, securityDescriptor };
+    return { identity, pathIdentity, securityDescriptor };
   } catch (error) {
     throw new Error(
       "Could not validate the Windows directory namespace through stable no-follow handles; Windows PowerShell ACL support is required.",

--- a/src/platform/windows-lock-root.ts
+++ b/src/platform/windows-lock-root.ts
@@ -3,10 +3,7 @@ import { lstat } from "node:fs/promises";
 import type { WindowsDirectorySecuritySnapshot } from "./windows-acl.js";
 
 export type WindowsLockRootIdentity = {
-  birthtimeNs: bigint;
-  dev: bigint;
   handleIdentity: string;
-  ino: bigint;
   securityDescriptor: string;
 };
 
@@ -20,17 +17,8 @@ function isTransientPathError(error: unknown): boolean {
   return code === "ENOENT" || code === "ENOTDIR";
 }
 
-function isSameWindowsLockRoot(
-  left: WindowsLockRootStats,
-  right: Pick<WindowsLockRootIdentity, "birthtimeNs" | "dev" | "ino">,
-): boolean {
-  return (
-    left.isDirectory() &&
-    !left.isSymbolicLink() &&
-    left.dev === right.dev &&
-    left.ino === right.ino &&
-    left.birthtimeNs === right.birthtimeNs
-  );
+function isPrivateWindowsLockRoot(stats: WindowsLockRootStats): boolean {
+  return stats.isDirectory() && !stats.isSymbolicLink();
 }
 
 async function readStableWindowsLockRootIdentity(options: {
@@ -39,53 +27,32 @@ async function readStableWindowsLockRootIdentity(options: {
   root: string;
 }): Promise<WindowsLockRootIdentity> {
   for (let attempt = 0; attempt < MAX_WINDOWS_LOCK_ROOT_SNAPSHOT_ATTEMPTS; attempt += 1) {
-    let before: WindowsLockRootStats;
+    let pathStats: WindowsLockRootStats;
     try {
-      before = await lstat(options.root, { bigint: true });
+      pathStats = await lstat(options.root, { bigint: true });
     } catch (error) {
       if (isTransientPathError(error)) {
         continue;
       }
       throw error;
     }
-    if (!before.isDirectory() || before.isSymbolicLink()) {
+    if (!isPrivateWindowsLockRoot(pathStats)) {
       throw new Error(`${options.errorPrefix} is not a private directory.`);
     }
-    let securitySnapshot: WindowsDirectorySecuritySnapshot;
     try {
-      securitySnapshot = await options.readSecuritySnapshot();
-    } catch (error) {
-      let afterFailure: WindowsLockRootStats;
-      try {
-        afterFailure = await lstat(options.root, { bigint: true });
-      } catch (pathError) {
-        if (isTransientPathError(pathError)) {
-          continue;
-        }
-        throw pathError;
+      const securitySnapshot = await options.readSecuritySnapshot();
+      if (securitySnapshot.pathIdentity !== securitySnapshot.identity) {
+        throw new Error(`${options.errorPrefix} path identity does not match its secure handle.`);
       }
-      if (!isSameWindowsLockRoot(afterFailure, before)) {
-        continue;
-      }
-      throw error;
-    }
-    let after: WindowsLockRootStats;
-    try {
-      after = await lstat(options.root, { bigint: true });
+      return {
+        handleIdentity: securitySnapshot.identity,
+        securityDescriptor: securitySnapshot.securityDescriptor,
+      };
     } catch (error) {
       if (isTransientPathError(error)) {
         continue;
       }
       throw error;
-    }
-    if (isSameWindowsLockRoot(after, before)) {
-      return {
-        birthtimeNs: before.birthtimeNs,
-        dev: before.dev,
-        handleIdentity: securitySnapshot.identity,
-        ino: before.ino,
-        securityDescriptor: securitySnapshot.securityDescriptor,
-      };
     }
   }
   throw new Error(`${options.errorPrefix} could not be stabilized.`);
@@ -137,9 +104,6 @@ export async function secureCachedWindowsLockRoot(options: {
       continue;
     }
     if (
-      current.dev === expected.dev &&
-      current.ino === expected.ino &&
-      current.birthtimeNs === expected.birthtimeNs &&
       current.handleIdentity === expected.handleIdentity &&
       current.securityDescriptor === expected.securityDescriptor
     ) {

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -3,6 +3,7 @@ import {
   appendFile,
   chmod,
   link,
+  lstat,
   mkdir,
   open,
   readFile,
@@ -39,10 +40,15 @@ import { createTempDir, disposeTempDir } from "./test-helpers.js";
 
 const directories: string[] = [];
 const stableWindowsDirectoryIdentity = "10:00000000000000000000000000000014";
-const readOwnerOnlyWindowsDirectorySecuritySnapshot = async () => ({
-  identity: stableWindowsDirectoryIdentity,
-  securityDescriptor: "owner-only",
-});
+const readOwnerOnlyWindowsDirectorySecuritySnapshot = async (directoryPath: string) => {
+  const stats = await lstat(directoryPath, { bigint: true });
+  const identity = `${stats.dev}:${stats.ino}:${stats.birthtimeNs}`;
+  return {
+    identity,
+    pathIdentity: identity,
+    securityDescriptor: "owner-only",
+  };
+};
 
 afterEach(async () => {
   await Promise.all(directories.splice(0).map(disposeTempDir));
@@ -401,6 +407,7 @@ describe("recorder", () => {
     };
     const readSecuritySnapshot = async () => ({
       identity: stableWindowsDirectoryIdentity,
+      pathIdentity: stableWindowsDirectoryIdentity,
       securityDescriptor,
     });
 
@@ -436,6 +443,7 @@ describe("recorder", () => {
     };
     const readSecuritySnapshot = async () => ({
       identity: handleIdentity,
+      pathIdentity: handleIdentity,
       securityDescriptor: "owner-only",
     });
 
@@ -469,6 +477,7 @@ describe("recorder", () => {
       }
       return {
         identity: stableWindowsDirectoryIdentity,
+        pathIdentity: stableWindowsDirectoryIdentity,
         securityDescriptor: "owner-only",
       };
     };
@@ -512,6 +521,7 @@ describe("recorder", () => {
       }
       return {
         identity: stableWindowsDirectoryIdentity,
+        pathIdentity: stableWindowsDirectoryIdentity,
         securityDescriptor: "owner-only",
       };
     };
@@ -571,6 +581,14 @@ describe("recorder", () => {
     expect(script).toContain("DiscretionaryAclPresent");
     expect(script).toContain("Private directory parent namespace has a null DACL.");
     expect(script).toContain("CreateDirectories");
+    expect(script).toContain(
+      "$inheritOnly = [System.Security.AccessControl.PropagationFlags]::InheritOnly",
+    );
+    expect(script).toContain("(($parentRule.PropagationFlags -band $inheritOnly) -ne 0)");
+    expect(script).not.toContain("-not $rejectChildCreation -and");
+    expect(script).toContain(
+      "if (([int64]$parentRule.FileSystemRights -band $unsafeRights) -ne 0)",
+    );
     expect(script).toContain("WriteData");
     expect(script).toContain("WriteAttributes");
     expect(script).toContain("[int64]0x40000000");
@@ -621,7 +639,7 @@ describe("recorder", () => {
     const calls: Parameters<WindowsAclRunner>[] = [];
     const run: WindowsAclRunner = async (...args) => {
       calls.push(args);
-      return `${stableWindowsDirectoryIdentity}\r\ndescriptor-base64`;
+      return `${stableWindowsDirectoryIdentity}\r\n${stableWindowsDirectoryIdentity}\r\ndescriptor-base64`;
     };
     const directoryPath = String.raw`C:\Temp\crabline-recorder-locks`;
 
@@ -629,6 +647,7 @@ describe("recorder", () => {
       readWindowsDirectorySecuritySnapshot(directoryPath, run, String.raw`C:\Windows`),
     ).resolves.toEqual({
       identity: stableWindowsDirectoryIdentity,
+      pathIdentity: stableWindowsDirectoryIdentity,
       securityDescriptor: "descriptor-base64",
     });
 
@@ -641,7 +660,10 @@ describe("recorder", () => {
     expect(script).toContain(
       "[CrablineWindowsDirectoryHandle]::ReadSecurityDescriptor($directory)",
     );
-    expect(script).toContain("[CrablineWindowsDirectoryHandle]::AssertSamePathIdentity(");
+    expect(script).toContain(
+      "$pathIdentity = [CrablineWindowsDirectoryHandle]::ReadPathIdentity($directoryPath)",
+    );
+    expect(script).toContain("$pathIdentity -ne $directoryIdentity");
     expect(script).toContain("[Convert]::ToBase64String($descriptor)");
     expect(script).toContain("Assert-SafeNamespaceChain $parent.FullName $false");
     expect(script).toContain("RawSecurityDescriptor");
@@ -659,7 +681,7 @@ describe("recorder", () => {
     const calls: Parameters<WindowsAclRunner>[] = [];
     const run: WindowsAclRunner = async (...args) => {
       calls.push(args);
-      return `${stableWindowsDirectoryIdentity}\r\ndescriptor-base64`;
+      return `${stableWindowsDirectoryIdentity}\r\n${stableWindowsDirectoryIdentity}\r\ndescriptor-base64`;
     };
     const directoryPath = String.raw`C:\Temp\custom-recorder`;
 
@@ -667,6 +689,7 @@ describe("recorder", () => {
       readWindowsDirectoryNamespaceSecuritySnapshot(directoryPath, run, String.raw`C:\Windows`),
     ).resolves.toEqual({
       identity: stableWindowsDirectoryIdentity,
+      pathIdentity: stableWindowsDirectoryIdentity,
       securityDescriptor: "descriptor-base64",
     });
 
@@ -674,9 +697,27 @@ describe("recorder", () => {
     const script = args.at(-1);
     expect(script).toContain("Assert-SafeNamespaceChain $directoryPath $true");
     expect(script).toContain("[CrablineWindowsDirectoryHandle]::Open($directoryPath, $false)");
-    expect(script).toContain("[CrablineWindowsDirectoryHandle]::AssertSamePathIdentity(");
+    expect(script).toContain(
+      "$pathIdentity = [CrablineWindowsDirectoryHandle]::ReadPathIdentity($directoryPath)",
+    );
+    expect(script).toContain("$pathIdentity -ne $directoryIdentity");
     expect(script).not.toContain("[CrablineWindowsDirectoryHandle]::WriteSecurityDescriptor(");
     expect(options.env.CRABLINE_PRIVATE_DIRECTORY_PATH).toBe(path.resolve(directoryPath));
+  });
+
+  it("rejects Windows security snapshots whose outer path resolves to another handle", async () => {
+    const replacementIdentity = "10:00000000000000000000000000000015";
+
+    await expect(
+      readWindowsDirectorySecuritySnapshot(
+        String.raw`C:\Temp\crabline-recorder-locks`,
+        async () =>
+          `${stableWindowsDirectoryIdentity}\r\n${replacementIdentity}\r\ndescriptor-base64`,
+        String.raw`C:\Windows`,
+      ),
+    ).rejects.toThrow(
+      "Could not read the Windows directory security descriptor through a stable no-follow handle",
+    );
   });
 
   it("matches managed Windows recorder directories case-insensitively", () => {
@@ -942,6 +983,31 @@ describe("recorder", () => {
           "Could not atomically create or verify an owner-only Windows directory",
         );
         await expect(stat(lockRoot)).rejects.toMatchObject({ code: "ENOENT" });
+      } finally {
+        execFileSync("icacls.exe", [parent, "/remove:g", "*S-1-1-0"], {
+          windowsHide: true,
+        });
+      }
+    },
+  );
+
+  it.runIf(process.platform === "win32")(
+    "allows inherit-only child-creation rights on Windows recorder lock-root parents",
+    async () => {
+      const directory = await createTempDir();
+      directories.push(directory);
+      const parent = path.join(directory, "inherit-only-creatable-parent");
+      const lockRoot = path.join(parent, "lock-root");
+      await mkdir(parent);
+      execFileSync("icacls.exe", [parent, "/grant", "*S-1-1-0:(CI)(IO)(AD)"], {
+        windowsHide: true,
+      });
+
+      try {
+        await expect(createOwnerOnlyWindowsDirectory(lockRoot)).resolves.toBeUndefined();
+        await expect(stat(lockRoot)).resolves.toMatchObject({
+          isDirectory: expect.any(Function),
+        });
       } finally {
         execFileSync("icacls.exe", [parent, "/remove:g", "*S-1-1-0"], {
           windowsHide: true,

--- a/test/server-recorder.test.ts
+++ b/test/server-recorder.test.ts
@@ -24,10 +24,17 @@ const lockMocks = vi.hoisted(() => {
   };
 });
 
-const readWindowsDirectorySecuritySnapshot = vi.fn(async () => ({
-  identity: "10:00000000000000000000000000000014",
-  securityDescriptor: "owner-only",
-}));
+const stableWindowsDirectoryIdentity = "10:00000000000000000000000000000014";
+const replacementWindowsDirectoryIdentity = "10:00000000000000000000000000000015";
+const windowsDirectorySecuritySnapshot = (
+  identity = stableWindowsDirectoryIdentity,
+  securityDescriptor = "owner-only",
+) => ({
+  identity,
+  pathIdentity: identity,
+  securityDescriptor,
+});
+const readWindowsDirectorySecuritySnapshot = vi.fn(async () => windowsDirectorySecuritySnapshot());
 
 const serverRecorderExistingOpenFlags =
   fsConstants.O_RDWR | fsConstants.O_APPEND | fsConstants.O_NONBLOCK | fsConstants.O_NOFOLLOW;
@@ -227,7 +234,8 @@ function serverEvent(pathname: string): ServerRequestEvent {
 }
 
 beforeEach(() => {
-  readWindowsDirectorySecuritySnapshot.mockClear();
+  readWindowsDirectorySecuritySnapshot.mockReset();
+  readWindowsDirectorySecuritySnapshot.mockResolvedValue(windowsDirectorySecuritySnapshot());
   lockMocks.release.mockReset();
   lockMocks.release.mockResolvedValue();
   lockMocks.lock.mockReset();
@@ -328,7 +336,7 @@ describe("server recorder", () => {
 
     expect(createWindowsDirectory).toHaveBeenCalledTimes(1);
     expect(createWindowsDirectory).toHaveBeenCalledWith(lockRoot);
-    expect(fsMocks.lstat).toHaveBeenCalledTimes(6);
+    expect(fsMocks.lstat).toHaveBeenCalledTimes(3);
     expect(fsMocks.lstat).toHaveBeenCalledWith(lockRoot, { bigint: true });
   });
 
@@ -360,14 +368,9 @@ describe("server recorder", () => {
       createWindowsDirectory,
       readWindowsDirectorySecuritySnapshot,
     });
-    fsMocks.lstat.mockResolvedValue({
-      dev: 10n,
-      ino: 21n,
-      isDirectory: () => true,
-      isSymbolicLink: () => false,
-      mode: 0o700n,
-      uid: BigInt(process.geteuid?.() ?? 0),
-    });
+    readWindowsDirectorySecuritySnapshot.mockResolvedValue(
+      windowsDirectorySecuritySnapshot(replacementWindowsDirectoryIdentity),
+    );
     await Promise.all([
       secureServerRecorderWindowsLockRoot(lockRoot, {
         createWindowsDirectory,
@@ -385,71 +388,13 @@ describe("server recorder", () => {
   it("bounds repeated Windows process-lock root replacement recovery", async () => {
     const lockRoot = path.join("/tmp", "crabline-server-recorder-unstable-locks");
     const createWindowsDirectory = vi.fn(async () => undefined);
-    fsMocks.lstat
-      .mockResolvedValueOnce({
-        dev: 10n,
-        ino: 20n,
-        isDirectory: () => true,
-        isSymbolicLink: () => false,
-        mode: 0o700n,
-        uid: BigInt(process.geteuid?.() ?? 0),
-      })
-      .mockResolvedValueOnce({
-        dev: 10n,
-        ino: 20n,
-        isDirectory: () => true,
-        isSymbolicLink: () => false,
-        mode: 0o700n,
-        uid: BigInt(process.geteuid?.() ?? 0),
-      })
-      .mockResolvedValueOnce({
-        dev: 10n,
-        ino: 21n,
-        isDirectory: () => true,
-        isSymbolicLink: () => false,
-        mode: 0o700n,
-        uid: BigInt(process.geteuid?.() ?? 0),
-      })
-      .mockResolvedValueOnce({
-        dev: 10n,
-        ino: 21n,
-        isDirectory: () => true,
-        isSymbolicLink: () => false,
-        mode: 0o700n,
-        uid: BigInt(process.geteuid?.() ?? 0),
-      })
-      .mockResolvedValueOnce({
-        dev: 10n,
-        ino: 22n,
-        isDirectory: () => true,
-        isSymbolicLink: () => false,
-        mode: 0o700n,
-        uid: BigInt(process.geteuid?.() ?? 0),
-      })
-      .mockResolvedValueOnce({
-        dev: 10n,
-        ino: 22n,
-        isDirectory: () => true,
-        isSymbolicLink: () => false,
-        mode: 0o700n,
-        uid: BigInt(process.geteuid?.() ?? 0),
-      })
-      .mockResolvedValueOnce({
-        dev: 10n,
-        ino: 23n,
-        isDirectory: () => true,
-        isSymbolicLink: () => false,
-        mode: 0o700n,
-        uid: BigInt(process.geteuid?.() ?? 0),
-      })
-      .mockResolvedValueOnce({
-        dev: 10n,
-        ino: 23n,
-        isDirectory: () => true,
-        isSymbolicLink: () => false,
-        mode: 0o700n,
-        uid: BigInt(process.geteuid?.() ?? 0),
-      });
+    const thirdWindowsDirectoryIdentity = "10:00000000000000000000000000000016";
+    const fourthWindowsDirectoryIdentity = "10:00000000000000000000000000000017";
+    readWindowsDirectorySecuritySnapshot
+      .mockResolvedValueOnce(windowsDirectorySecuritySnapshot(stableWindowsDirectoryIdentity))
+      .mockResolvedValueOnce(windowsDirectorySecuritySnapshot(replacementWindowsDirectoryIdentity))
+      .mockResolvedValueOnce(windowsDirectorySecuritySnapshot(thirdWindowsDirectoryIdentity))
+      .mockResolvedValueOnce(windowsDirectorySecuritySnapshot(fourthWindowsDirectoryIdentity));
 
     await expect(
       secureServerRecorderWindowsLockRoot(lockRoot, {
@@ -460,76 +405,16 @@ describe("server recorder", () => {
     expect(createWindowsDirectory).toHaveBeenCalledTimes(2);
   });
 
-  it("re-secures a Windows process-lock root when wide file IDs differ", async () => {
-    const lockRoot = path.join("/tmp", "crabline-server-recorder-wide-id-locks");
+  it("re-secures after an ABA lock-root snapshot comes from another directory handle", async () => {
+    const lockRoot = path.join("/tmp", "crabline-server-recorder-aba-locks");
     const createWindowsDirectory = vi.fn(async () => undefined);
-    const originalInode = 2n ** 53n;
-    const replacementInode = originalInode + 1n;
-    fsMocks.lstat
-      .mockResolvedValueOnce({
-        dev: 10n,
-        ino: originalInode,
-        isDirectory: () => true,
-        isSymbolicLink: () => false,
-        mode: 0o700n,
-        uid: BigInt(process.geteuid?.() ?? 0),
-      })
-      .mockResolvedValueOnce({
-        dev: 10n,
-        ino: originalInode,
-        isDirectory: () => true,
-        isSymbolicLink: () => false,
-        mode: 0o700n,
-        uid: BigInt(process.geteuid?.() ?? 0),
-      })
-      .mockResolvedValueOnce({
-        dev: 10n,
-        ino: replacementInode,
-        isDirectory: () => true,
-        isSymbolicLink: () => false,
-        mode: 0o700n,
-        uid: BigInt(process.geteuid?.() ?? 0),
-      })
-      .mockResolvedValueOnce({
-        dev: 10n,
-        ino: replacementInode,
-        isDirectory: () => true,
-        isSymbolicLink: () => false,
-        mode: 0o700n,
-        uid: BigInt(process.geteuid?.() ?? 0),
-      })
-      .mockResolvedValueOnce({
-        dev: 10n,
-        ino: replacementInode,
-        isDirectory: () => true,
-        isSymbolicLink: () => false,
-        mode: 0o700n,
-        uid: BigInt(process.geteuid?.() ?? 0),
-      })
-      .mockResolvedValueOnce({
-        dev: 10n,
-        ino: replacementInode,
-        isDirectory: () => true,
-        isSymbolicLink: () => false,
-        mode: 0o700n,
-        uid: BigInt(process.geteuid?.() ?? 0),
-      })
-      .mockResolvedValueOnce({
-        dev: 10n,
-        ino: replacementInode,
-        isDirectory: () => true,
-        isSymbolicLink: () => false,
-        mode: 0o700n,
-        uid: BigInt(process.geteuid?.() ?? 0),
-      })
-      .mockResolvedValueOnce({
-        dev: 10n,
-        ino: replacementInode,
-        isDirectory: () => true,
-        isSymbolicLink: () => false,
-        mode: 0o700n,
-        uid: BigInt(process.geteuid?.() ?? 0),
-      });
+    readWindowsDirectorySecuritySnapshot
+      .mockResolvedValueOnce(
+        windowsDirectorySecuritySnapshot(replacementWindowsDirectoryIdentity, "replacement-acl"),
+      )
+      .mockResolvedValueOnce(windowsDirectorySecuritySnapshot())
+      .mockResolvedValueOnce(windowsDirectorySecuritySnapshot())
+      .mockResolvedValueOnce(windowsDirectorySecuritySnapshot());
 
     await expect(
       secureServerRecorderWindowsLockRoot(lockRoot, {
@@ -539,7 +424,29 @@ describe("server recorder", () => {
     ).resolves.toBe(lockRoot);
 
     expect(createWindowsDirectory).toHaveBeenCalledTimes(2);
-    expect(fsMocks.lstat.mock.calls.every(([, options]) => options?.bigint === true)).toBe(true);
+    expect(fsMocks.lstat).toHaveBeenCalledTimes(4);
+    expect(fsMocks.lstat.mock.calls).toEqual(
+      Array.from({ length: 4 }, () => [lockRoot, { bigint: true }]),
+    );
+  });
+
+  it("rejects a Windows process-lock snapshot when the outer path identity mismatches", async () => {
+    const lockRoot = path.join("/tmp", "crabline-server-recorder-path-mismatch-locks");
+    const createWindowsDirectory = vi.fn(async () => undefined);
+    readWindowsDirectorySecuritySnapshot.mockResolvedValue({
+      identity: stableWindowsDirectoryIdentity,
+      pathIdentity: replacementWindowsDirectoryIdentity,
+      securityDescriptor: "owner-only",
+    });
+
+    await expect(
+      secureServerRecorderWindowsLockRoot(lockRoot, {
+        createWindowsDirectory,
+        readWindowsDirectorySecuritySnapshot,
+      }),
+    ).rejects.toThrow(
+      "Server recorder Windows lock root path identity does not match its secure handle.",
+    );
   });
 
   it("maps Windows path case aliases to the same process lock", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes Windows lock-root validation races where filesystem identity and ACL evidence could come from different directory instances, and harmless inherit-only ACEs could be treated as current-directory mutation rights.

## Why This Change Was Made

Binds path identity and ACL validation to the same no-follow handle snapshot and ignores inherit-only ACEs when evaluating rights on the current directory.

## User Impact

Windows recorder locking fails closed across directory replacement without rejecting inherited permissions that do not apply to the lock root itself.

## Evidence

- Sol-high autoreview on exact commit `9702c910c09c6f157be4f6288ebb54751f7e0575`: clean, confidence 0.88
- Crabbox Linux `pnpm verify`: run `run_9c413ea67443`, 65 files passed, 1,705 tests passed, 35 platform skips
- Windows-only tests are included but skipped on the Linux Crabbox runner
- Changelog entry included