### PR TITLE
fix(mattermost): direct messages reuse injected channels

### DIFF
--- a/src/servers/mattermost.ts
+++ b/src/servers/mattermost.ts
@@ -164,6 +164,10 @@ export function mattermostId(value: string): string {
   return createHash("sha256").update(value).digest("hex").slice(0, 26);
 }
 
+function mattermostDirectChannelName(firstUserId: string, secondUserId: string): string {
+  return [firstUserId, secondUserId].sort().join("__");
+}
+
 async function appendEvent(
   state: MattermostServerState,
   event: ServerRequestEvent,
@@ -583,11 +587,13 @@ function handleAdminInbound(params: {
   const channelName =
     readMattermostString(params.body.channelName ?? params.body.channel_name) ??
     previousChannel?.name ??
-    channelId;
+    (channelType === "D"
+      ? mattermostDirectChannelName(params.state.botUserId, senderId)
+      : channelId);
   const channelDisplayName =
     readMattermostString(params.body.channelDisplayName ?? params.body.channel_display_name) ??
     previousChannel?.display_name ??
-    channelName;
+    (channelType === "D" ? "" : channelName);
   const channel = {
     display_name: channelDisplayName,
     id: channelId,
@@ -732,7 +738,7 @@ async function handleApi(params: {
       return mattermostError("Authenticated user must belong to the direct channel", 403);
     }
     const participantIds = [...userIds].sort();
-    const channelName = participantIds.join("__");
+    const channelName = mattermostDirectChannelName(firstUserId, secondUserId);
     const existingChannel = [...state.channels.values()].find(
       (channel) => channel.type === "D" && channel.name === channelName,
     );

--- a/test/mattermost-server.test.ts
+++ b/test/mattermost-server.test.ts
@@ -877,6 +877,48 @@ describe("Mattermost local provider server", () => {
     }
   });
 
+  it("reuses an admin-injected direct channel through the native direct route", async () => {
+    const server = await startMattermostServer({
+      adminToken: "admin",
+      botToken: "fake",
+      maxCommittedChannels: 1,
+    });
+    servers.push(server);
+    const directName = [server.manifest.botUserId, USER_ID].sort().join("__");
+    const expectedChannel = {
+      display_name: "",
+      id: CHANNEL_ID,
+      name: directName,
+      type: "D",
+    };
+
+    const injected = await fetch(server.manifest.endpoints.adminInboundUrl, {
+      body: JSON.stringify({ channelId: CHANNEL_ID, senderId: USER_ID, text: "direct message" }),
+      headers: {
+        "content-type": "application/json",
+        "x-crabline-admin-token": "admin",
+      },
+      method: "POST",
+    });
+    expect(injected.status).toBe(200);
+
+    const retained = await fetch(`${server.manifest.endpoints.apiRoot}/channels/${CHANNEL_ID}`, {
+      headers: { authorization: "Bearer fake" },
+    });
+    await expect(retained.json()).resolves.toEqual(expectedChannel);
+
+    const direct = await fetch(`${server.manifest.endpoints.apiRoot}/channels/direct`, {
+      body: JSON.stringify([USER_ID, server.manifest.botUserId]),
+      headers: {
+        authorization: "Bearer fake",
+        "content-type": "application/json",
+      },
+      method: "POST",
+    });
+    expect(direct.status).toBe(201);
+    await expect(direct.json()).resolves.toEqual(expectedChannel);
+  });
+
   it("preserves unrelated retained channels when direct-channel IDs collide", async () => {
     const server = await startMattermostServer({
       adminToken: "admin",


### PR DESCRIPTION
## What Problem This Solves

Admin-injected direct messages were retained under the injected channel ID but defaulted the native Mattermost channel `name` and `display_name` to that ID. A later `POST /api/v4/channels/direct` lookup uses Mattermost's participant-derived DM name, so it could create a second channel and split one conversation across two identities.

## Why This Change Was Made

Mattermost defines a direct-channel name as the two participant IDs in lexical order joined by `__`, and stores an empty display name. Crabline now derives that identity through one helper for both admin ingress and the native direct-channel route. Explicit admin fields and previously retained channel metadata keep their existing precedence.

Authoritative contract checked at Mattermost `fbf8402d4bce027823d7788c8f48401d839f8b31`:

- [`GetDMNameFromIds`](https://github.com/mattermost/mattermost/blob/fbf8402d4bce027823d7788c8f48401d839f8b31/server/public/model/channel.go#L583-L587)
- [`CreateDirectChannel`](https://github.com/mattermost/mattermost/blob/fbf8402d4bce027823d7788c8f48401d839f8b31/server/channels/store/sqlstore/channel_store.go#L681-L693)

## User Impact

Mattermost-compatible clients now reuse the original admin-injected DM channel when they open the same direct conversation, preserving one channel ID and one conversation history.

## Evidence

- `pnpm test test/mattermost-server.test.ts` — 32 tests passed, including admin injection followed by `POST /channels/direct` with a one-channel retention limit and an exact same-channel assertion.
- `pnpm lint` — passed (format check, TypeScript test typecheck, and type-aware oxlint).
- `pnpm build` — passed.
- `$autoreview --mode local` — clean, no actionable findings; correctness 0.99.
- Production/test delta: `+9/-3` production, `+42/-0` tests.
- Exact base: `858a21c9ea7740ce1bf27bc0e351352be71e4d49`; exact head: `9fc67fa2348489f0ee805570c4941563a6ca8310`.
