### PR TITLE
fix(webhooks): harden request and probe lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Require the literal Crabline artifact channel driver and retry current-generation validation across concurrent artifact rotation.
 - Authenticate Telegram webhooks before reading request bodies and abort webhook handlers when clients disconnect.
 - Commit mock provider roundtrip sends atomically so aborted replies leave no partial outbound record.
+- Cancel uncommitted mock provider sends when adapter cleanup begins.
 - Preserve probe HTTP failures when response cancellation stalls and close readiness adapters before returning probe failures.
 - Bind private-directory ACL and recorder-lock mutations to verified identities, quarantine process locks before artifact cleanup, and preserve Windows ancestry rollback failures.
 - Require explicit remote iMessage API keys and decode legacy loopback channel metadata consistently.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Require the literal Crabline artifact channel driver and retry current-generation validation across concurrent artifact rotation.
 - Authenticate Telegram webhooks before reading request bodies and abort webhook handlers when clients disconnect.
 - Commit mock provider roundtrip sends atomically so aborted replies leave no partial outbound record.
+- Preserve probe HTTP failures when response cancellation stalls and close readiness adapters before returning probe failures.
 - Bind private-directory ACL and recorder-lock mutations to verified identities, quarantine process locks before artifact cleanup, and preserve Windows ancestry rollback failures.
 - Require explicit remote iMessage API keys and decode legacy loopback channel metadata consistently.
 - Preserve configured Mattermost bot identity during admin ingress and avoid overwriting retained channels on direct-channel ID collisions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Reject prototype-inherited provider registry keys during resolution.
 - Require the literal Crabline artifact channel driver and retry current-generation validation across concurrent artifact rotation.
 - Authenticate Telegram webhooks before reading request bodies and abort webhook handlers when clients disconnect.
+- Commit mock provider roundtrip sends atomically so aborted replies leave no partial outbound record.
 - Bind private-directory ACL and recorder-lock mutations to verified identities, quarantine process locks before artifact cleanup, and preserve Windows ancestry rollback failures.
 - Require explicit remote iMessage API keys and decode legacy loopback channel metadata consistently.
 - Preserve configured Mattermost bot identity during admin ingress and avoid overwriting retained channels on direct-channel ID collisions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Forward lazy cleanup admission fences synchronously to materialized providers.
 - Reject prototype-inherited provider registry keys during resolution.
 - Require the literal Crabline artifact channel driver and retry current-generation validation across concurrent artifact rotation.
+- Authenticate Telegram webhooks before reading request bodies and abort webhook handlers when clients disconnect.
 - Bind private-directory ACL and recorder-lock mutations to verified identities, quarantine process locks before artifact cleanup, and preserve Windows ancestry rollback failures.
 - Require explicit remote iMessage API keys and decode legacy loopback channel metadata consistently.
 - Preserve configured Mattermost bot identity during admin ingress and avoid overwriting retained channels on direct-channel ID collisions.

--- a/src/openclaw.ts
+++ b/src/openclaw.ts
@@ -609,16 +609,23 @@ export async function runOpenClawCrablineProviderReadiness(
       probeSettlement = getUnsettledOpenClawCrablineProviderProbe(error);
     }
     if (probeSettlement) {
-      const primaryFailure = probeFailure;
-      void waitForOpenClawCrablineProbeCleanup(probeSettlement).then(async () => {
-        try {
-          await adapter.close();
-        } catch (cleanupError) {
-          if (primaryFailure instanceof Error) {
-            attachOpenClawCrablineProbeCleanupFailure(primaryFailure, cleanupError);
-          }
+      await waitForOpenClawCrablineProbeCleanup(probeSettlement);
+      try {
+        await adapter.close();
+      } catch (cleanupError) {
+        if (probeFailure instanceof Error) {
+          attachOpenClawCrablineProbeCleanupFailure(probeFailure, cleanupError);
+        } else {
+          const combinedError = new Error(
+            "OpenClaw Crabline provider probe and cleanup both failed.",
+            { cause: cleanupError },
+          );
+          Object.defineProperty(combinedError, "errors", {
+            value: [probeFailure, cleanupError],
+          });
+          throw combinedError;
         }
-      });
+      }
     } else {
       try {
         await adapter.close();

--- a/src/openclaw/bridges/probe-response.ts
+++ b/src/openclaw/bridges/probe-response.ts
@@ -1,8 +1,4 @@
 export async function throwProbeHttpError(response: Response, message: string): Promise<never> {
-  try {
-    await response.body?.cancel();
-  } catch {
-    // Preserve the provider HTTP failure when response cleanup also fails.
-  }
+  void response.body?.cancel().catch(() => undefined);
   throw new Error(message);
 }

--- a/src/providers/builtin/telegram.ts
+++ b/src/providers/builtin/telegram.ts
@@ -222,7 +222,7 @@ export class TelegramProviderAdapter extends LocalMockProviderAdapter implements
       options: {
         ...(authenticateWebhook
           ? {
-              authenticateWebhookRequest(request: Request) {
+              preflightWebhookRequest(request: Request) {
                 return authenticateWebhook(request.headers.get("x-telegram-bot-api-secret-token"))
                   ? undefined
                   : new Response("unauthorized", { status: 401 });

--- a/src/providers/local-mock.ts
+++ b/src/providers/local-mock.ts
@@ -4,6 +4,7 @@ import type { ProviderConfig, ProviderPlatform } from "../config/schema.js";
 import { isJsonMediaType } from "../servers/http.js";
 import {
   appendRecordedInbound,
+  appendRecordedInboundBatch,
   cloneRecordedInboundCursor,
   createRecordedInboundCursor,
   waitForRecordedInbound,
@@ -53,6 +54,9 @@ export type LocalMockAdapterOptions = {
   ) => Promise<Response | undefined> | Response | undefined;
   normalizeWebhookPayload?: (payload: unknown) => unknown;
   platform: ProviderPlatform;
+  preflightWebhookRequest?: (
+    request: Request,
+  ) => Promise<Response | undefined> | Response | undefined;
   publicUrl?: string | undefined;
   recorderPath?: string | undefined;
   settleWebhookRequest?: (params: { accepted: boolean; payload: unknown; rawBody: string }) => void;
@@ -389,25 +393,27 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
     const threadId = this.#codec.resolveThreadId(context.fixture.target);
     const messageId = createMessageId(this.platform);
     signal?.throwIfAborted();
-    await appendRecordedInbound(this.#recorderPath, {
-      author: "user",
-      id: messageId,
-      provider: this.id,
-      raw: {
-        direction: "outbound",
-        mode: context.mode,
-        platform: this.platform,
+    const events: Parameters<typeof appendRecordedInboundBatch>[1] = [
+      {
+        author: "user",
+        id: messageId,
+        provider: this.id,
+        raw: {
+          direction: "outbound",
+          mode: context.mode,
+          platform: this.platform,
+        },
+        recordedDirection: "outbound",
+        sentAt: new Date().toISOString(),
+        text: context.text,
+        threadId,
       },
-      recordedDirection: "outbound",
-      sentAt: new Date().toISOString(),
-      text: context.text,
-      threadId,
-    });
+    ];
 
     if (context.mode !== "send" && context.fixture.target.behavior !== "sink") {
       await sleep(this.#config.loopback?.delayMs ?? 25, signal);
       signal?.throwIfAborted();
-      await appendRecordedInbound(this.#recorderPath, {
+      events.push({
         author: "assistant",
         id: `${messageId}-reply`,
         provider: this.id,
@@ -422,6 +428,7 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
         threadId,
       });
     }
+    await appendRecordedInboundBatch(this.#recorderPath, events);
 
     return {
       accepted: true,
@@ -708,6 +715,9 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
             (this.#options.handleWebhookPayload ? ["GET", "POST"] : ["POST"]),
           path: webhookPath,
           port,
+          ...(this.#options.preflightWebhookRequest
+            ? { preflight: this.#options.preflightWebhookRequest }
+            : {}),
         });
       } catch (error) {
         throw new CrablineError(

--- a/src/providers/local-mock.ts
+++ b/src/providers/local-mock.ts
@@ -389,10 +389,10 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
   }
 
   async #send(context: SendContext): Promise<SendResult> {
-    const { signal } = context;
+    const signal = this.#signalFor(context.signal);
     const threadId = this.#codec.resolveThreadId(context.fixture.target);
     const messageId = createMessageId(this.platform);
-    signal?.throwIfAborted();
+    signal.throwIfAborted();
     const events: Parameters<typeof appendRecordedInboundBatch>[1] = [
       {
         author: "user",
@@ -412,7 +412,7 @@ export class LocalMockProviderAdapter implements ProviderAdapter {
 
     if (context.mode !== "send" && context.fixture.target.behavior !== "sink") {
       await sleep(this.#config.loopback?.delayMs ?? 25, signal);
-      signal?.throwIfAborted();
+      signal.throwIfAborted();
       events.push({
         author: "assistant",
         id: `${messageId}-reply`,

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -1217,7 +1217,7 @@ export async function appendRecordedInbound(
 
 export async function appendRecordedInboundBatch(
   filePath: string,
-  events: InboundEnvelope[],
+  events: RecordableInboundEnvelope[],
 ): Promise<RecordedInboundEnvelope[]> {
   if (events.length === 0) {
     return [];

--- a/src/providers/webhook-server.ts
+++ b/src/providers/webhook-server.ts
@@ -126,6 +126,7 @@ async function toFetchRequest(
   url: URL,
   maxBodyBytes: number,
   bodyTimeoutMs: number,
+  signal: AbortSignal,
 ): Promise<Request> {
   const requestBody = await readRequestBody(request, maxBodyBytes, bodyTimeoutMs);
   const body =
@@ -133,8 +134,9 @@ async function toFetchRequest(
       ? undefined
       : requestBody;
 
-  const init: RequestInit = {
+  const init: RequestInit & { duplex?: "half" } = {
     headers: request.headers as Record<string, string>,
+    signal,
   };
   if (request.method) {
     init.method = request.method;
@@ -145,6 +147,38 @@ async function toFetchRequest(
   }
 
   return new Request(url, init);
+}
+
+function toFetchRequestMetadata(request: IncomingMessage, url: URL, signal: AbortSignal): Request {
+  return new Request(url, {
+    headers: request.headers as Record<string, string>,
+    ...(request.method ? { method: request.method } : {}),
+    signal,
+  });
+}
+
+function trackRequestLifetime(request: IncomingMessage): {
+  dispose(): void;
+  signal: AbortSignal;
+} {
+  const controller = new AbortController();
+  const abort = () => {
+    if (!controller.signal.aborted) {
+      controller.abort(new DOMException("Webhook client disconnected.", "AbortError"));
+    }
+  };
+  request.once("aborted", abort);
+  request.socket.once("close", abort);
+  if (request.aborted || request.socket.destroyed) {
+    abort();
+  }
+  return {
+    dispose() {
+      request.off("aborted", abort);
+      request.socket.off("close", abort);
+    },
+    signal: controller.signal,
+  };
 }
 
 async function writeFetchResponse(
@@ -255,6 +289,9 @@ export async function startWebhookServer(params: {
   onError?: ((error: unknown) => void) | undefined;
   path: string;
   port: number;
+  preflight?:
+    | ((request: Request) => Promise<Response | undefined> | Response | undefined)
+    | undefined;
   signal?: AbortSignal | undefined;
   shutdownGraceMs?: number | undefined;
 }): Promise<StartedWebhookServer> {
@@ -277,6 +314,7 @@ export async function startWebhookServer(params: {
       : requireTimerDelay(params.shutdownGraceMs, "Webhook shutdownGraceMs");
   let closing = false;
   const server = createServer(async (request, response) => {
+    const requestLifetime = trackRequestLifetime(request);
     try {
       if (closing) {
         drainRequestBodyWithDeadline(request, bodyTimeoutMs);
@@ -298,7 +336,22 @@ export async function startWebhookServer(params: {
         return;
       }
 
-      const fetchRequest = await toFetchRequest(request, url, maxBodyBytes, bodyTimeoutMs);
+      const preflightResponse = await params.preflight?.(
+        toFetchRequestMetadata(request, url, requestLifetime.signal),
+      );
+      if (preflightResponse) {
+        drainRequestBodyWithDeadline(request, bodyTimeoutMs);
+        await writeFetchResponse(response, preflightResponse);
+        return;
+      }
+
+      const fetchRequest = await toFetchRequest(
+        request,
+        url,
+        maxBodyBytes,
+        bodyTimeoutMs,
+        requestLifetime.signal,
+      );
       await writeFetchResponse(response, await params.handle(fetchRequest));
     } catch (error) {
       if (error instanceof ResponseDeliveryClosedError) {
@@ -341,6 +394,8 @@ export async function startWebhookServer(params: {
       } catch {
         response.destroy();
       }
+    } finally {
+      requestLifetime.dispose();
     }
   });
 

--- a/test/local-mock-provider.test.ts
+++ b/test/local-mock-provider.test.ts
@@ -963,6 +963,36 @@ describe("local mock provider", () => {
     await expect(readRecordedInbound(recorderPath)).resolves.toEqual([]);
   });
 
+  it("cancels an uncommitted roundtrip send during cleanup", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const recorderPath = path.join(directory, "cleanup-send.jsonl");
+    const config = createConfig();
+    config.loopback = { delayMs: 60_000 };
+    const provider = new LocalMockProviderAdapter({
+      codec: createGenericLocalMockTargetCodec("slack"),
+      config,
+      id: "provider-a",
+      options: {
+        defaultWebhook: { host: "127.0.0.1", path: "/slack/events", port: 0 },
+        endpointLabel: "events endpoint",
+        platform: "slack",
+        recorderPath,
+      },
+    });
+    providers.push(provider);
+    const sending = provider.send({
+      ...createContext(config),
+      mode: "roundtrip",
+      nonce: "cleanup-before-commit",
+      text: "do not commit",
+    });
+
+    await expect(provider.cleanup()).resolves.toBeUndefined();
+    await expect(sending).rejects.toThrow(/cleaned up/u);
+    await expect(readRecordedInbound(recorderPath)).resolves.toEqual([]);
+  });
+
   it("closes ingress at the cleanup fence and drains admitted webhook handlers", async () => {
     let handleRequest: ((request: Request) => Promise<Response>) | undefined;
     let releaseHandler!: () => void;

--- a/test/local-mock-provider.test.ts
+++ b/test/local-mock-provider.test.ts
@@ -11,7 +11,7 @@ import {
   createGenericLocalMockTargetCodec,
   LocalMockProviderAdapter,
 } from "../src/providers/local-mock.js";
-import { appendRecordedInbound } from "../src/providers/recorder.js";
+import { appendRecordedInbound, readRecordedInbound } from "../src/providers/recorder.js";
 import type { Registry } from "../src/providers/registry.js";
 import type { ProviderAdapter, ProviderContext } from "../src/providers/types.js";
 import { createTempDir, disposeTempDir, settleCleanup } from "./test-helpers.js";
@@ -927,7 +927,40 @@ describe("local mock provider", () => {
     ).rejects.toThrow(/cleaned up/u);
     await expect(sending).resolves.toMatchObject({ accepted: true });
     await expect(cleanup).resolves.toBeUndefined();
-    expect((await readFile(recorderPath, "utf8")).trim().split("\n")).toHaveLength(2);
+    await expect(readRecordedInbound(recorderPath)).resolves.toHaveLength(2);
+  });
+
+  it("does not commit a roundtrip send that aborts before its reply is ready", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const recorderPath = path.join(directory, "aborted-send.jsonl");
+    const config = createConfig();
+    config.loopback = { delayMs: 100 };
+    const provider = new LocalMockProviderAdapter({
+      codec: createGenericLocalMockTargetCodec("slack"),
+      config,
+      id: "provider-a",
+      options: {
+        defaultWebhook: { host: "127.0.0.1", path: "/slack/events", port: 0 },
+        endpointLabel: "events endpoint",
+        platform: "slack",
+        recorderPath,
+      },
+    });
+    providers.push(provider);
+    const controller = new AbortController();
+    const sending = provider.send({
+      ...createContext(config),
+      mode: "roundtrip",
+      nonce: "abort-before-commit",
+      signal: controller.signal,
+      text: "do not commit",
+    });
+
+    controller.abort(new DOMException("cancelled", "AbortError"));
+
+    await expect(sending).rejects.toThrow("cancelled");
+    await expect(readRecordedInbound(recorderPath)).resolves.toEqual([]);
   });
 
   it("closes ingress at the cleanup fence and drains admitted webhook handlers", async () => {

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -577,6 +577,24 @@ describe("OpenClaw local provider bridge", () => {
     }
   });
 
+  it("preserves a known probe HTTP failure when body cancellation stalls", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        new ReadableStream({
+          cancel() {
+            return new Promise<void>(() => {});
+          },
+        }),
+        { status: 503 },
+      ),
+    );
+    try {
+      await expect(probeOpenClawCrablineProvider(manifest)).rejects.toThrow(/HTTP 503/u);
+    } finally {
+      fetchMock.mockRestore();
+    }
+  });
+
   it.each([
     { ok: true },
     { ok: true, result: null },
@@ -3246,7 +3264,7 @@ describe("OpenClaw local provider bridge", () => {
     },
   );
 
-  it("defers readiness cleanup while an aborted provider probe remains unsettled", async () => {
+  it("closes readiness adapters before returning an unsettled probe failure", async () => {
     const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-probe-drain-"));
     const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
     const controller = new AbortController();
@@ -3293,24 +3311,16 @@ describe("OpenClaw local provider bridge", () => {
       await abortObserved;
 
       const result = await outcome;
-      expect(close).not.toHaveBeenCalled();
+      expect(close).toHaveBeenCalledTimes(1);
       expect(result.kind).toBe("rejected");
       expect(result).toMatchObject({
         error: expect.objectContaining({
+          cause: expect.objectContaining({
+            errors: expect.arrayContaining([cleanupFailure]),
+          }),
           message: "Crabline Telegram getMe probe timed out after 5000 ms.",
         }),
       });
-
-      await vi.waitFor(() => expect(close).toHaveBeenCalledTimes(1));
-      await vi.waitFor(() =>
-        expect(result).toMatchObject({
-          error: expect.objectContaining({
-            cause: expect.objectContaining({
-              errors: expect.arrayContaining([cleanupFailure]),
-            }),
-          }),
-        }),
-      );
     } finally {
       timeoutMock.mockRestore();
       await fs.rm(outputDir, { recursive: true, force: true });

--- a/test/registry-lifecycle.test.ts
+++ b/test/registry-lifecycle.test.ts
@@ -2,11 +2,14 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ManifestDefinition, ProviderConfig } from "../src/config/schema.js";
+import { readRecordedInbound } from "../src/providers/recorder.js";
 import { createRegistry, LazyProviderAdapter } from "../src/providers/registry.js";
 import type { ProviderAdapter, ProviderContext, SendContext } from "../src/providers/types.js";
 import { createTempDir, disposeTempDir } from "./test-helpers.js";
 
 type AppendRecordedInbound = typeof import("../src/providers/recorder.js").appendRecordedInbound;
+type AppendRecordedInboundBatch =
+  typeof import("../src/providers/recorder.js").appendRecordedInboundBatch;
 type StartWebhookServer = typeof import("../src/providers/webhook-server.js").startWebhookServer;
 type WaitForRecordedInbound = typeof import("../src/providers/recorder.js").waitForRecordedInbound;
 type WatchRecordedInbound = typeof import("../src/providers/recorder.js").watchRecordedInbound;
@@ -14,9 +17,11 @@ type WebhookHandler = Parameters<StartWebhookServer>[0]["handle"];
 
 const recorderMocks = vi.hoisted(() => ({
   actualAppendRecordedInbound: undefined as AppendRecordedInbound | undefined,
+  actualAppendRecordedInboundBatch: undefined as AppendRecordedInboundBatch | undefined,
   actualWaitForRecordedInbound: undefined as WaitForRecordedInbound | undefined,
   actualWatchRecordedInbound: undefined as WatchRecordedInbound | undefined,
   appendRecordedInbound: vi.fn<AppendRecordedInbound>(),
+  appendRecordedInboundBatch: vi.fn<AppendRecordedInboundBatch>(),
   waitForRecordedInbound: vi.fn<WaitForRecordedInbound>(),
   watchRecordedInbound: vi.fn<WatchRecordedInbound>(),
 }));
@@ -33,14 +38,17 @@ const telegramLifecycle = vi.hoisted(() => ({
 vi.mock("../src/providers/recorder.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../src/providers/recorder.js")>();
   recorderMocks.actualAppendRecordedInbound = actual.appendRecordedInbound;
+  recorderMocks.actualAppendRecordedInboundBatch = actual.appendRecordedInboundBatch;
   recorderMocks.actualWaitForRecordedInbound = actual.waitForRecordedInbound;
   recorderMocks.actualWatchRecordedInbound = actual.watchRecordedInbound;
   recorderMocks.appendRecordedInbound.mockImplementation(actual.appendRecordedInbound);
+  recorderMocks.appendRecordedInboundBatch.mockImplementation(actual.appendRecordedInboundBatch);
   recorderMocks.waitForRecordedInbound.mockImplementation(actual.waitForRecordedInbound);
   recorderMocks.watchRecordedInbound.mockImplementation(actual.watchRecordedInbound);
   return {
     ...actual,
     appendRecordedInbound: recorderMocks.appendRecordedInbound,
+    appendRecordedInboundBatch: recorderMocks.appendRecordedInboundBatch,
     waitForRecordedInbound: recorderMocks.waitForRecordedInbound,
     watchRecordedInbound: recorderMocks.watchRecordedInbound,
   };
@@ -79,6 +87,10 @@ beforeEach(() => {
   recorderMocks.appendRecordedInbound.mockReset();
   recorderMocks.appendRecordedInbound.mockImplementation(
     recorderMocks.actualAppendRecordedInbound!,
+  );
+  recorderMocks.appendRecordedInboundBatch.mockReset();
+  recorderMocks.appendRecordedInboundBatch.mockImplementation(
+    recorderMocks.actualAppendRecordedInboundBatch!,
   );
   recorderMocks.waitForRecordedInbound.mockReset();
   recorderMocks.waitForRecordedInbound.mockImplementation(
@@ -506,7 +518,7 @@ describe("lazy provider lifecycle", () => {
     expect(cleanup).toHaveBeenCalledOnce();
   });
 
-  it("drains an operation admitted before provider materialization", async () => {
+  it("cancels an uncommitted operation admitted before provider materialization", async () => {
     const directory = await createTempDir();
     const recorderPath = path.join(directory, "telegram.jsonl");
     let cleanup: Promise<void> | undefined;
@@ -526,9 +538,9 @@ describe("lazy provider lifecycle", () => {
 
       cleanup = provider.cleanup?.();
 
-      await expect(sending).resolves.toMatchObject({ accepted: true });
+      await expect(sending).rejects.toThrow(/cleaned up/u);
       await cleanup;
-      expect((await readFile(recorderPath, "utf8")).trim().split("\n")).toHaveLength(2);
+      await expect(readRecordedInbound(recorderPath)).resolves.toEqual([]);
     } finally {
       await sending?.catch(() => undefined);
       await cleanup?.catch(() => undefined);
@@ -536,7 +548,7 @@ describe("lazy provider lifecycle", () => {
     }
   });
 
-  it("waits for an admitted non-WhatsApp send before cleanup resolves", async () => {
+  it("waits for admitted non-WhatsApp persistence before cleanup resolves", async () => {
     const directory = await createTempDir();
     const recorderPath = path.join(directory, "telegram.jsonl");
     let cleanup: Promise<void> | undefined;
@@ -545,13 +557,9 @@ describe("lazy provider lifecycle", () => {
     const replyBlocked = new Promise<void>((resolve) => {
       releaseReply = resolve;
     });
-    let appendCount = 0;
-    recorderMocks.appendRecordedInbound.mockImplementation(async (...args) => {
-      appendCount += 1;
-      if (appendCount === 2) {
-        await replyBlocked;
-      }
-      return await recorderMocks.actualAppendRecordedInbound!(...args);
+    recorderMocks.appendRecordedInboundBatch.mockImplementation(async (...args) => {
+      await replyBlocked;
+      return await recorderMocks.actualAppendRecordedInboundBatch!(...args);
     });
 
     try {
@@ -568,7 +576,9 @@ describe("lazy provider lifecycle", () => {
       };
 
       sending = provider.send(sendContext);
-      await vi.waitFor(() => expect(recorderMocks.appendRecordedInbound).toHaveBeenCalledTimes(2));
+      await vi.waitFor(() =>
+        expect(recorderMocks.appendRecordedInboundBatch).toHaveBeenCalledTimes(1),
+      );
 
       let cleanupResolved = false;
       cleanup = provider.cleanup?.().then(() => {
@@ -581,7 +591,7 @@ describe("lazy provider lifecycle", () => {
       await cleanup;
       await sending;
       const contentsAfterCleanup = await readFile(recorderPath, "utf8");
-      expect(contentsAfterCleanup.trim().split("\n")).toHaveLength(2);
+      await expect(readRecordedInbound(recorderPath)).resolves.toHaveLength(2);
       await Promise.resolve();
       expect(await readFile(recorderPath, "utf8")).toBe(contentsAfterCleanup);
     } finally {

--- a/test/telegram-provider.test.ts
+++ b/test/telegram-provider.test.ts
@@ -1,5 +1,7 @@
+import { once } from "node:events";
+import { connect } from "node:net";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   normalizeTelegramWebhookPayload,
   resolveTelegramAdapterConfig,
@@ -351,6 +353,7 @@ describe("telegram provider", () => {
     expect(probe.details.join("\n")).toContain("webhook endpoint http://127.0.0.1:");
     expect(probe.details.join("\n")).toContain("channel reachable 123456789");
 
+    const since = new Date(Date.now() - 1000).toISOString();
     const result = await provider.send({
       ...createContext(config),
       mode: "roundtrip",
@@ -365,7 +368,7 @@ describe("telegram provider", () => {
       provider.waitForInbound({
         ...createContext(config),
         nonce: "nonce-1",
-        since: new Date(Date.now() - 1000).toISOString(),
+        since,
         threadId: result.threadId,
         timeoutMs: 500,
       }),
@@ -441,6 +444,40 @@ describe("telegram provider", () => {
       method: "POST",
     });
     expect(accepted.status).toBe(200);
+  });
+
+  it("rejects unauthenticated webhook headers before reading the request body", async () => {
+    const config = await createTelegramConfig(0, "test-token-placeholder");
+    const provider = new TelegramProviderAdapter("telegram", config, "crabline");
+    providers.push(provider);
+
+    const probe = await provider.probe(createContext(config));
+    const endpoint = new URL(
+      probe.details
+        .find((detail) => detail.startsWith("webhook endpoint "))!
+        .replace("webhook endpoint ", ""),
+    );
+    const socket = connect(Number(endpoint.port), endpoint.hostname);
+    socket.setEncoding("utf8");
+    socket.on("error", () => {});
+    let response = "";
+    socket.on("data", (chunk) => {
+      response += chunk;
+    });
+    await once(socket, "connect");
+    socket.write(
+      [
+        `POST ${endpoint.pathname} HTTP/1.1`,
+        `Host: ${endpoint.host}`,
+        "Content-Type: application/json",
+        "Content-Length: 100",
+        "",
+        "{",
+      ].join("\r\n"),
+    );
+
+    await vi.waitFor(() => expect(response).toContain("401 Unauthorized"));
+    socket.destroy();
   });
 
   it("rejects header-unsafe webhook secrets from the environment", async () => {

--- a/test/webhook-server.test.ts
+++ b/test/webhook-server.test.ts
@@ -64,6 +64,76 @@ describe("webhook server", () => {
     await expect(response.json()).resolves.toEqual({ echoed: true });
   });
 
+  it("runs preflight before consuming the request body", async () => {
+    const handle = vi.fn(async () => new Response("unreachable"));
+    const preflight = vi.fn(() => new Response("unauthorized", { status: 401 }));
+    const server = await startWebhookServer({
+      handle,
+      host: "127.0.0.1",
+      path: "/slack/events",
+      port: 0,
+      preflight,
+    });
+    cleanups.push(() => server.close());
+    const endpoint = new URL(server.endpointUrl);
+    const socket = connect(Number(endpoint.port), endpoint.hostname);
+    socket.setEncoding("utf8");
+    socket.on("error", () => {});
+    let response = "";
+    socket.on("data", (chunk) => {
+      response += chunk;
+    });
+    await once(socket, "connect");
+    socket.write(
+      [
+        `POST ${endpoint.pathname} HTTP/1.1`,
+        `Host: ${endpoint.host}`,
+        "Content-Length: 100",
+        "",
+        "x",
+      ].join("\r\n"),
+    );
+
+    await vi.waitFor(() => expect(response).toContain("401 Unauthorized"));
+    expect(preflight).toHaveBeenCalledOnce();
+    expect(handle).not.toHaveBeenCalled();
+    socket.destroy();
+  });
+
+  it("aborts the handler request when the client disconnects", async () => {
+    let requestSignal: AbortSignal | undefined;
+    let reportAdmission!: () => void;
+    const admitted = new Promise<void>((resolve) => {
+      reportAdmission = resolve;
+    });
+    const server = await startWebhookServer({
+      async handle(request) {
+        requestSignal = request.signal;
+        reportAdmission();
+        await new Promise<void>((resolve) => {
+          request.signal.addEventListener("abort", () => resolve(), { once: true });
+        });
+        return new Response("closed");
+      },
+      host: "127.0.0.1",
+      path: "/slack/events",
+      port: 0,
+    });
+    cleanups.push(() => server.close());
+    const endpoint = new URL(server.endpointUrl);
+    const socket = connect(Number(endpoint.port), endpoint.hostname);
+    socket.on("error", () => {});
+    await once(socket, "connect");
+    socket.write(
+      `POST ${endpoint.pathname} HTTP/1.1\r\nHost: ${endpoint.host}\r\nContent-Length: 0\r\n\r\n`,
+    );
+    await admitted;
+
+    socket.destroy();
+
+    await vi.waitFor(() => expect(requestSignal?.aborted).toBe(true));
+  });
+
   it("rejects non-matching paths", async () => {
     const server = await startWebhookServer({
       handle: async () => new Response("ok"),

--- a/test/whatsapp-provider-lifecycle.test.ts
+++ b/test/whatsapp-provider-lifecycle.test.ts
@@ -402,7 +402,7 @@ describe("WhatsApp provider lifecycle", () => {
     expect(recorderMocks.appendRecordedInbound).not.toHaveBeenCalled();
   });
 
-  it("waits for an admitted send before cleanup resolves", async () => {
+  it("waits for admitted send persistence before cleanup resolves", async () => {
     const directory = await createTempDir();
     const recorderPath = path.join(directory, "whatsapp.jsonl");
     let cleanup: Promise<void> | undefined;
@@ -411,13 +411,9 @@ describe("WhatsApp provider lifecycle", () => {
     const replyBlocked = new Promise<void>((resolve) => {
       releaseReply = resolve;
     });
-    let appendCount = 0;
-    recorderMocks.appendRecordedInbound.mockImplementation(async (...args) => {
-      appendCount += 1;
-      if (appendCount === 2) {
-        await replyBlocked;
-      }
-      return await recorderMocks.actualAppendRecordedInbound!(...args);
+    recorderMocks.appendRecordedInboundBatch.mockImplementation(async (...args) => {
+      await replyBlocked;
+      return await recorderMocks.actualAppendRecordedInboundBatch!(...args);
     });
 
     try {
@@ -430,9 +426,10 @@ describe("WhatsApp provider lifecycle", () => {
         nonce: "whatsapp-cleanup-race",
         text: "finish before cleanup",
       });
-      await vi.waitFor(() => expect(recorderMocks.appendRecordedInbound).toHaveBeenCalledTimes(2), {
-        timeout: 5_000,
-      });
+      await vi.waitFor(
+        () => expect(recorderMocks.appendRecordedInboundBatch).toHaveBeenCalledTimes(1),
+        { timeout: 5_000 },
+      );
 
       let cleanupResolved = false;
       cleanup = provider.cleanup().then(() => {
@@ -440,13 +437,13 @@ describe("WhatsApp provider lifecycle", () => {
       });
       await Promise.resolve();
       expect(cleanupResolved).toBe(false);
-      expect((await readFile(recorderPath, "utf8")).trim().split("\n")).toHaveLength(1);
+      await expect(readRecordedInbound(recorderPath)).resolves.toEqual([]);
 
       releaseReply?.();
       await cleanup;
       await sending;
       const contentsAfterCleanup = await readFile(recorderPath, "utf8");
-      expect(contentsAfterCleanup.trim().split("\n")).toHaveLength(2);
+      await expect(readRecordedInbound(recorderPath)).resolves.toHaveLength(2);
       await Promise.resolve();
       expect(await readFile(recorderPath, "utf8")).toBe(contentsAfterCleanup);
     } finally {


### PR DESCRIPTION
## Summary
- authenticate Telegram webhooks before body consumption and propagate client disconnects as request aborts
- commit mock roundtrips atomically and cancel uncommitted sends during cleanup
- preserve probe HTTP failures when response cancellation stalls
- close readiness adapters before returning probe failures
- add focused regression coverage and changelog entries

## Validation
- 207 focused tests
- TypeScript typecheck and formatting
- Codex autoreview: gpt-5.6-sol, high, clean
- Crabbox `pnpm verify`: run `run_f9a2a34a8ddd`, 65 files / 1,789 tests, green