### PR TITLE
chore(release): prepare Crabline 0.1.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.1.13 - 2026-07-30
 
 - Add a canonical Discord local provider server and OpenClaw bridge with REST
   v10, Gateway WebSocket, admin ingress, command registration, and recorder

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/crabline",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Standalone CLI for deterministic messaging provider E2E tests",
   "homepage": "https://github.com/openclaw/crabline#readme",
   "bugs": {


### PR DESCRIPTION
## What Problem This Solves

Prepares the exact canonical Crabline release required by the merged provider-server terminology cleanup (#250), Discord local provider server (#252), and the downstream OpenClaw integration PRs.

## What Changed

- Bumps `@openclaw/crabline` from 0.1.12 to 0.1.13.
- Dates the existing Unreleased changelog block as `0.1.13 - 2026-07-30`.
- Makes no runtime or API changes beyond the already-merged work described in the changelog.

## Landing and Release Order

#250 → #252 → this release-preparation PR → maintainer-created `v0.1.13` tag/release → downstream OpenClaw PRs.

This PR does not create a tag, publish npm, or merge anything.

## Verification

- `pnpm format:check` — passed
- `pnpm typecheck` — passed
- `oxlint` — passed through `pnpm lint`
- `pnpm build` — passed
- package-production focused tests — passed
- OpenClaw bridge suite rerun — 104/104 passed
- Matrix timeout case rerun in isolation — passed
- `npm pack --dry-run --json` — produced metadata for `@openclaw/crabline@0.1.13`, including the Discord server and bridge declarations
- fresh local autoreview — clean, no actionable findings

The complete local gate reached the Python autoreview harness and stopped because the system Python is 3.9.6 while the harness requires Python 3.10+. Running coverage directly produced 1,826 passing tests and five machine/load-sensitive failures: the unchanged Bash ref-type assertion, the macOS ACL representation assertion, and three timeouts. The OpenClaw timeout suite and the remaining Matrix timeout were green when rerun without parallel load. Exact-head GitHub CI remains the authoritative full gate.
