### PR TITLE
fix(providers): align native webhook and target contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Return valid Signal JSON-RPC method errors through successful HTTP responses.
 - Verify resolved loopback webhook addresses and complete HEAD responses without consuming representation bodies.
 - Bind Windows private ancestry creation and failed-file cleanup to stable handles, reject null legacy DACLs, and avoid unnecessary owner-write access during ACL repair.
+- Make Google Chat and Mattermost ingress POST-only, return protocol-safe Google acknowledgements, reject incomplete Pub/Sub identity config, scope generic Mattermost threads, and accept flat generic iMessage payloads.
 - Bind private-directory ACL and recorder-lock mutations to verified identities, quarantine process locks before artifact cleanup, and preserve Windows ancestry rollback failures.
 - Require explicit remote iMessage API keys and decode legacy loopback channel metadata consistently.
 - Preserve configured Mattermost bot identity during admin ingress and avoid overwriting retained channels on direct-channel ID collisions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Return valid Signal JSON-RPC method errors through successful HTTP responses.
 - Verify resolved loopback webhook addresses and complete HEAD responses without consuming representation bodies.
 - Bind Windows private ancestry creation and failed-file cleanup to stable handles, reject null legacy DACLs, and avoid unnecessary owner-write access during ACL repair.
+- Enforce five-character Telegram usernames, reject unsupported WhatsApp thread targets, and require canonical Matrix bot and sender IDs.
 - Make Google Chat and Mattermost ingress POST-only, return protocol-safe Google acknowledgements, reject incomplete Pub/Sub identity config, scope generic Mattermost threads, and accept flat generic iMessage payloads.
 - Bind private-directory ACL and recorder-lock mutations to verified identities, quarantine process locks before artifact cleanup, and preserve Windows ancestry rollback failures.
 - Require explicit remote iMessage API keys and decode legacy loopback channel metadata consistently.

--- a/README.md
+++ b/README.md
@@ -434,11 +434,12 @@ Examples:
 - Slack threads: `1700000000.000100`
 - Telegram chats: `-1001234567890` or `@channelusername`
 - Telegram topics: `42`
-- Telegram username targets require `@`, contain 4-32 letters, digits, or
+- Telegram username targets require `@`, contain 5-32 letters, digits, or
   underscores, and normalize to lowercase. Numeric chat IDs must be nonzero and
   have an absolute value no greater than `2^52 - 1`.
 - Built-in WhatsApp Cloud API users: digits-only `wa_id` values such as
   `15551234567`
+- Built-in WhatsApp Cloud API fixtures do not support `threadId` targets.
 - OpenClaw WhatsApp bridge users: `15551234567@s.whatsapp.net`
   (legacy `15551234567@c.us` inputs are accepted and canonicalized)
 - OpenClaw WhatsApp bridge groups: `120363001234567890@g.us`

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -124,7 +124,9 @@ header before JSON parsing or recorder writes:
   when omitted, and `credentials.client_email` remains the service-account
   email fallback when inline credentials are configured. Wrapped Pub/Sub
   `message.data` must be canonical base64 before Google Chat event
-  normalization.
+  normalization. Direct and wrapped Pub/Sub callbacks are POST-only. Successful
+  direct callbacks receive an empty `200` acknowledgement instead of a
+  synthetic chat message.
   Google Workspace add-on `chat.messagePayload` events are rejected until the
   adapter can bind the verified request to a configured add-on deployment
   identity.
@@ -136,7 +138,7 @@ header before JSON parsing or recorder writes:
 - Mattermost `webhookToken` or `MATTERMOST_TOKEN` verifies the `token` field in
   outgoing webhook form or JSON bodies. The token is removed before recorder
   persistence. Externally reachable callbacks require this token and an HTTPS
-  `webhook.publicUrl`.
+  `webhook.publicUrl`. Outgoing webhook ingress is POST-only.
 - iMessage webhook ingress currently has no provider-native authentication
   mode, so its listener and any advertised callback must remain loopback-only.
 - Feishu `verificationToken` or `FEISHU_VERIFICATION_TOKEN` verifies plaintext
@@ -599,11 +601,12 @@ as `telegram:`, `discord:`, or `slack:`.
 - Slack threads: `1700000000.000100`
 - Telegram chats: `-1001234567890` or `@channelusername`
 - Telegram topics: `42`
-- Telegram username targets require `@`, contain 4-32 letters, digits, or
+- Telegram username targets require `@`, contain 5-32 letters, digits, or
   underscores, and normalize to lowercase. Numeric chat IDs must be nonzero and
   have an absolute value no greater than `2^52 - 1`.
 - Built-in WhatsApp Cloud API users: digits-only `wa_id` values such as
   `15551234567`
+- Built-in WhatsApp Cloud API fixtures do not support `threadId` targets.
 - OpenClaw WhatsApp bridge users: `15551234567@s.whatsapp.net`
   (legacy `15551234567@c.us` inputs are accepted and canonicalized)
 - OpenClaw WhatsApp bridge groups: `120363001234567890@g.us`

--- a/src/providers/builtin/googlechat.ts
+++ b/src/providers/builtin/googlechat.ts
@@ -229,6 +229,12 @@ export class GoogleChatProviderAdapter extends LocalMockProviderAdapter implemen
     const endpointAudience = config.googlechat?.endpointUrl ?? config.googlechat?.webhook.publicUrl;
     const pubsubServiceAccount =
       config.googlechat?.pubsubServiceAccountEmail ?? config.googlechat?.credentials?.client_email;
+    if (config.googlechat?.pubsubAudience && !pubsubServiceAccount) {
+      throw new CrablineError(
+        "Google Chat pubsubAudience requires a Pub/Sub service-account identity via pubsubServiceAccountEmail or credentials.client_email.",
+        { kind: "config" },
+      );
+    }
     const authenticationConfigured =
       !config.googlechat?.disableSignatureVerification &&
       Boolean(
@@ -256,6 +262,7 @@ export class GoogleChatProviderAdapter extends LocalMockProviderAdapter implemen
       id,
       options: {
         ...(authenticateWebhookRequest ? { authenticateWebhookRequest } : {}),
+        createWebhookSuccessResponse: () => new Response(null, { status: 200 }),
         defaultWebhook: { host: "127.0.0.1", path: "/googlechat/webhook", port: 8792 },
         endpointLabel: "webhook endpoint",
         handleWebhookPayload: handleGoogleChatWebhookPayload,
@@ -267,6 +274,7 @@ export class GoogleChatProviderAdapter extends LocalMockProviderAdapter implemen
           ? path.resolve(config.googlechat.recorder.path)
           : undefined,
         webhook: config.googlechat?.webhook,
+        webhookMethods: ["POST"],
       },
     });
   }

--- a/src/providers/builtin/imessage.ts
+++ b/src/providers/builtin/imessage.ts
@@ -125,7 +125,10 @@ function normalizeIMessageWebhookPayload(payload: unknown) {
   }
 
   const message = optionalRecord(payload, "message");
-  if (message && !isNativeIMessageData(message)) {
+  if (
+    (message && !isNativeIMessageData(message)) ||
+    (!message && !isNativeIMessageData(payload) && optionalString(payload, "threadId"))
+  ) {
     return genericMockPayloadWithNativeThread({
       channelRule: IMESSAGE_THREAD_RULE,
       payload,

--- a/src/providers/builtin/matrix.ts
+++ b/src/providers/builtin/matrix.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
-import { isMatrixEventId, isMatrixRoomId } from "../../matrix-ids.js";
+import { isMatrixEventId, isMatrixRoomId, isMatrixUserId } from "../../matrix-ids.js";
 import { LocalMockProviderAdapter } from "../local-mock.js";
 import type { ProviderAdapter } from "../types.js";
 import {
@@ -30,6 +30,11 @@ export function resolveMatrixAdapterConfig(
         userID: config.matrix.auth.userID?.trim() || fallbackUserId,
       }
     : undefined;
+  if (!isMatrixUserId(configuredAuth?.userID ?? fallbackUserId)) {
+    throw new CrablineError("Matrix auth.userID must be a canonical Matrix user ID.", {
+      kind: "config",
+    });
+  }
   return {
     auth: configuredAuth ?? {
       accessToken: env.MATRIX_ACCESS_TOKEN ?? "local-mock-matrix-token",
@@ -157,7 +162,8 @@ export function normalizeMatrixWebhookPayload(payload: unknown, botUserId?: stri
   const roomId = optionalString(payload, "room_id");
   const eventId = optionalString(payload, "event_id");
   const eventType = optionalString(payload, "type");
-  const senderId = optionalString(payload, "sender");
+  const sender = payload.sender;
+  const senderId = typeof sender === "string" ? sender : undefined;
   const msgtype = content?.msgtype;
   const text = content?.body;
   if (eventType !== "m.room.message") {
@@ -197,6 +203,11 @@ export function normalizeMatrixWebhookPayload(payload: unknown, botUserId?: stri
       `Matrix thread root event_id must be a native ${MATRIX_EVENT_ID_RULE.name} such as ${MATRIX_EVENT_ID_RULE.example}.`,
       { kind: "inbound" },
     );
+  }
+  if (!senderId || !isMatrixUserId(senderId)) {
+    throw new CrablineError("Matrix sender must be a canonical Matrix user ID.", {
+      kind: "inbound",
+    });
   }
 
   return {

--- a/src/providers/builtin/mattermost.ts
+++ b/src/providers/builtin/mattermost.ts
@@ -225,6 +225,7 @@ export function normalizeMattermostWebhookPayload(
     const rootId =
       optionalString(genericMessage, "threadId") ?? optionalString(safePayload, "threadId");
     if (!channelId || !rootId || channelId === rootId) {
+      // Without channelId, the generic threadId is the channel-level conversation.
       return normalized as NormalizedMattermostWebhookPayload;
     }
     const scopedThreadId = mattermostThreadKey(

--- a/src/providers/builtin/mattermost.ts
+++ b/src/providers/builtin/mattermost.ts
@@ -144,6 +144,7 @@ export class MattermostProviderAdapter extends LocalMockProviderAdapter implemen
         publicUrl: config.mattermost?.webhook.publicUrl,
         recorderPath,
         webhook: config.mattermost?.webhook,
+        webhookMethods: ["POST"],
       },
     });
   }
@@ -212,12 +213,31 @@ export function normalizeMattermostWebhookPayload(
   }
 
   const safePayload = withoutMattermostWebhookToken(payload);
-  if (optionalRecord(safePayload, "message")) {
-    return genericMockPayloadWithNativeThread({
+  const genericMessage = optionalRecord(safePayload, "message");
+  if (genericMessage) {
+    const normalized = genericMockPayloadWithNativeThread({
       channelRule: MATTERMOST_ID_RULE,
       payload: safePayload,
       threadRule: MATTERMOST_ID_RULE,
-    }) as NormalizedMattermostWebhookPayload;
+    });
+    const channelId =
+      optionalString(genericMessage, "channelId") ?? optionalString(safePayload, "channelId");
+    const rootId =
+      optionalString(genericMessage, "threadId") ?? optionalString(safePayload, "threadId");
+    if (!channelId || !rootId || channelId === rootId) {
+      return normalized as NormalizedMattermostWebhookPayload;
+    }
+    const scopedThreadId = mattermostThreadKey(
+      requireNativeInboundId(channelId, MATTERMOST_ID_RULE, "Mattermost channelId"),
+      requireNativeInboundId(rootId, MATTERMOST_ID_RULE, "Mattermost threadId"),
+    );
+    return {
+      ...normalized,
+      ...("message" in normalized && isRecord(normalized.message)
+        ? { message: { ...normalized.message, threadId: scopedThreadId } }
+        : {}),
+      threadId: scopedThreadId,
+    } as NormalizedMattermostWebhookPayload;
   }
 
   const channelId = optionalString(safePayload, "channel_id");

--- a/src/providers/target-normalizers.ts
+++ b/src/providers/target-normalizers.ts
@@ -81,7 +81,7 @@ export const MSTEAMS_CONVERSATION_ID_RULE: NativeIdRule = {
 export const TELEGRAM_CHAT_ID_RULE: NativeIdRule = {
   example: "-1001234567890 or @channelusername",
   name: "Telegram chat id",
-  pattern: /^(?:-?[1-9]\d*|@[A-Za-z][A-Za-z0-9_]{3,31})$/u,
+  pattern: /^(?:-?[1-9]\d*|@[A-Za-z][A-Za-z0-9_]{4,31})$/u,
   validate: (value) =>
     value.startsWith("@") || BigInt(value.replace(/^-/u, "")) <= TELEGRAM_NATIVE_CHAT_ID_MAX,
 };
@@ -113,6 +113,7 @@ export const ZALO_ID_RULE: NativeIdRule = {
 };
 
 export const ZALO_UNSUPPORTED_THREAD_TARGET_ERROR = "Zalo does not support thread targets.";
+export const WHATSAPP_UNSUPPORTED_THREAD_TARGET_ERROR = "WhatsApp does not support thread targets.";
 
 function requireNativeId(value: string, rule: NativeIdRule, label: string): string {
   if (!matchesNativeId(value, rule)) {
@@ -427,6 +428,24 @@ const ZALO_TARGET_CODEC: LocalMockTargetCodec = {
   },
 };
 
+const WHATSAPP_BASE_TARGET_CODEC = createNativeTargetCodec({
+  channel: WHATSAPP_WA_ID_RULE,
+  channelLabel: "WhatsApp wa_id",
+});
+
+const WHATSAPP_TARGET_CODEC: LocalMockTargetCodec = {
+  normalize(target) {
+    if (target.threadId) {
+      throw new CrablineError(WHATSAPP_UNSUPPORTED_THREAD_TARGET_ERROR, { kind: "config" });
+    }
+    return WHATSAPP_BASE_TARGET_CODEC.normalize(target);
+  },
+  resolveThreadId(target) {
+    const normalized = this.normalize(target);
+    return normalized.channelId ?? normalized.id;
+  },
+};
+
 const BUILTIN_TARGET_CODECS = {
   discord: createNativeTargetCodec({
     channel: DISCORD_SNOWFLAKE_RULE,
@@ -457,10 +476,7 @@ const BUILTIN_TARGET_CODECS = {
   }),
   slack: SLACK_TARGET_CODEC,
   telegram: TELEGRAM_TARGET_CODEC,
-  whatsapp: createNativeTargetCodec({
-    channel: WHATSAPP_WA_ID_RULE,
-    channelLabel: "WhatsApp wa_id",
-  }),
+  whatsapp: WHATSAPP_TARGET_CODEC,
   zalo: ZALO_TARGET_CODEC,
 } satisfies Record<BuiltinProviderAdapterId, LocalMockTargetCodec>;
 

--- a/test/channel-setup-docs.test.ts
+++ b/test/channel-setup-docs.test.ts
@@ -96,6 +96,8 @@ describe("channel setup contracts", () => {
       expect(document).toContain("`U1234567890`");
       expect(document).toContain("`iMessage;-;chat-guid`");
       expect(document).toContain("`$eventid:matrix.org`");
+      expect(document).toContain("contain 5-32 letters");
+      expect(document).toContain("do not support `threadId` targets");
       expect(document).toContain("exactly 26 lowercase alphanumeric");
       expect(document).toContain("`a:opaque-conversation-id`");
     }

--- a/test/googlechat-provider.test.ts
+++ b/test/googlechat-provider.test.ts
@@ -108,6 +108,7 @@ describe("Google Chat webhook authentication", () => {
       /Pub\/Sub service-account identity/u,
     );
 
+    delete config.googlechat!.pubsubAudience;
     config.googlechat!.endpointUrl = "https://chat.example.test/googlechat/webhook";
     config.googlechat!.disableSignatureVerification = true;
     expect(() => new GoogleChatProviderAdapter("googlechat", config, "crabline")).toThrow(
@@ -122,6 +123,19 @@ describe("Google Chat webhook authentication", () => {
       /require HTTPS/u,
     );
     config.googlechat!.webhook.publicUrl = "https://chat.example.test/googlechat/webhook";
+    expect(() => new GoogleChatProviderAdapter("googlechat", config, "crabline")).not.toThrow();
+  });
+
+  it("rejects mixed direct and incomplete Pub/Sub authentication configuration", async () => {
+    const config = await createLocalMockConfig("googlechat", "/googlechat/webhook");
+    config.googlechat!.endpointUrl = "https://chat.example.test/googlechat/webhook";
+    config.googlechat!.pubsubAudience = "https://chat.example.test/pubsub";
+
+    expect(() => new GoogleChatProviderAdapter("googlechat", config, "crabline")).toThrow(
+      /Pub\/Sub service-account identity/u,
+    );
+
+    config.googlechat!.pubsubServiceAccountEmail = "chat-push@example.iam.gserviceaccount.com";
     expect(() => new GoogleChatProviderAdapter("googlechat", config, "crabline")).not.toThrow();
   });
 
@@ -377,6 +391,64 @@ describe("Google Chat webhook authentication", () => {
       await expect(readFile(config.googlechat!.recorder.path!, "utf8")).rejects.toMatchObject({
         code: "ENOENT",
       });
+    } finally {
+      await provider.cleanup();
+    }
+  });
+
+  it("exposes a POST-only route with an empty direct-event acknowledgement", async () => {
+    const config = await createLocalMockConfig("googlechat", "/googlechat/webhook");
+    config.googlechat!.endpointUrl = "https://chat.example.test/googlechat/webhook";
+    const keys = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const now = Date.now();
+    let certificateFetches = 0;
+    const provider = new GoogleChatProviderAdapter("googlechat", config, "crabline", {
+      fetch: async () => {
+        certificateFetches += 1;
+        return Response.json({
+          "test-key": keys.publicKey.export({ format: "pem", type: "spki" }).toString(),
+        });
+      },
+      now: () => now,
+    });
+    try {
+      const endpoint = endpointFromDetails(
+        (
+          await provider.probe(
+            createProviderContext("googlechat", config, {
+              id: "spaces/AAAABbbbCCC",
+              metadata: {},
+            }),
+          )
+        ).details,
+      );
+      const rejected = await fetch(endpoint);
+      expect(rejected.status).toBe(404);
+      expect(certificateFetches).toBe(0);
+
+      const jwt = signedJwt(keys.privateKey, {
+        aud: config.googlechat!.endpointUrl,
+        email: "chat@system.gserviceaccount.com",
+        email_verified: true,
+        exp: Math.floor(now / 1000) + 60,
+        iss: "https://accounts.google.com",
+      });
+      const accepted = await fetch(endpoint, {
+        body: JSON.stringify({
+          message: {
+            name: "spaces/AAAABbbbCCC/messages/msg-native",
+            sender: { type: "HUMAN" },
+            space: { name: "spaces/AAAABbbbCCC" },
+            text: "direct event",
+          },
+          type: "MESSAGE",
+        }),
+        headers: { authorization: `Bearer ${jwt}`, "content-type": "application/json" },
+        method: "POST",
+      });
+      expect(accepted.status).toBe(200);
+      expect(accepted.headers.get("content-type")).toBeNull();
+      await expect(accepted.text()).resolves.toBe("");
     } finally {
       await provider.cleanup();
     }

--- a/test/imessage-provider.test.ts
+++ b/test/imessage-provider.test.ts
@@ -206,6 +206,59 @@ describe("iMessage thread matching", () => {
     }
   });
 
+  it("accepts flat generic local-mock payloads with native targets", async () => {
+    const config = await createLocalMockConfig("imessage", "/imessage/webhook");
+    const provider = new IMessageProviderAdapter("imessage", config, "crabline");
+    const context = createProviderContext("imessage", config, {
+      id: "+15551234567",
+      metadata: {},
+    });
+    context.fixture.inboundMatch.author = "any";
+
+    try {
+      const endpoint = (await provider.probe(context)).details
+        .find((detail) => detail.startsWith("webhook endpoint "))
+        ?.replace("webhook endpoint ", "");
+      const since = new Date(Date.now() - 1000).toISOString();
+      const accepted = await fetch(endpoint!, {
+        body: JSON.stringify({
+          author: "user",
+          id: "imsg-flat-generic",
+          text: "flat generic payload",
+          threadId: "+15551234567",
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      expect(accepted.status).toBe(200);
+      await expect(
+        provider.waitForInbound({
+          ...context,
+          nonce: "flat generic payload",
+          since,
+          timeoutMs: 500,
+        }),
+      ).resolves.toMatchObject({
+        id: "imsg-flat-generic",
+        text: "flat generic payload",
+        threadId: "+15551234567",
+      });
+
+      const rejected = await fetch(endpoint!, {
+        body: JSON.stringify({
+          text: "invalid flat generic payload",
+          threadId: "chat-guid",
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+      expect(rejected.status).toBe(400);
+      await expect(rejected.text()).resolves.toMatch(/native iMessage recipient or chat GUID/u);
+    } finally {
+      await provider.cleanup();
+    }
+  });
+
   it("does not let an unrelated direct chat satisfy a recipient wait", async () => {
     const config = await createLocalMockConfig("imessage", "/imessage/webhook");
     const provider = new IMessageProviderAdapter("imessage", config, "crabline");

--- a/test/matrix-provider.default-runtime.test.ts
+++ b/test/matrix-provider.default-runtime.test.ts
@@ -87,6 +87,29 @@ describe("matrix provider default runtime", () => {
     });
   });
 
+  it("rejects non-native configured bot identities", () => {
+    for (const userID of ["bot", "@:example.com", "@Alice:example.com"]) {
+      expect(() =>
+        resolveMatrixAdapterConfig(createConfig(), "crabline", {
+          MATRIX_USER_ID: userID,
+        }),
+      ).toThrow("Matrix auth.userID must be a canonical Matrix user ID.");
+      expect(() =>
+        resolveMatrixAdapterConfig(
+          createConfig({
+            auth: {
+              accessToken: "test-token-placeholder",
+              type: "accessToken",
+              userID,
+            },
+          }),
+          "crabline",
+          {},
+        ),
+      ).toThrow("Matrix auth.userID must be a canonical Matrix user ID.");
+    }
+  });
+
   it("preserves configured Matrix metadata when provided", () => {
     expect(
       resolveMatrixAdapterConfig(

--- a/test/matrix-provider.test.ts
+++ b/test/matrix-provider.test.ts
@@ -99,6 +99,7 @@ describe("Matrix webhook normalizer", () => {
       content: { body: "hello", msgtype: "m.text" },
       event_id: "$event123:matrix.org",
       room_id: "!abc123:matrix.org",
+      sender: "@user:matrix.org",
       type: "m.room.message",
     };
 
@@ -121,6 +122,7 @@ describe("Matrix webhook normalizer", () => {
       },
       event_id: "$reply123:matrix.org",
       room_id: "!abc123:matrix.org",
+      sender: "@user:matrix.org",
       type: "m.room.message",
     };
 
@@ -145,12 +147,30 @@ describe("Matrix webhook normalizer", () => {
     ).toMatchObject({ author: "assistant" });
   });
 
+  it("rejects missing, malformed, and historical sender identities", () => {
+    for (const sender of [undefined, "bot", "@:matrix.org", "@Alice:matrix.org", 42]) {
+      expect(() =>
+        normalizeMatrixWebhookPayload(
+          {
+            content: { body: "invalid sender", msgtype: "m.text" },
+            event_id: "$bot123:matrix.org",
+            room_id: "!abc123:matrix.org",
+            sender,
+            type: "m.room.message",
+          },
+          "@bot:matrix.org",
+        ),
+      ).toThrow("Matrix sender must be a canonical Matrix user ID.");
+    }
+  });
+
   it("requires string message fields while allowing an empty body", () => {
     expect(
       normalizeMatrixWebhookPayload({
         content: { body: "", msgtype: "m.text" },
         event_id: "$empty123:matrix.org",
         room_id: "!abc123:matrix.org",
+        sender: "@user:matrix.org",
         type: "m.room.message",
       }),
     ).toMatchObject({ text: "" });

--- a/test/mattermost-provider.test.ts
+++ b/test/mattermost-provider.test.ts
@@ -245,6 +245,29 @@ describe("Mattermost webhook normalizer", () => {
     });
   });
 
+  it("scopes generic thread roots to their channel", () => {
+    const normalized = normalizeMattermostWebhookPayload({
+      message: {
+        channelId: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+        id: "cccccccccccccccccccccccccc",
+        text: "generic thread reply",
+        threadId: "bbbbbbbbbbbbbbbbbbbbbbbbbb",
+      },
+    });
+
+    expect(normalized).toMatchObject({
+      message: {
+        threadId: "aaaaaaaaaaaaaaaaaaaaaaaaaa:thread:bbbbbbbbbbbbbbbbbbbbbbbbbb",
+      },
+      threadId: "aaaaaaaaaaaaaaaaaaaaaaaaaa:thread:bbbbbbbbbbbbbbbbbbbbbbbbbb",
+    });
+    expect(
+      matchesMattermostThread(normalized.threadId, "bbbbbbbbbbbbbbbbbbbbbbbbbb", {
+        channelId: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+      }),
+    ).toBe(true);
+  });
+
   it("normalizes root posts to the channel target instead of their post id", () => {
     expect(
       normalizeMattermostWebhookPayload({
@@ -274,6 +297,24 @@ describe("Mattermost webhook normalizer", () => {
         },
       ),
     ).toBe(true);
+  });
+
+  it("rejects GET requests at the webhook route", async () => {
+    const config = await createLocalMockConfig("mattermost", "/mattermost/webhook");
+    const provider = new MattermostProviderAdapter("mattermost", config, "crabline");
+    const context = createProviderContext("mattermost", config, {
+      id: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+      metadata: {},
+    });
+    try {
+      const endpoint = (await provider.probe(context)).details
+        .find((detail) => detail.includes("webhook endpoint"))!
+        .replace(/^.*?(https?:\/\/\S+)$/u, "$1");
+      const response = await fetch(endpoint);
+      expect(response.status).toBe(404);
+    } finally {
+      await provider.cleanup();
+    }
   });
 
   it("rejects malformed native post ids", () => {

--- a/test/mattermost-provider.test.ts
+++ b/test/mattermost-provider.test.ts
@@ -268,6 +268,25 @@ describe("Mattermost webhook normalizer", () => {
     ).toBe(true);
   });
 
+  it("treats generic threadId without channelId as a channel-level conversation", () => {
+    const normalized = normalizeMattermostWebhookPayload({
+      message: {
+        text: "generic channel message",
+        threadId: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+      },
+    });
+
+    expect(normalized).toMatchObject({
+      message: { threadId: "aaaaaaaaaaaaaaaaaaaaaaaaaa" },
+      threadId: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+    });
+    expect(
+      matchesMattermostThread(normalized.threadId, "bbbbbbbbbbbbbbbbbbbbbbbbbb", {
+        channelId: "aaaaaaaaaaaaaaaaaaaaaaaaaa",
+      }),
+    ).toBe(false);
+  });
+
   it("normalizes root posts to the channel target instead of their post id", () => {
     expect(
       normalizeMattermostWebhookPayload({

--- a/test/registry.test.ts
+++ b/test/registry.test.ts
@@ -11,6 +11,7 @@ import { createRegistry } from "../src/providers/registry.js";
 import {
   normalizeBuiltinTarget,
   type BuiltinProviderAdapterId,
+  WHATSAPP_UNSUPPORTED_THREAD_TARGET_ERROR,
   ZALO_UNSUPPORTED_THREAD_TARGET_ERROR,
 } from "../src/providers/target-normalizers.js";
 import type { ProviderContext, SendContext, WaitContext } from "../src/providers/types.js";
@@ -119,15 +120,15 @@ describe("registry", () => {
   });
 
   it("enforces Telegram's native username length in shared target normalization", () => {
-    expect(normalizeBuiltinTarget("telegram", { id: "@Abcd", metadata: {} })).toMatchObject({
-      channelId: "@abcd",
+    expect(normalizeBuiltinTarget("telegram", { id: "@Abcde", metadata: {} })).toMatchObject({
+      channelId: "@abcde",
     });
     expect(
       normalizeBuiltinTarget("telegram", { id: `@${"a".repeat(32)}`, metadata: {} }),
     ).toMatchObject({
       channelId: `@${"a".repeat(32)}`,
     });
-    for (const id of ["abcd", "@abc", `@${"a".repeat(33)}`]) {
+    for (const id of ["abcd", "@abc", "@abcd", `@${"a".repeat(33)}`]) {
       expect(() => normalizeBuiltinTarget("telegram", { id, metadata: {} })).toThrow(
         /native Telegram chat id/u,
       );
@@ -283,7 +284,6 @@ describe("registry", () => {
         channelId: "15551234567",
         id: "15551234567",
         metadata: {},
-        threadId: "15551234567",
       },
     ],
     [
@@ -358,6 +358,18 @@ describe("registry", () => {
     expect(() => registry.resolve("zalo", fixture.id).normalizeTarget(target)).toThrow(
       ZALO_UNSUPPORTED_THREAD_TARGET_ERROR,
     );
+  });
+
+  it("rejects unsupported WhatsApp thread targets", () => {
+    for (const threadId of ["15557654321", "wamid.HBgLMTU1NTEyMzQ1NjcVAgARGBI5QTNDQTVC"]) {
+      expect(() =>
+        normalizeBuiltinTarget("whatsapp", {
+          id: "15551234567",
+          metadata: {},
+          threadId,
+        }),
+      ).toThrow(WHATSAPP_UNSUPPORTED_THREAD_TARGET_ERROR);
+    }
   });
 
   it("accepts Matrix v12 domainless room ids in lazy target normalization", () => {


### PR DESCRIPTION
## Summary
- enforce provider-native Google Chat and Mattermost webhook methods and response contracts
- reject incomplete Google Pub/Sub identity configuration and scope Mattermost thread fallback
- accept flat generic iMessage payloads while tightening Telegram, WhatsApp, and Matrix target identities
- preserve configured Mattermost fallback identity
- update channel documentation, examples, focused tests, and changelog

## Validation
- 142 focused tests
- TypeScript typecheck, lint, and formatting
- Codex autoreview: gpt-5.6-sol, high, clean
- Crabbox `pnpm verify`: run `run_9cf3fa8df1a2`, 65 files / 1,817 tests, green