### PR TITLE
fix(config): reject unsafe retry and ingress settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Validate serve options before credential reads, reject retry-unsafe nonce-free roundtrips, and restore authenticated external Mattermost webhook guidance.
 - Ignore inherit-only Windows ACEs for current-directory mutation checks and bind lock-root identity and ACL validation to the same no-follow handle across path replacement.
 - Reject blank Slack and Feishu ingress secrets, confine generated Telegram recorder paths, and compare WhatsApp and Mattermost bearer tokens in constant time.
 - Reject blank Mattermost readiness usernames and non-native Matrix thread IDs while preserving valid legacy smoke-only artifact generations.

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -135,9 +135,8 @@ header before JSON parsing or recorder writes:
   so its listener and any advertised callback must remain loopback-only.
 - Mattermost `webhookToken` or `MATTERMOST_TOKEN` verifies the `token` field in
   outgoing webhook form or JSON bodies. The token is removed before recorder
-  persistence. Mattermost webhook ingress is currently loopback-only:
-  non-loopback listener hosts and any `webhook.publicUrl` are rejected even
-  when a token is configured.
+  persistence. Externally reachable callbacks require this token and an HTTPS
+  `webhook.publicUrl`.
 - iMessage webhook ingress currently has no provider-native authentication
   mode, so its listener and any advertised callback must remain loopback-only.
 - Feishu `verificationToken` or `FEISHU_VERIFICATION_TOKEN` verifies plaintext

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -684,11 +684,6 @@ export function createProgram(
           kind: "config",
         });
       }
-      const credentials = await resolveServeCredentials(commandOptions.credentialsFd);
-      commandOptions.accessToken = credentials.accessToken;
-      commandOptions.adminToken = credentials.adminToken;
-      commandOptions.botToken = credentials.botToken;
-      commandOptions.signingSecret = credentials.signingSecret;
       if (!/^[0-9]+$/u.test(commandOptions.port)) {
         throw new CrablineError(`Invalid local server port: ${commandOptions.port}`, {
           kind: "config",
@@ -706,6 +701,11 @@ export function createProgram(
           kind: "config",
         });
       }
+      const credentials = await resolveServeCredentials(commandOptions.credentialsFd);
+      commandOptions.accessToken = credentials.accessToken;
+      commandOptions.adminToken = credentials.adminToken;
+      commandOptions.botToken = credentials.botToken;
+      commandOptions.signingSecret = credentials.signingSecret;
       let server: StartedCrablineServer | undefined;
       let startupSettled = false;
       let settleStartup: (() => void) | undefined;

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -64,19 +64,42 @@ type BuiltinAdapterName = (typeof BUILTIN_ADAPTERS)[number];
 type ProviderPlatformName = (typeof PROVIDER_PLATFORMS)[number];
 type FixtureModeConstraintInput = {
   inboundMatch: {
+    nonce: (typeof INBOUND_NONCE_MODES)[number];
     pattern?: string | undefined;
     strategy: (typeof INBOUND_STRATEGIES)[number];
   };
   mode: (typeof FIXTURE_MODES)[number];
+  retries: number;
 };
 
-export function fixtureModeValidationError(value: FixtureModeConstraintInput): string | undefined {
+type FixtureModeValidationIssue = {
+  message: string;
+  path: ["inboundMatch", "nonce" | "strategy"];
+};
+
+export function fixtureModeValidationIssue(
+  value: FixtureModeConstraintInput,
+): FixtureModeValidationIssue | undefined {
+  if (
+    (value.mode === "roundtrip" || value.mode === "agent") &&
+    value.retries > 0 &&
+    value.inboundMatch.nonce === "ignore"
+  ) {
+    return {
+      message: `${value.mode} mode cannot retry when inboundMatch.nonce=ignore because a late reply from an earlier attempt could be accepted`,
+      path: ["inboundMatch", "nonce"],
+    };
+  }
   if (
     value.mode === "agent" &&
     value.inboundMatch.strategy === "exact" &&
     value.inboundMatch.pattern
   ) {
-    return "agent mode cannot use inboundMatch.strategy=exact with a static pattern because replies must include the generated ACK nonce";
+    return {
+      message:
+        "agent mode cannot use inboundMatch.strategy=exact with a static pattern because replies must include the generated ACK nonce",
+      path: ["inboundMatch", "strategy"],
+    };
   }
   return undefined;
 }
@@ -750,12 +773,12 @@ export const FixtureSchema = z
     timeoutMs: TimerMsSchema.min(100).default(30_000),
   })
   .superRefine((value, ctx) => {
-    const validationError = fixtureModeValidationError(value);
-    if (validationError) {
+    const validationIssue = fixtureModeValidationIssue(value);
+    if (validationIssue) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: validationError,
-        path: ["inboundMatch", "strategy"],
+        message: validationIssue.message,
+        path: validationIssue.path,
       });
     }
   });
@@ -781,11 +804,7 @@ const StrictManifestSchema = z
   })
   .superRefine((manifest, ctx) => {
     for (const [providerId, provider] of Object.entries(manifest.providers)) {
-      if (
-        provider.adapter !== "matrix" &&
-        provider.adapter !== "mattermost" &&
-        provider.adapter !== "imessage"
-      ) {
+      if (provider.adapter !== "matrix" && provider.adapter !== "imessage") {
         continue;
       }
       const webhook = provider[provider.adapter]?.webhook;

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -5,7 +5,7 @@ import { createNonce } from "./nonces.js";
 import { compileInboundRegex } from "./safe-regex.js";
 import { type FailureKind, CrablineError, ensureErrorMessage } from "./errors.js";
 import { EXIT_CODES, type ExitCode } from "./exit-codes.js";
-import { fixtureModeValidationError, type ManifestDefinition } from "../config/schema.js";
+import { fixtureModeValidationIssue, type ManifestDefinition } from "../config/schema.js";
 import type { Registry } from "../providers/registry.js";
 
 export type CommandRunResult = {
@@ -297,15 +297,16 @@ export async function runFixtureCommand(params: {
   const mode = params.modeOverride ?? configuredFixture.mode;
   const fixture =
     mode === configuredFixture.mode ? configuredFixture : { ...configuredFixture, mode };
-  const validationError = fixtureModeValidationError(fixture);
-  if (validationError) {
+  const validationIssue = fixtureModeValidationIssue(fixture);
+  if (validationIssue) {
     return toFailure(
       configuredFixture.id,
       configuredFixture.provider,
       mode,
-      new CrablineError(`Invalid effective fixture "${configuredFixture.id}": ${validationError}`, {
-        kind: "config",
-      }),
+      new CrablineError(
+        `Invalid effective fixture "${configuredFixture.id}": ${validationIssue.message}`,
+        { kind: "config" },
+      ),
       "config",
     );
   }

--- a/test/channel-setup-docs.test.ts
+++ b/test/channel-setup-docs.test.ts
@@ -108,7 +108,7 @@ describe("channel setup contracts", () => {
     expect(matrixSection).toContain("`X-Crabline-Admin-Token`");
   });
 
-  it("documents ready-file protections and Mattermost ingress limits", async () => {
+  it("documents ready-file protections and Mattermost ingress authentication", async () => {
     const [readme, channelSetup] = await Promise.all([
       fs.readFile("README.md", "utf8"),
       fs.readFile("docs/channel-setup.md", "utf8"),
@@ -120,7 +120,8 @@ describe("channel setup contracts", () => {
       expect(document).toContain("Exclude ready files from version control and CI artifact");
       expect(document).toContain("delete them after use");
     }
-    expect(channelSetup).toContain("Mattermost webhook ingress is currently loopback-only");
-    expect(channelSetup).toContain("any `webhook.publicUrl` are rejected");
+    expect(channelSetup).toContain("Mattermost `webhookToken` or `MATTERMOST_TOKEN`");
+    expect(channelSetup).toContain("Externally reachable callbacks require this token");
+    expect(channelSetup).toContain("an HTTPS\n  `webhook.publicUrl`");
   });
 });

--- a/test/cli-credential-subprocess.test.ts
+++ b/test/cli-credential-subprocess.test.ts
@@ -1,4 +1,4 @@
-import { spawnSync, type SpawnSyncOptionsWithStringEncoding } from "node:child_process";
+import { spawn, spawnSync, type SpawnSyncOptionsWithStringEncoding } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -42,6 +42,59 @@ const spawnPnpmChecked = (args: string[], options: SpawnSyncOptionsWithStringEnc
 };
 
 describe("CLI credential subprocess ingress", () => {
+  it("rejects invalid serve options before reading stdin credentials", async () => {
+    const child = spawn(
+      process.execPath,
+      [
+        "--import",
+        "tsx",
+        "src/bin/crabline.ts",
+        "serve",
+        "slack",
+        "--port",
+        "invalid",
+        "--credentials-fd",
+        "0",
+      ],
+      {
+        cwd: process.cwd(),
+        env: { ...process.env, NO_COLOR: "1" },
+        stdio: ["pipe", "ignore", "pipe"],
+      },
+    );
+    const stderr: Buffer[] = [];
+    child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+
+    try {
+      const result = await Promise.race([
+        new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve, reject) => {
+          child.once("error", reject);
+          child.once("exit", (code, signal) => resolve({ code, signal }));
+        }),
+        new Promise<never>((_, reject) => {
+          timeout = setTimeout(
+            () => reject(new Error("serve blocked reading stdin credentials")),
+            3_000,
+          );
+        }),
+      ]);
+
+      expect(result).toEqual({ code: 10, signal: null });
+      expect(Buffer.concat(stderr).toString("utf8")).toContain(
+        "Invalid local server port: invalid",
+      );
+    } finally {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+      child.stdin.destroy();
+      if (child.exitCode === null && child.signalCode === null) {
+        child.kill();
+      }
+    }
+  });
+
   it("reads package-runner credentials from stdin fd 0", async () => {
     const directory = await createTempDir();
     directories.push(directory);

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -256,7 +256,7 @@ describe("manifest schema", () => {
   });
 
   it("rejects unsupported external ingress in strict manifests", () => {
-    for (const adapter of ["matrix", "mattermost", "imessage"] as const) {
+    for (const adapter of ["matrix", "imessage"] as const) {
       for (const webhook of [
         { host: "0.0.0.0" },
         { publicUrl: `https://${adapter}.example.test/webhook` },
@@ -277,6 +277,44 @@ describe("manifest schema", () => {
         ).toThrow(/does not support external webhook ingress/u);
       }
     }
+  });
+
+  it("accepts token-authenticated HTTPS Mattermost webhook ingress", () => {
+    expect(() =>
+      ManifestSchema.parse({
+        configVersion: 1,
+        fixtures: [],
+        providers: {
+          mattermost: {
+            adapter: "mattermost",
+            mattermost: {
+              webhook: {
+                host: "0.0.0.0",
+                publicUrl: "https://mattermost.example.test/webhook",
+              },
+              webhookToken: "sample",
+            },
+          },
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it("allows loopback-local HTTP Mattermost webhook ingress", () => {
+    expect(() =>
+      ManifestSchema.parse({
+        configVersion: 1,
+        fixtures: [],
+        providers: {
+          mattermost: {
+            adapter: "mattermost",
+            mattermost: {
+              webhook: { publicUrl: "http://127.0.0.1:8793/mattermost/webhook" },
+            },
+          },
+        },
+      }),
+    ).not.toThrow();
   });
 
   it("accepts equivalent IPv6 loopback hosts for local-only ingress", () => {
@@ -362,6 +400,33 @@ describe("manifest schema", () => {
       }),
     ).toThrow(/<=10/u);
   });
+
+  it.each(["roundtrip", "agent"] as const)(
+    "rejects retrying %s fixtures that ignore nonces",
+    (mode) => {
+      expect(() =>
+        ManifestSchema.parse({
+          configVersion: 1,
+          fixtures: [
+            {
+              id: `unsafe-${mode}`,
+              inboundMatch: { nonce: "ignore", strategy: "contains" },
+              mode,
+              provider: "local",
+              retries: 1,
+              target: { id: "echo-bot" },
+            },
+          ],
+          providers: { local: { adapter: "loopback" } },
+        }),
+      ).toThrow(
+        new RegExp(
+          `${mode} mode cannot retry when inboundMatch\\.nonce=ignore because a late reply`,
+          "u",
+        ),
+      );
+    },
+  );
 
   it("requires a service-account identity for Google Chat Pub/Sub audiences", () => {
     expect(() =>

--- a/test/run.behavior.test.ts
+++ b/test/run.behavior.test.ts
@@ -421,6 +421,41 @@ describe("run behavior", () => {
     expect(resolve).not.toHaveBeenCalled();
   });
 
+  it.each(["roundtrip", "agent"] as const)(
+    "rejects retry-unsafe %s mode overrides before resolving the provider",
+    async (modeOverride) => {
+      const resolve = vi.fn();
+      const retryingManifest: ManifestDefinition = {
+        ...manifest,
+        fixtures: [
+          {
+            ...manifest.fixtures[0]!,
+            inboundMatch: { author: "assistant", nonce: "ignore", strategy: "contains" },
+            mode: "send",
+            retries: 1,
+          },
+        ],
+      };
+
+      const result = await runFixtureCommand({
+        fixtureId: "fixture",
+        manifest: retryingManifest,
+        manifestPath: "/tmp/crabline.yaml",
+        modeOverride,
+        registry: {
+          catalog: OPENCLAW_SUPPORT_CATALOG,
+          resolve,
+        },
+      });
+
+      expect(result).toMatchObject({ failureKind: "config", mode: modeOverride, ok: false });
+      expect(result.diagnostics.join("\n")).toContain(
+        `${modeOverride} mode cannot retry when inboundMatch.nonce=ignore`,
+      );
+      expect(resolve).not.toHaveBeenCalled();
+    },
+  );
+
   it("requires an exact ACK and canonical nonce for agent replies", async () => {
     let waitCalls = 0;
     const provider: ProviderAdapter = {


### PR DESCRIPTION
## What Problem This Solves

Fixes issues where invalid serve options could consume credentials before failing, retry-unsafe roundtrip fixtures could be accepted, and authenticated external Mattermost ingress was rejected or undocumented.

## Why This Change Was Made

Validation now runs before credential reads, retry semantics are enforced after mode overrides, and Mattermost external webhooks require a token plus HTTPS while remaining supported.

## User Impact

Operators get deterministic startup failures without credential consumption, safe roundtrip retry behavior, and documented authenticated Mattermost webhook ingress.

## Evidence

- Sol-high autoreview: clean, confidence 0.91
- Crabbox Linux `pnpm verify`: `run_b9602d582a24`, 1,712 passed / 35 skipped
- `git diff --check`
