### PR TITLE
fix(providers): harden ingress normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Preserve native identity boundaries across Discord, Slack, loopback threads, and malformed smoke-lock records.
 - Preserve active WhatsApp inbound identities across replay-cache eviction, reject self-authored admin ingress, canonicalize Cloud webhook senders, and bound retained Zalo polling updates by bytes.
+- Accept valid fallback iMessage aliases and attachment-only Teams activities, canonicalize equal Telegram chat/topic IDs, and harden nonce, regex, JWT, Slack structured-text, and Telegram readiness validation.
 - Recognize server-generated Telegram username IDs in injected update state.
 - Require Telegram readiness responses to identify the bot encoded in the configured token.
 - Terminate and drain unused Windows script helper bootstrap processes after command timeouts.

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -200,6 +200,15 @@ const InboundMatchSchema = z
     if (value.strategy !== "regex" || !value.pattern) {
       return;
     }
+    const safetyError = inboundRegexSafetyError(value.pattern);
+    if (safetyError?.startsWith("must contain at most ")) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `inboundMatch.pattern ${safetyError}`,
+        path: ["pattern"],
+      });
+      return;
+    }
     try {
       RegExp(value.pattern, "u");
     } catch {
@@ -210,7 +219,6 @@ const InboundMatchSchema = z
       });
       return;
     }
-    const safetyError = inboundRegexSafetyError(value.pattern);
     if (safetyError) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,

--- a/src/core/matcher.ts
+++ b/src/core/matcher.ts
@@ -5,7 +5,46 @@ import type { InboundEnvelope, InboundMatchConfig } from "../providers/types.js"
 const EXACT_ACK_WORD =
   /(?<![\p{ID_Continue}\p{Mark}\p{Cf}])ACK(?![\p{ID_Continue}\p{Mark}\p{Cf}])/gu;
 const ACK_SEPARATOR = /[\p{White_Space}\p{P}\p{S}]/u;
-const IDENTIFIER_CONTINUATION = /[a-z0-9-]/iu;
+const IDENTIFIER_CONTINUATION = /[\p{ID_Continue}\p{Mark}\p{Cf}-]/u;
+
+function characterBefore(text: string, offset: number): string | undefined {
+  if (offset === 0) {
+    return undefined;
+  }
+  const previous = text.charCodeAt(offset - 1);
+  if (previous >= 0xdc00 && previous <= 0xdfff && offset > 1) {
+    const leading = text.charCodeAt(offset - 2);
+    if (leading >= 0xd800 && leading <= 0xdbff) {
+      return text.slice(offset - 2, offset);
+    }
+  }
+  return text[offset - 1];
+}
+
+function isCanonicalNonceOccurrence(text: string, offset: number, nonce: string): boolean {
+  const precedingCharacter = characterBefore(text, offset);
+  const followingOffset = offset + nonce.length;
+  const followingCharacter =
+    followingOffset < text.length
+      ? String.fromCodePoint(text.codePointAt(followingOffset)!)
+      : undefined;
+  return (
+    (!precedingCharacter || !IDENTIFIER_CONTINUATION.test(precedingCharacter)) &&
+    (!followingCharacter || !IDENTIFIER_CONTINUATION.test(followingCharacter))
+  );
+}
+
+function extractCanonicalNonces(text: string): string[] {
+  let searchOffset = 0;
+  return extractNonces(text).filter((nonce) => {
+    const offset = text.indexOf(nonce, searchOffset);
+    if (offset < 0) {
+      return false;
+    }
+    searchOffset = offset + nonce.length;
+    return isCanonicalNonceOccurrence(text, offset, nonce);
+  });
+}
 
 function hasAcknowledgementForNonce(text: string, nonce: string): boolean {
   for (const match of text.matchAll(EXACT_ACK_WORD)) {
@@ -17,11 +56,7 @@ function hasAcknowledgementForNonce(text: string, nonce: string): boolean {
       }
       offset += character.length;
     }
-    const followingCharacter = text[offset + nonce.length];
-    if (
-      text.startsWith(nonce, offset) &&
-      (!followingCharacter || !IDENTIFIER_CONTINUATION.test(followingCharacter))
-    ) {
+    if (text.startsWith(nonce, offset) && isCanonicalNonceOccurrence(text, offset, nonce)) {
       return true;
     }
   }
@@ -39,7 +74,7 @@ export function matchesInbound(
   }
 
   const text = envelope.text ?? "";
-  const extractedNonces = extractNonces(text);
+  const extractedNonces = extractCanonicalNonces(text);
 
   if (
     options?.requireAcknowledgement &&

--- a/src/openclaw/artifact-generation.ts
+++ b/src/openclaw/artifact-generation.ts
@@ -252,12 +252,19 @@ function isSuccessfulProbe(
       return value.ok === true;
     case "telegram": {
       const result = value.result;
+      const tokenBotId =
+        typeof manifest.botToken === "string"
+          ? /^([1-9]\d*):/u.exec(manifest.botToken)?.[1]
+          : undefined;
+      const expectedBotId = tokenBotId === undefined ? undefined : Number(tokenBotId);
       return (
         value.ok === true &&
         isRecord(result) &&
         typeof result.id === "number" &&
         Number.isSafeInteger(result.id) &&
         result.id > 0 &&
+        Number.isSafeInteger(expectedBotId) &&
+        result.id === expectedBotId &&
         result.is_bot === true &&
         typeof result.first_name === "string" &&
         result.first_name.length > 0

--- a/src/openclaw/bridges/slack.ts
+++ b/src/openclaw/bridges/slack.ts
@@ -4,7 +4,6 @@ import {
   DEFAULT_ACCOUNT_ID,
   isRecord,
   qaTargetForInbound,
-  readNonBlankString,
   readString,
 } from "../shared.js";
 import {
@@ -68,6 +67,12 @@ function slackConversationKind(channel: string): "direct" | "group" {
   return channel.startsWith("D") ? "direct" : "group";
 }
 
+function pushSlackText(value: unknown, output: string[]): void {
+  if (typeof value === "string" && value.trim()) {
+    output.push(value);
+  }
+}
+
 function structuredSlackValues(value: unknown): unknown[] {
   if (Array.isArray(value)) {
     return value;
@@ -125,10 +130,22 @@ function slackInlineText(value: unknown): string {
   return slackInlineText(value.elements);
 }
 
-function collectSlackFallbackText(value: unknown, output: string[]): void {
+function collectSlackTextValue(value: unknown, output: string[]): void {
+  if (typeof value === "string") {
+    pushSlackText(value, output);
+    return;
+  }
+  if (isRecord(value) && typeof value.text === "string") {
+    pushSlackText(value.text, output);
+    return;
+  }
+  collectSlackBlockText(value, output);
+}
+
+function collectSlackBlockText(value: unknown, output: string[]): void {
   if (Array.isArray(value)) {
     for (const entry of value) {
-      collectSlackFallbackText(entry, output);
+      collectSlackBlockText(entry, output);
     }
     return;
   }
@@ -140,27 +157,58 @@ function collectSlackFallbackText(value: unknown, output: string[]): void {
     value.type === "rich_text_preformatted" ||
     value.type === "rich_text_quote"
   ) {
-    const text = slackInlineText(value.elements);
-    if (text.trim()) {
-      output.push(text);
+    pushSlackText(slackInlineText(value.elements), output);
+    return;
+  }
+  for (const key of [
+    "alt_text",
+    "title",
+    "body",
+    "subtitle",
+    "subtext",
+    "details",
+    "output",
+  ] as const) {
+    collectSlackTextValue(value[key], output);
+  }
+  collectSlackTextValue(value.text, output);
+  for (const key of [
+    "blocks",
+    "elements",
+    "fields",
+    "rows",
+    "tasks",
+    "actions",
+    "hero_image",
+    "icon",
+  ] as const) {
+    collectSlackBlockText(value[key], output);
+  }
+}
+
+function collectSlackAttachmentText(value: unknown, output: string[]): void {
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      collectSlackAttachmentText(entry, output);
     }
     return;
   }
-  for (const key of ["fallback", "title", "alt_text"] as const) {
-    const text = readNonBlankString(value[key]);
-    if (text) {
-      output.push(text);
+  if (!isRecord(value)) {
+    return;
+  }
+  for (const key of ["fallback", "pretext", "author_name", "title", "text", "footer"] as const) {
+    pushSlackText(value[key], output);
+  }
+  if (Array.isArray(value.fields)) {
+    for (const field of value.fields) {
+      if (!isRecord(field)) {
+        continue;
+      }
+      pushSlackText(field.title, output);
+      pushSlackText(field.value, output);
     }
   }
-  const text = value.text;
-  if (typeof text === "string" && text.trim()) {
-    output.push(text);
-  } else if (isRecord(text)) {
-    collectSlackFallbackText(text, output);
-  }
-  for (const key of ["blocks", "elements", "fields"] as const) {
-    collectSlackFallbackText(value[key], output);
-  }
+  collectSlackBlockText(value.blocks, output);
 }
 
 function slackOutboundText(body: Record<string, unknown>): string | undefined {
@@ -170,8 +218,8 @@ function slackOutboundText(body: Record<string, unknown>): string | undefined {
     }
   }
   const fallback: string[] = [];
-  collectSlackFallbackText(structuredSlackValues(body.blocks), fallback);
-  collectSlackFallbackText(structuredSlackValues(body.attachments), fallback);
+  collectSlackBlockText(structuredSlackValues(body.blocks), fallback);
+  collectSlackAttachmentText(structuredSlackValues(body.attachments), fallback);
   return fallback.length > 0 ? fallback.join("\n") : undefined;
 }
 

--- a/src/providers/builtin/imessage.ts
+++ b/src/providers/builtin/imessage.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { CrablineError } from "../../core/errors.js";
 import type { ProviderConfig } from "../../config/schema.js";
 import { LocalMockProviderAdapter } from "../local-mock.js";
+import { matchesNativeId } from "../native-ids.js";
 import type { ProviderAdapter } from "../types.js";
 import { getBuiltinTargetCodec, IMESSAGE_THREAD_RULE } from "../target-normalizers.js";
 import {
@@ -137,7 +138,9 @@ function normalizeIMessageWebhookPayload(payload: unknown) {
   }
 
   const data = iMessageNativeData(payload);
-  const threadId = iMessageThreadIdentifiers(data)[0];
+  const threadId = iMessageThreadIdentifiers(data).find((candidate) =>
+    matchesNativeId(candidate, IMESSAGE_THREAD_RULE),
+  );
   const text = optionalString(data, "text") ?? optionalString(data, "message");
   if (!threadId || !text) {
     throw new CrablineError(

--- a/src/providers/builtin/msteams.ts
+++ b/src/providers/builtin/msteams.ts
@@ -222,6 +222,38 @@ function requireExternalMsTeamsWebhookAuthentication(
   });
 }
 
+function msTeamsAttachmentPlaceholder(payload: Record<string, unknown>): string | undefined {
+  if (!Array.isArray(payload.attachments)) {
+    return undefined;
+  }
+  let attachmentCount = 0;
+  let imageCount = 0;
+  for (const attachment of payload.attachments) {
+    if (!isRecord(attachment)) {
+      continue;
+    }
+    const contentType = optionalString(attachment, "contentType");
+    const hasContent =
+      contentType !== undefined ||
+      optionalString(attachment, "contentUrl") !== undefined ||
+      optionalString(attachment, "name") !== undefined ||
+      (attachment.content !== undefined && attachment.content !== null);
+    if (!hasContent) {
+      continue;
+    }
+    attachmentCount += 1;
+    if (contentType?.toLowerCase().startsWith("image/")) {
+      imageCount += 1;
+    }
+  }
+  if (attachmentCount === 0) {
+    return undefined;
+  }
+  return imageCount > 0
+    ? `<media:image>${imageCount > 1 ? ` (${imageCount} images)` : ""}`
+    : `<media:document>${attachmentCount > 1 ? ` (${attachmentCount} files)` : ""}`;
+}
+
 export function normalizeMsTeamsWebhookPayload(payload: unknown) {
   if (!isRecord(payload)) {
     throw new CrablineError("Microsoft Teams webhook payload must be an object", {
@@ -247,10 +279,11 @@ export function normalizeMsTeamsWebhookPayload(payload: unknown) {
   const from = optionalRecord(payload, "from");
   const channelId = optionalString(payload, "channelId");
   const conversationId = conversation ? optionalString(conversation, "id") : undefined;
-  const text = optionalString(payload, "text");
+  const activityText = optionalString(payload, "text");
+  const text = activityText?.trim() ? activityText : msTeamsAttachmentPlaceholder(payload);
   if (channelId !== "msteams" || !conversationId || !text) {
     throw new CrablineError(
-      "Microsoft Teams activity payload requires channelId=msteams, conversation.id, and text",
+      "Microsoft Teams activity payload requires channelId=msteams, conversation.id, and text or attachments",
       {
         kind: "inbound",
       },

--- a/src/providers/builtin/telegram.ts
+++ b/src/providers/builtin/telegram.ts
@@ -93,9 +93,7 @@ function normalizeGenericTelegramPayload(payload: Record<string, unknown>) {
         kind: "inbound",
       });
     }
-    if (threadId !== channelId) {
-      canonicalTopic = { chatId: channelId, topicId: threadId };
-    }
+    canonicalTopic = { chatId: channelId, topicId: threadId };
   }
   const genericPayload = canonicalTopic
     ? message

--- a/src/providers/signed-jwt.ts
+++ b/src/providers/signed-jwt.ts
@@ -46,6 +46,14 @@ function requireSafeDuration(value: number, name: string, allowZero = false): nu
   return value;
 }
 
+function readJwtClock(now: () => number): number {
+  const value = now();
+  if (!Number.isFinite(value)) {
+    throw new RangeError("JWT clock must return a finite number.");
+  }
+  return value;
+}
+
 function decodeBase64UrlPart(value: string, label: string): Buffer {
   if (!/^[A-Za-z0-9_-]+$/u.test(value)) {
     throw new Error(`${label} must use unpadded base64url encoding.`);
@@ -251,7 +259,8 @@ export function createCachedJwtKeyResolver<T>(params: {
   timeoutMs?: number | undefined;
   unknownKeyMessage: string;
 }) {
-  const now = params.now ?? Date.now;
+  const clock = params.now ?? Date.now;
+  const now = () => readJwtClock(clock);
   const refreshCooldownMs = requireSafeDuration(
     params.refreshCooldownMs ?? DEFAULT_UNKNOWN_KEY_COOLDOWN_MS,
     "refreshCooldownMs",
@@ -463,7 +472,7 @@ export async function verifySignedJwt(params: {
     throw new Error("JWT audience is invalid.");
   }
 
-  const now = Math.floor((params.now?.() ?? Date.now()) / 1000);
+  const now = Math.floor(readJwtClock(params.now ?? Date.now) / 1000);
   const skew = params.clockSkewSeconds ?? 300;
   if (!Number.isFinite(skew) || skew < 0) {
     throw new Error("JWT clock skew must be a finite non-negative number.");

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -74,6 +74,28 @@ describe("manifest schema", () => {
     }
   });
 
+  it("rejects oversized inbound regexes before native syntax validation", () => {
+    expect(() =>
+      ManifestSchema.parse({
+        configVersion: 1,
+        fixtures: [
+          {
+            id: "oversized-regex",
+            inboundMatch: {
+              nonce: "ignore",
+              pattern: `${"a".repeat(512)}(`,
+              strategy: "regex",
+            },
+            mode: "roundtrip",
+            provider: "local",
+            target: { id: "echo-bot" },
+          },
+        ],
+        providers: { local: { adapter: "loopback", platform: "loopback" } },
+      }),
+    ).toThrow(/inboundMatch\.pattern must contain at most 512 characters/u);
+  });
+
   it("accepts linear-time alternation and repetition", () => {
     for (const pattern of [
       "^(yes|no)$",

--- a/test/imessage-provider.test.ts
+++ b/test/imessage-provider.test.ts
@@ -156,6 +156,48 @@ describe("iMessage thread matching", () => {
     }
   });
 
+  it("uses the first valid native thread alias", async () => {
+    const config = await createLocalMockConfig("imessage", "/imessage/webhook");
+    const provider = new IMessageProviderAdapter("imessage", config, "crabline");
+    const context = createProviderContext("imessage", config, {
+      id: "+15551234567",
+      metadata: {},
+    });
+    context.fixture.inboundMatch.author = "any";
+
+    try {
+      const endpoint = (await provider.probe(context)).details
+        .find((detail) => detail.startsWith("webhook endpoint "))
+        ?.replace("webhook endpoint ", "");
+      const since = new Date(Date.now() - 1000).toISOString();
+      const response = await fetch(endpoint!, {
+        body: JSON.stringify({
+          chatGuid: "not-a-native-thread",
+          chatIdentifier: "+15551234567",
+          guid: "imsg-valid-alias",
+          text: "valid alias",
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      });
+
+      expect(response.status).toBe(200);
+      await expect(
+        provider.waitForInbound({
+          ...context,
+          nonce: "valid alias",
+          since,
+          timeoutMs: 500,
+        }),
+      ).resolves.toMatchObject({
+        id: "imsg-valid-alias",
+        threadId: "+15551234567",
+      });
+    } finally {
+      await provider.cleanup();
+    }
+  });
+
   it("normalizes native nested imsg notifications", async () => {
     const config = await createLocalMockConfig("imessage", "/imessage/webhook");
     const provider = new IMessageProviderAdapter("imessage", config, "crabline");

--- a/test/matcher.test.ts
+++ b/test/matcher.test.ts
@@ -74,6 +74,28 @@ describe("nonce + matcher", () => {
         nonce,
       ),
     ).toBe(false);
+    for (const suffix of ["\u0301", "\u200d", "\u203f"]) {
+      expect(
+        matchesInbound(
+          {
+            ...envelope,
+            text: `ACK ${otherNonce} then malformed ${nonce}${suffix}`,
+          },
+          config,
+          nonce,
+        ),
+      ).toBe(false);
+    }
+    expect(
+      matchesInbound(
+        {
+          ...envelope,
+          text: `malformed ${nonce}\u0301 then ${nonce}`,
+        },
+        config,
+        nonce,
+      ),
+    ).toBe(true);
   });
 
   it("requires a standalone ACK token and the expected canonical nonce for replies", () => {
@@ -104,6 +126,9 @@ describe("nonce + matcher", () => {
     expect(matchesReply(`ACK ${otherNonce} then ${nonce}`)).toBe(false);
     expect(matchesReply(`ACK ${nonce}-suffix`)).toBe(false);
     expect(matchesReply(`ACK ${nonce}-suffix then ${nonce}`)).toBe(false);
+    expect(matchesReply(`ACK ${nonce}\u0301`)).toBe(false);
+    expect(matchesReply(`ACK ${nonce}\u200d`)).toBe(false);
+    expect(matchesReply(`ACK ${nonce}\u203f`)).toBe(false);
     expect(matchesReply(`\u0301ACK ${nonce}`)).toBe(false);
     expect(matchesReply(`ACK\u0301 ${nonce}`)).toBe(false);
     expect(matchesReply(`\u20ddACK ${nonce}`)).toBe(false);

--- a/test/msteams-provider.test.ts
+++ b/test/msteams-provider.test.ts
@@ -53,6 +53,29 @@ describe("Microsoft Teams webhook authentication", () => {
     ).toThrow(/channelId=msteams/u);
   });
 
+  it("accepts attachment-only messages and rejects contentless activities", () => {
+    expect(
+      normalizeMsTeamsWebhookPayload({
+        attachments: [{ contentType: "image/png", contentUrl: "https://example.test/image.png" }],
+        channelId: "msteams",
+        conversation: { id: conversationId },
+        type: "message",
+      }),
+    ).toMatchObject({
+      text: "<media:image>",
+      threadId: conversationId,
+    });
+    expect(() =>
+      normalizeMsTeamsWebhookPayload({
+        attachments: [{}],
+        channelId: "msteams",
+        conversation: { id: conversationId },
+        text: " \n\t",
+        type: "message",
+      }),
+    ).toThrow(/text or attachments/u);
+  });
+
   it("returns the Bot Framework unsupported status for invoke activities", async () => {
     const response = handleMsTeamsWebhookPayload({
       channelId: "msteams",

--- a/test/openclaw-artifact-generation.test.ts
+++ b/test/openclaw-artifact-generation.test.ts
@@ -704,6 +704,31 @@ describe("OpenClaw artifact generation publication", () => {
       },
     },
     {
+      label: "readiness artifact for a different Telegram bot",
+      path: "providerReadinessArtifactPath",
+      corrupt: (artifact: Record<string, unknown>) => {
+        const providerReadiness = artifact.providerReadiness as Record<string, unknown>;
+        const result = providerReadiness.result as Record<string, unknown>;
+        const probe = result.probe as Record<string, unknown>;
+        return {
+          ...artifact,
+          providerReadiness: {
+            ...providerReadiness,
+            result: {
+              ...result,
+              probe: {
+                ...probe,
+                result: {
+                  ...((probe.result as Record<string, unknown>) ?? {}),
+                  id: 424_243,
+                },
+              },
+            },
+          },
+        };
+      },
+    },
+    {
       label: "readiness artifact with the wrong source",
       path: "providerReadinessArtifactPath",
       corrupt: (artifact: Record<string, unknown>) => ({

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -2111,6 +2111,49 @@ describe("OpenClaw local provider bridge", () => {
     ).toMatchObject({
       text: "<@U1234567890> in <#C1234567890>:wave:\nrepeat\nrepeat",
     });
+    expect(
+      createOpenClawCrablineOutboundFromRecorderEvent({
+        manifest: slackManifest,
+        targetByProviderTarget: new Map([["C1234567890", "group:qa"]]),
+        event: {
+          type: "api",
+          method: "POST",
+          path: "/api/chat.postMessage",
+          body: {
+            attachments: [
+              {
+                fields: [{ title: "field title", value: "field value" }],
+                pretext: "attachment pretext",
+              },
+            ],
+            blocks: [
+              {
+                rows: [
+                  [
+                    {
+                      elements: [{ text: "table cell", type: "text" }],
+                      type: "rich_text",
+                    },
+                  ],
+                ],
+                type: "table",
+              },
+              {
+                details: { text: "task details", type: "plain_text" },
+                tasks: [{ title: "nested task" }],
+                title: "task title",
+                type: "task_card",
+              },
+            ],
+            channel: "C1234567890",
+            text: "",
+          },
+        },
+      }),
+    ).toMatchObject({
+      text: "table cell\ntask title\ntask details\nnested task\nattachment pretext\nfield title\nfield value",
+      to: "group:qa",
+    });
   });
 
   it("maps Signal QA targets, inbound messages, and recorder events", () => {

--- a/test/signed-jwt.test.ts
+++ b/test/signed-jwt.test.ts
@@ -157,6 +157,46 @@ describe("signed JWT remote key cache", () => {
     }
   });
 
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    "rejects non-finite verification clocks: %s",
+    async (now) => {
+      const keys = generateKeyPairSync("rsa", { modulusLength: 2048 });
+      const token = signedJwt(keys.privateKey, {
+        aud: "crabline",
+        exp: 1_800_000_000,
+        iss: "issuer",
+      });
+
+      await expect(
+        verifySignedJwt({
+          audience: "crabline",
+          issuers: ["issuer"],
+          now: () => now,
+          resolveKey: async () => keys.publicKey,
+          token,
+        }),
+      ).rejects.toThrow(/JWT clock must return a finite number/u);
+    },
+  );
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    "rejects non-finite key-cache clocks: %s",
+    async (now) => {
+      const fetchKeys = vi.fn(async () => ({ expiresAt: 1_800_000_000_000, values: ["key"] }));
+      const resolveKey = createCachedJwtKeyResolver({
+        fetchKeys,
+        keyId: (value: string) => value,
+        now: () => now,
+        unknownKeyMessage: "unknown key",
+      });
+
+      await expect(resolveKey({ alg: "RS256", kid: "key" })).rejects.toThrow(
+        /JWT clock must return a finite number/u,
+      );
+      expect(fetchKeys).not.toHaveBeenCalled();
+    },
+  );
+
   it("rejects critical JWS extensions before resolving a signing key", async () => {
     const keys = generateKeyPairSync("rsa", { modulusLength: 2048 });
     const now = 1_700_000_000_000;

--- a/test/telegram-provider.test.ts
+++ b/test/telegram-provider.test.ts
@@ -342,6 +342,23 @@ describe("telegram provider", () => {
     });
   });
 
+  it("canonicalizes equal generic chat and topic ids", () => {
+    const payload = {
+      authorIsBot: true,
+      channelId: "42",
+      id: "generic-equal-topic",
+      text: "equal topic",
+      threadId: "42",
+    };
+
+    expect(normalizeTelegramWebhookPayload(payload)).toMatchObject({
+      id: "generic-equal-topic",
+      raw: payload,
+      text: "equal topic",
+      threadId: "42:42",
+    });
+  });
+
   it("probes and sends through the local mock service", async () => {
     const config = await createTelegramConfig(0);
     const provider = new TelegramProviderAdapter("telegram", config, "crabline");


### PR DESCRIPTION
## Summary
- preserve valid iMessage aliases and canonical Telegram topic identity
- harden acknowledgement, regex, and JWT boundary validation
- accept native Teams attachment-only activities and preserve structured Slack outbound evidence
- bind Telegram readiness evidence to the bot encoded by the configured token

## Validation
- focused tests: 332 passed
- typecheck, lint, and formatting: clean
- Crabbox `run_4c867f229758`: 65 files, 1,817 passed, 38 skipped
- autoreview: gpt-5.6-sol high, clean (0.91)

## Changelog
- added an Unreleased entry