### PR TITLE
refactor: remove legacy provider-server aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 ### OpenClaw integration
 
-- Version and validate artifact generations, readiness manifests, capability reports, recorder evidence, atomic pointers, legacy migration, and smoke-lock recovery.
+- Version and validate artifact generations, readiness manifests, capability reports, recorder evidence, atomic pointers, migration, and provider-readiness lock recovery.
 - Preserve native provider, target, thread, sender, direct-recipient, and accepted-send identities through OpenClaw bridge normalization without conflating local mock proof with OpenClaw execution.
 
 ### CLI, documentation, and delivery
@@ -38,7 +38,7 @@
 ## 0.1.11 - 2026-07-13
 
 - Contain Telegram response delivery failures when clients disconnect during request handling.
-- Recover interrupted artifact and recorder writes, publish immutable readiness evidence, and harden private-directory and smoke-lock durability.
+- Recover interrupted artifact and recorder writes, publish immutable readiness evidence, and harden private-directory and provider-readiness lock durability.
 
 ## 0.1.10 - 2026-07-13
 
@@ -63,7 +63,7 @@
 - Enforce safe Telegram identities while acknowledging valid unsupported updates.
 - Align Slack callback, thread-history, and message-text behavior with its native protocol.
 - Canonicalize WhatsApp identities and accepted-send evidence, publish webhook batches atomically with bounded retry deduplication, and preserve Zalo updates across disconnects and concurrent polls.
-- Harden shared runtime cleanup, terminal and script diagnostics, smoke artifact rollback, test helpers, source maps, and stable release publication.
+- Harden shared runtime cleanup, terminal and script diagnostics, provider-readiness artifact rollback, test helpers, source maps, and stable release publication.
 - Report Crabline provider readiness without claiming OpenClaw execution, require accepted exact-route recorder events for outbound delivery, pin production package exports and public types, and document canonical WhatsApp targets.
 - Harden release, CI, config, CLI, package, and OpenClaw artifact and process-identity boundaries.
 - Restore provider-native callbacks and authentication, preserve conversation targets and recorder progress, and harden local mock lifecycle and parsing.
@@ -72,13 +72,13 @@
 - Preserve Zalo polling updates across disconnects and webhook changes, reject future Matrix sync tokens, normalize JSON media types, and bound Signal SSE clients and buffers.
 - Authenticate configured Discord interactions, answer native PING requests, exclude outbound mock records from inbound matching, filter WhatsApp webhooks by phone number, and validate loopback pagination limits.
 - Bound WhatsApp binary-node complexity and signal bundles, align encoder and decoder limits, preserve coherent X25519 fallback behavior, validate queue startup before listening, keep reconnect delivery FIFO, and accept bounded legacy group JIDs.
-- Preserve primary watch and adapter-start failures, retain shutdown handlers through cleanup, validate smoke-lock tokens, enforce Zalo probe envelopes, and reject ambiguous config names and formats.
+- Preserve primary watch and adapter-start failures, retain shutdown handlers through cleanup, validate provider-readiness lock tokens, enforce Zalo probe envelopes, and reject ambiguous config names and formats.
 - Preserve provider-native WhatsApp message acknowledgements, legacy group JIDs, bounded inbound admission, WebSocket error isolation, and strict handshake varints.
 - Authenticate built-in Telegram, Slack, and Zalo webhooks, bound recorder wait state, accept Slack user send targets, preserve canonical Telegram topics, and complete WhatsApp cleanup after close failures.
 - Harden HTTP stream failure handling, bound Mattermost WebSocket delivery, move Slack rate-limit controls out of provider payloads, drain Slack callback bodies, and validate release dispatch and existing release state.
 - Harden ready-file replacement and artifact cleanup, use linear-time inbound regex matching, reject blank channel selections, redact malformed JSON details, and preserve slash-containing QA thread targets.
 - Hold serve ready-file ownership across startup and shutdown, preserve live manifests on failed replacement, and retain compound cleanup failures.
-- Reject invalid matchers and provider/fixture mismatches before side effects, drain aborted provider work before cleanup, preserve frozen primary smoke failures, and recover stale smoke locks after PID reuse.
+- Reject invalid matchers and provider/fixture mismatches before side effects, drain aborted provider work before cleanup, preserve frozen primary readiness failures, and recover stale provider-readiness locks after PID reuse.
 - Preserve Slack thread scope and validate Telegram command entities.
 - Authenticate WhatsApp webhook verification and deliveries and reject malformed batches atomically.
 - Cancel silent script watches and redact configured payload secrets from subprocess diagnostics.
@@ -88,7 +88,7 @@
 - Reject truncated WhatsApp GCM tags, invalid handshake wire types, and trailing binary-node data.
 - Randomize externally bound provider credentials, preserve Slack MPIM and Matrix sync errors, bound server shutdown, and enforce safe Zalo webhooks.
 - Order lazy cleanup after admitted dispatch, isolate loopback message state, and enforce effective modes and inbound deadlines.
-- Fence OpenClaw smoke artifact paths, clean abandoned generations safely, preserve primary probe failures and replacement files, and report post-commit lock cleanup failures.
+- Fence OpenClaw provider-readiness artifact paths, clean abandoned generations safely, preserve primary probe failures and replacement files, and report post-commit lock cleanup failures.
 - Isolate verified release packaging from OIDC-enabled npm publication and inspect the generated tarball before upload.
 - Reject Telegram protocol errors returned with HTTP 200 and preserve numeric identities without unsafe integer coercion.
 - Retire serve ready files on shutdown, preserve replacement manifests, and redact text-mode credentials unless explicitly requested.
@@ -99,7 +99,7 @@
 - Preserve recorder continuity across file replacement, keep fixture waits on one outbound until a match, and require canonical nonce tokens.
 - Enforce provider capability and adapter-config contracts, share native target normalization across lazy adapters, and make WhatsApp cleanup terminal.
 - Serialize WhatsApp Noise frames per session and reject invalid X25519 peer keys.
-- Serialize recorder persistence, atomically switch owner-only OpenClaw smoke generations under ownership-safe renewable locks, secure stable file identities with platform-native permissions, and enforce strict QA target and recorder normalization.
+- Serialize recorder persistence, atomically switch owner-only OpenClaw provider-readiness generations under ownership-safe renewable locks, secure stable file identities with platform-native permissions, and enforce strict QA target and recorder normalization.
 - Make CLI failures machine-readable, preserve stage-specific failure contracts, validate fixture provider references, redact script commands, and verify production-only tarball installs.
 - Normalize provider bridge thread IDs and round-trip canonical Telegram topic targets.
 - Drain authentication-rejected provider bodies, bound Zalo parsing, and enforce Telegram media fields.
@@ -141,26 +141,26 @@
 
 ## 0.1.5 - 2026-06-29
 
-- Rename fake-server internals and public server APIs while preserving fake-provider compatibility aliases and artifact paths.
+- Introduce canonical local provider server APIs while preserving the then-current compatibility aliases and artifact paths.
 
 ## 0.1.4 - 2026-06-29
 
-- Add the Baileys WebSocket WhatsApp fake provider server for OpenClaw WebSocket URL smoke runs.
+- Add the Baileys WebSocket WhatsApp local provider server for OpenClaw WebSocket URL smoke runs.
 
 ## 0.1.3 - 2026-06-26
 
-- Add the Slack fake provider server and WhatsApp runtime socket factory to the releasable package.
+- Add the Slack local provider server and WhatsApp runtime socket factory to the releasable package.
 - Preserve generated WhatsApp inbound message IDs when recorder-backed runtime sockets replay admin inbound messages.
 
 ## 0.1.1 - 2026-06-24
 
-- Add the WhatsApp fake provider server with Baileys-style mock socket support for OpenClaw QA runs.
-- Move OpenClaw fake-provider binding code to typed per-provider bridge adapters for Telegram and WhatsApp.
+- Add the WhatsApp local provider server with Baileys-style mock socket support for OpenClaw QA runs.
+- Move OpenClaw local provider binding code to typed per-provider bridge adapters for Telegram and WhatsApp.
 - Update release and CI GitHub Actions dependency pins.
 
 ## 0.1.0 - 2026-06-23
 
-- Harden deterministic provider mocks, fake Telegram APIs, recorder isolation, cleanup, and CLI behavior.
+- Harden deterministic provider mocks, local Telegram APIs, recorder isolation, cleanup, and CLI behavior.
 - Add repository security automation, CodeQL, dependency review, stale handling, and provenance-capable npm releases.
 - Add package documentation and OpenClaw ecosystem branding.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Remove obsolete provider-server aliases, duplicate artifact paths, and fallback readers; require canonical provider-readiness owner records and manifests.
+
 ## 0.1.12 - 2026-07-27
 
 ### Provider fidelity
@@ -141,7 +143,7 @@
 
 ## 0.1.5 - 2026-06-29
 
-- Introduce canonical local provider server APIs while preserving the then-current compatibility aliases and artifact paths.
+- Introduce the initial local provider server APIs and artifact paths.
 
 ## 0.1.4 - 2026-06-29
 

--- a/README.md
+++ b/README.md
@@ -351,7 +351,6 @@ The JSON manifest contains:
 - `endpoints.adminInboundUrl`: authenticated POST endpoint for test user
   messages using the WhatsApp Business webhook payload shape
 - `endpoints.messagesUrl`: provider-native Cloud API message and status endpoint
-- `endpoints.statusUrl`: alias for the same provider-native status endpoint
 - `recorderPath`: JSONL file of local provider API/admin traffic and Baileys
   WebSocket stanzas
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@
 Deterministic local messaging-channel mocks for OpenClaw QA.
 
 `crabline` is config-driven, CI-friendly, and deliberately has no `openclaw`
-dependency. It can run fixture-level local mocks, and it can also serve local
-provider APIs that OpenClaw live adapters can target during deterministic QA.
+dependency. A fixture-level **local mock provider** is a Crabline adapter used
+directly by fixture commands. A **local provider server** is a separate process
+that the Crabline channel driver starts so a real OpenClaw channel plugin can
+exercise its normal provider protocol during deterministic QA.
 
 ## What It Provides
 
@@ -15,16 +17,17 @@ provider APIs that OpenClaw live adapters can target during deterministic QA.
   `whatsapp`, and `zalo`
 - a `script` bridge for channels that are still exercised by external commands
 - per-provider local webhook endpoints for inbound events
-- local provider servers for live-adapter smoke tests for Mattermost, Matrix,
+- local provider servers for Crabline channel-driver tests for Mattermost, Matrix,
   Signal, Slack, Telegram, WhatsApp, and Zalo
 - JSONL recorder files for deterministic wait/watch behavior
 - nonce-based `send`, `roundtrip`, `agent`, `probe`, `run`, `watch`, and
   `doctor` commands
 - text output by default and stable `--json` output for automation
 
-Crabline local servers are not live-provider coverage. They let OpenClaw run its
-normal channel adapter code against a local provider-shaped API. Release lanes
-still need the `live` driver and real provider credentials.
+Crabline local provider servers are not live-provider coverage and are not the
+fixture-level local mock provider feature. They let the real OpenClaw channel
+plugin run against a local provider-shaped API. Release lanes still need the
+`live` driver and real provider credentials.
 
 ## Install
 
@@ -143,9 +146,10 @@ them only from sources you trust and review changes before use.
 
 ## Local Provider Servers
 
-`serve` starts provider-shaped HTTP APIs for OpenClaw live adapters. This is the
-preferred Smoke CI path because OpenClaw still uses its normal channel adapter,
-but the provider endpoint is local and deterministic.
+`serve` starts local provider servers for real OpenClaw channel plugins. This is
+the preferred Crabline channel-driver path because the plugin still uses its
+normal provider protocol while the provider endpoint is local and
+deterministic. It does not use Crabline's fixture-level local mock provider.
 
 Commands in this section use the installed-package form. In a source checkout,
 replace `crabline` with `pnpm dev`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,5 +13,5 @@ Include the affected version or commit, reproduction steps, impact, and any
 suggested mitigation. We will acknowledge reports as soon as practical and
 coordinate disclosure after a fix is available.
 
-Crabline is intended for local and CI test environments. Do not use its fake
+Crabline is intended for local and CI test environments. Do not use its local
 provider endpoints as production services or expose them to untrusted networks.

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -478,7 +478,6 @@ Manifest fields:
 - `endpoints.adminInboundUrl`: authenticated admin ingress for test user
   messages using the WhatsApp Business webhook payload shape
 - `endpoints.messagesUrl`: provider-native Cloud API message and status endpoint
-- `endpoints.statusUrl`: alias for the same provider-native status endpoint
 - `recorderPath`: JSONL provider traffic recorder for HTTP traffic and Baileys
   WebSocket stanzas. Multi-message webhook deliveries use one versioned batch
   line that Crabline's recorder APIs flatten into individual events.
@@ -687,17 +686,16 @@ contain `capabilityReport` and `providerReadiness` payloads while their manifest
 capability, and provider-readiness paths identify the authoritative immutable
 generation.
 
-Lock owners record both PID and process-start identity. Dead owners, and stale
-locks whose PID was reused by the next Crabline process, are reclaimed on the
-next run. New lock owners renew a 10-minute lease while the readiness run
-remains active, so a live run retains exclusive ownership beyond the initial
-lease. A heartbeat failure or lost ownership aborts publication before the
-generation is committed. Recovery first atomically moves a stale candidate away
-from the heartbeat path, then revalidates its token-specific lease before
-deletion; a renewal that wins the rename race is restored rather than reclaimed.
-The lease also bounds stale locks when an unrelated live process has inherited
-the abandoned PID. Older owner records remain PID-protected for compatibility
-and are reclaimed only after their recorded process exits.
+Lock owners use one versioned format containing the PID, process-start identity,
+and token-specific lease. Both the acquisition reservation and owner claim renew
+their 10-minute leases while the readiness run remains active, so a live run
+retains exclusive ownership beyond the initial lease. A heartbeat failure or
+lost ownership aborts publication before the generation is committed. Recovery
+first atomically moves a stale reservation into a uniquely named recovery claim,
+then revalidates its token-specific lease before deletion; a renewal that wins
+the rename race is restored rather than reclaimed. The lease also bounds stale
+locks when an unrelated live process has inherited the abandoned PID. Malformed
+or unversioned owner records fail closed and are not migrated or recovered.
 
 For release or live verification, use OpenClaw's live driver:
 

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -4,7 +4,7 @@ Crabline is a local mock service for OpenClaw channel contracts. It has two
 surfaces:
 
 - fixture-level local mocks used directly by the Crabline CLI
-- local provider servers that OpenClaw live adapters can target
+- local provider servers that real OpenClaw channel plugins can target
 
 Live channel testing belongs in OpenClaw's live channel adapters. Crabline
 belongs in deterministic smoke CI and local QA where the test needs
@@ -511,8 +511,8 @@ The admin ingress accepts JSON like:
 }
 ```
 
-Outbound text sends and composing presence are recorded through the fake
-provider messages and presence endpoints.
+Outbound text sends and composing presence are recorded through the local
+provider server's messages and presence endpoints.
 
 ### Zalo Server
 
@@ -639,7 +639,7 @@ chat IDs must be negative. Zero is invalid for every Telegram target kind.
 
 ## Smoke CI Guidance
 
-For deterministic CI, use Crabline through a mock channel driver:
+For deterministic CI, use the Crabline channel driver:
 
 ```yaml
 profile: smoke-ci
@@ -663,8 +663,8 @@ roundtrip. Real OpenClaw channel proof comes from QA scenarios that launch the
 gateway and run its normal channel adapter against the local provider.
 
 Crabline stages the manifest, capability report, and provider-readiness report
-inside one owner-only generation directory under the legacy
-`.crabline-smoke-artifacts/` store name, atomically installs the complete
+inside one owner-only generation directory under the
+`.crabline-channel-driver-artifacts/` store name, atomically installs the complete
 directory, and then atomically switches the single `current.json` pointer.
 Readers therefore see either the prior complete generation or the next complete
 generation, never per-file mixtures. Setup, probe, cleanup, staging, or

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -1221,7 +1221,6 @@ function renderServeProviderFields(
       `  baileysWebSocket: ${baileysWebSocketUrl}`,
       `  messages: ${manifest.endpoints.messagesUrl}`,
       `  phoneNumber: ${manifest.endpoints.phoneNumberUrl}`,
-      `  status: ${manifest.endpoints.statusUrl}`,
       `  selfJid: ${manifest.selfJid}`,
     ];
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,44 +3,31 @@ export { resolveWhatsAppAdapterConfig } from "./providers/builtin/whatsapp.js";
 export { startMattermostServer } from "./servers/mattermost.js";
 export { startMatrixServer } from "./servers/matrix.js";
 export { startSignalServer } from "./servers/signal.js";
-export { startSlackServer, startSlackServer as startSlackFakeServer } from "./servers/slack.js";
-export {
-  startTelegramServer,
-  startTelegramServer as startTelegramFakeServer,
-} from "./servers/telegram.js";
-export {
-  startWhatsAppServer,
-  startWhatsAppServer as startWhatsAppFakeServer,
-} from "./servers/whatsapp.js";
+export { startSlackServer } from "./servers/slack.js";
+export { startTelegramServer } from "./servers/telegram.js";
+export { startWhatsAppServer } from "./servers/whatsapp.js";
 export { startZaloServer } from "./servers/zalo.js";
 export {
   CRABLINE_SERVER_CHANNELS,
-  CRABLINE_SERVER_CHANNELS as CRABLINE_FAKE_PROVIDER_CHANNELS,
   isCrablineServerChannel,
-  isCrablineServerChannel as isCrablineFakeProviderChannel,
   startCrablineServer,
-  startCrablineServer as startCrablineFakeProviderServer,
 } from "./servers/index.js";
 export {
   createOpenClawCrablineAgentDelivery,
   createOpenClawCrablineChannelReportNotes,
-  createOpenClawCrablineProviderBinding as createOpenClawCrablineFakeProviderBinding,
   createOpenClawCrablineProviderBinding,
   createOpenClawCrablineInbound,
   createOpenClawCrablineOutboundFromRecorderEvent,
   OPENCLAW_CRABLINE_ARTIFACT_POINTER_PATH,
   OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY,
   OPENCLAW_CRABLINE_CHANNEL_CAPABILITY_MATRIX_PATH,
-  OPENCLAW_CRABLINE_CHANNEL_SMOKE_PATH,
   OPENCLAW_CRABLINE_PROVIDER_READINESS_PATH,
   OPENCLAW_CRABLINE_DEFAULT_CHANNEL,
   OPENCLAW_CRABLINE_MANIFEST_PATH,
-  probeOpenClawCrablineProvider as probeOpenClawCrablineFakeProvider,
   probeOpenClawCrablineProvider,
   resolveOpenClawCrablineChannel,
   resolveOpenClawCrablineChannelDriverSelection,
   runOpenClawCrablineProviderReadiness,
-  runOpenClawCrablineChannelDriverSmoke,
   startOpenClawCrablineAdapter,
 } from "./openclaw.js";
 export {
@@ -95,28 +82,19 @@ export type {
   StartSignalServerParams,
 } from "./servers/signal.js";
 export type {
-  SlackServerManifest as SlackFakeServerManifest,
   SlackServerManifest,
-  StartedSlackServer as StartedSlackFakeServer,
   StartedSlackServer,
-  StartSlackServerParams as StartSlackFakeServerParams,
   StartSlackServerParams,
 } from "./servers/slack.js";
 export type {
-  StartedTelegramServer as StartedTelegramFakeServer,
   StartedTelegramServer,
-  StartTelegramServerParams as StartTelegramFakeServerParams,
   StartTelegramServerParams,
-  TelegramServerManifest as TelegramFakeServerManifest,
   TelegramServerManifest,
 } from "./servers/telegram.js";
 export type {
-  StartedWhatsAppServer as StartedWhatsAppFakeServer,
   StartedWhatsAppServer,
-  StartWhatsAppServerParams as StartWhatsAppFakeServerParams,
   StartWhatsAppServerParams,
   WhatsAppBaileysMessage,
-  WhatsAppServerManifest as WhatsAppFakeServerManifest,
   WhatsAppServerManifest,
 } from "./servers/whatsapp.js";
 export type {
@@ -125,19 +103,14 @@ export type {
   ZaloServerManifest,
 } from "./servers/zalo.js";
 export type {
-  CrablineServerChannel as CrablineFakeProviderChannel,
   CrablineServerChannel,
-  CrablineServerManifest as CrablineFakeProviderManifest,
   CrablineServerManifest,
-  StartedCrablineServer as StartedCrablineFakeProviderServer,
   StartedCrablineServer,
-  StartCrablineServerParams as StartCrablineFakeProviderServerParams,
   StartCrablineServerParams,
 } from "./servers/index.js";
 export type {
   OpenClawCrablineAgentDelivery,
   OpenClawCrablineChannelDriverSelection,
-  OpenClawCrablineChannelDriverSmokeResult,
   OpenClawCrablineProviderReadinessResult,
   OpenClawCrablineConversation,
   OpenClawCrablineGatewayBinding,

--- a/src/openclaw.ts
+++ b/src/openclaw.ts
@@ -18,7 +18,6 @@ import { WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE } from "./openclaw/bridges/w
 import { ZALO_OPENCLAW_CRABLINE_PROVIDER_BRIDGE } from "./openclaw/bridges/zalo.js";
 import {
   OPENCLAW_CRABLINE_CHANNEL_CAPABILITY_MATRIX_PATH,
-  OPENCLAW_CRABLINE_CHANNEL_SMOKE_PATH,
   OPENCLAW_CRABLINE_PROVIDER_READINESS_PATH,
   OPENCLAW_CRABLINE_DEFAULT_CHANNEL,
   OPENCLAW_CRABLINE_ARTIFACT_POINTER_PATH,
@@ -49,9 +48,9 @@ import {
   type SecuredPrivateDirectory,
 } from "./openclaw/private-file.js";
 import {
-  acquireOpenClawCrablineSmokeRunLock,
-  releaseOpenClawCrablineSmokeRunLock,
-} from "./openclaw/smoke-lock.js";
+  acquireOpenClawCrablineProviderReadinessLock,
+  releaseOpenClawCrablineProviderReadinessLock,
+} from "./openclaw/provider-readiness-lock.js";
 import fs from "node:fs/promises";
 import path from "node:path";
 
@@ -59,7 +58,6 @@ export {
   OPENCLAW_CRABLINE_ARTIFACT_POINTER_PATH,
   OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY,
   OPENCLAW_CRABLINE_CHANNEL_CAPABILITY_MATRIX_PATH,
-  OPENCLAW_CRABLINE_CHANNEL_SMOKE_PATH,
   OPENCLAW_CRABLINE_PROVIDER_READINESS_PATH,
   OPENCLAW_CRABLINE_DEFAULT_CHANNEL,
   OPENCLAW_CRABLINE_MANIFEST_PATH,
@@ -67,7 +65,6 @@ export {
 export type {
   OpenClawCrablineAgentDelivery,
   OpenClawCrablineChannelDriverSelection,
-  OpenClawCrablineChannelDriverSmokeResult,
   OpenClawCrablineProviderReadinessResult,
   OpenClawCrablineConversation,
   OpenClawCrablineGatewayBinding,
@@ -92,7 +89,7 @@ const OPENCLAW_CRABLINE_PROVIDER_BRIDGE_LIST = Object.values(
   OPENCLAW_CRABLINE_PROVIDER_BRIDGES,
 ) as readonly OpenClawCrablineProviderBridge[];
 const RECORDER_TEMP_NAME_PATTERN =
-  /^\.([a-z]+)-fake-provider\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl\.tmp$/iu;
+  /^\.([a-z]+)-provider-server\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl\.tmp$/iu;
 const RECORDER_LOCK_REMOVAL_TOMBSTONE_PATTERN =
   /^\.(.+)\.\d+\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.remove$/iu;
 const OPENCLAW_CRABLINE_PROVIDER_PROBE_CLEANUP_GRACE_MS = 250;
@@ -217,7 +214,7 @@ function openClawCrablineRecorderLockTombstoneBaseName(name: string): string | n
 async function reclaimOpenClawCrablineRecorderTemporaryLock(
   directoryPath: string,
   name: string,
-  lock: Awaited<ReturnType<typeof acquireOpenClawCrablineSmokeRunLock>>,
+  lock: Awaited<ReturnType<typeof acquireOpenClawCrablineProviderReadinessLock>>,
   quarantineBaseName = name,
 ): Promise<void> {
   const lockPath = path.join(directoryPath, name);
@@ -266,7 +263,7 @@ async function reclaimOpenClawCrablineRecorderTemporaryLock(
 
 async function reclaimOpenClawCrablineRecorderTemporaries(
   directory: SecuredPrivateDirectory,
-  lock: Awaited<ReturnType<typeof acquireOpenClawCrablineSmokeRunLock>>,
+  lock: Awaited<ReturnType<typeof acquireOpenClawCrablineProviderReadinessLock>>,
 ): Promise<void> {
   const directoryPath = directory.directoryPath;
   await directory.assertIdentityAt();
@@ -419,7 +416,6 @@ export function resolveOpenClawCrablineChannelDriverSelection(params: {
     channelDriver: "crabline",
     capabilityMatrixPath: OPENCLAW_CRABLINE_CHANNEL_CAPABILITY_MATRIX_PATH,
     providerReadinessArtifactPath: OPENCLAW_CRABLINE_PROVIDER_READINESS_PATH,
-    smokeArtifactPath: OPENCLAW_CRABLINE_CHANNEL_SMOKE_PATH,
   };
 }
 
@@ -511,9 +507,9 @@ export async function startOpenClawCrablineAdapter(
 }
 
 type ProviderReadinessDependencies = {
-  acquireLock?: typeof acquireOpenClawCrablineSmokeRunLock;
+  acquireLock?: typeof acquireOpenClawCrablineProviderReadinessLock;
   publishGeneration?: typeof publishOpenClawCrablineArtifactGeneration;
-  releaseLock?: typeof releaseOpenClawCrablineSmokeRunLock;
+  releaseLock?: typeof releaseOpenClawCrablineProviderReadinessLock;
   startAdapter?: typeof startOpenClawCrablineAdapter;
   syncParent?: typeof syncParentDirectory;
 };
@@ -567,9 +563,11 @@ export async function runOpenClawCrablineProviderReadiness(
   dependencies: ProviderReadinessDependencies = {},
 ): Promise<OpenClawCrablineProviderReadinessResult> {
   const outputDir = path.resolve(params.outputDir);
-  const releaseLock = dependencies.releaseLock ?? releaseOpenClawCrablineSmokeRunLock;
+  const releaseLock = dependencies.releaseLock ?? releaseOpenClawCrablineProviderReadinessLock;
   const syncRecorderParent = dependencies.syncParent ?? syncParentDirectory;
-  const smokeLock = await (dependencies.acquireLock ?? acquireOpenClawCrablineSmokeRunLock)({
+  const providerReadinessLock = await (
+    dependencies.acquireLock ?? acquireOpenClawCrablineProviderReadinessLock
+  )({
     channel: params.selection.channel,
     outputDir,
   });
@@ -587,10 +585,10 @@ export async function runOpenClawCrablineProviderReadiness(
     );
     await artifactsDirectory.assertIdentityAt();
     await recorderDirectory.assertIdentityAt();
-    await reclaimOpenClawCrablineRecorderTemporaries(recorderDirectory, smokeLock);
+    await reclaimOpenClawCrablineRecorderTemporaries(recorderDirectory, providerReadinessLock);
     recorderPath = path.join(
       recorderDirectory.directoryPath,
-      `.${params.selection.channel}-fake-provider.${randomUUID()}.jsonl.tmp`,
+      `.${params.selection.channel}-provider-server.${randomUUID()}.jsonl.tmp`,
     );
     const adapter = await (dependencies.startAdapter ?? startOpenClawCrablineAdapter)({
       channel: params.selection.channel,
@@ -679,12 +677,12 @@ export async function runOpenClawCrablineProviderReadiness(
       dependencies.publishGeneration ?? publishOpenClawCrablineArtifactGeneration
     )({
       capabilityReport,
-      lock: smokeLock,
+      lock: providerReadinessLock,
       manifest: adapter.manifest,
       outputDir,
       recorderSnapshot: {
         contents: recorderSnapshotContents,
-        fileName: `${params.selection.channel}-fake-provider.jsonl`,
+        fileName: `${params.selection.channel}-provider-server.jsonl`,
       },
       selection: params.selection,
       providerReadiness,
@@ -712,8 +710,6 @@ export async function runOpenClawCrablineProviderReadiness(
         manifestPath: generation.manifestPath,
         providerReadiness: generation.providerReadiness,
         providerReadinessArtifactPath: generation.providerReadinessArtifactPath,
-        smoke: generation.providerReadiness,
-        smokeArtifactPath: generation.providerReadinessArtifactPath,
         ...(generation.warnings || recorderCleanupWarning
           ? {
               warnings: [
@@ -768,7 +764,7 @@ export async function runOpenClawCrablineProviderReadiness(
   }
 
   try {
-    await releaseLock(smokeLock);
+    await releaseLock(providerReadinessLock);
   } catch (cleanupError) {
     // The pointer switch is authoritative; lock removal cannot roll it back.
     if (!outcome.committed) {
@@ -782,7 +778,7 @@ export async function runOpenClawCrablineProviderReadiness(
                 ? cleanupError
                 : new AggregateError(
                     [existingCause, cleanupError],
-                    "OpenClaw Crabline smoke failure cleanup also failed.",
+                    "OpenClaw Crabline provider readiness failure cleanup also failed.",
                   ),
           });
         } catch {
@@ -790,9 +786,12 @@ export async function runOpenClawCrablineProviderReadiness(
         }
         throw outcome.error;
       }
-      const combinedError = new Error("OpenClaw Crabline smoke and lock cleanup both failed.", {
-        cause: cleanupError,
-      });
+      const combinedError = new Error(
+        "OpenClaw Crabline provider readiness and lock cleanup both failed.",
+        {
+          cause: cleanupError,
+        },
+      );
       Object.defineProperty(combinedError, "errors", {
         value: [outcome.error, cleanupError],
       });
@@ -803,7 +802,7 @@ export async function runOpenClawCrablineProviderReadiness(
       ...outcome.result,
       warnings: [
         ...(outcome.result.warnings ?? []),
-        `OpenClaw Crabline smoke committed but lock cleanup failed: ${detail}`,
+        `OpenClaw Crabline provider readiness committed but lock cleanup failed: ${detail}`,
       ],
     };
   }
@@ -813,9 +812,6 @@ export async function runOpenClawCrablineProviderReadiness(
   }
   return outcome.result;
 }
-
-/** @deprecated Use runOpenClawCrablineProviderReadiness. */
-export const runOpenClawCrablineChannelDriverSmoke = runOpenClawCrablineProviderReadiness;
 
 export function createOpenClawCrablineChannelReportNotes(
   selection: OpenClawCrablineChannelDriverSelection | null | undefined,
@@ -828,7 +824,7 @@ export function createOpenClawCrablineChannelReportNotes(
     `Channel driver: ${selection.channelDriver} local provider for ${selection.channel}.`,
     `Channel artifact pointer: ${OPENCLAW_CRABLINE_ARTIFACT_POINTER_PATH}.`,
     `Generation capability filename: ${selection.capabilityMatrixPath}.`,
-    `Generation provider-readiness filename: ${selection.providerReadinessArtifactPath ?? selection.smokeArtifactPath}.`,
+    `Generation provider-readiness filename: ${selection.providerReadinessArtifactPath}.`,
     "Crabline verifies the local provider API is ready; OpenClaw channel behavior is proven separately by QA scenarios that run the real channel adapter.",
   ];
 }

--- a/src/openclaw/artifact-generation.ts
+++ b/src/openclaw/artifact-generation.ts
@@ -14,12 +14,11 @@ import {
   OPENCLAW_CRABLINE_ARTIFACT_POINTER_PATH,
   OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY,
   OPENCLAW_CRABLINE_CHANNEL_CAPABILITY_MATRIX_PATH,
-  OPENCLAW_CRABLINE_CHANNEL_SMOKE_PATH,
   OPENCLAW_CRABLINE_PROVIDER_READINESS_PATH,
   OPENCLAW_CRABLINE_MANIFEST_PATH,
   type OpenClawCrablineChannelDriverSelection,
 } from "./shared.js";
-import type { OpenClawCrablineSmokeRunLock } from "./smoke-lock.js";
+import type { OpenClawCrablineProviderReadinessLock } from "./provider-readiness-lock.js";
 
 const GENERATION_NAME_PATTERN =
   /^generation-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu;
@@ -34,20 +33,16 @@ type OpenClawCrablineArtifactPointerBase = {
   manifestPath: string;
   previousGeneration?: string;
   providerReadinessArtifactPath: string;
-  smokeArtifactPath: string;
 };
 
-export type OpenClawCrablineArtifactPointer =
-  | (OpenClawCrablineArtifactPointerBase & { version: 1 })
-  | (OpenClawCrablineArtifactPointerBase & {
-      recorderSnapshotPath: string | null;
-      version: 2;
-    });
+export type OpenClawCrablineArtifactPointer = OpenClawCrablineArtifactPointerBase & {
+  recorderSnapshotPath: string | null;
+  version: 3;
+};
 
 export type PublishedOpenClawCrablineArtifactGeneration = OpenClawCrablineArtifactPointer & {
   pointerPath: string;
   providerReadiness: Record<string, unknown>;
-  smoke: Record<string, unknown>;
   warnings?: string[];
 };
 
@@ -69,14 +64,13 @@ type RecorderSnapshot = {
 function resolveProviderReadinessArtifactPath(
   selection: OpenClawCrablineChannelDriverSelection,
 ): typeof OPENCLAW_CRABLINE_PROVIDER_READINESS_PATH {
-  const readinessPath = selection.providerReadinessArtifactPath ?? selection.smokeArtifactPath;
   if (
     selection.capabilityMatrixPath !== OPENCLAW_CRABLINE_CHANNEL_CAPABILITY_MATRIX_PATH ||
-    readinessPath !== OPENCLAW_CRABLINE_PROVIDER_READINESS_PATH
+    selection.providerReadinessArtifactPath !== OPENCLAW_CRABLINE_PROVIDER_READINESS_PATH
   ) {
     throw new Error("OpenClaw Crabline artifact selection paths are malformed.");
   }
-  return readinessPath;
+  return selection.providerReadinessArtifactPath;
 }
 
 function isMissingPathError(error: unknown): boolean {
@@ -353,7 +347,7 @@ function parseArtifactPointer(contents: string): OpenClawCrablineArtifactPointer
     recorderSnapshotPath?: unknown;
     version?: unknown;
   };
-  if (value.version !== 1 && value.version !== 2) {
+  if (value.version !== 3) {
     throw new Error("OpenClaw Crabline artifact pointer is malformed.");
   }
   assertGenerationName(value.generation, "generation");
@@ -374,58 +368,37 @@ function parseArtifactPointer(contents: string): OpenClawCrablineArtifactPointer
       value.generation,
       OPENCLAW_CRABLINE_PROVIDER_READINESS_PATH,
     ),
-    smokeArtifactPath: generationArtifactPath(
-      value.generation,
-      OPENCLAW_CRABLINE_CHANNEL_SMOKE_PATH,
-    ),
   };
   if (
     typeof value.capabilityMatrixPath !== "string" ||
     value.capabilityMatrixPath !== expected.capabilityMatrixPath ||
     value.manifestPath !== expected.manifestPath ||
-    (value.version === 2 &&
-      value.providerReadinessArtifactPath !== expected.providerReadinessArtifactPath) ||
-    (value.providerReadinessArtifactPath !== undefined &&
-      value.providerReadinessArtifactPath !== expected.providerReadinessArtifactPath) ||
-    (value.smokeArtifactPath !== undefined &&
-      value.smokeArtifactPath !== expected.smokeArtifactPath) ||
-    (value.providerReadinessArtifactPath === undefined && value.smokeArtifactPath === undefined)
+    value.providerReadinessArtifactPath !== expected.providerReadinessArtifactPath
   ) {
     throw new Error("OpenClaw Crabline artifact pointer is malformed.");
   }
-  if (value.version === 1 && value.recorderSnapshotPath !== undefined) {
+  if (value.recorderSnapshotPath !== null && typeof value.recorderSnapshotPath !== "string") {
     throw new Error("OpenClaw Crabline artifact pointer is malformed.");
   }
-  if (value.version === 2) {
-    if (value.recorderSnapshotPath !== null && typeof value.recorderSnapshotPath !== "string") {
+  if (typeof value.recorderSnapshotPath === "string") {
+    const recorderFileName = path.basename(value.recorderSnapshotPath);
+    if (
+      !recorderFileName.endsWith(".jsonl") ||
+      value.recorderSnapshotPath !== generationArtifactPath(value.generation, recorderFileName)
+    ) {
       throw new Error("OpenClaw Crabline artifact pointer is malformed.");
-    }
-    if (typeof value.recorderSnapshotPath === "string") {
-      const recorderFileName = path.basename(value.recorderSnapshotPath);
-      if (
-        !recorderFileName.endsWith(".jsonl") ||
-        value.recorderSnapshotPath !== generationArtifactPath(value.generation, recorderFileName)
-      ) {
-        throw new Error("OpenClaw Crabline artifact pointer is malformed.");
-      }
     }
   }
 
-  const pointer = {
+  return {
     capabilityMatrixPath: value.capabilityMatrixPath,
     generation: value.generation,
     ...(value.previousGeneration ? { previousGeneration: value.previousGeneration } : {}),
     manifestPath: value.manifestPath,
-    providerReadinessArtifactPath: value.providerReadinessArtifactPath ?? value.smokeArtifactPath!,
-    smokeArtifactPath: value.smokeArtifactPath ?? value.providerReadinessArtifactPath!,
+    providerReadinessArtifactPath: value.providerReadinessArtifactPath,
+    recorderSnapshotPath: value.recorderSnapshotPath as string | null,
+    version: 3,
   };
-  return value.version === 1
-    ? { ...pointer, version: 1 }
-    : {
-        ...pointer,
-        recorderSnapshotPath: value.recorderSnapshotPath as string | null,
-        version: 2,
-      };
 }
 
 export async function readOpenClawCrablineArtifactPointer(
@@ -521,7 +494,6 @@ async function assertArtifactGenerationExists(
   const capabilityMatrix = await readArtifactObject(pointer.capabilityMatrixPath);
   const readiness = await readArtifactObject(pointer.providerReadinessArtifactPath);
   const providerReadiness = readiness.providerReadiness;
-  const smoke = readiness.smoke;
   if (
     !isGeneratedManifest(manifest) ||
     capabilityMatrix.version !== 1 ||
@@ -533,52 +505,24 @@ async function assertArtifactGenerationExists(
     capabilityMatrix.report === null ||
     typeof capabilityMatrix.report !== "object" ||
     Array.isArray(capabilityMatrix.report) ||
-    readiness.version !== 1 ||
+    readiness.version !== 2 ||
     readiness.source !== "openclaw/crabline" ||
     readiness.manifestPath !== pointer.manifestPath ||
     readiness.channelDriver !== "crabline" ||
     readiness.selectedChannel !== capabilityMatrix.selectedChannel ||
     manifest.provider !== readiness.selectedChannel ||
-    !isReadinessSection(
-      smoke,
-      manifest,
-      pointer.manifestPath,
-      pointer.version === 2 || providerReadiness !== undefined,
-    ) ||
-    (pointer.version === 2 &&
-      (!isReadinessSection(providerReadiness, manifest, pointer.manifestPath, true) ||
-        !isDeepStrictEqual(providerReadiness, smoke))) ||
-    (pointer.version === 1 &&
-      providerReadiness !== undefined &&
-      (!isReadinessSection(providerReadiness, manifest, pointer.manifestPath, true) ||
-        !isDeepStrictEqual(providerReadiness, smoke)))
+    !isReadinessSection(providerReadiness, manifest, pointer.manifestPath, true)
   ) {
     throw new Error("OpenClaw Crabline current artifact generation is incomplete.");
   }
   const manifestRecorderPath =
     typeof manifest.recorderPath === "string" ? manifest.recorderPath : undefined;
-  const providerReadinessRecorderPath = isRecord(providerReadiness)
-    ? readNestedRecorderPath(providerReadiness)
-    : undefined;
-  const smokeRecorderPath = readNestedRecorderPath(smoke);
-  const readinessRecorderPaths = [
-    ...(isRecord(providerReadiness) ? [providerReadinessRecorderPath] : []),
-    smokeRecorderPath,
-  ];
-  const recorderPaths = [manifestRecorderPath, ...readinessRecorderPaths];
+  const providerReadinessRecorderPath = readNestedRecorderPath(providerReadiness);
+  const recorderPaths = [manifestRecorderPath, providerReadinessRecorderPath];
   if (manifest.recorderPath !== undefined && typeof manifest.recorderPath !== "string") {
     throw new Error("OpenClaw Crabline current artifact generation is incomplete.");
   }
-  // The artifact store is owner-only; v1 compatibility covers historical layouts, not hostile same-owner rewrites.
-  if (
-    pointer.version === 1 &&
-    readinessRecorderPaths.every((recorderPath) => recorderPath === undefined) &&
-    (manifestRecorderPath === undefined ||
-      path.dirname(path.resolve(outputDir, manifestRecorderPath)) !== generationDirectory)
-  ) {
-    return;
-  }
-  if (pointer.version === 2 && pointer.recorderSnapshotPath === null) {
+  if (pointer.recorderSnapshotPath === null) {
     if (recorderPaths.some((recorderPath) => recorderPath !== undefined)) {
       throw new Error("OpenClaw Crabline current artifact generation is incomplete.");
     }
@@ -598,7 +542,6 @@ async function assertArtifactGenerationExists(
   }
   const recorderPath = resolvedRecorderPaths[0]!;
   if (
-    pointer.version === 2 &&
     pointer.recorderSnapshotPath !== null &&
     recorderPath !== path.resolve(outputDir, pointer.recorderSnapshotPath)
   ) {
@@ -653,7 +596,7 @@ async function readValidCurrentArtifactGeneration(
 }
 
 async function pruneArtifactStore(params: {
-  lock: OpenClawCrablineSmokeRunLock;
+  lock: OpenClawCrablineProviderReadinessLock;
   pointer: OpenClawCrablineArtifactPointer | null;
   store: Awaited<ReturnType<typeof securePrivateDirectory>>;
   directoryOptions?: Parameters<typeof securePrivateDirectory>[1];
@@ -696,7 +639,7 @@ async function pruneArtifactStore(params: {
 export async function publishOpenClawCrablineArtifactGeneration(
   params: {
     capabilityReport: unknown;
-    lock: OpenClawCrablineSmokeRunLock;
+    lock: OpenClawCrablineProviderReadinessLock;
     manifest: CrablineServerManifest;
     outputDir: string;
     recorderSnapshot?: RecorderSnapshot;
@@ -786,8 +729,7 @@ export async function publishOpenClawCrablineArtifactGeneration(
         providerReadinessArtifactPath,
       ),
       recorderSnapshotPath: recorderSnapshotPath ?? null,
-      smokeArtifactPath: generationArtifactPath(generation, providerReadinessArtifactPath),
-      version: 2,
+      version: 3,
     };
     const publishedManifest = recorderSnapshotPath
       ? { ...params.manifest, recorderPath: recorderSnapshotPath }
@@ -825,13 +767,12 @@ export async function publishOpenClawCrablineArtifactGeneration(
       {
         contents: `${JSON.stringify(
           {
-            version: 1,
+            version: 2,
             source: "openclaw/crabline",
             channelDriver: params.selection.channelDriver,
             selectedChannel: params.selection.channel,
             manifestPath: pointer.manifestPath,
             providerReadiness,
-            smoke: providerReadiness,
           },
           null,
           2,
@@ -916,7 +857,6 @@ export async function publishOpenClawCrablineArtifactGeneration(
       ...pointer,
       pointerPath: OPENCLAW_CRABLINE_ARTIFACT_POINTER_PATH,
       providerReadiness,
-      smoke: providerReadiness,
       ...(warnings ? { warnings } : {}),
     };
   } catch (error) {

--- a/src/openclaw/artifact-generation.ts
+++ b/src/openclaw/artifact-generation.ts
@@ -177,7 +177,6 @@ function isGeneratedManifest(value: Record<string, unknown>): boolean {
           "baileysWebSocketUrl",
           "messagesUrl",
           "phoneNumberUrl",
-          "statusUrl",
         ]) &&
         hasNonEmptyStringFields(env, [
           "CLOUD_API_ACCESS_TOKEN",
@@ -190,7 +189,6 @@ function isGeneratedManifest(value: Record<string, unknown>): boolean {
         endpoints.phoneNumberUrl ===
           `${endpoints.apiRoot as string}/${value.phoneNumberId as string}` &&
         endpoints.messagesUrl === `${endpoints.phoneNumberUrl as string}/messages` &&
-        endpoints.statusUrl === endpoints.messagesUrl &&
         endpoints.baileysWebSocketUrl ===
           `${baseUrl.replace(/^http/u, "ws")}/ws/chat?access_token=${encodeURIComponent(
             value.accessToken as string,

--- a/src/openclaw/bridges/matrix.ts
+++ b/src/openclaw/bridges/matrix.ts
@@ -134,7 +134,7 @@ export const MATRIX_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablinePr
         return {
           accountId: DEFAULT_ACCOUNT_ID,
           channel: "matrix",
-          createChannelDriverSmokeEnv: (env) => ({ ...env, ...matrix.env }),
+          createProviderReadinessEnv: (env) => ({ ...env, ...matrix.env }),
           createGatewayConfig: (openclawConfig = {}) => {
             const channels = isRecord(openclawConfig.channels) ? openclawConfig.channels : {};
             const matrixConfig = isRecord(channels.matrix) ? channels.matrix : {};

--- a/src/openclaw/bridges/mattermost.ts
+++ b/src/openclaw/bridges/mattermost.ts
@@ -63,7 +63,7 @@ export const MATTERMOST_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabli
         return {
           accountId: DEFAULT_ACCOUNT_ID,
           channel: "mattermost",
-          createChannelDriverSmokeEnv: (env) => ({ ...env, ...mattermost.env }),
+          createProviderReadinessEnv: (env) => ({ ...env, ...mattermost.env }),
           createGatewayConfig: (openclawConfig = {}) => {
             const channels = isRecord(openclawConfig.channels) ? openclawConfig.channels : {};
             const mattermostConfig = isRecord(channels.mattermost) ? channels.mattermost : {};

--- a/src/openclaw/bridges/signal.ts
+++ b/src/openclaw/bridges/signal.ts
@@ -91,7 +91,7 @@ export const SIGNAL_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablinePr
         return {
           accountId: DEFAULT_ACCOUNT_ID,
           channel: "signal",
-          createChannelDriverSmokeEnv: (env) => env,
+          createProviderReadinessEnv: (env) => env,
           createGatewayConfig: (openclawConfig = {}) => {
             const channels = isRecord(openclawConfig.channels) ? openclawConfig.channels : {};
             const signalConfig = isRecord(channels.signal) ? channels.signal : {};

--- a/src/openclaw/bridges/slack.ts
+++ b/src/openclaw/bridges/slack.ts
@@ -250,7 +250,7 @@ export const SLACK_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablinePro
         return {
           accountId: DEFAULT_ACCOUNT_ID,
           channel: "slack",
-          createChannelDriverSmokeEnv: (env) => ({
+          createProviderReadinessEnv: (env) => ({
             ...env,
             SLACK_API_URL: slack.endpoints.apiRoot,
             SLACK_BOT_TOKEN: slack.botToken,

--- a/src/openclaw/bridges/telegram.ts
+++ b/src/openclaw/bridges/telegram.ts
@@ -177,7 +177,7 @@ export const TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
         return {
           accountId: DEFAULT_ACCOUNT_ID,
           channel: "telegram",
-          createChannelDriverSmokeEnv: (env) => ({
+          createProviderReadinessEnv: (env) => ({
             ...env,
             TELEGRAM_BOT_TOKEN: telegram.botToken,
           }),

--- a/src/openclaw/bridges/whatsapp.ts
+++ b/src/openclaw/bridges/whatsapp.ts
@@ -73,7 +73,7 @@ export const WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
         return {
           accountId: DEFAULT_ACCOUNT_ID,
           channel: "whatsapp",
-          createChannelDriverSmokeEnv: (env) => ({
+          createProviderReadinessEnv: (env) => ({
             ...env,
             CRABLINE_WHATSAPP_ADMIN_TOKEN: whatsapp.adminToken,
             CRABLINE_WHATSAPP_RECORDER_PATH: whatsapp.recorderPath,

--- a/src/openclaw/bridges/zalo.ts
+++ b/src/openclaw/bridges/zalo.ts
@@ -54,7 +54,7 @@ export const ZALO_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablineProv
         return {
           accountId: DEFAULT_ACCOUNT_ID,
           channel: "zalo",
-          createChannelDriverSmokeEnv: (env) => ({ ...env, ...zalo.env }),
+          createProviderReadinessEnv: (env) => ({ ...env, ...zalo.env }),
           createGatewayConfig: (openclawConfig = {}) => {
             const channels = isRecord(openclawConfig.channels) ? openclawConfig.channels : {};
             const zaloConfig = isRecord(channels.zalo) ? channels.zalo : {};

--- a/src/openclaw/provider-readiness-lock.ts
+++ b/src/openclaw/provider-readiness-lock.ts
@@ -8,27 +8,16 @@ import { isCrablineServerChannel, type CrablineServerChannel } from "../servers/
 import { resolveWindowsPowerShellPath, securePrivateDirectory } from "./private-file.js";
 import { OPENCLAW_CRABLINE_MANIFEST_PATH } from "./shared.js";
 
-type LegacyProviderReadinessLockOwner = {
+type ProviderReadinessLockOwner = {
   channel: CrablineServerChannel;
-  pid: number;
-  token: string;
-};
-
-type ProcessIdentifiedProviderReadinessLockOwner = LegacyProviderReadinessLockOwner & {
   createdAtMs: number;
+  lockVersion: 1;
+  pid: number;
   processIdentity?: string;
   processIdentityV2?: string;
   processStartedAtMs: number;
+  token: string;
 };
-
-type RenewableProviderReadinessLockOwner = ProcessIdentifiedProviderReadinessLockOwner & {
-  leaseVersion: 1;
-};
-
-type ProviderReadinessLockOwner =
-  | LegacyProviderReadinessLockOwner
-  | ProcessIdentifiedProviderReadinessLockOwner
-  | RenewableProviderReadinessLockOwner;
 
 type ProviderReadinessLockRecord = {
   owner: ProviderReadinessLockOwner;
@@ -59,7 +48,7 @@ type GetProcessIdentity = (pid: number) => string | null;
 type StartHeartbeat = (renew: () => Promise<void>, intervalMs: number) => HeartbeatController;
 type BeforeRecoveryClaim = () => Promise<void>;
 type BeforeRecoveryDeleteClaim = () => Promise<void>;
-type BeforeCompatibilityMarkerRenew = () => Promise<void>;
+type BeforeReservationRenew = () => Promise<void>;
 type BeforeReleaseClaim = () => Promise<void>;
 type BeforeReleaseRename = () => Promise<void>;
 type BeforeReleaseRemove = () => Promise<void>;
@@ -68,7 +57,7 @@ type BeforeCommitFileRename = () => Promise<void>;
 type BeforeCommitRename = () => Promise<void>;
 type SecureWindowsDirectory = (directoryPath: string) => Promise<void>;
 type AfterLockDirectoryWrite = (directoryPath: string) => Promise<void>;
-type LockClaimKind = "commit" | "owned" | "recovering" | "release";
+type LockClaimKind = "commit" | "owned" | "recovery" | "release";
 type LockClaim = {
   directoryPath: string;
   kind: LockClaimKind;
@@ -96,7 +85,7 @@ const LOCK_OWNER_FILE = "owner.json";
 const LOCK_LEASE_FILE_PREFIX = "lease.";
 const LOCK_COMMIT_STAGE_FILE_PREFIX = "commit-stage.";
 const LOCK_STAGED_FILE_PREFIX = ".commit-file.";
-const LEGACY_RECOVERY_SUFFIX = ".recovering";
+const RECOVERY_CLAIM_SUFFIX = ".recovery";
 const COMMIT_CLAIM_SUFFIX = ".commit";
 const OWNED_CLAIM_SUFFIX = ".owned";
 const RELEASE_CLAIM_SUFFIX = ".release";
@@ -346,29 +335,16 @@ function parseLockOwner(contents: string): ProviderReadinessLockOwner {
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
     throw new Error("OpenClaw Crabline provider readiness lock owner metadata is malformed.");
   }
-  const owner = parsed as Partial<RenewableProviderReadinessLockOwner>;
+  const owner = parsed as Partial<ProviderReadinessLockOwner>;
   if (
     typeof owner.channel !== "string" ||
     !isCrablineServerChannel(owner.channel) ||
-    !isValidProcessId(owner.pid) ||
-    typeof owner.token !== "string" ||
-    !LOCK_TOKEN_PATTERN.test(owner.token)
-  ) {
-    throw new Error("OpenClaw Crabline provider readiness lock owner metadata is malformed.");
-  }
-
-  const hasCreatedAt = owner.createdAtMs !== undefined;
-  const hasProcessStartedAt = owner.processStartedAtMs !== undefined;
-  if (!hasCreatedAt && !hasProcessStartedAt && owner.leaseVersion === undefined) {
-    return {
-      channel: owner.channel,
-      pid: owner.pid,
-      token: owner.token,
-    };
-  }
-  if (
     !isPositiveSafeInteger(owner.createdAtMs) ||
+    owner.lockVersion !== 1 ||
+    !isValidProcessId(owner.pid) ||
     !isPositiveSafeInteger(owner.processStartedAtMs) ||
+    typeof owner.token !== "string" ||
+    !LOCK_TOKEN_PATTERN.test(owner.token) ||
     (owner.processIdentity !== undefined &&
       (typeof owner.processIdentity !== "string" ||
         owner.processIdentity.length === 0 ||
@@ -380,24 +356,10 @@ function parseLockOwner(contents: string): ProviderReadinessLockOwner {
   ) {
     throw new Error("OpenClaw Crabline provider readiness lock owner metadata is malformed.");
   }
-  if (owner.leaseVersion === undefined) {
-    return {
-      channel: owner.channel,
-      createdAtMs: owner.createdAtMs,
-      pid: owner.pid,
-      ...(owner.processIdentity ? { processIdentity: owner.processIdentity } : {}),
-      ...(owner.processIdentityV2 ? { processIdentityV2: owner.processIdentityV2 } : {}),
-      processStartedAtMs: owner.processStartedAtMs,
-      token: owner.token,
-    };
-  }
-  if (owner.leaseVersion !== 1) {
-    throw new Error("OpenClaw Crabline provider readiness lock owner metadata is malformed.");
-  }
   return {
     channel: owner.channel,
     createdAtMs: owner.createdAtMs,
-    leaseVersion: owner.leaseVersion,
+    lockVersion: owner.lockVersion,
     pid: owner.pid,
     ...(owner.processIdentity ? { processIdentity: owner.processIdentity } : {}),
     ...(owner.processIdentityV2 ? { processIdentityV2: owner.processIdentityV2 } : {}),
@@ -432,18 +394,14 @@ async function readLockRecord(lockDirectory: string): Promise<LockRecordReadResu
   try {
     handle = await fs.open(path.join(lockDirectory, LOCK_OWNER_FILE), "r");
     const record = await readLockRecordFromHandle(handle);
-    if (isRenewableOwner(record.owner)) {
-      try {
-        const leaseStats = await fs.stat(
-          path.join(lockDirectory, leaseFileName(record.owner.token)),
-        );
-        if (Number.isFinite(leaseStats.mtimeMs) && leaseStats.mtimeMs > 0) {
-          record.renewedAtMs = Math.max(record.renewedAtMs, leaseStats.mtimeMs);
-        }
-      } catch (error) {
-        if (!isMissingPathError(error)) {
-          throw error;
-        }
+    try {
+      const leaseStats = await fs.stat(path.join(lockDirectory, leaseFileName(record.owner.token)));
+      if (Number.isFinite(leaseStats.mtimeMs) && leaseStats.mtimeMs > 0) {
+        record.renewedAtMs = Math.max(record.renewedAtMs, leaseStats.mtimeMs);
+      }
+    } catch (error) {
+      if (!isMissingPathError(error)) {
+        throw error;
       }
     }
     return { kind: "record", record };
@@ -455,18 +413,6 @@ async function readLockRecord(lockDirectory: string): Promise<LockRecordReadResu
   } finally {
     await handle?.close();
   }
-}
-
-function hasProcessIdentity(
-  owner: ProviderReadinessLockOwner,
-): owner is ProcessIdentifiedProviderReadinessLockOwner | RenewableProviderReadinessLockOwner {
-  return "processStartedAtMs" in owner;
-}
-
-function isRenewableOwner(
-  owner: ProviderReadinessLockOwner,
-): owner is RenewableProviderReadinessLockOwner {
-  return "leaseVersion" in owner && owner.leaseVersion === 1;
 }
 
 export const isProcessAlive: IsProcessAlive = (pid) => {
@@ -625,35 +571,21 @@ function getCachedCurrentProcessIdentityV2(): string | null {
   return (cachedCurrentProcessIdentityV2 ??= getProcessIdentityV2(process.pid));
 }
 
-function hasExactProcessIdentity(owner: ProviderReadinessLockOwner): owner is (
-  | ProcessIdentifiedProviderReadinessLockOwner
-  | RenewableProviderReadinessLockOwner
-) & {
+function hasExactProcessIdentity(
+  owner: ProviderReadinessLockOwner,
+): owner is ProviderReadinessLockOwner & {
   processIdentity: string;
 } {
-  return hasProcessIdentity(owner) && typeof owner.processIdentity === "string";
+  return typeof owner.processIdentity === "string";
 }
 
-function hasCoarseDarwinProcessIdentity(owner: ProviderReadinessLockOwner): owner is (
-  | ProcessIdentifiedProviderReadinessLockOwner
-  | RenewableProviderReadinessLockOwner
-) & {
-  processIdentity: string;
-} {
-  if (!hasExactProcessIdentity(owner)) {
-    return false;
-  }
-  return /^darwin:\d+\.\d+:(?!us:).+$/u.test(owner.processIdentity);
-}
-
-type ProcessIdentityMatch = "legacy" | "mismatch" | "unknown" | "v2";
+type ProcessIdentityMatch = "match" | "mismatch" | "unknown";
 
 function compareProcessIdentity(
   owner: ProviderReadinessLockOwner,
   runtime: ProviderReadinessLockRuntime,
 ): ProcessIdentityMatch {
   if (
-    hasProcessIdentity(owner) &&
     owner.pid === runtime.currentPid &&
     owner.processStartedAtMs !== runtime.currentProcessStartedAtMs
   ) {
@@ -662,13 +594,13 @@ function compareProcessIdentity(
   if (!hasExactProcessIdentity(owner)) {
     return "unknown";
   }
-  if (hasProcessIdentity(owner) && typeof owner.processIdentityV2 === "string") {
+  if (typeof owner.processIdentityV2 === "string") {
     const actualProcessIdentityV2 =
       owner.pid === runtime.currentPid
         ? runtime.currentProcessIdentityV2
         : runtime.getProcessIdentityV2(owner.pid);
     if (actualProcessIdentityV2 !== null) {
-      return owner.processIdentityV2 === actualProcessIdentityV2 ? "v2" : "mismatch";
+      return owner.processIdentityV2 === actualProcessIdentityV2 ? "match" : "mismatch";
     }
   }
   const actualProcessIdentity =
@@ -678,7 +610,7 @@ function compareProcessIdentity(
   if (actualProcessIdentity === null) {
     return "unknown";
   }
-  return owner.processIdentity === actualProcessIdentity ? "legacy" : "mismatch";
+  return owner.processIdentity === actualProcessIdentity ? "match" : "mismatch";
 }
 
 function hasProcessIdentityMismatch(
@@ -700,17 +632,6 @@ function isLockOwnerActive(
   if (identityMatch === "mismatch") {
     return false;
   }
-  if (!isRenewableOwner(owner)) {
-    if (
-      owner.pid !== runtime.currentPid &&
-      hasCoarseDarwinProcessIdentity(owner) &&
-      identityMatch !== "v2"
-    ) {
-      const ageMs = runtime.now() - Math.max(owner.createdAtMs, record.renewedAtMs);
-      return ageMs >= -runtime.leaseMs && ageMs <= runtime.leaseMs;
-    }
-    return true;
-  }
   const ageMs = runtime.now() - Math.max(owner.createdAtMs, record.renewedAtMs);
   return ageMs >= -runtime.leaseMs && ageMs <= runtime.leaseMs;
 }
@@ -720,7 +641,6 @@ function needsLiveOwnerConfirmation(
   runtime: ProviderReadinessLockRuntime,
 ): boolean {
   return (
-    isRenewableOwner(record.owner) &&
     runtime.isProcessAlive(record.owner.pid) &&
     !hasProcessIdentityMismatch(record.owner, runtime) &&
     !isLockOwnerActive(record, runtime)
@@ -881,27 +801,7 @@ async function removeOwnedLock(params: {
   return true;
 }
 
-async function renewCompatibilityMarker(params: {
-  handle: FileHandle;
-  lockDirectory: string;
-  renewedAtMs: number;
-  securedDirectory: Awaited<ReturnType<typeof securePrivateDirectory>>;
-  token: string;
-}): Promise<boolean> {
-  await params.securedDirectory.assertIdentityAt(params.lockDirectory);
-  const observed = await readLockRecord(params.lockDirectory);
-  if (observed.kind === "missing" || observed.record.owner.token !== params.token) {
-    return false;
-  }
-  const renewedAt = new Date(params.renewedAtMs);
-  await params.handle.utimes(renewedAt, renewedAt);
-  await params.handle.sync();
-  await params.securedDirectory.assertIdentityAt(params.lockDirectory);
-  const revalidated = await readLockRecord(params.lockDirectory);
-  return revalidated.kind === "record" && revalidated.record.owner.token === params.token;
-}
-
-async function assertCompatibilityMarkerOwned(params: {
+async function assertReservationOwned(params: {
   lockDirectory: string;
   securedDirectory: Awaited<ReturnType<typeof securePrivateDirectory>>;
   token: string;
@@ -909,37 +809,8 @@ async function assertCompatibilityMarkerOwned(params: {
   await params.securedDirectory.assertIdentityAt(params.lockDirectory);
   const observed = await readLockRecord(params.lockDirectory);
   if (observed.kind === "missing" || observed.record.owner.token !== params.token) {
-    throw new Error("OpenClaw Crabline provider readiness lock compatibility marker was lost.");
+    throw new Error("OpenClaw Crabline provider readiness lock reservation was lost.");
   }
-}
-
-async function retireCompatibilityMarker(
-  handle: FileHandle,
-  owner: RenewableProviderReadinessLockOwner,
-): Promise<void> {
-  const retiredOwner: RenewableProviderReadinessLockOwner = {
-    ...owner,
-    createdAtMs: 1,
-    pid: MAX_PROCESS_ID,
-    ...(owner.processIdentity ? { processIdentity: "retired" } : {}),
-    ...(owner.processIdentityV2 ? { processIdentityV2: "retired" } : {}),
-    processStartedAtMs: 1,
-  };
-  const originalBytes = Buffer.byteLength(`${JSON.stringify(owner)}\n`, "utf8");
-  const retiredJson = JSON.stringify(retiredOwner);
-  const retiredBytes = Buffer.byteLength(retiredJson, "utf8") + 1;
-  const targetBytes = Math.max(originalBytes, retiredBytes);
-  const paddingBytes = targetBytes - retiredBytes;
-  const retiredContents = `${retiredJson}${" ".repeat(paddingBytes)}\n`;
-  const written = await handle.write(retiredContents, 0, "utf8");
-  if (written.bytesWritten !== targetBytes) {
-    throw new Error(
-      "OpenClaw Crabline provider readiness lock compatibility marker retirement was incomplete.",
-    );
-  }
-  const retiredAt = new Date(1);
-  await handle.utimes(retiredAt, retiredAt);
-  await handle.sync();
 }
 
 async function renewOwnedLock(
@@ -956,7 +827,7 @@ async function renewOwnedLock(
     if (
       observed.kind === "missing" ||
       observed.record.owner.token !== token ||
-      !isRenewableOwner(observed.record.owner)
+      observed.record.owner.lockVersion !== 1
     ) {
       return false;
     }
@@ -972,7 +843,7 @@ async function renewOwnedLock(
     if (
       revalidated.kind === "missing" ||
       revalidated.record.owner.token !== token ||
-      !isRenewableOwner(revalidated.record.owner)
+      revalidated.record.owner.lockVersion !== 1
     ) {
       return false;
     }
@@ -995,7 +866,7 @@ function claimPrefix(lockDirectory: string, suffix: string): string {
 async function listLockClaims(lockDirectory: string): Promise<LockClaim[]> {
   const directory = path.dirname(lockDirectory);
   const prefixes: Array<{ kind: LockClaimKind; prefix: string }> = [
-    { kind: "recovering", prefix: claimPrefix(lockDirectory, LEGACY_RECOVERY_SUFFIX) },
+    { kind: "recovery", prefix: claimPrefix(lockDirectory, RECOVERY_CLAIM_SUFFIX) },
     { kind: "commit", prefix: claimPrefix(lockDirectory, COMMIT_CLAIM_SUFFIX) },
     { kind: "owned", prefix: claimPrefix(lockDirectory, OWNED_CLAIM_SUFFIX) },
     { kind: "release", prefix: claimPrefix(lockDirectory, RELEASE_CLAIM_SUFFIX) },
@@ -1016,32 +887,6 @@ async function listLockClaims(lockDirectory: string): Promise<LockClaim[]> {
     });
   }
   return claims.sort((left, right) => left.directoryPath.localeCompare(right.directoryPath));
-}
-
-async function claimLegacyRecoveryDirectory(
-  lockDirectory: string,
-  expectedToken?: string,
-): Promise<void> {
-  const legacyRecoveryDirectory = `${lockDirectory}${LEGACY_RECOVERY_SUFFIX}`;
-  if (!(await pathExists(legacyRecoveryDirectory))) {
-    return;
-  }
-  if (expectedToken !== undefined) {
-    const observed = await readLockRecord(legacyRecoveryDirectory);
-    if (observed.kind === "missing" || observed.record.owner.token !== expectedToken) {
-      return;
-    }
-  }
-  try {
-    await fs.rename(
-      legacyRecoveryDirectory,
-      `${lockDirectory}${LEGACY_RECOVERY_SUFFIX}.${randomUUID()}`,
-    );
-  } catch (error) {
-    if (!isMissingPathError(error)) {
-      throw error;
-    }
-  }
 }
 
 async function resolveLockClaim(params: {
@@ -1073,7 +918,7 @@ async function resolveLockClaim(params: {
     return;
   }
   if (isLockOwnerActive(observed.record, params.runtime)) {
-    if (params.claim.kind === "recovering") {
+    if (params.claim.kind === "recovery") {
       try {
         await fs.rename(params.claim.directoryPath, params.lockDirectory);
       } catch (error) {
@@ -1094,7 +939,7 @@ async function resolveLockClaim(params: {
     params.runtime,
   );
   if (confirmation === "renewed") {
-    if (params.claim.kind === "recovering") {
+    if (params.claim.kind === "recovery") {
       try {
         await fs.rename(params.claim.directoryPath, params.lockDirectory);
       } catch (error) {
@@ -1146,7 +991,6 @@ async function resolveLockClaims(params: {
   requestedChannel: CrablineServerChannel;
   runtime: ProviderReadinessLockRuntime;
 }): Promise<void> {
-  await claimLegacyRecoveryDirectory(params.lockDirectory);
   for (const claim of await listLockClaims(params.lockDirectory)) {
     await resolveLockClaim({
       ...params,
@@ -1193,7 +1037,7 @@ async function resolveLockContention(params: {
   }
 
   await params.beforeRecoveryClaim();
-  const claimDirectory = `${params.lockDirectory}${LEGACY_RECOVERY_SUFFIX}.${randomUUID()}`;
+  const claimDirectory = `${params.lockDirectory}${RECOVERY_CLAIM_SUFFIX}.${randomUUID()}`;
   try {
     await fs.rename(params.lockDirectory, claimDirectory);
   } catch (error) {
@@ -1208,7 +1052,7 @@ async function resolveLockContention(params: {
     ...params,
     claim: {
       directoryPath: claimDirectory,
-      kind: "recovering",
+      kind: "recovery",
     },
   });
 }
@@ -1218,7 +1062,7 @@ async function createLockCandidate(params: {
   candidateDirectory?: string;
   includeLease?: boolean;
   lockDirectory: string;
-  owner: RenewableProviderReadinessLockOwner;
+  owner: ProviderReadinessLockOwner;
   platform?: NodeJS.Platform;
   secureWindowsDirectory?: SecureWindowsDirectory;
 }): Promise<{
@@ -1279,7 +1123,7 @@ export async function acquireOpenClawCrablineProviderReadinessLock(
   dependencies: {
     afterLockCandidateInstall?: AfterLockDirectoryWrite;
     afterLockOwnerClaimInstall?: AfterLockDirectoryWrite;
-    afterLockOwnerWrite?: AfterLockDirectoryWrite;
+    afterLockReservationWrite?: AfterLockDirectoryWrite;
     getProcessIdentity?: GetProcessIdentity;
     getProcessIdentityV2?: GetProcessIdentity;
     isProcessAlive?: IsProcessAlive;
@@ -1294,7 +1138,7 @@ export async function acquireOpenClawCrablineProviderReadinessLock(
     beforeCommitClaim?: BeforeCommitClaim;
     beforeCommitFileRename?: BeforeCommitFileRename;
     beforeCommitRename?: BeforeCommitRename;
-    beforeCompatibilityMarkerRenew?: BeforeCompatibilityMarkerRenew;
+    beforeReservationRenew?: BeforeReservationRenew;
     beforeRecoveryDeleteClaim?: BeforeRecoveryDeleteClaim;
     beforeRecoveryClaim?: BeforeRecoveryClaim;
     beforeReleaseClaim?: BeforeReleaseClaim;
@@ -1363,10 +1207,10 @@ export async function acquireOpenClawCrablineProviderReadinessLock(
   ) {
     throw new Error("Invalid OpenClaw Crabline provider readiness lock runtime.");
   }
-  const owner: RenewableProviderReadinessLockOwner = {
+  const owner: ProviderReadinessLockOwner = {
     channel: params.channel,
     createdAtMs,
-    leaseVersion: 1,
+    lockVersion: 1,
     pid: runtime.currentPid,
     ...(runtime.currentProcessIdentity ? { processIdentity: runtime.currentProcessIdentity } : {}),
     ...(runtime.currentProcessIdentityV2
@@ -1375,14 +1219,9 @@ export async function acquireOpenClawCrablineProviderReadinessLock(
     processStartedAtMs: runtime.currentProcessStartedAtMs,
     token,
   };
-  const compatibilityOwner: RenewableProviderReadinessLockOwner = {
-    ...owner,
-    createdAtMs: 1,
-  };
-
   for (;;) {
     const lockClaims = await listLockClaims(lockDirectory);
-    if (lockClaims.length > 0 || (await pathExists(`${lockDirectory}${LEGACY_RECOVERY_SUFFIX}`))) {
+    if (lockClaims.length > 0) {
       await resolveLockClaims({
         beforeRecoveryDeleteClaim:
           dependencies.beforeRecoveryDeleteClaim ?? (async () => undefined),
@@ -1396,12 +1235,11 @@ export async function acquireOpenClawCrablineProviderReadinessLock(
 
     const ownerDirectory = `${lockDirectory}${OWNED_CLAIM_SUFFIX}.${token}`;
     const { candidateDirectory, securedDirectory } = await createLockCandidate({
-      ...(dependencies.afterLockOwnerWrite
-        ? { afterOwnerWrite: dependencies.afterLockOwnerWrite }
+      ...(dependencies.afterLockReservationWrite
+        ? { afterOwnerWrite: dependencies.afterLockReservationWrite }
         : {}),
-      includeLease: false,
       lockDirectory,
-      owner: compatibilityOwner,
+      owner,
       ...(dependencies.platform ? { platform: dependencies.platform } : {}),
       ...(dependencies.secureWindowsDirectory
         ? { secureWindowsDirectory: dependencies.secureWindowsDirectory }
@@ -1422,39 +1260,9 @@ export async function acquireOpenClawCrablineProviderReadinessLock(
       await fs.rm(candidateDirectory, { force: true, recursive: true }).catch(() => undefined);
       throw error;
     }
-    let compatibilityMarkerHandle: FileHandle | undefined;
-    try {
-      compatibilityMarkerHandle = await fs.open(
-        path.join(candidateDirectory, LOCK_OWNER_FILE),
-        "r+",
-      );
-      const compatibilityRecord = await readLockRecordFromHandle(compatibilityMarkerHandle);
-      if (compatibilityRecord.owner.token !== token) {
-        throw new Error(
-          "OpenClaw Crabline provider readiness lock compatibility marker was replaced.",
-        );
-      }
-      const activeAt = new Date(createdAtMs);
-      await compatibilityMarkerHandle.utimes(activeAt, activeAt);
-      await compatibilityMarkerHandle.sync();
-    } catch (error) {
-      await compatibilityMarkerHandle?.close().catch(() => undefined);
-      await fs.rm(candidateDirectory, { force: true, recursive: true }).catch(() => undefined);
-      await fs
-        .rm(ownerCandidate.candidateDirectory, { force: true, recursive: true })
-        .catch(() => undefined);
-      throw error;
-    }
-    if (!compatibilityMarkerHandle) {
-      throw new Error(
-        "OpenClaw Crabline provider readiness lock compatibility marker was not opened.",
-      );
-    }
-    const markerHandle = compatibilityMarkerHandle;
     try {
       await fs.rename(candidateDirectory, lockDirectory);
     } catch (error) {
-      await markerHandle.close().catch(() => undefined);
       await fs.rm(candidateDirectory, { force: true, recursive: true }).catch(() => undefined);
       await fs
         .rm(ownerCandidate.candidateDirectory, { force: true, recursive: true })
@@ -1477,8 +1285,6 @@ export async function acquireOpenClawCrablineProviderReadinessLock(
       await securedDirectory.assertIdentityAt(lockDirectory);
       const installed = await readLockRecord(lockDirectory);
       if (installed.kind !== "record" || installed.record.owner.token !== token) {
-        await retireCompatibilityMarker(markerHandle, compatibilityOwner);
-        await markerHandle.close();
         await fs.rm(ownerCandidate.candidateDirectory, { force: true, recursive: true });
         continue;
       }
@@ -1498,20 +1304,13 @@ export async function acquireOpenClawCrablineProviderReadinessLock(
         } else {
           await fs.rm(ownerCandidate.candidateDirectory, { force: true, recursive: true });
         }
-        await retireCompatibilityMarker(markerHandle, compatibilityOwner);
+        await removeOwnedLock({
+          lockDirectory,
+          ownedDirectory: lockDirectory,
+          token,
+        });
       } catch (caughtCleanupError) {
         cleanupError = caughtCleanupError;
-      }
-      try {
-        await markerHandle.close();
-      } catch (closeError) {
-        cleanupError =
-          cleanupError === undefined
-            ? closeError
-            : new AggregateError(
-                [cleanupError, closeError],
-                "OpenClaw Crabline provider readiness lock setup cleanup also failed.",
-              );
       }
       if (cleanupError !== undefined) {
         const aggregateError = new AggregateError(
@@ -1527,23 +1326,23 @@ export async function acquireOpenClawCrablineProviderReadinessLock(
     const competingClaims = (await listLockClaims(lockDirectory)).filter(
       (claim) => claim.directoryPath !== ownerDirectory,
     );
-    if (
-      competingClaims.length > 0 ||
-      (await pathExists(`${lockDirectory}${LEGACY_RECOVERY_SUFFIX}`))
-    ) {
+    if (competingClaims.length > 0) {
       const removed = await removeOwnedLock({
         lockDirectory,
         ownedDirectory: ownerDirectory,
         token,
       });
       if (!removed) {
-        await markerHandle.close();
         throw new Error("OpenClaw Crabline provider readiness lock ownership was lost.");
       }
-      try {
-        await retireCompatibilityMarker(markerHandle, compatibilityOwner);
-      } finally {
-        await markerHandle.close();
+      if (
+        !(await removeOwnedLock({
+          lockDirectory,
+          ownedDirectory: lockDirectory,
+          token,
+        }))
+      ) {
+        throw new Error("OpenClaw Crabline provider readiness lock reservation was lost.");
       }
       await resolveLockClaims({
         beforeRecoveryDeleteClaim:
@@ -1562,19 +1361,7 @@ export async function acquireOpenClawCrablineProviderReadinessLock(
     let lastRenewedAtMs = createdAtMs;
     let pendingRenewal = Promise.resolve();
     let commitFenceConsumed = false;
-    let markerClosed = false;
-    let markerRetired = false;
     let heartbeat: HeartbeatController;
-    const retireMarker = async () => {
-      if (!markerRetired) {
-        await retireCompatibilityMarker(markerHandle, compatibilityOwner);
-        markerRetired = true;
-      }
-      if (!markerClosed) {
-        await markerHandle.close();
-        markerClosed = true;
-      }
-    };
     const renew = async () => {
       const renewal = pendingRenewal
         .catch(() => undefined)
@@ -1595,19 +1382,9 @@ export async function acquireOpenClawCrablineProviderReadinessLock(
           if (!(await renewOwnedLock(ownedDirectory, token, renewedAtMs))) {
             throw new Error("OpenClaw Crabline provider readiness lock ownership was lost.");
           }
-          await dependencies.beforeCompatibilityMarkerRenew?.();
-          if (
-            !(await renewCompatibilityMarker({
-              handle: markerHandle,
-              lockDirectory,
-              renewedAtMs,
-              securedDirectory,
-              token,
-            }))
-          ) {
-            throw new Error(
-              "OpenClaw Crabline provider readiness lock compatibility marker was lost.",
-            );
+          await dependencies.beforeReservationRenew?.();
+          if (!(await renewOwnedLock(lockDirectory, token, renewedAtMs))) {
+            throw new Error("OpenClaw Crabline provider readiness lock reservation was lost.");
           }
           lastRenewedAtMs = renewedAtMs;
         });
@@ -1626,7 +1403,11 @@ export async function acquireOpenClawCrablineProviderReadinessLock(
           ownedDirectory: ownerDirectory,
           token,
         });
-        await retireMarker();
+        await removeOwnedLock({
+          lockDirectory,
+          ownedDirectory: lockDirectory,
+          token,
+        });
       } catch (cleanupError) {
         const aggregateError = new AggregateError(
           [error, cleanupError],
@@ -1647,7 +1428,7 @@ export async function acquireOpenClawCrablineProviderReadinessLock(
         heartbeat.assertHealthy();
         await renew();
         heartbeat.assertHealthy();
-        await assertCompatibilityMarkerOwned({
+        await assertReservationOwned({
           lockDirectory,
           securedDirectory,
           token,
@@ -1749,7 +1530,7 @@ export async function acquireOpenClawCrablineProviderReadinessLock(
         heartbeat.assertHealthy();
 
         await dependencies.beforeCommitClaim?.();
-        await assertCompatibilityMarkerOwned({
+        await assertReservationOwned({
           lockDirectory,
           securedDirectory,
           token,
@@ -1805,7 +1586,7 @@ export async function acquireOpenClawCrablineProviderReadinessLock(
         await heartbeat.settle();
         heartbeat.assertHealthy();
         await dependencies.beforeCommitRename?.();
-        await assertCompatibilityMarkerOwned({
+        await assertReservationOwned({
           lockDirectory,
           securedDirectory,
           token,
@@ -1908,7 +1689,6 @@ export async function acquireOpenClawCrablineProviderReadinessLock(
             : {}),
           token,
         });
-        await claimLegacyRecoveryDirectory(lockDirectory, token);
         for (const claim of await listLockClaims(lockDirectory)) {
           await removeOwnedLock({
             lockDirectory,
@@ -1919,7 +1699,14 @@ export async function acquireOpenClawCrablineProviderReadinessLock(
             token,
           });
         }
-        await retireMarker();
+        await removeOwnedLock({
+          lockDirectory,
+          ownedDirectory: lockDirectory,
+          ...(dependencies.removeDirectory
+            ? { removeDirectory: dependencies.removeDirectory }
+            : {}),
+          token,
+        });
         released = true;
       },
     };

--- a/src/openclaw/provider-readiness-lock.ts
+++ b/src/openclaw/provider-readiness-lock.ts
@@ -8,34 +8,34 @@ import { isCrablineServerChannel, type CrablineServerChannel } from "../servers/
 import { resolveWindowsPowerShellPath, securePrivateDirectory } from "./private-file.js";
 import { OPENCLAW_CRABLINE_MANIFEST_PATH } from "./shared.js";
 
-type LegacySmokeLockOwner = {
+type LegacyProviderReadinessLockOwner = {
   channel: CrablineServerChannel;
   pid: number;
   token: string;
 };
 
-type ProcessIdentifiedSmokeLockOwner = LegacySmokeLockOwner & {
+type ProcessIdentifiedProviderReadinessLockOwner = LegacyProviderReadinessLockOwner & {
   createdAtMs: number;
   processIdentity?: string;
   processIdentityV2?: string;
   processStartedAtMs: number;
 };
 
-type RenewableSmokeLockOwner = ProcessIdentifiedSmokeLockOwner & {
+type RenewableProviderReadinessLockOwner = ProcessIdentifiedProviderReadinessLockOwner & {
   leaseVersion: 1;
 };
 
-type SmokeLockOwner =
-  | LegacySmokeLockOwner
-  | ProcessIdentifiedSmokeLockOwner
-  | RenewableSmokeLockOwner;
+type ProviderReadinessLockOwner =
+  | LegacyProviderReadinessLockOwner
+  | ProcessIdentifiedProviderReadinessLockOwner
+  | RenewableProviderReadinessLockOwner;
 
-type SmokeLockRecord = {
-  owner: SmokeLockOwner;
+type ProviderReadinessLockRecord = {
+  owner: ProviderReadinessLockOwner;
   renewedAtMs: number;
 };
 
-export type OpenClawCrablineSmokeRunLock = {
+export type OpenClawCrablineProviderReadinessLock = {
   assertOwned(): Promise<void>;
   commitFileAtomically(params: {
     contents: string;
@@ -79,7 +79,7 @@ type DirectoryIdentity = {
 };
 type FileIdentity = DirectoryIdentity;
 
-type SmokeLockRuntime = {
+type ProviderReadinessLockRuntime = {
   currentProcessIdentity: string | null;
   currentProcessIdentityV2: string | null;
   currentPid: number;
@@ -149,7 +149,9 @@ const startHeartbeat: StartHeartbeat = (renew, intervalMs) => {
   return {
     assertHealthy() {
       if (failure !== undefined) {
-        throw new Error("OpenClaw Crabline smoke lock heartbeat failed.", { cause: failure });
+        throw new Error("OpenClaw Crabline provider readiness lock heartbeat failed.", {
+          cause: failure,
+        });
       }
     },
     async settle() {
@@ -182,7 +184,7 @@ async function readDirectoryIdentity(directoryPath: string): Promise<DirectoryId
   try {
     const stats = await fs.lstat(directoryPath, { bigint: true });
     if (!stats.isDirectory() || stats.ino <= 0n) {
-      throw new Error("OpenClaw Crabline smoke lock claim is not a directory.");
+      throw new Error("OpenClaw Crabline provider readiness lock claim is not a directory.");
     }
     return {
       device: stats.dev,
@@ -248,7 +250,7 @@ async function removeVerifiedLockDirectory(params: {
       await readDirectoryIdentity(params.directoryPath),
     )
   ) {
-    throw new Error("OpenClaw Crabline smoke lock cleanup target changed.");
+    throw new Error("OpenClaw Crabline provider readiness lock cleanup target changed.");
   }
   await params.beforeRemove?.();
   const quarantinePath = `${params.directoryPath}.cleanup.${randomUUID()}`;
@@ -259,14 +261,16 @@ async function removeVerifiedLockDirectory(params: {
     quarantinedIdentity = { device: stats.dev, inode: stats.ino };
   }
   if (!hasSameDirectoryIdentity(params.expectedIdentity, quarantinedIdentity)) {
-    throw new Error("OpenClaw Crabline smoke lock cleanup target changed.");
+    throw new Error("OpenClaw Crabline provider readiness lock cleanup target changed.");
   }
 
   const entries = fsSync.readdirSync(quarantinePath);
   const artifacts: Array<{ identity: FileIdentity; path: string }> = [];
   for (const entry of entries) {
     if (!isOwnedLockArtifactName(entry, params.token)) {
-      throw new Error("OpenClaw Crabline smoke lock cleanup found an unexpected artifact.");
+      throw new Error(
+        "OpenClaw Crabline provider readiness lock cleanup found an unexpected artifact.",
+      );
     }
     const artifactPath = path.join(quarantinePath, entry);
     const artifactStats = fsSync.lstatSync(artifactPath, { bigint: true });
@@ -276,7 +280,9 @@ async function removeVerifiedLockDirectory(params: {
       artifactStats.nlink !== 1n ||
       artifactStats.ino <= 0n
     ) {
-      throw new Error("OpenClaw Crabline smoke lock cleanup found an unsafe artifact.");
+      throw new Error(
+        "OpenClaw Crabline provider readiness lock cleanup found an unsafe artifact.",
+      );
     }
     artifacts.push({
       identity: { device: artifactStats.dev, inode: artifactStats.ino },
@@ -302,7 +308,7 @@ async function removeVerifiedLockDirectory(params: {
       artifactStats.dev !== artifact.identity.device ||
       artifactStats.ino !== artifact.identity.inode
     ) {
-      throw new Error("OpenClaw Crabline smoke lock cleanup artifact changed.");
+      throw new Error("OpenClaw Crabline provider readiness lock cleanup artifact changed.");
     }
     fsSync.unlinkSync(artifact.path);
   }
@@ -313,7 +319,7 @@ async function removeVerifiedLockDirectory(params: {
     finalStats.dev !== params.expectedIdentity.device ||
     finalStats.ino !== params.expectedIdentity.inode
   ) {
-    throw new Error("OpenClaw Crabline smoke lock cleanup target changed.");
+    throw new Error("OpenClaw Crabline provider readiness lock cleanup target changed.");
   }
   fsSync.rmdirSync(quarantinePath);
 }
@@ -328,19 +334,19 @@ function isValidProcessId(value: unknown): value is number {
 
 const LOCK_TOKEN_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u;
 
-function parseLockOwner(contents: string): SmokeLockOwner {
+function parseLockOwner(contents: string): ProviderReadinessLockOwner {
   let parsed: unknown;
   try {
     parsed = JSON.parse(contents);
   } catch (error) {
-    throw new Error("OpenClaw Crabline smoke lock owner metadata is malformed.", {
+    throw new Error("OpenClaw Crabline provider readiness lock owner metadata is malformed.", {
       cause: error,
     });
   }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new Error("OpenClaw Crabline smoke lock owner metadata is malformed.");
+    throw new Error("OpenClaw Crabline provider readiness lock owner metadata is malformed.");
   }
-  const owner = parsed as Partial<RenewableSmokeLockOwner>;
+  const owner = parsed as Partial<RenewableProviderReadinessLockOwner>;
   if (
     typeof owner.channel !== "string" ||
     !isCrablineServerChannel(owner.channel) ||
@@ -348,7 +354,7 @@ function parseLockOwner(contents: string): SmokeLockOwner {
     typeof owner.token !== "string" ||
     !LOCK_TOKEN_PATTERN.test(owner.token)
   ) {
-    throw new Error("OpenClaw Crabline smoke lock owner metadata is malformed.");
+    throw new Error("OpenClaw Crabline provider readiness lock owner metadata is malformed.");
   }
 
   const hasCreatedAt = owner.createdAtMs !== undefined;
@@ -372,7 +378,7 @@ function parseLockOwner(contents: string): SmokeLockOwner {
         owner.processIdentityV2.length === 0 ||
         owner.processIdentityV2.length > 256))
   ) {
-    throw new Error("OpenClaw Crabline smoke lock owner metadata is malformed.");
+    throw new Error("OpenClaw Crabline provider readiness lock owner metadata is malformed.");
   }
   if (owner.leaseVersion === undefined) {
     return {
@@ -386,7 +392,7 @@ function parseLockOwner(contents: string): SmokeLockOwner {
     };
   }
   if (owner.leaseVersion !== 1) {
-    throw new Error("OpenClaw Crabline smoke lock owner metadata is malformed.");
+    throw new Error("OpenClaw Crabline provider readiness lock owner metadata is malformed.");
   }
   return {
     channel: owner.channel,
@@ -404,7 +410,7 @@ function leaseFileName(token: string): string {
   return `${LOCK_LEASE_FILE_PREFIX}${token}.json`;
 }
 
-async function readLockRecordFromHandle(handle: FileHandle): Promise<SmokeLockRecord> {
+async function readLockRecordFromHandle(handle: FileHandle): Promise<ProviderReadinessLockRecord> {
   const owner = parseLockOwner(await handle.readFile("utf8"));
   const stats = await handle.stat();
   return {
@@ -413,7 +419,9 @@ async function readLockRecordFromHandle(handle: FileHandle): Promise<SmokeLockRe
   };
 }
 
-type LockRecordReadResult = { kind: "missing" } | { kind: "record"; record: SmokeLockRecord };
+type LockRecordReadResult =
+  | { kind: "missing" }
+  | { kind: "record"; record: ProviderReadinessLockRecord };
 
 function isMissingPathError(error: unknown): boolean {
   return (error as NodeJS.ErrnoException).code === "ENOENT";
@@ -450,12 +458,14 @@ async function readLockRecord(lockDirectory: string): Promise<LockRecordReadResu
 }
 
 function hasProcessIdentity(
-  owner: SmokeLockOwner,
-): owner is ProcessIdentifiedSmokeLockOwner | RenewableSmokeLockOwner {
+  owner: ProviderReadinessLockOwner,
+): owner is ProcessIdentifiedProviderReadinessLockOwner | RenewableProviderReadinessLockOwner {
   return "processStartedAtMs" in owner;
 }
 
-function isRenewableOwner(owner: SmokeLockOwner): owner is RenewableSmokeLockOwner {
+function isRenewableOwner(
+  owner: ProviderReadinessLockOwner,
+): owner is RenewableProviderReadinessLockOwner {
   return "leaseVersion" in owner && owner.leaseVersion === 1;
 }
 
@@ -615,18 +625,18 @@ function getCachedCurrentProcessIdentityV2(): string | null {
   return (cachedCurrentProcessIdentityV2 ??= getProcessIdentityV2(process.pid));
 }
 
-function hasExactProcessIdentity(owner: SmokeLockOwner): owner is (
-  | ProcessIdentifiedSmokeLockOwner
-  | RenewableSmokeLockOwner
+function hasExactProcessIdentity(owner: ProviderReadinessLockOwner): owner is (
+  | ProcessIdentifiedProviderReadinessLockOwner
+  | RenewableProviderReadinessLockOwner
 ) & {
   processIdentity: string;
 } {
   return hasProcessIdentity(owner) && typeof owner.processIdentity === "string";
 }
 
-function hasCoarseDarwinProcessIdentity(owner: SmokeLockOwner): owner is (
-  | ProcessIdentifiedSmokeLockOwner
-  | RenewableSmokeLockOwner
+function hasCoarseDarwinProcessIdentity(owner: ProviderReadinessLockOwner): owner is (
+  | ProcessIdentifiedProviderReadinessLockOwner
+  | RenewableProviderReadinessLockOwner
 ) & {
   processIdentity: string;
 } {
@@ -639,8 +649,8 @@ function hasCoarseDarwinProcessIdentity(owner: SmokeLockOwner): owner is (
 type ProcessIdentityMatch = "legacy" | "mismatch" | "unknown" | "v2";
 
 function compareProcessIdentity(
-  owner: SmokeLockOwner,
-  runtime: SmokeLockRuntime,
+  owner: ProviderReadinessLockOwner,
+  runtime: ProviderReadinessLockRuntime,
 ): ProcessIdentityMatch {
   if (
     hasProcessIdentity(owner) &&
@@ -671,11 +681,17 @@ function compareProcessIdentity(
   return owner.processIdentity === actualProcessIdentity ? "legacy" : "mismatch";
 }
 
-function hasProcessIdentityMismatch(owner: SmokeLockOwner, runtime: SmokeLockRuntime): boolean {
+function hasProcessIdentityMismatch(
+  owner: ProviderReadinessLockOwner,
+  runtime: ProviderReadinessLockRuntime,
+): boolean {
   return compareProcessIdentity(owner, runtime) === "mismatch";
 }
 
-function isLockOwnerActive(record: SmokeLockRecord, runtime: SmokeLockRuntime): boolean {
+function isLockOwnerActive(
+  record: ProviderReadinessLockRecord,
+  runtime: ProviderReadinessLockRuntime,
+): boolean {
   const { owner } = record;
   if (!runtime.isProcessAlive(owner.pid)) {
     return false;
@@ -699,7 +715,10 @@ function isLockOwnerActive(record: SmokeLockRecord, runtime: SmokeLockRuntime): 
   return ageMs >= -runtime.leaseMs && ageMs <= runtime.leaseMs;
 }
 
-function needsLiveOwnerConfirmation(record: SmokeLockRecord, runtime: SmokeLockRuntime): boolean {
+function needsLiveOwnerConfirmation(
+  record: ProviderReadinessLockRecord,
+  runtime: ProviderReadinessLockRuntime,
+): boolean {
   return (
     isRenewableOwner(record.owner) &&
     runtime.isProcessAlive(record.owner.pid) &&
@@ -716,8 +735,8 @@ function heartbeatIntervalMs(leaseMs: number): number {
 
 async function confirmObservedOwner(
   lockDirectory: string,
-  observed: SmokeLockRecord,
-  runtime: SmokeLockRuntime,
+  observed: ProviderReadinessLockRecord,
+  runtime: ProviderReadinessLockRuntime,
 ): Promise<OwnerConfirmation> {
   if (!needsLiveOwnerConfirmation(observed, runtime)) {
     return "unchanged";
@@ -743,7 +762,7 @@ function activeRunError(params: {
   requestedChannel: CrablineServerChannel;
 }): Error {
   return new Error(
-    `OpenClaw Crabline smoke is already running for channel "${params.channel ?? "unknown"}" in "${params.outputDir}"; cannot start channel "${params.requestedChannel}".`,
+    `OpenClaw Crabline provider readiness is already running for channel "${params.channel ?? "unknown"}" in "${params.outputDir}"; cannot start channel "${params.requestedChannel}".`,
     params.cause === undefined ? undefined : { cause: params.cause },
   );
 }
@@ -764,17 +783,21 @@ async function resolveConfinedPath(
 ): Promise<string> {
   const resolvedPath = path.resolve(candidatePath);
   if (resolvedPath !== candidatePath) {
-    throw new Error(`OpenClaw Crabline smoke lock ${description} escapes its output directory.`);
+    throw new Error(
+      `OpenClaw Crabline provider readiness lock ${description} escapes its output directory.`,
+    );
   }
   const parentPath = candidateKind === "directory" ? resolvedPath : path.dirname(resolvedPath);
   let realParentPath: string;
   try {
     realParentPath = await fs.realpath(parentPath);
   } catch {
-    throw new Error(`OpenClaw Crabline smoke lock ${description} is invalid.`);
+    throw new Error(`OpenClaw Crabline provider readiness lock ${description} is invalid.`);
   }
   if (!isPathConfinedTo(rootPath, realParentPath)) {
-    throw new Error(`OpenClaw Crabline smoke lock ${description} escapes its output directory.`);
+    throw new Error(
+      `OpenClaw Crabline provider readiness lock ${description} escapes its output directory.`,
+    );
   }
   return candidateKind === "directory"
     ? realParentPath
@@ -789,7 +812,7 @@ async function removeOwnedLock(params: {
   onOwnedDirectoryChange?: (directoryPath: string) => void;
   ownedDirectory: string;
   removeDirectory?: RemoveLockDirectory;
-  runtime?: SmokeLockRuntime;
+  runtime?: ProviderReadinessLockRuntime;
   token: string;
 }): Promise<boolean> {
   await params.beforeClaim?.();
@@ -886,15 +909,15 @@ async function assertCompatibilityMarkerOwned(params: {
   await params.securedDirectory.assertIdentityAt(params.lockDirectory);
   const observed = await readLockRecord(params.lockDirectory);
   if (observed.kind === "missing" || observed.record.owner.token !== params.token) {
-    throw new Error("OpenClaw Crabline smoke lock compatibility marker was lost.");
+    throw new Error("OpenClaw Crabline provider readiness lock compatibility marker was lost.");
   }
 }
 
 async function retireCompatibilityMarker(
   handle: FileHandle,
-  owner: RenewableSmokeLockOwner,
+  owner: RenewableProviderReadinessLockOwner,
 ): Promise<void> {
-  const retiredOwner: RenewableSmokeLockOwner = {
+  const retiredOwner: RenewableProviderReadinessLockOwner = {
     ...owner,
     createdAtMs: 1,
     pid: MAX_PROCESS_ID,
@@ -910,7 +933,9 @@ async function retireCompatibilityMarker(
   const retiredContents = `${retiredJson}${" ".repeat(paddingBytes)}\n`;
   const written = await handle.write(retiredContents, 0, "utf8");
   if (written.bytesWritten !== targetBytes) {
-    throw new Error("OpenClaw Crabline smoke lock compatibility marker retirement was incomplete.");
+    throw new Error(
+      "OpenClaw Crabline provider readiness lock compatibility marker retirement was incomplete.",
+    );
   }
   const retiredAt = new Date(1);
   await handle.utimes(retiredAt, retiredAt);
@@ -983,7 +1008,7 @@ async function listLockClaims(lockDirectory: string): Promise<LockClaim[]> {
       continue;
     }
     if (!entry.isDirectory()) {
-      throw new Error("OpenClaw Crabline smoke lock claim is not a directory.");
+      throw new Error("OpenClaw Crabline provider readiness lock claim is not a directory.");
     }
     claims.push({
       directoryPath: path.join(directory, entry.name),
@@ -1025,7 +1050,7 @@ async function resolveLockClaim(params: {
   lockDirectory: string;
   outputDir: string;
   requestedChannel: CrablineServerChannel;
-  runtime: SmokeLockRuntime;
+  runtime: ProviderReadinessLockRuntime;
 }): Promise<void> {
   const observed = await readLockRecord(params.claim.directoryPath);
   if (observed.kind === "missing") {
@@ -1119,7 +1144,7 @@ async function resolveLockClaims(params: {
   lockDirectory: string;
   outputDir: string;
   requestedChannel: CrablineServerChannel;
-  runtime: SmokeLockRuntime;
+  runtime: ProviderReadinessLockRuntime;
 }): Promise<void> {
   await claimLegacyRecoveryDirectory(params.lockDirectory);
   for (const claim of await listLockClaims(params.lockDirectory)) {
@@ -1136,7 +1161,7 @@ async function resolveLockContention(params: {
   lockDirectory: string;
   outputDir: string;
   requestedChannel: CrablineServerChannel;
-  runtime: SmokeLockRuntime;
+  runtime: ProviderReadinessLockRuntime;
   beforeRecoveryClaim: BeforeRecoveryClaim;
 }): Promise<void> {
   const observed = await readLockRecord(params.lockDirectory);
@@ -1193,7 +1218,7 @@ async function createLockCandidate(params: {
   candidateDirectory?: string;
   includeLease?: boolean;
   lockDirectory: string;
-  owner: RenewableSmokeLockOwner;
+  owner: RenewableProviderReadinessLockOwner;
   platform?: NodeJS.Platform;
   secureWindowsDirectory?: SecureWindowsDirectory;
 }): Promise<{
@@ -1246,7 +1271,7 @@ async function createLockCandidate(params: {
   }
 }
 
-export async function acquireOpenClawCrablineSmokeRunLock(
+export async function acquireOpenClawCrablineProviderReadinessLock(
   params: {
     channel: CrablineServerChannel;
     outputDir: string;
@@ -1279,7 +1304,7 @@ export async function acquireOpenClawCrablineSmokeRunLock(
     sleep?: Sleep;
     startHeartbeat?: StartHeartbeat;
   } = {},
-): Promise<OpenClawCrablineSmokeRunLock> {
+): Promise<OpenClawCrablineProviderReadinessLock> {
   const requestedOutputDir = path.resolve(params.outputDir);
   await fs.mkdir(requestedOutputDir, { recursive: true });
   const outputDir = await fs.realpath(requestedOutputDir);
@@ -1293,7 +1318,7 @@ export async function acquireOpenClawCrablineSmokeRunLock(
   await securedOutputDirectory.assertIdentityAt(outputDir);
   const outputDirectoryIdentity = await readDirectoryIdentity(outputDir);
   if (outputDirectoryIdentity === null) {
-    throw new Error("OpenClaw Crabline smoke lock output directory is invalid.");
+    throw new Error("OpenClaw Crabline provider readiness lock output directory is invalid.");
   }
   const lockDirectory = path.join(outputDir, `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`);
   const token = randomUUID();
@@ -1305,7 +1330,7 @@ export async function acquireOpenClawCrablineSmokeRunLock(
     dependencies.getProcessIdentityV2 ??
     ((pid) =>
       pid === process.pid ? getCachedCurrentProcessIdentityV2() : getProcessIdentityV2(pid));
-  const runtime: SmokeLockRuntime = {
+  const runtime: ProviderReadinessLockRuntime = {
     currentPid,
     currentProcessIdentity:
       dependencies.processIdentity === undefined
@@ -1336,9 +1361,9 @@ export async function acquireOpenClawCrablineSmokeRunLock(
     !isPositiveSafeInteger(runtime.leaseMs) ||
     !isPositiveSafeInteger(createdAtMs)
   ) {
-    throw new Error("Invalid OpenClaw Crabline smoke lock runtime.");
+    throw new Error("Invalid OpenClaw Crabline provider readiness lock runtime.");
   }
-  const owner: RenewableSmokeLockOwner = {
+  const owner: RenewableProviderReadinessLockOwner = {
     channel: params.channel,
     createdAtMs,
     leaseVersion: 1,
@@ -1350,7 +1375,7 @@ export async function acquireOpenClawCrablineSmokeRunLock(
     processStartedAtMs: runtime.currentProcessStartedAtMs,
     token,
   };
-  const compatibilityOwner: RenewableSmokeLockOwner = {
+  const compatibilityOwner: RenewableProviderReadinessLockOwner = {
     ...owner,
     createdAtMs: 1,
   };
@@ -1405,7 +1430,9 @@ export async function acquireOpenClawCrablineSmokeRunLock(
       );
       const compatibilityRecord = await readLockRecordFromHandle(compatibilityMarkerHandle);
       if (compatibilityRecord.owner.token !== token) {
-        throw new Error("OpenClaw Crabline smoke lock compatibility marker was replaced.");
+        throw new Error(
+          "OpenClaw Crabline provider readiness lock compatibility marker was replaced.",
+        );
       }
       const activeAt = new Date(createdAtMs);
       await compatibilityMarkerHandle.utimes(activeAt, activeAt);
@@ -1419,7 +1446,9 @@ export async function acquireOpenClawCrablineSmokeRunLock(
       throw error;
     }
     if (!compatibilityMarkerHandle) {
-      throw new Error("OpenClaw Crabline smoke lock compatibility marker was not opened.");
+      throw new Error(
+        "OpenClaw Crabline provider readiness lock compatibility marker was not opened.",
+      );
     }
     const markerHandle = compatibilityMarkerHandle;
     try {
@@ -1481,13 +1510,13 @@ export async function acquireOpenClawCrablineSmokeRunLock(
             ? closeError
             : new AggregateError(
                 [cleanupError, closeError],
-                "OpenClaw Crabline smoke lock setup cleanup also failed.",
+                "OpenClaw Crabline provider readiness lock setup cleanup also failed.",
               );
       }
       if (cleanupError !== undefined) {
         const aggregateError = new AggregateError(
           [error, cleanupError],
-          "OpenClaw Crabline smoke lock setup and cleanup failed.",
+          "OpenClaw Crabline provider readiness lock setup and cleanup failed.",
         );
         aggregateError.cause = error;
         throw aggregateError;
@@ -1509,7 +1538,7 @@ export async function acquireOpenClawCrablineSmokeRunLock(
       });
       if (!removed) {
         await markerHandle.close();
-        throw new Error("OpenClaw Crabline smoke lock ownership was lost.");
+        throw new Error("OpenClaw Crabline provider readiness lock ownership was lost.");
       }
       try {
         await retireCompatibilityMarker(markerHandle, compatibilityOwner);
@@ -1559,10 +1588,12 @@ export async function acquireOpenClawCrablineSmokeRunLock(
           lastObservedNowMs = nowMs;
           const renewedAtMs = clockRegressed ? lastRenewedAtMs + 1 : nowMs;
           if (!Number.isSafeInteger(renewedAtMs)) {
-            throw new Error("OpenClaw Crabline smoke lock renewal timestamp overflowed.");
+            throw new Error(
+              "OpenClaw Crabline provider readiness lock renewal timestamp overflowed.",
+            );
           }
           if (!(await renewOwnedLock(ownedDirectory, token, renewedAtMs))) {
-            throw new Error("OpenClaw Crabline smoke lock ownership was lost.");
+            throw new Error("OpenClaw Crabline provider readiness lock ownership was lost.");
           }
           await dependencies.beforeCompatibilityMarkerRenew?.();
           if (
@@ -1574,7 +1605,9 @@ export async function acquireOpenClawCrablineSmokeRunLock(
               token,
             }))
           ) {
-            throw new Error("OpenClaw Crabline smoke lock compatibility marker was lost.");
+            throw new Error(
+              "OpenClaw Crabline provider readiness lock compatibility marker was lost.",
+            );
           }
           lastRenewedAtMs = renewedAtMs;
         });
@@ -1597,7 +1630,7 @@ export async function acquireOpenClawCrablineSmokeRunLock(
       } catch (cleanupError) {
         const aggregateError = new AggregateError(
           [error, cleanupError],
-          "OpenClaw Crabline smoke lock heartbeat startup and cleanup failed.",
+          "OpenClaw Crabline provider readiness lock heartbeat startup and cleanup failed.",
         );
         aggregateError.cause = error;
         throw aggregateError;
@@ -1609,7 +1642,7 @@ export async function acquireOpenClawCrablineSmokeRunLock(
     return {
       async assertOwned() {
         if (released || heartbeatStopped) {
-          throw new Error("OpenClaw Crabline smoke lock has already been released.");
+          throw new Error("OpenClaw Crabline provider readiness lock has already been released.");
         }
         heartbeat.assertHealthy();
         await renew();
@@ -1622,10 +1655,12 @@ export async function acquireOpenClawCrablineSmokeRunLock(
       },
       async commitFileAtomically({ contents, destinationPath, stageDirectory, stageFile }) {
         if (released) {
-          throw new Error("OpenClaw Crabline smoke lock has already been released.");
+          throw new Error("OpenClaw Crabline provider readiness lock has already been released.");
         }
         if (commitFenceConsumed || heartbeatStopped || ownedDirectory !== ownerDirectory) {
-          throw new Error("OpenClaw Crabline smoke lock has already committed its fence.");
+          throw new Error(
+            "OpenClaw Crabline provider readiness lock has already committed its fence.",
+          );
         }
         heartbeat.assertHealthy();
         await renew();
@@ -1645,11 +1680,13 @@ export async function acquireOpenClawCrablineSmokeRunLock(
         await securedDestinationDirectory.assertIdentityAt(destinationDirectory);
         const destinationDirectoryIdentity = await readDirectoryIdentity(destinationDirectory);
         if (destinationDirectoryIdentity === null) {
-          throw new Error("OpenClaw Crabline smoke lock commit destination is invalid.");
+          throw new Error(
+            "OpenClaw Crabline provider readiness lock commit destination is invalid.",
+          );
         }
         if (destinationDirectoryIdentity.device !== outputDirectoryIdentity.device) {
           throw new Error(
-            "OpenClaw Crabline smoke lock commit destination is on another filesystem.",
+            "OpenClaw Crabline provider readiness lock commit destination is on another filesystem.",
           );
         }
         const resolvedStageDirectory = stageDirectory
@@ -1665,20 +1702,25 @@ export async function acquireOpenClawCrablineSmokeRunLock(
           try {
             stageDirectoryIdentity = await readDirectoryIdentity(resolvedStageDirectory);
           } catch (error) {
-            throw new Error("OpenClaw Crabline smoke lock commit stage directory is invalid.", {
-              cause: error,
-            });
+            throw new Error(
+              "OpenClaw Crabline provider readiness lock commit stage directory is invalid.",
+              {
+                cause: error,
+              },
+            );
           }
         }
         if (stageDirectory && stageDirectoryIdentity === null) {
-          throw new Error("OpenClaw Crabline smoke lock commit stage directory is invalid.");
+          throw new Error(
+            "OpenClaw Crabline provider readiness lock commit stage directory is invalid.",
+          );
         }
         if (
           stageDirectoryIdentity !== null &&
           stageDirectoryIdentity.device !== outputDirectoryIdentity.device
         ) {
           throw new Error(
-            "OpenClaw Crabline smoke lock commit stage directory is on another filesystem.",
+            "OpenClaw Crabline provider readiness lock commit stage directory is on another filesystem.",
           );
         }
         const stagedFileName = `.commit-file.${token}.${randomUUID()}.tmp`;
@@ -1692,13 +1734,15 @@ export async function acquireOpenClawCrablineSmokeRunLock(
             )
           ) {
             throw new Error(
-              "OpenClaw Crabline smoke lock commit stage directory identity changed.",
+              "OpenClaw Crabline provider readiness lock commit stage directory identity changed.",
             );
           }
         }
         const stagedFileIdentity = await readFileIdentity(stagedFilePath);
         if (stagedFileIdentity === null) {
-          throw new Error("OpenClaw Crabline smoke lock commit stage file is invalid.");
+          throw new Error(
+            "OpenClaw Crabline provider readiness lock commit stage file is invalid.",
+          );
         }
         heartbeat.assertHealthy();
         await renew();
@@ -1718,14 +1762,14 @@ export async function acquireOpenClawCrablineSmokeRunLock(
           observed.kind === "missing" ||
           observed.record.owner.token !== token
         ) {
-          throw new Error("OpenClaw Crabline smoke lock ownership was lost.");
+          throw new Error("OpenClaw Crabline provider readiness lock ownership was lost.");
         }
 
         try {
           await fs.rename(ownerDirectory, commitClaim);
         } catch (error) {
           if (isMissingPathError(error)) {
-            throw new Error("OpenClaw Crabline smoke lock ownership was lost.", {
+            throw new Error("OpenClaw Crabline provider readiness lock ownership was lost.", {
               cause: error,
             });
           }
@@ -1751,7 +1795,7 @@ export async function acquireOpenClawCrablineSmokeRunLock(
               }
             }
           }
-          throw new Error("OpenClaw Crabline smoke lock commit fence was lost.");
+          throw new Error("OpenClaw Crabline provider readiness lock commit fence was lost.");
         }
 
         await dependencies.beforeCommitFileRename?.();
@@ -1774,7 +1818,9 @@ export async function acquireOpenClawCrablineSmokeRunLock(
             !hasSameDirectoryIdentity(stageDirectoryIdentity, currentDirectoryIdentity) ||
             !hasSameDirectoryIdentity(stagedFileIdentity, currentFileIdentity)
           ) {
-            const error = new Error("OpenClaw Crabline smoke lock commit stage identity changed.");
+            const error = new Error(
+              "OpenClaw Crabline provider readiness lock commit stage identity changed.",
+            );
             Object.assign(error, { code: "ENOENT", path: claimedStagedFilePath });
             throw error;
           }
@@ -1784,12 +1830,16 @@ export async function acquireOpenClawCrablineSmokeRunLock(
             await readFileIdentity(claimedStagedFilePath),
           )
         ) {
-          throw new Error("OpenClaw Crabline smoke lock commit stage identity changed.");
+          throw new Error(
+            "OpenClaw Crabline provider readiness lock commit stage identity changed.",
+          );
         }
         if (
           !hasSameDirectoryIdentity(outputDirectoryIdentity, await readDirectoryIdentity(outputDir))
         ) {
-          throw new Error("OpenClaw Crabline smoke lock output directory identity changed.");
+          throw new Error(
+            "OpenClaw Crabline provider readiness lock output directory identity changed.",
+          );
         }
         await securedOutputDirectory.assertIdentityAt(outputDir);
         let currentDestinationDirectoryIdentity: DirectoryIdentity | null = null;
@@ -1805,7 +1855,7 @@ export async function acquireOpenClawCrablineSmokeRunLock(
           )
         ) {
           throw new Error(
-            "OpenClaw Crabline smoke lock commit destination directory identity changed.",
+            "OpenClaw Crabline provider readiness lock commit destination directory identity changed.",
           );
         }
         await securedDestinationDirectory.assertIdentityAt(destinationDirectory);
@@ -1816,9 +1866,11 @@ export async function acquireOpenClawCrablineSmokeRunLock(
           "file",
         );
         if (revalidatedDestinationPath !== resolvedDestinationPath) {
-          throw new Error("OpenClaw Crabline smoke lock commit destination path identity changed.");
+          throw new Error(
+            "OpenClaw Crabline provider readiness lock commit destination path identity changed.",
+          );
         }
-        // The owner-only output tree and smoke lock serialize supported writers; confinement does
+        // The owner-only output tree and provider readiness lock serialize supported writers; confinement does
         // not treat another process running as the same OS user as a lower-privilege adversary.
         await fs.rename(claimedStagedFilePath, revalidatedDestinationPath);
       },
@@ -1874,8 +1926,8 @@ export async function acquireOpenClawCrablineSmokeRunLock(
   }
 }
 
-export async function releaseOpenClawCrablineSmokeRunLock(
-  lock: Pick<OpenClawCrablineSmokeRunLock, "release">,
+export async function releaseOpenClawCrablineProviderReadinessLock(
+  lock: Pick<OpenClawCrablineProviderReadinessLock, "release">,
   dependencies: {
     sleep?: Sleep;
   } = {},

--- a/src/openclaw/provider-readiness-lock.ts
+++ b/src/openclaw/provider-readiness-lock.ts
@@ -806,9 +806,19 @@ async function assertReservationOwned(params: {
   securedDirectory: Awaited<ReturnType<typeof securePrivateDirectory>>;
   token: string;
 }): Promise<void> {
-  await params.securedDirectory.assertIdentityAt(params.lockDirectory);
   const observed = await readLockRecord(params.lockDirectory);
   if (observed.kind === "missing" || observed.record.owner.token !== params.token) {
+    throw new Error("OpenClaw Crabline provider readiness lock reservation was lost.");
+  }
+  try {
+    await params.securedDirectory.assertIdentityAt(params.lockDirectory);
+  } catch (error) {
+    throw new Error("OpenClaw Crabline provider readiness lock reservation was lost.", {
+      cause: error,
+    });
+  }
+  const revalidated = await readLockRecord(params.lockDirectory);
+  if (revalidated.kind === "missing" || revalidated.record.owner.token !== params.token) {
     throw new Error("OpenClaw Crabline provider readiness lock reservation was lost.");
   }
 }

--- a/src/openclaw/shared.ts
+++ b/src/openclaw/shared.ts
@@ -4,12 +4,10 @@ import type { ServerEventObserver } from "../servers/recorder.js";
 
 export const DEFAULT_ACCOUNT_ID = "default";
 export const OPENCLAW_CRABLINE_CHANNEL_CAPABILITY_MATRIX_PATH =
-  "crabline-fake-provider-capabilities.json";
-export const OPENCLAW_CRABLINE_PROVIDER_READINESS_PATH = "crabline-fake-provider-smoke.json";
-/** @deprecated Use OPENCLAW_CRABLINE_PROVIDER_READINESS_PATH. */
-export const OPENCLAW_CRABLINE_CHANNEL_SMOKE_PATH = OPENCLAW_CRABLINE_PROVIDER_READINESS_PATH;
-export const OPENCLAW_CRABLINE_MANIFEST_PATH = "crabline-fake-provider-server.json";
-export const OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY = ".crabline-smoke-artifacts";
+  "crabline-channel-driver-capabilities.json";
+export const OPENCLAW_CRABLINE_PROVIDER_READINESS_PATH = "crabline-provider-readiness.json";
+export const OPENCLAW_CRABLINE_MANIFEST_PATH = "crabline-provider-server.json";
+export const OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY = ".crabline-channel-driver-artifacts";
 export const OPENCLAW_CRABLINE_ARTIFACT_POINTER_PATH = `${OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY}/current.json`;
 export const OPENCLAW_CRABLINE_DEFAULT_CHANNEL = "telegram";
 
@@ -30,25 +28,18 @@ export type OpenClawCrablineChannelDriverSelection = {
   channel: CrablineServerChannel;
   channelDriver: "crabline";
   capabilityMatrixPath: typeof OPENCLAW_CRABLINE_CHANNEL_CAPABILITY_MATRIX_PATH;
-  providerReadinessArtifactPath?: typeof OPENCLAW_CRABLINE_PROVIDER_READINESS_PATH;
-  smokeArtifactPath: typeof OPENCLAW_CRABLINE_CHANNEL_SMOKE_PATH;
+  providerReadinessArtifactPath: typeof OPENCLAW_CRABLINE_PROVIDER_READINESS_PATH;
 };
 
-/** @deprecated Use OpenClawCrablineProviderReadinessResult. */
-export type OpenClawCrablineChannelDriverSmokeResult = {
+export type OpenClawCrablineProviderReadinessResult = {
   artifactPointerPath: string;
   capabilityReport: unknown;
   capabilityMatrixPath: string;
   generation: string;
   manifestPath: string;
-  smoke: unknown;
-  smokeArtifactPath: string;
-  warnings?: string[];
-};
-
-export type OpenClawCrablineProviderReadinessResult = OpenClawCrablineChannelDriverSmokeResult & {
   providerReadiness: unknown;
   providerReadinessArtifactPath: string;
+  warnings?: string[];
 };
 export type OpenClawCrablineConversation = {
   id: string;
@@ -58,7 +49,7 @@ export type OpenClawCrablineConversation = {
 export type OpenClawCrablineGatewayBinding = {
   accountId: string;
   channel: string;
-  createChannelDriverSmokeEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv;
+  createProviderReadinessEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv;
   createGatewayConfig(openclawConfig?: Record<string, unknown>): Record<string, unknown>;
   requiredPluginIds: string[];
 };

--- a/src/servers/whatsapp.ts
+++ b/src/servers/whatsapp.ts
@@ -78,7 +78,6 @@ export type WhatsAppServerManifest = {
     baileysWebSocketUrl: string;
     messagesUrl: string;
     phoneNumberUrl: string;
-    statusUrl: string;
   };
   env: {
     CLOUD_API_ACCESS_TOKEN: string;
@@ -845,7 +844,6 @@ export async function startWhatsAppServer(
         baileysWebSocketUrl,
         messagesUrl,
         phoneNumberUrl,
-        statusUrl: messagesUrl,
       },
       env: {
         CLOUD_API_ACCESS_TOKEN: state.accessToken,

--- a/test/openclaw-artifact-generation.test.ts
+++ b/test/openclaw-artifact-generation.test.ts
@@ -12,9 +12,9 @@ import {
   type CrablineServerManifest,
 } from "../src/index.js";
 import {
-  acquireOpenClawCrablineSmokeRunLock,
-  type OpenClawCrablineSmokeRunLock,
-} from "../src/openclaw/smoke-lock.js";
+  acquireOpenClawCrablineProviderReadinessLock,
+  type OpenClawCrablineProviderReadinessLock,
+} from "../src/openclaw/provider-readiness-lock.js";
 import { createTempDir, disposeTempDir } from "./test-helpers.js";
 
 const manifest: CrablineServerManifest = {
@@ -52,10 +52,10 @@ const mattermostManifest = {
   version: 1,
 } satisfies CrablineServerManifest;
 
-function createLock(): OpenClawCrablineSmokeRunLock & {
+function createLock(): OpenClawCrablineProviderReadinessLock & {
   assertOwned: ReturnType<typeof vi.fn<() => Promise<void>>>;
   commitFileAtomically: ReturnType<
-    typeof vi.fn<OpenClawCrablineSmokeRunLock["commitFileAtomically"]>
+    typeof vi.fn<OpenClawCrablineProviderReadinessLock["commitFileAtomically"]>
   >;
 } {
   return {
@@ -104,7 +104,7 @@ function publishParamsWithRecorderSnapshot(outputDir: string, lock = createLock(
     ...publishParams(outputDir, lock),
     recorderSnapshot: {
       contents: '{"accepted":true}\n',
-      fileName: "telegram-fake-provider.jsonl",
+      fileName: "telegram-provider-server.jsonl",
     },
   };
 }
@@ -147,75 +147,6 @@ describe("OpenClaw artifact generation publication", () => {
       /Post-commit\s+cleanup retains only the current and previous pointer generations/u,
     );
     expect(channelSetup).not.toContain("not removed automatically");
-  });
-
-  it("reads legacy smoke-only artifact pointers", async () => {
-    const outputDir = await createTempDir();
-    try {
-      const result = await publishOpenClawCrablineArtifactGeneration(publishParams(outputDir), {
-        createGenerationId: () => "11111111-1111-4111-8111-111111111111",
-      });
-      const pointerPath = path.join(outputDir, OPENCLAW_CRABLINE_ARTIFACT_POINTER_PATH);
-      const pointer = JSON.parse(await fs.readFile(pointerPath, "utf8")) as Record<string, unknown>;
-      delete pointer.providerReadinessArtifactPath;
-      delete pointer.recorderSnapshotPath;
-      pointer.version = 1;
-      await fs.writeFile(pointerPath, `${JSON.stringify(pointer, null, 2)}\n`);
-
-      await expect(readOpenClawCrablineArtifactPointer(outputDir)).resolves.toMatchObject({
-        providerReadinessArtifactPath: result.providerReadinessArtifactPath,
-        smokeArtifactPath: result.smokeArtifactPath,
-        version: 1,
-      });
-    } finally {
-      await disposeTempDir(outputDir);
-    }
-  });
-
-  it("validates every existing section in legacy smoke-only generations", async () => {
-    const outputDir = await createTempDir();
-    try {
-      const first = await publishOpenClawCrablineArtifactGeneration(
-        publishParamsWithRecorderSnapshot(outputDir),
-        { createGenerationId: () => "11111111-1111-4111-8111-111111111111" },
-      );
-      const pointerPath = path.join(outputDir, OPENCLAW_CRABLINE_ARTIFACT_POINTER_PATH);
-      const pointer = JSON.parse(await fs.readFile(pointerPath, "utf8")) as Record<string, unknown>;
-      delete pointer.providerReadinessArtifactPath;
-      delete pointer.recorderSnapshotPath;
-      pointer.version = 1;
-      await fs.writeFile(pointerPath, `${JSON.stringify(pointer, null, 2)}\n`);
-
-      const readinessPath = path.join(outputDir, first.smokeArtifactPath);
-      const readiness = JSON.parse(await fs.readFile(readinessPath, "utf8")) as {
-        providerReadiness?: unknown;
-        smoke: { result: Record<string, unknown> };
-      };
-      delete readiness.providerReadiness;
-      delete readiness.smoke.result.proof;
-      delete readiness.smoke.result.ready;
-      const validSmokeOnlyReadiness = `${JSON.stringify(readiness, null, 2)}\n`;
-      readiness.smoke.result.endpoints = {};
-      await fs.writeFile(readinessPath, `${JSON.stringify(readiness, null, 2)}\n`);
-
-      await expect(
-        publishOpenClawCrablineArtifactGeneration(publishParams(outputDir), {
-          createGenerationId: () => "22222222-2222-4222-8222-222222222222",
-        }),
-      ).rejects.toThrow("OpenClaw Crabline current artifact generation is incomplete.");
-
-      await fs.writeFile(readinessPath, validSmokeOnlyReadiness);
-      await expect(
-        publishOpenClawCrablineArtifactGeneration(publishParams(outputDir), {
-          createGenerationId: () => "22222222-2222-4222-8222-222222222222",
-        }),
-      ).resolves.toMatchObject({
-        previousGeneration: first.generation,
-        version: 2,
-      });
-    } finally {
-      await disposeTempDir(outputDir);
-    }
   });
 
   it("rejects whitespace-only Mattermost usernames in readiness evidence", async () => {
@@ -326,8 +257,7 @@ describe("OpenClaw artifact generation publication", () => {
         manifestPath: result.manifestPath,
         providerReadinessArtifactPath: result.providerReadinessArtifactPath,
         recorderSnapshotPath: null,
-        smokeArtifactPath: result.providerReadinessArtifactPath,
-        version: 2,
+        version: 3,
       });
       for (const artifactPath of [
         result.manifestPath,
@@ -379,10 +309,8 @@ describe("OpenClaw artifact generation publication", () => {
         await fs.readFile(path.join(outputDir, first.providerReadinessArtifactPath), "utf8"),
       ) as {
         providerReadiness: { result: Record<string, unknown> };
-        smoke: { result: Record<string, unknown> };
       };
       expect(readiness.providerReadiness.result).not.toHaveProperty("recorderPath");
-      expect(readiness.smoke.result).not.toHaveProperty("recorderPath");
 
       await expect(
         publishOpenClawCrablineArtifactGeneration(paramsWithRecorderReference, {
@@ -391,88 +319,14 @@ describe("OpenClaw artifact generation publication", () => {
       ).resolves.toMatchObject({
         previousGeneration: first.generation,
         recorderSnapshotPath: null,
-        version: 2,
+        version: 3,
       });
     } finally {
       await disposeTempDir(outputDir);
     }
   });
 
-  it("replaces a legacy generation with an external recorder path", async () => {
-    const outputDir = await createTempDir();
-    try {
-      const first = await publishOpenClawCrablineArtifactGeneration(publishParams(outputDir), {
-        createGenerationId: () => "11111111-1111-4111-8111-111111111111",
-      });
-      const pointerPath = path.join(outputDir, OPENCLAW_CRABLINE_ARTIFACT_POINTER_PATH);
-      const legacyPointer = JSON.parse(await fs.readFile(pointerPath, "utf8")) as Record<
-        string,
-        unknown
-      >;
-      delete legacyPointer.recorderSnapshotPath;
-      legacyPointer.version = 1;
-      await fs.writeFile(pointerPath, `${JSON.stringify(legacyPointer, null, 2)}\n`);
-
-      const legacyManifestPath = path.join(outputDir, first.manifestPath);
-      const legacyManifest = JSON.parse(await fs.readFile(legacyManifestPath, "utf8")) as Record<
-        string,
-        unknown
-      >;
-      legacyManifest.recorderPath = "/tmp/crabline/legacy-telegram.jsonl";
-      await fs.writeFile(legacyManifestPath, `${JSON.stringify(legacyManifest, null, 2)}\n`);
-
-      const replacement = await publishOpenClawCrablineArtifactGeneration(
-        publishParams(outputDir),
-        { createGenerationId: () => "22222222-2222-4222-8222-222222222222" },
-      );
-
-      expect(replacement).toMatchObject({
-        previousGeneration: first.generation,
-        version: 2,
-      });
-      await expect(readOpenClawCrablineArtifactPointer(outputDir)).resolves.toMatchObject({
-        generation: replacement.generation,
-        previousGeneration: first.generation,
-        version: 2,
-      });
-      await expect(
-        fs.readFile(path.join(outputDir, replacement.manifestPath), "utf8"),
-      ).resolves.not.toContain("recorderPath");
-    } finally {
-      await disposeTempDir(outputDir);
-    }
-  });
-
-  it("replaces a legacy generation without recorder evidence", async () => {
-    const outputDir = await createTempDir();
-    try {
-      const first = await publishOpenClawCrablineArtifactGeneration(publishParams(outputDir), {
-        createGenerationId: () => "11111111-1111-4111-8111-111111111111",
-      });
-      const pointerPath = path.join(outputDir, OPENCLAW_CRABLINE_ARTIFACT_POINTER_PATH);
-      const legacyPointer = JSON.parse(await fs.readFile(pointerPath, "utf8")) as Record<
-        string,
-        unknown
-      >;
-      delete legacyPointer.recorderSnapshotPath;
-      legacyPointer.version = 1;
-      await fs.writeFile(pointerPath, `${JSON.stringify(legacyPointer, null, 2)}\n`);
-
-      const replacement = await publishOpenClawCrablineArtifactGeneration(
-        publishParams(outputDir),
-        { createGenerationId: () => "22222222-2222-4222-8222-222222222222" },
-      );
-
-      expect(replacement).toMatchObject({
-        previousGeneration: first.generation,
-        version: 2,
-      });
-    } finally {
-      await disposeTempDir(outputDir);
-    }
-  });
-
-  it("rejects a current pointer downgraded without a legacy manifest shape", async () => {
+  it("rejects a current pointer with an unsupported schema version", async () => {
     const outputDir = await createTempDir();
     try {
       await publishOpenClawCrablineArtifactGeneration(
@@ -755,17 +609,6 @@ describe("OpenClaw artifact generation publication", () => {
         },
       }),
     },
-    {
-      label: "smoke readiness with a mismatched manifest reference",
-      path: "providerReadinessArtifactPath",
-      corrupt: (artifact: Record<string, unknown>) => ({
-        ...artifact,
-        smoke: {
-          ...(artifact.smoke as Record<string, unknown>),
-          manifestPath: "other-manifest.json",
-        },
-      }),
-    },
   ] as const)(
     "rejects a generated $label before pointer publication",
     async ({ corrupt, path: field }) => {
@@ -813,10 +656,8 @@ describe("OpenClaw artifact generation publication", () => {
       const readinessPath = path.join(outputDir, current.providerReadinessArtifactPath);
       const readiness = JSON.parse(await fs.readFile(readinessPath, "utf8")) as {
         providerReadiness: { result: Record<string, unknown> };
-        smoke: { result: Record<string, unknown> };
       };
       delete readiness.providerReadiness.result.recorderPath;
-      delete readiness.smoke.result.recorderPath;
       await fs.writeFile(readinessPath, `${JSON.stringify(readiness, null, 2)}\n`);
 
       await expect(
@@ -854,10 +695,8 @@ describe("OpenClaw artifact generation publication", () => {
       const readinessPath = path.join(outputDir, second.providerReadinessArtifactPath);
       const readiness = JSON.parse(await fs.readFile(readinessPath, "utf8")) as {
         providerReadiness: { result: { recorderPath: string } };
-        smoke: { result: { recorderPath: string } };
       };
       readiness.providerReadiness.result.recorderPath = firstManifest.recorderPath;
-      readiness.smoke.result.recorderPath = firstManifest.recorderPath;
       await fs.writeFile(readinessPath, `${JSON.stringify(readiness)}\n`);
 
       await expect(
@@ -971,10 +810,6 @@ describe("OpenClaw artifact generation publication", () => {
                 generation,
                 successorGeneration,
               ),
-              smokeArtifactPath: String(pointer.smokeArtifactPath).replace(
-                generation,
-                successorGeneration,
-              ),
             },
             null,
             2,
@@ -1056,13 +891,13 @@ describe("OpenClaw artifact generation publication", () => {
       async settle() {},
       async stop() {},
     });
-    let expiredLock: OpenClawCrablineSmokeRunLock | undefined;
-    let successorLock: OpenClawCrablineSmokeRunLock | undefined;
+    let expiredLock: OpenClawCrablineProviderReadinessLock | undefined;
+    let successorLock: OpenClawCrablineProviderReadinessLock | undefined;
     let successorPublication:
       | ReturnType<typeof publishOpenClawCrablineArtifactGeneration>
       | undefined;
     try {
-      expiredLock = await acquireOpenClawCrablineSmokeRunLock(
+      expiredLock = await acquireOpenClawCrablineProviderReadinessLock(
         { channel: "telegram", outputDir },
         {
           isProcessAlive: () => true,
@@ -1075,7 +910,7 @@ describe("OpenClaw artifact generation publication", () => {
       );
 
       now = 2_001;
-      successorLock = await acquireOpenClawCrablineSmokeRunLock(
+      successorLock = await acquireOpenClawCrablineProviderReadinessLock(
         { channel: "telegram", outputDir },
         {
           isProcessAlive: () => true,
@@ -1118,7 +953,7 @@ describe("OpenClaw artifact generation publication", () => {
           },
           { createGenerationId: () => "11111111-1111-4111-8111-111111111111" },
         ),
-      ).rejects.toThrow("OpenClaw Crabline smoke lock ownership was lost.");
+      ).rejects.toThrow("OpenClaw Crabline provider readiness lock ownership was lost.");
       await expect(fs.stat(successorGenerationPath)).resolves.toBeDefined();
 
       resumeSuccessor?.();
@@ -1153,10 +988,10 @@ describe("OpenClaw artifact generation publication", () => {
       async settle() {},
       async stop() {},
     });
-    let oldLock: OpenClawCrablineSmokeRunLock | undefined;
-    let successorLock: OpenClawCrablineSmokeRunLock | undefined;
+    let oldLock: OpenClawCrablineProviderReadinessLock | undefined;
+    let successorLock: OpenClawCrablineProviderReadinessLock | undefined;
     try {
-      oldLock = await acquireOpenClawCrablineSmokeRunLock(
+      oldLock = await acquireOpenClawCrablineProviderReadinessLock(
         { channel: "telegram", outputDir },
         {
           beforeCommitFileRename: async () => {
@@ -1185,7 +1020,7 @@ describe("OpenClaw artifact generation publication", () => {
 
       await oldOwnerFencedPromise;
       now = 2_001;
-      successorLock = await acquireOpenClawCrablineSmokeRunLock(
+      successorLock = await acquireOpenClawCrablineProviderReadinessLock(
         { channel: "telegram", outputDir },
         {
           isProcessAlive: () => true,
@@ -1210,7 +1045,7 @@ describe("OpenClaw artifact generation publication", () => {
 
       resumeOldOwner?.();
       await expect(oldPublication).rejects.toThrow(
-        "OpenClaw Crabline smoke lock ownership was lost.",
+        "OpenClaw Crabline provider readiness lock ownership was lost.",
       );
       await expect(readOpenClawCrablineArtifactPointer(outputDir)).resolves.toMatchObject({
         generation: successor.generation,
@@ -1295,7 +1130,7 @@ describe("OpenClaw artifact generation publication", () => {
           String(args[0]).endsWith(
             path.join(
               "generation-11111111-1111-4111-8111-111111111111",
-              "crabline-fake-provider-server.json",
+              "crabline-provider-server.json",
             ),
           )
         ) {
@@ -1342,9 +1177,9 @@ describe("OpenClaw artifact generation publication", () => {
     const outputDir = await createTempDir();
     const storePath = path.join(outputDir, OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY);
     const displacedStorePath = `${storePath}.displaced`;
-    let lock: OpenClawCrablineSmokeRunLock | undefined;
+    let lock: OpenClawCrablineProviderReadinessLock | undefined;
     try {
-      lock = await acquireOpenClawCrablineSmokeRunLock(
+      lock = await acquireOpenClawCrablineProviderReadinessLock(
         { channel: "telegram", outputDir },
         {
           beforeCommitFileRename: async () => {

--- a/test/openclaw-provider-readiness-lock.test.ts
+++ b/test/openclaw-provider-readiness-lock.test.ts
@@ -2,14 +2,14 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
-  acquireOpenClawCrablineSmokeRunLock,
+  acquireOpenClawCrablineProviderReadinessLock,
   darwinProcessIdentityEnvironment,
   isProcessAlive,
   processIdentityFromDarwin,
   processIdentityFromLinuxStat,
   processStartedAtMsFromTimeOrigin,
-  releaseOpenClawCrablineSmokeRunLock,
-} from "../src/openclaw/smoke-lock.js";
+  releaseOpenClawCrablineProviderReadinessLock,
+} from "../src/openclaw/provider-readiness-lock.js";
 import { OPENCLAW_CRABLINE_MANIFEST_PATH } from "../src/openclaw/shared.js";
 import { createTempDir, disposeTempDir } from "./test-helpers.js";
 
@@ -23,12 +23,14 @@ async function findOwnedLockDirectory(outputDir: string): Promise<string> {
   const prefix = `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock.owned.`;
   const matches = (await fs.readdir(outputDir)).filter((entry) => entry.startsWith(prefix));
   if (matches.length !== 1) {
-    throw new Error(`Expected one owned smoke-lock directory, found ${matches.length}.`);
+    throw new Error(
+      `Expected one owned provider-readiness-lock directory, found ${matches.length}.`,
+    );
   }
   return path.join(outputDir, matches[0]!);
 }
 
-describe("OpenClaw smoke lock cleanup", () => {
+describe("OpenClaw provider readiness lock cleanup", () => {
   it("extracts the exact Linux process start token", () => {
     expect(
       processIdentityFromLinuxStat(
@@ -87,7 +89,7 @@ describe("OpenClaw smoke lock cleanup", () => {
     async () => {
       const outputDir = await createTempDir();
       try {
-        const lock = await acquireOpenClawCrablineSmokeRunLock(
+        const lock = await acquireOpenClawCrablineProviderReadinessLock(
           { channel: "telegram", outputDir },
           { startHeartbeat: disableHeartbeat },
         );
@@ -140,7 +142,7 @@ describe("OpenClaw smoke lock cleanup", () => {
       );
 
       await expect(
-        acquireOpenClawCrablineSmokeRunLock(
+        acquireOpenClawCrablineProviderReadinessLock(
           { channel: "telegram", outputDir },
           {
             isProcessAlive: () => true,
@@ -150,7 +152,7 @@ describe("OpenClaw smoke lock cleanup", () => {
             startHeartbeat: disableHeartbeat,
           },
         ),
-      ).rejects.toThrow("OpenClaw Crabline smoke lock owner metadata is malformed.");
+      ).rejects.toThrow("OpenClaw Crabline provider readiness lock owner metadata is malformed.");
     } finally {
       await disposeTempDir(outputDir);
     }
@@ -167,7 +169,7 @@ describe("OpenClaw smoke lock cleanup", () => {
       await fs.writeFile(path.join(lockDirectory, "owner.json"), "null\n");
 
       await expect(
-        acquireOpenClawCrablineSmokeRunLock(
+        acquireOpenClawCrablineProviderReadinessLock(
           { channel: "telegram", outputDir },
           {
             isProcessAlive: () => true,
@@ -177,7 +179,7 @@ describe("OpenClaw smoke lock cleanup", () => {
             startHeartbeat: disableHeartbeat,
           },
         ),
-      ).rejects.toThrow("OpenClaw Crabline smoke lock owner metadata is malformed.");
+      ).rejects.toThrow("OpenClaw Crabline provider readiness lock owner metadata is malformed.");
     } finally {
       await disposeTempDir(outputDir);
     }
@@ -189,7 +191,7 @@ describe("OpenClaw smoke lock cleanup", () => {
     const stageFile = vi.fn(async () => undefined);
     try {
       await fs.mkdir(path.join(outputDir, "nested"));
-      const lock = await acquireOpenClawCrablineSmokeRunLock(
+      const lock = await acquireOpenClawCrablineProviderReadinessLock(
         { channel: "telegram", outputDir },
         { startHeartbeat: disableHeartbeat },
       );
@@ -236,7 +238,7 @@ describe("OpenClaw smoke lock cleanup", () => {
     const stageFile = vi.fn(async () => undefined);
     try {
       await fs.symlink(outsideDir, stageDirectory, "dir");
-      const lock = await acquireOpenClawCrablineSmokeRunLock(
+      const lock = await acquireOpenClawCrablineProviderReadinessLock(
         { channel: "telegram", outputDir },
         { startHeartbeat: disableHeartbeat },
       );
@@ -266,7 +268,7 @@ describe("OpenClaw smoke lock cleanup", () => {
     try {
       await fs.mkdir(outsideStage);
       await fs.symlink(outsideDir, linkedAncestor, "dir");
-      const lock = await acquireOpenClawCrablineSmokeRunLock(
+      const lock = await acquireOpenClawCrablineProviderReadinessLock(
         { channel: "telegram", outputDir },
         { startHeartbeat: disableHeartbeat },
       );
@@ -301,7 +303,7 @@ describe("OpenClaw smoke lock cleanup", () => {
     const displacedDirectory = path.join(outputDir, "displaced-nested");
     try {
       await fs.mkdir(destinationDirectory);
-      const lock = await acquireOpenClawCrablineSmokeRunLock(
+      const lock = await acquireOpenClawCrablineProviderReadinessLock(
         { channel: "telegram", outputDir },
         {
           beforeCommitRename: async () => {
@@ -339,7 +341,7 @@ describe("OpenClaw smoke lock cleanup", () => {
     const displacedAncestor = path.join(outsideDir, "ancestor");
     try {
       await fs.mkdir(destinationDirectory, { recursive: true });
-      const lock = await acquireOpenClawCrablineSmokeRunLock(
+      const lock = await acquireOpenClawCrablineProviderReadinessLock(
         { channel: "telegram", outputDir },
         {
           beforeCommitRename: async () => {
@@ -374,7 +376,7 @@ describe("OpenClaw smoke lock cleanup", () => {
     const outsideDir = await createTempDir();
     let now = 1_000;
     try {
-      const expiredLock = await acquireOpenClawCrablineSmokeRunLock(
+      const expiredLock = await acquireOpenClawCrablineProviderReadinessLock(
         { channel: "telegram", outputDir },
         {
           isProcessAlive: () => true,
@@ -413,7 +415,7 @@ describe("OpenClaw smoke lock cleanup", () => {
       );
 
       now = 2_001;
-      const successorLock = await acquireOpenClawCrablineSmokeRunLock(
+      const successorLock = await acquireOpenClawCrablineProviderReadinessLock(
         { channel: "telegram", outputDir },
         {
           isProcessAlive: () => true,
@@ -441,7 +443,7 @@ describe("OpenClaw smoke lock cleanup", () => {
     let now = 1_000;
     try {
       await fs.mkdir(stageDirectory);
-      const expiredLock = await acquireOpenClawCrablineSmokeRunLock(
+      const expiredLock = await acquireOpenClawCrablineProviderReadinessLock(
         { channel: "telegram", outputDir },
         {
           isProcessAlive: () => true,
@@ -482,7 +484,7 @@ describe("OpenClaw smoke lock cleanup", () => {
       );
 
       now = 2_001;
-      const successorLock = await acquireOpenClawCrablineSmokeRunLock(
+      const successorLock = await acquireOpenClawCrablineProviderReadinessLock(
         { channel: "telegram", outputDir },
         {
           isProcessAlive: () => true,
@@ -508,7 +510,7 @@ describe("OpenClaw smoke lock cleanup", () => {
     const displacedDirectory = path.join(outputDir, "displaced-stage");
     try {
       await fs.mkdir(stageDirectory);
-      const lock = await acquireOpenClawCrablineSmokeRunLock(
+      const lock = await acquireOpenClawCrablineProviderReadinessLock(
         { channel: "telegram", outputDir },
         {
           beforeCommitFileRename: async () => {
@@ -545,7 +547,7 @@ describe("OpenClaw smoke lock cleanup", () => {
         events.push("secure");
         expect(await fs.readdir(directoryPath)).toEqual([]);
       });
-      const lock = await acquireOpenClawCrablineSmokeRunLock(
+      const lock = await acquireOpenClawCrablineProviderReadinessLock(
         { channel: "telegram", outputDir },
         {
           now: () => 1_000,
@@ -591,7 +593,7 @@ describe("OpenClaw smoke lock cleanup", () => {
     const aclError = new Error("ACL unavailable");
     try {
       await expect(
-        acquireOpenClawCrablineSmokeRunLock(
+        acquireOpenClawCrablineProviderReadinessLock(
           { channel: "telegram", outputDir },
           {
             now: () => 1_000,
@@ -622,7 +624,7 @@ describe("OpenClaw smoke lock cleanup", () => {
     let displacedPath = "";
     try {
       await expect(
-        acquireOpenClawCrablineSmokeRunLock(
+        acquireOpenClawCrablineProviderReadinessLock(
           { channel: "telegram", outputDir },
           {
             afterLockOwnerWrite: async (candidateDirectory) => {
@@ -651,7 +653,7 @@ describe("OpenClaw smoke lock cleanup", () => {
     let displacedPath = "";
     try {
       await expect(
-        acquireOpenClawCrablineSmokeRunLock(
+        acquireOpenClawCrablineProviderReadinessLock(
           { channel: "telegram", outputDir },
           {
             afterLockCandidateInstall: async (lockDirectory) => {
@@ -683,7 +685,7 @@ describe("OpenClaw smoke lock cleanup", () => {
     const setupFailure = new Error("owner claim setup failed");
     try {
       await expect(
-        acquireOpenClawCrablineSmokeRunLock(params, {
+        acquireOpenClawCrablineProviderReadinessLock(params, {
           afterLockOwnerClaimInstall: async () => {
             throw setupFailure;
           },
@@ -708,7 +710,7 @@ describe("OpenClaw smoke lock cleanup", () => {
       expect((await fs.stat(compatibilityOwnerPath)).mtimeMs).toBeCloseTo(1, 0);
 
       const sleep = vi.fn(async () => undefined);
-      const replacementLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+      const replacementLock = await acquireOpenClawCrablineProviderReadinessLock(params, {
         sleep,
         startHeartbeat: disableHeartbeat,
       });
@@ -730,7 +732,7 @@ describe("OpenClaw smoke lock cleanup", () => {
     const sleep = vi.fn(async (_delayMs: number) => undefined);
 
     await expect(
-      releaseOpenClawCrablineSmokeRunLock({ release }, { sleep }),
+      releaseOpenClawCrablineProviderReadinessLock({ release }, { sleep }),
     ).resolves.toBeUndefined();
 
     expect(release).toHaveBeenCalledTimes(3);
@@ -744,7 +746,7 @@ describe("OpenClaw smoke lock cleanup", () => {
     });
     const sleep = vi.fn(async (_delayMs: number) => undefined);
 
-    await expect(releaseOpenClawCrablineSmokeRunLock({ release }, { sleep })).rejects.toBe(
+    await expect(releaseOpenClawCrablineProviderReadinessLock({ release }, { sleep })).rejects.toBe(
       releaseError,
     );
 
@@ -765,17 +767,17 @@ describe("OpenClaw smoke lock cleanup", () => {
         await fs.rm(lockDirectory, { force: true, recursive: true });
       });
       const params = { channel: "telegram" as const, outputDir };
-      const lock = await acquireOpenClawCrablineSmokeRunLock(params, { removeDirectory });
+      const lock = await acquireOpenClawCrablineProviderReadinessLock(params, { removeDirectory });
 
       await expect(lock.release()).rejects.toBe(removalError);
-      await expect(acquireOpenClawCrablineSmokeRunLock(params)).rejects.toThrow(
-        `OpenClaw Crabline smoke is already running for channel "telegram" in "${path.resolve(outputDir)}"`,
+      await expect(acquireOpenClawCrablineProviderReadinessLock(params)).rejects.toThrow(
+        `OpenClaw Crabline provider readiness is already running for channel "telegram" in "${path.resolve(outputDir)}"`,
       );
 
       await expect(lock.release()).resolves.toBeUndefined();
       expect(removeDirectory).toHaveBeenCalledTimes(2);
 
-      const nextLock = await acquireOpenClawCrablineSmokeRunLock(params);
+      const nextLock = await acquireOpenClawCrablineProviderReadinessLock(params);
       await expect(nextLock.release()).resolves.toBeUndefined();
     } finally {
       await disposeTempDir(outputDir);
@@ -787,13 +789,13 @@ describe("OpenClaw smoke lock cleanup", () => {
     const params = { channel: "telegram" as const, outputDir };
     let sentinelPath: string | undefined;
     try {
-      const lock = await acquireOpenClawCrablineSmokeRunLock(params, {
+      const lock = await acquireOpenClawCrablineProviderReadinessLock(params, {
         beforeReleaseRemove: async () => {
           const releaseDirectory = (await fs.readdir(outputDir))
             .filter((entry) => entry.includes(".lock.release."))
             .map((entry) => path.join(outputDir, entry))[0];
           if (!releaseDirectory) {
-            throw new Error("Expected a smoke lock release directory.");
+            throw new Error("Expected a provider readiness lock release directory.");
           }
           await fs.rename(releaseDirectory, `${releaseDirectory}.original`);
           const replacementTree = path.join(releaseDirectory, "replacement");
@@ -805,7 +807,7 @@ describe("OpenClaw smoke lock cleanup", () => {
       });
 
       await expect(lock.release()).rejects.toThrow(
-        "OpenClaw Crabline smoke lock cleanup target changed.",
+        "OpenClaw Crabline provider readiness lock cleanup target changed.",
       );
       expect(sentinelPath).toBeDefined();
       const quarantineDirectory = (await fs.readdir(outputDir))
@@ -826,13 +828,13 @@ describe("OpenClaw smoke lock cleanup", () => {
     let releaseDirectory: string | undefined;
     let replacementIdentity: { dev: bigint; ino: bigint } | undefined;
     try {
-      const lock = await acquireOpenClawCrablineSmokeRunLock(params, {
+      const lock = await acquireOpenClawCrablineProviderReadinessLock(params, {
         beforeReleaseRemove: async () => {
           releaseDirectory = (await fs.readdir(outputDir))
             .filter((entry) => entry.includes(".lock.release."))
             .map((entry) => path.join(outputDir, entry))[0];
           if (!releaseDirectory) {
-            throw new Error("Expected a smoke lock release directory.");
+            throw new Error("Expected a provider readiness lock release directory.");
           }
           await fs.rename(releaseDirectory, `${releaseDirectory}.original`);
           await fs.mkdir(releaseDirectory);
@@ -843,7 +845,7 @@ describe("OpenClaw smoke lock cleanup", () => {
       });
 
       await expect(lock.release()).rejects.toThrow(
-        "OpenClaw Crabline smoke lock cleanup target changed.",
+        "OpenClaw Crabline provider readiness lock cleanup target changed.",
       );
       const quarantineDirectory = (await fs.readdir(outputDir))
         .filter((entry) => entry.includes(".lock.release.") && entry.includes(".cleanup."))
@@ -866,13 +868,13 @@ describe("OpenClaw smoke lock cleanup", () => {
     const params = { channel: "telegram" as const, outputDir };
     try {
       await fs.writeFile(outsideOwnerPath, "preserve\n");
-      const lock = await acquireOpenClawCrablineSmokeRunLock(params, {
+      const lock = await acquireOpenClawCrablineProviderReadinessLock(params, {
         beforeReleaseRemove: async () => {
           const releaseDirectory = (await fs.readdir(outputDir))
             .filter((entry) => entry.includes(".lock.release."))
             .map((entry) => path.join(outputDir, entry))[0];
           if (!releaseDirectory) {
-            throw new Error("Expected a smoke lock release directory.");
+            throw new Error("Expected a provider readiness lock release directory.");
           }
           await fs.rename(releaseDirectory, `${releaseDirectory}.original`);
           await fs.symlink(outsideDir, releaseDirectory, "dir");
@@ -881,7 +883,7 @@ describe("OpenClaw smoke lock cleanup", () => {
       });
 
       await expect(lock.release()).rejects.toThrow(
-        "OpenClaw Crabline smoke lock cleanup target changed.",
+        "OpenClaw Crabline provider readiness lock cleanup target changed.",
       );
       await expect(fs.readFile(outsideOwnerPath, "utf8")).resolves.toBe("preserve\n");
     } finally {
@@ -903,10 +905,12 @@ describe("OpenClaw smoke lock cleanup", () => {
     const releaseValidatedPromise = new Promise<void>((resolve) => {
       releaseValidated = resolve;
     });
-    let successorLock: Awaited<ReturnType<typeof acquireOpenClawCrablineSmokeRunLock>> | undefined;
+    let successorLock:
+      | Awaited<ReturnType<typeof acquireOpenClawCrablineProviderReadinessLock>>
+      | undefined;
     let successorRenew: (() => Promise<void>) | undefined;
     try {
-      const oldLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+      const oldLock = await acquireOpenClawCrablineProviderReadinessLock(params, {
         beforeReleaseRename: async () => {
           releaseValidated?.();
           await resumeReleasePromise;
@@ -925,7 +929,7 @@ describe("OpenClaw smoke lock cleanup", () => {
 
       await fs.rename(oldOwnerDirectory, suspendedOwnerDirectory);
       await fs.rename(markerDirectory, suspendedMarkerDirectory);
-      successorLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+      successorLock = await acquireOpenClawCrablineProviderReadinessLock(params, {
         startHeartbeat: (renew, intervalMs) => {
           successorRenew = renew;
           return disableHeartbeat(renew, intervalMs);
@@ -955,14 +959,14 @@ describe("OpenClaw smoke lock cleanup", () => {
     const outputDir = await createTempDir();
     const params = { channel: "telegram" as const, outputDir };
     try {
-      const firstLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+      const firstLock = await acquireOpenClawCrablineProviderReadinessLock(params, {
         isProcessAlive: () => true,
         now: () => 1_000,
         pid: 4_242,
         processIdentity: "test:first",
         processStartedAtMs: 100,
       });
-      const replacementLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+      const replacementLock = await acquireOpenClawCrablineProviderReadinessLock(params, {
         isProcessAlive: () => true,
         now: () => 1_100,
         pid: 4_242,
@@ -972,14 +976,14 @@ describe("OpenClaw smoke lock cleanup", () => {
 
       await firstLock.release();
       await expect(
-        acquireOpenClawCrablineSmokeRunLock(params, {
+        acquireOpenClawCrablineProviderReadinessLock(params, {
           isProcessAlive: () => true,
           now: () => 1_200,
           pid: 4_242,
           processIdentity: "test:second",
           processStartedAtMs: 200,
         }),
-      ).rejects.toThrow("OpenClaw Crabline smoke is already running");
+      ).rejects.toThrow("OpenClaw Crabline provider readiness is already running");
       await replacementLock.release();
     } finally {
       await disposeTempDir(outputDir);
@@ -990,14 +994,14 @@ describe("OpenClaw smoke lock cleanup", () => {
     const outputDir = await createTempDir();
     const params = { channel: "telegram" as const, outputDir };
     try {
-      const firstLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+      const firstLock = await acquireOpenClawCrablineProviderReadinessLock(params, {
         isProcessAlive: () => true,
         now: () => 1_000,
         pid: 4_242,
         processIdentity: null,
         processStartedAtMs: 100,
       });
-      const replacementLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+      const replacementLock = await acquireOpenClawCrablineProviderReadinessLock(params, {
         isProcessAlive: () => true,
         now: () => 1_100,
         pid: 4_242,
@@ -1035,16 +1039,16 @@ describe("OpenClaw smoke lock cleanup", () => {
       await fs.utimes(path.join(lockDirectory, "owner.json"), new Date(1_000), new Date(1_000));
 
       await expect(
-        acquireOpenClawCrablineSmokeRunLock(params, {
+        acquireOpenClawCrablineProviderReadinessLock(params, {
           isProcessAlive: () => legacyOwnerAlive,
           now: () => 2_000,
           pid: 5_252,
           processStartedAtMs: 200,
         }),
-      ).rejects.toThrow("OpenClaw Crabline smoke is already running");
+      ).rejects.toThrow("OpenClaw Crabline provider readiness is already running");
 
       legacyOwnerAlive = false;
-      const replacementLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+      const replacementLock = await acquireOpenClawCrablineProviderReadinessLock(params, {
         isProcessAlive: () => legacyOwnerAlive,
         now: () => 2_000,
         pid: 5_252,
@@ -1079,7 +1083,7 @@ describe("OpenClaw smoke lock cleanup", () => {
       );
 
       await expect(
-        acquireOpenClawCrablineSmokeRunLock(params, {
+        acquireOpenClawCrablineProviderReadinessLock(params, {
           isProcessAlive: () => true,
           getProcessIdentity: () => "test:prior",
           leaseMs: 1_000,
@@ -1087,7 +1091,7 @@ describe("OpenClaw smoke lock cleanup", () => {
           pid: 5_252,
           processStartedAtMs: 200,
         }),
-      ).rejects.toThrow("OpenClaw Crabline smoke is already running");
+      ).rejects.toThrow("OpenClaw Crabline provider readiness is already running");
     } finally {
       await disposeTempDir(outputDir);
     }
@@ -1119,7 +1123,7 @@ describe("OpenClaw smoke lock cleanup", () => {
       await fs.utimes(ownerPath, new Date(1_000), new Date(1_000));
 
       await expect(
-        acquireOpenClawCrablineSmokeRunLock(params, {
+        acquireOpenClawCrablineProviderReadinessLock(params, {
           getProcessIdentity: () => coarseIdentity,
           isProcessAlive: () => true,
           leaseMs: 1_000,
@@ -1127,7 +1131,7 @@ describe("OpenClaw smoke lock cleanup", () => {
           pid: 5_252,
           processStartedAtMs: 200,
         }),
-      ).rejects.toThrow("OpenClaw Crabline smoke is already running");
+      ).rejects.toThrow("OpenClaw Crabline provider readiness is already running");
     } finally {
       await disposeTempDir(outputDir);
     }
@@ -1158,7 +1162,7 @@ describe("OpenClaw smoke lock cleanup", () => {
       );
       await fs.utimes(ownerPath, new Date(1_000), new Date(1_000));
 
-      const replacementLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+      const replacementLock = await acquireOpenClawCrablineProviderReadinessLock(params, {
         getProcessIdentity: () => coarseIdentity,
         isProcessAlive: () => true,
         leaseMs: 1_000,
@@ -1203,7 +1207,7 @@ describe("OpenClaw smoke lock cleanup", () => {
       await fs.utimes(ownerPath, new Date(1_000), new Date(1_000));
 
       await expect(
-        acquireOpenClawCrablineSmokeRunLock(params, {
+        acquireOpenClawCrablineProviderReadinessLock(params, {
           getProcessIdentity: () => coarseIdentity,
           getProcessIdentityV2: () => preciseIdentity,
           isProcessAlive: () => true,
@@ -1212,7 +1216,7 @@ describe("OpenClaw smoke lock cleanup", () => {
           pid: 5_252,
           processStartedAtMs: 200,
         }),
-      ).rejects.toThrow("OpenClaw Crabline smoke is already running");
+      ).rejects.toThrow("OpenClaw Crabline provider readiness is already running");
     } finally {
       await disposeTempDir(outputDir);
     }
@@ -1241,7 +1245,7 @@ describe("OpenClaw smoke lock cleanup", () => {
         { mode: 0o600 },
       );
 
-      const replacementLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+      const replacementLock = await acquireOpenClawCrablineProviderReadinessLock(params, {
         getProcessIdentity: () => "darwin:1783864000.123456:Sun Jul 12 16:04:00 2026",
         getProcessIdentityV2: () => "darwin:1783864000.123456:us:1783872240900000",
         isProcessAlive: () => true,
@@ -1280,7 +1284,7 @@ describe("OpenClaw smoke lock cleanup", () => {
         { mode: 0o600 },
       );
 
-      const replacementLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+      const replacementLock = await acquireOpenClawCrablineProviderReadinessLock(params, {
         getProcessIdentity: () => null,
         isProcessAlive: () => false,
         leaseMs: 1_000,
@@ -1318,7 +1322,7 @@ describe("OpenClaw smoke lock cleanup", () => {
         { mode: 0o600 },
       );
 
-      const replacementLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+      const replacementLock = await acquireOpenClawCrablineProviderReadinessLock(params, {
         getProcessIdentity: () => "test:replacement",
         isProcessAlive: () => true,
         leaseMs: 1_000,
@@ -1356,7 +1360,7 @@ describe("OpenClaw smoke lock cleanup", () => {
         { mode: 0o600 },
       );
 
-      const replacementLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+      const replacementLock = await acquireOpenClawCrablineProviderReadinessLock(params, {
         getProcessIdentity: () => null,
         isProcessAlive: () => true,
         leaseMs: 1_000,
@@ -1396,7 +1400,7 @@ describe("OpenClaw smoke lock cleanup", () => {
         { mode: 0o600 },
       );
 
-      const replacementLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+      const replacementLock = await acquireOpenClawCrablineProviderReadinessLock(params, {
         getProcessIdentity: () => darwinIdentity,
         isProcessAlive: () => true,
         leaseMs: 1_000,
@@ -1431,11 +1435,11 @@ describe("OpenClaw smoke lock cleanup", () => {
       );
 
       await expect(
-        acquireOpenClawCrablineSmokeRunLock(
+        acquireOpenClawCrablineProviderReadinessLock(
           { channel: "telegram", outputDir },
           { isProcessAlive: () => true, now: () => 1_000, pid: 5_252 },
         ),
-      ).rejects.toThrow("OpenClaw Crabline smoke lock owner metadata is malformed.");
+      ).rejects.toThrow("OpenClaw Crabline provider readiness lock owner metadata is malformed.");
     } finally {
       await disposeTempDir(outputDir);
     }
@@ -1463,14 +1467,14 @@ describe("OpenClaw smoke lock cleanup", () => {
       await fs.utimes(ownerPath, new Date(1_000), new Date(1_000));
 
       await expect(
-        acquireOpenClawCrablineSmokeRunLock(params, {
+        acquireOpenClawCrablineProviderReadinessLock(params, {
           isProcessAlive: () => true,
           leaseMs: 1_000,
           now: () => 3_001,
           pid: 5_252,
           processStartedAtMs: 200,
         }),
-      ).rejects.toThrow("OpenClaw Crabline smoke is already running");
+      ).rejects.toThrow("OpenClaw Crabline provider readiness is already running");
     } finally {
       await disposeTempDir(outputDir);
     }
@@ -1485,10 +1489,10 @@ describe("OpenClaw smoke lock cleanup", () => {
     let suspendedMarkerDirectory = "";
     let suspendedOwnerDirectory = "";
     let replacementLock:
-      | Awaited<ReturnType<typeof acquireOpenClawCrablineSmokeRunLock>>
+      | Awaited<ReturnType<typeof acquireOpenClawCrablineProviderReadinessLock>>
       | undefined;
     try {
-      const lock = await acquireOpenClawCrablineSmokeRunLock(params, {
+      const lock = await acquireOpenClawCrablineProviderReadinessLock(params, {
         isProcessAlive: () => true,
         leaseMs: 1_000,
         now: () => now,
@@ -1517,8 +1521,8 @@ describe("OpenClaw smoke lock cleanup", () => {
       await fs.rename(ownerDirectory, suspendedOwnerDirectory);
       await fs.rename(markerDirectory, suspendedMarkerDirectory);
       now = 2_600;
-      await expect(renew!()).rejects.toThrow("smoke lock ownership was lost");
-      replacementLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+      await expect(renew!()).rejects.toThrow("provider readiness lock ownership was lost");
+      replacementLock = await acquireOpenClawCrablineProviderReadinessLock(params, {
         isProcessAlive: () => true,
         leaseMs: 1_000,
         now: () => 2_600,
@@ -1547,7 +1551,7 @@ describe("OpenClaw smoke lock cleanup", () => {
     let now = 1_000;
     let renew: (() => Promise<void>) | undefined;
     try {
-      const lock = await acquireOpenClawCrablineSmokeRunLock(params, {
+      const lock = await acquireOpenClawCrablineProviderReadinessLock(params, {
         isProcessAlive: () => true,
         leaseMs: 1_000,
         now: () => now,
@@ -1561,7 +1565,7 @@ describe("OpenClaw smoke lock cleanup", () => {
 
       now = 2_001;
       await expect(
-        acquireOpenClawCrablineSmokeRunLock(params, {
+        acquireOpenClawCrablineProviderReadinessLock(params, {
           beforeRecoveryDeleteClaim: async () => {
             now = 1_999;
             await renew!();
@@ -1574,7 +1578,7 @@ describe("OpenClaw smoke lock cleanup", () => {
           processStartedAtMs: 200,
           startHeartbeat: disableHeartbeat,
         }),
-      ).rejects.toThrow("OpenClaw Crabline smoke is already running");
+      ).rejects.toThrow("OpenClaw Crabline provider readiness is already running");
 
       await expect(fs.stat(await findOwnedLockDirectory(outputDir))).resolves.toBeDefined();
       await lock.release();
@@ -1599,7 +1603,7 @@ describe("OpenClaw smoke lock cleanup", () => {
     let now = 1_000;
     let commitPromise: Promise<void> | undefined;
     try {
-      const lock = await acquireOpenClawCrablineSmokeRunLock(params, {
+      const lock = await acquireOpenClawCrablineProviderReadinessLock(params, {
         beforeCommitFileRename: async () => {
           commitClaimed?.();
           await allowCommitPromise;
@@ -1625,7 +1629,7 @@ describe("OpenClaw smoke lock cleanup", () => {
 
       now = 2_001;
       await expect(
-        acquireOpenClawCrablineSmokeRunLock(params, {
+        acquireOpenClawCrablineProviderReadinessLock(params, {
           beforeRecoveryDeleteClaim: async () => {
             now = 1_999;
             await renew!();
@@ -1638,7 +1642,7 @@ describe("OpenClaw smoke lock cleanup", () => {
           processStartedAtMs: 200,
           startHeartbeat: disableHeartbeat,
         }),
-      ).rejects.toThrow("OpenClaw Crabline smoke is already running");
+      ).rejects.toThrow("OpenClaw Crabline provider readiness is already running");
 
       const lockClaims = (await fs.readdir(outputDir)).filter((entry) => entry.includes(".lock."));
       expect(lockClaims.filter((entry) => entry.includes(".commit."))).toHaveLength(1);
@@ -1671,7 +1675,7 @@ describe("OpenClaw smoke lock cleanup", () => {
     let oldCommit: Promise<void> | undefined;
     try {
       await fs.mkdir(stageDirectory);
-      const oldLock = await acquireOpenClawCrablineSmokeRunLock(
+      const oldLock = await acquireOpenClawCrablineProviderReadinessLock(
         { channel: "telegram", outputDir },
         {
           beforeCommitRename: async () => {
@@ -1697,7 +1701,7 @@ describe("OpenClaw smoke lock cleanup", () => {
       await oldCommitReadyPromise;
 
       now = 2_001;
-      const successorLock = await acquireOpenClawCrablineSmokeRunLock(
+      const successorLock = await acquireOpenClawCrablineProviderReadinessLock(
         { channel: "telegram", outputDir },
         {
           isProcessAlive: () => true,
@@ -1738,7 +1742,7 @@ describe("OpenClaw smoke lock cleanup", () => {
     let failCommitClaim = true;
     try {
       await fs.mkdir(stageDirectory);
-      const lock = await acquireOpenClawCrablineSmokeRunLock(
+      const lock = await acquireOpenClawCrablineProviderReadinessLock(
         { channel: "telegram", outputDir },
         {
           beforeCommitClaim: async () => {
@@ -1773,7 +1777,7 @@ describe("OpenClaw smoke lock cleanup", () => {
     const outputDir = await createTempDir();
     let now = 1_000;
     try {
-      const expiredLock = await acquireOpenClawCrablineSmokeRunLock(
+      const expiredLock = await acquireOpenClawCrablineProviderReadinessLock(
         { channel: "telegram", outputDir },
         {
           isProcessAlive: () => true,
@@ -1792,7 +1796,7 @@ describe("OpenClaw smoke lock cleanup", () => {
       );
 
       now = 2_001;
-      const successorLock = await acquireOpenClawCrablineSmokeRunLock(
+      const successorLock = await acquireOpenClawCrablineProviderReadinessLock(
         { channel: "telegram", outputDir },
         {
           isProcessAlive: () => true,
@@ -1821,7 +1825,7 @@ describe("OpenClaw smoke lock cleanup", () => {
     const params = { channel: "telegram" as const, outputDir };
     const confirmationSleep = vi.fn(async (_delayMs: number) => undefined);
     try {
-      const firstLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+      const firstLock = await acquireOpenClawCrablineProviderReadinessLock(params, {
         isProcessAlive: () => true,
         leaseMs: 1_000,
         now: () => 1_000,
@@ -1831,16 +1835,16 @@ describe("OpenClaw smoke lock cleanup", () => {
       });
 
       await expect(
-        acquireOpenClawCrablineSmokeRunLock(params, {
+        acquireOpenClawCrablineProviderReadinessLock(params, {
           isProcessAlive: () => true,
           leaseMs: 1_000,
           now: () => 1_999,
           pid: 5_252,
           processStartedAtMs: 200,
         }),
-      ).rejects.toThrow("OpenClaw Crabline smoke is already running");
+      ).rejects.toThrow("OpenClaw Crabline provider readiness is already running");
 
-      const replacementLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+      const replacementLock = await acquireOpenClawCrablineProviderReadinessLock(params, {
         isProcessAlive: () => true,
         leaseMs: 1_000,
         now: () => 2_001,
@@ -1863,7 +1867,7 @@ describe("OpenClaw smoke lock cleanup", () => {
     const outputDir = await createTempDir();
     const params = { channel: "telegram" as const, outputDir };
     try {
-      const firstLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+      const firstLock = await acquireOpenClawCrablineProviderReadinessLock(params, {
         isProcessAlive: () => true,
         leaseMs: 1_000,
         now: () => 1_000,
@@ -1884,7 +1888,7 @@ describe("OpenClaw smoke lock cleanup", () => {
       );
       await fs.utimes(compatibilityOwnerPath, future, future);
 
-      const replacementLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+      const replacementLock = await acquireOpenClawCrablineProviderReadinessLock(params, {
         isProcessAlive: () => true,
         leaseMs: 1_000,
         now: () => 2_000,
@@ -1906,7 +1910,7 @@ describe("OpenClaw smoke lock cleanup", () => {
     let now = 1_000;
     let renew: (() => Promise<void>) | undefined;
     try {
-      const firstLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+      const firstLock = await acquireOpenClawCrablineProviderReadinessLock(params, {
         isProcessAlive: () => true,
         leaseMs: 1_000,
         now: () => now,
@@ -1920,7 +1924,7 @@ describe("OpenClaw smoke lock cleanup", () => {
 
       now = 100_000;
       await expect(
-        acquireOpenClawCrablineSmokeRunLock(params, {
+        acquireOpenClawCrablineProviderReadinessLock(params, {
           isProcessAlive: () => true,
           leaseMs: 1_000,
           now: () => now,
@@ -1931,7 +1935,7 @@ describe("OpenClaw smoke lock cleanup", () => {
           },
           startHeartbeat: disableHeartbeat,
         }),
-      ).rejects.toThrow("OpenClaw Crabline smoke is already running");
+      ).rejects.toThrow("OpenClaw Crabline provider readiness is already running");
 
       await firstLock.release();
     } finally {
@@ -1945,7 +1949,7 @@ describe("OpenClaw smoke lock cleanup", () => {
     let now = 100_000;
     let renew: (() => Promise<void>) | undefined;
     try {
-      const firstLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+      const firstLock = await acquireOpenClawCrablineProviderReadinessLock(params, {
         isProcessAlive: () => true,
         leaseMs: 1_000,
         now: () => now,
@@ -1960,7 +1964,7 @@ describe("OpenClaw smoke lock cleanup", () => {
       now = 1_000;
       await renew!();
       await expect(
-        acquireOpenClawCrablineSmokeRunLock(params, {
+        acquireOpenClawCrablineProviderReadinessLock(params, {
           isProcessAlive: () => true,
           leaseMs: 1_000,
           now: () => now,
@@ -1971,7 +1975,7 @@ describe("OpenClaw smoke lock cleanup", () => {
           },
           startHeartbeat: disableHeartbeat,
         }),
-      ).rejects.toThrow("OpenClaw Crabline smoke is already running");
+      ).rejects.toThrow("OpenClaw Crabline provider readiness is already running");
 
       await firstLock.release();
     } finally {
@@ -1983,7 +1987,7 @@ describe("OpenClaw smoke lock cleanup", () => {
     const outputDir = await createTempDir();
     const params = { channel: "telegram" as const, outputDir };
     try {
-      const lock = await acquireOpenClawCrablineSmokeRunLock(params, {
+      const lock = await acquireOpenClawCrablineProviderReadinessLock(params, {
         startHeartbeat: disableHeartbeat,
       });
       const ownerPath = path.join(await findOwnedLockDirectory(outputDir), "owner.json");
@@ -1993,7 +1997,9 @@ describe("OpenClaw smoke lock cleanup", () => {
         await fs.writeFile(ownerPath, owner);
       });
 
-      await expect(releaseOpenClawCrablineSmokeRunLock(lock, { sleep })).resolves.toBeUndefined();
+      await expect(
+        releaseOpenClawCrablineProviderReadinessLock(lock, { sleep }),
+      ).resolves.toBeUndefined();
       expect(sleep).toHaveBeenCalledTimes(1);
     } finally {
       await disposeTempDir(outputDir);
@@ -2005,7 +2011,7 @@ describe("OpenClaw smoke lock cleanup", () => {
     const params = { channel: "telegram" as const, outputDir };
     let runHeartbeat: (() => Promise<void>) | undefined;
     try {
-      const lock = await acquireOpenClawCrablineSmokeRunLock(params, {
+      const lock = await acquireOpenClawCrablineProviderReadinessLock(params, {
         startHeartbeat: (renew) => {
           let failure: unknown;
           let pending: Promise<void> | undefined;
@@ -2018,7 +2024,7 @@ describe("OpenClaw smoke lock cleanup", () => {
           return {
             assertHealthy() {
               if (failure !== undefined) {
-                throw new Error("OpenClaw Crabline smoke lock heartbeat failed.", {
+                throw new Error("OpenClaw Crabline provider readiness lock heartbeat failed.", {
                   cause: failure,
                 });
               }
@@ -2048,7 +2054,7 @@ describe("OpenClaw smoke lock cleanup", () => {
             await fs.writeFile(filePath, contents);
           },
         }),
-      ).rejects.toThrow("OpenClaw Crabline smoke lock heartbeat failed.");
+      ).rejects.toThrow("OpenClaw Crabline provider readiness lock heartbeat failed.");
 
       await fs.writeFile(ownerPath, owner);
       await expect(lock.release()).resolves.toBeUndefined();
@@ -2069,9 +2075,9 @@ describe("OpenClaw smoke lock cleanup", () => {
     const markerRenewalStartedPromise = new Promise<void>((resolve) => {
       markerRenewalStarted = resolve;
     });
-    let lock: Awaited<ReturnType<typeof acquireOpenClawCrablineSmokeRunLock>> | undefined;
+    let lock: Awaited<ReturnType<typeof acquireOpenClawCrablineProviderReadinessLock>> | undefined;
     try {
-      lock = await acquireOpenClawCrablineSmokeRunLock(params, {
+      lock = await acquireOpenClawCrablineProviderReadinessLock(params, {
         beforeCompatibilityMarkerRenew: async () => {
           markerRenewalStarted?.();
           await markerRenewalGate;
@@ -2107,7 +2113,7 @@ describe("OpenClaw smoke lock cleanup", () => {
       });
       expect((await fs.stat(compatibilityOwnerPath)).mtimeMs).toBeCloseTo(1, 0);
 
-      const replacementLock = await acquireOpenClawCrablineSmokeRunLock(params, {
+      const replacementLock = await acquireOpenClawCrablineProviderReadinessLock(params, {
         startHeartbeat: disableHeartbeat,
       });
       await replacementLock.release();
@@ -2128,7 +2134,7 @@ describe("OpenClaw smoke lock cleanup", () => {
       allowScheduledRenewal = resolve;
     });
     try {
-      const lock = await acquireOpenClawCrablineSmokeRunLock(params, {
+      const lock = await acquireOpenClawCrablineProviderReadinessLock(params, {
         beforeCommitFileRename: async () => {
           startScheduledRenewal?.();
         },
@@ -2144,7 +2150,7 @@ describe("OpenClaw smoke lock cleanup", () => {
           return {
             assertHealthy() {
               if (failure !== undefined) {
-                throw new Error("OpenClaw Crabline smoke lock heartbeat failed.", {
+                throw new Error("OpenClaw Crabline provider readiness lock heartbeat failed.", {
                   cause: failure,
                 });
               }
@@ -2181,7 +2187,7 @@ describe("OpenClaw smoke lock cleanup", () => {
             await fs.writeFile(filePath, contents);
           },
         }),
-      ).rejects.toThrow("OpenClaw Crabline smoke lock heartbeat failed.");
+      ).rejects.toThrow("OpenClaw Crabline provider readiness lock heartbeat failed.");
       await expect(fs.stat(destinationPath)).rejects.toMatchObject({ code: "ENOENT" });
       await lock.release();
     } finally {

--- a/test/openclaw-provider-readiness-lock.test.ts
+++ b/test/openclaw-provider-readiness-lock.test.ts
@@ -560,12 +560,9 @@ describe("OpenClaw provider readiness lock cleanup", () => {
       );
 
       const ownedDirectory = await findOwnedLockDirectory(outputDir);
-      const compatibilityDirectory = path.join(
-        outputDir,
-        `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`,
-      );
+      const reservationDirectory = path.join(outputDir, `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`);
       expect(await fs.readdir(ownedDirectory)).toEqual(expect.arrayContaining(["owner.json"]));
-      expect(await fs.readdir(compatibilityDirectory)).toEqual(
+      expect(await fs.readdir(reservationDirectory)).toEqual(
         expect.arrayContaining(["owner.json"]),
       );
 
@@ -627,7 +624,7 @@ describe("OpenClaw provider readiness lock cleanup", () => {
         acquireOpenClawCrablineProviderReadinessLock(
           { channel: "telegram", outputDir },
           {
-            afterLockOwnerWrite: async (candidateDirectory) => {
+            afterLockReservationWrite: async (candidateDirectory) => {
               displacedPath = `${candidateDirectory}.displaced`;
               await fs.rename(candidateDirectory, displacedPath);
               await fs.mkdir(candidateDirectory);
@@ -679,7 +676,7 @@ describe("OpenClaw provider readiness lock cleanup", () => {
     }
   });
 
-  it("retires an installed compatibility marker when owner-claim setup fails", async () => {
+  it("removes an installed reservation when owner-claim setup fails", async () => {
     const outputDir = await createTempDir();
     const params = { channel: "telegram" as const, outputDir };
     const setupFailure = new Error("owner claim setup failed");
@@ -697,17 +694,9 @@ describe("OpenClaw provider readiness lock cleanup", () => {
           entry.startsWith(`.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock.owned.`),
         ),
       ).toEqual([]);
-      const compatibilityOwnerPath = path.join(
-        outputDir,
-        `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`,
-        "owner.json",
-      );
-      expect(JSON.parse(await fs.readFile(compatibilityOwnerPath, "utf8"))).toMatchObject({
-        createdAtMs: 1,
-        pid: 2_147_483_647,
-        processStartedAtMs: 1,
-      });
-      expect((await fs.stat(compatibilityOwnerPath)).mtimeMs).toBeCloseTo(1, 0);
+      await expect(
+        fs.access(path.join(outputDir, `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`)),
+      ).rejects.toMatchObject({ code: "ENOENT" });
 
       const sleep = vi.fn(async () => undefined);
       const replacementLock = await acquireOpenClawCrablineProviderReadinessLock(params, {
@@ -775,7 +764,7 @@ describe("OpenClaw provider readiness lock cleanup", () => {
       );
 
       await expect(lock.release()).resolves.toBeUndefined();
-      expect(removeDirectory).toHaveBeenCalledTimes(2);
+      expect(removeDirectory).toHaveBeenCalledTimes(3);
 
       const nextLock = await acquireOpenClawCrablineProviderReadinessLock(params);
       await expect(nextLock.release()).resolves.toBeUndefined();
@@ -895,7 +884,7 @@ describe("OpenClaw provider readiness lock cleanup", () => {
   it("does not transiently relocate a successor while its heartbeat runs", async () => {
     const outputDir = await createTempDir();
     const params = { channel: "telegram" as const, outputDir };
-    let suspendedMarkerDirectory = "";
+    let suspendedReservationDirectory = "";
     let suspendedOwnerDirectory = "";
     let resumeRelease: (() => void) | undefined;
     let releaseValidated: (() => void) | undefined;
@@ -922,13 +911,13 @@ describe("OpenClaw provider readiness lock cleanup", () => {
         outputDir,
         `.suspended-${path.basename(oldOwnerDirectory)}`,
       );
-      const markerDirectory = path.join(outputDir, `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`);
-      suspendedMarkerDirectory = path.join(outputDir, ".suspended-compatibility-marker");
+      const reservationDirectory = path.join(outputDir, `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`);
+      suspendedReservationDirectory = path.join(outputDir, ".suspended-reservation");
       const oldRelease = oldLock.release();
       await releaseValidatedPromise;
 
       await fs.rename(oldOwnerDirectory, suspendedOwnerDirectory);
-      await fs.rename(markerDirectory, suspendedMarkerDirectory);
+      await fs.rename(reservationDirectory, suspendedReservationDirectory);
       successorLock = await acquireOpenClawCrablineProviderReadinessLock(params, {
         startHeartbeat: (renew, intervalMs) => {
           successorRenew = renew;
@@ -941,15 +930,15 @@ describe("OpenClaw provider readiness lock cleanup", () => {
       await expect(successorRenew!()).resolves.toBeUndefined();
       await expect(successorLock.assertOwned()).resolves.toBeUndefined();
       await expect(fs.stat(await findOwnedLockDirectory(outputDir))).resolves.toBeDefined();
-      await expect(fs.stat(markerDirectory)).resolves.toBeDefined();
+      await expect(fs.stat(reservationDirectory)).resolves.toBeDefined();
     } finally {
       resumeRelease?.();
       await successorLock?.release();
       if (suspendedOwnerDirectory) {
         await fs.rm(suspendedOwnerDirectory, { force: true, recursive: true });
       }
-      if (suspendedMarkerDirectory) {
-        await fs.rm(suspendedMarkerDirectory, { force: true, recursive: true });
+      if (suspendedReservationDirectory) {
+        await fs.rm(suspendedReservationDirectory, { force: true, recursive: true });
       }
       await disposeTempDir(outputDir);
     }
@@ -1017,14 +1006,13 @@ describe("OpenClaw provider readiness lock cleanup", () => {
     }
   });
 
-  it("keeps an active legacy-format lock owned by its live PID", async () => {
+  it("rejects an unversioned minimal owner record", async () => {
     const outputDir = await createTempDir();
     const params = { channel: "telegram" as const, outputDir };
     const lockDirectory = path.join(
       path.resolve(outputDir),
       `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`,
     );
-    let legacyOwnerAlive = true;
     try {
       await fs.mkdir(lockDirectory, { mode: 0o700 });
       await fs.writeFile(
@@ -1032,7 +1020,7 @@ describe("OpenClaw provider readiness lock cleanup", () => {
         `${JSON.stringify({
           channel: "telegram",
           pid: 4_242,
-          token: "legacy",
+          token: "unversioned",
         })}\n`,
         { mode: 0o600 },
       );
@@ -1040,27 +1028,18 @@ describe("OpenClaw provider readiness lock cleanup", () => {
 
       await expect(
         acquireOpenClawCrablineProviderReadinessLock(params, {
-          isProcessAlive: () => legacyOwnerAlive,
+          isProcessAlive: () => true,
           now: () => 2_000,
           pid: 5_252,
           processStartedAtMs: 200,
         }),
-      ).rejects.toThrow("OpenClaw Crabline provider readiness is already running");
-
-      legacyOwnerAlive = false;
-      const replacementLock = await acquireOpenClawCrablineProviderReadinessLock(params, {
-        isProcessAlive: () => legacyOwnerAlive,
-        now: () => 2_000,
-        pid: 5_252,
-        processStartedAtMs: 200,
-      });
-      await replacementLock.release();
+      ).rejects.toThrow("OpenClaw Crabline provider readiness lock owner metadata is malformed.");
     } finally {
       await disposeTempDir(outputDir);
     }
   });
 
-  it("keeps an active pre-heartbeat owner beyond its original lease age", async () => {
+  it("rejects an unversioned process-identified owner record", async () => {
     const outputDir = await createTempDir();
     const params = { channel: "telegram" as const, outputDir };
     const lockDirectory = path.join(
@@ -1091,13 +1070,13 @@ describe("OpenClaw provider readiness lock cleanup", () => {
           pid: 5_252,
           processStartedAtMs: 200,
         }),
-      ).rejects.toThrow("OpenClaw Crabline provider readiness is already running");
+      ).rejects.toThrow("OpenClaw Crabline provider readiness lock owner metadata is malformed.");
     } finally {
       await disposeTempDir(outputDir);
     }
   });
 
-  it("matches a recent legacy Darwin owner using its stable coarse identity", async () => {
+  it("matches a recent canonical Darwin owner using its stable coarse identity", async () => {
     const outputDir = await createTempDir();
     const params = { channel: "telegram" as const, outputDir };
     const lockDirectory = path.join(
@@ -1113,6 +1092,7 @@ describe("OpenClaw provider readiness lock cleanup", () => {
         `${JSON.stringify({
           channel: "telegram",
           createdAtMs: 1_000,
+          lockVersion: 1,
           pid: 4_242,
           processIdentity: coarseIdentity,
           processStartedAtMs: 100,
@@ -1153,6 +1133,7 @@ describe("OpenClaw provider readiness lock cleanup", () => {
         `${JSON.stringify({
           channel: "telegram",
           createdAtMs: 1_000,
+          lockVersion: 1,
           pid: 4_242,
           processIdentity: coarseIdentity,
           processStartedAtMs: 100,
@@ -1179,7 +1160,7 @@ describe("OpenClaw provider readiness lock cleanup", () => {
     }
   });
 
-  it("keeps a stale remote owner when its precise Darwin identity is verified", async () => {
+  it("reclaims a stale canonical owner when its precise Darwin identity is verified", async () => {
     const outputDir = await createTempDir();
     const params = { channel: "telegram" as const, outputDir };
     const lockDirectory = path.join(
@@ -1196,6 +1177,7 @@ describe("OpenClaw provider readiness lock cleanup", () => {
         `${JSON.stringify({
           channel: "telegram",
           createdAtMs: 1_000,
+          lockVersion: 1,
           pid: 4_242,
           processIdentity: coarseIdentity,
           processIdentityV2: preciseIdentity,
@@ -1206,17 +1188,18 @@ describe("OpenClaw provider readiness lock cleanup", () => {
       );
       await fs.utimes(ownerPath, new Date(1_000), new Date(1_000));
 
-      await expect(
-        acquireOpenClawCrablineProviderReadinessLock(params, {
-          getProcessIdentity: () => coarseIdentity,
-          getProcessIdentityV2: () => preciseIdentity,
-          isProcessAlive: () => true,
-          leaseMs: 1_000,
-          now: () => 10_000,
-          pid: 5_252,
-          processStartedAtMs: 200,
-        }),
-      ).rejects.toThrow("OpenClaw Crabline provider readiness is already running");
+      const replacementLock = await acquireOpenClawCrablineProviderReadinessLock(params, {
+        getProcessIdentity: () => coarseIdentity,
+        getProcessIdentityV2: () => preciseIdentity,
+        isProcessAlive: () => true,
+        leaseMs: 1_000,
+        now: () => 10_000,
+        pid: 5_252,
+        processStartedAtMs: 200,
+        startHeartbeat: disableHeartbeat,
+      });
+      await expect(replacementLock.assertOwned()).resolves.toBeUndefined();
+      await replacementLock.release();
     } finally {
       await disposeTempDir(outputDir);
     }
@@ -1236,6 +1219,7 @@ describe("OpenClaw provider readiness lock cleanup", () => {
         `${JSON.stringify({
           channel: "telegram",
           createdAtMs: 1_000,
+          lockVersion: 1,
           pid: 4_242,
           processIdentity: "darwin:1783864000.123456:Sun Jul 12 16:04:00 2026",
           processIdentityV2: "darwin:1783864000.123456:us:1783872240100000",
@@ -1263,7 +1247,7 @@ describe("OpenClaw provider readiness lock cleanup", () => {
     }
   });
 
-  it("reclaims a dead pre-heartbeat owner when its start time is unavailable", async () => {
+  it("reclaims a dead canonical owner when its start time is unavailable", async () => {
     const outputDir = await createTempDir();
     const params = { channel: "telegram" as const, outputDir };
     const lockDirectory = path.join(
@@ -1277,6 +1261,7 @@ describe("OpenClaw provider readiness lock cleanup", () => {
         `${JSON.stringify({
           channel: "telegram",
           createdAtMs: 1_000,
+          lockVersion: 1,
           pid: 4_242,
           processStartedAtMs: 100,
           token: "prior",
@@ -1300,7 +1285,7 @@ describe("OpenClaw provider readiness lock cleanup", () => {
     }
   });
 
-  it("reclaims a pre-heartbeat lock after its PID is reused", async () => {
+  it("reclaims a canonical lock after its PID is reused", async () => {
     const outputDir = await createTempDir();
     const params = { channel: "telegram" as const, outputDir };
     const lockDirectory = path.join(
@@ -1314,6 +1299,7 @@ describe("OpenClaw provider readiness lock cleanup", () => {
         `${JSON.stringify({
           channel: "telegram",
           createdAtMs: 1_000,
+          lockVersion: 1,
           pid: 4_242,
           processIdentity: "test:prior",
           processStartedAtMs: 100,
@@ -1352,6 +1338,7 @@ describe("OpenClaw provider readiness lock cleanup", () => {
         `${JSON.stringify({
           channel: "telegram",
           createdAtMs: 1_000,
+          lockVersion: 1,
           pid: 4_242,
           processIdentity: "test:prior",
           processStartedAtMs: 100,
@@ -1392,6 +1379,7 @@ describe("OpenClaw provider readiness lock cleanup", () => {
         `${JSON.stringify({
           channel: "telegram",
           createdAtMs: 1_000,
+          lockVersion: 1,
           pid: 4_242,
           processIdentity: darwinIdentity,
           processStartedAtMs: 100,
@@ -1445,48 +1433,13 @@ describe("OpenClaw provider readiness lock cleanup", () => {
     }
   });
 
-  it("keeps an expired legacy lock while its PID is still alive", async () => {
-    const outputDir = await createTempDir();
-    const params = { channel: "telegram" as const, outputDir };
-    const lockDirectory = path.join(
-      path.resolve(outputDir),
-      `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`,
-    );
-    const ownerPath = path.join(lockDirectory, "owner.json");
-    try {
-      await fs.mkdir(lockDirectory, { mode: 0o700 });
-      await fs.writeFile(
-        ownerPath,
-        `${JSON.stringify({
-          channel: "telegram",
-          pid: 4_242,
-          token: "legacy",
-        })}\n`,
-        { mode: 0o600 },
-      );
-      await fs.utimes(ownerPath, new Date(1_000), new Date(1_000));
-
-      await expect(
-        acquireOpenClawCrablineProviderReadinessLock(params, {
-          isProcessAlive: () => true,
-          leaseMs: 1_000,
-          now: () => 3_001,
-          pid: 5_252,
-          processStartedAtMs: 200,
-        }),
-      ).rejects.toThrow("OpenClaw Crabline provider readiness is already running");
-    } finally {
-      await disposeTempDir(outputDir);
-    }
-  });
-
   it("does not renew a lock after its owned claim is moved", async () => {
     const outputDir = await createTempDir();
     const params = { channel: "telegram" as const, outputDir };
     let now = 1_000;
     let renew: (() => Promise<void>) | undefined;
     const stop = vi.fn(async () => undefined);
-    let suspendedMarkerDirectory = "";
+    let suspendedReservationDirectory = "";
     let suspendedOwnerDirectory = "";
     let replacementLock:
       | Awaited<ReturnType<typeof acquireOpenClawCrablineProviderReadinessLock>>
@@ -1508,18 +1461,21 @@ describe("OpenClaw provider readiness lock cleanup", () => {
       now = 1_800;
       await renew!();
       const ownerDirectory = await findOwnedLockDirectory(outputDir);
-      const markerDirectory = path.join(outputDir, `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`);
-      const markerOwnerPath = path.join(markerDirectory, "owner.json");
+      const reservationDirectory = path.join(outputDir, `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`);
+      const reservationOwnerPath = path.join(reservationDirectory, "owner.json");
       const ownedOwner = JSON.parse(
         await fs.readFile(path.join(ownerDirectory, "owner.json"), "utf8"),
       );
-      const markerOwner = JSON.parse(await fs.readFile(markerOwnerPath, "utf8"));
-      expect(markerOwner.token).toBe(ownedOwner.token);
-      expect((await fs.stat(markerOwnerPath)).mtimeMs).toBeCloseTo(1_800, 0);
+      const reservationOwner = JSON.parse(await fs.readFile(reservationOwnerPath, "utf8"));
+      expect(reservationOwner.token).toBe(ownedOwner.token);
+      expect(
+        (await fs.stat(path.join(reservationDirectory, `lease.${reservationOwner.token}.json`)))
+          .mtimeMs,
+      ).toBeCloseTo(1_800, 0);
       suspendedOwnerDirectory = path.join(outputDir, `.suspended-${path.basename(ownerDirectory)}`);
-      suspendedMarkerDirectory = path.join(outputDir, ".suspended-compatibility-marker");
+      suspendedReservationDirectory = path.join(outputDir, ".suspended-reservation");
       await fs.rename(ownerDirectory, suspendedOwnerDirectory);
-      await fs.rename(markerDirectory, suspendedMarkerDirectory);
+      await fs.rename(reservationDirectory, suspendedReservationDirectory);
       now = 2_600;
       await expect(renew!()).rejects.toThrow("provider readiness lock ownership was lost");
       replacementLock = await acquireOpenClawCrablineProviderReadinessLock(params, {
@@ -1538,8 +1494,8 @@ describe("OpenClaw provider readiness lock cleanup", () => {
       if (suspendedOwnerDirectory) {
         await fs.rm(suspendedOwnerDirectory, { force: true, recursive: true });
       }
-      if (suspendedMarkerDirectory) {
-        await fs.rm(suspendedMarkerDirectory, { force: true, recursive: true });
+      if (suspendedReservationDirectory) {
+        await fs.rm(suspendedReservationDirectory, { force: true, recursive: true });
       }
       await disposeTempDir(outputDir);
     }
@@ -1659,7 +1615,7 @@ describe("OpenClaw provider readiness lock cleanup", () => {
     }
   });
 
-  it("fences an expired commit after a successor replaces its compatibility marker", async () => {
+  it("fences an expired commit after a successor replaces its reservation", async () => {
     const outputDir = await createTempDir();
     const stageDirectory = path.join(outputDir, "artifacts");
     const destinationPath = path.join(stageDirectory, "current.json");
@@ -1876,7 +1832,7 @@ describe("OpenClaw provider readiness lock cleanup", () => {
         startHeartbeat: disableHeartbeat,
       });
       const future = new Date(10_000);
-      const compatibilityOwnerPath = path.join(
+      const reservationOwnerPath = path.join(
         outputDir,
         `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`,
         "owner.json",
@@ -1886,7 +1842,7 @@ describe("OpenClaw provider readiness lock cleanup", () => {
         future,
         future,
       );
-      await fs.utimes(compatibilityOwnerPath, future, future);
+      await fs.utimes(reservationOwnerPath, future, future);
 
       const replacementLock = await acquireOpenClawCrablineProviderReadinessLock(params, {
         isProcessAlive: () => true,
@@ -2063,24 +2019,24 @@ describe("OpenClaw provider readiness lock cleanup", () => {
     }
   });
 
-  it("drains an in-flight renewal before retiring the compatibility marker", async () => {
+  it("drains an in-flight renewal before removing the reservation", async () => {
     const outputDir = await createTempDir();
     const params = { channel: "telegram" as const, outputDir };
-    let allowMarkerRenewal: (() => void) | undefined;
-    let markerRenewalStarted: (() => void) | undefined;
+    let allowReservationRenewal: (() => void) | undefined;
+    let reservationRenewalStarted: (() => void) | undefined;
     let renew: (() => Promise<void>) | undefined;
-    const markerRenewalGate = new Promise<void>((resolve) => {
-      allowMarkerRenewal = resolve;
+    const reservationRenewalGate = new Promise<void>((resolve) => {
+      allowReservationRenewal = resolve;
     });
-    const markerRenewalStartedPromise = new Promise<void>((resolve) => {
-      markerRenewalStarted = resolve;
+    const reservationRenewalStartedPromise = new Promise<void>((resolve) => {
+      reservationRenewalStarted = resolve;
     });
     let lock: Awaited<ReturnType<typeof acquireOpenClawCrablineProviderReadinessLock>> | undefined;
     try {
       lock = await acquireOpenClawCrablineProviderReadinessLock(params, {
-        beforeCompatibilityMarkerRenew: async () => {
-          markerRenewalStarted?.();
-          await markerRenewalGate;
+        beforeReservationRenew: async () => {
+          reservationRenewalStarted?.();
+          await reservationRenewalGate;
         },
         startHeartbeat: (heartbeat, intervalMs) => {
           renew = heartbeat;
@@ -2088,7 +2044,7 @@ describe("OpenClaw provider readiness lock cleanup", () => {
         },
       });
       const renewal = renew!();
-      await markerRenewalStartedPromise;
+      await reservationRenewalStartedPromise;
 
       let releaseSettled = false;
       const release = lock.release().then(() => {
@@ -2097,28 +2053,20 @@ describe("OpenClaw provider readiness lock cleanup", () => {
       await new Promise<void>((resolve) => setImmediate(resolve));
       expect(releaseSettled).toBe(false);
 
-      allowMarkerRenewal?.();
+      allowReservationRenewal?.();
       await renewal;
       await release;
 
-      const compatibilityOwnerPath = path.join(
-        outputDir,
-        `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`,
-        "owner.json",
-      );
-      expect(JSON.parse(await fs.readFile(compatibilityOwnerPath, "utf8"))).toMatchObject({
-        createdAtMs: 1,
-        pid: 2_147_483_647,
-        processStartedAtMs: 1,
-      });
-      expect((await fs.stat(compatibilityOwnerPath)).mtimeMs).toBeCloseTo(1, 0);
+      await expect(
+        fs.access(path.join(outputDir, `.${OPENCLAW_CRABLINE_MANIFEST_PATH}.lock`)),
+      ).rejects.toMatchObject({ code: "ENOENT" });
 
       const replacementLock = await acquireOpenClawCrablineProviderReadinessLock(params, {
         startHeartbeat: disableHeartbeat,
       });
       await replacementLock.release();
     } finally {
-      allowMarkerRenewal?.();
+      allowReservationRenewal?.();
       await lock?.release().catch(() => undefined);
       await disposeTempDir(outputDir);
     }

--- a/test/openclaw-provider-readiness-lock.test.ts
+++ b/test/openclaw-provider-readiness-lock.test.ts
@@ -1679,7 +1679,7 @@ describe("OpenClaw provider readiness lock cleanup", () => {
 
       allowOldCommit?.();
       await expect(oldCommit).rejects.toThrow(
-        "Private directory path identity changed during publication.",
+        "OpenClaw Crabline provider readiness lock reservation was lost.",
       );
       await expect(fs.readFile(destinationPath, "utf8")).resolves.toBe("successor\n");
       await oldLock.release();

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -5,31 +5,23 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
-  CRABLINE_FAKE_PROVIDER_CHANNELS,
   CRABLINE_SERVER_CHANNELS,
   createOpenClawCrablineAgentDelivery,
   createOpenClawCrablineChannelReportNotes,
-  createOpenClawCrablineFakeProviderBinding,
   createOpenClawCrablineProviderBinding,
   createOpenClawCrablineInbound,
   createOpenClawCrablineOutboundFromRecorderEvent as translateOpenClawCrablineOutbound,
-  isCrablineFakeProviderChannel,
   isCrablineServerChannel,
   OPENCLAW_CRABLINE_ARTIFACT_POINTER_PATH,
   OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY,
   OPENCLAW_CRABLINE_CHANNEL_CAPABILITY_MATRIX_PATH,
-  OPENCLAW_CRABLINE_CHANNEL_SMOKE_PATH,
   OPENCLAW_CRABLINE_PROVIDER_READINESS_PATH,
   OPENCLAW_CRABLINE_MANIFEST_PATH,
-  probeOpenClawCrablineFakeProvider,
   probeOpenClawCrablineProvider,
   resolveOpenClawCrablineChannelDriverSelection,
-  runOpenClawCrablineChannelDriverSmoke,
   runOpenClawCrablineProviderReadiness,
-  startCrablineFakeProviderServer,
   startCrablineServer,
   startOpenClawCrablineAdapter,
-  type CrablineFakeProviderManifest,
   type CrablineServerManifest,
   type OpenClawCrablineChannelDriverSelection,
   type OpenClawCrablineConversation,
@@ -82,11 +74,14 @@ function createOpenClawCrablineOutboundFromRecorderEvent(
   });
 }
 
-function startSmokeLockHolder(outputDir: string, channel: string): ChildProcessWithoutNullStreams {
-  const lockModuleUrl = new URL("../src/openclaw/smoke-lock.ts", import.meta.url).href;
+function startProviderReadinessLockHolder(
+  outputDir: string,
+  channel: string,
+): ChildProcessWithoutNullStreams {
+  const lockModuleUrl = new URL("../src/openclaw/provider-readiness-lock.ts", import.meta.url).href;
   const script = `
-    import { acquireOpenClawCrablineSmokeRunLock } from ${JSON.stringify(lockModuleUrl)};
-    const lock = await acquireOpenClawCrablineSmokeRunLock({
+    import { acquireOpenClawCrablineProviderReadinessLock } from ${JSON.stringify(lockModuleUrl)};
+    const lock = await acquireOpenClawCrablineProviderReadinessLock({
       channel: process.argv[2],
       outputDir: process.argv[1],
     });
@@ -102,13 +97,13 @@ function startSmokeLockHolder(outputDir: string, channel: string): ChildProcessW
   );
 }
 
-async function waitForSmokeLock(child: ChildProcessWithoutNullStreams): Promise<void> {
+async function waitForProviderReadinessLock(child: ChildProcessWithoutNullStreams): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     let stdout = "";
     let stderr = "";
     const timeout = setTimeout(() => {
       cleanup();
-      reject(new Error(`Timed out waiting for smoke lock holder. stderr: ${stderr}`));
+      reject(new Error(`Timed out waiting for provider readiness lock holder. stderr: ${stderr}`));
     }, 10_000);
     const cleanup = () => {
       clearTimeout(timeout);
@@ -130,7 +125,7 @@ async function waitForSmokeLock(child: ChildProcessWithoutNullStreams): Promise<
       cleanup();
       reject(
         new Error(
-          `Smoke lock holder exited before acquiring the lock (code=${code}, signal=${signal}). stderr: ${stderr}`,
+          `Provider readiness lock holder exited before acquiring the lock (code=${code}, signal=${signal}). stderr: ${stderr}`,
         ),
       );
     };
@@ -333,7 +328,7 @@ describe("OpenClaw local provider bridge", () => {
         return {
           accountId: this.label,
           channel: this.label,
-          createChannelDriverSmokeEnv: (env: NodeJS.ProcessEnv) => env,
+          createProviderReadinessEnv: (env: NodeJS.ProcessEnv) => env,
           createGatewayConfig: () => ({}),
           requiredPluginIds: [],
         };
@@ -399,19 +394,17 @@ describe("OpenClaw local provider bridge", () => {
     expect(channelConfig.streaming === undefined || isRecord(channelConfig.streaming)).toBe(true);
   });
 
-  it("keeps legacy fake-provider root aliases", () => {
-    const legacyManifest: CrablineFakeProviderManifest = manifest;
+  it("exposes canonical server APIs and conversation types", () => {
     const conversation: OpenClawCrablineConversation = {
       id: "alice",
       kind: "direct",
     };
 
-    expect(CRABLINE_FAKE_PROVIDER_CHANNELS).toBe(CRABLINE_SERVER_CHANNELS);
-    expect(isCrablineFakeProviderChannel).toBe(isCrablineServerChannel);
-    expect(startCrablineFakeProviderServer).toBe(startCrablineServer);
-    expect(createOpenClawCrablineFakeProviderBinding).toBe(createOpenClawCrablineProviderBinding);
-    expect(probeOpenClawCrablineFakeProvider).toBe(probeOpenClawCrablineProvider);
-    expect(legacyManifest.provider).toBe("telegram");
+    expect(CRABLINE_SERVER_CHANNELS).toContain("telegram");
+    expect(isCrablineServerChannel("telegram")).toBe(true);
+    expect(startCrablineServer).toEqual(expect.any(Function));
+    expect(createOpenClawCrablineProviderBinding).toEqual(expect.any(Function));
+    expect(probeOpenClawCrablineProvider).toEqual(expect.any(Function));
     expect(conversation).toEqual({ id: "alice", kind: "direct" });
   });
 
@@ -676,23 +669,20 @@ describe("OpenClaw local provider bridge", () => {
   });
 
   it("resolves channel-driver metadata through Crabline", () => {
-    expect(OPENCLAW_CRABLINE_CHANNEL_SMOKE_PATH).toBe(OPENCLAW_CRABLINE_PROVIDER_READINESS_PATH);
-    expect(runOpenClawCrablineChannelDriverSmoke).toBe(runOpenClawCrablineProviderReadiness);
     expect(resolveOpenClawCrablineChannelDriverSelection({})).toEqual({
       capabilityMatrixPath: OPENCLAW_CRABLINE_CHANNEL_CAPABILITY_MATRIX_PATH,
       channel: "telegram",
       channelDriver: "crabline",
       providerReadinessArtifactPath: OPENCLAW_CRABLINE_PROVIDER_READINESS_PATH,
-      smokeArtifactPath: OPENCLAW_CRABLINE_PROVIDER_READINESS_PATH,
     });
-    const legacySelection: OpenClawCrablineChannelDriverSelection = {
+    const selection: OpenClawCrablineChannelDriverSelection = {
       capabilityMatrixPath: OPENCLAW_CRABLINE_CHANNEL_CAPABILITY_MATRIX_PATH,
       channel: "telegram",
       channelDriver: "crabline",
-      smokeArtifactPath: OPENCLAW_CRABLINE_CHANNEL_SMOKE_PATH,
+      providerReadinessArtifactPath: OPENCLAW_CRABLINE_PROVIDER_READINESS_PATH,
     };
-    expect(createOpenClawCrablineChannelReportNotes(legacySelection)[3]).toBe(
-      "Generation provider-readiness filename: crabline-fake-provider-smoke.json.",
+    expect(createOpenClawCrablineChannelReportNotes(selection)[3]).toBe(
+      "Generation provider-readiness filename: crabline-provider-readiness.json.",
     );
     expect(resolveOpenClawCrablineChannelDriverSelection({ channel: " TELEGRAM " })).toMatchObject({
       channel: "telegram",
@@ -733,7 +723,7 @@ describe("OpenClaw local provider bridge", () => {
       channel: "zalo",
       requiredPluginIds: ["zalo"],
     });
-    expect(binding.createChannelDriverSmokeEnv({ EXISTING: "value" })).toMatchObject({
+    expect(binding.createProviderReadinessEnv({ EXISTING: "value" })).toMatchObject({
       EXISTING: "value",
       ZALO_API_URL: "http://127.0.0.1:7531",
       ZALO_BOT_TOKEN: "crabline-zalo-bot-token",
@@ -908,7 +898,7 @@ describe("OpenClaw local provider bridge", () => {
         },
       },
     });
-    expect(binding.createChannelDriverSmokeEnv({})).toMatchObject({
+    expect(binding.createProviderReadinessEnv({})).toMatchObject({
       TELEGRAM_BOT_TOKEN: "424242:crabline-telegram-token",
     });
   });
@@ -948,7 +938,7 @@ describe("OpenClaw local provider bridge", () => {
         },
       },
     });
-    expect(binding.createChannelDriverSmokeEnv({})).toMatchObject({
+    expect(binding.createProviderReadinessEnv({})).toMatchObject({
       CRABLINE_WHATSAPP_ADMIN_TOKEN: "crabline-whatsapp-admin-token",
       CRABLINE_WHATSAPP_RECORDER_PATH: "/tmp/crabline/whatsapp.jsonl",
       CRABLINE_WHATSAPP_SELF_JID: "15550000000@s.whatsapp.net",
@@ -990,7 +980,7 @@ describe("OpenClaw local provider bridge", () => {
         },
       },
     });
-    expect(binding.createChannelDriverSmokeEnv({})).toMatchObject({
+    expect(binding.createProviderReadinessEnv({})).toMatchObject({
       SLACK_API_URL: "http://127.0.0.1:2468/api/",
       SLACK_BOT_TOKEN: "xoxb-crabline-slack-token",
       SLACK_SIGNING_SECRET: "crabline-slack-signing-secret",
@@ -3088,8 +3078,8 @@ describe("OpenClaw local provider bridge", () => {
   it("accepts exact provider API route evidence without claiming OpenClaw execution", async () => {
     const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-provider-readiness-"));
     try {
-      const legacyManifestPath = path.join(outputDir, OPENCLAW_CRABLINE_MANIFEST_PATH);
-      await fs.writeFile(legacyManifestPath, "permissive stale manifest\n", { mode: 0o666 });
+      const unmanagedManifestPath = path.join(outputDir, OPENCLAW_CRABLINE_MANIFEST_PATH);
+      await fs.writeFile(unmanagedManifestPath, "permissive unmanaged manifest\n", { mode: 0o666 });
       const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
       const result = await runProviderReadinessWithDependencies(
         {
@@ -3134,12 +3124,6 @@ describe("OpenClaw local provider bridge", () => {
             ok: true,
             proof: "provider-api-probe",
             provider: "telegram",
-            ready: true,
-          },
-        },
-        smoke: {
-          result: {
-            ok: true,
             ready: true,
           },
         },
@@ -3198,7 +3182,7 @@ describe("OpenClaw local provider bridge", () => {
         manifestPath: result.manifestPath,
         selectedChannel: "telegram",
         source: "openclaw/crabline",
-        version: 1,
+        version: 2,
         providerReadiness: {
           manifestPath: result.manifestPath,
           result: {
@@ -3209,7 +3193,7 @@ describe("OpenClaw local provider bridge", () => {
             recorderPath: path.join(
               OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY,
               result.generation,
-              "telegram-fake-provider.jsonl",
+              "telegram-provider-server.jsonl",
             ),
             probe: {
               ok: true,
@@ -3218,12 +3202,6 @@ describe("OpenClaw local provider bridge", () => {
                 username: "crabline_bot",
               },
             },
-          },
-        },
-        smoke: {
-          result: {
-            ok: true,
-            ready: true,
           },
         },
       });
@@ -3235,7 +3213,7 @@ describe("OpenClaw local provider bridge", () => {
         path.join(
           OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY,
           result.generation,
-          "telegram-fake-provider.jsonl",
+          "telegram-provider-server.jsonl",
         ),
       );
       await expect(
@@ -3246,7 +3224,9 @@ describe("OpenClaw local provider bridge", () => {
           entry.endsWith(".tmp"),
         ),
       ).toEqual([]);
-      expect(await fs.readFile(legacyManifestPath, "utf8")).toBe("permissive stale manifest\n");
+      expect(await fs.readFile(unmanagedManifestPath, "utf8")).toBe(
+        "permissive unmanaged manifest\n",
+      );
       const manifestMode = (await fs.stat(path.join(outputDir, result.manifestPath))).mode & 0o777;
       const expectedMode = process.platform === "win32" ? manifestMode : 0o600;
       expect(manifestMode).toBe(expectedMode);
@@ -3256,9 +3236,9 @@ describe("OpenClaw local provider bridge", () => {
       });
       expect(createOpenClawCrablineChannelReportNotes(selection)).toEqual([
         "Channel driver: crabline local provider for telegram.",
-        "Channel artifact pointer: .crabline-smoke-artifacts/current.json.",
-        "Generation capability filename: crabline-fake-provider-capabilities.json.",
-        "Generation provider-readiness filename: crabline-fake-provider-smoke.json.",
+        "Channel artifact pointer: .crabline-channel-driver-artifacts/current.json.",
+        "Generation capability filename: crabline-channel-driver-capabilities.json.",
+        "Generation provider-readiness filename: crabline-provider-readiness.json.",
         "Crabline verifies the local provider API is ready; OpenClaw channel behavior is proven separately by QA scenarios that run the real channel adapter.",
       ]);
     } finally {
@@ -3525,7 +3505,7 @@ describe("OpenClaw local provider bridge", () => {
       const externalDirectory = await fs.mkdtemp(
         path.join(os.tmpdir(), "crabline-recorder-external-"),
       );
-      const staleName = ".telegram-fake-provider.11111111-1111-4111-8111-111111111111.jsonl.tmp";
+      const staleName = ".telegram-provider-server.11111111-1111-4111-8111-111111111111.jsonl.tmp";
       const sentinelPath = path.join(externalDirectory, staleName);
       const startAdapter = vi.fn<typeof startOpenClawCrablineAdapter>();
       try {
@@ -3560,15 +3540,16 @@ describe("OpenClaw local provider bridge", () => {
   it("reclaims only exact stale readiness recorder temporaries", async () => {
     const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-recorder-recovery-"));
     const recorderDirectory = path.join(outputDir, "artifacts", "crabline");
-    const staleTelegram = ".telegram-fake-provider.11111111-1111-4111-8111-111111111111.jsonl.tmp";
-    const staleSlack = ".slack-fake-provider.22222222-2222-4222-8222-222222222222.jsonl.tmp";
+    const staleTelegram =
+      ".telegram-provider-server.11111111-1111-4111-8111-111111111111.jsonl.tmp";
+    const staleSlack = ".slack-provider-server.22222222-2222-4222-8222-222222222222.jsonl.tmp";
     const staleTelegramLock = `${staleTelegram}.lock`;
-    const lookalike = ".telegram-fake-provider.not-a-uuid.jsonl.tmp";
+    const lookalike = ".telegram-provider-server.not-a-uuid.jsonl.tmp";
     const lookalikeLock = `${staleTelegram}.lock.extra`;
     const unrelatedLock = "unrelated.lock";
     const lookalikeTombstone = `.${staleTelegramLock}.1234.not-a-uuid.remove`;
     const matchingDirectory =
-      ".telegram-fake-provider.33333333-3333-4333-8333-333333333333.jsonl.tmp";
+      ".telegram-provider-server.33333333-3333-4333-8333-333333333333.jsonl.tmp";
     const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
     try {
       await fs.mkdir(path.join(recorderDirectory, matchingDirectory), { recursive: true });
@@ -3632,7 +3613,8 @@ describe("OpenClaw local provider bridge", () => {
   it("reclaims recorder lock tombstones after interrupted removal", async () => {
     const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-recorder-lock-retry-"));
     const recorderDirectory = path.join(outputDir, "artifacts", "crabline");
-    const lockName = ".telegram-fake-provider.55555555-5555-4555-8555-555555555555.jsonl.tmp.lock";
+    const lockName =
+      ".telegram-provider-server.55555555-5555-4555-8555-555555555555.jsonl.tmp.lock";
     const removalFailure = new Error("simulated recorder lock tombstone removal interruption");
     const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
     let rmSpy: ReturnType<typeof vi.spyOn> | undefined;
@@ -3671,7 +3653,7 @@ describe("OpenClaw local provider bridge", () => {
       );
       expect(retainedTombstones).toHaveLength(1);
       expect(retainedTombstones[0]).toMatch(
-        /^\.\.telegram-fake-provider\.55555555-5555-4555-8555-555555555555\.jsonl\.tmp\.lock\.\d+\.[0-9a-f-]{36}\.remove$/u,
+        /^\.\.telegram-provider-server\.55555555-5555-4555-8555-555555555555\.jsonl\.tmp\.lock\.\d+\.[0-9a-f-]{36}\.remove$/u,
       );
 
       await runProviderReadinessWithDependencies({ outputDir, selection }, { startAdapter });
@@ -3692,7 +3674,7 @@ describe("OpenClaw local provider bridge", () => {
       const recorderDirectory = path.join(outputDir, "artifacts", "crabline");
       const targetDirectory = path.join(outputDir, "external-lock-target");
       const lockName =
-        ".telegram-fake-provider.44444444-4444-4444-8444-444444444444.jsonl.tmp.lock";
+        ".telegram-provider-server.44444444-4444-4444-8444-444444444444.jsonl.tmp.lock";
       const lockPath = path.join(recorderDirectory, lockName);
       const tombstoneName = `.${lockName}.1234.66666666-6666-4666-8666-666666666666.remove`;
       const tombstonePath = path.join(recorderDirectory, tombstoneName);
@@ -3756,7 +3738,9 @@ describe("OpenClaw local provider bridge", () => {
       await publicationStarted;
       await expect(
         runOpenClawCrablineProviderReadiness({ outputDir, selection: slack }),
-      ).rejects.toThrow('OpenClaw Crabline smoke is already running for channel "telegram"');
+      ).rejects.toThrow(
+        'OpenClaw Crabline provider readiness is already running for channel "telegram"',
+      );
       resumePublication?.();
       await first;
 
@@ -3828,14 +3812,14 @@ describe("OpenClaw local provider bridge", () => {
         },
       });
       expect(result.warnings).toEqual([
-        "OpenClaw Crabline smoke committed but lock cleanup failed: lock release retries exhausted",
+        "OpenClaw Crabline provider readiness committed but lock cleanup failed: lock release retries exhausted",
       ]);
     } finally {
       await fs.rm(outputDir, { recursive: true, force: true });
     }
   });
 
-  it("preserves the primary smoke failure when lock cleanup also fails", async () => {
+  it("preserves the primary readiness failure when lock cleanup also fails", async () => {
     const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-openclaw-errors-"));
     const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
     const primaryFailure = new Error("probe failed");
@@ -3866,10 +3850,12 @@ describe("OpenClaw local provider bridge", () => {
     }
   });
 
-  it("preserves a frozen smoke failure when lock cleanup also fails", async () => {
-    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-openclaw-frozen-smoke-"));
+  it("preserves a frozen readiness failure when lock cleanup also fails", async () => {
+    const outputDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "crabline-openclaw-frozen-readiness-"),
+    );
     const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
-    const primaryFailure = Object.freeze(new Error("frozen smoke failure"));
+    const primaryFailure = Object.freeze(new Error("frozen readiness failure"));
     try {
       await expect(
         runProviderReadinessWithDependencies(
@@ -4071,21 +4057,21 @@ describe("OpenClaw local provider bridge", () => {
     }
   });
 
-  it("rejects cross-process smoke runs that share an output artifact set", async () => {
+  it("rejects concurrent provider-readiness runs that share an output artifact set", async () => {
     const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-openclaw-overlap-"));
-    const holder = startSmokeLockHolder(outputDir, "telegram");
+    const holder = startProviderReadinessLockHolder(outputDir, "telegram");
     try {
-      await waitForSmokeLock(holder);
+      await waitForProviderReadinessLock(holder);
       const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
       const otherSelection = resolveOpenClawCrablineChannelDriverSelection({ channel: "slack" });
 
       await expect(runOpenClawCrablineProviderReadiness({ outputDir, selection })).rejects.toThrow(
-        `OpenClaw Crabline smoke is already running for channel "telegram" in "${outputDir}"; cannot start channel "telegram".`,
+        `OpenClaw Crabline provider readiness is already running for channel "telegram" in "${outputDir}"; cannot start channel "telegram".`,
       );
       await expect(
         runOpenClawCrablineProviderReadiness({ outputDir, selection: otherSelection }),
       ).rejects.toThrow(
-        `OpenClaw Crabline smoke is already running for channel "telegram" in "${outputDir}"; cannot start channel "slack".`,
+        `OpenClaw Crabline provider readiness is already running for channel "telegram" in "${outputDir}"; cannot start channel "slack".`,
       );
 
       const holderExit = once(holder, "exit");
@@ -4107,11 +4093,11 @@ describe("OpenClaw local provider bridge", () => {
     }
   });
 
-  it("recovers a smoke lock abandoned by a terminated process", async () => {
+  it("recovers a provider readiness lock abandoned by a terminated process", async () => {
     const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-openclaw-stale-lock-"));
-    const holder = startSmokeLockHolder(outputDir, "telegram");
+    const holder = startProviderReadinessLockHolder(outputDir, "telegram");
     try {
-      await waitForSmokeLock(holder);
+      await waitForProviderReadinessLock(holder);
       const holderExit = once(holder, "exit");
       holder.kill("SIGKILL");
       await holderExit;

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -256,7 +256,6 @@ const whatsappManifest: CrablineServerManifest = {
     baileysWebSocketUrl: "ws://127.0.0.1:5678/ws/chat?access_token=crabline-whatsapp-access-token",
     messagesUrl: "http://127.0.0.1:5678/v25.0/100000000000000/messages",
     phoneNumberUrl: "http://127.0.0.1:5678/v25.0/100000000000000",
-    statusUrl: "http://127.0.0.1:5678/v25.0/100000000000000/messages",
   },
   env: {
     CLOUD_API_ACCESS_TOKEN: "crabline-whatsapp-access-token",

--- a/test/package-production.test.ts
+++ b/test/package-production.test.ts
@@ -10,7 +10,6 @@ const execFileAsync = promisify(execFile);
 const DEV_ONLY_RUNTIME_PACKAGES = ["baileys"] as const;
 const PUBLIC_RUNTIME_EXPORTS = [
   "BUILTIN_ADAPTERS",
-  "CRABLINE_FAKE_PROVIDER_CHANNELS",
   "CRABLINE_SERVER_CHANNELS",
   "FIXTURE_MODES",
   "INBOUND_AUTHORS",
@@ -20,7 +19,6 @@ const PUBLIC_RUNTIME_EXPORTS = [
   "OPENCLAW_CRABLINE_ARTIFACT_POINTER_PATH",
   "OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY",
   "OPENCLAW_CRABLINE_CHANNEL_CAPABILITY_MATRIX_PATH",
-  "OPENCLAW_CRABLINE_CHANNEL_SMOKE_PATH",
   "OPENCLAW_CRABLINE_DEFAULT_CHANNEL",
   "OPENCLAW_CRABLINE_MANIFEST_PATH",
   "OPENCLAW_CRABLINE_PROVIDER_READINESS_PATH",
@@ -29,40 +27,30 @@ const PUBLIC_RUNTIME_EXPORTS = [
   "ProviderConfigSchema",
   "createOpenClawCrablineAgentDelivery",
   "createOpenClawCrablineChannelReportNotes",
-  "createOpenClawCrablineFakeProviderBinding",
   "createOpenClawCrablineInbound",
   "createOpenClawCrablineOutboundFromRecorderEvent",
   "createOpenClawCrablineProviderBinding",
   "createRegistry",
-  "isCrablineFakeProviderChannel",
   "isCrablineServerChannel",
-  "probeOpenClawCrablineFakeProvider",
   "probeOpenClawCrablineProvider",
   "resolveOpenClawCrablineChannel",
   "resolveOpenClawCrablineChannelDriverSelection",
   "resolveTelegramAdapterConfig",
   "resolveWhatsAppAdapterConfig",
-  "runOpenClawCrablineChannelDriverSmoke",
   "runOpenClawCrablineProviderReadiness",
-  "startCrablineFakeProviderServer",
   "startCrablineServer",
   "startMatrixServer",
   "startMattermostServer",
   "startOpenClawCrablineAdapter",
   "startSignalServer",
-  "startSlackFakeServer",
   "startSlackServer",
-  "startTelegramFakeServer",
   "startTelegramServer",
-  "startWhatsAppFakeServer",
   "startWhatsAppServer",
   "startZaloServer",
 ] as const;
 const PUBLIC_TYPE_EXPORTS = [
   "BuiltinAdapterId",
   "CatalogEntry",
-  "CrablineFakeProviderChannel",
-  "CrablineFakeProviderManifest",
   "CrablineServerChannel",
   "CrablineServerManifest",
   "FixtureDefinition",
@@ -74,7 +62,6 @@ const PUBLIC_TYPE_EXPORTS = [
   "NormalizedTarget",
   "OpenClawCrablineAgentDelivery",
   "OpenClawCrablineChannelDriverSelection",
-  "OpenClawCrablineChannelDriverSmokeResult",
   "OpenClawCrablineConversation",
   "OpenClawCrablineGatewayBinding",
   "OpenClawCrablineInbound",
@@ -93,40 +80,29 @@ const PUBLIC_TYPE_EXPORTS = [
   "ServerEventObserver",
   "ServerRequestEvent",
   "SignalServerManifest",
-  "SlackFakeServerManifest",
   "SlackServerManifest",
-  "StartedCrablineFakeProviderServer",
   "StartedCrablineServer",
   "StartedMattermostServer",
   "StartedMatrixServer",
   "StartedOpenClawCrablineAdapter",
   "StartedSignalServer",
-  "StartedSlackFakeServer",
   "StartedSlackServer",
-  "StartedTelegramFakeServer",
   "StartedTelegramServer",
-  "StartedWhatsAppFakeServer",
   "StartedWhatsAppServer",
   "StartedZaloServer",
-  "StartCrablineFakeProviderServerParams",
   "StartCrablineServerParams",
   "StartMattermostServerParams",
   "StartMatrixServerParams",
   "StartOpenClawCrablineAdapterParams",
   "StartSignalServerParams",
-  "StartSlackFakeServerParams",
   "StartSlackServerParams",
-  "StartTelegramFakeServerParams",
   "StartTelegramServerParams",
-  "StartWhatsAppFakeServerParams",
   "StartWhatsAppServerParams",
   "StartZaloServerParams",
-  "TelegramFakeServerManifest",
   "TelegramServerManifest",
   "WaitContext",
   "WatchContext",
   "WhatsAppBaileysMessage",
-  "WhatsAppFakeServerManifest",
   "WhatsAppServerManifest",
   "ZaloServerManifest",
 ] as const;
@@ -136,6 +112,14 @@ const IMPORT_PATTERNS = DEV_ONLY_RUNTIME_PACKAGES.map(
       String.raw`(?:from\s+["']${escapeRegex(packageName)}["']|import\(\s*["']${escapeRegex(packageName)}["']\s*\)|require\(\s*["']${escapeRegex(packageName)}["']\s*\))`,
       "u",
     ),
+);
+const OBSOLETE_SERVER_DECLARATION_PATTERN = new RegExp(
+  [
+    ["fake", "provider"].join("[-_ ]?"),
+    ["fake", "server"].join("[-_ ]?"),
+    ["channel", "driver", "smoke"].join("[^A-Za-z0-9]*"),
+  ].join("|"),
+  "iu",
 );
 
 describe("production package", () => {
@@ -303,6 +287,19 @@ describe("production package", () => {
       );
       expect(JSON.parse(importOutput) as string[]).toEqual(PUBLIC_RUNTIME_EXPORTS);
 
+      const declarationFiles = files.filter(
+        (file) => file.startsWith("dist/src/") && file.endsWith(".d.ts"),
+      );
+      expect(declarationFiles).not.toEqual([]);
+      await Promise.all(
+        declarationFiles.map(async (file) => {
+          const contents = await fs.readFile(path.join(root, file), "utf8");
+          expect(contents, `${file} contains an obsolete server declaration`).not.toMatch(
+            OBSOLETE_SERVER_DECLARATION_PATTERN,
+          );
+        }),
+      );
+
       await fs.writeFile(
         path.join(consumerDirectory, "consumer.ts"),
         [
@@ -310,17 +307,7 @@ describe("production package", () => {
           `import type { ${PUBLIC_TYPE_EXPORTS.join(", ")} } from "@openclaw/crabline";`,
           "const start: typeof startCrablineServer = startCrablineServer;",
           `type PublicTypes = [${PUBLIC_TYPE_EXPORTS.join(", ")}];`,
-          "const legacySmokeResult: OpenClawCrablineChannelDriverSmokeResult = {",
-          '  artifactPointerPath: "pointer.json",',
-          "  capabilityReport: {},",
-          '  capabilityMatrixPath: "capabilities.json",',
-          '  generation: "generation-legacy",',
-          '  manifestPath: "manifest.json",',
-          "  smoke: { result: { ok: true } },",
-          '  smokeArtifactPath: "smoke.json",',
-          "};",
           "declare const publicTypes: PublicTypes;",
-          "void legacySmokeResult;",
           "void start;",
           "void publicTypes;",
           "",

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -654,7 +654,7 @@ describe("whatsapp local provider server", () => {
       },
     });
 
-    const outboundStatus = await fetch(server.manifest.endpoints.statusUrl, {
+    const outboundStatus = await fetch(server.manifest.endpoints.messagesUrl, {
       body: JSON.stringify({
         message_id: sentPayload.messages[0]!.id,
         messaging_product: "whatsapp",
@@ -670,7 +670,7 @@ describe("whatsapp local provider server", () => {
     await expect(outboundStatus.json()).resolves.toMatchObject({
       error: { message: "(#100) Invalid parameter: message_id" },
     });
-    const unknownStatus = await fetch(server.manifest.endpoints.statusUrl, {
+    const unknownStatus = await fetch(server.manifest.endpoints.messagesUrl, {
       body: JSON.stringify({
         message_id: "wamid.UNKNOWN",
         messaging_product: "whatsapp",
@@ -749,7 +749,7 @@ describe("whatsapp local provider server", () => {
         object: "whatsapp_business_account",
       },
     });
-    const status = await fetch(server.manifest.endpoints.statusUrl, {
+    const status = await fetch(server.manifest.endpoints.messagesUrl, {
       body: JSON.stringify({
         message_id: inboundPayload.message.key.id,
         messaging_product: "whatsapp",


### PR DESCRIPTION
## What Problem This Solves

Crabline's local provider-server/OpenClaw channel-driver integration still exposed obsolete `fake-provider` aliases, fallback artifact schemas, duplicate fields, and legacy artifact names. That made the public package and generated declarations describe one runtime architecture with two vocabularies.

## Why This Change Was Made

This is a clean break to the canonical server API and provider-readiness artifact contract. It removes the aliases and fallback readers outright, publishes only the current artifact schema, and renames recorder, lock, and artifact paths around local provider servers and the Crabline channel driver. It does not change Crabline's separate fixture-level local mock provider feature.

Landing order: this Crabline PR, a separately authorized exact npm release, then the dependent OpenClaw terminology PR. A separate Crabline Discord provider-server prerequisite/release must land before the OpenClaw Discord channel-driver PR.

## User Impact

Consumers must use `CRABLINE_SERVER_CHANNELS`, `isCrablineServerChannel`, `startCrablineServer`, `createOpenClawCrablineProviderBinding`, and `probeOpenClawCrablineProvider`. Old exports, artifact paths, duplicate fields, and schema fallbacks no longer exist. Fixture commands continue to use the unchanged local mock provider adapters.

## Evidence

- Pre-edit audit: 135 legacy integration match lines across 15 tracked files, plus the two tracked `smoke-lock` filenames. Per-file counts: `CHANGELOG.md` 5; `src/index.ts` 24; `src/openclaw.ts` 10; `src/openclaw/artifact-generation.ts` 11; seven bridge files 1 each; `src/openclaw/shared.ts` 9; `test/openclaw-artifact-generation.test.ts` 6; `test/openclaw.test.ts` 37; `test/package-production.test.ts` 26.
- Post-edit audit: zero legacy integration matches in tracked contents, tracked filenames, and built `dist/**/*.d.ts`; retained legacy server-terminology count is zero.
- Fixture boundary: no diff under `src/providers`, `src/config`, or `fixtures`; the README explicitly distinguishes fixture-level local mock providers from local provider servers.
- Focused verification: 217/217 relevant OpenClaw/artifact/lock/package tests passed; the artifact subset passed 45/45.
- Full `pnpm verify`: lint, format, typecheck, oxlint, autoreview tooling, and build passed. Coverage ran 1,856 tests: 1,817 passed, 35 skipped, and four host/baseline failures remained (two Matrix timing flakes passed 36/36 on focused rerun; unchanged macOS ACL and Bash 3.2 release-workflow expectations reproduce under Node 22 and 26).
- Fresh autoreview was attempted in local staged-worktree, per-commit, and branch modes. The helper failed closed before reviewer execution: the security lock/artifact patches were classified as secret-like, while the rename-expanded branch bundle exceeded its 180 KB safety limit. No code was redacted and no safety check was bypassed; no findings were emitted. Exact-head CI and ClawSweeper remain required before human merge readiness.
- `git diff --check` passed.

No package was published and this PR must not be merged by automation.
