### PR TITLE
fix(providers): preserve native identity semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Preserve native identity boundaries across Discord, Slack, loopback threads, and malformed smoke-lock records.
 - Recognize server-generated Telegram username IDs in injected update state.
 - Require Telegram readiness responses to identify the bot encoded in the configured token.
 - Terminate and drain unused Windows script helper bootstrap processes after command timeouts.

--- a/src/openclaw/smoke-lock.ts
+++ b/src/openclaw/smoke-lock.ts
@@ -329,14 +329,18 @@ function isValidProcessId(value: unknown): value is number {
 const LOCK_TOKEN_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u;
 
 function parseLockOwner(contents: string): SmokeLockOwner {
-  let owner: Partial<RenewableSmokeLockOwner>;
+  let parsed: unknown;
   try {
-    owner = JSON.parse(contents) as Partial<RenewableSmokeLockOwner>;
+    parsed = JSON.parse(contents);
   } catch (error) {
     throw new Error("OpenClaw Crabline smoke lock owner metadata is malformed.", {
       cause: error,
     });
   }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("OpenClaw Crabline smoke lock owner metadata is malformed.");
+  }
+  const owner = parsed as Partial<RenewableSmokeLockOwner>;
   if (
     typeof owner.channel !== "string" ||
     !isCrablineServerChannel(owner.channel) ||

--- a/src/providers/builtin/discord.ts
+++ b/src/providers/builtin/discord.ts
@@ -216,7 +216,12 @@ export function normalizeDiscordWebhookPayload(payload: unknown) {
   }
 
   const authorRecord = isRecord(author) ? author : undefined;
-  const threadId = optionalString(payload, "thread_id") ?? channelId;
+  const nativeChannelId = requireNativeInboundId(
+    channelId,
+    DISCORD_SNOWFLAKE_RULE,
+    "Discord channel_id",
+  );
+  const threadId = optionalString(payload, "thread_id") ?? nativeChannelId;
   return {
     author: authorFromBotFlag(authorRecord?.bot === true),
     ...(optionalString(payload, "id") ? { id: optionalString(payload, "id") } : {}),

--- a/src/providers/builtin/loopback.ts
+++ b/src/providers/builtin/loopback.ts
@@ -239,10 +239,11 @@ export class LoopbackChatAdapter {
   }
 
   fetchThread(threadId: string) {
+    const address = this.decodeThreadId(threadId);
     return Promise.resolve({
-      channelId: this.channelIdFromThreadId(threadId),
+      channelId: address.channelId ?? address.id,
       id: threadId,
-      isDM: true,
+      isDM: address.channelId === undefined,
       metadata: {},
     });
   }

--- a/src/providers/builtin/slack.ts
+++ b/src/providers/builtin/slack.ts
@@ -72,6 +72,7 @@ function authenticateSlackWebhook(
   request: Request,
   rawBody: string,
   signingSecret: string,
+  now: () => number = Date.now,
 ): Response | undefined {
   const timestamp = request.headers.get("x-slack-request-timestamp");
   const signature = request.headers.get("x-slack-signature");
@@ -80,7 +81,7 @@ function authenticateSlackWebhook(
     !timestamp ||
     !signature ||
     !Number.isSafeInteger(timestampSeconds) ||
-    Math.abs(Date.now() / 1000 - timestampSeconds) > SLACK_SIGNATURE_TOLERANCE_SECONDS
+    Math.abs(now() / 1000 - timestampSeconds) > SLACK_SIGNATURE_TOLERANCE_SECONDS
   ) {
     return new Response("unauthorized", { status: 401 });
   }
@@ -532,7 +533,7 @@ export class SlackProviderAdapter extends LocalMockProviderAdapter implements Pr
       expiryHead: 0,
       expiryQueue: [],
       inFlight: new Map(),
-      now: slackRuntime.now ?? Date.now,
+      now: slackRuntime.now ?? (() => Date.now()),
     };
     super({
       codec: getBuiltinTargetCodec("slack"),
@@ -542,7 +543,12 @@ export class SlackProviderAdapter extends LocalMockProviderAdapter implements Pr
         ...(resolvedConfig.signingSecret
           ? {
               authenticateWebhookRequest(request: Request, rawBody: string) {
-                return authenticateSlackWebhook(request, rawBody, resolvedConfig.signingSecret!);
+                return authenticateSlackWebhook(
+                  request,
+                  rawBody,
+                  resolvedConfig.signingSecret!,
+                  replayState.now,
+                );
               },
             }
           : {}),

--- a/src/providers/target-normalizers.ts
+++ b/src/providers/target-normalizers.ts
@@ -15,7 +15,7 @@ export type BuiltinProviderAdapterId = Exclude<BuiltinAdapterId, "script">;
 export const DISCORD_SNOWFLAKE_RULE: NativeIdRule = {
   example: "123456789012345678",
   name: "Discord snowflake id",
-  pattern: /^[1-9]\d{16,19}$/u,
+  pattern: /^[1-9]\d{0,19}$/u,
   validate: (value) => BigInt(value) <= 18_446_744_073_709_551_615n,
 };
 

--- a/test/discord-provider.test.ts
+++ b/test/discord-provider.test.ts
@@ -371,6 +371,14 @@ describe("discord provider", () => {
 
     expect(
       provider.normalizeTarget({
+        id: "1",
+        metadata: {},
+      }),
+    ).toMatchObject({
+      channelId: "1",
+    });
+    expect(
+      provider.normalizeTarget({
         id: "123456789012345678",
         metadata: { guildId: "987654321098765432" },
       }),
@@ -422,6 +430,16 @@ describe("discord provider", () => {
         ),
       ).toBe(false);
     }
+  });
+
+  it("validates native channel ids even when a thread id is present", () => {
+    expect(() =>
+      normalizeDiscordWebhookPayload({
+        channel_id: "invalid",
+        content: "hello",
+        thread_id: "123456789012345678",
+      }),
+    ).toThrow(/Discord channel_id/u);
   });
 
   it("only accepts POST requests at the interactions endpoint", async () => {

--- a/test/loopback-adapter.test.ts
+++ b/test/loopback-adapter.test.ts
@@ -63,6 +63,7 @@ describe("loopback chat adapter", () => {
     await expect(adapter.fetchThread(threadId)).resolves.toMatchObject({
       channelId: address.channelId,
       id: threadId,
+      isDM: false,
     });
 
     const legacyThreadId = "loopback:legacy::topic";
@@ -70,8 +71,15 @@ describe("loopback chat adapter", () => {
     await expect(adapter.fetchThread(legacyThreadId)).resolves.toMatchObject({
       channelId: "legacy",
       id: legacyThreadId,
+      isDM: false,
     });
     expect(adapter.channelIdFromThreadId("plain-id::topic")).toBe("plain-id");
+    await expect(
+      adapter.fetchThread(adapter.encodeThreadId({ id: "direct-user" })),
+    ).resolves.toMatchObject({
+      channelId: "direct-user",
+      isDM: true,
+    });
   });
 
   it("preserves legacy percent-encoded-looking thread ids", () => {

--- a/test/openclaw-smoke-lock.test.ts
+++ b/test/openclaw-smoke-lock.test.ts
@@ -156,6 +156,33 @@ describe("OpenClaw smoke lock cleanup", () => {
     }
   });
 
+  it("classifies non-object lock owners as malformed metadata", async () => {
+    const outputDir = await createTempDir();
+    const lockDirectory = path.join(
+      path.resolve(outputDir),
+      `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`,
+    );
+    try {
+      await fs.mkdir(lockDirectory);
+      await fs.writeFile(path.join(lockDirectory, "owner.json"), "null\n");
+
+      await expect(
+        acquireOpenClawCrablineSmokeRunLock(
+          { channel: "telegram", outputDir },
+          {
+            isProcessAlive: () => true,
+            now: () => 1_000,
+            pid: 5_252,
+            processStartedAtMs: 200,
+            startHeartbeat: disableHeartbeat,
+          },
+        ),
+      ).rejects.toThrow("OpenClaw Crabline smoke lock owner metadata is malformed.");
+    } finally {
+      await disposeTempDir(outputDir);
+    }
+  });
+
   it("rejects commit paths outside the lock output before staging", async () => {
     const outputDir = await createTempDir();
     const outsideDir = await createTempDir();

--- a/test/slack-provider.test.ts
+++ b/test/slack-provider.test.ts
@@ -767,6 +767,39 @@ describe("slack provider", () => {
     expect(accepted.status).toBe(200);
   });
 
+  it("uses the injected clock for signature freshness", async () => {
+    const signingSecret = "test-token-placeholder";
+    const config = await createSlackConfig(0, signingSecret);
+    const now = 1_700_000_000_000;
+    const provider = new SlackProviderAdapter("slack", config, "crabline", {
+      now: () => now,
+    });
+    providers.push(provider);
+    const endpoint = endpointFromDetails((await provider.probe(createContext(config))).details);
+    const timestamp = Math.floor(now / 1000).toString();
+    const body = JSON.stringify({
+      event: {
+        channel: "C1234567890",
+        text: "fixed clock",
+        ts: "1700000001.000200",
+        type: "message",
+      },
+      type: "event_callback",
+    });
+
+    const response = await fetch(endpoint, {
+      body,
+      headers: {
+        "content-type": "application/json",
+        "x-slack-request-timestamp": timestamp,
+        "x-slack-signature": slackSignature(signingSecret, timestamp, body),
+      },
+      method: "POST",
+    });
+
+    expect(response.status).toBe(200);
+  });
+
   it("deduplicates retries by outer event_id without suppressing distinct events", async () => {
     const signingSecret = "test-token-placeholder";
     const config = await createSlackConfig(0, signingSecret);


### PR DESCRIPTION
## Summary
- validate Discord channel IDs independently and accept the full unsigned snowflake range
- classify loopback channel threads correctly and bind Slack signature freshness to the injected clock
- reject non-object smoke-lock owner records with the stable malformed-metadata error

## Validation
- targeted Vitest: 146 passed
- TypeScript: clean
- Crabbox `run_826debc47ec0`: 65 files, 1,803 passed, 38 skipped
- autoreview: gpt-5.6-sol high, clean (0.96)

## Changelog
- added an Unreleased entry