### PR TITLE
fix(servers): preserve WhatsApp and Zalo state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Preserve native identity boundaries across Discord, Slack, loopback threads, and malformed smoke-lock records.
+- Preserve active WhatsApp inbound identities across replay-cache eviction, reject self-authored admin ingress, canonicalize Cloud webhook senders, and bound retained Zalo polling updates by bytes.
 - Recognize server-generated Telegram username IDs in injected update state.
 - Require Telegram readiness responses to identify the bot encoded in the configured token.
 - Terminate and drain unused Windows script helper bootstrap processes after command timeouts.

--- a/README.md
+++ b/README.md
@@ -393,7 +393,9 @@ API methods accept GET query parameters or POST requests. Admin
 ingress injects a native Zalo update into the active polling or webhook
 transport. Webhook delivery posts the native `{ event_name, message }` update
 directly. OpenClaw-specific endpoint, config, and target mapping remain in the
-isolated bridge.
+isolated bridge. Programmatic `startZaloServer()` callers can tune the retained
+polling queue with `maxPendingInboundEvents` and `maxPendingInboundBytes`; the
+byte limit defaults to 64 MiB.
 
 The admin ingress accepts JSON like:
 

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -539,6 +539,10 @@ receives the native Zalo `{ event_name, message }` update directly with
 otherwise injected messages are returned by `getUpdates`. Provider errors use
 Zalo's `{ ok, error_code, description }` shape.
 
+Programmatic `startZaloServer()` callers can tune the retained polling queue
+with `maxPendingInboundEvents` and `maxPendingInboundBytes`; the byte limit
+defaults to 64 MiB and remains reserved until the polling response commits.
+
 `setWebhook` requires HTTPS, matching Zalo's public API. A loopback-bound
 Crabline server also accepts a loopback HTTP URL for independent local client
 tests. Non-loopback binds reject webhook destinations that resolve to private,

--- a/src/servers/whatsapp.ts
+++ b/src/servers/whatsapp.ts
@@ -225,6 +225,22 @@ type WhatsAppMessageIdReservation = {
   id: string;
 };
 
+/** @internal */
+export function isWhatsAppMessageIdInUse(
+  state: {
+    inboundMessageIds: ReadonlySet<string>;
+    pendingMessageIds: ReadonlySet<string>;
+    recentMessageIds: ReadonlyMap<string, true>;
+  },
+  id: string,
+): boolean {
+  return (
+    state.inboundMessageIds.has(id) ||
+    state.pendingMessageIds.has(id) ||
+    state.recentMessageIds.has(id)
+  );
+}
+
 function reserveMessageId(
   state: WhatsAppServerState,
   requestedId?: string,
@@ -237,7 +253,7 @@ function reserveMessageId(
         `messageId must not exceed ${MAX_WHATSAPP_MESSAGE_ID_BYTES} UTF-8 bytes.`,
       );
     }
-    if (state.pendingMessageIds.has(id) || state.recentMessageIds.has(id)) {
+    if (isWhatsAppMessageIdInUse(state, id)) {
       return graphParameterError(
         "(#100) Invalid parameter: messageId",
         "messageId must be unique within this WhatsApp server.",
@@ -246,7 +262,7 @@ function reserveMessageId(
   } else {
     do {
       id = `wamid.FAKE${String(state.nextMessageId++).padStart(8, "0")}`;
-    } while (state.pendingMessageIds.has(id) || state.recentMessageIds.has(id));
+    } while (isWhatsAppMessageIdInUse(state, id));
   }
   state.pendingMessageIds.add(id);
   let settled = false;
@@ -284,7 +300,8 @@ function reserveMessageId(
 }
 
 function waIdFromJid(jid: string): string {
-  return jid.split("@", 1)[0]?.split(":", 1)[0] ?? jid;
+  const correlationJid = canonicalizeWhatsAppUserCorrelationJid(jid);
+  return correlationJid?.split("@", 1)[0] ?? jid;
 }
 
 function directPeerIdentity(jid: string): string {
@@ -462,6 +479,14 @@ async function handleAdminInbound(params: {
   const senderJid = requireWhatsAppSenderJid(params.body.senderJid ?? params.body.from);
   if (senderJid instanceof Response) {
     return { response: senderJid };
+  }
+  if (directPeerIdentity(senderJid) === directPeerIdentity(params.state.selfJid)) {
+    return {
+      response: graphParameterError(
+        "(#100) Invalid parameter: senderJid",
+        "senderJid must not identify the configured WhatsApp self identity.",
+      ),
+    };
   }
   const isGroupChat = isWhatsAppGroupJid(chatJid);
   if (!isGroupChat && directPeerIdentity(chatJid) !== directPeerIdentity(senderJid)) {

--- a/src/servers/zalo.ts
+++ b/src/servers/zalo.ts
@@ -33,6 +33,7 @@ import {
 type ZaloChatType = "GROUP" | "PRIVATE";
 
 const DEFAULT_WEBHOOK_DELIVERY_TIMEOUT_MS = 5_000;
+const DEFAULT_MAX_PENDING_INBOUND_BYTES = 64 * 1024 * 1024;
 const MAX_ACTIVE_ZALO_WEBHOOK_VALIDATIONS = 8;
 const MAX_ZALO_REDACTION_DEPTH = 32;
 const MAX_WEBHOOK_DELIVERY_TIMEOUT_MS = 30_000;
@@ -83,6 +84,7 @@ type ZaloServerState = {
   botToken: string;
   closing: boolean;
   inboundAdmission: Promise<void>;
+  maxPendingInboundBytes: number;
   maxPendingInboundEvents: number;
   nextMessage: number;
   nextUpdateOrder: number;
@@ -90,8 +92,11 @@ type ZaloServerState = {
   pendingInboundAdmissions: number;
   pendingRequest: PendingUpdateRequest | undefined;
   recorderPath: string;
+  retainedUpdateBytes: number;
+  retainedUpdateCount: number;
   reservedUpdateOrders: Set<number>;
   restrictWebhookTargets: boolean;
+  updateBytes: WeakMap<ZaloUpdate, number>;
   updateOrders: WeakMap<ZaloUpdate, number>;
   updates: ZaloUpdate[];
   webhook: { secretToken: string; updatedAt: number; url: string } | undefined;
@@ -131,6 +136,7 @@ export type StartZaloServerParams = {
   onEvent?: ServerEventObserver | undefined;
   port?: number | undefined;
   recorderPath?: string | undefined;
+  maxPendingInboundBytes?: number | undefined;
   maxPendingInboundEvents?: number | undefined;
   webhookDeliveryTimeoutMs?: number | undefined;
 };
@@ -308,6 +314,16 @@ function webhookDeliveryTimeoutMs(value: number | undefined): number {
   return Math.max(1, Math.min(Math.floor(value), MAX_WEBHOOK_DELIVERY_TIMEOUT_MS));
 }
 
+function maxPendingInboundBytes(value: number | undefined): number {
+  if (value === undefined) {
+    return DEFAULT_MAX_PENDING_INBOUND_BYTES;
+  }
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new Error("maxPendingInboundBytes must be a positive safe integer.");
+  }
+  return value;
+}
+
 async function validateWebhookUrl(
   url: URL,
   state: Pick<ZaloServerState, "allowLoopbackHttpWebhook" | "restrictWebhookTargets">,
@@ -450,6 +466,40 @@ function pollingUpdateOrder(state: ZaloServerState, update: ZaloUpdate): number 
   return order;
 }
 
+function pollingUpdateBytes(state: ZaloServerState, update: ZaloUpdate): number {
+  const existing = state.updateBytes.get(update);
+  if (existing !== undefined) {
+    return existing;
+  }
+  const bytes = Buffer.byteLength(JSON.stringify(update), "utf8");
+  state.updateBytes.set(update, bytes);
+  return bytes;
+}
+
+function retainPollingUpdate(state: ZaloServerState, update: ZaloUpdate): boolean {
+  const bytes = pollingUpdateBytes(state, update);
+  if (
+    state.retainedUpdateCount >= state.maxPendingInboundEvents ||
+    state.retainedUpdateBytes + bytes > state.maxPendingInboundBytes
+  ) {
+    state.updateBytes.delete(update);
+    return false;
+  }
+  state.retainedUpdateCount += 1;
+  state.retainedUpdateBytes += bytes;
+  return true;
+}
+
+function releasePollingUpdate(state: ZaloServerState, update: ZaloUpdate): void {
+  const bytes = state.updateBytes.get(update);
+  if (bytes === undefined) {
+    throw new Error("Zalo polling update retention was released without a reservation.");
+  }
+  state.updateBytes.delete(update);
+  state.retainedUpdateCount -= 1;
+  state.retainedUpdateBytes -= bytes;
+}
+
 function queuePollingUpdate(state: ZaloServerState, update: ZaloUpdate): void {
   const order = pollingUpdateOrder(state, update);
   const insertionIndex = state.updates.findIndex(
@@ -492,7 +542,7 @@ function flushPendingPollingUpdate(state: ZaloServerState): void {
 
 function reservedUpdateResponse(state: ZaloServerState, update: ZaloUpdate): HttpJsonHandlerResult {
   let settled = false;
-  const release = () => {
+  const releaseReservation = () => {
     if (settled) {
       return false;
     }
@@ -502,14 +552,15 @@ function reservedUpdateResponse(state: ZaloServerState, update: ZaloUpdate): Htt
   };
   return {
     onWriteFailure() {
-      if (!release()) {
+      if (!releaseReservation()) {
         return;
       }
       queuePollingUpdate(state, update);
       flushPendingPollingUpdate(state);
     },
     onWriteSuccess() {
-      if (release()) {
+      if (releaseReservation()) {
+        releasePollingUpdate(state, update);
         flushPendingPollingUpdate(state);
       }
     },
@@ -602,30 +653,23 @@ async function waitForUpdate(
   }
 }
 
-function deliverPollingUpdate(state: ZaloServerState, update: ZaloUpdate): boolean {
+function deliverPollingUpdate(state: ZaloServerState, update: ZaloUpdate): void {
   pollingUpdateOrder(state, update);
   if (state.updates.length > 0 || hasEarlierReservedPollingUpdate(state, update)) {
-    if (state.updates.length + state.reservedUpdateOrders.size >= state.maxPendingInboundEvents) {
-      return false;
-    }
     queuePollingUpdate(state, update);
     flushPendingPollingUpdate(state);
-    return true;
+    return;
   }
   const pending = state.pendingRequest;
   if (pending) {
     if (isPendingUpdateRequestLive(pending)) {
       reservePollingUpdate(state, update);
       settlePendingUpdate(state, pending, { kind: "update", update });
-      return true;
+      return;
     }
     settlePendingUpdate(state, pending, { kind: "disconnect" });
   }
-  if (state.updates.length + state.reservedUpdateOrders.size >= state.maxPendingInboundEvents) {
-    return false;
-  }
   queuePollingUpdate(state, update);
-  return true;
 }
 
 async function deliverWebhookUpdate(
@@ -689,9 +733,8 @@ async function handleAdminInbound(
     drainRequestBody(request);
     return zaloError("Webhook configuration is in progress", 409);
   }
-  const queued =
-    state.webhook?.url === undefined ? state.updates.length + state.reservedUpdateOrders.size : 0;
-  if (queued + state.pendingInboundAdmissions >= state.maxPendingInboundEvents) {
+  const retainedUpdates = state.webhook?.url === undefined ? state.retainedUpdateCount : 0;
+  if (retainedUpdates + state.pendingInboundAdmissions >= state.maxPendingInboundEvents) {
     drainRequestBody(request);
     return zaloError(
       `Pending inbound queue is full (${state.maxPendingInboundEvents} updates)`,
@@ -705,6 +748,7 @@ async function handleAdminInbound(
     releaseAdmission = resolve;
   });
   let admissionPending = true;
+  let retainedPollingUpdate: ZaloUpdate | undefined;
   try {
     const parsedBody = await parseUnknownRequestBody(request);
     await previousAdmission;
@@ -718,15 +762,7 @@ async function handleAdminInbound(
     if (chatId instanceof Response || senderId instanceof Response || text instanceof Response) {
       return [chatId, senderId, text].find((value) => value instanceof Response) as Response;
     }
-    if (
-      !state.webhook?.url &&
-      state.updates.length + state.reservedUpdateOrders.size >= state.maxPendingInboundEvents
-    ) {
-      return zaloError(
-        `Pending inbound queue is full (${state.maxPendingInboundEvents} updates)`,
-        429,
-      );
-    }
+    const webhook = state.webhook;
     const update: ZaloUpdate = {
       event_name: "message.text.received",
       message: {
@@ -741,6 +777,17 @@ async function handleAdminInbound(
         text,
       },
     };
+    if (!webhook?.url) {
+      if (!retainPollingUpdate(state, update)) {
+        return zaloError(
+          `Pending inbound queue is full (${state.maxPendingInboundEvents} updates)`,
+          429,
+        );
+      }
+      retainedPollingUpdate = update;
+      state.pendingInboundAdmissions -= 1;
+      admissionPending = false;
+    }
     await appendEvent(state, {
       at: new Date().toISOString(),
       body: redactParams(body),
@@ -749,23 +796,20 @@ async function handleAdminInbound(
       query: redactParams(queryRecord(url)) as Record<string, string>,
       type: "admin",
     });
-    if (state.webhook?.url) {
-      const error = await deliverWebhookUpdate(state, state.webhook, update);
+    if (webhook?.url) {
+      const error = await deliverWebhookUpdate(state, webhook, update);
       if (error) {
         return error;
       }
     } else {
-      state.pendingInboundAdmissions -= 1;
-      admissionPending = false;
-      if (!deliverPollingUpdate(state, update)) {
-        return zaloError(
-          `Pending inbound queue is full (${state.maxPendingInboundEvents} updates)`,
-          429,
-        );
-      }
+      deliverPollingUpdate(state, update);
+      retainedPollingUpdate = undefined;
     }
     return zaloOk(update);
   } finally {
+    if (retainedPollingUpdate) {
+      releasePollingUpdate(state, retainedPollingUpdate);
+    }
     await previousAdmission;
     releaseAdmission();
     if (admissionPending) {
@@ -938,6 +982,7 @@ export async function startZaloServer(
       (isLoopbackHost(host) ? "crabline-zalo-bot-token" : randomBytes(32).toString("base64url")),
     closing: false,
     inboundAdmission: Promise.resolve(),
+    maxPendingInboundBytes: maxPendingInboundBytes(params.maxPendingInboundBytes),
     maxPendingInboundEvents: resolveMaxPendingInboundEvents(params.maxPendingInboundEvents),
     nextMessage: 1,
     nextUpdateOrder: 1,
@@ -945,8 +990,11 @@ export async function startZaloServer(
     pendingInboundAdmissions: 0,
     pendingRequest: undefined,
     recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "zalo.jsonl"),
+    retainedUpdateBytes: 0,
+    retainedUpdateCount: 0,
     reservedUpdateOrders: new Set(),
     restrictWebhookTargets: true,
+    updateBytes: new WeakMap(),
     updateOrders: new WeakMap(),
     updates: [],
     webhook: undefined,

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -36,6 +36,7 @@ import {
   canonicalizeWhatsAppUserCorrelationJid,
   canonicalizeWhatsAppUserJid,
 } from "../src/servers/whatsapp-jid.js";
+import { isWhatsAppMessageIdInUse } from "../src/servers/whatsapp.js";
 import type { BinaryNode } from "../src/servers/whatsapp-wire/binary-node.js";
 import { Curve, ensureSignalPublicKey, type KeyPair } from "../src/servers/whatsapp-wire/crypto.js";
 import { createTempDir, disposeTempDir, requestHttp } from "./test-helpers.js";
@@ -823,9 +824,31 @@ describe("whatsapp local provider server", () => {
     });
     expect(mismatchedLidSender.status).toBe(400);
 
+    for (const body of [
+      {
+        chatJid: "15550000000@s.whatsapp.net",
+        senderJid: "15550000000_7:2@s.whatsapp.net",
+      },
+      {
+        chatJid: "120363001234567890@g.us",
+        senderJid: "15550000000:3@s.whatsapp.net",
+      },
+    ]) {
+      const selfSender = await sendInbound(body);
+      expect(selfSender.status).toBe(400);
+      await expect(selfSender.json()).resolves.toMatchObject({
+        error: {
+          error_data: {
+            details: "senderJid must not identify the configured WhatsApp self identity.",
+          },
+          message: "(#100) Invalid parameter: senderJid",
+        },
+      });
+    }
+
     const direct = await sendInbound({
       chatJid: "15551234567:4@c.us",
-      senderJid: "15551234567:2@s.whatsapp.net",
+      senderJid: "15551234567_7:2@s.whatsapp.net",
     });
     expect(direct.status).toBe(200);
     const directBody = (await direct.json()) as {
@@ -843,6 +866,7 @@ describe("whatsapp local provider server", () => {
             changes: [
               {
                 value: {
+                  contacts: [{ wa_id: "15551234567" }],
                   messages: [{ from: "15551234567" }],
                 },
               },
@@ -941,6 +965,23 @@ describe("whatsapp local provider server", () => {
           event.body?.messageId === "wamid.FAKE00000001",
       ),
     ).toHaveLength(1);
+  });
+
+  it("keeps active inbound message ids reserved after recent-cache eviction", () => {
+    const messageId = "wamid.active-inbound";
+    const recentMessageIds = new Map([[messageId, true] as const]);
+    recentMessageIds.delete(messageId);
+
+    expect(
+      isWhatsAppMessageIdInUse(
+        {
+          inboundMessageIds: new Set([messageId]),
+          pendingMessageIds: new Set(),
+          recentMessageIds,
+        },
+        messageId,
+      ),
+    ).toBe(true);
   });
 
   it("separates PN and LID signal bundle/session keys while normalizing devices", () => {

--- a/test/zalo-server.test.ts
+++ b/test/zalo-server.test.ts
@@ -28,6 +28,12 @@ function adminHeaders(server: StartedZaloServer) {
 }
 
 describe("Zalo local provider server", () => {
+  it("validates pending polling byte limits before binding", async () => {
+    await expect(startZaloServer({ maxPendingInboundBytes: 0 })).rejects.toThrow(
+      "maxPendingInboundBytes must be a positive safe integer.",
+    );
+  });
+
   it("serves the Bot API over GET and POST and delivers admin inbound", async () => {
     const directory = await createTempDir();
     directories.push(directory);
@@ -1373,6 +1379,63 @@ describe("Zalo local provider server", () => {
       error_code: 429,
       ok: false,
     });
+  });
+
+  it("retains polling byte reservations across delivery failure and releases them on success", async () => {
+    const server = await startZaloServer({
+      adminToken: "admin",
+      botToken: "sample",
+      maxPendingInboundBytes: 1_000,
+      maxPendingInboundEvents: 10,
+    });
+    servers.push(server);
+    const sendInbound = (text: string) =>
+      fetch(server.manifest.endpoints.adminInboundUrl, {
+        body: JSON.stringify({ chatId: "chat-1", senderId: "user-1", text }),
+        headers: adminHeaders(server),
+        method: "POST",
+      });
+
+    expect((await sendInbound("x".repeat(400))).status).toBe(200);
+
+    const responsePrototype = ServerResponse.prototype as unknown as {
+      end: (...args: unknown[]) => ServerResponse;
+    };
+    const originalEnd = responsePrototype.end;
+    let heldResponse: ServerResponse | undefined;
+    let reportHeldResponse!: () => void;
+    const heldResponseObserved = new Promise<void>((resolve) => {
+      reportHeldResponse = resolve;
+    });
+    responsePrototype.end = function (this: ServerResponse, ...args: unknown[]) {
+      if (this.req?.url?.includes("/getUpdates") && !heldResponse) {
+        heldResponse = this;
+        reportHeldResponse();
+        return this;
+      }
+      return Reflect.apply(originalEnd, this, args) as ServerResponse;
+    };
+
+    const failedPoll = requestHttp({
+      method: "GET",
+      url: `${server.manifest.baseUrl}/botsample/getUpdates?timeout=0`,
+    });
+    try {
+      await heldResponseObserved;
+      expect((await sendInbound("y".repeat(400))).status).toBe(429);
+      heldResponse!.destroy(new Error("simulated response failure"));
+      await expect(failedPoll).rejects.toBeInstanceOf(Error);
+    } finally {
+      responsePrototype.end = originalEnd;
+      heldResponse?.destroy();
+    }
+
+    expect((await sendInbound("z".repeat(400))).status).toBe(429);
+    const restored = await fetch(`${server.manifest.baseUrl}/botsample/getUpdates?timeout=0`);
+    await expect(restored.json()).resolves.toMatchObject({
+      result: { message: { text: "x".repeat(400) } },
+    });
+    expect((await sendInbound("released")).status).toBe(200);
   });
 
   it("rejects invalid bot tokens and unauthenticated admin ingress", async () => {


### PR DESCRIPTION
## Summary
- keep active WhatsApp inbound message IDs reserved beyond replay-cache eviction
- reject self-authored admin ingress and canonicalize Cloud webhook sender identities
- bound retained Zalo polling updates by count and encoded bytes with commit-aware release accounting

## Validation
- focused tests: 75 passed
- typecheck, build, lint, and formatting: clean
- Crabbox `run_71b343b068bc`: 65 files, 1,806 passed, 38 skipped
- autoreview: gpt-5.6-sol high, clean (0.86)

## Changelog
- added an Unreleased entry and documented `maxPendingInboundBytes`