### PR TITLE
fix(openclaw): logical Telegram and Mattermost targets reach provider servers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -117,6 +117,7 @@ export type {
 export type {
   OpenClawCrablineAgentDelivery,
   OpenClawCrablineChannelDriverSelection,
+  OpenClawCrablineCorrelatedAgentDelivery,
   OpenClawCrablineProviderReadinessResult,
   OpenClawCrablineConversation,
   OpenClawCrablineGatewayBinding,
@@ -124,5 +125,6 @@ export type {
   OpenClawCrablineInboundInput,
   OpenClawCrablineOutboundMessage,
   StartedOpenClawCrablineAdapter,
+  StartedOpenClawCrablineCorrelatedAdapter,
   StartOpenClawCrablineAdapterParams,
 } from "./openclaw.js";

--- a/src/openclaw.ts
+++ b/src/openclaw.ts
@@ -28,8 +28,8 @@ import {
   isRecord,
   parseQaTarget,
   runOpenClawCrablineProviderProbe,
-  type OpenClawCrablineAgentDelivery,
   type OpenClawCrablineChannelDriverSelection,
+  type OpenClawCrablineCorrelatedAgentDelivery,
   type OpenClawCrablineProviderReadinessResult,
   type OpenClawCrablineGatewayBinding,
   type OpenClawCrablineInbound,
@@ -38,7 +38,7 @@ import {
   type OpenClawCrablineProviderAdapter,
   type OpenClawCrablineProviderBridge,
   type OpenClawCrablineProviderBridgeRegistry,
-  type StartedOpenClawCrablineAdapter,
+  type StartedOpenClawCrablineCorrelatedAdapter,
   type StartOpenClawCrablineAdapterParams,
 } from "./openclaw/shared.js";
 import { publishOpenClawCrablineArtifactGeneration } from "./openclaw/artifact-generation.js";
@@ -66,6 +66,7 @@ export {
 export type {
   OpenClawCrablineAgentDelivery,
   OpenClawCrablineChannelDriverSelection,
+  OpenClawCrablineCorrelatedAgentDelivery,
   OpenClawCrablineProviderReadinessResult,
   OpenClawCrablineConversation,
   OpenClawCrablineGatewayBinding,
@@ -73,6 +74,7 @@ export type {
   OpenClawCrablineInboundInput,
   OpenClawCrablineOutboundMessage,
   StartedOpenClawCrablineAdapter,
+  StartedOpenClawCrablineCorrelatedAdapter,
   StartOpenClawCrablineAdapterParams,
 } from "./openclaw/shared.js";
 
@@ -441,7 +443,7 @@ export function createOpenClawCrablineProviderBinding(
 export function createOpenClawCrablineAgentDelivery(params: {
   manifest: CrablineServerManifest;
   target: string;
-}): OpenClawCrablineAgentDelivery {
+}): OpenClawCrablineCorrelatedAgentDelivery {
   return createOpenClawCrablineProviderAdapter(params.manifest).createAgentDelivery(
     parseQaTarget(params.target),
   );
@@ -471,7 +473,7 @@ export async function startOpenClawCrablineAdapter(
     createProviderAdapter?: typeof createOpenClawCrablineProviderAdapter;
     startServer?: (params: StartCrablineServerParams) => Promise<StartedCrablineServer>;
   } = {},
-): Promise<StartedOpenClawCrablineAdapter> {
+): Promise<StartedOpenClawCrablineCorrelatedAdapter> {
   const server: StartedCrablineServer = await (dependencies.startServer ?? startCrablineServer)({
     channel: params.channel,
     onEvent: params.onEvent,
@@ -497,6 +499,9 @@ export async function startOpenClawCrablineAdapter(
         }),
       manifest: server.manifest,
       probe: () => providerAdapter.probe(),
+      resolveInboundProviderTargetKey: ({ inbound, response }) =>
+        providerAdapter.resolveInboundProviderTargetKey?.({ inbound, response }) ??
+        inbound.providerTargetKey,
     };
   } catch (error) {
     try {

--- a/src/openclaw/bridges/discord.ts
+++ b/src/openclaw/bridges/discord.ts
@@ -103,10 +103,24 @@ export const DISCORD_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablineP
         if (parsed.threadId) {
           const threadId = discordId(parsed.threadId, "Discord thread");
           const to = `channel:${threadId}`;
-          return { channel: "discord", replyChannel: "discord", replyTo: to, to };
+          return {
+            channel: "discord",
+            providerTargetKey: providerTargetKey(threadId),
+            replyChannel: "discord",
+            replyTo: to,
+            to,
+          };
         }
         const to = `${parsed.kind === "direct" ? "user" : "channel"}:${id}`;
-        return { channel: "discord", replyChannel: "discord", replyTo: to, to };
+        return {
+          channel: "discord",
+          providerTargetKey: providerTargetKey(
+            parsed.kind === "direct" ? discordDirectChannelId(discord.botUserId, id) : id,
+          ),
+          replyChannel: "discord",
+          replyTo: to,
+          to,
+        };
       },
       createInbound(input) {
         const conversationId = discordId(input.conversation.id, "Discord conversation");

--- a/src/openclaw/bridges/matrix.ts
+++ b/src/openclaw/bridges/matrix.ts
@@ -177,6 +177,7 @@ export const MATRIX_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablinePr
         const to = `room:${roomId}`;
         return {
           channel: "matrix",
+          providerTargetKey: roomId,
           replyChannel: "matrix",
           replyTo: to,
           to,

--- a/src/openclaw/bridges/mattermost.ts
+++ b/src/openclaw/bridges/mattermost.ts
@@ -1,6 +1,7 @@
 import {
   canonicalConversationIdForInbound,
   createAdminInboundRequest,
+  createProviderIdRegistry,
   createOpenClawCrablineProviderBridge,
   DEFAULT_ACCOUNT_ID,
   isRecord,
@@ -11,29 +12,49 @@ import {
 import { mattermostId } from "../../servers/mattermost.js";
 import { throwProbeHttpError } from "./probe-response.js";
 
+const MATTERMOST_ID_PATTERN = /^[a-z0-9]{26}$/u;
+
 function nativeId(value: string, label = "Mattermost target"): string {
   const trimmed = value.trim();
-  if (!/^[a-z0-9]{26}$/u.test(trimmed)) {
+  if (!MATTERMOST_ID_PATTERN.test(trimmed)) {
     throw new Error(`${label} must be exactly 26 lowercase alphanumeric characters.`);
   }
   return trimmed;
 }
 
-function directChannelId(botUserId: string, userId: string): string {
-  return mattermostId(`dm:${[botUserId, userId].sort().join(":")}`);
+function providerId(
+  value: string,
+  label: string,
+  registry: ReturnType<typeof createProviderIdRegistry>,
+): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error(`${label} is required.`);
+  }
+  return MATTERMOST_ID_PATTERN.test(trimmed)
+    ? registry.reserveNative(trimmed)
+    : registry.resolveLogical(trimmed);
+}
+
+function directTargetKey(userId: string): string {
+  return `user:${userId}`;
 }
 
 function targetKey(channelId: string, rootId?: string): string {
   return rootId ? `${channelId}:thread:${rootId}` : channelId;
 }
 
-function threadRootId(channelId: string, value: string): string {
-  return nativeId(value, `Mattermost root post for channel ${channelId}`);
-}
-
 export const MATTERMOST_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablineProviderBridge({
   provider: "mattermost",
   createAdapter(mattermost) {
+    const createRegistry = (label: string) =>
+      createProviderIdRegistry({
+        candidate: mattermostId,
+        conflictLabel: label,
+      });
+    const userIds = createRegistry("Mattermost user target");
+    const channelIds = createRegistry("Mattermost channel target");
+    const postIds = createRegistry("Mattermost post target");
     return {
       async probe(signal) {
         const response = await fetch(`${mattermost.endpoints.apiRoot}/users/me`, {
@@ -94,9 +115,20 @@ export const MATTERMOST_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabli
         if (parsed.threadId) {
           throw new Error("Mattermost thread targets require OpenClaw QA thread forwarding.");
         }
-        const id = nativeId(parsed.id);
+        const registry = parsed.kind === "direct" ? userIds : channelIds;
+        const targetId = parsed.id.trim();
+        const id =
+          parsed.native || MATTERMOST_ID_PATTERN.test(targetId)
+            ? registry.reserveNative(nativeId(targetId))
+            : registry.resolveLogical(targetId);
         const to = parsed.kind === "direct" ? `user:${id}` : `channel:${id}`;
-        return { channel: "mattermost", replyChannel: "mattermost", replyTo: to, to };
+        return {
+          channel: "mattermost",
+          providerTargetKey: parsed.kind === "direct" ? directTargetKey(id) : id,
+          replyChannel: "mattermost",
+          replyTo: to,
+          to,
+        };
       },
       createInbound(input) {
         const kind = input.conversation.kind === "direct" ? "direct" : "group";
@@ -104,30 +136,42 @@ export const MATTERMOST_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabli
         if (!conversationId) {
           throw new Error("Mattermost conversation id is required.");
         }
-        const senderId = nativeId(input.senderId);
-        const recipientId = kind === "direct" ? nativeId(conversationId) : undefined;
+        const senderId = providerId(input.senderId, "Mattermost sender", userIds);
+        const recipientId =
+          kind === "direct"
+            ? providerId(conversationId, "Mattermost conversation", userIds)
+            : undefined;
         if (recipientId !== undefined && recipientId !== senderId) {
           throw new Error(
             "Mattermost direct conversation and sender must identify the same recipient.",
           );
         }
         const channelId =
-          kind === "direct"
-            ? directChannelId(mattermost.botUserId, senderId)
-            : nativeId(conversationId);
+          kind === "group"
+            ? providerId(conversationId, "Mattermost conversation", channelIds)
+            : undefined;
         const threadId = input.threadId?.trim();
-        const rootId = threadId ? threadRootId(channelId, threadId) : undefined;
+        const rootId = threadId
+          ? MATTERMOST_ID_PATTERN.test(threadId)
+            ? postIds.reserveNative(threadId)
+            : postIds.resolveLogical(
+                `thread:${kind === "group" ? channelId : senderId}:${threadId}`,
+              )
+          : undefined;
         return {
           ...createAdminInboundRequest(mattermost),
           providerBody: {
-            channelId,
+            ...(channelId ? { channelId } : {}),
             channelType: kind === "direct" ? "D" : "O",
             ...(rootId ? { rootId } : {}),
             senderId,
             ...(input.senderName ? { senderName: input.senderName } : {}),
             text: input.text,
           },
-          providerTargetKey: targetKey(channelId, rootId),
+          providerTargetKey:
+            kind === "direct"
+              ? targetKey(directTargetKey(senderId), rootId)
+              : targetKey(channelId!, rootId),
           qaTarget: qaTargetForInbound(input),
           stateConversation: { id: conversationId, kind },
           ...(rootId ? { threadId: rootId } : {}),
@@ -149,7 +193,19 @@ export const MATTERMOST_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabli
         if (!channelId || !text) {
           return null;
         }
-        const target = targetByProviderTarget.get(targetKey(channelId, rootId));
+        const providerTargetKey = targetKey(channelId, rootId);
+        const channel = isRecord(event.channel) ? event.channel : undefined;
+        const directUserId =
+          channel?.type === "D"
+            ? readString(channel.name)
+                ?.split("__")
+                .find((participant) => participant !== mattermost.botUserId)
+            : undefined;
+        const target =
+          targetByProviderTarget.get(providerTargetKey) ??
+          (directUserId
+            ? targetByProviderTarget.get(targetKey(directTargetKey(directUserId), rootId))
+            : undefined);
         if (!target) {
           return null;
         }
@@ -160,6 +216,17 @@ export const MATTERMOST_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabli
           text,
           to: target,
         };
+      },
+      resolveInboundProviderTargetKey({ response }) {
+        const post = isRecord(response) && isRecord(response.post) ? response.post : undefined;
+        const channelId = post ? readString(post.channel_id) : undefined;
+        const rootId = post ? readString(post.root_id) : undefined;
+        if (!channelId) {
+          throw new Error(
+            "Crabline Mattermost inbound response did not identify its provider channel.",
+          );
+        }
+        return targetKey(channelId, rootId);
       },
     };
   },

--- a/src/openclaw/bridges/signal.ts
+++ b/src/openclaw/bridges/signal.ts
@@ -122,7 +122,13 @@ export const SIGNAL_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablinePr
           throw new Error("Signal does not support thread targets.");
         }
         const to = signalTarget(parsed.kind, parsed.id);
-        return { channel: "signal", replyChannel: "signal", replyTo: to, to };
+        return {
+          channel: "signal",
+          providerTargetKey: to,
+          replyChannel: "signal",
+          replyTo: to,
+          to,
+        };
       },
       createInbound(input) {
         if (input.threadId !== undefined) {

--- a/src/openclaw/bridges/slack.ts
+++ b/src/openclaw/bridges/slack.ts
@@ -27,7 +27,7 @@ function requireSlackTargetKind(
   parsed: { kind: "direct" | "group"; native: boolean; threadId?: string },
   targetId: string,
 ): void {
-  if (parsed.native || parsed.threadId !== undefined) {
+  if ((parsed.native && parsed.kind === "direct") || parsed.threadId !== undefined) {
     return;
   }
   const nativeKind = /^[DUW]/u.test(targetId) ? "direct" : "group";
@@ -299,6 +299,7 @@ export const SLACK_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablinePro
         requireSlackTargetKind(parsed, to);
         return {
           channel: "slack",
+          providerTargetKey: slackTargetKey(to, threadTs),
           to,
           replyChannel: "slack",
           replyTo: slackTargetKey(to, threadTs),

--- a/src/openclaw/bridges/telegram.ts
+++ b/src/openclaw/bridges/telegram.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import {
   createAdminInboundRequest,
+  createProviderIdRegistry,
   createOpenClawCrablineProviderBridge,
   DEFAULT_ACCOUNT_ID,
   isRecord,
@@ -17,14 +18,13 @@ import {
 } from "../../servers/telegram-identity.js";
 import { throwProbeHttpError } from "./probe-response.js";
 
-const TELEGRAM_SYMBOLIC_ID_BASE = TELEGRAM_NATIVE_CHAT_ID_MAX + 1n;
-const TELEGRAM_SYMBOLIC_ID_RANGE = 1n << 50n;
+const TELEGRAM_SYMBOLIC_ID_RANGE = TELEGRAM_NATIVE_CHAT_ID_MAX;
 const TELEGRAM_OUTBOUND_METHOD_RE =
   /\/(sendAnimation|sendAudio|sendDocument|sendMessage|sendPhoto|sendVideo)$/iu;
 function normalizeTelegramChatId(
   kind: "direct" | "group",
   id: string,
-  options: { preserveGroupUsername: boolean },
+  registry: ReturnType<typeof createProviderIdRegistry>,
 ): string {
   const value = id.trim();
   if (!value) {
@@ -44,30 +44,28 @@ function normalizeTelegramChatId(
     if (numericId < -TELEGRAM_NATIVE_CHAT_ID_MAX || numericId > TELEGRAM_NATIVE_CHAT_ID_MAX) {
       throw new Error("Telegram native numeric targets must fit within 52 significant bits.");
     }
-    return numericId.toString();
+    return registry.reserveNative(numericId.toString());
   }
   if (value.startsWith("@")) {
     const username = canonicalizeTelegramUsername(value);
     if (!username) {
       throw new Error("Telegram usernames must contain 4-32 letters, digits, or underscores.");
     }
-    if (kind === "group" && options.preserveGroupUsername) {
+    if (kind === "group") {
       return username;
     }
-    if (kind === "group") {
-      return String(telegramUsernameChatId(username));
-    }
-    return syntheticTelegramChatId(kind, username);
+    return registry.resolveLogical(username);
   }
-  return syntheticTelegramChatId(kind, value);
+  return registry.resolveLogical(value);
 }
 
 function syntheticTelegramChatId(kind: "direct" | "group", value: string): string {
   const hash = createHash("sha256").update(`${kind}:${value}`).digest().readBigUInt64BE();
+  const id = 1n + (hash % TELEGRAM_SYMBOLIC_ID_RANGE);
   if (kind === "group") {
-    return String(-(TELEGRAM_SYMBOLIC_ID_BASE + (hash % TELEGRAM_SYMBOLIC_ID_RANGE)));
+    return String(-id);
   }
-  return String(TELEGRAM_SYMBOLIC_ID_BASE + (hash % TELEGRAM_SYMBOLIC_ID_RANGE));
+  return String(id);
 }
 
 function telegramTargetKey(chatId: string, threadId?: number) {
@@ -134,6 +132,16 @@ function parseTelegramThreadTargetId(value: unknown): number | undefined {
 export const TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablineProviderBridge({
   provider: "telegram",
   createAdapter(telegram) {
+    const directIds = createProviderIdRegistry({
+      candidate: (logicalKey) => syntheticTelegramChatId("direct", logicalKey),
+      conflictLabel: "Telegram direct target",
+    });
+    const groupIds = createProviderIdRegistry({
+      candidate: (logicalKey) => syntheticTelegramChatId("group", logicalKey),
+      conflictLabel: "Telegram group target",
+    });
+    const normalizeChat = (kind: "direct" | "group", id: string) =>
+      normalizeTelegramChatId(kind, id, kind === "direct" ? directIds : groupIds);
     return {
       async probe(signal) {
         const configuredBotId = /^([1-9]\d*):/u.exec(telegram.botToken)?.[1];
@@ -231,13 +239,12 @@ export const TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
             TELEGRAM_CHAT_USERNAME_PATTERN.test(parsed.id.trim()))
             ? "group"
             : parsed.kind;
-        const chatId = normalizeTelegramChatId(kind, parsed.id, {
-          preserveGroupUsername: true,
-        });
+        const chatId = normalizeChat(kind, parsed.id);
         const threadId = parseTelegramThreadTargetId(parsed.threadId);
         const to = telegramTargetKey(chatId, threadId);
         return {
           channel: "telegram",
+          providerTargetKey: to,
           to,
           replyChannel: "telegram",
           replyTo: to,
@@ -245,12 +252,8 @@ export const TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
       },
       createInbound(input) {
         const kind = input.conversation.kind === "direct" ? "direct" : "group";
-        const chatId = normalizeTelegramChatId(kind, input.conversation.id, {
-          preserveGroupUsername: false,
-        });
-        const senderId = normalizeTelegramChatId("direct", input.senderId, {
-          preserveGroupUsername: false,
-        });
+        const chatId = normalizeChat(kind, input.conversation.id);
+        const senderId = normalizeChat("direct", input.senderId);
         if (kind === "direct" && chatId !== senderId) {
           throw new Error(
             "Telegram direct conversation and sender must normalize to the same identity.",
@@ -263,6 +266,11 @@ export const TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
             chatId,
             fromId: Number(senderId),
             fromName: input.senderName ?? input.senderId,
+            // Threaded group ingress must provision the same provider facts required by later
+            // Telegram topic sends; private-chat topics use the bot-level topic capability.
+            ...(threadId !== undefined && kind === "group"
+              ? { chatType: "supergroup", isForum: true }
+              : {}),
             ...(threadId !== undefined ? { messageThreadId: threadId } : {}),
             ...(input.nativeCommand
               ? {
@@ -274,7 +282,7 @@ export const TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
           providerTargetKey: telegramTargetKey(chatId, threadId),
           qaTarget: qaTargetForInbound(input),
           stateConversation: {
-            id: chatId,
+            id: input.conversation.id.trim(),
             kind: kind === "group" ? "group" : "direct",
           },
           ...(threadId !== undefined ? { threadId: String(threadId) } : {}),
@@ -288,7 +296,8 @@ export const TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
         if (!method || !isRecord(event.body)) {
           return null;
         }
-        const chatId = canonicalTelegramRecorderChatId(event.body.chat_id);
+        const requestedChatId = readString(event.body.chat_id);
+        const chatId = canonicalTelegramRecorderChatId(requestedChatId);
         const text =
           method === "sendmessage"
             ? readNonBlankString(event.body.text)
@@ -302,6 +311,9 @@ export const TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
         } catch {
           return null;
         }
+        const requestedProviderTargetKey = requestedChatId
+          ? telegramTargetKey(requestedChatId, threadId)
+          : undefined;
         const providerTargetKey = telegramTargetKey(chatId, threadId);
         return {
           accountId: DEFAULT_ACCOUNT_ID,
@@ -309,9 +321,24 @@ export const TELEGRAM_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
           senderName: "OpenClaw QA",
           text,
           to:
+            (requestedProviderTargetKey
+              ? targetByProviderTarget.get(requestedProviderTargetKey)
+              : undefined) ??
             targetByProviderTarget.get(providerTargetKey) ??
             (threadId === undefined ? chatId : providerTargetKey),
         };
+      },
+      resolveInboundProviderTargetKey({ response }) {
+        const update =
+          isRecord(response) && isRecord(response.update) ? response.update : undefined;
+        const message = update && isRecord(update.message) ? update.message : undefined;
+        const chat = message && isRecord(message.chat) ? message.chat : undefined;
+        const chatId = canonicalTelegramRecorderChatId(chat?.id);
+        if (!chatId) {
+          throw new Error("Crabline Telegram inbound response did not identify its provider chat.");
+        }
+        const threadId = parseTelegramThreadTargetId(message?.message_thread_id);
+        return telegramTargetKey(chatId, threadId);
       },
     };
   },

--- a/src/openclaw/bridges/whatsapp.ts
+++ b/src/openclaw/bridges/whatsapp.ts
@@ -29,7 +29,7 @@ function requireWhatsAppTargetKind(
   parsed: { kind: "direct" | "group"; native: boolean },
   targetId: string,
 ): void {
-  if (parsed.native) {
+  if (parsed.native && parsed.kind === "direct") {
     return;
   }
   const nativeKind = targetId.endsWith("@g.us") ? "group" : "direct";
@@ -123,6 +123,7 @@ export const WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrabline
         const to = canonicalizeWhatsAppUserCorrelationJid(nativeTo)!;
         return {
           channel: "whatsapp",
+          providerTargetKey: to,
           to,
           replyChannel: "whatsapp",
           replyTo: to,

--- a/src/openclaw/bridges/zalo.ts
+++ b/src/openclaw/bridges/zalo.ts
@@ -82,7 +82,7 @@ export const ZALO_OPENCLAW_CRABLINE_PROVIDER_BRIDGE = createOpenClawCrablineProv
           throw new Error(ZALO_UNSUPPORTED_THREAD_TARGET_ERROR);
         }
         const to = nativeId(parsed.id);
-        return { channel: "zalo", replyChannel: "zalo", replyTo: to, to };
+        return { channel: "zalo", providerTargetKey: to, replyChannel: "zalo", replyTo: to, to };
       },
       createInbound(input) {
         if (input.threadId) {

--- a/src/openclaw/shared.ts
+++ b/src/openclaw/shared.ts
@@ -62,6 +62,11 @@ export type OpenClawCrablineAgentDelivery = {
   to: string;
 };
 
+export type OpenClawCrablineCorrelatedAgentDelivery = OpenClawCrablineAgentDelivery & {
+  /** Adapter correlation key used to associate later provider recorder events with this target. */
+  providerTargetKey: string;
+};
+
 export type OpenClawCrablineInboundInput = {
   conversation: {
     id: string;
@@ -111,6 +116,18 @@ export type StartedOpenClawCrablineAdapter = OpenClawCrablineGatewayBinding & {
   probe(): Promise<unknown>;
 };
 
+export type StartedOpenClawCrablineCorrelatedAdapter = Omit<
+  StartedOpenClawCrablineAdapter,
+  "createAgentDelivery"
+> & {
+  createAgentDelivery(params: { target: string }): OpenClawCrablineCorrelatedAgentDelivery;
+  /** Resolves the provider-authoritative key from a successful inbound response. */
+  resolveInboundProviderTargetKey(params: {
+    inbound: OpenClawCrablineInbound;
+    response: unknown;
+  }): string;
+};
+
 export type ParsedQaTarget = {
   kind: "direct" | "group";
   id: string;
@@ -118,8 +135,40 @@ export type ParsedQaTarget = {
   threadId?: string;
 };
 
+export function createProviderIdRegistry(params: {
+  candidate(logicalKey: string): string;
+  conflictLabel: string;
+}) {
+  const idByLogicalKey = new Map<string, string>();
+  const ownerById = new Map<string, string>();
+  return {
+    resolveLogical(logicalKey: string) {
+      const existingId = idByLogicalKey.get(logicalKey);
+      if (existingId) {
+        return existingId;
+      }
+      const candidate = params.candidate(logicalKey);
+      const owner = ownerById.get(candidate);
+      if (owner && owner !== `logical:${logicalKey}`) {
+        throw new Error(`${params.conflictLabel} conflicts with another provider identity.`);
+      }
+      idByLogicalKey.set(logicalKey, candidate);
+      ownerById.set(candidate, `logical:${logicalKey}`);
+      return candidate;
+    },
+    reserveNative(nativeId: string) {
+      const owner = ownerById.get(nativeId);
+      if (owner?.startsWith("logical:")) {
+        throw new Error(`${params.conflictLabel} native id conflicts with a logical identity.`);
+      }
+      ownerById.set(nativeId, `native:${nativeId}`);
+      return nativeId;
+    },
+  };
+}
+
 export type OpenClawCrablineProviderAdapter = {
-  createAgentDelivery(parsed: ParsedQaTarget): OpenClawCrablineAgentDelivery;
+  createAgentDelivery(parsed: ParsedQaTarget): OpenClawCrablineCorrelatedAgentDelivery;
   createBinding(): OpenClawCrablineGatewayBinding;
   createInbound(input: OpenClawCrablineInboundInput): OpenClawCrablineInbound;
   createOutboundFromRecorderEvent(params: {
@@ -127,6 +176,10 @@ export type OpenClawCrablineProviderAdapter = {
     targetByProviderTarget: ReadonlyMap<string, string>;
   }): OpenClawCrablineOutboundMessage | null;
   probe(signal?: AbortSignal): Promise<unknown>;
+  resolveInboundProviderTargetKey?(params: {
+    inbound: OpenClawCrablineInbound;
+    response: unknown;
+  }): string;
 };
 
 export type OpenClawCrablineProviderBridge<
@@ -176,6 +229,11 @@ export function createOpenClawCrablineProviderBridge<
       probe(signal) {
         return adapter.probe(signal);
       },
+      ...(adapter.resolveInboundProviderTargetKey
+        ? {
+            resolveInboundProviderTargetKey: adapter.resolveInboundProviderTargetKey.bind(adapter),
+          }
+        : {}),
     };
   };
   const bridge: OpenClawCrablineProviderBridge<ProviderManifest> = {
@@ -303,12 +361,16 @@ export function parseQaTarget(target: string): ParsedQaTarget {
   if (trimmed.startsWith("thread:")) {
     const encoded = trimmed.startsWith("thread:/v1/");
     const rest = trimmed.slice(encoded ? "thread:/v1/".length : "thread:".length);
-    const slash = rest.indexOf("/");
-    if (slash <= 0 || slash !== rest.lastIndexOf("/")) {
+    const components = rest.split("/");
+    const explicitKind =
+      encoded && components.length === 3 && (components[0] === "dm" || components[0] === "group")
+        ? components.shift()
+        : undefined;
+    if (components.length !== 2) {
       return invalidTarget();
     }
-    let id = rest.slice(0, slash).trim();
-    let threadId = rest.slice(slash + 1).trim();
+    let id = components[0]!.trim();
+    let threadId = components[1]!.trim();
     if (encoded) {
       try {
         id = decodeURIComponent(id).trim();
@@ -320,11 +382,16 @@ export function parseQaTarget(target: string): ParsedQaTarget {
     if (!id || !threadId) {
       return invalidTarget();
     }
-    return { kind: "group", id, native: false, threadId };
+    return {
+      kind: explicitKind === "dm" ? "direct" : "group",
+      id,
+      native: false,
+      threadId,
+    };
   }
   if (trimmed.startsWith("channel:")) {
     const id = trimmed.slice("channel:".length).trim();
-    return id ? { kind: "group", id, native: false } : invalidTarget();
+    return id ? { kind: "group", id, native: true } : invalidTarget();
   }
   if (trimmed.startsWith("group:")) {
     const id = trimmed.slice("group:".length).trim();
@@ -357,7 +424,7 @@ export function qaTargetForInbound(input: OpenClawCrablineInboundInput) {
   const threadId = input.threadId?.trim();
   const prefix = input.conversation.kind === "direct" ? "dm" : "group";
   return threadId
-    ? `thread:/v1/${encodeQaThreadComponent(conversationId)}/${encodeQaThreadComponent(threadId)}`
+    ? `thread:/v1/${input.conversation.kind === "direct" ? "dm/" : ""}${encodeQaThreadComponent(conversationId)}/${encodeQaThreadComponent(threadId)}`
     : `${prefix}:${conversationId}`;
 }
 

--- a/src/servers/mattermost.ts
+++ b/src/servers/mattermost.ts
@@ -88,6 +88,7 @@ type MattermostWebSocketEvent = {
 };
 type MattermostRecorderEvent = ServerRequestEvent & {
   accepted?: boolean | undefined;
+  channel?: MattermostChannel | undefined;
 };
 
 type MattermostServerState = {
@@ -507,6 +508,15 @@ function nextDirectChannelId(state: MattermostServerState, seed: string): string
   return channelId;
 }
 
+function findDirectChannel(
+  state: MattermostServerState,
+  channelName: string,
+): MattermostChannel | undefined {
+  return [...state.channels.values()].find(
+    (channel) => channel.type === "D" && channel.name === channelName,
+  );
+}
+
 function webSocketEventTooLargeResponse(): Response {
   return mattermostError("WebSocket event is too large", 413);
 }
@@ -520,13 +530,13 @@ function handleAdminInbound(params: {
       return jsonResponse({ error: `${field} must be a string`, ok: false }, 400);
     }
   }
-  const channelId = readMattermostId(params.body.channelId ?? params.body.channel_id);
+  const requestedChannelId = readMattermostId(params.body.channelId ?? params.body.channel_id);
   const senderId = readMattermostId(params.body.senderId ?? params.body.user_id);
   const text = readMattermostMessage(params.body.text ?? params.body.message);
-  if (!channelId || !senderId || !text) {
-    return jsonResponse({ error: "channelId, senderId, and text are required", ok: false }, 400);
+  if (!senderId || !text) {
+    return jsonResponse({ error: "senderId and text are required", ok: false }, 400);
   }
-  if (!isMattermostId(channelId)) {
+  if (requestedChannelId && !isMattermostId(requestedChannelId)) {
     return jsonResponse(
       { error: "channelId must be a 26-character Mattermost ID", ok: false },
       400,
@@ -556,7 +566,6 @@ function handleAdminInbound(params: {
     return pendingQueueFullResponse(params.state);
   }
   const previousUser = params.state.users.get(senderId);
-  const previousChannel = params.state.channels.get(channelId);
   const senderName =
     params.body.senderName === undefined
       ? (previousUser?.username ?? senderId)
@@ -577,19 +586,40 @@ function handleAdminInbound(params: {
   if (usernameOwner && usernameOwner !== senderId) {
     return jsonResponse({ error: "senderName is already in use", ok: false }, 400);
   }
+  const requestedChannel = requestedChannelId
+    ? params.state.channels.get(requestedChannelId)
+    : undefined;
   const channelType =
     params.body.channelType === undefined
-      ? (previousChannel?.type ?? "D")
+      ? (requestedChannel?.type ?? "D")
       : readMattermostString(params.body.channelType);
   if (!channelType || !MATTERMOST_CHANNEL_TYPES.has(channelType)) {
     return jsonResponse({ error: "channelType is not supported", ok: false }, 400);
   }
-  const channelName =
-    readMattermostString(params.body.channelName ?? params.body.channel_name) ??
-    previousChannel?.name ??
-    (channelType === "D"
-      ? mattermostDirectChannelName(params.state.botUserId, senderId)
-      : channelId);
+  const suppliedChannelName = readMattermostString(
+    params.body.channelName ?? params.body.channel_name,
+  );
+  const canonicalDirectName = mattermostDirectChannelName(params.state.botUserId, senderId);
+  const resolveCanonicalDirect = channelType === "D" && !requestedChannelId;
+  if (!requestedChannelId && !resolveCanonicalDirect) {
+    return jsonResponse({ error: "channelId is required", ok: false }, 400);
+  }
+  const existingDirect = resolveCanonicalDirect
+    ? findDirectChannel(params.state, canonicalDirectName)
+    : undefined;
+  const channelId = resolveCanonicalDirect
+    ? (existingDirect?.id ??
+      nextDirectChannelId(params.state, `dm:${canonicalDirectName.replace("__", ":")}`))
+    : requestedChannelId;
+  if (!channelId) {
+    return jsonResponse({ error: "channelId is required", ok: false }, 400);
+  }
+  const previousChannel = params.state.channels.get(channelId);
+  const channelName = resolveCanonicalDirect
+    ? canonicalDirectName
+    : (suppliedChannelName ??
+      previousChannel?.name ??
+      (channelType === "D" ? canonicalDirectName : channelId));
   const channelDisplayName =
     readMattermostString(params.body.channelDisplayName ?? params.body.channel_display_name) ??
     previousChannel?.display_name ??
@@ -737,18 +767,15 @@ async function handleApi(params: {
     if (firstUserId !== state.botUserId && secondUserId !== state.botUserId) {
       return mattermostError("Authenticated user must belong to the direct channel", 403);
     }
-    const participantIds = [...userIds].sort();
     const channelName = mattermostDirectChannelName(firstUserId, secondUserId);
-    const existingChannel = [...state.channels.values()].find(
-      (channel) => channel.type === "D" && channel.name === channelName,
-    );
+    const existingChannel = findDirectChannel(state, channelName);
     if (existingChannel) {
       return jsonResponse(existingChannel, 201);
     }
     if (state.channels.size >= state.maxCommittedChannels) {
       return mattermostError("Too many retained channels", 503);
     }
-    const channelId = nextDirectChannelId(state, `dm:${participantIds.join(":")}`);
+    const channelId = nextDirectChannelId(state, `dm:${channelName.replace("__", ":")}`);
     const channel = { display_name: "", id: channelId, name: channelName, type: "D" };
     if (!canRetainCommittedValues(state, [[undefined, channel]])) {
       return mattermostError("Too much retained state", 503);
@@ -957,6 +984,8 @@ async function handleRequest(request: IncomingMessage, state: MattermostServerSt
       });
   if (method === "POST" && url.pathname === "/api/v4/posts") {
     event.accepted = response.status === 201;
+    const channelId = isJsonObject(body) ? readMattermostId(body.channel_id) : undefined;
+    event.channel = channelId ? state.channels.get(channelId) : undefined;
   }
   event.accepted ??= response.ok;
   await appendEvent(state, event, response.ok && method !== "GET");

--- a/test/discord-openclaw-bridge.test.ts
+++ b/test/discord-openclaw-bridge.test.ts
@@ -56,14 +56,16 @@ describe("Discord OpenClaw bridge", () => {
     const adapter = await startOpenClawCrablineAdapter({ channel: "discord" });
     adapters.push(adapter);
     expect(adapter.createAgentDelivery({ target: `dm:${USER_ID}` })).toMatchObject({
+      providerTargetKey: expect.stringMatching(/^\d{17,20}$/u),
       to: `user:${USER_ID}`,
     });
     expect(adapter.createAgentDelivery({ target: `group:${CHANNEL_ID}` })).toMatchObject({
+      providerTargetKey: CHANNEL_ID,
       to: `channel:${CHANNEL_ID}`,
     });
     expect(
       adapter.createAgentDelivery({ target: `thread:${CHANNEL_ID}/${THREAD_ID}` }),
-    ).toMatchObject({ to: `channel:${THREAD_ID}` });
+    ).toMatchObject({ providerTargetKey: THREAD_ID, to: `channel:${THREAD_ID}` });
 
     const inbound = adapter.createInbound({
       input: {

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -23,6 +23,7 @@ import {
   startCrablineServer,
   startOpenClawCrablineAdapter,
   type CrablineServerManifest,
+  type OpenClawCrablineAgentDelivery,
   type OpenClawCrablineChannelDriverSelection,
   type OpenClawCrablineConversation,
 } from "../src/index.js";
@@ -32,10 +33,8 @@ import {
 } from "../src/openclaw/artifact-generation.js";
 import { MATRIX_OPENCLAW_CRABLINE_PROVIDER_BRIDGE } from "../src/openclaw/bridges/matrix.js";
 import { SIGNAL_OPENCLAW_CRABLINE_PROVIDER_BRIDGE } from "../src/openclaw/bridges/signal.js";
-import {
-  isTelegramUsernameChatId,
-  TELEGRAM_NATIVE_CHAT_ID_MAX,
-} from "../src/servers/telegram-identity.js";
+import { TELEGRAM_NATIVE_CHAT_ID_MAX } from "../src/servers/telegram-identity.js";
+import { mattermostId } from "../src/servers/mattermost.js";
 import {
   createOpenClawCrablineProviderBridge,
   isRecord,
@@ -317,6 +316,7 @@ describe("OpenClaw local provider bridge", () => {
       createAgentDelivery() {
         return {
           channel: this.label,
+          providerTargetKey: this.label,
           replyChannel: this.label,
           replyTo: this.label,
           to: this.label,
@@ -739,6 +739,9 @@ describe("OpenClaw local provider bridge", () => {
         },
       },
     });
+    expect(
+      createOpenClawCrablineAgentDelivery({ manifest: zaloManifest, target: "group:group-1" }),
+    ).toMatchObject({ providerTargetKey: "group-1", to: "group-1" });
 
     expect(
       createOpenClawCrablineInbound({
@@ -1053,11 +1056,12 @@ describe("OpenClaw local provider bridge", () => {
     });
     expect(symbolicDelivery).toEqual({
       channel: "telegram",
+      providerTargetKey: expect.stringMatching(/^\d+$/u),
       to: expect.stringMatching(/^\d+$/u),
       replyChannel: "telegram",
       replyTo: symbolicDelivery.to,
     });
-    expect(BigInt(symbolicDelivery.to)).toBeGreaterThanOrEqual(1n << 52n);
+    expect(BigInt(symbolicDelivery.to)).toBeLessThanOrEqual(TELEGRAM_NATIVE_CHAT_ID_MAX);
     expect(() =>
       createOpenClawCrablineAgentDelivery({
         manifest,
@@ -1074,14 +1078,18 @@ describe("OpenClaw local provider bridge", () => {
       manifest,
       target: "group:alice",
     });
-    expect(BigInt(symbolicGroupDelivery.to)).toBeLessThanOrEqual(-(1n << 52n));
+    expect(symbolicGroupDelivery.providerTargetKey).toBe(symbolicGroupDelivery.to);
+    expect(BigInt(symbolicGroupDelivery.to)).toBeGreaterThanOrEqual(-TELEGRAM_NATIVE_CHAT_ID_MAX);
     expect(Number.isSafeInteger(Number(symbolicGroupDelivery.to))).toBe(true);
     expect(
       createOpenClawCrablineAgentDelivery({
         manifest,
         target: "thread:alice/42",
-      }).to,
-    ).toBe(`${symbolicGroupDelivery.to}:topic:42`);
+      }),
+    ).toMatchObject({
+      providerTargetKey: `${symbolicGroupDelivery.to}:topic:42`,
+      to: `${symbolicGroupDelivery.to}:topic:42`,
+    });
     expect(createOpenClawCrablineAgentDelivery({ manifest, target: "dm:42424242" }).to).toBe(
       "42424242",
     );
@@ -1146,7 +1154,7 @@ describe("OpenClaw local provider bridge", () => {
       providerUrl: "http://127.0.0.1:1234/crabline/telegram/inbound",
       qaTarget: "dm:alice",
       stateConversation: {
-        id: symbolicDelivery.to,
+        id: "alice",
         kind: "direct",
       },
     });
@@ -1162,7 +1170,7 @@ describe("OpenClaw local provider bridge", () => {
     ).toMatchObject({
       providerBody: { chatId: "42424242", fromId: 42_424_242 },
       providerTargetKey: "42424242",
-      stateConversation: { id: "42424242", kind: "direct" },
+      stateConversation: { id: "00042424242", kind: "direct" },
     });
     const usernameDirectInbound = createOpenClawCrablineInbound({
       manifest,
@@ -1179,7 +1187,7 @@ describe("OpenClaw local provider bridge", () => {
       },
       providerTargetKey: expect.stringMatching(/^\d+$/u),
       stateConversation: {
-        id: expect.stringMatching(/^\d+$/u),
+        id: "@alice",
         kind: "direct",
       },
     });
@@ -1217,22 +1225,23 @@ describe("OpenClaw local provider bridge", () => {
     });
     expect(usernameGroupInbound).toMatchObject({
       providerBody: {
-        chatId: expect.stringMatching(/^-\d+$/u),
+        chatId: "@channelusername",
         fromId: expect.any(Number),
       },
-      providerTargetKey: expect.stringMatching(/^-\d+$/u),
+      providerTargetKey: "@channelusername",
       qaTarget: "group:@channelusername",
       stateConversation: {
-        id: expect.stringMatching(/^-\d+$/u),
+        id: "@channelusername",
         kind: "group",
       },
     });
-    expect(usernameGroupInbound.providerBody.chatId).not.toBe("@channelusername");
-    const usernameGroupChatId = BigInt(String(usernameGroupInbound.providerBody.chatId));
-    expect(usernameGroupChatId).toBeLessThan(0n);
-    expect(-usernameGroupChatId).toBeGreaterThan(TELEGRAM_NATIVE_CHAT_ID_MAX);
-    expect(isTelegramUsernameChatId(Number(usernameGroupChatId))).toBe(true);
     expect(usernameGroupInbound.providerBody.chatId).not.toBe(symbolicGroupDelivery.to);
+    expect(
+      createOpenClawCrablineAgentDelivery({
+        manifest,
+        target: "channel:@channelusername",
+      }).providerTargetKey,
+    ).toBe(usernameGroupInbound.providerTargetKey);
     expect(
       createOpenClawCrablineInbound({
         manifest,
@@ -1317,7 +1326,9 @@ describe("OpenClaw local provider bridge", () => {
         },
       }).providerBody,
     ).toMatchObject({
+      chatType: "supergroup",
       chatId: expect.stringMatching(/^-\d+$/u),
+      isForum: true,
       messageThreadId: 42,
     });
     const normalizedTopicInbound = createOpenClawCrablineInbound({
@@ -1330,7 +1341,11 @@ describe("OpenClaw local provider bridge", () => {
       },
     });
     expect(normalizedTopicInbound).toMatchObject({
-      providerBody: { messageThreadId: 42 },
+      providerBody: {
+        chatType: "supergroup",
+        isForum: true,
+        messageThreadId: 42,
+      },
       providerTargetKey: `${symbolicGroupDelivery.to}:topic:42`,
       qaTarget: "thread:/v1/alice/42",
       threadId: "42",
@@ -1367,7 +1382,7 @@ describe("OpenClaw local provider bridge", () => {
           method: "POST",
           path: "/bot<redacted>/SeNdMeSsAgE",
           body: {
-            chat_id: "100001",
+            chat_id: 100001,
             text: "  hello\n",
           },
         },
@@ -1460,20 +1475,15 @@ describe("OpenClaw local provider bridge", () => {
           threadId: "42",
         },
       });
-      const registration = await fetch(telegram.endpoints.adminInboundUrl, {
-        body: JSON.stringify({
-          my_chat_member: {
-            chat: {
-              id: Number(inbound.providerBody.chatId),
-              is_forum: true,
-              type: "supergroup",
-              username: "examplegroup",
-            },
-          },
-          update_id: 1,
-        }),
+      const inboundResponse = await fetch(telegram.endpoints.adminInboundUrl, {
+        body: JSON.stringify(inbound.providerBody),
         headers: inbound.providerHeaders,
         method: "POST",
+      });
+      const inboundPayload: unknown = await inboundResponse.json();
+      const inboundProviderTargetKey = adapter.resolveInboundProviderTargetKey({
+        inbound,
+        response: inboundPayload,
       });
       const response = await fetch(`${telegram.baseUrl}/bot${telegram.botToken}/sendMessage`, {
         body: JSON.stringify({
@@ -1489,11 +1499,10 @@ describe("OpenClaw local provider bridge", () => {
       };
 
       expect(delivery.to).toBe("@examplegroup");
-      expect(registration.status).toBe(200);
+      expect(inboundResponse.status).toBe(200);
       expect(response.status).toBe(200);
-      expect(String(payload.result.chat.id)).toBe(inbound.providerBody.chatId);
+      expect(inboundProviderTargetKey).toBe(`${payload.result.chat.id}:topic:42`);
       expect(payload.result.message_thread_id).toBe(42);
-      expect(inbound.providerTargetKey).toBe(`${payload.result.chat.id}:topic:42`);
       expect(
         adapter.createOutboundFromRecorderEvent({
           event: {
@@ -1507,7 +1516,10 @@ describe("OpenClaw local provider bridge", () => {
             path: "/bot<redacted>/sendMessage",
             type: "api",
           },
-          targetByProviderTarget: new Map([[inbound.providerTargetKey, inbound.qaTarget]]),
+          targetByProviderTarget: new Map([
+            [delivery.providerTargetKey, inbound.qaTarget],
+            [inboundProviderTargetKey, inbound.qaTarget],
+          ]),
         }),
       ).toMatchObject({
         text: "outbound topic message",
@@ -1575,6 +1587,22 @@ describe("OpenClaw local provider bridge", () => {
     expect(
       createOpenClawCrablineAgentDelivery({ manifest, target: " thread:alice / 42 " }).to,
     ).toBe(createOpenClawCrablineAgentDelivery({ manifest, target: "thread:alice/42" }).to);
+  });
+
+  it("keeps the released agent delivery shape source-compatible", () => {
+    const delivery: OpenClawCrablineAgentDelivery = {
+      channel: "telegram",
+      replyChannel: "telegram",
+      replyTo: "42",
+      to: "42",
+    };
+
+    expect(delivery).toEqual({
+      channel: "telegram",
+      replyChannel: "telegram",
+      replyTo: "42",
+      to: "42",
+    });
   });
 
   it("validates Telegram numeric target signs by declared kind", () => {
@@ -1660,6 +1688,7 @@ describe("OpenClaw local provider bridge", () => {
       }),
     ).toEqual({
       channel: "whatsapp",
+      providerTargetKey: "15551234567@s.whatsapp.net",
       to: "15551234567@s.whatsapp.net",
       replyChannel: "whatsapp",
       replyTo: "15551234567@s.whatsapp.net",
@@ -1680,6 +1709,12 @@ describe("OpenClaw local provider bridge", () => {
       createOpenClawCrablineAgentDelivery({
         manifest: whatsappManifest,
         target: "group:15551234567@s.whatsapp.net",
+      }),
+    ).toThrow("WhatsApp target kind does not match the native JID.");
+    expect(() =>
+      createOpenClawCrablineAgentDelivery({
+        manifest: whatsappManifest,
+        target: "channel:15551234567@s.whatsapp.net",
       }),
     ).toThrow("WhatsApp target kind does not match the native JID.");
     expect(() =>
@@ -1917,6 +1952,7 @@ describe("OpenClaw local provider bridge", () => {
       }),
     ).toEqual({
       channel: "slack",
+      providerTargetKey: "C1234567890:thread:1700000000.000100",
       to: "C1234567890",
       replyChannel: "slack",
       replyTo: "C1234567890:thread:1700000000.000100",
@@ -1928,6 +1964,7 @@ describe("OpenClaw local provider bridge", () => {
       }),
     ).toEqual({
       channel: "slack",
+      providerTargetKey: "D1234567890:thread:1700000000.000100",
       to: "D1234567890",
       replyChannel: "slack",
       replyTo: "D1234567890:thread:1700000000.000100",
@@ -1968,6 +2005,12 @@ describe("OpenClaw local provider bridge", () => {
       createOpenClawCrablineAgentDelivery({
         manifest: slackManifest,
         target: "group:D1234567890",
+      }),
+    ).toThrow("Slack target kind does not match the native conversation id.");
+    expect(() =>
+      createOpenClawCrablineAgentDelivery({
+        manifest: slackManifest,
+        target: "channel:D1234567890",
       }),
     ).toThrow("Slack target kind does not match the native conversation id.");
 
@@ -2150,6 +2193,7 @@ describe("OpenClaw local provider bridge", () => {
       createOpenClawCrablineAgentDelivery({ manifest: signalManifest, target: "group:group-1" }),
     ).toEqual({
       channel: "signal",
+      providerTargetKey: "group:group-1",
       replyChannel: "signal",
       replyTo: "group:group-1",
       to: "group:group-1",
@@ -2597,12 +2641,39 @@ describe("OpenClaw local provider bridge", () => {
     });
     expect(delivery).toEqual({
       channel: "mattermost",
+      providerTargetKey: `user:${userId}`,
       replyChannel: "mattermost",
       replyTo: `user:${userId}`,
       to: `user:${userId}`,
     });
 
-    for (const target of ["dm:alice", "group:UPPERCASEIDENTIFIER123456"]) {
+    const logicalDirectDelivery = createOpenClawCrablineAgentDelivery({
+      manifest: mattermostManifest,
+      target: "dm:alice",
+    });
+    expect(logicalDirectDelivery).toMatchObject({
+      providerTargetKey: expect.stringMatching(/^user:[a-z0-9]{26}$/u),
+      to: expect.stringMatching(/^user:[a-z0-9]{26}$/u),
+    });
+    const logicalGroupDelivery = createOpenClawCrablineAgentDelivery({
+      manifest: mattermostManifest,
+      target: "group:general",
+    });
+    expect(logicalGroupDelivery).toMatchObject({
+      providerTargetKey: expect.stringMatching(/^[a-z0-9]{26}$/u),
+      to: expect.stringMatching(/^channel:[a-z0-9]{26}$/u),
+    });
+    expect(logicalGroupDelivery.to).toBe(`channel:${logicalGroupDelivery.providerTargetKey}`);
+    const nativeGroupDelivery = createOpenClawCrablineAgentDelivery({
+      manifest: mattermostManifest,
+      target: `group:${channelId}`,
+    });
+    expect(nativeGroupDelivery).toMatchObject({
+      providerTargetKey: channelId,
+      to: `channel:${channelId}`,
+    });
+
+    for (const target of ["alice", "UPPERCASEIDENTIFIER123456"]) {
       expect(() =>
         createOpenClawCrablineAgentDelivery({
           manifest: mattermostManifest,
@@ -2610,6 +2681,23 @@ describe("OpenClaw local provider bridge", () => {
         }),
       ).toThrow("must be exactly 26 lowercase alphanumeric characters");
     }
+
+    const logicalInbound = createOpenClawCrablineInbound({
+      manifest: mattermostManifest,
+      input: {
+        conversation: { id: "alice", kind: "direct" },
+        senderId: "alice",
+        text: "logical direct",
+      },
+    });
+    expect(logicalInbound).toMatchObject({
+      providerBody: {
+        senderId: logicalDirectDelivery.to.slice("user:".length),
+      },
+      providerTargetKey: logicalDirectDelivery.providerTargetKey,
+      qaTarget: "dm:alice",
+      stateConversation: { id: "alice", kind: "direct" },
+    });
 
     expect(() =>
       createOpenClawCrablineAgentDelivery({
@@ -2641,6 +2729,8 @@ describe("OpenClaw local provider bridge", () => {
       },
     });
     expect(inbound.providerBody.senderId).toBe(userId);
+    expect(inbound.providerBody).not.toHaveProperty("channelId");
+    expect(inbound.providerTargetKey).toBe(delivery.providerTargetKey);
     expect(() =>
       createOpenClawCrablineInbound({
         manifest: mattermostManifest,
@@ -2664,12 +2754,13 @@ describe("OpenClaw local provider bridge", () => {
       ).toThrow("OpenClaw Crabline inbound conversation id is required.");
     }
 
+    const directChannelId = "ababababababababababababab";
     expect(
       createOpenClawCrablineOutboundFromRecorderEvent({
         manifest: mattermostManifest,
-        targetByProviderTarget: new Map([[inbound.providerTargetKey, `dm:${userId}`]]),
+        targetByProviderTarget: new Map([[directChannelId, `dm:${userId}`]]),
         event: {
-          body: { channel_id: inbound.providerTargetKey, message: "hello from openclaw" },
+          body: { channel_id: directChannelId, message: "hello from openclaw" },
           method: "POST",
           path: "/api/v4/posts",
           type: "api",
@@ -2687,7 +2778,7 @@ describe("OpenClaw local provider bridge", () => {
         manifest: mattermostManifest,
         targetByProviderTarget: new Map(),
         event: {
-          body: { channel_id: inbound.providerTargetKey, message: "unmapped reply" },
+          body: { channel_id: directChannelId, message: "unmapped reply" },
           method: "POST",
           path: "/api/v4/posts",
           type: "api",
@@ -2714,6 +2805,10 @@ describe("OpenClaw local provider bridge", () => {
       },
     });
     expect(threadInbound.providerTargetKey).toBe(`${channelId}:thread:${rootId}`);
+    expect(threadInbound.providerBody).toMatchObject({ channelId, rootId, senderId: userId });
+    expect(threadInbound.providerTargetKey.startsWith(nativeGroupDelivery.providerTargetKey)).toBe(
+      true,
+    );
     expect(threadInbound.threadId).toBe(rootId);
     const otherThreadInbound = createOpenClawCrablineInbound({
       manifest: mattermostManifest,
@@ -2754,17 +2849,43 @@ describe("OpenClaw local provider bridge", () => {
         },
       }),
     ).toMatchObject({ to: `group:${channelId}` });
-    expect(() =>
-      createOpenClawCrablineInbound({
-        manifest: mattermostManifest,
-        input: {
-          conversation: { id: channelId, kind: "group" },
-          senderId: userId,
-          text: "invalid root",
-          threadId: "parent",
-        },
-      }),
-    ).toThrow("must be exactly 26 lowercase alphanumeric characters");
+    const logicalThreadInbound = createOpenClawCrablineInbound({
+      manifest: mattermostManifest,
+      input: {
+        conversation: { id: channelId, kind: "group" },
+        senderId: userId,
+        text: "logical root",
+        threadId: "parent",
+      },
+    });
+    expect(logicalThreadInbound.providerBody.rootId).toMatch(/^[a-z0-9]{26}$/u);
+    expect(logicalThreadInbound.providerTargetKey).toBe(
+      `${channelId}:thread:${logicalThreadInbound.providerBody.rootId}`,
+    );
+    const otherSenderLogicalThread = createOpenClawCrablineInbound({
+      manifest: mattermostManifest,
+      input: {
+        conversation: { id: channelId, kind: "group" },
+        senderId: otherUserId,
+        text: "same logical root from another sender",
+        threadId: "parent",
+      },
+    });
+    const otherGroupLogicalThread = createOpenClawCrablineInbound({
+      manifest: mattermostManifest,
+      input: {
+        conversation: { id: otherChannelId, kind: "group" },
+        senderId: userId,
+        text: "same logical root in another group",
+        threadId: "parent",
+      },
+    });
+    expect(otherSenderLogicalThread.providerBody.rootId).toBe(
+      logicalThreadInbound.providerBody.rootId,
+    );
+    expect(otherGroupLogicalThread.providerBody.rootId).not.toBe(
+      logicalThreadInbound.providerBody.rootId,
+    );
     expect(
       createOpenClawCrablineOutboundFromRecorderEvent({
         manifest: mattermostManifest,
@@ -2795,6 +2916,7 @@ describe("OpenClaw local provider bridge", () => {
       }),
     ).toEqual({
       channel: "matrix",
+      providerTargetKey: roomId,
       replyChannel: "matrix",
       replyTo: `room:${roomId}`,
       to: `room:${roomId}`,
@@ -3017,6 +3139,18 @@ describe("OpenClaw local provider bridge", () => {
       native: false,
       threadId: "42",
     });
+    expect(parseQaTarget("thread:/v1/dm/42")).toEqual({
+      id: "dm",
+      kind: "group",
+      native: false,
+      threadId: "42",
+    });
+    expect(parseQaTarget("thread:/v1/dm/alice/42")).toEqual({
+      id: "alice",
+      kind: "direct",
+      native: false,
+      threadId: "42",
+    });
 
     const binding = createOpenClawCrablineProviderBinding(matrixManifest);
     expect(binding).toMatchObject({ channel: "matrix", requiredPluginIds: ["matrix"] });
@@ -3033,6 +3167,277 @@ describe("OpenClaw local provider bridge", () => {
         },
       },
     });
+  });
+
+  it("posts symbolic Telegram direct, group, and topic inbound through the provider bridge", async () => {
+    const adapter = await startOpenClawCrablineAdapter({ channel: "telegram" });
+    try {
+      const direct = adapter.createInbound({
+        input: {
+          conversation: { id: "alice", kind: "direct" },
+          senderId: "alice",
+          text: "symbolic direct",
+        },
+      });
+      const group = adapter.createInbound({
+        input: {
+          conversation: { id: "general", kind: "group" },
+          senderId: "alice",
+          text: "symbolic group",
+        },
+      });
+      const directTopic = adapter.createInbound({
+        input: {
+          conversation: { id: "alice", kind: "direct" },
+          senderId: "alice",
+          text: "symbolic private topic",
+          threadId: "42",
+        },
+      });
+      const topic = adapter.createInbound({
+        input: {
+          conversation: { id: "general", kind: "group" },
+          senderId: "alice",
+          text: "symbolic topic",
+          threadId: "42",
+        },
+      });
+
+      expect(adapter.createAgentDelivery({ target: "dm:alice" }).providerTargetKey).toBe(
+        direct.providerTargetKey,
+      );
+      expect(adapter.createAgentDelivery({ target: "group:general" }).providerTargetKey).toBe(
+        group.providerTargetKey,
+      );
+      expect(directTopic.qaTarget).toBe("thread:/v1/dm/alice/42");
+      expect(adapter.createAgentDelivery({ target: directTopic.qaTarget }).providerTargetKey).toBe(
+        directTopic.providerTargetKey,
+      );
+      expect(directTopic.providerBody).not.toHaveProperty("chatType");
+      expect(directTopic.providerBody).not.toHaveProperty("isForum");
+      expect(adapter.createAgentDelivery({ target: "thread:general/42" }).providerTargetKey).toBe(
+        topic.providerTargetKey,
+      );
+      expect(topic.providerBody).toMatchObject({
+        chatType: "supergroup",
+        isForum: true,
+        messageThreadId: 42,
+      });
+
+      for (const inbound of [direct, directTopic, group, topic]) {
+        const response = await fetch(inbound.providerUrl, {
+          body: JSON.stringify(inbound.providerBody),
+          headers: inbound.providerHeaders,
+          method: "POST",
+        });
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toMatchObject({ ok: true });
+      }
+    } finally {
+      await adapter.close();
+    }
+  });
+
+  it("keeps Telegram logical and explicit native identities distinct per adapter", async () => {
+    const logicalFirst = await startOpenClawCrablineAdapter({ channel: "telegram" });
+    const nativeFirst = await startOpenClawCrablineAdapter({ channel: "telegram" });
+    try {
+      const logicalDirect = logicalFirst.createAgentDelivery({ target: "dm:alice" });
+      expect(() =>
+        logicalFirst.createAgentDelivery({ target: logicalDirect.providerTargetKey }),
+      ).toThrow("native id conflicts with a logical identity");
+      const logicalGroup = logicalFirst.createAgentDelivery({ target: "group:general" });
+      expect(() =>
+        logicalFirst.createAgentDelivery({ target: `channel:${logicalGroup.providerTargetKey}` }),
+      ).toThrow("native id conflicts with a logical identity");
+
+      nativeFirst.createAgentDelivery({ target: logicalDirect.providerTargetKey });
+      expect(() => nativeFirst.createAgentDelivery({ target: "dm:alice" })).toThrow(
+        "conflicts with another provider identity",
+      );
+      nativeFirst.createAgentDelivery({ target: `channel:${logicalGroup.providerTargetKey}` });
+      expect(() => nativeFirst.createAgentDelivery({ target: "group:general" })).toThrow(
+        "conflicts with another provider identity",
+      );
+    } finally {
+      await Promise.all([logicalFirst.close(), nativeFirst.close()]);
+    }
+  });
+
+  it("posts symbolic Mattermost direct, group, and thread inbound through the provider bridge", async () => {
+    const adapter = await startOpenClawCrablineAdapter({ channel: "mattermost" });
+    try {
+      const direct = adapter.createInbound({
+        input: {
+          conversation: { id: "alice", kind: "direct" },
+          senderId: "alice",
+          text: "symbolic direct",
+        },
+      });
+      const group = adapter.createInbound({
+        input: {
+          conversation: { id: "general", kind: "group" },
+          senderId: "alice",
+          text: "symbolic group",
+        },
+      });
+      const thread = adapter.createInbound({
+        input: {
+          conversation: { id: "general", kind: "group" },
+          senderId: "alice",
+          text: "symbolic thread",
+          threadId: "parent",
+        },
+      });
+
+      expect(adapter.createAgentDelivery({ target: "dm:alice" }).providerTargetKey).toBe(
+        direct.providerTargetKey,
+      );
+      expect(adapter.createAgentDelivery({ target: "group:general" }).providerTargetKey).toBe(
+        group.providerTargetKey,
+      );
+      expect(thread.providerTargetKey).toMatch(
+        new RegExp(`^${group.providerTargetKey}:thread:[a-z0-9]{26}$`, "u"),
+      );
+      expect(thread.providerBody).toMatchObject({
+        channelId: group.providerTargetKey,
+        rootId: expect.stringMatching(/^[a-z0-9]{26}$/u),
+        senderId: expect.stringMatching(/^[a-z0-9]{26}$/u),
+      });
+
+      for (const inbound of [direct, group, thread]) {
+        const response = await fetch(inbound.providerUrl, {
+          body: JSON.stringify(inbound.providerBody),
+          headers: inbound.providerHeaders,
+          method: "POST",
+        });
+        expect(response.status).toBe(200);
+        const payload: unknown = await response.json();
+        expect(payload).toMatchObject({ ok: true });
+        expect(adapter.resolveInboundProviderTargetKey({ inbound, response: payload })).toMatch(
+          /^[a-z0-9]{26}(?::thread:[a-z0-9]{26})?$/u,
+        );
+      }
+    } finally {
+      await adapter.close();
+    }
+  });
+
+  it("uses Mattermost's authoritative direct-channel allocation for inbound and delivery", async () => {
+    const events: unknown[] = [];
+    const adapter = await startOpenClawCrablineAdapter({
+      channel: "mattermost",
+      onEvent: (event) => {
+        events.push(event);
+      },
+    });
+    try {
+      if (adapter.manifest.provider !== "mattermost") {
+        throw new Error("Expected Mattermost provider manifest.");
+      }
+      const direct = adapter.createInbound({
+        input: {
+          conversation: { id: "alice", kind: "direct" },
+          senderId: "alice",
+          text: "direct allocation",
+        },
+      });
+      const userId = String(direct.providerBody.senderId);
+      const predictedChannelId = mattermostId(
+        `dm:${[adapter.manifest.botUserId, userId].sort().join(":")}`,
+      );
+      const occupyingGroup = adapter.createInbound({
+        input: {
+          conversation: { id: predictedChannelId, kind: "group" },
+          senderId: "alice",
+          text: "occupy the direct seed",
+        },
+      });
+      const inject = async (inbound: typeof direct) => {
+        const response = await fetch(inbound.providerUrl, {
+          body: JSON.stringify(inbound.providerBody),
+          headers: inbound.providerHeaders,
+          method: "POST",
+        });
+        expect(response.status).toBe(200);
+        return (await response.json()) as unknown;
+      };
+      await inject(occupyingGroup);
+      const directPayload = await inject(direct);
+      const directProviderTargetKey = adapter.resolveInboundProviderTargetKey({
+        inbound: direct,
+        response: directPayload,
+      });
+      const channelId = directProviderTargetKey;
+      expect(channelId).toMatch(/^[a-z0-9]{26}$/u);
+      expect(channelId).not.toBe(predictedChannelId);
+
+      const delivery = adapter.createAgentDelivery({ target: "dm:alice" });
+      const directChannelResponse = await fetch(
+        `${adapter.manifest.endpoints.apiRoot}/channels/direct`,
+        {
+          body: JSON.stringify([adapter.manifest.botUserId, userId]),
+          headers: {
+            authorization: `Bearer ${adapter.manifest.botToken}`,
+            "content-type": "application/json",
+          },
+          method: "POST",
+        },
+      );
+      expect(directChannelResponse.status).toBe(201);
+      await expect(directChannelResponse.json()).resolves.toMatchObject({
+        id: channelId,
+        type: "D",
+      });
+
+      const targetByProviderTarget = new Map([[delivery.providerTargetKey, direct.qaTarget]]);
+      for (const event of events) {
+        adapter.createOutboundFromRecorderEvent({ event, targetByProviderTarget });
+      }
+      const replyResponse = await fetch(`${adapter.manifest.endpoints.apiRoot}/posts`, {
+        body: JSON.stringify({ channel_id: channelId, message: "direct reply" }),
+        headers: {
+          authorization: `Bearer ${adapter.manifest.botToken}`,
+          "content-type": "application/json",
+        },
+        method: "POST",
+      });
+      expect(replyResponse.status).toBe(201);
+      const replyEvent = events.at(-1);
+      expect(
+        adapter.createOutboundFromRecorderEvent({ event: replyEvent, targetByProviderTarget }),
+      ).toMatchObject({ text: "direct reply", to: direct.qaTarget });
+    } finally {
+      await adapter.close();
+    }
+  });
+
+  it("keeps Mattermost logical and explicit native identities distinct per adapter", async () => {
+    const logicalFirst = await startOpenClawCrablineAdapter({ channel: "mattermost" });
+    const nativeFirst = await startOpenClawCrablineAdapter({ channel: "mattermost" });
+    try {
+      const logicalDirect = logicalFirst.createAgentDelivery({ target: "dm:alice" });
+      const directId = logicalDirect.to.slice("user:".length);
+      expect(() => logicalFirst.createAgentDelivery({ target: directId })).toThrow(
+        "native id conflicts with a logical identity",
+      );
+      const logicalGroup = logicalFirst.createAgentDelivery({ target: "group:general" });
+      const groupId = logicalGroup.to.slice("channel:".length);
+      expect(() => logicalFirst.createAgentDelivery({ target: `channel:${groupId}` })).toThrow(
+        "native id conflicts with a logical identity",
+      );
+
+      nativeFirst.createAgentDelivery({ target: directId });
+      expect(() => nativeFirst.createAgentDelivery({ target: "dm:alice" })).toThrow(
+        "conflicts with another provider identity",
+      );
+      nativeFirst.createAgentDelivery({ target: `channel:${groupId}` });
+      expect(() => nativeFirst.createAgentDelivery({ target: "group:general" })).toThrow(
+        "conflicts with another provider identity",
+      );
+    } finally {
+      await Promise.all([logicalFirst.close(), nativeFirst.close()]);
+    }
   });
 
   it("posts WhatsApp OpenClaw inbound with admin headers into the local provider", async () => {

--- a/test/package-production.test.ts
+++ b/test/package-production.test.ts
@@ -3,11 +3,31 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
 import { parse } from "yaml";
+import type {
+  CrablineServerManifest,
+  OpenClawCrablineAgentDelivery,
+  OpenClawCrablineGatewayBinding,
+  OpenClawCrablineInbound,
+  OpenClawCrablineInboundInput,
+  OpenClawCrablineOutboundMessage,
+  StartedOpenClawCrablineAdapter,
+} from "../src/index.js";
 
 const execFileAsync = promisify(execFile);
 const DEV_ONLY_RUNTIME_PACKAGES = ["baileys"] as const;
+type ReleasedStartedOpenClawCrablineAdapter = OpenClawCrablineGatewayBinding & {
+  close(): Promise<void>;
+  createAgentDelivery(params: { target: string }): OpenClawCrablineAgentDelivery;
+  createInbound(params: { input: OpenClawCrablineInboundInput }): OpenClawCrablineInbound;
+  createOutboundFromRecorderEvent(params: {
+    event: unknown;
+    targetByProviderTarget: ReadonlyMap<string, string>;
+  }): OpenClawCrablineOutboundMessage | null;
+  manifest: CrablineServerManifest;
+  probe(): Promise<unknown>;
+};
 const PUBLIC_RUNTIME_EXPORTS = [
   "BUILTIN_ADAPTERS",
   "CRABLINE_SERVER_CHANNELS",
@@ -65,6 +85,7 @@ const PUBLIC_TYPE_EXPORTS = [
   "OpenClawCrablineAgentDelivery",
   "OpenClawCrablineChannelDriverSelection",
   "OpenClawCrablineConversation",
+  "OpenClawCrablineCorrelatedAgentDelivery",
   "OpenClawCrablineGatewayBinding",
   "OpenClawCrablineInbound",
   "OpenClawCrablineInboundInput",
@@ -88,6 +109,7 @@ const PUBLIC_TYPE_EXPORTS = [
   "StartedMattermostServer",
   "StartedMatrixServer",
   "StartedOpenClawCrablineAdapter",
+  "StartedOpenClawCrablineCorrelatedAdapter",
   "StartedSignalServer",
   "StartedSlackServer",
   "StartDiscordServerParams",
@@ -127,6 +149,10 @@ const OBSOLETE_SERVER_DECLARATION_PATTERN = new RegExp(
 );
 
 describe("production package", () => {
+  it("keeps the released started-adapter shape source-compatible", () => {
+    expectTypeOf<ReleasedStartedOpenClawCrablineAdapter>().toExtend<StartedOpenClawCrablineAdapter>();
+  });
+
   it("builds distributable output before running package verification", async () => {
     const pkg = JSON.parse(await fs.readFile("package.json", "utf8")) as {
       scripts?: Record<string, string>;


### PR DESCRIPTION
Closes #261

## What Problem This Solves

OpenClaw QA scenarios with logical Telegram or Mattermost identities could be rejected by Crabline's strict provider servers or correlated to a predicted provider ID rather than the ID the server actually accepted. Telegram usernames were rewritten before provider ingress, direct-thread targets lost their conversation kind, and Mattermost direct-channel collisions could diverge from the bridge's predicted channel.

This unblocks removing provider-specific ID and forum-metadata inference from [openclaw/openclaw#118008](https://github.com/openclaw/openclaw/pull/118008).

## Why This Change Was Made

Crabline's OpenClaw adapter now exposes `resolveInboundProviderTargetKey(...)`, so the successful provider-server response is the authoritative inbound correlation boundary. Telegram keeps canonical `@username` destinations in provider requests and supplies forum facts for group topics. Mattermost's server owns direct-channel allocation and collision handling; accepted post evidence carries the provider-native channel context needed to correlate direct delivery without a cache or predicted channel ID.

Logical identities that must be emitted before a provider response use the existing bounded deterministic mapper plus adapter-scoped reverse ownership. A logical identity and an explicit native identity can no longer silently claim the same provider ID in either insertion order. Mattermost's shipped lexical contract remains intact: valid 26-character IDs are provider-native even when written under `dm:` or `group:` prefixes, and delivery/inbound correlation tests cover those native-shaped conversation, sender, and thread values.

Direct-thread QA targets add an explicit `dm` discriminator. Existing group-thread encodings remain readable, including conversations literally named `dm` or `group`.

Related context:

- [Crabline #250](https://github.com/openclaw/crabline/pull/250)
- [Crabline #252](https://github.com/openclaw/crabline/pull/252)
- [Crabline release 0.1.13](https://github.com/openclaw/crabline/releases/tag/v0.1.13)

## User Impact

OpenClaw QA Lab can send portable Telegram and Mattermost DM, group, and thread/topic identities without knowing provider allocation rules. Successful inbound responses provide the exact provider key to persist. Provider-native targets remain accepted, malformed targets remain rejected, and the servers remain provider-faithful.

Persistence impact is additive: no existing recorder/evidence field is renamed or replaced, and no schema or version changes. Accepted Mattermost post events add the provider-native `channel` object already committed by the server; this is required for same-event authoritative direct-message correlation. Existing group-thread target values keep their prior syntax; only direct-thread generation gains the kind discriminator needed to avoid misreading persisted direct evidence as a group.

## Evidence

Before the change on `858a21c9ea7740ce1bf27bc0e351352be71e4d49`:

- Bridge-created Telegram symbolic group-topic ingress returned HTTP 400.
- Mattermost `createAgentDelivery({ target: "dm:alice" })` rejected the logical target.
- A Mattermost group occupying the deterministic direct-channel seed caused `/channels/direct` to allocate a different channel than the bridge predicted.
- A direct threaded inbound target reparsed as a group.

After the change at `99a0528fc0bad66312147f14122d2a5d10bd4c1a`:

- `pnpm test test/openclaw.test.ts --testTimeout=20000` — 109 passed on the final implementation.
- `pnpm test test/mattermost-server.test.ts --testTimeout=10000` — 31 passed.
- Focused bridge/server proofs cover Telegram username group/topic and private-topic ingress, direct-thread kind roundtrip, logical/native conflicts in both insertion orders, Mattermost direct-channel collision/reuse, provider-native-shaped IDs, authoritative inbound results, and delivery correlation from provider-native post context.
- `pnpm lint` — passed (format, typecheck, and type-aware oxlint).
- `pnpm build` — passed.
- `git diff --check` — passed.
- Fresh repository autoreview (`gpt-5.6-sol`, high) — clean, no findings; patch correct (0.88 confidence).
- The earlier full repository run remains 1,826 passed with 8 unrelated platform/timing-sensitive failures; no changed bridge assertion failed.

Production delta versus the base is +276/-65; tests are +430/-52. Positive production growth establishes the authoritative response boundary, reverse identity ownership, direct-thread kind preservation, and server-owned Mattermost allocation/correlation contracts.
