### PR TITLE
fix(tooling): enforce audit policy boundaries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,7 @@
 /.github/pull_request_template.md @openclaw/openclaw-secops
 /.github/workflows/ @openclaw/openclaw-secops
 /.agents/skills/ @openclaw/openclaw-secops
+/AGENTS.md @openclaw/openclaw-secops
 /SECURITY.md @openclaw/openclaw-secops
 /package.json @openclaw/openclaw-secops
 /pnpm-lock.yaml @openclaw/openclaw-secops

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Cancel uncommitted mock provider sends when adapter cleanup begins.
 - Preserve probe HTTP failures when response cancellation stalls and close readiness adapters before returning probe failures.
 - Run the TypeScript autoreview contract in the dedicated suite, protect root agent policy, and ship a provider-native iMessage fixture target.
+- Normalize nullish compiled-regex candidates and reject unsafe OpenClaw integers and whitespace-only webhook secrets without rewriting valid secret bytes.
 - Bind private-directory ACL and recorder-lock mutations to verified identities, quarantine process locks before artifact cleanup, and preserve Windows ancestry rollback failures.
 - Require explicit remote iMessage API keys and decode legacy loopback channel metadata consistently.
 - Preserve configured Mattermost bot identity during admin ingress and avoid overwriting retained channels on direct-channel ID collisions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Commit mock provider roundtrip sends atomically so aborted replies leave no partial outbound record.
 - Cancel uncommitted mock provider sends when adapter cleanup begins.
 - Preserve probe HTTP failures when response cancellation stalls and close readiness adapters before returning probe failures.
+- Run the TypeScript autoreview contract in the dedicated suite, protect root agent policy, and ship a provider-native iMessage fixture target.
 - Bind private-directory ACL and recorder-lock mutations to verified identities, quarantine process locks before artifact cleanup, and preserve Windows ancestry rollback failures.
 - Require explicit remote iMessage API keys and decode legacy loopback channel metadata consistently.
 - Preserve configured Mattermost bot identity during admin ingress and avoid overwriting retained channels on direct-channel ID collisions.

--- a/fixtures/examples/crabline.example.yaml
+++ b/fixtures/examples/crabline.example.yaml
@@ -203,4 +203,4 @@ fixtures:
     provider: imessage
     mode: roundtrip
     target:
-      id: chat-guid
+      id: iMessage;-;chat-guid

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "prepare": "npm run build",
     "run": "tsx src/bin/crabline.ts run",
     "test": "vitest run",
-    "test:autoreview": "node tools/run-autoreview-tests.mjs",
+    "test:autoreview": "vitest run test/autoreview-tooling.test.ts && node tools/run-autoreview-tests.mjs",
     "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "typecheck": "tsc -p tsconfig.test.json",

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -124,6 +124,11 @@ const HttpsUrlSchema = HttpUrlSchema.refine((value) => {
   }
 }, "URL must use https");
 
+const NonBlankSecretSchema = z
+  .string()
+  .min(1)
+  .refine((value) => value.trim().length > 0, "secret must not be blank");
+
 const HeaderValueSchema = z
   .string()
   .min(1)
@@ -250,7 +255,7 @@ const SlackWebhookSchema = z.strictObject({
 
 const SlackConfigSchema = z.strictObject({
   recorder: SlackRecorderSchema.default({}),
-  signingSecret: z.string().min(1).optional(),
+  signingSecret: NonBlankSecretSchema.optional(),
   webhook: SlackWebhookSchema.default({
     host: "127.0.0.1",
     path: "/slack/events",
@@ -441,10 +446,10 @@ const TelegramConfigSchema = z.strictObject({
 const FeishuConfigSchema = z.strictObject({
   appId: z.string().min(1).optional(),
   appSecret: z.string().min(1).optional(),
-  encryptKey: z.string().min(1).optional(),
+  encryptKey: NonBlankSecretSchema.optional(),
   recorder: z.strictObject({ path: z.string().min(1).optional() }).default({}),
   userName: z.string().min(1).optional(),
-  verificationToken: z.string().min(1).optional(),
+  verificationToken: NonBlankSecretSchema.optional(),
   webhook: z
     .strictObject({
       host: z.string().min(1).default("127.0.0.1"),

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -567,7 +567,7 @@ export async function runFixtureCommand(params: {
                 matchesInbound(candidate, preparedInboundMatch, nonce, {
                   requireAcknowledgement: mode === "agent",
                 }) &&
-                (!compiledInboundRegex || compiledInboundRegex.test(candidate.text))
+                (!compiledInboundRegex || compiledInboundRegex.test(candidate.text ?? ""))
               ) {
                 inbound = candidate;
                 break;

--- a/src/openclaw/shared.ts
+++ b/src/openclaw/shared.ts
@@ -294,7 +294,8 @@ export function readInteger(value: unknown): number | undefined {
   if (!stringValue || !/^-?\d+$/u.test(stringValue)) {
     return undefined;
   }
-  return Number(stringValue);
+  const parsed = Number(stringValue);
+  return Number.isSafeInteger(parsed) ? parsed : undefined;
 }
 
 export function parseQaTarget(target: string): ParsedQaTarget {

--- a/test/autoreview-tooling.test.ts
+++ b/test/autoreview-tooling.test.ts
@@ -8,6 +8,16 @@ import { describe, expect, it } from "vitest";
 const execFileAsync = promisify(execFile);
 
 describe("autoreview tooling", () => {
+  it("runs this contract test from the dedicated autoreview suite", async () => {
+    const packageJson = JSON.parse(await fs.readFile("package.json", "utf8")) as {
+      scripts?: Record<string, string>;
+    };
+
+    expect(packageJson.scripts?.["test:autoreview"]).toContain(
+      "vitest run test/autoreview-tooling.test.ts",
+    );
+  });
+
   it("requires Python 3.10 across every launcher", async () => {
     const [runner, shellLauncher, powershellLauncher, harness] = await Promise.all([
       fs.readFile("tools/run-autoreview-tests.mjs", "utf8"),

--- a/test/channel-setup-docs.test.ts
+++ b/test/channel-setup-docs.test.ts
@@ -34,6 +34,9 @@ describe("channel setup contracts", () => {
     const targetId = manifest.fixtures.find((fixture) => fixture.provider === "mattermost")?.target
       .id;
     expect(targetId).toMatch(/^[a-z0-9]{26}$/u);
+    expect(manifest.fixtures.find((fixture) => fixture.provider === "imessage")?.target.id).toBe(
+      "iMessage;-;chat-guid",
+    );
   });
 
   it("keeps documented support lists synchronized with schema and catalog", async () => {

--- a/test/ci-workflow.test.ts
+++ b/test/ci-workflow.test.ts
@@ -204,6 +204,7 @@ describe("CI workflow hardening", () => {
 
     expect(codeowners).toContain("/.github/actions/ @openclaw/openclaw-secops");
     expect(codeowners).toContain("/.github/pull_request_template.md @openclaw/openclaw-secops");
+    expect(codeowners).toContain("/AGENTS.md @openclaw/openclaw-secops");
     expect(codeowners).toContain("/tools/ @openclaw/openclaw-secops");
     expect(codeqlWorkflow.on?.push?.paths).toContain(".github/actions/**");
     expect(codeqlWorkflow.on?.pull_request?.paths).toContain(".github/actions/**");

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -216,6 +216,33 @@ describe("manifest schema", () => {
   });
 
   it.each([
+    ["slack", "signingSecret"],
+    ["feishu", "encryptKey"],
+    ["feishu", "verificationToken"],
+  ] as const)(
+    "rejects whitespace-only %s.%s secrets without trimming valid bytes",
+    (adapter, field) => {
+      const parseSecret = (secret: string) => {
+        const provider = ManifestSchema.parse({
+          configVersion: 1,
+          fixtures: [],
+          providers: {
+            provider: {
+              adapter,
+              [adapter]: { [field]: secret },
+            },
+          },
+        }).providers.provider;
+        const adapterConfig = provider?.[adapter] as Record<string, unknown> | undefined;
+        return adapterConfig?.[field];
+      };
+
+      expect(() => parseSecret(" \t\n ")).toThrow(/secret must not be blank/u);
+      expect(parseSecret(" secret bytes ")).toBe(" secret bytes ");
+    },
+  );
+
+  it.each([
     "/slack/../events",
     "/slack\\events",
     "//example.test/events",

--- a/test/http-server.test.ts
+++ b/test/http-server.test.ts
@@ -135,6 +135,10 @@ describe("server HTTP body reader", () => {
     expect(readInteger(String(Number.MIN_SAFE_INTEGER))).toBe(Number.MIN_SAFE_INTEGER);
     expect(readInteger(String(Number.MAX_SAFE_INTEGER + 1))).toBeUndefined();
     expect(readInteger("-9007199254740992")).toBeUndefined();
+    expect(readInteger(9_007_199_254_740_992n)).toBeUndefined();
+    expect(readInteger(Number.NaN)).toBeUndefined();
+    expect(readInteger(Number.POSITIVE_INFINITY)).toBeUndefined();
+    expect(readInteger(Number.NEGATIVE_INFINITY)).toBeUndefined();
   });
 
   it("recognizes JSON media types case-insensitively", async () => {

--- a/test/package-production.test.ts
+++ b/test/package-production.test.ts
@@ -432,7 +432,7 @@ describe("production package", () => {
     ]);
     const pkg = JSON.parse(pkgContents) as { scripts?: Record<string, string> };
 
-    expect(pkg.scripts?.["test:autoreview"]).toBe("node tools/run-autoreview-tests.mjs");
+    expect(pkg.scripts?.["test:autoreview"]).toContain("node tools/run-autoreview-tests.mjs");
     expect(pkg.scripts?.verify).toContain("pnpm test:autoreview");
     expect(launcher).toContain("sys.version_info >= (3, 10)");
     expect(launcher).toContain("Python 3.10 or newer is required");

--- a/test/run.behavior.test.ts
+++ b/test/run.behavior.test.ts
@@ -233,7 +233,12 @@ describe("run behavior", () => {
           id: `inbound-${waitCalls}`,
           provider: "mock",
           sentAt: new Date().toISOString(),
-          text: waitCalls === 3 ? "expected reply" : "unrelated reply",
+          text:
+            waitCalls === 1
+              ? (undefined as unknown as string)
+              : waitCalls === 3
+                ? "expected reply"
+                : "unrelated reply",
           threadId: "thread",
         };
       },


### PR DESCRIPTION
## Summary
- include the TypeScript tooling suite in the dedicated autoreview test command
- protect root `AGENTS.md` through CODEOWNERS
- use a native iMessage target in the canonical fixture
- reject unsafe integer parsing, nullish matcher input, and blank configured secrets
- add focused regression coverage and changelog entries

## Validation
- 176 focused tests plus 14 package/tooling regression tests
- TypeScript typecheck and formatting
- lint, build, dedicated autoreview suite
- Codex autoreview: gpt-5.6-sol, high, clean (0.93)
- Crabbox `pnpm verify`: run `run_8f1248f488f1`, 65 files / 1,793 tests, green