### PR TITLE
fix(servers): align provider protocol boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Preserve probe HTTP failures when response cancellation stalls and close readiness adapters before returning probe failures.
 - Run the TypeScript autoreview contract in the dedicated suite, protect root agent policy, and ship a provider-native iMessage fixture target.
 - Normalize nullish compiled-regex candidates and reject unsafe OpenClaw integers and whitespace-only webhook secrets without rewriting valid secret bytes.
+- Verify resolved loopback webhook addresses and complete HEAD responses without consuming representation bodies.
 - Bind private-directory ACL and recorder-lock mutations to verified identities, quarantine process locks before artifact cleanup, and preserve Windows ancestry rollback failures.
 - Require explicit remote iMessage API keys and decode legacy loopback channel metadata consistently.
 - Preserve configured Mattermost bot identity during admin ingress and avoid overwriting retained channels on direct-channel ID collisions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Preserve probe HTTP failures when response cancellation stalls and close readiness adapters before returning probe failures.
 - Run the TypeScript autoreview contract in the dedicated suite, protect root agent policy, and ship a provider-native iMessage fixture target.
 - Normalize nullish compiled-regex candidates and reject unsafe OpenClaw integers and whitespace-only webhook secrets without rewriting valid secret bytes.
+- Decouple Mattermost REST post acceptance from WebSocket buffers and bound retained state by bytes.
 - Emit Matrix v10 event IDs in domainless hash form and reject invalid timeline filter limits.
 - Return valid Signal JSON-RPC method errors through successful HTTP responses.
 - Verify resolved loopback webhook addresses and complete HEAD responses without consuming representation bodies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Preserve probe HTTP failures when response cancellation stalls and close readiness adapters before returning probe failures.
 - Run the TypeScript autoreview contract in the dedicated suite, protect root agent policy, and ship a provider-native iMessage fixture target.
 - Normalize nullish compiled-regex candidates and reject unsafe OpenClaw integers and whitespace-only webhook secrets without rewriting valid secret bytes.
+- Return valid Signal JSON-RPC method errors through successful HTTP responses.
 - Verify resolved loopback webhook addresses and complete HEAD responses without consuming representation bodies.
 - Bind private-directory ACL and recorder-lock mutations to verified identities, quarantine process locks before artifact cleanup, and preserve Windows ancestry rollback failures.
 - Require explicit remote iMessage API keys and decode legacy loopback channel metadata consistently.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Preserve probe HTTP failures when response cancellation stalls and close readiness adapters before returning probe failures.
 - Run the TypeScript autoreview contract in the dedicated suite, protect root agent policy, and ship a provider-native iMessage fixture target.
 - Normalize nullish compiled-regex candidates and reject unsafe OpenClaw integers and whitespace-only webhook secrets without rewriting valid secret bytes.
+- Emit Matrix v10 event IDs in domainless hash form and reject invalid timeline filter limits.
 - Return valid Signal JSON-RPC method errors through successful HTTP responses.
 - Verify resolved loopback webhook addresses and complete HEAD responses without consuming representation bodies.
 - Bind private-directory ACL and recorder-lock mutations to verified identities, quarantine process locks before artifact cleanup, and preserve Windows ancestry rollback failures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Preserve probe HTTP failures when response cancellation stalls and close readiness adapters before returning probe failures.
 - Run the TypeScript autoreview contract in the dedicated suite, protect root agent policy, and ship a provider-native iMessage fixture target.
 - Normalize nullish compiled-regex candidates and reject unsafe OpenClaw integers and whitespace-only webhook secrets without rewriting valid secret bytes.
+- Preserve recorder directory sync failures when handle cleanup also fails.
 - Decouple Mattermost REST post acceptance from WebSocket buffers and bound retained state by bytes.
 - Emit Matrix v10 event IDs in domainless hash form and reject invalid timeline filter limits.
 - Return valid Signal JSON-RPC method errors through successful HTTP responses.

--- a/src/servers/http.ts
+++ b/src/servers/http.ts
@@ -346,6 +346,24 @@ export async function writeResponse(
       throw new Error("HTTP response closed before delivery completed.");
     }
 
+    if (response.req?.method === "HEAD") {
+      cancelBody(new Error("HEAD response body is not transferred."));
+      response.statusCode = fetchResponse.status;
+      writeFetchResponseHeaders(response, fetchResponse);
+      let onFinish!: () => void;
+      const finished = new Promise<void>((resolve) => {
+        onFinish = resolve;
+        response.once("finish", onFinish);
+      });
+      try {
+        response.end();
+        await Promise.race([finished, stopped]);
+      } finally {
+        response.off("finish", onFinish);
+      }
+      return;
+    }
+
     const chunks: Buffer[] = [];
     let bodyLength = 0;
     if (reader) {

--- a/src/servers/matrix.ts
+++ b/src/servers/matrix.ts
@@ -205,6 +205,8 @@ function decodeMatrixPathSegment(value: string): string {
 
 function eventId(state: MatrixServerState): string {
   return `$${createHash("sha256")
+    .update(state.serverName)
+    .update("\0")
     .update(`event-${state.nextEvent++}`)
     .digest("base64url")}`;
 }

--- a/src/servers/matrix.ts
+++ b/src/servers/matrix.ts
@@ -151,8 +151,8 @@ export type StartMatrixServerParams = {
   serverName?: string | undefined;
 };
 
-function matrixId(prefix: "$" | "!", value: string, serverName: string): string {
-  return `${prefix}${createHash("sha256").update(value).digest("hex").slice(0, 16)}:${serverName}`;
+function matrixRoomId(value: string, serverName: string): string {
+  return `!${createHash("sha256").update(value).digest("hex").slice(0, 16)}:${serverName}`;
 }
 
 async function appendEvent(
@@ -204,7 +204,9 @@ function decodeMatrixPathSegment(value: string): string {
 }
 
 function eventId(state: MatrixServerState): string {
-  return matrixId("$", `event-${state.nextEvent++}`, state.serverName);
+  return `$${createHash("sha256")
+    .update(`event-${state.nextEvent++}`)
+    .digest("base64url")}`;
 }
 
 function notifySyncWaiters(state: MatrixServerState): void {
@@ -427,11 +429,30 @@ function transactionResponse(
   return response;
 }
 
-function readTimelineLimit(filter: Record<string, unknown> | undefined): number | undefined {
+function readTimelineLimit(
+  filter: Record<string, unknown> | undefined,
+): number | Response | undefined {
   const room = filter?.room;
-  const timeline = isJsonObject(room) ? room.timeline : undefined;
-  const limit = isJsonObject(timeline) ? readInteger(timeline.limit) : undefined;
-  return limit === undefined ? undefined : Math.max(0, limit);
+  if (room === undefined) {
+    return undefined;
+  }
+  if (!isJsonObject(room)) {
+    return matrixError("M_INVALID_PARAM", "Invalid room filter", 400);
+  }
+  const timeline = room.timeline;
+  if (timeline === undefined) {
+    return undefined;
+  }
+  if (!isJsonObject(timeline)) {
+    return matrixError("M_INVALID_PARAM", "Invalid timeline filter", 400);
+  }
+  if (!Object.hasOwn(timeline, "limit")) {
+    return undefined;
+  }
+  const limit = timeline.limit;
+  return typeof limit === "number" && Number.isSafeInteger(limit) && limit > 0
+    ? limit
+    : matrixError("M_INVALID_PARAM", "Invalid timeline limit", 400);
 }
 
 function resolveSyncFilter(
@@ -610,6 +631,9 @@ async function handleSync(url: URL, state: MatrixServerState): Promise<Response>
     return filter;
   }
   const timelineLimit = readTimelineLimit(filter);
+  if (timelineLimit instanceof Response) {
+    return timelineLimit;
+  }
   const timeout = Math.min(readInteger(url.searchParams.get("timeout")) ?? 0, 1_000);
   const hasNewEvents =
     (state.directRoomsSequence !== undefined &&
@@ -1093,7 +1117,7 @@ export async function startMatrixServer(
     syncWaiters: new Set(),
     transactions: new Map(),
   };
-  const roomId = params.roomId ?? matrixId("!", "default-room", serverName);
+  const roomId = params.roomId ?? matrixRoomId("default-room", serverName);
   state.rooms.set(
     roomId,
     createRoom({

--- a/src/servers/mattermost.ts
+++ b/src/servers/mattermost.ts
@@ -482,6 +482,17 @@ function commitNextPost(
   setCommittedValue(state, state.posts, pending.post.id, pending.post);
 }
 
+function commitNextPostIfCapacity(
+  state: MattermostServerState,
+  pending: ReturnType<typeof buildNextPost>,
+): boolean {
+  if (!canRetainCommittedValues(state, [[undefined, pending.post]])) {
+    return false;
+  }
+  commitNextPost(state, pending);
+  return true;
+}
+
 function nextDirectChannelId(state: MattermostServerState, seed: string): string {
   let collision = 0;
   let channelId: string;
@@ -808,11 +819,10 @@ async function handleApi(params: {
       userId: state.botUserId,
     });
     const { post } = pendingPost;
-    if (!canRetainCommittedValues(state, [[undefined, post]])) {
+    if (!commitNextPostIfCapacity(state, pendingPost)) {
       return mattermostError("Too much retained state", 503);
     }
     const event = postEvent("posted", post, state.botUsername, channel);
-    commitNextPost(state, pendingPost);
     broadcast(state, event, false);
     return jsonResponse(post, 201);
   }

--- a/src/servers/mattermost.ts
+++ b/src/servers/mattermost.ts
@@ -32,7 +32,9 @@ const DEFAULT_MAX_WEBSOCKET_MESSAGE_BYTES = 64 * 1024;
 const DEFAULT_MAX_UNAUTHENTICATED_WEBSOCKET_CLIENTS = 32;
 const DEFAULT_MAX_COMMITTED_CHANNELS = 1_000;
 const DEFAULT_MAX_COMMITTED_POSTS = 1_000;
+const DEFAULT_MAX_COMMITTED_STATE_BYTES = 64 * 1024 * 1024;
 const DEFAULT_MAX_COMMITTED_USERS = 1_000;
+const DEFAULT_MAX_PENDING_INBOUND_BYTES = 64 * 1024 * 1024;
 const MATTERMOST_ID_PATTERN = /^[a-z0-9]{26}(?![\s\S])/u;
 const MATTERMOST_USERNAME_PATTERN = /^[a-z0-9._-]{1,64}$/u;
 const MATTERMOST_CHANNEL_TYPES = new Set(["D", "G", "O", "P"]);
@@ -68,6 +70,12 @@ type MattermostChannel = {
   type: string;
 };
 
+type MattermostUser = {
+  id: string;
+  update_at: number;
+  username: string;
+};
+
 type MattermostWebSocketEvent = {
   broadcast: {
     channel_id: string;
@@ -88,18 +96,22 @@ type MattermostServerState = {
   botUserId: string;
   botUsername: string;
   channels: Map<string, MattermostChannel>;
+  committedStateBytes: number;
   maxCommittedChannels: number;
   maxCommittedPosts: number;
+  maxCommittedStateBytes: number;
   maxCommittedUsers: number;
+  maxPendingInboundBytes: number;
   maxPendingInboundEvents: number;
   maxWebSocketBufferedBytes: number;
   nextPost: number;
   onEvent: ServerEventObserver | undefined;
+  pendingEventBytes: number;
   pendingEvents: MattermostWebSocketEvent[];
   posts: Map<string, MattermostPost>;
   recorderPath: string;
   userIdsByUsername: Map<string, string>;
-  users: Map<string, { id: string; username: string; update_at: number }>;
+  users: Map<string, MattermostUser>;
   websocketClients: Map<WebSocket, number>;
 };
 
@@ -138,7 +150,9 @@ export type StartMattermostServerParams = {
   recorderPath?: string | undefined;
   maxCommittedChannels?: number | undefined;
   maxCommittedPosts?: number | undefined;
+  maxCommittedStateBytes?: number | undefined;
   maxCommittedUsers?: number | undefined;
+  maxPendingInboundBytes?: number | undefined;
   maxPendingInboundEvents?: number | undefined;
   maxWebSocketBufferedBytes?: number | undefined;
   maxWebSocketMessageBytes?: number | undefined;
@@ -270,6 +284,49 @@ function webSocketEventBytes(event: MattermostWebSocketEvent): number {
   return Buffer.byteLength(JSON.stringify({ ...event, seq: Number.MAX_SAFE_INTEGER }), "utf8");
 }
 
+function retainedValueBytes(value: unknown): number {
+  const serialized = JSON.stringify(value);
+  return serialized === undefined ? 0 : Buffer.byteLength(serialized, "utf8");
+}
+
+function retainedValueDelta(previous: unknown, next: unknown): number {
+  return retainedValueBytes(next) - retainedValueBytes(previous);
+}
+
+function canRetainCommittedValues(
+  state: MattermostServerState,
+  replacements: ReadonlyArray<readonly [previous: unknown, next: unknown]>,
+): boolean {
+  const delta = replacements.reduce(
+    (total, [previous, next]) => total + retainedValueDelta(previous, next),
+    0,
+  );
+  return state.committedStateBytes + delta <= state.maxCommittedStateBytes;
+}
+
+function setCommittedValue<Key, Value>(
+  state: MattermostServerState,
+  values: Map<Key, Value>,
+  key: Key,
+  value: Value,
+): void {
+  state.committedStateBytes += retainedValueDelta(values.get(key), value);
+  values.set(key, value);
+}
+
+function deleteCommittedValue<Key, Value>(
+  state: MattermostServerState,
+  values: Map<Key, Value>,
+  key: Key,
+): void {
+  const previous = values.get(key);
+  if (previous === undefined) {
+    return;
+  }
+  state.committedStateBytes -= retainedValueBytes(previous);
+  values.delete(key);
+}
+
 function sendEvent(
   state: MattermostServerState,
   client: WebSocket,
@@ -353,7 +410,12 @@ function broadcast(
   if (state.pendingEvents.length >= state.maxPendingInboundEvents) {
     return false;
   }
+  const eventBytes = retainedValueBytes(event);
+  if (state.pendingEventBytes + eventBytes > state.maxPendingInboundBytes) {
+    return false;
+  }
   state.pendingEvents.push(event);
+  state.pendingEventBytes += eventBytes;
   return true;
 }
 
@@ -367,7 +429,7 @@ function pendingQueueFullResponse(state: MattermostServerState): Response {
   );
 }
 
-function committedStateFullResponse(resource: "channels" | "posts" | "users"): Response {
+function committedStateFullResponse(resource: "channels" | "posts" | "state" | "users"): Response {
   return jsonResponse(
     {
       error: `Committed Mattermost ${resource} limit reached`,
@@ -417,7 +479,7 @@ function commitNextPost(
   pending: ReturnType<typeof buildNextPost>,
 ): void {
   state.nextPost = pending.nextPost;
-  state.posts.set(pending.post.id, pending.post);
+  setCommittedValue(state, state.posts, pending.post.id, pending.post);
 }
 
 function nextDirectChannelId(state: MattermostServerState, seed: string): string {
@@ -559,6 +621,17 @@ function handleAdminInbound(params: {
     rootPost?.id,
   );
   const { post } = pendingPost;
+  const user = { id: senderId, update_at: Date.now(), username: senderName };
+  if (
+    !canRetainCommittedValues(params.state, [
+      [previousUser, user],
+      [previousChannel, channel],
+      [undefined, rootPost],
+      [undefined, post],
+    ])
+  ) {
+    return committedStateFullResponse("state");
+  }
   const event = postEvent("posted", post, senderName, channel);
   if (webSocketEventBytes(event) > params.state.maxWebSocketBufferedBytes) {
     return jsonResponse({ error: "Inbound event is too large", ok: false }, 413);
@@ -568,31 +641,31 @@ function handleAdminInbound(params: {
     params.state.userIdsByUsername.delete(previousUser?.username ?? "");
   }
   params.state.userIdsByUsername.set(senderName, senderId);
-  params.state.users.set(senderId, { id: senderId, update_at: Date.now(), username: senderName });
-  params.state.channels.set(channelId, channel);
+  setCommittedValue(params.state, params.state.users, senderId, user);
+  setCommittedValue(params.state, params.state.channels, channelId, channel);
   if (rootPost) {
-    params.state.posts.set(rootPost.id, rootPost);
+    setCommittedValue(params.state, params.state.posts, rootPost.id, rootPost);
   }
   commitNextPost(params.state, pendingPost);
   const rollback = () => {
-    params.state.posts.delete(post.id);
+    deleteCommittedValue(params.state, params.state.posts, post.id);
     if (rootPost) {
-      params.state.posts.delete(rootPost.id);
+      deleteCommittedValue(params.state, params.state.posts, rootPost.id);
     }
     params.state.nextPost = previousNextPost;
     if (previousUser) {
-      params.state.users.set(senderId, previousUser);
+      setCommittedValue(params.state, params.state.users, senderId, previousUser);
       params.state.userIdsByUsername.set(previousUser.username, senderId);
     } else {
-      params.state.users.delete(senderId);
+      deleteCommittedValue(params.state, params.state.users, senderId);
     }
     if (previousUser?.username !== senderName) {
       params.state.userIdsByUsername.delete(senderName);
     }
     if (previousChannel) {
-      params.state.channels.set(channelId, previousChannel);
+      setCommittedValue(params.state, params.state.channels, channelId, previousChannel);
     } else {
-      params.state.channels.delete(channelId);
+      deleteCommittedValue(params.state, params.state.channels, channelId);
     }
   };
   if (!broadcast(params.state, event)) {
@@ -660,7 +733,10 @@ async function handleApi(params: {
     }
     const channelId = nextDirectChannelId(state, `dm:${participantIds.join(":")}`);
     const channel = { display_name: "", id: channelId, name: channelName, type: "D" };
-    state.channels.set(channelId, channel);
+    if (!canRetainCommittedValues(state, [[undefined, channel]])) {
+      return mattermostError("Too much retained state", 503);
+    }
+    setCommittedValue(state, state.channels, channelId, channel);
     return jsonResponse(channel, 201);
   }
   if (!isJsonObject(body)) {
@@ -732,10 +808,10 @@ async function handleApi(params: {
       userId: state.botUserId,
     });
     const { post } = pendingPost;
-    const event = postEvent("posted", post, state.botUsername, channel);
-    if (webSocketEventBytes(event) > state.maxWebSocketBufferedBytes) {
-      return webSocketEventTooLargeResponse();
+    if (!canRetainCommittedValues(state, [[undefined, post]])) {
+      return mattermostError("Too much retained state", 503);
     }
+    const event = postEvent("posted", post, state.botUsername, channel);
     commitNextPost(state, pendingPost);
     broadcast(state, event, false);
     return jsonResponse(post, 201);
@@ -755,6 +831,9 @@ async function handleApi(params: {
     }
     const editedAt = Math.max(Date.now(), post.update_at + 1);
     const updated = { ...post, edit_at: editedAt, message, update_at: editedAt };
+    if (!canRetainCommittedValues(state, [[post, updated]])) {
+      return mattermostError("Too much retained state", 503);
+    }
     const event = postEvent(
       "post_edited",
       updated,
@@ -764,7 +843,7 @@ async function handleApi(params: {
     if (webSocketEventBytes(event) > state.maxWebSocketBufferedBytes) {
       return webSocketEventTooLargeResponse();
     }
-    state.posts.set(updated.id, updated);
+    setCommittedValue(state, state.posts, updated.id, updated);
     broadcast(state, event, false);
     return jsonResponse(updated);
   }
@@ -787,7 +866,7 @@ async function handleApi(params: {
     if (webSocketEventBytes(event) > state.maxWebSocketBufferedBytes) {
       return webSocketEventTooLargeResponse();
     }
-    state.posts.delete(post.id);
+    deleteCommittedValue(state, state.posts, post.id);
     broadcast(state, event, false);
     return jsonResponse({ status: "OK" });
   }
@@ -959,9 +1038,15 @@ function attachWebSocketServer(params: {
           event: "hello",
         });
         const pending = params.state.pendingEvents.splice(0);
+        params.state.pendingEventBytes = 0;
         for (const [index, event] of pending.entries()) {
           if (!sendEvent(params.state, client, event)) {
-            params.state.pendingEvents.unshift(...pending.slice(index));
+            const remaining = pending.slice(index);
+            params.state.pendingEvents.unshift(...remaining);
+            params.state.pendingEventBytes = remaining.reduce(
+              (total, queuedEvent) => total + retainedValueBytes(queuedEvent),
+              0,
+            );
             break;
           }
         }
@@ -1045,6 +1130,16 @@ export async function startMattermostServer(
     "maxUnauthenticatedWebSocketClients",
     DEFAULT_MAX_UNAUTHENTICATED_WEBSOCKET_CLIENTS,
   );
+  const maxCommittedStateBytes = resolvePositiveLimit(
+    params.maxCommittedStateBytes,
+    "maxCommittedStateBytes",
+    DEFAULT_MAX_COMMITTED_STATE_BYTES,
+  );
+  const botUser = { id: botUserId, update_at: Date.now(), username: botUsername };
+  const initialCommittedStateBytes = retainedValueBytes(botUser);
+  if (initialCommittedStateBytes > maxCommittedStateBytes) {
+    throw new Error("maxCommittedStateBytes cannot retain the configured bot user.");
+  }
   const state: MattermostServerState = {
     adminToken: params.adminToken ?? randomBytes(24).toString("base64url"),
     botToken:
@@ -1053,6 +1148,7 @@ export async function startMattermostServer(
     botUserId,
     botUsername,
     channels: new Map(),
+    committedStateBytes: initialCommittedStateBytes,
     maxCommittedChannels: resolvePositiveLimit(
       params.maxCommittedChannels,
       "maxCommittedChannels",
@@ -1063,10 +1159,16 @@ export async function startMattermostServer(
       "maxCommittedPosts",
       DEFAULT_MAX_COMMITTED_POSTS,
     ),
+    maxCommittedStateBytes,
     maxCommittedUsers: resolvePositiveLimit(
       params.maxCommittedUsers,
       "maxCommittedUsers",
       DEFAULT_MAX_COMMITTED_USERS,
+    ),
+    maxPendingInboundBytes: resolvePositiveLimit(
+      params.maxPendingInboundBytes,
+      "maxPendingInboundBytes",
+      DEFAULT_MAX_PENDING_INBOUND_BYTES,
     ),
     maxPendingInboundEvents: resolveMaxPendingInboundEvents(params.maxPendingInboundEvents),
     maxWebSocketBufferedBytes: resolvePositiveLimit(
@@ -1076,11 +1178,12 @@ export async function startMattermostServer(
     ),
     nextPost: 1,
     onEvent: params.onEvent,
+    pendingEventBytes: 0,
     pendingEvents: [],
     posts: new Map(),
     recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "mattermost.jsonl"),
     userIdsByUsername: new Map([[botUsername, botUserId]]),
-    users: new Map([[botUserId, { id: botUserId, update_at: Date.now(), username: botUsername }]]),
+    users: new Map([[botUserId, botUser]]),
     websocketClients: new Map(),
   };
   const httpServer = await startHttpJsonServer({

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -44,6 +44,19 @@ export class ServerRecorderCommittedError extends AggregateError {
 
 class ServerRecorderRotationError extends Error {}
 
+class ServerRecorderDirectorySyncError extends AggregateError {
+  constructor(
+    readonly syncError: unknown,
+    readonly closeError: unknown,
+  ) {
+    super(
+      [syncError, closeError],
+      "Server recorder directory sync and handle cleanup both failed.",
+      { cause: syncError },
+    );
+  }
+}
+
 type RecorderFileIdentity = {
   dev: bigint;
   ino: bigint;
@@ -244,10 +257,26 @@ async function syncDirectory(directoryPath: string): Promise<void> {
     return;
   }
   const directory = await open(directoryPath, "r");
+  let syncError: unknown;
   try {
     await directory.sync();
-  } finally {
+  } catch (error) {
+    syncError = error;
+  }
+  let closeError: unknown;
+  try {
     await directory.close();
+  } catch (error) {
+    closeError = error;
+  }
+  if (syncError !== undefined && closeError !== undefined) {
+    throw new ServerRecorderDirectorySyncError(syncError, closeError);
+  }
+  if (syncError !== undefined) {
+    throw syncError;
+  }
+  if (closeError !== undefined) {
+    throw closeError;
   }
 }
 
@@ -1270,6 +1299,14 @@ async function appendRecorderAttempt(params: {
           } catch (error) {
             if (error instanceof ServerRecorderCommittedError) {
               throw error;
+            }
+            if (error instanceof ServerRecorderDirectorySyncError) {
+              throw new ServerRecorderCommittedError(
+                params.logicalPath,
+                error.syncError,
+                [error.closeError],
+                true,
+              );
             }
             throw new ServerRecorderCommittedError(params.logicalPath, error, [], true);
           }

--- a/src/servers/signal.ts
+++ b/src/servers/signal.ts
@@ -562,7 +562,7 @@ async function handleRpc(params: {
         record: false,
         response: notification
           ? new Response(null, { status: 204 })
-          : rpcError(-32602, "Invalid params", id),
+          : rpcError(-32602, "Invalid params", id, 200),
       };
     }
     const account = params.body.params.account;
@@ -572,7 +572,7 @@ async function handleRpc(params: {
         record: false,
         response: notification
           ? new Response(null, { status: 204 })
-          : rpcError(-32602, "Specified account does not exist", id),
+          : rpcError(-32602, "Specified account does not exist", id, 200),
       };
     }
     const timestamp = nextSignalTimestamp(params.state);
@@ -582,7 +582,7 @@ async function handleRpc(params: {
         record: false,
         response: notification
           ? new Response(null, { status: 204 })
-          : rpcError(-32603, "Timestamp capacity exhausted", id),
+          : rpcError(-32603, "Timestamp capacity exhausted", id, 200),
       };
     }
     return {

--- a/src/servers/webhook-target.ts
+++ b/src/servers/webhook-target.ts
@@ -524,7 +524,7 @@ export async function validateWebhookTarget(params: {
   if (params.url.protocol !== "https:" && !allowThisLoopbackHttp) {
     return { error: "https-required" };
   }
-  if (!params.restrictPrivateAddresses) {
+  if (!params.restrictPrivateAddresses && !allowThisLoopbackHttp) {
     return { addresses: undefined };
   }
 

--- a/test/http-server.test.ts
+++ b/test/http-server.test.ts
@@ -336,21 +336,68 @@ describe("server HTTP body reader", () => {
   });
 
   it("preserves representation length metadata for HEAD responses", async () => {
+    let cancelled = false;
     const server = await startHttpJsonServer({
       async handle() {
-        return new Response(null, {
-          headers: { "content-length": "8" },
-        });
+        return new Response(
+          new ReadableStream({
+            cancel() {
+              cancelled = true;
+            },
+            start(controller) {
+              controller.enqueue(Buffer.alloc(65, 0x78));
+            },
+          }),
+          {
+            headers: { "content-length": "65" },
+          },
+        );
       },
       host: "127.0.0.1",
+      maxResponseBodyBytes: 64,
       port: 0,
       serverName: "test",
     });
 
     try {
       const response = await fetch(server.baseUrl, { method: "HEAD" });
-      expect(response.headers.get("content-length")).toBe("8");
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-length")).toBe("65");
       await expect(response.text()).resolves.toBe("");
+      expect(cancelled).toBe(true);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("does not wait for an unfinished HEAD representation body", async () => {
+    let cancelled = false;
+    const server = await startHttpJsonServer({
+      async handle() {
+        return new Response(
+          new ReadableStream({
+            cancel() {
+              cancelled = true;
+            },
+          }),
+          {
+            headers: { "content-length": "123" },
+            status: 202,
+          },
+        );
+      },
+      host: "127.0.0.1",
+      maxResponseBodyBytes: 1,
+      port: 0,
+      serverName: "test",
+    });
+
+    try {
+      const response = await fetch(server.baseUrl, { method: "HEAD" });
+      expect(response.status).toBe(202);
+      expect(response.headers.get("content-length")).toBe("123");
+      await expect(response.text()).resolves.toBe("");
+      expect(cancelled).toBe(true);
     } finally {
       await server.close();
     }

--- a/test/matrix-server.test.ts
+++ b/test/matrix-server.test.ts
@@ -26,6 +26,8 @@ function auth(token: string) {
   return { authorization: `Bearer ${token}` };
 }
 
+const ROOM_V10_EVENT_ID = /^\$[A-Za-z0-9_-]{43}$/u;
+
 describe("Matrix local provider server", () => {
   it("serves the native client-server API and records room sends", async () => {
     const directory = await createTempDir();
@@ -76,21 +78,34 @@ describe("Matrix local provider server", () => {
         method: "PUT",
       },
     );
-    await expect(sent.json()).resolves.toMatchObject({ event_id: expect.stringMatching(/^\$/u) });
+    const sentBody = (await sent.json()) as { event_id: string };
+    expect(sentBody.event_id).toMatch(ROOM_V10_EVENT_ID);
 
     const sync = await fetch(`${server.manifest.endpoints.syncUrl}?timeout=0`, {
       headers: auth("test-token-placeholder"),
     });
     const syncBody = (await sync.json()) as {
-      rooms: { join: Record<string, { timeline: { events: unknown[] } }> };
+      rooms: {
+        join: Record<
+          string,
+          {
+            state: { events: Array<{ event_id: string }> };
+            timeline: { events: Array<{ event_id: string }> };
+          }
+        >;
+      };
     };
-    expect(syncBody.rooms.join["!qa:matrix.test"]?.timeline.events).toContainEqual(
+    const room = syncBody.rooms.join["!qa:matrix.test"];
+    expect(room?.timeline.events).toContainEqual(
       expect.objectContaining({
         content: { body: "hello Matrix", msgtype: "m.text" },
         sender: server.manifest.botUserId,
         type: "m.room.message",
       }),
     );
+    for (const event of [...(room?.state.events ?? []), ...(room?.timeline.events ?? [])]) {
+      expect(event.event_id).toMatch(ROOM_V10_EVENT_ID);
+    }
 
     const records = (await fs.readFile(recorderPath, "utf8"))
       .trim()
@@ -260,6 +275,24 @@ describe("Matrix local provider server", () => {
       error: "Cannot get filters for another user",
     });
   });
+
+  it.each(["1", -1, 0, 1.5, Number.MAX_SAFE_INTEGER + 1])(
+    "rejects invalid timeline filter limit %j",
+    async (limit) => {
+      const server = await startMatrixServer({ accessToken: "test-token-placeholder" });
+      servers.push(server);
+      const filter = encodeURIComponent(JSON.stringify({ room: { timeline: { limit } } }));
+      const response = await fetch(`${server.manifest.endpoints.syncUrl}?filter=${filter}`, {
+        headers: auth("test-token-placeholder"),
+      });
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({
+        errcode: "M_INVALID_PARAM",
+        error: "Invalid timeline limit",
+      });
+    },
+  );
 
   it("bounds retained filters by count and aggregate bytes", async () => {
     const server = await startMatrixServer({ accessToken: "test-token-placeholder" });

--- a/test/matrix-server.test.ts
+++ b/test/matrix-server.test.ts
@@ -29,6 +29,40 @@ function auth(token: string) {
 const ROOM_V10_EVENT_ID = /^\$[A-Za-z0-9_-]{43}$/u;
 
 describe("Matrix local provider server", () => {
+  it("scopes generated room-v10 event IDs to the server identity", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    const roomId = "!qa:matrix.test";
+    const start = async (serverName: string) => {
+      const server = await startMatrixServer({
+        accessToken: "test-token-placeholder",
+        recorderPath: path.join(directory, `${serverName}.jsonl`),
+        roomId,
+        serverName,
+      });
+      servers.push(server);
+      return server;
+    };
+    const [first, second] = await Promise.all([start("one.test"), start("two.test")]);
+    const send = async (server: StartedMatrixServer) => {
+      const response = await fetch(
+        `${server.manifest.endpoints.clientApiRoot}/rooms/${encodeURIComponent(roomId)}/send/m.room.message/txn-1`,
+        {
+          body: JSON.stringify({ body: "hello Matrix", msgtype: "m.text" }),
+          headers: { ...auth("test-token-placeholder"), "content-type": "application/json" },
+          method: "PUT",
+        },
+      );
+      expect(response.status).toBe(200);
+      return ((await response.json()) as { event_id: string }).event_id;
+    };
+
+    const [firstEventId, secondEventId] = await Promise.all([send(first), send(second)]);
+    expect(firstEventId).toMatch(ROOM_V10_EVENT_ID);
+    expect(secondEventId).toMatch(ROOM_V10_EVENT_ID);
+    expect(secondEventId).not.toBe(firstEventId);
+  });
+
   it("serves the native client-server API and records room sends", async () => {
     const directory = await createTempDir();
     directories.push(directory);

--- a/test/mattermost-server.test.ts
+++ b/test/mattermost-server.test.ts
@@ -1655,6 +1655,36 @@ describe("Mattermost local provider server", () => {
     });
   });
 
+  it("commits concurrent REST posts within one aggregate byte budget", async () => {
+    const server = await startMattermostServer({
+      adminToken: "admin",
+      botToken: "fake",
+      maxCommittedStateBytes: 1_500,
+    });
+    servers.push(server);
+    const registered = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({ channelId: CHANNEL_ID, senderId: USER_ID, text: "register" }),
+      headers: {
+        "content-type": "application/json",
+        "x-crabline-admin-token": "admin",
+      },
+      method: "POST",
+    });
+    expect(registered.status).toBe(200);
+
+    const sendPost = () =>
+      fetch(`${server.manifest.endpoints.apiRoot}/posts`, {
+        body: JSON.stringify({ channel_id: CHANNEL_ID, message: "x".repeat(400) }),
+        headers: {
+          authorization: "Bearer fake",
+          "content-type": "application/json",
+        },
+        method: "POST",
+      });
+    const responses = await Promise.all([sendPost(), sendPost()]);
+    expect(responses.map((response) => response.status).sort()).toEqual([201, 503]);
+  });
+
   it("bounds disconnected pending events by aggregate bytes and releases the budget", async () => {
     const server = await startMattermostServer({
       adminToken: "admin",

--- a/test/mattermost-server.test.ts
+++ b/test/mattermost-server.test.ts
@@ -1360,7 +1360,7 @@ describe("Mattermost local provider server", () => {
     expect((await sendInbound("queue is full")).status).toBe(503);
   });
 
-  it("rejects oversized REST events atomically without disconnecting other clients", async () => {
+  it("creates valid REST posts independently of WebSocket buffer limits", async () => {
     const server = await startMattermostServer({
       adminToken: "admin",
       botToken: "fake",
@@ -1411,10 +1411,11 @@ describe("Mattermost local provider server", () => {
       },
       method: "POST",
     });
-    expect(oversized.status).toBe(413);
-    await expect(oversized.json()).resolves.toMatchObject({
-      message: "WebSocket event is too large",
-      status_code: 413,
+    expect(oversized.status).toBe(201);
+    const oversizedPost = (await oversized.json()) as { id: string; message: string };
+    expect(oversizedPost).toMatchObject({
+      id: mattermostId("post-2"),
+      message: "x".repeat(2_000),
     });
     await Promise.all([firstQuiet, secondQuiet]);
     expect(first.readyState).toBe(WebSocket.OPEN);
@@ -1432,7 +1433,7 @@ describe("Mattermost local provider server", () => {
     });
     expect(accepted.status).toBe(201);
     await expect(accepted.json()).resolves.toMatchObject({
-      id: mattermostId("post-2"),
+      id: mattermostId("post-3"),
       message: "accepted after rejection",
     });
     await expect(firstDelivered).resolves.toMatchObject({ event: "posted" });
@@ -1550,11 +1551,17 @@ describe("Mattermost local provider server", () => {
     await expect(startMattermostServer({ maxCommittedPosts: 0 })).rejects.toThrow(
       "maxCommittedPosts must be a positive safe integer.",
     );
+    await expect(startMattermostServer({ maxCommittedStateBytes: 0 })).rejects.toThrow(
+      "maxCommittedStateBytes must be a positive safe integer.",
+    );
     await expect(startMattermostServer({ maxCommittedUsers: 0 })).rejects.toThrow(
       "maxCommittedUsers must be a positive safe integer.",
     );
     await expect(startMattermostServer({ maxWebSocketBufferedBytes: 0 })).rejects.toThrow(
       "maxWebSocketBufferedBytes must be a positive safe integer.",
+    );
+    await expect(startMattermostServer({ maxPendingInboundBytes: 0 })).rejects.toThrow(
+      "maxPendingInboundBytes must be a positive safe integer.",
     );
     await expect(startMattermostServer({ maxWebSocketMessageBytes: 0 })).rejects.toThrow(
       "maxWebSocketMessageBytes must be a positive safe integer.",
@@ -1615,6 +1622,86 @@ describe("Mattermost local provider server", () => {
       { headers: { authorization: "Bearer fake" } },
     );
     expect(missingChannel.status).toBe(404);
+  });
+
+  it("bounds committed state by aggregate bytes before mutation", async () => {
+    const server = await startMattermostServer({
+      adminToken: "admin",
+      botToken: "fake",
+      maxCommittedStateBytes: 1_500,
+      maxPendingInboundBytes: 5_000,
+    });
+    servers.push(server);
+    const sendInbound = () =>
+      fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({
+          channelId: CHANNEL_ID,
+          senderId: USER_ID,
+          text: "x".repeat(400),
+        }),
+        headers: {
+          "content-type": "application/json",
+          "x-crabline-admin-token": "admin",
+        },
+        method: "POST",
+      });
+
+    expect((await sendInbound()).status).toBe(200);
+    const rejected = await sendInbound();
+    expect(rejected.status).toBe(503);
+    await expect(rejected.json()).resolves.toEqual({
+      error: "Committed Mattermost state limit reached",
+      ok: false,
+    });
+  });
+
+  it("bounds disconnected pending events by aggregate bytes and releases the budget", async () => {
+    const server = await startMattermostServer({
+      adminToken: "admin",
+      botToken: "fake",
+      maxCommittedStateBytes: 5_000,
+      maxPendingInboundBytes: 1_500,
+    });
+    servers.push(server);
+    const sendInbound = async () =>
+      await fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({
+          channelId: CHANNEL_ID,
+          senderId: USER_ID,
+          text: "x".repeat(400),
+        }),
+        headers: {
+          "content-type": "application/json",
+          "x-crabline-admin-token": "admin",
+        },
+        method: "POST",
+      });
+
+    const first = await sendInbound();
+    expect(first.status).toBe(200);
+    const firstPost = ((await first.json()) as { post: { id: string } }).post;
+    expect((await sendInbound()).status).toBe(503);
+
+    const socket = new WebSocket(server.manifest.endpoints.websocketUrl);
+    await waitForSocketOpen(socket);
+    const initialMessages = nextMessages(socket, 3);
+    socket.send(
+      JSON.stringify({
+        action: "authentication_challenge",
+        data: { token: "fake" },
+        seq: 1,
+      }),
+    );
+    await expect(initialMessages).resolves.toHaveLength(3);
+
+    const delivered = nextMessage(socket);
+    const third = await sendInbound();
+    expect(third.status).toBe(200);
+    const thirdPost = ((await third.json()) as { post: { id: string } }).post;
+    expect(firstPost.id).toBe(mattermostId("post-1"));
+    expect(thirdPost.id).toBe(mattermostId("post-2"));
+    await expect(delivered).resolves.toMatchObject({ event: "posted" });
+    socket.close();
   });
 
   it("drains authorized GET and DELETE request bodies", async () => {

--- a/test/server-recorder.test.ts
+++ b/test/server-recorder.test.ts
@@ -648,6 +648,35 @@ describe("server recorder", () => {
     expect(observer).toHaveBeenCalledWith(retryEvent);
   });
 
+  it("preserves a directory sync failure when handle cleanup also fails", async () => {
+    const recorderPath = path.join("/tmp", "recorder-sync-close-failure", "events.jsonl");
+    const syncFailure = new Error("recorder directory sync failed");
+    const closeFailure = new Error("recorder directory close failed");
+    const observer = vi.fn<(event: ServerRequestEvent) => void>();
+    fsMocks.directory.sync.mockRejectedValueOnce(syncFailure);
+    fsMocks.directory.close.mockImplementation(async () => {
+      if (fsMocks.directory.sync.mock.calls.length > 0) {
+        throw closeFailure;
+      }
+    });
+
+    const failure = await recordServerEvent({
+      event: serverEvent("/sync-close-failure"),
+      onEvent: observer,
+      recorderPath,
+    }).catch((error: unknown) => error);
+
+    expect(failure).toBeInstanceOf(ServerRecorderCommittedError);
+    expect(failure).toMatchObject({
+      cause: syncFailure,
+      committed: true,
+      indeterminate: true,
+      name: "ServerRecorderCommittedError",
+    });
+    expect((failure as ServerRecorderCommittedError).errors).toEqual([syncFailure, closeFailure]);
+    expect(observer).not.toHaveBeenCalled();
+  });
+
   it("fails newly created recorder ancestry sync and retries the uncached inode", async () => {
     const firstParent = path.join("/tmp", "recorder-created-denied");
     const finalParent = path.join(firstParent, "nested");

--- a/test/signal-server.test.ts
+++ b/test/signal-server.test.ts
@@ -314,6 +314,7 @@ describe("signal local provider server", () => {
         headers: { "content-type": "application/json" },
         method: "POST",
       });
+      expect(invalid.status).toBe(200);
       await expect(invalid.json()).resolves.toEqual({
         error: { code: -32602, message: "Invalid params" },
         id: `invalid-${method}`,
@@ -401,6 +402,7 @@ describe("signal local provider server", () => {
         headers: { "content-type": "application/json" },
         method: "POST",
       });
+      expect(response.status).toBe(200);
       return await response.json();
     }
 

--- a/test/webhook-target.test.ts
+++ b/test/webhook-target.test.ts
@@ -122,6 +122,30 @@ describe("webhook target validation", () => {
     ).resolves.toEqual({ error: "private-address" });
   });
 
+  it("verifies loopback HTTP DNS answers when private-address filtering is disabled", async () => {
+    await expect(
+      validateWebhookTarget({
+        allowLoopbackHttp: true,
+        dnsLookupPool: new WebhookDnsLookupPool(1, async () => [
+          { address: "93.184.216.34", family: 4 },
+        ]),
+        restrictPrivateAddresses: false,
+        url: new URL("http://hook.localhost/webhook"),
+      }),
+    ).resolves.toEqual({ error: "private-address" });
+
+    await expect(
+      validateWebhookTarget({
+        allowLoopbackHttp: true,
+        dnsLookupPool: new WebhookDnsLookupPool(1, async () => [
+          { address: "127.0.0.1", family: 4 },
+        ]),
+        restrictPrivateAddresses: false,
+        url: new URL("http://hook.localhost/webhook"),
+      }),
+    ).resolves.toEqual({ addresses: [{ address: "127.0.0.1", family: 4 }] });
+  });
+
   it.each(["ftp://93.184.216.34/webhook", "ws://93.184.216.34/webhook"])(
     "rejects unsupported webhook protocol %s",
     async (url) => {


### PR DESCRIPTION
## Summary
- validate resolved loopback targets and honor HEAD body semantics
- preserve Signal JSON-RPC method errors over HTTP 200
- emit Matrix v10 event IDs with server identity and reject invalid timeline limits
- decouple Mattermost REST acceptance from WebSocket buffers and commit retained bytes atomically
- preserve primary recorder durability failures during handle cleanup
- add focused regression coverage and changelog entries

## Validation
- 356 focused tests across protocol servers
- TypeScript typecheck and formatting
- Codex autoreview: gpt-5.6-sol, high, clean (0.90) after review fixes
- Crabbox `pnpm verify`: run `run_058bfe8582f9`, 65 files / 1,805 tests, green