### PR TITLE
fix(telegram): tighten synthetic identity and readiness boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Require Telegram readiness responses to identify the bot encoded in the configured token.
 - Terminate and drain unused Windows script helper bootstrap processes after command timeouts.
 - Keep synthetic Telegram username chat IDs outside the native chat-ID range.
 - Retain Slack event identities across the full delayed-delivery retry horizon with bounded replay state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Recognize server-generated Telegram username IDs in injected update state.
 - Require Telegram readiness responses to identify the bot encoded in the configured token.
 - Terminate and drain unused Windows script helper bootstrap processes after command timeouts.
 - Keep synthetic Telegram username chat IDs outside the native chat-ID range.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Keep synthetic Telegram username chat IDs outside the native chat-ID range.
 - Retain Slack event identities across the full delayed-delivery retry horizon with bounded replay state.
 - Retain Feishu replay identities through the full signed-callback validity horizon without evicting live entries.
 - Accept unrestricted Microsoft Bot Connector signing keys with empty endorsement lists.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Terminate and drain unused Windows script helper bootstrap processes after command timeouts.
 - Keep synthetic Telegram username chat IDs outside the native chat-ID range.
 - Retain Slack event identities across the full delayed-delivery retry horizon with bounded replay state.
 - Retain Feishu replay identities through the full signed-callback validity horizon without evicting live entries.

--- a/src/openclaw/bridges/telegram.ts
+++ b/src/openclaw/bridges/telegram.ts
@@ -136,6 +136,7 @@ export const TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
   createAdapter(telegram) {
     return {
       async probe(signal) {
+        const configuredBotId = /^([1-9]\d*):/u.exec(telegram.botToken)?.[1];
         const response = await fetch(
           `${telegram.endpoints.apiRoot}/bot${telegram.botToken}/getMe`,
           signal ? { signal } : {},
@@ -161,6 +162,7 @@ export const TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
           typeof result.id !== "number" ||
           !Number.isSafeInteger(result.id) ||
           result.id <= 0 ||
+          configuredBotId !== String(result.id) ||
           result.is_bot !== true ||
           !readNonBlankString(result.first_name) ||
           (result.username !== undefined &&

--- a/src/providers/builtin/script.ts
+++ b/src/providers/builtin/script.ts
@@ -258,8 +258,14 @@ const WINDOWS_PROCESS_TERMINATOR_SOURCE = [
   "}",
 ].join("");
 
+type WindowsJobHelperBootstrap = {
+  controller: AbortController;
+  promise: Promise<string>;
+  waiters: number;
+};
+
 let windowsJobHelperPath: string | undefined;
-let windowsJobHelperPromise: Promise<string> | undefined;
+let windowsJobHelperBootstrap: WindowsJobHelperBootstrap | undefined;
 
 function removeWindowsJobHelper(directory: string): void {
   try {
@@ -273,23 +279,63 @@ function runWindowsJobHelperCommand(
   executable: string,
   args: string[],
   options: ExecFileOptions,
+  signal: AbortSignal,
 ): Promise<void> {
+  if (signal.aborted) {
+    return Promise.reject(signal.reason ?? new Error("Windows script helper bootstrap aborted."));
+  }
   return new Promise((resolve, reject) => {
-    try {
-      execFile(executable, args, options, (error) => {
-        if (error) {
-          reject(error);
-          return;
-        }
+    const startedAtMs = Date.now();
+    let child: ChildProcess;
+    let settled = false;
+    let aborting = false;
+    const finish = (error?: unknown) => {
+      if (settled || aborting) {
+        return;
+      }
+      settled = true;
+      signal.removeEventListener("abort", abort);
+      if (error) {
+        reject(error);
+      } else {
         resolve();
-      });
+      }
+    };
+    const abort = () => {
+      if (settled || aborting) {
+        return;
+      }
+      aborting = true;
+      signal.removeEventListener("abort", abort);
+      void (async () => {
+        try {
+          await terminateChild(child, startedAtMs, observedAtMs);
+        } catch {
+          // The command still needs to be drained before returning the original abort.
+        }
+        await waitForChildClose(childClosed);
+        settled = true;
+        reject(signal.reason ?? new Error("Windows script helper bootstrap aborted."));
+      })();
+    };
+    try {
+      child = execFile(executable, args, options, (error) => finish(error ?? undefined));
     } catch (error) {
       reject(error);
+      return;
+    }
+    const observedAtMs = Date.now();
+    const childClosed = new Promise<ScriptChildExit>((resolveClose) => {
+      child.once("close", (code, closeSignal) => resolveClose({ code, signal: closeSignal }));
+    });
+    signal.addEventListener("abort", abort, { once: true });
+    if (signal.aborted) {
+      abort();
     }
   });
 }
 
-async function createWindowsJobHelper(): Promise<string> {
+async function createWindowsJobHelper(signal: AbortSignal): Promise<string> {
   if (windowsJobHelperPath !== undefined) {
     return windowsJobHelperPath;
   }
@@ -321,17 +367,23 @@ async function createWindowsJobHelper(): Promise<string> {
         timeout: 15_000,
         windowsHide: true,
       },
+      signal,
     );
     const probeCommand = windowsShellCommand("exit 0");
-    await runWindowsJobHelperCommand(helperPath, [], {
-      env: {
-        ...process.env,
-        [WINDOWS_JOB_COMMAND_ENV]: Buffer.from(probeCommand.commandLine).toString("base64"),
-        [WINDOWS_JOB_SHELL_ENV]: Buffer.from(probeCommand.shell).toString("base64"),
+    await runWindowsJobHelperCommand(
+      helperPath,
+      [],
+      {
+        env: {
+          ...process.env,
+          [WINDOWS_JOB_COMMAND_ENV]: Buffer.from(probeCommand.commandLine).toString("base64"),
+          [WINDOWS_JOB_SHELL_ENV]: Buffer.from(probeCommand.shell).toString("base64"),
+        },
+        timeout: 5_000,
+        windowsHide: true,
       },
-      timeout: 5_000,
-      windowsHide: true,
-    });
+      signal,
+    );
   } catch (error) {
     removeWindowsJobHelper(directory);
     throw new Error("Could not initialize the Windows script Job Object helper.", {
@@ -343,42 +395,90 @@ async function createWindowsJobHelper(): Promise<string> {
   return helperPath;
 }
 
-function ensureWindowsJobHelper(): Promise<string> {
+function releaseWindowsJobHelperWaiter(
+  bootstrap: WindowsJobHelperBootstrap,
+  reason?: unknown,
+): boolean {
+  bootstrap.waiters -= 1;
+  if (
+    bootstrap.waiters !== 0 ||
+    windowsJobHelperBootstrap !== bootstrap ||
+    windowsJobHelperPath !== undefined
+  ) {
+    return false;
+  }
+  windowsJobHelperBootstrap = undefined;
+  bootstrap.controller.abort(
+    reason ?? new Error("Windows script helper bootstrap has no active waiters."),
+  );
+  return true;
+}
+
+function ensureWindowsJobHelper(signal?: AbortSignal): Promise<string> {
   if (windowsJobHelperPath !== undefined) {
     return Promise.resolve(windowsJobHelperPath);
   }
-  windowsJobHelperPromise ??= createWindowsJobHelper().finally(() => {
-    windowsJobHelperPromise = undefined;
-  });
-  return windowsJobHelperPromise;
-}
-
-function waitForPromiseOrAbort<T>(
-  createPromise: () => Promise<T>,
-  signal?: AbortSignal,
-): Promise<T> {
   if (signal?.aborted) {
     return Promise.reject(signal.reason ?? new Error("Script command aborted."));
   }
-  const promise = createPromise();
-  if (!signal) {
-    return promise;
-  }
-  return new Promise((resolve, reject) => {
-    const abort = () => {
-      reject(signal.reason ?? new Error("Script command aborted."));
+  let bootstrap = windowsJobHelperBootstrap;
+  if (!bootstrap) {
+    const controller = new AbortController();
+    bootstrap = {
+      controller,
+      promise: Promise.resolve(""),
+      waiters: 0,
     };
-    signal.addEventListener("abort", abort, { once: true });
-    void promise.then(
+    bootstrap.promise = createWindowsJobHelper(controller.signal).finally(() => {
+      if (windowsJobHelperBootstrap === bootstrap) {
+        windowsJobHelperBootstrap = undefined;
+      }
+    });
+    windowsJobHelperBootstrap = bootstrap;
+  }
+  bootstrap.waiters += 1;
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const finish = (callback: () => void) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      signal?.removeEventListener("abort", abort);
+      callback();
+    };
+    const abort = () => {
+      finish(() => {
+        const reason = signal?.reason ?? new Error("Script command aborted.");
+        const drainsBootstrap = releaseWindowsJobHelperWaiter(bootstrap, reason);
+        if (drainsBootstrap) {
+          void bootstrap.promise.then(
+            () => reject(reason),
+            () => reject(reason),
+          );
+        } else {
+          reject(reason);
+        }
+      });
+    };
+    signal?.addEventListener("abort", abort, { once: true });
+    void bootstrap.promise.then(
       (value) => {
-        signal.removeEventListener("abort", abort);
-        resolve(value);
+        finish(() => {
+          releaseWindowsJobHelperWaiter(bootstrap);
+          resolve(value);
+        });
       },
       (error: unknown) => {
-        signal.removeEventListener("abort", abort);
-        reject(error);
+        finish(() => {
+          releaseWindowsJobHelperWaiter(bootstrap);
+          reject(error);
+        });
       },
     );
+    if (signal?.aborted) {
+      abort();
+    }
   });
 }
 
@@ -438,7 +538,7 @@ async function spawnScriptChild(
   let startedAtMs: number;
   let child: SpawnedScriptChild;
   if (process.platform === "win32") {
-    const helperPath = await waitForPromiseOrAbort(ensureWindowsJobHelper, signal);
+    const helperPath = await ensureWindowsJobHelper(signal);
     if (signal?.aborted) {
       throw signal.reason ?? new Error("Script command aborted.");
     }
@@ -1253,6 +1353,7 @@ function runScript<T>(params: {
     let timeout: NodeJS.Timeout;
     let timeoutGrace: NodeJS.Timeout | undefined;
     const spawnAbortController = new AbortController();
+    let spawnCompletion: Promise<void> | undefined;
 
     const finish = (callback: () => Promise<void> | void) => {
       if (settled) {
@@ -1269,6 +1370,8 @@ function runScript<T>(params: {
     const stopChild = async () => {
       if (child) {
         await terminateChild(child, childStartedAtMs, childObservedAtMs);
+      } else {
+        await spawnCompletion;
       }
     };
 
@@ -1400,10 +1503,10 @@ function runScript<T>(params: {
       return;
     }
 
-    void spawnScriptChild(params, spawnAbortController.signal).then(
-      (spawned) => {
+    spawnCompletion = spawnScriptChild(params, spawnAbortController.signal).then(
+      async (spawned) => {
         if (settled) {
-          void terminateChild(spawned.child, spawned.startedAtMs, spawned.observedAtMs);
+          await terminateChild(spawned.child, spawned.startedAtMs, spawned.observedAtMs);
           return;
         }
         child = spawned.child;

--- a/src/servers/telegram-identity.ts
+++ b/src/servers/telegram-identity.ts
@@ -5,7 +5,8 @@ export const TELEGRAM_BOT_USERNAME_PATTERN = /^@[A-Za-z][A-Za-z0-9_]{4,31}$/u;
 export const TELEGRAM_CHAT_USERNAME_PATTERN = /^@[A-Za-z][A-Za-z0-9_]{3,31}$/u;
 
 const TELEGRAM_SYNTHETIC_ID_RANGE = 1n << 50n;
-const TELEGRAM_USERNAME_ID_BASE = TELEGRAM_NATIVE_CHAT_ID_MAX - TELEGRAM_SYNTHETIC_ID_RANGE + 1n;
+const TELEGRAM_USERNAME_ID_BASE = TELEGRAM_NATIVE_CHAT_ID_MAX + 1n;
+const TELEGRAM_USERNAME_ID_MAX = TELEGRAM_USERNAME_ID_BASE + TELEGRAM_SYNTHETIC_ID_RANGE - 1n;
 
 export function canonicalizeTelegramUsername(value: string): string | undefined {
   const username = value.trim();
@@ -28,5 +29,5 @@ export function isTelegramUsernameChatId(value: number): boolean {
     return false;
   }
   const magnitude = BigInt(-value);
-  return magnitude >= TELEGRAM_USERNAME_ID_BASE && magnitude <= TELEGRAM_NATIVE_CHAT_ID_MAX;
+  return magnitude >= TELEGRAM_USERNAME_ID_BASE && magnitude <= TELEGRAM_USERNAME_ID_MAX;
 }

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -859,6 +859,15 @@ function telegramNumericChatId(value: unknown): number | undefined {
   return Number(integerValue);
 }
 
+function telegramStoredChatId(value: unknown): number | undefined {
+  const nativeChatId = telegramNumericChatId(value);
+  if (nativeChatId !== undefined) {
+    return nativeChatId;
+  }
+  const chatId = toIntegerValue(value);
+  return chatId !== undefined && isTelegramUsernameChatId(chatId) ? chatId : undefined;
+}
+
 async function appendEvent(state: TelegramServerState, event: TelegramServerEvent) {
   await recordServerEvent({ event, onEvent: state.onEvent, recorderPath: state.recorderPath });
 }
@@ -991,7 +1000,7 @@ function telegramChatFromRecord(value: unknown): TelegramChat | undefined {
   if (!isJsonObject(value)) {
     return undefined;
   }
-  const id = telegramNumericChatId(value.id);
+  const id = telegramStoredChatId(value.id);
   const type = telegramChatType(value.type);
   if (id === undefined || !type) {
     return undefined;
@@ -1487,7 +1496,7 @@ function explicitTelegramMessageChatId(body: Record<string, unknown>): number | 
       continue;
     }
     const chat = isJsonObject(message.chat) ? message.chat : undefined;
-    const chatId = telegramNumericChatId(chat?.id);
+    const chatId = telegramStoredChatId(chat?.id);
     if (chatId === undefined) {
       return false;
     }
@@ -1498,7 +1507,7 @@ function explicitTelegramMessageChatId(body: Record<string, unknown>): number | 
     callbackQuery && isJsonObject(callbackQuery.message) ? callbackQuery.message : undefined;
   if (callbackMessage?.message_id !== undefined) {
     const chat = isJsonObject(callbackMessage.chat) ? callbackMessage.chat : undefined;
-    const chatId = telegramNumericChatId(chat?.id);
+    const chatId = telegramStoredChatId(chat?.id);
     if (chatId === undefined) {
       return false;
     }
@@ -1664,7 +1673,7 @@ function isValidIgnoredTelegramUpdate(body: Record<string, unknown>): boolean {
       updateId === undefined ||
       updateId < 1 ||
       !chat ||
-      telegramNumericChatId(chat.id) === undefined ||
+      telegramStoredChatId(chat.id) === undefined ||
       messageId === undefined ||
       messageId < 0 ||
       (message.from !== undefined &&

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -447,6 +447,7 @@ describe("OpenClaw local provider bridge", () => {
     { ok: true },
     { ok: true, result: null },
     { ok: true, result: { first_name: "Crabline", id: 424_242, is_bot: false } },
+    { ok: true, result: { first_name: "Crabline", id: 424_243, is_bot: true } },
     {
       ok: true,
       result: { first_name: "Crabline", id: 424_242, is_bot: true, username: "abc" },

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -41,6 +41,10 @@ import {
 import { MATRIX_OPENCLAW_CRABLINE_PROVIDER_BRIDGE } from "../src/openclaw/bridges/matrix.js";
 import { SIGNAL_OPENCLAW_CRABLINE_PROVIDER_BRIDGE } from "../src/openclaw/bridges/signal.js";
 import {
+  isTelegramUsernameChatId,
+  TELEGRAM_NATIVE_CHAT_ID_MAX,
+} from "../src/servers/telegram-identity.js";
+import {
   createOpenClawCrablineProviderBridge,
   isRecord,
   parseQaTarget,
@@ -1237,7 +1241,8 @@ describe("OpenClaw local provider bridge", () => {
     expect(usernameGroupInbound.providerBody.chatId).not.toBe("@channelusername");
     const usernameGroupChatId = BigInt(String(usernameGroupInbound.providerBody.chatId));
     expect(usernameGroupChatId).toBeLessThan(0n);
-    expect(-usernameGroupChatId).toBeLessThanOrEqual((1n << 52n) - 1n);
+    expect(-usernameGroupChatId).toBeGreaterThan(TELEGRAM_NATIVE_CHAT_ID_MAX);
+    expect(isTelegramUsernameChatId(Number(usernameGroupChatId))).toBe(true);
     expect(usernameGroupInbound.providerBody.chatId).not.toBe(symbolicGroupDelivery.to);
     expect(
       createOpenClawCrablineInbound({

--- a/test/script-provider-windows.test.ts
+++ b/test/script-provider-windows.test.ts
@@ -225,10 +225,22 @@ describe("script provider Windows cleanup", () => {
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
-  it("counts Job Object helper bootstrap against the command timeout", async () => {
+  it("terminates and drains Job Object helper bootstrap after its last waiter times out", async () => {
     vi.resetModules();
     execFileMock.mockReset();
-    execFileMock.mockReturnValueOnce(createFakeChild(1109));
+    const bootstrapChild = createFakeChild(1109);
+    let bootstrapClosed = false;
+    execFileMock.mockReturnValueOnce(bootstrapChild);
+    spawnMock.mockImplementationOnce(() =>
+      createCleanupChild(0, () => {
+        bootstrapClosed = true;
+        Object.defineProperty(bootstrapChild, "exitCode", {
+          configurable: true,
+          value: 1,
+        });
+        bootstrapChild.emit("close", 1, null);
+      }),
+    );
     const { ScriptProviderAdapter: IsolatedScriptProviderAdapter } =
       await import("../src/providers/builtin/script.js");
     const context = createContext();
@@ -248,7 +260,61 @@ describe("script provider Windows cleanup", () => {
     expect(ensureErrorMessage(failure)).toContain(
       `Script command timed out after ${context.fixture.timeoutMs}ms.`,
     );
-    expect(spawnMock).not.toHaveBeenCalled();
+    expect(spawnMock.mock.calls[0]?.[0]).toBe("powershell.exe");
+    expect(bootstrapClosed).toBe(true);
+  });
+
+  it("keeps shared Job Object helper bootstrap alive for another waiter", async () => {
+    vi.resetModules();
+    execFileMock.mockReset();
+    const bootstrapChild = createFakeChild(1110);
+    let completeBootstrap: ((error: null, stdout: string, stderr: string) => void) | undefined;
+    execFileMock
+      .mockImplementationOnce((...args: unknown[]) => {
+        completeBootstrap = args.at(-1) as typeof completeBootstrap;
+        return bootstrapChild;
+      })
+      .mockImplementation(completeExecFileSuccessfully);
+    const scriptChild = createFakeChild(1111);
+    spawnMock.mockReturnValueOnce(scriptChild);
+    const { ScriptProviderAdapter: IsolatedScriptProviderAdapter } =
+      await import("../src/providers/builtin/script.js");
+    const firstContext = createContext();
+    const secondContext = createContext();
+    secondContext.fixture.timeoutMs = 100;
+    const provider = new IsolatedScriptProviderAdapter(firstContext);
+
+    const firstFailurePromise = provider
+      .send({
+        ...firstContext,
+        mode: "send",
+        nonce: "nonce-1",
+        text: "payload",
+      })
+      .catch((error: unknown) => error);
+    const secondFailurePromise = provider
+      .send({
+        ...secondContext,
+        mode: "send",
+        nonce: "nonce-2",
+        text: "payload",
+      })
+      .catch((error: unknown) => error);
+    await vi.advanceTimersByTimeAsync(firstContext.fixture.timeoutMs);
+    const firstFailure = await firstFailurePromise;
+
+    expect(ensureErrorMessage(firstFailure)).toContain(
+      `Script command timed out after ${firstContext.fixture.timeoutMs}ms.`,
+    );
+    expect(bootstrapChild.kill).not.toHaveBeenCalled();
+
+    completeBootstrap?.(null, "", "");
+    await flushScriptSpawn();
+    scriptChild.emit("close", 7, null);
+    await secondFailurePromise;
+
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+    expect(spawnMock.mock.calls[0]?.[0]).toMatch(/crabline-script-job\.exe$/u);
   });
 
   it("starts scripts inside an atomic kill-on-close Job Object", async () => {

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { startTelegramServer, type StartedTelegramServer } from "../src/index.js";
 import { handleTelegramGetUpdates, withTelegramWebhookDeadline } from "../src/servers/telegram.js";
 import {
+  isTelegramUsernameChatId,
   TELEGRAM_NATIVE_CHAT_ID_MAX,
   telegramUsernameChatId,
 } from "../src/servers/telegram-identity.js";
@@ -49,6 +50,28 @@ afterEach(async () => {
 });
 
 describe("telegram local provider server", () => {
+  it("assigns deterministic username IDs outside the native chat range", () => {
+    for (const nativeChatId of [
+      -Number(TELEGRAM_NATIVE_CHAT_ID_MAX),
+      -1,
+      1,
+      Number(TELEGRAM_NATIVE_CHAT_ID_MAX),
+    ]) {
+      expect(isTelegramUsernameChatId(nativeChatId)).toBe(false);
+    }
+
+    for (const username of ["@Crabline_Channel", "@another_channel", "@collectible"]) {
+      const chatId = telegramUsernameChatId(username);
+      expect(chatId).toBeDefined();
+      expect(Number.isSafeInteger(chatId)).toBe(true);
+      expect(BigInt(Math.abs(chatId!))).toBeGreaterThan(TELEGRAM_NATIVE_CHAT_ID_MAX);
+      expect(isTelegramUsernameChatId(chatId!)).toBe(true);
+    }
+    expect(telegramUsernameChatId("@Crabline_Channel")).toBe(
+      telegramUsernameChatId("@crabline_channel"),
+    );
+  });
+
   it("accepts only GET and POST and resolves Bot API methods case-insensitively", async () => {
     const server = await startTelegramServer({ botToken: "sample" });
     servers.push(server);
@@ -252,16 +275,6 @@ describe("telegram local provider server", () => {
     });
     expect(secondPayload.result).toMatchObject({ message_id: 2 });
     expect(secondPayload.result.chat.id).toBe(firstPayload.result.chat.id);
-
-    for (const username of ["@Crabline_Channel", "@another_channel", "@collectible"]) {
-      const chatId = telegramUsernameChatId(username);
-      expect(chatId).toBeDefined();
-      expect(Number.isSafeInteger(chatId)).toBe(true);
-      expect(BigInt(Math.abs(chatId!)) <= TELEGRAM_NATIVE_CHAT_ID_MAX).toBe(true);
-    }
-    expect(telegramUsernameChatId("@Crabline_Channel")).toBe(
-      telegramUsernameChatId("@crabline_channel"),
-    );
   });
 
   it("preserves registered channel and supergroup types for username destinations", async () => {


### PR DESCRIPTION
## Summary
- keep deterministic Telegram username IDs outside the native chat-ID range
- accept those IDs only in server-stored and admin-injected update state
- bind readiness to the bot identity encoded in the configured token
- drain timed-out Windows script helper bootstrap processes
- add focused server, bridge, and Windows lifecycle regressions plus changelog entries

## Validation
- 188 focused tests
- TypeScript typecheck and formatting
- Codex autoreview: gpt-5.6-sol, high, clean (0.86)
- Crabbox `pnpm verify`: `run_cf5d6f559fb9` on `cbx_b8404fef94b3` (65 files; 1,800 passed, 38 skipped; exit 0)