### PR TITLE
fix(providers): tighten native target correlation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Reject blank Slack and Feishu ingress secrets, confine generated Telegram recorder paths, and compare WhatsApp and Mattermost bearer tokens in constant time.
 - Reject blank Mattermost readiness usernames and non-native Matrix thread IDs while preserving valid legacy smoke-only artifact generations.
 - Provision CI Go from the tools module, lint both workflow YAML extensions, and build distributable output before package verification.
+- Tighten native target correlation and conversation state across Slack, Signal, Zalo, Discord, and Matrix.
 - Give the recorder-scan roundtrip regression enough time to complete on loaded CI workers.
 - Reject invalid shared HTTP body limits, webhook deadlines, and signed-JWT cache timings before starting I/O.
 - Cancel provider-created webhook responses when recorder persistence fails before delivery.

--- a/src/providers/builtin/discord.ts
+++ b/src/providers/builtin/discord.ts
@@ -25,6 +25,7 @@ type DiscordRuntime = {
 };
 
 const DISCORD_SIGNATURE_MAX_SKEW_SECONDS = 5 * 60;
+const DISCORD_THREAD_CHANNEL_TYPES = new Set([10, 11, 12]);
 
 function resolveDiscordAdapterConfigValue(
   config: ProviderConfig,
@@ -197,6 +198,13 @@ export function normalizeDiscordWebhookPayload(payload: unknown) {
   const data = optionalRecord(payload, "data");
   const author = optionalRecord(payload, "author") ?? optionalRecord(payload, "member")?.user;
   const channelId = optionalString(payload, "channel_id");
+  const channel = optionalRecord(payload, "channel");
+  const embeddedChannelId = channel ? optionalString(channel, "id") : undefined;
+  if (embeddedChannelId && channelId && embeddedChannelId !== channelId) {
+    throw new CrablineError("Discord interaction channel.id must match channel_id", {
+      kind: "inbound",
+    });
+  }
   const text =
     optionalString(payload, "content") ??
     (data ? (optionalString(data, "content") ?? discordInteractionText(data)) : undefined) ??
@@ -216,6 +224,34 @@ export function normalizeDiscordWebhookPayload(payload: unknown) {
     text,
     threadId: requireNativeInboundId(threadId, DISCORD_SNOWFLAKE_RULE, "Discord thread_id"),
   };
+}
+
+export function matchesDiscordThread(
+  candidateThreadId: string,
+  expectedThreadId: string | undefined,
+  target: { channelId?: string | undefined; threadId?: string | undefined },
+  raw?: unknown,
+): boolean {
+  if (!expectedThreadId || candidateThreadId === expectedThreadId) {
+    return true;
+  }
+  if (
+    target.threadId ||
+    !target.channelId ||
+    expectedThreadId !== target.channelId ||
+    !isRecord(raw)
+  ) {
+    return false;
+  }
+  const channel = optionalRecord(raw, "channel");
+  const channelType = channel?.type;
+  return Boolean(
+    channel &&
+    typeof channelType === "number" &&
+    DISCORD_THREAD_CHANNEL_TYPES.has(channelType) &&
+    optionalString(channel, "id") === candidateThreadId &&
+    optionalString(channel, "parent_id") === target.channelId,
+  );
 }
 
 export function createDiscordInteractionResponse(payload: unknown): Response {
@@ -277,11 +313,13 @@ export class DiscordProviderAdapter extends LocalMockProviderAdapter implements 
         createWebhookSuccessResponse: createDiscordInteractionResponse,
         endpointLabel: "interactions endpoint",
         handleWebhookPayload: handleDiscordWebhookPayload,
+        matchesThread: matchesDiscordThread,
         normalizeWebhookPayload: normalizeDiscordWebhookPayload,
         platform: "discord",
         publicUrl: config.discord?.webhook.publicUrl,
         recorderPath: toRecorderPath(id, config),
         webhook: config.discord?.webhook,
+        webhookMethods: ["POST"],
       },
     });
   }

--- a/src/providers/builtin/matrix.ts
+++ b/src/providers/builtin/matrix.ts
@@ -100,12 +100,25 @@ export function normalizeMatrixWebhookPayload(payload: unknown, botUserId?: stri
     throw new CrablineError("Matrix webhook payload must be an object", { kind: "inbound" });
   }
 
-  if (optionalRecord(payload, "message")) {
+  const message = optionalRecord(payload, "message");
+  if (
+    (message && ("text" in message || "threadId" in message)) ||
+    "text" in payload ||
+    "threadId" in payload
+  ) {
     const normalized = genericMockPayloadWithNativeThread({
       channelRule: MATRIX_ROOM_ID_RULE,
       payload,
       threadRule: MATRIX_EVENT_ID_RULE,
     });
+    const threadId =
+      (message ? optionalString(message, "threadId") : undefined) ??
+      optionalString(payload, "threadId");
+    const roomId =
+      (message ? optionalString(message, "channelId") : undefined) ??
+      optionalString(payload, "channelId") ??
+      optionalString(payload, "roomId") ??
+      optionalString(payload, "room_id");
     if (
       "threadId" in normalized &&
       !isMatrixRoomId(normalized.threadId) &&
@@ -115,6 +128,27 @@ export function normalizeMatrixWebhookPayload(payload: unknown, botUserId?: stri
         `mock webhook threadId must be a native ${MATRIX_EVENT_ID_RULE.name} or ${MATRIX_ROOM_ID_RULE.name}.`,
         { kind: "inbound" },
       );
+    }
+    if (threadId && isMatrixEventId(threadId)) {
+      if (!roomId || !isMatrixRoomId(roomId)) {
+        throw new CrablineError(
+          `Matrix generic event threadId requires a native ${MATRIX_ROOM_ID_RULE.name} channelId.`,
+          { kind: "inbound" },
+        );
+      }
+      const scopedThreadId = matrixThreadKey(roomId, threadId);
+      return {
+        ...normalized,
+        ...("message" in normalized && isRecord(normalized.message)
+          ? { message: { ...normalized.message, threadId: scopedThreadId } }
+          : {}),
+        threadId: scopedThreadId,
+      };
+    }
+    if (threadId && isMatrixRoomId(threadId) && roomId && roomId !== threadId) {
+      throw new CrablineError("Matrix generic room threadId must match channelId.", {
+        kind: "inbound",
+      });
     }
     return normalized;
   }

--- a/src/providers/builtin/slack.ts
+++ b/src/providers/builtin/slack.ts
@@ -3,12 +3,18 @@ import path from "node:path";
 import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
 import { LocalMockProviderAdapter } from "../local-mock.js";
-import { slackTargetKey, SLACK_CHANNEL_ID_RULE, SLACK_TS_RULE } from "../slack-ids.js";
+import {
+  slackTargetKey,
+  SLACK_CHANNEL_ID_RULE,
+  SLACK_TS_RULE,
+  SLACK_USER_ID_RULE,
+} from "../slack-ids.js";
 import { getBuiltinTargetCodec } from "../target-normalizers.js";
 import type { InboundEnvelope, ProviderAdapter } from "../types.js";
 import {
   genericMockPayloadWithNativeThread,
   isRecord,
+  optionalRecord,
   optionalString,
   requireNativeInboundId,
 } from "./native-local-mock.js";
@@ -309,6 +315,7 @@ function matchesSlackThread(
   candidateThreadId: string,
   expectedThreadId: string | undefined,
   target: { channelId?: string | undefined },
+  raw?: unknown,
 ): boolean {
   if (!expectedThreadId) {
     return true;
@@ -317,9 +324,30 @@ function matchesSlackThread(
     target.channelId && SLACK_TS_RULE.pattern.test(expectedThreadId)
       ? slackTargetKey(target.channelId, expectedThreadId)
       : expectedThreadId;
-  return (
+  if (
     candidateThreadId === scopedExpectedThreadId ||
     candidateThreadId.startsWith(`${scopedExpectedThreadId}:`)
+  ) {
+    return true;
+  }
+  if (
+    !target.channelId ||
+    !SLACK_USER_ID_RULE.pattern.test(target.channelId) ||
+    expectedThreadId !== target.channelId ||
+    !isRecord(raw)
+  ) {
+    return false;
+  }
+  const event = optionalRecord(raw, "event");
+  const message = event?.subtype === "message_changed" ? optionalRecord(event, "message") : event;
+  const channel = event ? optionalString(event, "channel") : undefined;
+  const user =
+    (event ? optionalString(event, "user") : undefined) ??
+    (message ? optionalString(message, "user") : undefined);
+  return Boolean(
+    channel?.startsWith("D") &&
+    user === target.channelId &&
+    (candidateThreadId === channel || candidateThreadId.startsWith(`${channel}:thread:`)),
   );
 }
 

--- a/src/providers/builtin/zalo.ts
+++ b/src/providers/builtin/zalo.ts
@@ -59,6 +59,7 @@ export class ZaloProviderAdapter extends LocalMockProviderAdapter implements Pro
           : {}),
         defaultWebhook: { host: "127.0.0.1", path: "/zalo/webhook", port: 8794 },
         endpointLabel: "webhook endpoint",
+        matchesThread: matchesZaloTarget,
         normalizeWebhookPayload: normalizeZaloWebhookPayload,
         platform: "zalo",
         publicUrl: config.zalo?.webhook.publicUrl,
@@ -69,6 +70,13 @@ export class ZaloProviderAdapter extends LocalMockProviderAdapter implements Pro
       },
     });
   }
+}
+
+export function matchesZaloTarget(
+  candidateThreadId: string,
+  expectedThreadId: string | undefined,
+): boolean {
+  return expectedThreadId === undefined || candidateThreadId === expectedThreadId;
 }
 
 export function normalizeZaloWebhookPayload(payload: unknown) {

--- a/src/providers/local-mock.ts
+++ b/src/providers/local-mock.ts
@@ -58,6 +58,7 @@ export type LocalMockAdapterOptions = {
   settleWebhookRequest?: (params: { accepted: boolean; payload: unknown; rawBody: string }) => void;
   webhook?: LocalMockWebhookConfig | undefined;
   webhookCleanupGraceMs?: number | undefined;
+  webhookMethods?: readonly string[] | undefined;
 };
 
 const MAX_WAIT_CURSORS = 64;
@@ -702,7 +703,9 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
         return await startWebhookServer({
           handle: (request) => this.#handleWebhook(request),
           host,
-          methods: this.#options.handleWebhookPayload ? ["GET", "POST"] : ["POST"],
+          methods:
+            this.#options.webhookMethods ??
+            (this.#options.handleWebhookPayload ? ["GET", "POST"] : ["POST"]),
           path: webhookPath,
           port,
         });

--- a/src/servers/signal.ts
+++ b/src/servers/signal.ts
@@ -398,6 +398,24 @@ function normalizeSignalPhoneNumber(value: unknown): string | undefined {
   return number && SIGNAL_PHONE_NUMBER_RE.test(number) ? number : undefined;
 }
 
+function isSignalDirectRecipient(value: unknown): boolean {
+  const recipient = readSignalRpcString(value);
+  if (!recipient) {
+    return false;
+  }
+  if (SIGNAL_UUID_RE.test(recipient)) {
+    return true;
+  }
+  // signal-cli treats recognized prefixes as terminal instead of retrying them as phone numbers.
+  if (recipient.startsWith("PNI:")) {
+    return SIGNAL_UUID_RE.test(recipient.slice(4));
+  }
+  if (recipient.startsWith("u:")) {
+    return recipient.length > 2;
+  }
+  return SIGNAL_PHONE_NUMBER_RE.test(recipient);
+}
+
 function nextSignalTimestamp(state: SignalServerState): number {
   return Math.max(state.nextTimestamp, (state.lastCommittedTimestamp ?? -1) + 1);
 }
@@ -665,10 +683,23 @@ function hasValidOptionalSignalString(params: Record<string, unknown>, field: st
   return params[field] === undefined || typeof params[field] === "string";
 }
 
+function hasValidSignalDirectRecipients(params: Record<string, unknown>): boolean {
+  return ["recipient", "recipients"].every((field) => {
+    const value = params[field];
+    return (
+      value === undefined ||
+      (Array.isArray(value)
+        ? value.length > 0 && value.every(isSignalDirectRecipient)
+        : isSignalDirectRecipient(value))
+    );
+  });
+}
+
 function validSignalRpcParams(method: string, value: unknown): value is Record<string, unknown> {
   if (
     !isJsonObject(value) ||
     !hasValidSignalRecipientFieldTypes(value) ||
+    !hasValidSignalDirectRecipients(value) ||
     !hasValidOptionalSignalString(value, "account") ||
     (value.noteToSelf !== undefined && typeof value.noteToSelf !== "boolean")
   ) {
@@ -691,7 +722,7 @@ function validSignalRpcParams(method: string, value: unknown): value is Record<s
       hasValidOptionalSignalString(value, "targetAuthor") &&
       hasRecipients(value) &&
       readSignalRpcString(value.emoji) !== undefined &&
-      readSignalRpcString(value.targetAuthor) !== undefined &&
+      isSignalDirectRecipient(value.targetAuthor) &&
       validTimestamp(value.targetTimestamp)
     );
   }
@@ -945,8 +976,12 @@ function signalRequestHostAllowed(
 export async function startSignalServer(
   params: StartSignalServerParams = {},
 ): Promise<StartedSignalServer> {
+  const account = normalizeSignalPhoneNumber(params.account ?? "+15550000000");
+  if (!account) {
+    throw new Error("account must be an E.164 telephone number.");
+  }
   const state: SignalServerState = {
-    account: params.account ?? "+15550000000",
+    account,
     adminToken: params.adminToken ?? randomBytes(24).toString("base64url"),
     clients: new Set(),
     clientBuffers: new Map(),

--- a/src/servers/slack.ts
+++ b/src/servers/slack.ts
@@ -96,7 +96,7 @@ type SlackRetryReason =
   | "too_many_redirects"
   | "unknown_error";
 
-type SlackCursorKind = "history" | "replies";
+type SlackCursorKind = "history" | "list" | "replies";
 
 class SlackEventHttpError extends Error {
   constructor(readonly status: number) {
@@ -355,8 +355,16 @@ function randomDecimalDigits(length: number): string {
 }
 
 function nextDmChannelId(state: SlackServerState): string {
-  const index = state.nextDmIndex++;
-  return `D${String(index).padStart(9, "0")}`;
+  for (;;) {
+    const index = state.nextDmIndex++;
+    const channelId = `D${String(index).padStart(9, "0")}`;
+    if (
+      !state.messagesByChannel.has(channelId) &&
+      ![...state.userDmChannels.values()].includes(channelId)
+    ) {
+      return channelId;
+    }
+  }
 }
 
 function nextMpimChannelId(state: SlackServerState): string {
@@ -372,6 +380,17 @@ function dmChannelForUser(state: SlackServerState, userId: string): string {
   const channelId = nextDmChannelId(state);
   state.userDmChannels.set(userId, channelId);
   return channelId;
+}
+
+function rememberDmChannel(state: SlackServerState, userId: string, channelId: string): void {
+  if (!channelId.startsWith("D")) {
+    return;
+  }
+  const mappedUser = [...state.userDmChannels].find(([, value]) => value === channelId)?.[0];
+  if (mappedUser && mappedUser !== userId) {
+    return;
+  }
+  state.userDmChannels.set(userId, channelId);
 }
 
 function mpimChannelForUsers(
@@ -432,7 +451,11 @@ function decodeSlackCursor(value: unknown, kind: SlackCursorKind): string | Resp
       return slackError("invalid_cursor");
     }
     const boundary = decoded.slice(prefix.length);
-    return SLACK_TS_RULE.pattern.test(boundary) && encodeSlackCursor(kind, boundary) === cursor
+    const validBoundary =
+      kind === "list"
+        ? SLACK_CHANNEL_ID_RULE.pattern.test(boundary)
+        : SLACK_TS_RULE.pattern.test(boundary);
+    return validBoundary && encodeSlackCursor(kind, boundary) === cursor
       ? boundary
       : slackError("invalid_cursor");
   } catch {
@@ -449,6 +472,81 @@ function appendMessage(state: SlackServerState, message: SlackMessage): SlackMes
   messages.push(message);
   state.messagesByChannel.set(message.channel, messages);
   return message;
+}
+
+function slackConversation(
+  state: SlackServerState,
+  channelId: string,
+): Record<string, unknown> | undefined {
+  const dmUser = [...state.userDmChannels].find(([, value]) => value === channelId)?.[0];
+  const mpim = [...state.userMpimChannels.values()].find((candidate) => candidate.id === channelId);
+  const hasMessages = state.messagesByChannel.has(channelId);
+  if (!dmUser && !mpim && !hasMessages) {
+    return undefined;
+  }
+  if (dmUser) {
+    return {
+      id: channelId,
+      is_channel: false,
+      is_group: false,
+      is_im: true,
+      is_mpim: false,
+      user: dmUser,
+    };
+  }
+  if (mpim) {
+    return {
+      id: channelId,
+      is_channel: false,
+      is_group: false,
+      is_im: false,
+      is_mpim: true,
+      is_private: true,
+      members: [state.botUserId, ...mpim.users],
+      name: "crabline",
+    };
+  }
+  return {
+    id: channelId,
+    is_channel: channelId.startsWith("C"),
+    is_group: channelId.startsWith("G"),
+    is_im: channelId.startsWith("D"),
+    is_mpim: false,
+    name: "crabline",
+  };
+}
+
+function slackConversations(state: SlackServerState): Record<string, unknown>[] {
+  const ids = new Set([
+    ...state.messagesByChannel.keys(),
+    ...state.userDmChannels.values(),
+    ...[...state.userMpimChannels.values()].map((channel) => channel.id),
+  ]);
+  return [...ids]
+    .sort()
+    .map((channelId) => slackConversation(state, channelId))
+    .filter((channel): channel is Record<string, unknown> => channel !== undefined);
+}
+
+function requireSlackConversationTypes(value: unknown): Set<string> | Response {
+  const types = new Set(
+    (readTrimmedString(value) ?? "public_channel")
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter(Boolean),
+  );
+  const supported = new Set(["im", "mpim", "private_channel", "public_channel"]);
+  return [...types].every((type) => supported.has(type)) ? types : slackError("invalid_types");
+}
+
+function slackConversationType(conversation: Record<string, unknown>): string {
+  if (conversation.is_im === true) {
+    return "im";
+  }
+  if (conversation.is_mpim === true) {
+    return "mpim";
+  }
+  return conversation.is_group === true ? "private_channel" : "public_channel";
 }
 
 async function appendEvent(state: SlackServerState, event: ServerRequestEvent, committed = false) {
@@ -852,10 +950,13 @@ async function handleSlackApi(params: {
       if (rateLimit) {
         rateLimit.remaining -= 1;
       }
-      const channel = requireSlackSendTargetId(params.body.channel);
-      if (channel instanceof Response) {
-        return channel;
+      const requestedChannel = requireSlackSendTargetId(params.body.channel);
+      if (requestedChannel instanceof Response) {
+        return requestedChannel;
       }
+      const channel = SLACK_USER_ID_RULE.pattern.test(requestedChannel)
+        ? dmChannelForUser(params.state, requestedChannel)
+        : requestedChannel;
       const text = readSlackText(params.body.text) ?? "";
       const attachments = readStructuredArray(params.body.attachments, "invalid_attachments");
       if (attachments instanceof Response) {
@@ -934,23 +1035,36 @@ async function handleSlackApi(params: {
       if (channel instanceof Response) {
         return channel;
       }
-      const mpim = [...params.state.userMpimChannels.values()].find(
-        (candidate) => candidate.id === channel,
+      const conversation = slackConversation(params.state, channel);
+      return conversation ? slackOk({ channel: conversation }) : slackError("channel_not_found");
+    }
+    case "conversations.list": {
+      const types = requireSlackConversationTypes(params.body.types);
+      if (types instanceof Response) {
+        return types;
+      }
+      const limit = requireSlackLimit(params.body.limit);
+      if (limit instanceof Response) {
+        return limit;
+      }
+      const boundary = decodeSlackCursor(params.body.cursor, "list");
+      if (boundary instanceof Response) {
+        return boundary;
+      }
+      const remaining = slackConversations(params.state).filter((conversation) => {
+        const channelId = readTrimmedString(conversation.id);
+        return channelId && (boundary === undefined || channelId > boundary);
+      });
+      const virtualPage = remaining.slice(0, limit);
+      const channels = virtualPage.filter((conversation) =>
+        types.has(slackConversationType(conversation)),
       );
+      const hasMore = virtualPage.length < remaining.length;
+      const nextBoundary = readTrimmedString(virtualPage.at(-1)?.id);
       return slackOk({
-        channel: {
-          id: channel,
-          is_channel: channel.startsWith("C"),
-          is_group: mpim ? false : channel.startsWith("G"),
-          is_im: channel.startsWith("D"),
-          ...(mpim
-            ? {
-                is_mpim: true,
-                is_private: true,
-                members: [params.state.botUserId, ...mpim.users],
-              }
-            : {}),
-          name: "crabline",
+        channels,
+        response_metadata: {
+          next_cursor: hasMore && nextBoundary ? encodeSlackCursor("list", nextBoundary) : "",
         },
       });
     }
@@ -958,6 +1072,9 @@ async function handleSlackApi(params: {
       const channel = requireSlackChannelId(params.body.channel);
       if (channel instanceof Response) {
         return channel;
+      }
+      if (!slackConversation(params.state, channel)) {
+        return slackError("channel_not_found");
       }
       const oldest = requireSlackThreadTs(params.body.oldest);
       if (oldest instanceof Response) {
@@ -1005,6 +1122,9 @@ async function handleSlackApi(params: {
       const channel = requireSlackChannelId(params.body.channel);
       if (channel instanceof Response) {
         return channel;
+      }
+      if (!slackConversation(params.state, channel)) {
+        return slackError("channel_not_found");
       }
       const ts = requireSlackThreadTs(params.body.ts);
       if (ts instanceof Response) {
@@ -1070,6 +1190,7 @@ async function handleAdminInbound(params: {
   if (user instanceof Response) {
     return user;
   }
+  rememberDmChannel(params.state, user, channel);
   const threadTs = requireSlackThreadTs(params.body.threadTs ?? params.body.thread_ts);
   if (threadTs instanceof Response) {
     return threadTs;

--- a/test/discord-provider.test.ts
+++ b/test/discord-provider.test.ts
@@ -7,6 +7,7 @@ import {
   createDiscordInteractionResponse,
   DiscordProviderAdapter,
   handleDiscordWebhookPayload,
+  matchesDiscordThread,
   normalizeDiscordWebhookPayload,
 } from "../src/providers/builtin/discord.js";
 import type { ProviderConfig } from "../src/config/schema.js";
@@ -387,6 +388,55 @@ describe("discord provider", () => {
       channelId: "123456789012345678",
       threadId: "223456789012345678",
     });
+    for (const type of [10, 11, 12]) {
+      expect(
+        matchesDiscordThread(
+          "223456789012345678",
+          "123456789012345678",
+          { channelId: "123456789012345678" },
+          {
+            channel: {
+              id: "223456789012345678",
+              parent_id: "123456789012345678",
+              type,
+            },
+            channel_id: "223456789012345678",
+          },
+        ),
+      ).toBe(true);
+    }
+    for (const type of [0, 2]) {
+      expect(
+        matchesDiscordThread(
+          "223456789012345678",
+          "123456789012345678",
+          { channelId: "123456789012345678" },
+          {
+            channel: {
+              id: "223456789012345678",
+              parent_id: "123456789012345678",
+              type,
+            },
+            channel_id: "223456789012345678",
+          },
+        ),
+      ).toBe(false);
+    }
+  });
+
+  it("only accepts POST requests at the interactions endpoint", async () => {
+    const config = await createDiscordConfig(0);
+    const provider = new DiscordProviderAdapter("discord", config, "crabline");
+    providers.push(provider);
+    const endpoint = (await provider.probe(createContext(config))).details
+      .find((detail) => detail.startsWith("interactions endpoint "))
+      ?.replace("interactions endpoint ", "");
+    expect(endpoint).toBeDefined();
+
+    for (const method of ["GET", "PUT"]) {
+      const response = await fetch(endpoint!, { method });
+      expect(response.status).toBe(404);
+    }
   });
 
   it("rejects encoded or non-snowflake targets", async () => {
@@ -494,6 +544,57 @@ describe("discord provider", () => {
     await expect(waitPromise).resolves.toMatchObject({
       id: "333456789012345678",
       text: "ACK nonce-2",
+    });
+  });
+
+  it("correlates thread interactions through their native parent channel", async () => {
+    const config = await createDiscordConfig(0);
+    const provider = new DiscordProviderAdapter("discord", config, "crabline");
+    providers.push(provider);
+    const context = createContext(config);
+    context.fixture.inboundMatch = {
+      author: "user",
+      nonce: "contains",
+      strategy: "contains",
+    };
+    const endpoint = (await provider.probe(context)).details
+      .find((detail) => detail.startsWith("interactions endpoint "))
+      ?.replace("interactions endpoint ", "");
+    expect(endpoint).toBeDefined();
+    const waiting = provider.waitForInbound({
+      ...context,
+      nonce: "parent-nonce",
+      since: new Date(Date.now() - 1000).toISOString(),
+      timeoutMs: 500,
+    });
+
+    for (const [id, parentId, type] of [
+      ["223456789012345676", "123456789012345678", 0],
+      ["223456789012345677", "999456789012345678", 11],
+      ["223456789012345678", "123456789012345678", 11],
+    ] as const) {
+      const response = await fetch(endpoint!, {
+        body: JSON.stringify({
+          channel: { id, parent_id: parentId, type },
+          channel_id: id,
+          data: {
+            name: "approve",
+            options: [{ name: "nonce", type: 3, value: "parent-nonce" }],
+          },
+          id: id.replace(/^223/u, "444"),
+          member: { user: { bot: false, id: "555456789012345678" } },
+          type: 2,
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      expect(response.status).toBe(200);
+    }
+
+    await expect(waiting).resolves.toMatchObject({
+      author: "user",
+      id: "444456789012345678",
+      threadId: "223456789012345678",
     });
   });
 

--- a/test/matrix-provider.test.ts
+++ b/test/matrix-provider.test.ts
@@ -189,6 +189,46 @@ describe("Matrix webhook normalizer", () => {
     ).toBe(true);
   });
 
+  it("scopes generic event thread ids to their Matrix room", () => {
+    const roomId = "!abc123:matrix.org";
+    const eventId = "$event123:matrix.org";
+    const scopedThreadId = `${roomId}:thread:${eventId}`;
+
+    expect(
+      normalizeMatrixWebhookPayload({
+        channelId: roomId,
+        id: "$reply123:matrix.org",
+        text: "top-level generic",
+        threadId: eventId,
+      }),
+    ).toMatchObject({ threadId: scopedThreadId });
+    expect(
+      normalizeMatrixWebhookPayload({
+        message: {
+          channelId: roomId,
+          id: "$reply124:matrix.org",
+          text: "nested generic",
+          threadId: eventId,
+        },
+      }),
+    ).toMatchObject({
+      message: { threadId: scopedThreadId },
+      threadId: scopedThreadId,
+    });
+    expect(() =>
+      normalizeMatrixWebhookPayload({
+        id: "$reply125:matrix.org",
+        text: "unscoped generic",
+        threadId: eventId,
+      }),
+    ).toThrow(/requires a native Matrix room id channelId/u);
+    expect(
+      matchesMatrixThread("!other:matrix.org:thread:$event123:matrix.org", eventId, {
+        channelId: roomId,
+      }),
+    ).toBe(false);
+  });
+
   it("requires native event identity, type, and thread roots", () => {
     expect(() =>
       normalizeMatrixWebhookPayload({

--- a/test/signal-server.test.ts
+++ b/test/signal-server.test.ts
@@ -437,6 +437,59 @@ describe("signal local provider server", () => {
     ]);
   });
 
+  it("validates direct recipients against the configured Signal account", async () => {
+    const account = "+15550001111";
+    const server = await startSignalServer({ account });
+    servers.push(server);
+
+    async function send(id: string, recipient: string | string[]) {
+      const response = await fetch(server.manifest.endpoints.rpcUrl, {
+        body: JSON.stringify({
+          id,
+          jsonrpc: "2.0",
+          method: "send",
+          params: { message: "hello", recipient },
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      return await response.json();
+    }
+
+    for (const [id, recipient] of [
+      ["e164", "+15551234567"],
+      ["aci", "123e4567-e89b-12d3-a456-426614174000"],
+      ["pni", "PNI:123e4567-e89b-12d3-a456-426614174000"],
+      ["username", "u:alice"],
+    ] as const) {
+      await expect(send(id, recipient)).resolves.toMatchObject({
+        id,
+        result: { timestamp: expect.any(Number) },
+      });
+    }
+
+    for (const [id, recipient] of [
+      ["plain-username", "alice"],
+      ["email", "alice@example.test"],
+      ["invalid-pni", "PNI:not-a-uuid"],
+      ["numeric-pni", "PNI:1"],
+      ["local-number", "5551234567"],
+      ["short-number", "1"],
+      ["invalid-number", "+0123"],
+      ["mixed-array", ["+15551234567", "alice"] as string[]],
+    ] as const) {
+      await expect(send(id, recipient)).resolves.toEqual({
+        error: { code: -32602, message: "Invalid params" },
+        id,
+        jsonrpc: "2.0",
+      });
+    }
+
+    await expect(startSignalServer({ account: "alice" })).rejects.toThrow(
+      /account must be an E\.164 telephone number/u,
+    );
+  });
+
   it("enforces JSON-RPC envelopes and does not respond to notifications", async () => {
     const directory = await createTempDir();
     directories.push(directory);

--- a/test/slack-provider.test.ts
+++ b/test/slack-provider.test.ts
@@ -292,6 +292,52 @@ describe("slack provider", () => {
     });
   });
 
+  it.each(["U1234567890", "W1234567890"])(
+    "correlates native D-channel events to direct target %s",
+    async (userId) => {
+      const config = await createSlackConfig(0);
+      const provider = new SlackProviderAdapter("slack", config, "crabline");
+      providers.push(provider);
+      const context = createContext(config, { id: userId, metadata: {} });
+      context.fixture.inboundMatch = { author: "user", nonce: "contains", strategy: "contains" };
+      const endpoint = endpointFromDetails((await provider.probe(context)).details);
+      const nonce = `direct-${userId}`;
+      const waiting = provider.waitForInbound({
+        ...context,
+        nonce,
+        since: new Date(Date.now() - 1000).toISOString(),
+        timeoutMs: 500,
+      });
+
+      for (const [channel, eventUser] of [
+        ["D9999999999", "U9999999999"],
+        ["D1234567890", userId],
+      ]) {
+        const response = await fetch(endpoint, {
+          body: JSON.stringify({
+            event: {
+              channel,
+              text: `ACK ${nonce}`,
+              ts: channel === "D1234567890" ? "1700000002.000300" : "1700000001.000200",
+              type: "message",
+              user: eventUser,
+            },
+            type: "event_callback",
+          }),
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        });
+        expect(response.status).toBe(200);
+      }
+
+      await expect(waiting).resolves.toMatchObject({
+        author: "user",
+        text: `ACK ${nonce}`,
+        threadId: "D1234567890",
+      });
+    },
+  );
+
   it("normalizes Slack message_changed callbacks from the replacement message", async () => {
     const config = await createSlackConfig(0);
     const provider = new SlackProviderAdapter("slack", config, "crabline");

--- a/test/slack-server.test.ts
+++ b/test/slack-server.test.ts
@@ -156,6 +156,31 @@ describe("slack local provider server", () => {
           channel: "C1234567890",
         })
       ).json(),
+    ).resolves.toEqual({
+      error: "channel_not_found",
+      ok: false,
+    });
+
+    const direct = await slackApi(server, "chat.postMessage", {
+      channel: "U1234567890",
+      text: "direct hello",
+    });
+    await expect(direct.json()).resolves.toMatchObject({
+      channel: "D000000001",
+      message: { channel: "D000000001" },
+      ok: true,
+    });
+
+    await postMessage(server, {
+      channel: "C1234567890",
+      text: "channel hello",
+    });
+    await expect(
+      (
+        await slackApi(server, "conversations.info", {
+          channel: "C1234567890",
+        })
+      ).json(),
     ).resolves.toMatchObject({
       channel: {
         id: "C1234567890",
@@ -163,6 +188,14 @@ describe("slack local provider server", () => {
       },
       ok: true,
     });
+
+    const listed = (await (
+      await slackApi(server, "conversations.list", {
+        types: "public_channel,im",
+      })
+    ).json()) as { channels: { id: string }[]; ok: boolean };
+    expect(listed.ok).toBe(true);
+    expect(listed.channels.map((channel) => channel.id)).toEqual(["C1234567890", "D000000001"]);
   });
 
   it("opens stable MPIMs and rejects conversations with more than eight users", async () => {
@@ -229,6 +262,51 @@ describe("slack local provider server", () => {
       error: "invalid_user_combination",
       ok: false,
     });
+  });
+
+  it("paginates conversations.list with stable cursors", async () => {
+    const server = await startTestSlackServer();
+    for (const channel of ["C1111111111", "C2222222222"]) {
+      await postMessage(server, { channel, text: channel });
+    }
+    for (const user of ["U1111111111", "U2222222222"]) {
+      await slackApi(server, "conversations.open", { users: user });
+    }
+    await slackApi(server, "conversations.open", {
+      users: "U3333333333,U4444444444",
+    });
+
+    const ids: string[] = [];
+    let cursor = "";
+    do {
+      const response = await slackApi(server, "conversations.list", {
+        cursor,
+        limit: 2,
+        types: "public_channel,private_channel,mpim,im",
+      });
+      const payload = (await response.json()) as {
+        channels: Array<{ id: string }>;
+        response_metadata: { next_cursor: string };
+      };
+      ids.push(...payload.channels.map((channel) => channel.id));
+      cursor = payload.response_metadata.next_cursor;
+    } while (cursor);
+
+    expect(ids).toEqual(["C1111111111", "C2222222222", "D000000001", "D000000002", "G000000001"]);
+
+    for (const invalidCursor of [
+      "not-a-cursor",
+      Buffer.from("history:1700000000.000100", "utf8").toString("base64url"),
+    ]) {
+      const invalid = await slackApi(server, "conversations.list", {
+        cursor: invalidCursor,
+        limit: 2,
+      });
+      await expect(invalid.json()).resolves.toEqual({
+        error: "invalid_cursor",
+        ok: false,
+      });
+    }
   });
 
   it("bounds request bodies and does not record rejected API authentication", async () => {
@@ -637,7 +715,10 @@ describe("slack local provider server", () => {
     const history = await slackApi(server, "conversations.history", {
       channel: "C1234567890",
     });
-    await expect(history.json()).resolves.toMatchObject({ messages: [], ok: true });
+    await expect(history.json()).resolves.toEqual({
+      error: "channel_not_found",
+      ok: false,
+    });
   });
 
   it("validates chat.postMessage metadata format and schema", async () => {

--- a/test/zalo-provider.test.ts
+++ b/test/zalo-provider.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { CrablineError } from "../src/core/errors.js";
 import {
+  matchesZaloTarget,
   normalizeZaloWebhookPayload,
   resolveZaloAdapterConfig,
   ZaloProviderAdapter,
@@ -104,6 +105,12 @@ describe("Zalo webhook normalizer", () => {
     } finally {
       await provider.cleanup();
     }
+  });
+
+  it("matches native target identities exactly", () => {
+    expect(matchesZaloTarget("user-1", "user-1")).toBe(true);
+    expect(matchesZaloTarget("user-1:thread-2", "user-1")).toBe(false);
+    expect(matchesZaloTarget("user-10", "user-1")).toBe(false);
   });
 
   it("rejects unsupported thread targets during normalization", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes provider mocks accepting or correlating native targets too loosely, including Slack direct-message routing and pagination, Signal recipients, Discord interaction/thread semantics, Matrix thread scope, and Zalo identities.

## Why This Change Was Made

Each provider now applies its native identifier and endpoint rules at the provider boundary, with focused state and pagination regressions.

## User Impact

Compatible clients receive deterministic native behavior instead of false matches, invented channels, or cross-room correlations.

## Evidence

- Sol-high autoreview: clean, confidence 0.84
- Crabbox Linux `pnpm verify`: `run_9a01dfd07975`, 1,720 passed / 35 skipped
- `git diff --check`
