### PR TITLE
fix(runtime): fence lifecycle and lock races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Preserve native identity boundaries across Discord, Slack, loopback threads, and malformed smoke-lock records.
 - Preserve active WhatsApp inbound identities across replay-cache eviction, reject self-authored admin ingress, canonicalize Cloud webhook senders, and bound retained Zalo polling updates by bytes.
 - Accept valid fallback iMessage aliases and attachment-only Teams activities, canonicalize equal Telegram chat/topic IDs, and harden nonce, regex, JWT, Slack structured-text, and Telegram readiness validation.
+- Fence provider recorder publication, lazy cleanup dispatch, and lock recovery against replacement races while bounding stale smoke-lock confirmation.
 - Recognize server-generated Telegram username IDs in injected update state.
 - Require Telegram readiness responses to identify the bot encoded in the configured token.
 - Terminate and drain unused Windows script helper bootstrap processes after command timeouts.

--- a/src/openclaw/smoke-lock.ts
+++ b/src/openclaw/smoke-lock.ts
@@ -710,6 +710,10 @@ function needsLiveOwnerConfirmation(record: SmokeLockRecord, runtime: SmokeLockR
 
 type OwnerConfirmation = "changed" | "renewed" | "unchanged";
 
+function heartbeatIntervalMs(leaseMs: number): number {
+  return Math.max(1, Math.floor(leaseMs / 3));
+}
+
 async function confirmObservedOwner(
   lockDirectory: string,
   observed: SmokeLockRecord,
@@ -718,7 +722,7 @@ async function confirmObservedOwner(
   if (!needsLiveOwnerConfirmation(observed, runtime)) {
     return "unchanged";
   }
-  await runtime.sleep(runtime.leaseMs);
+  await runtime.sleep(heartbeatIntervalMs(runtime.leaseMs));
   const revalidated = await readLockRecord(lockDirectory);
   if (revalidated.kind !== "record") {
     return "unchanged";
@@ -1580,7 +1584,7 @@ export async function acquireOpenClawCrablineSmokeRunLock(
     try {
       heartbeat = (dependencies.startHeartbeat ?? startHeartbeat)(
         renew,
-        Math.max(1, Math.floor(runtime.leaseMs / 3)),
+        heartbeatIntervalMs(runtime.leaseMs),
       );
     } catch (error) {
       try {

--- a/src/platform/process-owned-lock.ts
+++ b/src/platform/process-owned-lock.ts
@@ -692,6 +692,63 @@ function parseOwner(lockDirectory: fs.PathLike): ParsedLockOwner | null | undefi
       };
 }
 
+function restoreDisplacedPublishedLockDirectory(
+  displacedPath: string,
+  lockDirectory: string,
+): void {
+  try {
+    const displaced = fs.lstatSync(displacedPath, { bigint: true });
+    const owner = parseOwner(displacedPath);
+    if (
+      !displaced.isDirectory() ||
+      displaced.isSymbolicLink() ||
+      owner === null ||
+      owner === undefined
+    ) {
+      return;
+    }
+  } catch {
+    return;
+  }
+  try {
+    fs.lstatSync(lockDirectory);
+    return;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      return;
+    }
+  }
+  try {
+    // The coordination claim excludes compliant publishers. If an unexpected
+    // published directory races this restore, its owner file makes it nonempty,
+    // so rename refuses to replace it and the displaced directory stays preserved.
+    fs.renameSync(displacedPath, lockDirectory);
+  } catch {
+    // Preserve the displaced directory at its claim-local path if restoration races.
+  }
+}
+
+function renamedDirectoryMatches(
+  claimedPath: string,
+  lockDirectory: string,
+  expectedIdentity: DirectoryIdentity,
+): boolean {
+  try {
+    const claimed = fs.lstatSync(claimedPath, { bigint: true });
+    if (
+      claimed.isDirectory() &&
+      !claimed.isSymbolicLink() &&
+      directoryIdentityMatches(expectedIdentity, claimed)
+    ) {
+      return true;
+    }
+  } catch {
+    // Restore or preserve any directory displaced after the final identity check.
+  }
+  restoreDisplacedPublishedLockDirectory(claimedPath, lockDirectory);
+  return false;
+}
+
 function abandonedOwnerMarkerPath(lockDirectory: fs.PathLike, ownerToken: string): string {
   const digest = createHash("sha256").update(ownerToken).digest("hex");
   return path.join(String(lockDirectory), `${ABANDONED_OWNER_PREFIX}${digest}`);
@@ -1694,6 +1751,12 @@ export function createProcessOwnedLockFileSystem(
               finish(renameError);
               return;
             }
+            if (
+              !renamedDirectoryMatches(tombstonePath, directory, directoryIdentity(initialStats))
+            ) {
+              finish(lockCleanupError("Recorder lock release displaced a replacement directory."));
+              return;
+            }
             ownedDirectories.delete(coordinationKey);
             abandonedDirectoryIdentities.delete(coordinationKey);
             abandonedOwnerKeys.delete(abandonedOwnerKey(directory, token));
@@ -1866,6 +1929,10 @@ export function createProcessOwnedLockFileSystem(
             finish(renameError);
             return;
           }
+          if (!renamedDirectoryMatches(tombstonePath, directory, directoryIdentity(initialStats))) {
+            finish(lockCleanupError("Recorder lock recovery displaced a replacement directory."));
+            return;
+          }
           try {
             removeLockDirectorySync(tombstonePath, directoryIdentity(initialStats));
             if (candidate) {
@@ -1930,6 +1997,9 @@ export function createProcessOwnedLockFileSystem(
       }
       const tombstonePath = `${claimPath}.${token}.release`;
       fs.renameSync(directoryPath, tombstonePath);
+      if (!renamedDirectoryMatches(tombstonePath, directory, directoryIdentity(ownedDirectory))) {
+        throw lockCleanupError("Recorder lock release displaced a replacement directory.");
+      }
       removeLockDirectorySync(tombstonePath, directoryIdentity(ownedDirectory));
       ownedDirectories.delete(canonicalLockDirectoryPath(directory));
     } finally {

--- a/src/providers/recorder.ts
+++ b/src/providers/recorder.ts
@@ -429,8 +429,19 @@ async function resolveRecorderPublicationPath(filePath: string): Promise<string>
 async function openRecorderForAppend(
   filePath: string,
 ): Promise<{ created: boolean; handle: Awaited<ReturnType<typeof open>> }> {
-  const createFlags = process.platform === "win32" ? "wx+" : "ax+";
-  const existingFlags = process.platform === "win32" ? "r+" : "a+";
+  const createFlags =
+    process.platform === "win32"
+      ? "wx+"
+      : fsConstants.O_RDWR |
+        fsConstants.O_APPEND |
+        fsConstants.O_CREAT |
+        fsConstants.O_EXCL |
+        fsConstants.O_NONBLOCK |
+        fsConstants.O_NOFOLLOW;
+  const existingFlags =
+    process.platform === "win32"
+      ? "r+"
+      : fsConstants.O_RDWR | fsConstants.O_APPEND | fsConstants.O_NONBLOCK | fsConstants.O_NOFOLLOW;
   try {
     return {
       created: true,

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -308,9 +308,7 @@ export class LazyProviderAdapter implements ProviderAdapter {
     for (const watch of this.#activeWatches) {
       watch.abort();
     }
-    if (this.#providerInstance) {
-      this.#beginProviderCleanup(this.#providerInstance);
-    }
+    this.#beginProviderCleanupIfReady();
   }
 
   async cleanup(): Promise<void> {
@@ -353,6 +351,7 @@ export class LazyProviderAdapter implements ProviderAdapter {
     this.#providerPromise ??= this.#factory()
       .then((provider) => {
         this.#providerInstance = provider;
+        this.#beginProviderCleanupIfReady();
         return provider;
       })
       .catch((error: unknown) => {
@@ -438,6 +437,18 @@ export class LazyProviderAdapter implements ProviderAdapter {
     }
   }
 
+  #beginProviderCleanupIfReady(): void {
+    const provider = this.#providerInstance;
+    if (
+      !this.#cleanedUp ||
+      !provider ||
+      [...this.#inFlightOperations].some((operation) => !operation.dispatch.reached)
+    ) {
+      return;
+    }
+    this.#beginProviderCleanup(provider);
+  }
+
   #runOperation<T>(
     run: (provider: ProviderAdapter) => Promise<T>,
     signal?: AbortSignal,
@@ -449,6 +460,14 @@ export class LazyProviderAdapter implements ProviderAdapter {
       return Promise.reject(signal.reason ?? new Error("Provider operation aborted."));
     }
     const dispatch = createDispatchBarrier();
+    let rejectCompletion!: (reason?: unknown) => void;
+    let resolveCompletion!: (value: T | PromiseLike<T>) => void;
+    const completion = new Promise<T>((resolve, reject) => {
+      rejectCompletion = reject;
+      resolveCompletion = resolve;
+    });
+    const operation = { completion, dispatch };
+    this.#inFlightOperations.add(operation);
     const underlying = (async () => {
       try {
         const provider = await this.#provider();
@@ -457,19 +476,20 @@ export class LazyProviderAdapter implements ProviderAdapter {
         }
         const result = run(provider);
         dispatch.reach();
+        this.#beginProviderCleanupIfReady();
         return await result;
       } catch (error) {
         dispatch.reach();
+        this.#beginProviderCleanupIfReady();
         throw error;
       }
     })();
-    const operation = { completion: underlying, dispatch };
-    this.#inFlightOperations.add(operation);
-    void underlying.then(
+    void underlying.then(resolveCompletion, rejectCompletion);
+    void completion.then(
       () => this.#inFlightOperations.delete(operation),
       () => this.#inFlightOperations.delete(operation),
     );
-    return underlying;
+    return completion;
   }
 
   #cleanedUpError(): CrablineError {

--- a/test/openclaw-smoke-lock.test.ts
+++ b/test/openclaw-smoke-lock.test.ts
@@ -1816,9 +1816,10 @@ describe("OpenClaw smoke lock cleanup", () => {
     }
   });
 
-  it("expires an old lock whose PID now belongs to another live process", async () => {
+  it("confirms a stale live PID for one heartbeat interval before reclaiming it", async () => {
     const outputDir = await createTempDir();
     const params = { channel: "telegram" as const, outputDir };
+    const confirmationSleep = vi.fn(async (_delayMs: number) => undefined);
     try {
       const firstLock = await acquireOpenClawCrablineSmokeRunLock(params, {
         isProcessAlive: () => true,
@@ -1845,9 +1846,12 @@ describe("OpenClaw smoke lock cleanup", () => {
         now: () => 2_001,
         pid: 5_252,
         processStartedAtMs: 200,
+        sleep: confirmationSleep,
         startHeartbeat: disableHeartbeat,
       });
       expect(replacementLock).toBeDefined();
+      expect(confirmationSleep).toHaveBeenCalled();
+      expect(confirmationSleep.mock.calls.every(([delayMs]) => delayMs === 333)).toBe(true);
       await firstLock.release();
       await replacementLock.release();
     } finally {

--- a/test/process-owned-lock.test.ts
+++ b/test/process-owned-lock.test.ts
@@ -1146,6 +1146,120 @@ describe("process-owned lock filesystem", () => {
     }
   }, 10_000);
 
+  it("restores a published replacement displaced by the final stale-owner rename", async () => {
+    const target = await createLockTarget();
+    const lockDirectory = `${target}.lock`;
+    const originalDirectory = `${lockDirectory}.original`;
+    const owner = await startIdleProcess();
+    const replacementOwner = await currentOwnerRecord();
+    const replacementGeneration = String(replacementOwner.token);
+    await mkdir(lockDirectory);
+    const ownerPath = await writeOwner(lockDirectory, {
+      pid: owner.pid,
+      processStartedAtMs: 1,
+    });
+    await utimes(ownerPath, new Date(0), new Date(0));
+    await utimes(lockDirectory, new Date(0), new Date(0));
+
+    const rename = fs.rename.bind(fs);
+    let replacementSentinel = "";
+    const renameSpy = vi.spyOn(fs, "rename").mockImplementationOnce(((
+      oldPath: fs.PathLike,
+      newPath: fs.PathLike,
+      callback: (error: NodeJS.ErrnoException | null) => void,
+    ) => {
+      fs.renameSync(lockDirectory, originalDirectory);
+      fs.mkdirSync(lockDirectory);
+      fs.writeFileSync(
+        path.join(lockDirectory, "crabline-owner.json"),
+        `${JSON.stringify(replacementOwner)}\n`,
+      );
+      replacementSentinel = path.join(lockDirectory, "replacement");
+      fs.writeFileSync(replacementSentinel, "preserve");
+      rename(oldPath, newPath, callback);
+    }) as typeof fs.rename);
+
+    try {
+      await expect(acquire(target)).rejects.toMatchObject({ code: "ELOCKED" });
+      await expect(readFile(replacementSentinel, "utf8")).resolves.toBe("preserve");
+      await expect(
+        readFile(path.join(lockDirectory, "crabline-owner.json"), "utf8"),
+      ).resolves.toContain(replacementGeneration);
+    } finally {
+      renameSpy.mockRestore();
+      await rm(lockDirectory, { force: true, recursive: true });
+      await rm(originalDirectory, { force: true, recursive: true });
+      owner.child.stdin.end();
+      await once(owner.child, "exit");
+    }
+  }, 10_000);
+
+  it("preserves a displaced replacement when another published directory wins restoration", async () => {
+    const target = await createLockTarget();
+    const lockDirectory = `${target}.lock`;
+    const originalDirectory = `${lockDirectory}.original`;
+    const owner = await startIdleProcess();
+    const displacedOwner = await currentOwnerRecord();
+    const winningOwner = await currentOwnerRecord();
+    await mkdir(lockDirectory);
+    const ownerPath = await writeOwner(lockDirectory, {
+      pid: owner.pid,
+      processStartedAtMs: 1,
+    });
+    await utimes(ownerPath, new Date(0), new Date(0));
+    await utimes(lockDirectory, new Date(0), new Date(0));
+
+    const rename = fs.rename.bind(fs);
+    const renameSync = fs.renameSync.bind(fs);
+    let displacedPath = "";
+    let displacedSentinel = "";
+    let winningSentinel = "";
+    const renameSpy = vi.spyOn(fs, "rename").mockImplementationOnce(((
+      oldPath: fs.PathLike,
+      newPath: fs.PathLike,
+      callback: (error: NodeJS.ErrnoException | null) => void,
+    ) => {
+      displacedPath = String(newPath);
+      fs.renameSync(lockDirectory, originalDirectory);
+      fs.mkdirSync(lockDirectory);
+      fs.writeFileSync(
+        path.join(lockDirectory, "crabline-owner.json"),
+        `${JSON.stringify(displacedOwner)}\n`,
+      );
+      displacedSentinel = path.join(lockDirectory, "displaced");
+      fs.writeFileSync(displacedSentinel, "preserve displaced");
+      rename(oldPath, newPath, callback);
+    }) as typeof fs.rename);
+    const renameSyncSpy = vi.spyOn(fs, "renameSync").mockImplementation(((oldPath, newPath) => {
+      if (String(oldPath) === displacedPath && String(newPath) === lockDirectory) {
+        fs.mkdirSync(lockDirectory);
+        fs.writeFileSync(
+          path.join(lockDirectory, "crabline-owner.json"),
+          `${JSON.stringify(winningOwner)}\n`,
+        );
+        winningSentinel = path.join(lockDirectory, "winning");
+        fs.writeFileSync(winningSentinel, "preserve winner");
+      }
+      renameSync(oldPath, newPath);
+    }) as typeof fs.renameSync);
+
+    try {
+      await expect(acquire(target)).rejects.toMatchObject({ code: "ELOCKED" });
+      await expect(readFile(winningSentinel, "utf8")).resolves.toBe("preserve winner");
+      await expect(readFile(path.join(displacedPath, "displaced"), "utf8")).resolves.toBe(
+        "preserve displaced",
+      );
+    } finally {
+      renameSyncSpy.mockRestore();
+      renameSpy.mockRestore();
+      await rm(displacedPath, { force: true, recursive: true });
+      await rm(lockDirectory, { force: true, recursive: true });
+      await rm(originalDirectory, { force: true, recursive: true });
+      owner.child.stdin.end();
+      await once(owner.child, "exit");
+    }
+  }, 10_000);
+
   it.runIf(process.platform === "darwin")(
     "publishes a sub-second Darwin process identity",
     async () => {

--- a/test/recorder-concurrency.test.ts
+++ b/test/recorder-concurrency.test.ts
@@ -1,10 +1,11 @@
 import path from "node:path";
-import { constants as fsConstants } from "node:fs";
+import fs, { constants as fsConstants } from "node:fs";
 import {
   chmod,
   link,
   mkdir,
   mkdtemp,
+  readFile,
   realpath,
   rename,
   rm,
@@ -34,7 +35,7 @@ const fsMocks = vi.hoisted(() => ({
   providerRealpathFailure: undefined as Error | undefined,
   providerRealpathFailureAfterWrites: 0,
   providerRecorderPath: "",
-  providerOpen: vi.fn<(filePath: string, flags: string, mode?: number | string) => void>(),
+  providerOpen: vi.fn<(filePath: string, flags: number | string, mode?: number | string) => void>(),
   providerSync: vi.fn<(filePath: string) => Promise<void>>(),
   providerWrite: vi.fn<(filePath: string, data: string) => Promise<void>>(),
   serverDirectory: "",
@@ -52,6 +53,15 @@ const fsMocks = vi.hoisted(() => ({
 }));
 
 const serverRecorderExistingOpenFlags =
+  fsConstants.O_RDWR | fsConstants.O_APPEND | fsConstants.O_NONBLOCK | fsConstants.O_NOFOLLOW;
+const providerRecorderCreateOpenFlags =
+  fsConstants.O_RDWR |
+  fsConstants.O_APPEND |
+  fsConstants.O_CREAT |
+  fsConstants.O_EXCL |
+  fsConstants.O_NONBLOCK |
+  fsConstants.O_NOFOLLOW;
+const providerRecorderExistingOpenFlags =
   fsConstants.O_RDWR | fsConstants.O_APPEND | fsConstants.O_NONBLOCK | fsConstants.O_NOFOLLOW;
 
 const osMocks = vi.hoisted(() => ({
@@ -190,17 +200,17 @@ vi.mock("node:fs/promises", async (importOriginal) => {
           },
         } as unknown as Awaited<ReturnType<typeof actual.open>>;
       }
-      if (
-        (args[1] === "a+" || args[1] === "ax+") &&
-        filePath.includes("crabline-provider-recorder")
-      ) {
-        fsMocks.providerOpen(filePath, args[1], args[2]);
+      const providerRecorderOpen =
+        filePath.includes("crabline-provider-recorder") &&
+        (args[1] === "r+" ||
+          args[1] === "wx+" ||
+          args[1] === providerRecorderCreateOpenFlags ||
+          args[1] === providerRecorderExistingOpenFlags);
+      if (providerRecorderOpen) {
+        fsMocks.providerOpen(filePath, args[1]!, args[2]);
       }
       const handle = await actual.open(...args);
-      if (
-        (args[1] === "a+" || args[1] === "ax+") &&
-        filePath.includes("crabline-provider-recorder")
-      ) {
+      if (providerRecorderOpen) {
         handle.sync = async () => {
           await fsMocks.providerSync(filePath);
         };
@@ -1108,10 +1118,10 @@ describe("recorder append serialization", () => {
           : [[fsMocks.providerDirectory], [fsMocks.providerDirectory]],
       );
       expect(fsMocks.providerOpen.mock.calls.map(([, flags, mode]) => [flags, mode])).toEqual([
-        ["ax+", 0o600],
-        ["a+", 0o600],
-        ["ax+", 0o600],
-        ["a+", 0o600],
+        [process.platform === "win32" ? "wx+" : providerRecorderCreateOpenFlags, 0o600],
+        [process.platform === "win32" ? "r+" : providerRecorderExistingOpenFlags, 0o600],
+        [process.platform === "win32" ? "wx+" : providerRecorderCreateOpenFlags, 0o600],
+        [process.platform === "win32" ? "r+" : providerRecorderExistingOpenFlags, 0o600],
       ]);
       const identityLockPath = fsMocks.lock.mock.calls
         .map(([lockPath]) => String(lockPath))
@@ -1121,6 +1131,52 @@ describe("recorder append serialization", () => {
       await rm(recorderPath, { force: true });
     }
   });
+
+  it.skipIf(process.platform === "win32")(
+    "does not follow a recorder path replaced by a symlink before append open",
+    async () => {
+      const tempRoot = await mkdtemp(
+        path.join(tmpdir(), "crabline-provider-recorder-symlink-race-"),
+      );
+      const recorderPath = path.join(tempRoot, "events.jsonl");
+      const displacedPath = path.join(tempRoot, "events.original.jsonl");
+      const outsidePath = path.join(tempRoot, "outside.txt");
+      fsMocks.providerDirectory = await realpath(tempRoot);
+      await writeFile(recorderPath, "", { mode: 0o600 });
+      await writeFile(outsidePath, "preserve", { mode: 0o600 });
+      const publicationPath = await realpath(recorderPath);
+      let replaced = false;
+      fsMocks.providerOpen.mockImplementation((filePath, flags) => {
+        if (
+          !replaced &&
+          filePath === publicationPath &&
+          flags === providerRecorderExistingOpenFlags
+        ) {
+          replaced = true;
+          fs.renameSync(publicationPath, displacedPath);
+          fs.symlinkSync(outsidePath, publicationPath);
+        }
+      });
+
+      try {
+        await expect(
+          appendRecordedInbound(recorderPath, {
+            author: "assistant",
+            id: "symlink-race",
+            provider: "slack",
+            sentAt: "2026-07-12T10:00:00.000Z",
+            text: "must not escape",
+            threadId: "slack:C123",
+          }),
+        ).rejects.toMatchObject({ code: "ELOOP" });
+        expect(replaced).toBe(true);
+        await expect(readFile(outsidePath, "utf8")).resolves.toBe("preserve");
+        expect(fsMocks.providerWrite).not.toHaveBeenCalled();
+      } finally {
+        await rm(tempRoot, { force: true, recursive: true });
+      }
+    },
+  );
 
   it.skipIf(process.platform === "win32")(
     "repairs a UID-scoped adjacent lock namespace without an OS account entry",

--- a/test/registry-lifecycle.test.ts
+++ b/test/registry-lifecycle.test.ts
@@ -518,6 +518,115 @@ describe("lazy provider lifecycle", () => {
     expect(cleanup).toHaveBeenCalledOnce();
   });
 
+  it("does not let cleanup overtake an admitted operation on a materialized provider", async () => {
+    const events: string[] = [];
+    const concrete: ProviderAdapter = {
+      id: "test",
+      platform: "loopback",
+      status: "ready",
+      supports: ["probe", "send"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      async probe() {
+        return { details: [], healthy: true };
+      },
+      async send() {
+        events.push("send");
+        return { accepted: true, messageId: "sent", threadId: "thread" };
+      },
+      async waitForInbound() {
+        return null;
+      },
+      beginCleanup() {
+        events.push("beginCleanup");
+      },
+      async cleanup() {
+        events.push("cleanup");
+      },
+    };
+    const provider = new LazyProviderAdapter({
+      adapterName: "test",
+      factory: async () => concrete,
+      id: "test",
+      normalizeTarget: concrete.normalizeTarget.bind(concrete),
+      platform: "loopback",
+      status: "ready",
+      supports: ["probe", "send"],
+    });
+    const { context } = createTelegramManifest("/tmp/unused.jsonl");
+    await provider.probe(context);
+
+    const sending = provider.send({
+      ...context,
+      mode: "send",
+      nonce: "materialized-cleanup-race",
+      text: "dispatch first",
+    });
+    provider.beginCleanup();
+
+    expect(events).toEqual([]);
+    await expect(sending).resolves.toMatchObject({ accepted: true });
+    await provider.cleanup();
+    expect(events).toEqual(["send", "beginCleanup", "cleanup"]);
+  });
+
+  it("does not let a materialization microtask cleanup overtake admitted work", async () => {
+    const events: string[] = [];
+    const concrete: ProviderAdapter = {
+      id: "test",
+      platform: "loopback",
+      status: "ready",
+      supports: ["send"],
+      normalizeTarget(target) {
+        return { id: target.id, metadata: target.metadata };
+      },
+      async probe() {
+        return { details: [], healthy: true };
+      },
+      async send() {
+        events.push("send");
+        return { accepted: true, messageId: "sent", threadId: "thread" };
+      },
+      async waitForInbound() {
+        return null;
+      },
+      beginCleanup() {
+        events.push("beginCleanup");
+      },
+      async cleanup() {
+        events.push("cleanup");
+      },
+    };
+    const provider = new LazyProviderAdapter({
+      adapterName: "test",
+      factory: async () => concrete,
+      id: "test",
+      normalizeTarget: concrete.normalizeTarget.bind(concrete),
+      platform: "loopback",
+      status: "ready",
+      supports: ["send"],
+    });
+    const { context } = createTelegramManifest("/tmp/unused.jsonl");
+    const sending = provider.send({
+      ...context,
+      mode: "send",
+      nonce: "materialization-microtask-race",
+      text: "dispatch first",
+    });
+    await new Promise<void>((resolve) => {
+      queueMicrotask(() => {
+        provider.beginCleanup();
+        resolve();
+      });
+    });
+
+    expect(events).toEqual([]);
+    await expect(sending).resolves.toMatchObject({ accepted: true });
+    await provider.cleanup();
+    expect(events).toEqual(["send", "beginCleanup", "cleanup"]);
+  });
+
   it("cancels an uncommitted operation admitted before provider materialization", async () => {
     const directory = await createTempDir();
     const recorderPath = path.join(directory, "telegram.jsonl");


### PR DESCRIPTION
## Summary
- refuse provider recorder publication symlink swaps with no-follow append opens
- defer lazy-provider cleanup fences until admitted work dispatches
- preserve replacement lock directories across final rename races and shorten stale-owner confirmation to one heartbeat

## Validation
- focused tests: 153 passed, 3 skipped
- typecheck and formatting: clean
- Crabbox `run_86fb23a78e08`: 65 files, 1,822 passed, 38 skipped
- autoreview: gpt-5.6-sol high, clean (0.86)

## Changelog
- added an Unreleased entry