### PR TITLE
fix(telegram): keep Markdown parsing responsive on malformed links

### DIFF
--- a/src/servers/slack.ts
+++ b/src/servers/slack.ts
@@ -198,10 +198,17 @@ function requireSlackToken(
   state: SlackServerState,
 ): Response | undefined {
   const authorization = request.headers.authorization;
-  const tokenFromHeader =
-    typeof authorization === "string"
-      ? /^Bearer\s+(.+)$/iu.exec(authorization.trim())?.[1]?.trim()
-      : undefined;
+  let tokenFromHeader: string | undefined;
+  if (typeof authorization === "string") {
+    const trimmed = authorization.trim();
+    if (trimmed.slice(0, 6).toLowerCase() === "bearer" && /\s/u.test(trimmed[6] ?? "")) {
+      let tokenStart = 7;
+      while (tokenStart < trimmed.length && /\s/u.test(trimmed[tokenStart]!)) {
+        tokenStart += 1;
+      }
+      tokenFromHeader = trimmed.slice(tokenStart).trim() || undefined;
+    }
+  }
   const token = tokenFromHeader ?? readTrimmedString(body.token);
   if (!token) {
     return slackError("not_authed");

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -1617,6 +1617,62 @@ function stripTelegramMarkdownExpandableMarker(line: string): string {
   return markers % 2 === 1 ? line.slice(0, -2) : line;
 }
 
+// Keep this scan strictly forward-only: this request path accepts client-controlled
+// Markdown, and backtracking over malformed link destinations amplifies CPU use.
+function stripTelegramMarkdownLinks(value: string): string {
+  const output: string[] = [];
+  let copyStart = 0;
+  let searchStart = 0;
+
+  while (searchStart < value.length) {
+    const labelStart = value.indexOf("[", searchStart);
+    if (labelStart < 0) {
+      break;
+    }
+
+    let labelEnd = labelStart + 1;
+    while (labelEnd < value.length && value[labelEnd] !== "]" && value[labelEnd] !== "\n") {
+      labelEnd += 1;
+    }
+    if (labelEnd === labelStart + 1 || value[labelEnd] !== "]" || value[labelEnd + 1] !== "(") {
+      searchStart = labelEnd < value.length ? labelEnd + 1 : value.length;
+      continue;
+    }
+
+    let destinationEnd = labelEnd + 2;
+    let matched = false;
+    while (destinationEnd < value.length) {
+      const character = value[destinationEnd]!;
+      if (character === "\n") {
+        break;
+      }
+      if (character === ")") {
+        output.push(value.slice(copyStart, labelStart), value.slice(labelStart + 1, labelEnd));
+        copyStart = destinationEnd + 1;
+        searchStart = copyStart;
+        matched = true;
+        break;
+      }
+      if (
+        character === "\\" &&
+        destinationEnd + 1 < value.length &&
+        value[destinationEnd + 1] !== "\n"
+      ) {
+        destinationEnd += 2;
+        continue;
+      }
+      destinationEnd += 1;
+    }
+    if (matched) {
+      continue;
+    }
+    searchStart = destinationEnd < value.length ? destinationEnd + 1 : value.length;
+  }
+
+  output.push(value.slice(copyStart));
+  return output.join("");
+}
+
 function telegramMarkdownText(value: string, versionTwo: boolean): string {
   let parsed = protectTelegramMarkdownEscapes(value, versionTwo)
     .replace(/```(?:[^\n]*\n)?([\s\S]*?)```/gu, (_match, content: string) =>
@@ -1626,8 +1682,8 @@ function telegramMarkdownText(value: string, versionTwo: boolean): string {
     .replace(
       /!\[([^\]\n]+)\]\(tg:\/\/(?:emoji\?id=\d+|time\?unix=-?\d+(?:&format=[rwdDtT]+)?)\)/gu,
       "$1",
-    )
-    .replace(/\[([^\]\n]+)\]\((?:\\.|[^)\n])*\)/gu, "$1");
+    );
+  parsed = stripTelegramMarkdownLinks(parsed);
   if (versionTwo) {
     parsed = parsed
       .replace(/^(?:\*\*)?>[^\n]*$/gmu, stripTelegramMarkdownExpandableMarker)

--- a/test/slack-server.test.ts
+++ b/test/slack-server.test.ts
@@ -115,6 +115,11 @@ describe("slack local provider server", () => {
       method: "POST",
     });
     await expect(lowerCaseBearer.json()).resolves.toMatchObject({ ok: true });
+    const paddedBearer = await fetch(`${server.manifest.endpoints.apiRoot}auth.test`, {
+      headers: { authorization: `Bearer${" ".repeat(8_000)}xoxb-fake` },
+      method: "POST",
+    });
+    await expect(paddedBearer.json()).resolves.toMatchObject({ ok: true });
 
     const unauthenticated = await fetch(`${server.manifest.endpoints.apiRoot}auth.test`, {
       method: "POST",

--- a/test/telegram-server.test.ts
+++ b/test/telegram-server.test.ts
@@ -927,6 +927,32 @@ describe("telegram local provider server", () => {
         })
       ).status,
     ).toBe(200);
+    expect(
+      (
+        await fetch(`${apiRoot}/sendMessage`, {
+          body: JSON.stringify({
+            chat_id: 42,
+            parse_mode: "MarkdownV2",
+            text: `[${"x".repeat(4096)}](https://example.test/a\\)b)`,
+          }),
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        })
+      ).status,
+    ).toBe(200);
+    expect(
+      (
+        await fetch(`${apiRoot}/sendMessage`, {
+          body: JSON.stringify({
+            chat_id: 42,
+            parse_mode: "MarkdownV2",
+            text: `[x](${"a".repeat(1024 * 1024)})`,
+          }),
+          headers: { "content-type": "application/json" },
+          method: "POST",
+        })
+      ).status,
+    ).toBe(200);
     for (const text of [
       `\`${"*".repeat(4096)}\``,
       `\`\`\`\n${"*".repeat(4096)}\`\`\``,
@@ -1063,6 +1089,27 @@ describe("telegram local provider server", () => {
         })
       ).status,
     ).toBe(400);
+  });
+
+  it("parses unterminated Markdown link destinations without backtracking", async () => {
+    const server = await startTelegramServer({ botToken: "test-token-placeholder" });
+    servers.push(server);
+    const startedAt = performance.now();
+    const response = await fetch(
+      `${server.manifest.baseUrl}/bottest-token-placeholder/sendMessage`,
+      {
+        body: JSON.stringify({
+          chat_id: 42,
+          parse_mode: "MarkdownV2",
+          text: `[x](${"\\".repeat(38)}`,
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(performance.now() - startedAt).toBeLessThan(1_000);
   });
 
   it("rejects control characters in webhook secrets", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Telegram-compatible clients could submit malformed Markdown link destinations that consumed excessive CPU before Crabline applied Telegram's semantic text limits. It also removes a polynomial Slack bearer-token regex on long whitespace runs.

## Why This Change Was Made

Telegram Markdown link stripping now uses a strictly forward-only scanner while preserving Telegram's existing post-parse 4,096/1,024 character limits and acceptance behavior. Slack bearer headers use a linear prefix/whitespace scan.

## User Impact

Crabline provider servers remain responsive under hostile Telegram Markdown and oversized Slack authorization whitespace without introducing a new provider-visible source-size limit.

## Evidence

- focused Telegram/Slack tests: 92 passed, including a 1 MiB Markdown destination accepted under the existing post-parse contract
- prior focused tranche: 63 passed
- TypeScript typecheck
- targeted `oxfmt --check`
- `git diff --check`
- autoreview: clean, no accepted/actionable findings
