### PR TITLE
fix(providers): retain native chat delivery state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Retain Slack event identities across the full delayed-delivery retry horizon.
 - Retain Feishu replay identities through the full signed-callback validity horizon without evicting live entries.
 - Accept unrestricted Microsoft Bot Connector signing keys with empty endorsement lists.
 - Keep Slack MPIM allocation separate from existing private-conversation state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Retain Slack event identities across the full delayed-delivery retry horizon.
+- Retain Slack event identities across the full delayed-delivery retry horizon with bounded replay state.
 - Retain Feishu replay identities through the full signed-callback validity horizon without evicting live entries.
 - Accept unrestricted Microsoft Bot Connector signing keys with empty endorsement lists.
 - Keep Slack MPIM allocation separate from existing private-conversation state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Retain Feishu replay identities through the full signed-callback validity horizon without evicting live entries.
 - Accept unrestricted Microsoft Bot Connector signing keys with empty endorsement lists.
 - Keep Slack MPIM allocation separate from existing private-conversation state.
 - Deduplicate Slack Events API retries by outer event identity and correlate threaded DMs through their native D-channel.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Deduplicate Slack Events API retries by outer event identity and correlate threaded DMs through their native D-channel.
 - Forward lazy cleanup admission fences synchronously to materialized providers.
 - Reject prototype-inherited provider registry keys during resolution.
 - Require the literal Crabline artifact channel driver and retry current-generation validation across concurrent artifact rotation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Accept unrestricted Microsoft Bot Connector signing keys with empty endorsement lists.
 - Keep Slack MPIM allocation separate from existing private-conversation state.
 - Deduplicate Slack Events API retries by outer event identity and correlate threaded DMs through their native D-channel.
 - Forward lazy cleanup admission fences synchronously to materialized providers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Keep Slack MPIM allocation separate from existing private-conversation state.
 - Deduplicate Slack Events API retries by outer event identity and correlate threaded DMs through their native D-channel.
 - Forward lazy cleanup admission fences synchronously to materialized providers.
 - Reject prototype-inherited provider registry keys during resolution.

--- a/src/providers/builtin/feishu.ts
+++ b/src/providers/builtin/feishu.ts
@@ -26,9 +26,11 @@ type FeishuEnvironment = Partial<
 
 type FeishuAuthRuntime = {
   now?: (() => number) | undefined;
+  replayCacheLimit?: number | undefined;
 };
 
 type FeishuReplayReservation = {
+  expiresAt: number;
   keys: Set<string>;
   promise: Promise<boolean>;
   resolve: (accepted: boolean) => void;
@@ -176,6 +178,7 @@ function createFeishuWebhookAuthenticatorWithReplay(
     if (!replayState) {
       return undefined;
     }
+    const callbackExpiresAt = (callbackTimestamp ?? now) + FEISHU_MAX_CALLBACK_AGE_MS;
     pruneFeishuReplayCache(replayState.accepted, now);
     while (callbackKeys.length > 0) {
       if (callbackKeys.some((key) => replayState.accepted.has(key))) {
@@ -185,7 +188,16 @@ function createFeishuWebhookAuthenticatorWithReplay(
         .map((key) => replayState.inFlight.get(key))
         .find((candidate) => candidate !== undefined);
       if (!reservation) {
-        reserveFeishuCallback(replayState, callbackKeys);
+        if (
+          !reserveFeishuCallback(
+            replayState,
+            callbackKeys,
+            callbackExpiresAt,
+            runtime.replayCacheLimit ?? FEISHU_REPLAY_CACHE_LIMIT,
+          )
+        ) {
+          return feishuReplayCapacityResponse();
+        }
         break;
       }
       if (await reservation.promise) {
@@ -473,12 +485,23 @@ function readFeishuCallbackKeys(payload: unknown, encryptedEnvelope: unknown): s
   return encrypted ? [`encrypted:${createHash("sha256").update(encrypted).digest("hex")}`] : [];
 }
 
-function reserveFeishuCallback(replayState: FeishuReplayState, callbackKeys: string[]): void {
+function reserveFeishuCallback(
+  replayState: FeishuReplayState,
+  callbackKeys: string[],
+  expiresAt: number,
+  cacheLimit: number,
+): boolean {
+  const occupiedKeys = new Set([...replayState.accepted.keys(), ...replayState.inFlight.keys()]);
+  const newKeys = new Set(callbackKeys.filter((key) => !occupiedKeys.has(key)));
+  if (occupiedKeys.size + newKeys.size > cacheLimit) {
+    return false;
+  }
   let resolveReservation!: (accepted: boolean) => void;
   const promise = new Promise<boolean>((resolve) => {
     resolveReservation = resolve;
   });
   const reservation: FeishuReplayReservation = {
+    expiresAt,
     keys: new Set(callbackKeys),
     promise,
     resolve: resolveReservation,
@@ -486,6 +509,7 @@ function reserveFeishuCallback(replayState: FeishuReplayState, callbackKeys: str
   for (const key of callbackKeys) {
     replayState.inFlight.set(key, reservation);
   }
+  return true;
 }
 
 function acceptFeishuCallback(
@@ -497,7 +521,14 @@ function acceptFeishuCallback(
   const callbackKeys = readFeishuCallbackKeys(payload, encryptedEnvelope);
   pruneFeishuReplayCache(replayState.accepted, now);
   for (const key of callbackKeys) {
-    replayState.accepted.set(key, now);
+    const reservation = replayState.inFlight.get(key);
+    replayState.accepted.set(
+      key,
+      Math.max(
+        replayState.accepted.get(key) ?? 0,
+        reservation?.expiresAt ?? now + FEISHU_MAX_CALLBACK_AGE_MS,
+      ),
+    );
   }
   const reservations = new Set(
     callbackKeys
@@ -539,14 +570,18 @@ function releaseFeishuReservation(
 }
 
 function pruneFeishuReplayCache(recentCallbacks: Map<string, number>, now: number): void {
-  for (const [key, acceptedAt] of recentCallbacks) {
-    if (
-      now - acceptedAt > FEISHU_MAX_CALLBACK_AGE_MS ||
-      recentCallbacks.size > FEISHU_REPLAY_CACHE_LIMIT
-    ) {
+  for (const [key, expiresAt] of recentCallbacks) {
+    if (now > expiresAt) {
       recentCallbacks.delete(key);
     }
   }
+}
+
+function feishuReplayCapacityResponse(): Response {
+  return new Response("service unavailable", {
+    headers: { "cache-control": "no-store" },
+    status: 503,
+  });
 }
 
 function unauthorizedFeishuWebhook(): Response {

--- a/src/providers/builtin/msteams.ts
+++ b/src/providers/builtin/msteams.ts
@@ -140,7 +140,11 @@ export function createMsTeamsWebhookAuthenticator(
         now: runtime.now,
         async resolveKey(header) {
           const key = await resolveSigningKey(header);
-          if (key.endorsements && !key.endorsements.includes(channelId)) {
+          if (
+            key.endorsements &&
+            key.endorsements.length > 0 &&
+            !key.endorsements.includes(channelId)
+          ) {
             throw new Error("Bot Connector JWT key does not endorse the activity channel.");
           }
           try {

--- a/src/providers/builtin/slack.ts
+++ b/src/providers/builtin/slack.ts
@@ -22,7 +22,7 @@ import {
 import { requireExternalWebhookAuthentication } from "./external-webhook-auth.js";
 
 const SLACK_SIGNATURE_TOLERANCE_SECONDS = 5 * 60;
-const SLACK_EVENT_RETRY_RETENTION_MS = 10 * 60_000;
+const SLACK_EVENT_RETRY_RETENTION_MS = 25 * 60 * 60_000;
 
 type SlackEnvironment = Partial<Pick<NodeJS.ProcessEnv, "SLACK_SIGNING_SECRET">>;
 

--- a/src/providers/builtin/slack.ts
+++ b/src/providers/builtin/slack.ts
@@ -22,9 +22,18 @@ import {
 import { requireExternalWebhookAuthentication } from "./external-webhook-auth.js";
 
 const SLACK_SIGNATURE_TOLERANCE_SECONDS = 5 * 60;
-const SLACK_EVENT_RETRY_RETENTION_MS = 25 * 60 * 60_000;
+const SLACK_EVENT_RETRY_RETENTION_HOURS = 25;
+const SLACK_EVENT_RATE_LIMIT_PER_HOUR = 30_000;
+const SLACK_EVENT_RETRY_RETENTION_MS = SLACK_EVENT_RETRY_RETENTION_HOURS * 60 * 60_000;
+const SLACK_EVENT_REPLAY_CACHE_LIMIT =
+  SLACK_EVENT_RATE_LIMIT_PER_HOUR * SLACK_EVENT_RETRY_RETENTION_HOURS;
 
 type SlackEnvironment = Partial<Pick<NodeJS.ProcessEnv, "SLACK_SIGNING_SECRET">>;
+
+type SlackRuntime = {
+  now?: (() => number) | undefined;
+  replayCacheLimit?: number | undefined;
+};
 
 type SlackEventReservation = {
   promise: Promise<boolean>;
@@ -33,7 +42,11 @@ type SlackEventReservation = {
 
 type SlackEventReplayState = {
   accepted: Map<string, number>;
+  cacheLimit: number;
+  expiryHead: number;
+  expiryQueue: Array<{ eventId: string; expiresAt: number }>;
   inFlight: Map<string, SlackEventReservation>;
+  now: () => number;
 };
 
 export function resolveSlackAdapterConfig(
@@ -423,7 +436,7 @@ async function handleSlackEventReplay(
   if (!eventId || !SLACK_EVENT_ID_RULE.pattern.test(eventId)) {
     return undefined;
   }
-  const now = Date.now();
+  const now = state.now();
   pruneSlackEventReplayState(state, now);
   for (;;) {
     if (state.accepted.has(eventId)) {
@@ -431,6 +444,9 @@ async function handleSlackEventReplay(
     }
     const pending = state.inFlight.get(eventId);
     if (!pending) {
+      if (state.accepted.size + state.inFlight.size >= state.cacheLimit) {
+        return slackEventReplayCapacityResponse();
+      }
       reserveSlackEvent(state, eventId);
       return undefined;
     }
@@ -469,21 +485,40 @@ function settleSlackEventReplay(
   }
   state.inFlight.delete(eventId);
   if (accepted) {
-    state.accepted.set(eventId, Date.now() + SLACK_EVENT_RETRY_RETENTION_MS);
+    const expiresAt = state.now() + SLACK_EVENT_RETRY_RETENTION_MS;
+    state.accepted.set(eventId, expiresAt);
+    state.expiryQueue.push({ eventId, expiresAt });
   }
   reservation.resolve(accepted);
 }
 
 function pruneSlackEventReplayState(state: SlackEventReplayState, now: number): void {
-  for (const [eventId, expiresAt] of state.accepted) {
-    if (now > expiresAt) {
+  while (state.expiryHead < state.expiryQueue.length) {
+    const { eventId, expiresAt } = state.expiryQueue[state.expiryHead]!;
+    if (now <= expiresAt) {
+      break;
+    }
+    state.expiryHead += 1;
+    if (state.accepted.get(eventId) === expiresAt) {
       state.accepted.delete(eventId);
     }
   }
+  if (state.expiryHead >= 1_024 && state.expiryHead * 2 >= state.expiryQueue.length) {
+    state.expiryQueue = state.expiryQueue.slice(state.expiryHead);
+    state.expiryHead = 0;
+  }
+}
+
+function slackEventReplayCapacityResponse(): Response {
+  return new Response("service unavailable", {
+    headers: { "cache-control": "no-store" },
+    status: 503,
+  });
 }
 
 export class SlackProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
-  constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
+  constructor(id: string, config: ProviderConfig, _userName: string, runtime?: unknown) {
+    const slackRuntime = (runtime as SlackRuntime | undefined) ?? {};
     const resolvedConfig = resolveSlackAdapterConfig(config);
     requireExternalWebhookAuthentication({
       authenticated: Boolean(resolvedConfig.signingSecret),
@@ -493,7 +528,11 @@ export class SlackProviderAdapter extends LocalMockProviderAdapter implements Pr
     });
     const replayState: SlackEventReplayState = {
       accepted: new Map(),
+      cacheLimit: slackRuntime.replayCacheLimit ?? SLACK_EVENT_REPLAY_CACHE_LIMIT,
+      expiryHead: 0,
+      expiryQueue: [],
       inFlight: new Map(),
+      now: slackRuntime.now ?? Date.now,
     };
     super({
       codec: getBuiltinTargetCodec("slack"),

--- a/src/providers/builtin/slack.ts
+++ b/src/providers/builtin/slack.ts
@@ -6,6 +6,7 @@ import { LocalMockProviderAdapter } from "../local-mock.js";
 import {
   slackTargetKey,
   SLACK_CHANNEL_ID_RULE,
+  SLACK_EVENT_ID_RULE,
   SLACK_TS_RULE,
   SLACK_USER_ID_RULE,
 } from "../slack-ids.js";
@@ -21,8 +22,19 @@ import {
 import { requireExternalWebhookAuthentication } from "./external-webhook-auth.js";
 
 const SLACK_SIGNATURE_TOLERANCE_SECONDS = 5 * 60;
+const SLACK_EVENT_RETRY_RETENTION_MS = 10 * 60_000;
 
 type SlackEnvironment = Partial<Pick<NodeJS.ProcessEnv, "SLACK_SIGNING_SECRET">>;
+
+type SlackEventReservation = {
+  promise: Promise<boolean>;
+  resolve: (accepted: boolean) => void;
+};
+
+type SlackEventReplayState = {
+  accepted: Map<string, number>;
+  inFlight: Map<string, SlackEventReservation>;
+};
 
 export function resolveSlackAdapterConfig(
   config: ProviderConfig,
@@ -257,13 +269,20 @@ export function normalizeSlackEventsPayload(payload: unknown) {
       });
     }
     const threadTs = message.thread_ts;
-    const eventId = isMessageChanged
-      ? optionalString(event, "event_ts")
-      : optionalString(message, "ts");
+    const callbackEventId = optionalString(payload, "event_id");
+    const eventId =
+      callbackEventId ??
+      (isMessageChanged ? optionalString(event, "event_ts") : optionalString(message, "ts"));
     return {
       author: slackAuthorFromEvent(message),
       ...(eventId
-        ? { id: requireNativeInboundId(eventId, SLACK_TS_RULE, "Slack event timestamp") }
+        ? {
+            id: requireNativeInboundId(
+              eventId,
+              callbackEventId ? SLACK_EVENT_ID_RULE : SLACK_TS_RULE,
+              callbackEventId ? "Slack event_id" : "Slack event timestamp",
+            ),
+          }
         : {}),
       raw: safePayload,
       text,
@@ -330,12 +349,7 @@ function matchesSlackThread(
   ) {
     return true;
   }
-  if (
-    !target.channelId ||
-    !SLACK_USER_ID_RULE.pattern.test(target.channelId) ||
-    expectedThreadId !== target.channelId ||
-    !isRecord(raw)
-  ) {
+  if (!target.channelId || !SLACK_USER_ID_RULE.pattern.test(target.channelId) || !isRecord(raw)) {
     return false;
   }
   const event = optionalRecord(raw, "event");
@@ -344,10 +358,17 @@ function matchesSlackThread(
   const user =
     (event ? optionalString(event, "user") : undefined) ??
     (message ? optionalString(message, "user") : undefined);
+  if (!channel?.startsWith("D") || user !== target.channelId) {
+    return false;
+  }
+  if (expectedThreadId === target.channelId) {
+    return candidateThreadId === channel || candidateThreadId.startsWith(`${channel}:thread:`);
+  }
+  const messageThreadTs = message ? optionalString(message, "thread_ts") : undefined;
   return Boolean(
-    channel?.startsWith("D") &&
-    user === target.channelId &&
-    (candidateThreadId === channel || candidateThreadId.startsWith(`${channel}:thread:`)),
+    SLACK_TS_RULE.pattern.test(expectedThreadId) &&
+    messageThreadTs === expectedThreadId &&
+    candidateThreadId === slackTargetKey(channel, expectedThreadId),
   );
 }
 
@@ -391,6 +412,76 @@ export function handleSlackWebhookPayload(payload: unknown): Response | undefine
   return undefined;
 }
 
+async function handleSlackEventReplay(
+  payload: unknown,
+  state: SlackEventReplayState,
+): Promise<Response | undefined> {
+  if (!isRecord(payload) || payload.type !== "event_callback") {
+    return undefined;
+  }
+  const eventId = optionalString(payload, "event_id");
+  if (!eventId || !SLACK_EVENT_ID_RULE.pattern.test(eventId)) {
+    return undefined;
+  }
+  const now = Date.now();
+  pruneSlackEventReplayState(state, now);
+  for (;;) {
+    if (state.accepted.has(eventId)) {
+      return new Response(null, { status: 200 });
+    }
+    const pending = state.inFlight.get(eventId);
+    if (!pending) {
+      reserveSlackEvent(state, eventId);
+      return undefined;
+    }
+    if (await pending.promise) {
+      return new Response(null, { status: 200 });
+    }
+  }
+}
+
+function reserveSlackEvent(state: SlackEventReplayState, eventId: string): void {
+  let resolveReservation!: (accepted: boolean) => void;
+  const promise = new Promise<boolean>((resolve) => {
+    resolveReservation = resolve;
+  });
+  state.inFlight.set(eventId, {
+    promise,
+    resolve: resolveReservation,
+  });
+}
+
+function settleSlackEventReplay(
+  state: SlackEventReplayState,
+  payload: unknown,
+  accepted: boolean,
+): void {
+  if (!isRecord(payload)) {
+    return;
+  }
+  const eventId = optionalString(payload, "event_id");
+  if (!eventId) {
+    return;
+  }
+  const reservation = state.inFlight.get(eventId);
+  if (!reservation) {
+    return;
+  }
+  state.inFlight.delete(eventId);
+  if (accepted) {
+    state.accepted.set(eventId, Date.now() + SLACK_EVENT_RETRY_RETENTION_MS);
+  }
+  reservation.resolve(accepted);
+}
+
+function pruneSlackEventReplayState(state: SlackEventReplayState, now: number): void {
+  for (const [eventId, expiresAt] of state.accepted) {
+    if (now > expiresAt) {
+      state.accepted.delete(eventId);
+    }
+  }
+}
+
 export class SlackProviderAdapter extends LocalMockProviderAdapter implements ProviderAdapter {
   constructor(id: string, config: ProviderConfig, _userName: string, _runtime?: unknown) {
     const resolvedConfig = resolveSlackAdapterConfig(config);
@@ -400,6 +491,10 @@ export class SlackProviderAdapter extends LocalMockProviderAdapter implements Pr
       requirement: "slack.signingSecret or SLACK_SIGNING_SECRET",
       webhook: config.slack?.webhook,
     });
+    const replayState: SlackEventReplayState = {
+      accepted: new Map(),
+      inFlight: new Map(),
+    };
     super({
       codec: getBuiltinTargetCodec("slack"),
       config,
@@ -414,7 +509,12 @@ export class SlackProviderAdapter extends LocalMockProviderAdapter implements Pr
           : {}),
         defaultWebhook: { host: "127.0.0.1", path: "/slack/events", port: 8787 },
         endpointLabel: "events endpoint",
-        handleWebhookPayload: handleSlackWebhookPayload,
+        async handleWebhookPayload(payload) {
+          return (
+            handleSlackWebhookPayload(payload) ??
+            (await handleSlackEventReplay(payload, replayState))
+          );
+        },
         matchesThread: matchesSlackThread,
         normalizeWebhookPayload: normalizeSlackEventsPayload,
         platform: "slack",
@@ -422,6 +522,9 @@ export class SlackProviderAdapter extends LocalMockProviderAdapter implements Pr
         recorderPath: config.slack?.recorder.path
           ? path.resolve(config.slack.recorder.path)
           : undefined,
+        settleWebhookRequest({ accepted, payload }) {
+          settleSlackEventReplay(replayState, payload, accepted);
+        },
         webhook: config.slack?.webhook,
       },
     });

--- a/src/providers/slack-ids.ts
+++ b/src/providers/slack-ids.ts
@@ -18,6 +18,12 @@ export const SLACK_USER_ID_RULE: NativeIdRule = {
   pattern: /^[UW][A-Z0-9]{2,}$/u,
 };
 
+export const SLACK_EVENT_ID_RULE: NativeIdRule = {
+  example: "Ev1234567890",
+  name: "Slack event id",
+  pattern: /^Ev[A-Z0-9]{2,}$/u,
+};
+
 export const SLACK_TS_RULE: NativeIdRule = {
   example: "1700000000.000100",
   name: "Slack timestamp",

--- a/src/servers/slack.ts
+++ b/src/servers/slack.ts
@@ -368,8 +368,16 @@ function nextDmChannelId(state: SlackServerState): string {
 }
 
 function nextMpimChannelId(state: SlackServerState): string {
-  const index = state.nextMpimIndex++;
-  return `G${String(index).padStart(9, "0")}`;
+  for (;;) {
+    const index = state.nextMpimIndex++;
+    const channelId = `G${String(index).padStart(9, "0")}`;
+    if (
+      !state.messagesByChannel.has(channelId) &&
+      ![...state.userMpimChannels.values()].some((channel) => channel.id === channelId)
+    ) {
+      return channelId;
+    }
+  }
 }
 
 function dmChannelForUser(state: SlackServerState, userId: string): string {

--- a/test/feishu-provider.test.ts
+++ b/test/feishu-provider.test.ts
@@ -600,6 +600,135 @@ describe("Feishu webhook normalizer", () => {
     ).resolves.toMatchObject({ status: 401 });
   });
 
+  it("retains future-skewed callback identities until their signatures expire", async () => {
+    const config = await createLocalMockConfig("feishu", "/feishu/webhook");
+    const encryptKey = "encrypt-key";
+    let now = 1_700_000_000_000;
+    config.feishu!.encryptKey = encryptKey;
+    const provider = new FeishuProviderAdapter("feishu", config, "crabline", {
+      env: {},
+      now: () => now,
+    });
+    const context = createProviderContext("feishu", config, {
+      id: "oc_abc123",
+      metadata: {},
+    });
+    const endpoint = (await provider.probe(context)).details
+      .find((detail) => detail.startsWith("webhook endpoint "))
+      ?.replace("webhook endpoint ", "");
+    expect(endpoint).toBeDefined();
+    const nativePayload = {
+      event: {
+        message: {
+          chat_id: "oc_abc123",
+          content: JSON.stringify({ text: "future skew" }),
+          message_id: "om_future123",
+          message_type: "text",
+        },
+      },
+      header: { event_id: "event-future" },
+      schema: "2.0",
+    };
+    const rawBody = JSON.stringify({
+      encrypt: encryptFeishuPayload(nativePayload, encryptKey),
+    });
+    const timestamp = String(now / 1_000 + 300);
+    const nonce = "future-skew";
+    const signature = createHash("sha256")
+      .update(timestamp + nonce + encryptKey + rawBody)
+      .digest("hex");
+    const send = () =>
+      fetch(endpoint!, {
+        body: rawBody,
+        headers: {
+          "content-type": "application/json",
+          "x-lark-request-nonce": nonce,
+          "x-lark-request-timestamp": timestamp,
+          "x-lark-signature": signature,
+        },
+        method: "POST",
+      });
+
+    try {
+      expect((await send()).status).toBe(200);
+      now += 5 * 60_000 + 1;
+      expect((await send()).status).toBe(200);
+      expect(
+        (await readFile(config.feishu!.recorder.path!, "utf8")).trim().split("\n"),
+      ).toHaveLength(1);
+    } finally {
+      await provider.cleanup();
+    }
+  });
+
+  it("rejects new callbacks instead of evicting unexpired replay identities", async () => {
+    const config = await createLocalMockConfig("feishu", "/feishu/webhook");
+    const encryptKey = "encrypt-key";
+    const now = 1_700_000_000_000;
+    config.feishu!.encryptKey = encryptKey;
+    const provider = new FeishuProviderAdapter("feishu", config, "crabline", {
+      env: {},
+      now: () => now,
+      replayCacheLimit: 2,
+    });
+    const context = createProviderContext("feishu", config, {
+      id: "oc_abc123",
+      metadata: {},
+    });
+    const endpoint = (await provider.probe(context)).details
+      .find((detail) => detail.startsWith("webhook endpoint "))
+      ?.replace("webhook endpoint ", "");
+    expect(endpoint).toBeDefined();
+    const send = async (index: number): Promise<Response> => {
+      const rawBody = JSON.stringify({
+        encrypt: encryptFeishuPayload(
+          {
+            event: {
+              message: {
+                chat_id: "oc_abc123",
+                content: JSON.stringify({ text: `capacity ${index}` }),
+                message_id: `om_capacity${index}`,
+                message_type: "text",
+              },
+            },
+            header: { event_id: `event-capacity-${index}` },
+            schema: "2.0",
+          },
+          encryptKey,
+        ),
+      });
+      const timestamp = String(now / 1_000);
+      const nonce = `capacity-${index}`;
+      const signature = createHash("sha256")
+        .update(timestamp + nonce + encryptKey + rawBody)
+        .digest("hex");
+      return await fetch(endpoint!, {
+        body: rawBody,
+        headers: {
+          "content-type": "application/json",
+          "x-lark-request-nonce": nonce,
+          "x-lark-request-timestamp": timestamp,
+          "x-lark-signature": signature,
+        },
+        method: "POST",
+      });
+    };
+
+    try {
+      expect((await send(1)).status).toBe(200);
+      expect((await send(2)).status).toBe(200);
+      expect((await send(3)).status).toBe(503);
+      expect((await send(1)).status).toBe(200);
+      const records = (await readFile(config.feishu!.recorder.path!, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as { id: string });
+      expect(records.map((record) => record.id)).toEqual(["om_capacity1", "om_capacity2"]);
+    } finally {
+      await provider.cleanup();
+    }
+  });
+
   it("suppresses retries only after successful recorder persistence", async () => {
     const config = await createLocalMockConfig("feishu", "/feishu/webhook");
     const encryptKey = "encrypt-key";

--- a/test/msteams-provider.test.ts
+++ b/test/msteams-provider.test.ts
@@ -255,7 +255,7 @@ describe("Microsoft Teams webhook authentication", () => {
         }),
         body,
       ),
-    ).resolves.toMatchObject({ status: 401 });
+    ).resolves.toBeUndefined();
 
     const differentEndorsementAuthenticator = createMsTeamsWebhookAuthenticator(config, {
       fetch: async (input: string | URL | Request) =>

--- a/test/slack-provider.test.ts
+++ b/test/slack-provider.test.ts
@@ -1,7 +1,7 @@
 import { createHmac } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ProviderConfig } from "../src/config/schema.js";
 import {
   handleSlackWebhookPayload,
@@ -773,7 +773,8 @@ describe("slack provider", () => {
     const provider = new SlackProviderAdapter("slack", config, "crabline");
     providers.push(provider);
     const endpoint = endpointFromDetails((await provider.probe(createContext(config))).details);
-    const timestamp = Math.floor(Date.now() / 1000).toString();
+    let now = 1_700_000_000_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
     const send = async (eventId: string, text: string, retryNumber?: string): Promise<Response> => {
       const body = JSON.stringify({
         event: {
@@ -786,6 +787,7 @@ describe("slack provider", () => {
         event_id: eventId,
         type: "event_callback",
       });
+      const timestamp = Math.floor(now / 1000).toString();
       return await fetch(endpoint, {
         body,
         headers: {
@@ -803,18 +805,23 @@ describe("slack provider", () => {
       });
     };
 
-    expect((await send("EvRETRY001", "original delivery")).status).toBe(200);
-    expect((await send("EvRETRY001", "original delivery", "1")).status).toBe(200);
-    expect((await send("EvDISTINCT001", "distinct event")).status).toBe(200);
+    try {
+      expect((await send("EvRETRY001", "original delivery")).status).toBe(200);
+      now += 24 * 60 * 60_000;
+      expect((await send("EvRETRY001", "original delivery", "1")).status).toBe(200);
+      expect((await send("EvDISTINCT001", "distinct event")).status).toBe(200);
 
-    const records = (await readFile(config.slack!.recorder.path!, "utf8"))
-      .trim()
-      .split("\n")
-      .map((line) => JSON.parse(line) as { id: string; text: string });
-    expect(records).toEqual([
-      expect.objectContaining({ id: "EvRETRY001", text: "original delivery" }),
-      expect.objectContaining({ id: "EvDISTINCT001", text: "distinct event" }),
-    ]);
+      const records = (await readFile(config.slack!.recorder.path!, "utf8"))
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as { id: string; text: string });
+      expect(records).toEqual([
+        expect.objectContaining({ id: "EvRETRY001", text: "original delivery" }),
+        expect.objectContaining({ id: "EvDISTINCT001", text: "distinct event" }),
+      ]);
+    } finally {
+      nowSpy.mockRestore();
+    }
   });
 
   it("acknowledges unsupported, typeless, and textless callbacks without recording them", async () => {

--- a/test/slack-provider.test.ts
+++ b/test/slack-provider.test.ts
@@ -824,6 +824,52 @@ describe("slack provider", () => {
     }
   });
 
+  it("rejects new events instead of evicting retained replay identities", async () => {
+    const signingSecret = "test-token-placeholder";
+    const config = await createSlackConfig(0, signingSecret);
+    const provider = new SlackProviderAdapter("slack", config, "crabline", {
+      replayCacheLimit: 2,
+    });
+    providers.push(provider);
+    const endpoint = endpointFromDetails((await provider.probe(createContext(config))).details);
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const send = async (eventId: string): Promise<Response> => {
+      const body = JSON.stringify({
+        event: {
+          channel: "C1234567890",
+          text: eventId,
+          ts: "1700000001.000200",
+          type: "message",
+          user: "U1234567890",
+        },
+        event_id: eventId,
+        type: "event_callback",
+      });
+      return await fetch(endpoint, {
+        body,
+        headers: {
+          "content-type": "application/json",
+          "x-slack-request-timestamp": timestamp,
+          "x-slack-signature": slackSignature(signingSecret, timestamp, body),
+        },
+        method: "POST",
+      });
+    };
+
+    expect((await send("EvCAPACITY01")).status).toBe(200);
+    expect((await send("EvCAPACITY02")).status).toBe(200);
+    const rejected = await send("EvCAPACITY03");
+    expect(rejected.status).toBe(503);
+    expect(rejected.headers.get("cache-control")).toBe("no-store");
+    expect((await send("EvCAPACITY01")).status).toBe(200);
+
+    const records = (await readFile(config.slack!.recorder.path!, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { id: string });
+    expect(records.map((record) => record.id)).toEqual(["EvCAPACITY01", "EvCAPACITY02"]);
+  });
+
   it("acknowledges unsupported, typeless, and textless callbacks without recording them", async () => {
     const signingSecret = "test-token-placeholder";
     const config = await createSlackConfig(0, signingSecret);

--- a/test/slack-provider.test.ts
+++ b/test/slack-provider.test.ts
@@ -35,10 +35,12 @@ describe("Slack URL verification", () => {
         ts: "1700000001.000200",
         type: "message",
       },
+      event_id: "Ev1234567890",
       token: "placeholder",
       type: "event_callback",
     });
 
+    expect(normalized.id).toBe("Ev1234567890");
     expect(normalized.raw).toMatchObject({ type: "event_callback" });
     expect(normalized.raw).not.toHaveProperty("token");
   });
@@ -334,6 +336,60 @@ describe("slack provider", () => {
         author: "user",
         text: `ACK ${nonce}`,
         threadId: "D1234567890",
+      });
+    },
+  );
+
+  it.each(["U1234567890", "W1234567890"])(
+    "correlates threaded D-channel events to direct target %s",
+    async (userId) => {
+      const config = await createSlackConfig(0);
+      const threadTs = "1700000000.000100";
+      const provider = new SlackProviderAdapter("slack", config, "crabline");
+      providers.push(provider);
+      const context = createContext(config, {
+        id: userId,
+        metadata: {},
+        threadId: threadTs,
+      });
+      context.fixture.inboundMatch = { author: "user", nonce: "contains", strategy: "contains" };
+      const endpoint = endpointFromDetails((await provider.probe(context)).details);
+      const nonce = `threaded-direct-${userId}`;
+      const waiting = provider.waitForInbound({
+        ...context,
+        nonce,
+        since: new Date(Date.now() - 1000).toISOString(),
+        timeoutMs: 500,
+      });
+
+      for (const [eventId, candidateThreadTs] of [
+        ["EvWRONGTHREAD1", "1700000000.000101"],
+        ["EvRIGHTTHREAD1", threadTs],
+      ]) {
+        const response = await fetch(endpoint, {
+          body: JSON.stringify({
+            event: {
+              channel: "D1234567890",
+              text: `ACK ${nonce}`,
+              thread_ts: candidateThreadTs,
+              ts: candidateThreadTs === threadTs ? "1700000002.000300" : "1700000001.000200",
+              type: "message",
+              user: userId,
+            },
+            event_id: eventId,
+            type: "event_callback",
+          }),
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        });
+        expect(response.status).toBe(200);
+      }
+
+      await expect(waiting).resolves.toMatchObject({
+        author: "user",
+        id: "EvRIGHTTHREAD1",
+        text: `ACK ${nonce}`,
+        threadId: `D1234567890:thread:${threadTs}`,
       });
     },
   );
@@ -709,6 +765,56 @@ describe("slack provider", () => {
       method: "POST",
     });
     expect(accepted.status).toBe(200);
+  });
+
+  it("deduplicates retries by outer event_id without suppressing distinct events", async () => {
+    const signingSecret = "test-token-placeholder";
+    const config = await createSlackConfig(0, signingSecret);
+    const provider = new SlackProviderAdapter("slack", config, "crabline");
+    providers.push(provider);
+    const endpoint = endpointFromDetails((await provider.probe(createContext(config))).details);
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const send = async (eventId: string, text: string, retryNumber?: string): Promise<Response> => {
+      const body = JSON.stringify({
+        event: {
+          channel: "C1234567890",
+          text,
+          ts: "1700000001.000200",
+          type: "message",
+          user: "U1234567890",
+        },
+        event_id: eventId,
+        type: "event_callback",
+      });
+      return await fetch(endpoint, {
+        body,
+        headers: {
+          "content-type": "application/json",
+          ...(retryNumber
+            ? {
+                "x-slack-retry-num": retryNumber,
+                "x-slack-retry-reason": "http_timeout",
+              }
+            : {}),
+          "x-slack-request-timestamp": timestamp,
+          "x-slack-signature": slackSignature(signingSecret, timestamp, body),
+        },
+        method: "POST",
+      });
+    };
+
+    expect((await send("EvRETRY001", "original delivery")).status).toBe(200);
+    expect((await send("EvRETRY001", "original delivery", "1")).status).toBe(200);
+    expect((await send("EvDISTINCT001", "distinct event")).status).toBe(200);
+
+    const records = (await readFile(config.slack!.recorder.path!, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as { id: string; text: string });
+    expect(records).toEqual([
+      expect.objectContaining({ id: "EvRETRY001", text: "original delivery" }),
+      expect.objectContaining({ id: "EvDISTINCT001", text: "distinct event" }),
+    ]);
   });
 
   it("acknowledges unsupported, typeless, and textless callbacks without recording them", async () => {

--- a/test/slack-server.test.ts
+++ b/test/slack-server.test.ts
@@ -264,6 +264,64 @@ describe("slack local provider server", () => {
     });
   });
 
+  it("does not alias MPIM allocation with an existing private conversation", async () => {
+    const server = await startTestSlackServer();
+    await postMessage(server, {
+      channel: "G000000001",
+      text: "existing private conversation",
+    });
+
+    const opened = await slackApi(server, "conversations.open", {
+      users: "U111,U222",
+    });
+    await expect(opened.json()).resolves.toMatchObject({
+      channel: {
+        id: "G000000002",
+        is_mpim: true,
+      },
+      ok: true,
+    });
+    await postMessage(server, {
+      channel: "G000000002",
+      text: "new MPIM conversation",
+    });
+
+    await expect(
+      (
+        await slackApi(server, "conversations.info", {
+          channel: "G000000001",
+        })
+      ).json(),
+    ).resolves.toMatchObject({
+      channel: {
+        id: "G000000001",
+        is_group: true,
+        is_mpim: false,
+      },
+      ok: true,
+    });
+    await expect(
+      (
+        await slackApi(server, "conversations.history", {
+          channel: "G000000001",
+        })
+      ).json(),
+    ).resolves.toMatchObject({
+      messages: [{ text: "existing private conversation" }],
+      ok: true,
+    });
+    await expect(
+      (
+        await slackApi(server, "conversations.history", {
+          channel: "G000000002",
+        })
+      ).json(),
+    ).resolves.toMatchObject({
+      messages: [{ text: "new MPIM conversation" }],
+      ok: true,
+    });
+  });
+
   it("paginates conversations.list with stable cursors", async () => {
     const server = await startTestSlackServer();
     for (const channel of ["C1111111111", "C2222222222"]) {


### PR DESCRIPTION
## Summary
- preserve Slack event identity across threads and delayed retries
- bound retained Slack replay state for one full documented delivery horizon
- prevent MPIM channel alias collisions and retain native conversation correlation
- retain Feishu replay identities for the full accepted delivery window
- accept Teams signing keys without optional endorsement restrictions
- add focused provider/server regressions and changelog entries

## Validation
- 95 focused tests
- TypeScript typecheck and formatting
- Codex autoreview: gpt-5.6-sol, high, clean (0.87) after bounded-cache fixes
- Crabbox `pnpm verify`: `run_fe486d8dabd3` on `cbx_b8404fef94b3` (65 files; 1,797 passed, 38 skipped; exit 0)