### PR TITLE
fix(openclaw): stabilize artifact generation reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Forward lazy cleanup admission fences synchronously to materialized providers.
 - Reject prototype-inherited provider registry keys during resolution.
+- Require the literal Crabline artifact channel driver and retry current-generation validation across concurrent artifact rotation.
 - Bind private-directory ACL and recorder-lock mutations to verified identities, quarantine process locks before artifact cleanup, and preserve Windows ancestry rollback failures.
 - Require explicit remote iMessage API keys and decode legacy loopback channel metadata consistently.
 - Preserve configured Mattermost bot identity during admin ingress and avoid overwriting retained channels on direct-channel ID collisions.

--- a/src/openclaw/artifact-generation.ts
+++ b/src/openclaw/artifact-generation.ts
@@ -27,6 +27,7 @@ const STAGING_NAME_PATTERN =
   /^\.staging-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
 const REMOVAL_TOMBSTONE_PATTERN =
   /^\.(.+)\.\d+\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.remove$/iu;
+const CURRENT_GENERATION_READ_ATTEMPTS = 8;
 type OpenClawCrablineArtifactPointerBase = {
   capabilityMatrixPath: string;
   generation: string;
@@ -438,7 +439,7 @@ export async function readOpenClawCrablineArtifactPointer(
   }
 }
 
-async function assertCurrentGenerationExists(
+async function assertArtifactGenerationExists(
   outputDir: string,
   pointer: OpenClawCrablineArtifactPointer,
 ): Promise<void> {
@@ -519,8 +520,7 @@ async function assertCurrentGenerationExists(
     capabilityMatrix.version !== 1 ||
     capabilityMatrix.source !== "openclaw/crabline" ||
     capabilityMatrix.manifestPath !== pointer.manifestPath ||
-    typeof capabilityMatrix.channelDriver !== "string" ||
-    capabilityMatrix.channelDriver.length === 0 ||
+    capabilityMatrix.channelDriver !== "crabline" ||
     typeof capabilityMatrix.selectedChannel !== "string" ||
     capabilityMatrix.selectedChannel.length === 0 ||
     capabilityMatrix.report === null ||
@@ -529,7 +529,7 @@ async function assertCurrentGenerationExists(
     readiness.version !== 1 ||
     readiness.source !== "openclaw/crabline" ||
     readiness.manifestPath !== pointer.manifestPath ||
-    readiness.channelDriver !== capabilityMatrix.channelDriver ||
+    readiness.channelDriver !== "crabline" ||
     readiness.selectedChannel !== capabilityMatrix.selectedChannel ||
     manifest.provider !== readiness.selectedChannel ||
     !isReadinessSection(
@@ -612,6 +612,39 @@ async function assertCurrentGenerationExists(
   throw new Error("OpenClaw Crabline current artifact generation is incomplete.");
 }
 
+async function readValidCurrentArtifactGeneration(
+  outputDir: string,
+  initialPointer: OpenClawCrablineArtifactPointer,
+): Promise<OpenClawCrablineArtifactPointer> {
+  let pointer = initialPointer;
+  let lastValidationError: unknown;
+  for (let attempt = 0; attempt < CURRENT_GENERATION_READ_ATTEMPTS; attempt += 1) {
+    try {
+      await assertArtifactGenerationExists(outputDir, pointer);
+      lastValidationError = undefined;
+    } catch (error) {
+      lastValidationError = error;
+    }
+
+    const currentPointer = await readOpenClawCrablineArtifactPointer(outputDir);
+    if (currentPointer === null || isDeepStrictEqual(currentPointer, pointer)) {
+      if (lastValidationError !== undefined) {
+        throw lastValidationError;
+      }
+      if (currentPointer === null) {
+        throw new Error("OpenClaw Crabline current artifact generation is incomplete.");
+      }
+      return pointer;
+    }
+    pointer = currentPointer;
+  }
+
+  throw new Error(
+    "OpenClaw Crabline current artifact generation changed too frequently to validate.",
+    lastValidationError === undefined ? undefined : { cause: lastValidationError },
+  );
+}
+
 async function pruneArtifactStore(params: {
   lock: OpenClawCrablineSmokeRunLock;
   pointer: OpenClawCrablineArtifactPointer | null;
@@ -682,11 +715,11 @@ export async function publishOpenClawCrablineArtifactGeneration(
   await output.assertIdentityAt();
   await store.assertIdentityAt();
   await params.lock.assertOwned();
-  const currentPointer = await readOpenClawCrablineArtifactPointer(outputDir);
+  let currentPointer = await readOpenClawCrablineArtifactPointer(outputDir);
   await output.assertIdentityAt();
   await store.assertIdentityAt();
   if (currentPointer) {
-    await assertCurrentGenerationExists(outputDir, currentPointer);
+    currentPointer = await readValidCurrentArtifactGeneration(outputDir, currentPointer);
     await output.assertIdentityAt();
     await store.assertIdentityAt();
   }
@@ -836,7 +869,7 @@ export async function publishOpenClawCrablineArtifactGeneration(
     await output.assertIdentityAt();
     await store.assertIdentityAt();
     await staging.assertIdentityAt(generationPath);
-    await assertCurrentGenerationExists(outputDir, pointer);
+    await assertArtifactGenerationExists(outputDir, pointer);
     await output.assertIdentityAt();
     await store.assertIdentityAt();
     await staging.assertIdentityAt(generationPath);

--- a/test/openclaw-artifact-generation.test.ts
+++ b/test/openclaw-artifact-generation.test.ts
@@ -616,6 +616,35 @@ describe("OpenClaw artifact generation publication", () => {
     }
   });
 
+  it("requires the literal Crabline channel driver in current artifact generations", async () => {
+    const outputDir = await createTempDir();
+    try {
+      const current = await publishOpenClawCrablineArtifactGeneration(publishParams(outputDir), {
+        createGenerationId: () => "11111111-1111-4111-8111-111111111111",
+      });
+      for (const artifactPath of [
+        current.capabilityMatrixPath,
+        current.providerReadinessArtifactPath,
+      ]) {
+        const resolvedPath = path.join(outputDir, artifactPath);
+        const artifact = JSON.parse(await fs.readFile(resolvedPath, "utf8")) as Record<
+          string,
+          unknown
+        >;
+        artifact.channelDriver = "other-driver";
+        await fs.writeFile(resolvedPath, `${JSON.stringify(artifact, null, 2)}\n`);
+      }
+
+      await expect(
+        publishOpenClawCrablineArtifactGeneration(publishParams(outputDir), {
+          createGenerationId: () => "22222222-2222-4222-8222-222222222222",
+        }),
+      ).rejects.toThrow("OpenClaw Crabline current artifact generation is incomplete.");
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
   it.each([
     {
       label: "empty manifest",
@@ -1213,6 +1242,73 @@ describe("OpenClaw artifact generation publication", () => {
         second.generation,
       );
     } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
+  it("retries a coherent current-generation read after A is pruned by B and C", async () => {
+    const outputDir = await createTempDir();
+    let resumeReader: (() => void) | undefined;
+    let readerStarted: (() => void) | undefined;
+    const readerBlocked = new Promise<void>((resolve) => {
+      resumeReader = resolve;
+    });
+    const atArtifactRead = new Promise<void>((resolve) => {
+      readerStarted = resolve;
+    });
+    const originalReadFile = fs.readFile.bind(fs);
+    let blockFirstGenerationRead = true;
+    let readFileSpy: ReturnType<typeof vi.spyOn> | undefined;
+    let reader: ReturnType<typeof publishOpenClawCrablineArtifactGeneration> | undefined;
+    try {
+      await publishOpenClawCrablineArtifactGeneration(publishParams(outputDir), {
+        createGenerationId: () => "11111111-1111-4111-8111-111111111111",
+      });
+      readFileSpy = vi.spyOn(fs, "readFile").mockImplementation(async (...args) => {
+        if (
+          blockFirstGenerationRead &&
+          String(args[0]).endsWith(
+            path.join(
+              "generation-11111111-1111-4111-8111-111111111111",
+              "crabline-fake-provider-server.json",
+            ),
+          )
+        ) {
+          blockFirstGenerationRead = false;
+          readerStarted?.();
+          await readerBlocked;
+        }
+        return originalReadFile(...args);
+      });
+      reader = publishOpenClawCrablineArtifactGeneration(publishParams(outputDir), {
+        createGenerationId: () => "44444444-4444-4444-8444-444444444444",
+      });
+      await atArtifactRead;
+
+      await publishOpenClawCrablineArtifactGeneration(publishParams(outputDir), {
+        createGenerationId: () => "22222222-2222-4222-8222-222222222222",
+      });
+      const third = await publishOpenClawCrablineArtifactGeneration(publishParams(outputDir), {
+        createGenerationId: () => "33333333-3333-4333-8333-333333333333",
+      });
+      await expect(
+        fs.stat(
+          path.join(
+            outputDir,
+            OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY,
+            "generation-11111111-1111-4111-8111-111111111111",
+          ),
+        ),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+
+      resumeReader?.();
+      await expect(reader).resolves.toMatchObject({
+        previousGeneration: third.generation,
+      });
+    } finally {
+      resumeReader?.();
+      await reader?.catch(() => undefined);
+      readFileSpy?.mockRestore();
       await disposeTempDir(outputDir);
     }
   });


### PR DESCRIPTION
## Summary
- require literal Crabline channel-driver metadata for generated artifacts
- retry coherent reads across concurrent A/B/C generation rotation and pruning
- add artifact-generation regression coverage
- document the behavior change in the changelog

## Validation
- 49 focused tests
- TypeScript typecheck
- Codex autoreview: gpt-5.6-sol, high, clean
- Crabbox `pnpm verify`: run `run_716aef7531a6`, 65 files / 1,783 tests, green