### PR TITLE
fix(providers): harden registry lifecycle boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Forward lazy cleanup admission fences synchronously to materialized providers.
 - Bind private-directory ACL and recorder-lock mutations to verified identities, quarantine process locks before artifact cleanup, and preserve Windows ancestry rollback failures.
 - Require explicit remote iMessage API keys and decode legacy loopback channel metadata consistently.
 - Preserve configured Mattermost bot identity during admin ingress and avoid overwriting retained channels on direct-channel ID collisions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Forward lazy cleanup admission fences synchronously to materialized providers.
+- Reject prototype-inherited provider registry keys during resolution.
 - Bind private-directory ACL and recorder-lock mutations to verified identities, quarantine process locks before artifact cleanup, and preserve Windows ancestry rollback failures.
 - Require explicit remote iMessage API keys and decode legacy loopback channel metadata consistently.
 - Preserve configured Mattermost bot identity during admin ingress and avoid overwriting retained channels on direct-channel ID collisions.

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -142,8 +142,10 @@ export class LazyProviderAdapter implements ProviderAdapter {
   readonly #normalizeTarget: ProviderAdapter["normalizeTarget"];
   readonly #activeWatches = new Set<ActiveWatch>();
   readonly #inFlightOperations = new Set<AdmittedOperation>();
+  readonly #providerCleanupErrors: unknown[] = [];
   #cleanedUp = false;
   #cleanupPromise: Promise<void> | null = null;
+  #providerCleanupBegun = false;
   #providerInstance: ProviderAdapter | null = null;
   #providerPromise: Promise<ProviderAdapter> | null = null;
 
@@ -306,6 +308,9 @@ export class LazyProviderAdapter implements ProviderAdapter {
     for (const watch of this.#activeWatches) {
       watch.abort();
     }
+    if (this.#providerInstance) {
+      this.#beginProviderCleanup(this.#providerInstance);
+    }
   }
 
   async cleanup(): Promise<void> {
@@ -406,12 +411,8 @@ export class LazyProviderAdapter implements ProviderAdapter {
     if (!provider) {
       return;
     }
-    const errors: unknown[] = [];
-    try {
-      provider.beginCleanup?.();
-    } catch (error) {
-      errors.push(error);
-    }
+    this.#beginProviderCleanup(provider);
+    const errors = [...this.#providerCleanupErrors];
     try {
       await provider.cleanup?.();
     } catch (error) {
@@ -422,6 +423,18 @@ export class LazyProviderAdapter implements ProviderAdapter {
     }
     if (errors.length > 1) {
       throw new AggregateError(errors, "Provider teardown failed.");
+    }
+  }
+
+  #beginProviderCleanup(provider: ProviderAdapter): void {
+    if (this.#providerCleanupBegun) {
+      return;
+    }
+    this.#providerCleanupBegun = true;
+    try {
+      provider.beginCleanup?.();
+    } catch (error) {
+      this.#providerCleanupErrors.push(error);
     }
   }
 

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -112,7 +112,7 @@ function createDispatchBarrier(): DispatchBarrier {
 }
 
 function isLazyAdapter(adapter: BuiltinAdapterId): adapter is LazyAdapterId {
-  return adapter in LAZY_PROVIDER_FACTORIES;
+  return Object.hasOwn(LAZY_PROVIDER_FACTORIES, adapter);
 }
 
 function createLazyProvider(params: {
@@ -485,7 +485,9 @@ export function createRegistry(manifest: ManifestDefinition, manifestPath: strin
       if (!fixture) {
         throw new CrablineError(`Unknown fixture: ${fixtureId}`, { kind: "config" });
       }
-      const config = manifest.providers[providerId];
+      const config = Object.hasOwn(manifest.providers, providerId)
+        ? manifest.providers[providerId]
+        : undefined;
       if (!config) {
         throw new CrablineError(`Unknown provider: ${providerId}`, { kind: "config" });
       }

--- a/test/registry-lifecycle.test.ts
+++ b/test/registry-lifecycle.test.ts
@@ -462,7 +462,7 @@ describe("lazy provider lifecycle", () => {
     }
   });
 
-  it("deduplicates concurrent cleanup after the synchronous fence", async () => {
+  it("forwards the synchronous cleanup fence to a materialized provider once", async () => {
     const beginCleanup = vi.fn();
     const cleanup = vi.fn(async () => undefined);
     const concrete: ProviderAdapter = {
@@ -498,6 +498,8 @@ describe("lazy provider lifecycle", () => {
     await provider.probe(context);
 
     provider.beginCleanup();
+    expect(beginCleanup).toHaveBeenCalledOnce();
+
     await Promise.all([provider.cleanup(), provider.cleanup()]);
 
     expect(beginCleanup).toHaveBeenCalledOnce();

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -482,6 +482,16 @@ describe("registry", () => {
     expect(() => registry.resolve("missing", "fixture")).toThrow(/Unknown provider/);
   });
 
+  it.each(["constructor", "__proto__"])(
+    "rejects inherited provider registry key %s",
+    (providerId) => {
+      const registry = createRegistry(manifest, "/tmp/crabline.yaml");
+      expect(() => registry.resolve(providerId, "fixture")).toThrow(
+        `Unknown provider: ${providerId}`,
+      );
+    },
+  );
+
   it("rejects resolving a fixture through a different provider", () => {
     const mismatchedManifest: ManifestDefinition = {
       ...manifest,


### PR DESCRIPTION
## Summary
- forward lazy provider cleanup fences synchronously to materialized adapters
- reject inherited object keys during provider lookup
- add lifecycle and registry regression coverage
- document both behavior fixes in the changelog

## Validation
- 47 focused tests
- TypeScript typecheck
- Codex autoreview: gpt-5.6-sol, high, clean
- Crabbox `pnpm verify`: run `run_c3e89711a082`, 65 files / 1,781 tests, green