### PR TITLE
fix(windows): harden private publication handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Emit Matrix v10 event IDs in domainless hash form and reject invalid timeline filter limits.
 - Return valid Signal JSON-RPC method errors through successful HTTP responses.
 - Verify resolved loopback webhook addresses and complete HEAD responses without consuming representation bodies.
+- Bind Windows private ancestry creation and failed-file cleanup to stable handles, reject null legacy DACLs, and avoid unnecessary owner-write access during ACL repair.
 - Bind private-directory ACL and recorder-lock mutations to verified identities, quarantine process locks before artifact cleanup, and preserve Windows ancestry rollback failures.
 - Require explicit remote iMessage API keys and decode legacy loopback channel metadata consistently.
 - Preserve configured Mattermost bot identity during admin ingress and avoid overwriting retained channels on direct-channel ID collisions.

--- a/src/openclaw/private-file.ts
+++ b/src/openclaw/private-file.ts
@@ -5,7 +5,10 @@ import fs, { type FileHandle } from "node:fs/promises";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 import { promisify } from "node:util";
-import { applyOwnerOnlyWindowsDirectoryAcl as applyOwnerOnlyWindowsDirectoryAclByHandle } from "../platform/windows-acl.js";
+import {
+  applyOwnerOnlyWindowsDirectoryAcl as applyOwnerOnlyWindowsDirectoryAclByHandle,
+  createOwnerOnlyWindowsDirectoryAncestry as createOwnerOnlyWindowsDirectoryAncestryByHandle,
+} from "../platform/windows-acl.js";
 
 const execFileAsync = promisify(execFile);
 const WINDOWS_ACL_COMMAND_TIMEOUT_MS = 15_000;
@@ -27,6 +30,7 @@ public static class CrablinePrivateFileIdentity
 {
     private const int FileInternalInformationClass = 6;
     private const int FileFsVolumeInformationClass = 1;
+    private const int FileDispositionInfoClass = 4;
 
     [StructLayout(LayoutKind.Sequential)]
     private struct IoStatusBlock
@@ -39,6 +43,13 @@ public static class CrablinePrivateFileIdentity
     private struct FileInternalInformation
     {
         public long IndexNumber;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct FileDispositionInfo
+    {
+        [MarshalAs(UnmanagedType.Bool)]
+        public bool DeleteFile;
     }
 
     [DllImport("ntdll.dll")]
@@ -57,6 +68,15 @@ public static class CrablinePrivateFileIdentity
         [Out] byte[] volumeInformation,
         uint length,
         int volumeInformationClass
+    );
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool SetFileInformationByHandle(
+        SafeFileHandle file,
+        int informationClass,
+        ref FileDispositionInfo information,
+        uint bufferSize
     );
 
     [DllImport("ntdll.dll")]
@@ -102,6 +122,21 @@ public static class CrablinePrivateFileIdentity
             System.Globalization.CultureInfo.InvariantCulture
         );
     }
+
+    public static void MarkDelete(SafeFileHandle file)
+    {
+        FileDispositionInfo disposition = new FileDispositionInfo {
+            DeleteFile = true
+        };
+        if (!SetFileInformationByHandle(
+            file,
+            FileDispositionInfoClass,
+            ref disposition,
+            (uint)Marshal.SizeOf(typeof(FileDispositionInfo))
+        )) {
+            throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+    }
 }
 "@
 
@@ -124,7 +159,8 @@ $acl.SetAccessRule($rule)
 $rights = (
   [System.Security.AccessControl.FileSystemRights]::Read -bor
   [System.Security.AccessControl.FileSystemRights]::Write -bor
-  [System.Security.AccessControl.FileSystemRights]::ReadPermissions
+  [System.Security.AccessControl.FileSystemRights]::ReadPermissions -bor
+  [System.Security.AccessControl.FileSystemRights]::Delete
 )
 $stream = [System.IO.FileStream]::new(
   $filePath,
@@ -164,173 +200,22 @@ try {
   [Console]::Out.Write(
     [CrablinePrivateFileIdentity]::Read($stream.SafeFileHandle)
   )
-} finally {
-  $stream.Dispose()
-}
-`;
-
-const WINDOWS_CREATE_OWNER_ONLY_DIRECTORY_ANCESTRY_SCRIPT = String.raw`
-$ErrorActionPreference = "Stop"
-$directoryPath = $env:CRABLINE_PRIVATE_DIRECTORY_PATH
-if ([string]::IsNullOrWhiteSpace($directoryPath)) {
-  throw "CRABLINE_PRIVATE_DIRECTORY_PATH is required."
-}
-
-Add-Type -TypeDefinition @"
-using System;
-using System.ComponentModel;
-using System.Runtime.InteropServices;
-
-public static class CrablinePrivateDirectory
-{
-    [StructLayout(LayoutKind.Sequential)]
-    private struct SecurityAttributes
-    {
-        public int Length;
-        public IntPtr SecurityDescriptor;
-        [MarshalAs(UnmanagedType.Bool)]
-        public bool InheritHandle;
-    }
-
-    [DllImport(
-        "kernel32.dll",
-        CharSet = CharSet.Unicode,
-        SetLastError = true
-    )]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static extern bool CreateDirectory(
-        string path,
-        ref SecurityAttributes securityAttributes
-    );
-
-    public static void CreateNew(string path, byte[] securityDescriptor)
-    {
-        GCHandle descriptorHandle = GCHandle.Alloc(
-            securityDescriptor,
-            GCHandleType.Pinned
-        );
-        try {
-            SecurityAttributes attributes = new SecurityAttributes {
-                Length = Marshal.SizeOf(typeof(SecurityAttributes)),
-                SecurityDescriptor = descriptorHandle.AddrOfPinnedObject(),
-                InheritHandle = false
-            };
-            if (!CreateDirectory(path, ref attributes)) {
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-            }
-        } finally {
-            descriptorHandle.Free();
-        }
-    }
-}
-"@
-
-$identity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
-$sid = $identity.User
-if ($null -eq $sid) {
-  throw "Could not resolve the current Windows user SID."
-}
-
-$acl = [System.Security.AccessControl.DirectorySecurity]::new()
-$acl.SetOwner($sid)
-$acl.SetAccessRuleProtection($true, $false)
-$inheritance = (
-  [System.Security.AccessControl.InheritanceFlags]::ContainerInherit -bor
-  [System.Security.AccessControl.InheritanceFlags]::ObjectInherit
-)
-$rule = [System.Security.AccessControl.FileSystemAccessRule]::new(
-  $sid,
-  [System.Security.AccessControl.FileSystemRights]::FullControl,
-  $inheritance,
-  [System.Security.AccessControl.PropagationFlags]::None,
-  [System.Security.AccessControl.AccessControlType]::Allow
-)
-$acl.SetAccessRule($rule)
-$descriptor = $acl.GetSecurityDescriptorBinaryForm()
-
-$target = [System.IO.Path]::GetFullPath($directoryPath)
-$missing = [System.Collections.Generic.List[string]]::new()
-$current = $target
-while (-not [System.IO.Directory]::Exists($current)) {
-  if ([System.IO.File]::Exists($current)) {
-    throw "Private directory ancestry contains a non-directory entry."
-  }
-  $missing.Add($current)
-  $parent = [System.IO.Directory]::GetParent($current)
-  if ($null -eq $parent) {
-    throw "Private directory ancestry has no existing parent."
-  }
-  $current = $parent.FullName
-}
-
-$paths = $missing.ToArray()
-[Array]::Reverse($paths)
-$created = [System.Collections.Generic.List[string]]::new()
-try {
-  foreach ($candidate in $paths) {
-    [CrablinePrivateDirectory]::CreateNew($candidate, $descriptor)
-    $created.Add($candidate)
-
-    $actual = [System.IO.DirectoryInfo]::new($candidate).GetAccessControl()
-    $ownerSid = $actual.GetOwner([System.Security.Principal.SecurityIdentifier])
-    $rules = @($actual.GetAccessRules(
-      $true,
-      $true,
-      [System.Security.Principal.SecurityIdentifier]
-    ))
-    if (-not $actual.AreAccessRulesProtected) {
-      throw "Private directory DACL still inherits permissions."
-    }
-    if ($ownerSid.Value -ne $sid.Value) {
-      throw "Private directory owner SID does not match the current user."
-    }
-    if ($rules.Count -ne 1) {
-      throw "Private directory DACL must contain exactly one access rule."
-    }
-    $actualRule = $rules[0]
-    if (
-      $actualRule.IsInherited -or
-      $actualRule.IdentityReference.Value -ne $sid.Value -or
-      $actualRule.AccessControlType -ne [System.Security.AccessControl.AccessControlType]::Allow -or
-      (($actualRule.FileSystemRights -band [System.Security.AccessControl.FileSystemRights]::FullControl) -ne [System.Security.AccessControl.FileSystemRights]::FullControl) -or
-      (($actualRule.InheritanceFlags -band $inheritance) -ne $inheritance)
-    ) {
-      throw "Private directory DACL is not owner-only inheritable full control."
-    }
-
-    $entries = [System.IO.Directory]::EnumerateFileSystemEntries($candidate).GetEnumerator()
-    try {
-      if ($entries.MoveNext()) {
-        throw "New private directory was populated during creation."
-      }
-    } finally {
-      $entries.Dispose()
-    }
-  }
 } catch {
   $primaryError = $_.Exception
-  $cleanupErrors = [System.Collections.Generic.List[System.Exception]]::new()
-  for ($index = $created.Count - 1; $index -ge 0; $index--) {
-    try {
-      [System.IO.Directory]::Delete($created[$index], $false)
-    } catch {
-      $cleanupErrors.Add($_.Exception)
-    }
-  }
-  if ($cleanupErrors.Count -gt 0) {
+  try {
+    [CrablinePrivateFileIdentity]::MarkDelete($stream.SafeFileHandle)
+  } catch {
     $aggregateErrors = [System.Collections.Generic.List[System.Exception]]::new()
     $aggregateErrors.Add($primaryError)
-    $aggregateErrors.AddRange($cleanupErrors)
+    $aggregateErrors.Add($_.Exception)
     throw [System.AggregateException]::new(
-      "Private directory ancestry creation and rollback cleanup failed.",
+      "Private file creation and handle-bound cleanup failed.",
       $aggregateErrors
     )
   }
   throw $primaryError
-}
-
-if ($created.Count -gt 0) {
-  [Console]::Out.Write($created[0])
+} finally {
+  $stream.Dispose()
 }
 `;
 
@@ -452,6 +337,17 @@ $genericAll = [uint32]0x10000000
 $inheritOnly = [System.Security.AccessControl.PropagationFlags]::InheritOnly
 
 $actual = Get-Acl -LiteralPath $directoryPath
+$rawDescriptor = [System.Security.AccessControl.RawSecurityDescriptor]::new(
+  $actual.GetSecurityDescriptorBinaryForm(),
+  0
+)
+if (
+  (($rawDescriptor.ControlFlags -band
+    [System.Security.AccessControl.ControlFlags]::DiscretionaryAclPresent) -eq 0) -or
+  $null -eq $rawDescriptor.DiscretionaryAcl
+) {
+  throw "Directory has an absent or null DACL in private mutation ancestry."
+}
 $ownerSid = $actual.GetOwner([System.Security.Principal.SecurityIdentifier])
 if ($trustedSids -notcontains $ownerSid.Value) {
   throw "Directory owner is not trusted for private mutation ancestry."
@@ -515,6 +411,17 @@ $mutationAccessMask = [BitConverter]::ToUInt32(
 )
 
 $actual = Get-Acl -LiteralPath $directoryPath
+$rawDescriptor = [System.Security.AccessControl.RawSecurityDescriptor]::new(
+  $actual.GetSecurityDescriptorBinaryForm(),
+  0
+)
+if (
+  (($rawDescriptor.ControlFlags -band
+    [System.Security.AccessControl.ControlFlags]::DiscretionaryAclPresent) -eq 0) -or
+  $null -eq $rawDescriptor.DiscretionaryAcl
+) {
+  throw "Directory has an absent or null DACL in private mutation ancestry."
+}
 $ownerSid = $actual.GetOwner([System.Security.Principal.SecurityIdentifier])
 if ($trustedSids -notcontains $ownerSid.Value) {
   throw "Directory owner is not trusted for private mutation ancestry."
@@ -625,28 +532,7 @@ export async function createOwnerOnlyWindowsDirectoryAncestry(
   systemRoot: string | null | undefined = process.env.SystemRoot,
 ): Promise<string | undefined> {
   try {
-    const powershellPath = resolveWindowsPowerShellPath(systemRoot);
-    const output = await run(
-      powershellPath,
-      [
-        "-NoLogo",
-        "-NoProfile",
-        "-NonInteractive",
-        "-Command",
-        WINDOWS_CREATE_OWNER_ONLY_DIRECTORY_ANCESTRY_SCRIPT,
-      ],
-      {
-        env: {
-          ...process.env,
-          CRABLINE_PRIVATE_DIRECTORY_PATH: path.resolve(directoryPath),
-        },
-        killSignal: "SIGKILL",
-        timeout: WINDOWS_ACL_COMMAND_TIMEOUT_MS,
-        windowsHide: true,
-      },
-    );
-    const firstCreatedDirectory = output.trim();
-    return firstCreatedDirectory.length > 0 ? firstCreatedDirectory : undefined;
+    return await createOwnerOnlyWindowsDirectoryAncestryByHandle(directoryPath, run, systemRoot);
   } catch (error) {
     throw new Error(
       "Could not atomically create and verify owner-only Windows private directory ancestry; Windows PowerShell security descriptor support is required.",

--- a/src/platform/windows-acl.ts
+++ b/src/platform/windows-acl.ts
@@ -16,6 +16,8 @@ using Microsoft.Win32.SafeHandles;
 public static class CrablineWindowsDirectoryHandle
 {
     private const uint FileReadAttributes = 0x00000080;
+    private const uint FileTraverse = 0x00000020;
+    private const uint Delete = 0x00010000;
     private const uint ReadControl = 0x00020000;
     private const uint WriteDac = 0x00040000;
     private const uint WriteOwner = 0x00080000;
@@ -25,6 +27,7 @@ public static class CrablineWindowsDirectoryHandle
     private const uint OpenExisting = 3;
     private const uint FileFlagBackupSemantics = 0x02000000;
     private const uint FileFlagOpenReparsePoint = 0x00200000;
+    private const uint FileOpen = 1;
     private const uint FileCreate = 2;
     private const uint FileDirectoryFile = 0x00000001;
     private const uint FileSynchronousIoNonAlert = 0x00000020;
@@ -34,6 +37,7 @@ public static class CrablineWindowsDirectoryHandle
     private const uint DirectoryAttribute = 0x00000010;
     private const uint ReparsePointAttribute = 0x00000400;
     private const int FileIdInfoClass = 18;
+    private const int FileDispositionInfoClass = 4;
     private const uint OwnerSecurityInformation = 0x00000001;
     private const uint DaclSecurityInformation = 0x00000004;
     private const uint ProtectedDaclSecurityInformation = 0x80000000;
@@ -73,6 +77,13 @@ public static class CrablineWindowsDirectoryHandle
     {
         public ulong VolumeSerialNumber;
         public FileId128 FileId;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct FileDispositionInfo
+    {
+        [MarshalAs(UnmanagedType.Bool)]
+        public bool DeleteFile;
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -150,6 +161,15 @@ public static class CrablineWindowsDirectoryHandle
         uint bufferSize
     );
 
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool SetFileInformationByHandle(
+        SafeFileHandle file,
+        int informationClass,
+        ref FileDispositionInfo information,
+        uint bufferSize
+    );
+
     [DllImport("advapi32.dll")]
     private static extern uint GetSecurityInfo(
         SafeFileHandle file,
@@ -200,15 +220,35 @@ public static class CrablineWindowsDirectoryHandle
         IntPtr memory
     );
 
-    public static SafeFileHandle Open(string path, bool writable)
+    private static uint AccessMask(
+        bool writeDacl,
+        bool writeOwner,
+        bool traverse
+    )
     {
         uint access = FileReadAttributes | ReadControl;
-        if (writable) {
-            access |= WriteDac | WriteOwner;
+        if (traverse) {
+            access |= FileTraverse;
         }
+        if (writeDacl) {
+            access |= WriteDac;
+        }
+        if (writeOwner) {
+            access |= WriteOwner;
+        }
+        return access;
+    }
+
+    public static SafeFileHandle Open(
+        string path,
+        bool writeDacl,
+        bool writeOwner,
+        bool traverse
+    )
+    {
         SafeFileHandle file = CreateFile(
             path,
-            access,
+            AccessMask(writeDacl, writeOwner, traverse),
             ShareRead | ShareWrite,
             IntPtr.Zero,
             OpenExisting,
@@ -227,30 +267,47 @@ public static class CrablineWindowsDirectoryHandle
         }
     }
 
-    public static SafeFileHandle Create(string path, byte[] securityDescriptor)
+    private static SafeFileHandle OpenRelativeCore(
+        SafeFileHandle parent,
+        string name,
+        bool writeDacl,
+        bool writeOwner,
+        bool traverse,
+        uint createDisposition,
+        byte[] securityDescriptor,
+        bool deleteAccess
+    )
     {
-        string fullPath = Path.GetFullPath(path);
-        string nativePath;
-        if (fullPath.StartsWith(@"\\?\", StringComparison.Ordinal)) {
-            nativePath = @"\??\" + fullPath.Substring(4);
-        } else if (fullPath.StartsWith(@"\\", StringComparison.Ordinal)) {
-            nativePath = @"\??\UNC\" + fullPath.Substring(2);
-        } else {
-            nativePath = @"\??\" + fullPath;
+        if (
+            String.IsNullOrEmpty(name) ||
+            name == "." ||
+            name == ".." ||
+            name.IndexOf(Path.DirectorySeparatorChar) >= 0 ||
+            name.IndexOf(Path.AltDirectorySeparatorChar) >= 0
+        ) {
+            throw new ArgumentException(
+                "Private directory child name must be one path component.",
+                "name"
+            );
         }
-        int pathBytes = nativePath.Length * 2;
+        int pathBytes = name.Length * 2;
         if (pathBytes > UInt16.MaxValue - 2) {
             throw new PathTooLongException();
         }
 
-        GCHandle descriptorHandle = GCHandle.Alloc(
-            securityDescriptor,
-            GCHandleType.Pinned
-        );
+        GCHandle descriptorHandle = default(GCHandle);
         IntPtr pathBuffer = IntPtr.Zero;
         IntPtr objectNameBuffer = IntPtr.Zero;
+        bool parentAddRef = false;
         try {
-            pathBuffer = Marshal.StringToHGlobalUni(nativePath);
+            if (securityDescriptor != null) {
+                descriptorHandle = GCHandle.Alloc(
+                    securityDescriptor,
+                    GCHandleType.Pinned
+                );
+            }
+            parent.DangerousAddRef(ref parentAddRef);
+            pathBuffer = Marshal.StringToHGlobalUni(name);
             UnicodeString objectName = new UnicodeString {
                 Length = (ushort)pathBytes,
                 MaximumLength = (ushort)(pathBytes + 2),
@@ -262,27 +319,27 @@ public static class CrablineWindowsDirectoryHandle
             Marshal.StructureToPtr(objectName, objectNameBuffer, false);
             ObjectAttributes attributes = new ObjectAttributes {
                 Length = Marshal.SizeOf(typeof(ObjectAttributes)),
-                RootDirectory = IntPtr.Zero,
+                RootDirectory = parent.DangerousGetHandle(),
                 ObjectName = objectNameBuffer,
                 Attributes = ObjectCaseInsensitive,
-                SecurityDescriptor = descriptorHandle.AddrOfPinnedObject(),
+                SecurityDescriptor = securityDescriptor == null
+                    ? IntPtr.Zero
+                    : descriptorHandle.AddrOfPinnedObject(),
                 SecurityQualityOfService = IntPtr.Zero
             };
             IoStatusBlock ioStatus;
             SafeFileHandle file;
             int status = NtCreateFile(
                 out file,
-                FileReadAttributes |
-                    ReadControl |
-                    WriteDac |
-                    WriteOwner |
+                AccessMask(writeDacl, writeOwner, traverse) |
+                    (deleteAccess ? Delete : 0) |
                     Synchronize,
                 ref attributes,
                 out ioStatus,
                 IntPtr.Zero,
                 FileAttributeNormal,
                 ShareRead | ShareWrite,
-                FileCreate,
+                createDisposition,
                 FileDirectoryFile |
                     FileSynchronousIoNonAlert |
                     FileOpenReparsePoint,
@@ -296,7 +353,7 @@ public static class CrablineWindowsDirectoryHandle
             }
             if (file == null || file.IsInvalid) {
                 throw new InvalidOperationException(
-                    "Windows did not return the created directory handle."
+                    "Windows did not return the directory handle."
                 );
             }
             try {
@@ -313,7 +370,65 @@ public static class CrablineWindowsDirectoryHandle
             if (pathBuffer != IntPtr.Zero) {
                 Marshal.FreeHGlobal(pathBuffer);
             }
-            descriptorHandle.Free();
+            if (parentAddRef) {
+                parent.DangerousRelease();
+            }
+            if (descriptorHandle.IsAllocated) {
+                descriptorHandle.Free();
+            }
+        }
+    }
+
+    public static SafeFileHandle CreateRelative(
+        SafeFileHandle parent,
+        string name,
+        byte[] securityDescriptor
+    )
+    {
+        return OpenRelativeCore(
+            parent,
+            name,
+            true,
+            false,
+            true,
+            FileCreate,
+            securityDescriptor,
+            true
+        );
+    }
+
+    public static SafeFileHandle OpenRelative(
+        SafeFileHandle parent,
+        string name,
+        bool writeDacl,
+        bool writeOwner,
+        bool traverse
+    )
+    {
+        return OpenRelativeCore(
+            parent,
+            name,
+            writeDacl,
+            writeOwner,
+            traverse,
+            FileOpen,
+            null,
+            false
+        );
+    }
+
+    public static void MarkDelete(SafeFileHandle file)
+    {
+        FileDispositionInfo disposition = new FileDispositionInfo {
+            DeleteFile = true
+        };
+        if (!SetFileInformationByHandle(
+            file,
+            FileDispositionInfoClass,
+            ref disposition,
+            (uint)Marshal.SizeOf(typeof(FileDispositionInfo))
+        )) {
+            throw new Win32Exception(Marshal.GetLastWin32Error());
         }
     }
 
@@ -401,7 +516,8 @@ public static class CrablineWindowsDirectoryHandle
 
     public static void WriteSecurityDescriptor(
         SafeFileHandle file,
-        byte[] securityDescriptor
+        byte[] securityDescriptor,
+        bool writeOwner
     )
     {
         GCHandle descriptorHandle = GCHandle.Alloc(
@@ -410,14 +526,16 @@ public static class CrablineWindowsDirectoryHandle
         );
         try {
             IntPtr descriptor = descriptorHandle.AddrOfPinnedObject();
-            IntPtr owner;
-            bool ownerDefaulted;
-            if (!GetSecurityDescriptorOwner(
-                descriptor,
-                out owner,
-                out ownerDefaulted
-            )) {
-                throw new Win32Exception(Marshal.GetLastWin32Error());
+            IntPtr owner = IntPtr.Zero;
+            if (writeOwner) {
+                bool ownerDefaulted;
+                if (!GetSecurityDescriptorOwner(
+                    descriptor,
+                    out owner,
+                    out ownerDefaulted
+                )) {
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+                }
             }
             bool daclPresent;
             IntPtr dacl;
@@ -430,17 +548,21 @@ public static class CrablineWindowsDirectoryHandle
             )) {
                 throw new Win32Exception(Marshal.GetLastWin32Error());
             }
-            if (!daclPresent) {
+            if (!daclPresent || dacl == IntPtr.Zero) {
                 throw new InvalidOperationException(
-                    "Private directory security descriptor has no DACL."
+                    "Private directory security descriptor has no usable DACL."
                 );
+            }
+            uint securityInformation =
+                DaclSecurityInformation |
+                ProtectedDaclSecurityInformation;
+            if (writeOwner) {
+                securityInformation |= OwnerSecurityInformation;
             }
             uint error = SetSecurityInfo(
                 file,
                 SeFileObject,
-                OwnerSecurityInformation |
-                    DaclSecurityInformation |
-                    ProtectedDaclSecurityInformation,
+                securityInformation,
                 owner,
                 IntPtr.Zero,
                 dacl,
@@ -469,7 +591,7 @@ public static class CrablineWindowsDirectoryHandle
 
     public static string ReadPathIdentity(string path)
     {
-        using (SafeFileHandle current = Open(path, false)) {
+        using (SafeFileHandle current = Open(path, false, false, false)) {
             return ReadIdentity(current);
         }
     }
@@ -502,13 +624,35 @@ if ($null -eq $sid) {
   throw "Could not resolve the current Windows user SID."
 }
 
-$directory = [CrablineWindowsDirectoryHandle]::Open($directoryPath, $true)
+$inspection = [CrablineWindowsDirectoryHandle]::Open(
+  $directoryPath,
+  $false,
+  $false,
+  $false
+)
+$directory = $null
 try {
-  $directoryIdentity = [CrablineWindowsDirectoryHandle]::ReadIdentity($directory)
+  $directoryIdentity = [CrablineWindowsDirectoryHandle]::ReadIdentity($inspection)
   $acl = [System.Security.AccessControl.DirectorySecurity]::new()
   $acl.SetSecurityDescriptorBinaryForm(
-    [CrablineWindowsDirectoryHandle]::ReadSecurityDescriptor($directory)
+    [CrablineWindowsDirectoryHandle]::ReadSecurityDescriptor($inspection)
   )
+  $currentOwner = $acl.GetOwner(
+    [System.Security.Principal.SecurityIdentifier]
+  )
+  $writeOwner = $currentOwner.Value -ne $sid.Value
+  $directory = [CrablineWindowsDirectoryHandle]::Open(
+    $directoryPath,
+    $true,
+    $writeOwner,
+    $false
+  )
+  if (
+    [CrablineWindowsDirectoryHandle]::ReadIdentity($directory) -ne
+    $directoryIdentity
+  ) {
+    throw "Private directory identity changed before ACL repair."
+  }
   $acl.SetOwner($sid)
   $acl.SetAccessRuleProtection($true, $false)
   $existingRules = @($acl.GetAccessRules(
@@ -533,7 +677,8 @@ try {
   $acl.SetAccessRule($rule)
   [CrablineWindowsDirectoryHandle]::WriteSecurityDescriptor(
     $directory,
-    $acl.GetSecurityDescriptorBinaryForm()
+    $acl.GetSecurityDescriptorBinaryForm(),
+    $writeOwner
   )
 
   $actual = [System.Security.AccessControl.DirectorySecurity]::new()
@@ -574,7 +719,10 @@ try {
     $directoryIdentity
   )
 } finally {
-  $directory.Dispose()
+  if ($null -ne $directory) {
+    $directory.Dispose()
+  }
+  $inspection.Dispose()
 }
 `;
 
@@ -603,7 +751,12 @@ function Assert-SafeParentNamespace(
   [string]$candidate,
   [bool]$rejectChildCreation
 ) {
-  $parentDirectory = [CrablineWindowsDirectoryHandle]::Open($candidate, $false)
+  $parentDirectory = [CrablineWindowsDirectoryHandle]::Open(
+    $candidate,
+    $false,
+    $false,
+    $false
+  )
   try {
     # ReadIdentity rejects reparse points, so the lexical walk cannot cross a junction.
     $parentIdentity = [CrablineWindowsDirectoryHandle]::ReadIdentity($parentDirectory)
@@ -743,65 +896,140 @@ if ($missing.Count -eq 0) {
   }
   $current = $parent.FullName
 }
-Assert-SafeNamespaceChain $current ($missing.Count -gt 0)
 
 $directory = $null
-if ($missing.Count -eq 0) {
-  $directory = [CrablineWindowsDirectoryHandle]::Open($directoryPath, $true)
-  $acl = [System.Security.AccessControl.DirectorySecurity]::new()
-  $acl.SetSecurityDescriptorBinaryForm(
-    [CrablineWindowsDirectoryHandle]::ReadSecurityDescriptor($directory)
-  )
-  $acl.SetOwner($sid)
-  $acl.SetAccessRuleProtection($true, $false)
-  $existingRules = @($acl.GetAccessRules(
-    $true,
-    $false,
-    [System.Security.Principal.SecurityIdentifier]
-  ))
-  foreach ($existingRule in $existingRules) {
-    [void]$acl.RemoveAccessRuleSpecific($existingRule)
-  }
-  $acl.SetAccessRule($rule)
-  [CrablineWindowsDirectoryHandle]::WriteSecurityDescriptor(
-    $directory,
-    $acl.GetSecurityDescriptorBinaryForm()
-  )
-} else {
-  $paths = $missing.ToArray()
-  [Array]::Reverse($paths)
-  foreach ($candidate in $paths) {
-    $createdDirectory = $null
-    try {
-      $createdDirectory = [CrablineWindowsDirectoryHandle]::Create(
-        $candidate,
-        $descriptor
-      )
-    } catch [System.ComponentModel.Win32Exception] {
-      if (
-        $_.Exception.NativeErrorCode -ne 80 -and
-        $_.Exception.NativeErrorCode -ne 183
-      ) {
-        throw
-      }
-      $createdDirectory = [CrablineWindowsDirectoryHandle]::Open($candidate, $true)
-      [void][CrablineWindowsDirectoryHandle]::ReadIdentity($createdDirectory)
-      [CrablineWindowsDirectoryHandle]::WriteSecurityDescriptor(
-        $createdDirectory,
-        $descriptor
-      )
-    }
-    if ($candidate -eq $directoryPath) {
-      $directory = $createdDirectory
-    } else {
-      $createdDirectory.Dispose()
-    }
-  }
-}
-if ($null -eq $directory) {
-  throw "Windows did not return the private directory handle."
-}
+$heldDirectories = [System.Collections.Generic.List[Microsoft.Win32.SafeHandles.SafeFileHandle]]::new()
+$createdDirectories = [System.Collections.Generic.List[Microsoft.Win32.SafeHandles.SafeFileHandle]]::new()
+$firstCreatedDirectory = $null
 try {
+  if ($missing.Count -eq 0) {
+    $inspection = [CrablineWindowsDirectoryHandle]::Open(
+      $directoryPath,
+      $false,
+      $false,
+      $false
+    )
+    $heldDirectories.Add($inspection)
+    $directoryIdentity = [CrablineWindowsDirectoryHandle]::ReadIdentity($inspection)
+    Assert-SafeNamespaceChain $current $false
+    [CrablineWindowsDirectoryHandle]::AssertSamePathIdentity(
+      $directoryPath,
+      $directoryIdentity
+    )
+    $currentAcl = [System.Security.AccessControl.DirectorySecurity]::new()
+    $currentAcl.SetSecurityDescriptorBinaryForm(
+      [CrablineWindowsDirectoryHandle]::ReadSecurityDescriptor($inspection)
+    )
+    $currentOwner = $currentAcl.GetOwner(
+      [System.Security.Principal.SecurityIdentifier]
+    )
+    $writeOwner = $currentOwner.Value -ne $sid.Value
+    $directory = [CrablineWindowsDirectoryHandle]::Open(
+      $directoryPath,
+      $true,
+      $writeOwner,
+      $false
+    )
+    $heldDirectories.Add($directory)
+    if (
+      [CrablineWindowsDirectoryHandle]::ReadIdentity($directory) -ne
+      $directoryIdentity
+    ) {
+      throw "Private directory identity changed before ACL repair."
+    }
+    [CrablineWindowsDirectoryHandle]::WriteSecurityDescriptor(
+      $directory,
+      $descriptor,
+      $writeOwner
+    )
+  } else {
+    $paths = $missing.ToArray()
+    [Array]::Reverse($paths)
+    $parentDirectory = [CrablineWindowsDirectoryHandle]::Open(
+      $current,
+      $false,
+      $false,
+      $true
+    )
+    $heldDirectories.Add($parentDirectory)
+    $existingParentIdentity = [CrablineWindowsDirectoryHandle]::ReadIdentity(
+      $parentDirectory
+    )
+    Assert-SafeNamespaceChain $current $true
+    [CrablineWindowsDirectoryHandle]::AssertSamePathIdentity(
+      $current,
+      $existingParentIdentity
+    )
+
+    foreach ($candidate in $paths) {
+      $childName = [System.IO.Path]::GetFileName($candidate)
+      $createdDirectory = $null
+      try {
+        $createdDirectory = [CrablineWindowsDirectoryHandle]::CreateRelative(
+          $parentDirectory,
+          $childName,
+          $descriptor
+        )
+        $createdDirectories.Add($createdDirectory)
+        if ($null -eq $firstCreatedDirectory) {
+          $firstCreatedDirectory = $candidate
+        }
+      } catch [System.ComponentModel.Win32Exception] {
+        if (
+          $_.Exception.NativeErrorCode -ne 80 -and
+          $_.Exception.NativeErrorCode -ne 183
+        ) {
+          throw
+        }
+        $inspection = [CrablineWindowsDirectoryHandle]::OpenRelative(
+          $parentDirectory,
+          $childName,
+          $false,
+          $false,
+          $false
+        )
+        $heldDirectories.Add($inspection)
+        $childIdentity = [CrablineWindowsDirectoryHandle]::ReadIdentity($inspection)
+        $currentAcl = [System.Security.AccessControl.DirectorySecurity]::new()
+        $currentAcl.SetSecurityDescriptorBinaryForm(
+          [CrablineWindowsDirectoryHandle]::ReadSecurityDescriptor($inspection)
+        )
+        $currentOwner = $currentAcl.GetOwner(
+          [System.Security.Principal.SecurityIdentifier]
+        )
+        $writeOwner = $currentOwner.Value -ne $sid.Value
+        $createdDirectory = [CrablineWindowsDirectoryHandle]::OpenRelative(
+          $parentDirectory,
+          $childName,
+          $true,
+          $writeOwner,
+          $true
+        )
+        if (
+          [CrablineWindowsDirectoryHandle]::ReadIdentity($createdDirectory) -ne
+          $childIdentity
+        ) {
+          $createdDirectory.Dispose()
+          throw "Private directory identity changed before ACL repair."
+        }
+        [CrablineWindowsDirectoryHandle]::WriteSecurityDescriptor(
+          $createdDirectory,
+          $descriptor,
+          $writeOwner
+        )
+      }
+      $heldDirectories.Add($createdDirectory)
+      $parentDirectory = $createdDirectory
+    }
+    $directory = $parentDirectory
+    [CrablineWindowsDirectoryHandle]::AssertSamePathIdentity(
+      $current,
+      $existingParentIdentity
+    )
+  }
+  if ($null -eq $directory) {
+    throw "Windows did not return the private directory handle."
+  }
   $directoryIdentity = [CrablineWindowsDirectoryHandle]::ReadIdentity($directory)
   $actual = [System.Security.AccessControl.DirectorySecurity]::new()
   $actual.SetSecurityDescriptorBinaryForm(
@@ -836,8 +1064,36 @@ try {
     $directoryPath,
     $directoryIdentity
   )
+  if ($null -ne $firstCreatedDirectory) {
+    [Console]::Out.Write($firstCreatedDirectory)
+  }
+} catch {
+  $primaryError = $_.Exception
+  $cleanupErrors = [System.Collections.Generic.List[System.Exception]]::new()
+  for ($index = $createdDirectories.Count - 1; $index -ge 0; $index--) {
+    try {
+      [CrablineWindowsDirectoryHandle]::MarkDelete(
+        $createdDirectories[$index]
+      )
+      $createdDirectories[$index].Dispose()
+    } catch {
+      $cleanupErrors.Add($_.Exception)
+    }
+  }
+  if ($cleanupErrors.Count -gt 0) {
+    $aggregateErrors = [System.Collections.Generic.List[System.Exception]]::new()
+    $aggregateErrors.Add($primaryError)
+    $aggregateErrors.AddRange($cleanupErrors)
+    throw [System.AggregateException]::new(
+      "Private directory ancestry creation and rollback cleanup failed.",
+      $aggregateErrors
+    )
+  }
+  throw $primaryError
 } finally {
-  $directory.Dispose()
+  for ($index = $heldDirectories.Count - 1; $index -ge 0; $index--) {
+    $heldDirectories[$index].Dispose()
+  }
 }
 `;
 
@@ -874,7 +1130,12 @@ if ($null -eq $parent) {
 }
 Assert-SafeNamespaceChain $parent.FullName $false
 
-$directory = [CrablineWindowsDirectoryHandle]::Open($directoryPath, $false)
+$directory = [CrablineWindowsDirectoryHandle]::Open(
+  $directoryPath,
+  $false,
+  $false,
+  $false
+)
 try {
   $directoryIdentity = [CrablineWindowsDirectoryHandle]::ReadIdentity($directory)
   $descriptor = [CrablineWindowsDirectoryHandle]::ReadSecurityDescriptor($directory)
@@ -950,7 +1211,12 @@ ${WINDOWS_SAFE_PARENT_NAMESPACE_HELPER}
 
 Assert-SafeNamespaceChain $directoryPath $true
 
-$directory = [CrablineWindowsDirectoryHandle]::Open($directoryPath, $false)
+$directory = [CrablineWindowsDirectoryHandle]::Open(
+  $directoryPath,
+  $false,
+  $false,
+  $false
+)
 try {
   $directoryIdentity = [CrablineWindowsDirectoryHandle]::ReadIdentity($directory)
   $descriptor = [CrablineWindowsDirectoryHandle]::ReadSecurityDescriptor($directory)
@@ -1032,32 +1298,42 @@ export async function applyOwnerOnlyWindowsDirectoryAcl(
   }
 }
 
+export async function createOwnerOnlyWindowsDirectoryAncestry(
+  directoryPath: string,
+  run: WindowsAclRunner = runWindowsAclCommand,
+  systemRoot: string | null | undefined = process.env.SystemRoot,
+): Promise<string | undefined> {
+  const powershellPath = resolveWindowsPowerShellPath(systemRoot);
+  const output = await run(
+    powershellPath,
+    [
+      "-NoLogo",
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      WINDOWS_CREATE_OWNER_ONLY_DIRECTORY_SCRIPT,
+    ],
+    {
+      env: {
+        ...process.env,
+        CRABLINE_PRIVATE_DIRECTORY_PATH: path.resolve(directoryPath),
+      },
+      killSignal: "SIGKILL",
+      timeout: WINDOWS_ACL_COMMAND_TIMEOUT_MS,
+      windowsHide: true,
+    },
+  );
+  const firstCreatedDirectory = output.trim();
+  return firstCreatedDirectory.length > 0 ? firstCreatedDirectory : undefined;
+}
+
 export async function createOwnerOnlyWindowsDirectory(
   directoryPath: string,
   run: WindowsAclRunner = runWindowsAclCommand,
   systemRoot: string | null | undefined = process.env.SystemRoot,
 ): Promise<void> {
   try {
-    const powershellPath = resolveWindowsPowerShellPath(systemRoot);
-    await run(
-      powershellPath,
-      [
-        "-NoLogo",
-        "-NoProfile",
-        "-NonInteractive",
-        "-Command",
-        WINDOWS_CREATE_OWNER_ONLY_DIRECTORY_SCRIPT,
-      ],
-      {
-        env: {
-          ...process.env,
-          CRABLINE_PRIVATE_DIRECTORY_PATH: path.resolve(directoryPath),
-        },
-        killSignal: "SIGKILL",
-        timeout: WINDOWS_ACL_COMMAND_TIMEOUT_MS,
-        windowsHide: true,
-      },
-    );
+    await createOwnerOnlyWindowsDirectoryAncestry(directoryPath, run, systemRoot);
   } catch (error) {
     throw new Error(
       "Could not atomically create or verify an owner-only Windows directory; Windows PowerShell ACL support is required.",

--- a/test/openclaw-private-file.test.ts
+++ b/test/openclaw-private-file.test.ts
@@ -2288,6 +2288,12 @@ describe("OpenClaw private file publication", () => {
     expect(script).toContain("FileInternalInformationClass = 6");
     expect(script).toContain("NtQueryVolumeInformationFile");
     expect(script).toContain("FileFsVolumeInformationClass = 1");
+    expect(script).toContain("[System.Security.AccessControl.FileSystemRights]::Delete");
+    expect(script).not.toContain("[System.IO.FileShare]::Delete");
+    expect(script).toContain("SetFileInformationByHandle");
+    expect(script).toContain("FileDispositionInfoClass = 4");
+    expect(script).toContain("[CrablinePrivateFileIdentity]::MarkDelete($stream.SafeFileHandle)");
+    expect(script).toContain("Private file creation and handle-bound cleanup failed.");
     expect(script).not.toContain("Set-Acl");
     expect(script).toContain("AreAccessRulesProtected");
     expect(script).toContain("$rules.Count -ne 1");
@@ -2296,6 +2302,42 @@ describe("OpenClaw private file publication", () => {
     expect(options.timeout).toBe(15_000);
     expect(options.windowsHide).toBe(true);
   });
+
+  it.skipIf(process.platform !== "win32")(
+    "removes a failed owner-only file creation by handle so an immediate retry succeeds",
+    async () => {
+      const directory = await createTempDir();
+      try {
+        const filePath = path.join(directory, "retry.claim");
+        let injectFailure = true;
+        const run: WindowsAclRunner = async (command, args, options) => {
+          const script = args.at(-1)!;
+          const executedScript = injectFailure
+            ? script.replace(
+                "$actual = $stream.GetAccessControl()",
+                'throw "injected post-creation failure"',
+              )
+            : script;
+          injectFailure = false;
+          return execFileSync(command, [...args.slice(0, -1), executedScript], {
+            encoding: "utf8",
+            env: options.env,
+            killSignal: options.killSignal,
+            timeout: options.timeout,
+            windowsHide: options.windowsHide,
+          });
+        };
+
+        await expect(createOwnerOnlyWindowsFile(filePath, run)).rejects.toThrow(
+          "Could not atomically create and verify an owner-only Windows private file",
+        );
+        const identity = await createOwnerOnlyWindowsFile(filePath, run);
+        expect(identity.inode > 0n).toBe(true);
+      } finally {
+        await disposeTempDir(directory);
+      }
+    },
+  );
 
   it.skipIf(process.platform !== "win32")(
     "stops Windows claim ancestry before system-owned directories",
@@ -2340,7 +2382,7 @@ describe("OpenClaw private file publication", () => {
     expect(options.timeout).toBe(15_000);
   });
 
-  it("uses CreateDirectoryW with a protected ACL for every missing Windows ancestor", async () => {
+  it("creates every missing Windows ancestor relative to a held parent handle", async () => {
     const calls: Parameters<WindowsAclRunner>[] = [];
     const run: WindowsAclRunner = async (...args) => {
       calls.push(args);
@@ -2356,10 +2398,18 @@ describe("OpenClaw private file publication", () => {
     const [command, args, options] = calls[0]!;
     expect(command).toBe(String.raw`C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`);
     const script = args.at(-1);
-    expect(script).toContain("CreateDirectory(");
-    expect(script).toContain("SecurityAttributes");
+    expect(script).toContain("NtCreateFile(");
+    expect(script).toContain("FileTraverse = 0x00000020");
+    expect(script).toContain("if (traverse) {\n            access |= FileTraverse;");
+    expect(script).toContain("RootDirectory = parent.DangerousGetHandle()");
+    expect(script).toContain("[CrablineWindowsDirectoryHandle]::CreateRelative(");
+    expect(script).toContain("[CrablineWindowsDirectoryHandle]::OpenRelative(");
+    expect(script).toContain("[CrablineWindowsDirectoryHandle]::ReadIdentity($parentDirectory)");
+    expect(script).toContain("$current,\n      $false,\n      $false,\n      $true");
+    expect(script).toContain("Assert-SafeNamespaceChain $current $true");
+    expect(script).toContain("[CrablineWindowsDirectoryHandle]::AssertSamePathIdentity(");
     expect(script).toContain("SetAccessRuleProtection($true, $false)");
-    expect(script).toContain("New private directory was populated during creation.");
+    expect(script).toContain("[CrablineWindowsDirectoryHandle]::MarkDelete(");
     expect(script).toContain("Private directory ancestry creation and rollback cleanup failed.");
     expect(script).toContain("[System.AggregateException]::new(");
     expect(script).toContain("$aggregateErrors");
@@ -2471,6 +2521,9 @@ describe("OpenClaw private file publication", () => {
 
     const script = calls[0]![1].at(-1);
     expect(script).toContain("$genericMutationRights = [uint32]0x50000000");
+    expect(script).toContain("RawSecurityDescriptor");
+    expect(script).toContain("DiscretionaryAclPresent");
+    expect(script).toContain("Directory has an absent or null DACL");
     expect(script).toContain('"S-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464"');
     expect(script).toContain("[BitConverter]::GetBytes([int32]$rule.FileSystemRights)");
     expect(script).toContain(
@@ -2496,11 +2549,60 @@ describe("OpenClaw private file publication", () => {
     expect(script).toContain("TakeOwnership");
     expect(script).toContain("$ancestorReplacementMask");
     expect(script).toContain("$genericAll = [uint32]0x10000000");
+    expect(script).toContain("RawSecurityDescriptor");
+    expect(script).toContain("DiscretionaryAclPresent");
+    expect(script).toContain("Directory has an absent or null DACL");
     expect(script).toContain('"S-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464"');
     expect(script).toContain("[BitConverter]::GetBytes([int32]$rule.FileSystemRights)");
     expect(script).toContain("$appliesToDirectory");
     expect(script).not.toContain("Set-Acl");
   });
+
+  it.skipIf(process.platform !== "win32")(
+    "rejects absent or null DACLs in both legacy Windows ancestry checks",
+    async () => {
+      const directory = await createTempDir();
+      try {
+        const powershellPath = path.join(
+          process.env.SystemRoot ?? String.raw`C:\Windows`,
+          "System32",
+          "WindowsPowerShell",
+          "v1.0",
+          "powershell.exe",
+        );
+        execFileSync(
+          powershellPath,
+          [
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            [
+              "$acl = Get-Acl -LiteralPath $env:CRABLINE_TEST_NULL_DACL",
+              [
+                '$acl.SetSecurityDescriptorSddlForm("D:NO_ACCESS_CONTROL",',
+                "[System.Security.AccessControl.AccessControlSections]::Access)",
+              ].join(" "),
+              "Set-Acl -LiteralPath $env:CRABLINE_TEST_NULL_DACL -AclObject $acl",
+            ].join("; "),
+          ],
+          {
+            env: { ...process.env, CRABLINE_TEST_NULL_DACL: directory },
+            windowsHide: true,
+          },
+        );
+
+        await expect(verifySafeWindowsDirectoryEntryParent(directory)).rejects.toThrow(
+          "Private mutation boundary has a replaceable Windows ancestor.",
+        );
+        await expect(verifySafeWindowsDirectoryMutationBoundary(directory)).rejects.toThrow(
+          "Private mutation ancestry has an unsafe Windows ACL.",
+        );
+      } finally {
+        await disposeTempDir(directory);
+      }
+    },
+  );
 
   it.skipIf(process.platform !== "win32")(
     "rejects Windows mutation boundary ancestry with untrusted delete-child rights",

--- a/test/recorder.test.ts
+++ b/test/recorder.test.ts
@@ -562,13 +562,15 @@ describe("recorder", () => {
     expect(script).toContain("[System.IO.Directory]::Exists($current)");
     expect(script).toContain("$directoryPath.TrimEnd(");
     expect(script).toContain("NtCreateFile(");
+    expect(script).toContain("FileTraverse = 0x00000020");
+    expect(script).toContain("if (traverse) {\n            access |= FileTraverse;");
     expect(script).toContain("FileCreate");
     expect(script).toContain("FileDirectoryFile");
     expect(script).toContain("FileOpenReparsePoint");
-    expect(script).toContain("[CrablineWindowsDirectoryHandle]::Create(");
-    expect(script.indexOf('StartsWith(@"\\\\?\\",')).toBeLessThan(
-      script.indexOf('StartsWith(@"\\\\",'),
-    );
+    expect(script).toContain("[CrablineWindowsDirectoryHandle]::CreateRelative(");
+    expect(script).toContain("[CrablineWindowsDirectoryHandle]::OpenRelative(");
+    expect(script).toContain("RootDirectory = parent.DangerousGetHandle()");
+    expect(script).toContain("parent.DangerousAddRef(ref parentAddRef)");
     expect(script).toContain("FileFlagOpenReparsePoint");
     expect(script).toContain("DirectoryAttribute");
     expect(script).toContain("ReparsePointAttribute");
@@ -593,16 +595,17 @@ describe("recorder", () => {
     expect(script).toContain("WriteAttributes");
     expect(script).toContain("[int64]0x40000000");
     expect(script).toContain("DeleteSubdirectoriesAndFiles");
-    expect(script).toContain("Assert-SafeNamespaceChain $current ($missing.Count -gt 0)");
+    expect(script).toContain("Assert-SafeNamespaceChain $current $true");
     expect(script).toContain("Private directory parent namespace permits untrusted replacement.");
-    expect(script).toContain("[CrablineWindowsDirectoryHandle]::Create(");
     expect(script).toContain("catch [System.ComponentModel.Win32Exception]");
     expect(script).toContain("$_.Exception.NativeErrorCode -ne 80");
     expect(script).toContain("$_.Exception.NativeErrorCode -ne 183");
-    expect(script).toContain(
-      "[void][CrablineWindowsDirectoryHandle]::ReadIdentity($createdDirectory)",
-    );
+    expect(script).toContain("$existingParentIdentity");
+    expect(script).toContain("$childIdentity");
+    expect(script).toContain("$current,\n      $false,\n      $false,\n      $true");
     expect(script).toContain("[CrablineWindowsDirectoryHandle]::WriteSecurityDescriptor(");
+    expect(script).toContain("[CrablineWindowsDirectoryHandle]::MarkDelete(");
+    expect(script).toContain("Private directory ancestry creation and rollback cleanup failed.");
     expect(script).toContain("AssertSamePathIdentity");
     expect(script).not.toContain("[System.IO.Directory]::CreateDirectory(");
     expect(script).not.toContain("$directory.SetAccessControl($acl)");
@@ -627,7 +630,10 @@ describe("recorder", () => {
     expect(script).toContain("DirectoryAttribute");
     expect(script).toContain("GetFileInformationByHandleEx(");
     expect(script).toContain("FileIdInfoClass");
-    expect(script).toContain("[CrablineWindowsDirectoryHandle]::Open($directoryPath, $true)");
+    expect(script).toContain("$writeOwner = $currentOwner.Value -ne $sid.Value");
+    expect(script).toContain("$true,\n    $writeOwner");
+    expect(script).toContain("if (writeOwner) {\n            access |= WriteOwner;");
+    expect(script).toContain("if (writeOwner) {\n                securityInformation |=");
     expect(script).toContain("[CrablineWindowsDirectoryHandle]::WriteSecurityDescriptor(");
     expect(script).toContain("[CrablineWindowsDirectoryHandle]::AssertSamePathIdentity(");
     expect(script).not.toContain("Set-Acl");
@@ -655,7 +661,7 @@ describe("recorder", () => {
     const script = args.at(-1);
     expect(script).toContain("AreAccessRulesProtected");
     expect(script).toContain("$rules.Count -ne 1");
-    expect(script).toContain("[CrablineWindowsDirectoryHandle]::Open($directoryPath, $false)");
+    expect(script).toContain("$directoryPath,\n  $false,\n  $false");
     expect(script).toContain("[CrablineWindowsDirectoryHandle]::ReadIdentity($directory)");
     expect(script).toContain(
       "[CrablineWindowsDirectoryHandle]::ReadSecurityDescriptor($directory)",
@@ -696,7 +702,7 @@ describe("recorder", () => {
     const [, args, options] = calls[0]!;
     const script = args.at(-1);
     expect(script).toContain("Assert-SafeNamespaceChain $directoryPath $true");
-    expect(script).toContain("[CrablineWindowsDirectoryHandle]::Open($directoryPath, $false)");
+    expect(script).toContain("$directoryPath,\n  $false,\n  $false");
     expect(script).toContain(
       "$pathIdentity = [CrablineWindowsDirectoryHandle]::ReadPathIdentity($directoryPath)",
     );
@@ -802,6 +808,58 @@ describe("recorder", () => {
       await expect(stat(lockRoot)).resolves.toMatchObject({
         isDirectory: expect.any(Function),
       });
+    },
+  );
+
+  it.runIf(process.platform === "win32")(
+    "repairs an owner-correct Windows directory without requesting WRITE_OWNER",
+    async () => {
+      const directory = await createTempDir();
+      directories.push(directory);
+      const lockRoot = path.join(directory, "dacl-only-repair");
+      await mkdir(lockRoot);
+      const powershellPath = path.join(
+        process.env.SystemRoot ?? String.raw`C:\Windows`,
+        "System32",
+        "WindowsPowerShell",
+        "v1.0",
+        "powershell.exe",
+      );
+      execFileSync(
+        powershellPath,
+        [
+          "-NoLogo",
+          "-NoProfile",
+          "-NonInteractive",
+          "-Command",
+          [
+            "$sid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User",
+            "$acl = [System.Security.AccessControl.DirectorySecurity]::new()",
+            "$acl.SetOwner($sid)",
+            "$acl.SetAccessRuleProtection($true, $false)",
+            [
+              "$rights = [System.Security.AccessControl.FileSystemRights]::ReadAndExecute -bor",
+              "[System.Security.AccessControl.FileSystemRights]::ChangePermissions",
+            ].join(" "),
+            [
+              "$rule = [System.Security.AccessControl.FileSystemAccessRule]::new(",
+              "$sid, $rights,",
+              "[System.Security.AccessControl.AccessControlType]::Allow)",
+            ].join(" "),
+            "$acl.SetAccessRule($rule)",
+            "Set-Acl -LiteralPath $env:CRABLINE_TEST_DACL_ONLY -AclObject $acl",
+          ].join("; "),
+        ],
+        {
+          env: { ...process.env, CRABLINE_TEST_DACL_ONLY: lockRoot },
+          windowsHide: true,
+        },
+      );
+
+      await expect(applyOwnerOnlyWindowsDirectoryAcl(lockRoot)).resolves.toBeUndefined();
+      await expect(readWindowsDirectorySecurityDescriptor(lockRoot)).resolves.toEqual(
+        expect.any(String),
+      );
     },
   );
 


### PR DESCRIPTION
## Summary
- bind Windows private ancestry creation and rollback cleanup to stable handles
- reject null legacy DACLs and preserve publication identity checks
- avoid unnecessary owner-write access during ACL repair
- add focused Windows regression coverage and changelog entry

## Validation
- 210 focused tests passed, 31 Windows-only skipped locally
- TypeScript typecheck, lint, and formatting
- Codex autoreview: gpt-5.6-sol, high, clean (0.87)
- Crabbox `pnpm verify`: run `run_377a27316589`, 65 files / 1,808 tests, green