### PR TITLE
fix: Windows readiness runs fail when channels publish together

### DIFF
--- a/src/openclaw/private-file.ts
+++ b/src/openclaw/private-file.ts
@@ -4,6 +4,7 @@ import { constants as fsConstants, readFileSync, type BigIntStats } from "node:f
 import fs, { type FileHandle } from "node:fs/promises";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
+import { setTimeout as delay } from "node:timers/promises";
 import { promisify } from "node:util";
 import {
   applyOwnerOnlyWindowsDirectoryAcl as applyOwnerOnlyWindowsDirectoryAclByHandle,
@@ -1302,6 +1303,22 @@ type PrivateMutationClaim = {
   release(): Promise<void>;
 };
 
+type PrivateMutationClaimWaitOptions = {
+  now?: () => number;
+  retryDelayMs?: number;
+  signal?: AbortSignal;
+  sleep?: (delayMs: number, signal?: AbortSignal) => Promise<void>;
+  timeoutMs?: number;
+};
+
+type PreparedPrivateMutationClaimWait = {
+  now: () => number;
+  retryDelayMs: number;
+  signal?: AbortSignal;
+  sleep: (delayMs: number, signal?: AbortSignal) => Promise<void>;
+  timeoutMs: number;
+};
+
 export type PrivateMutationClaimRuntime = {
   getProcessIdentity(pid: number): string | null;
   isProcessAlive(pid: number): boolean;
@@ -1322,6 +1339,42 @@ const PRIVATE_MUTATION_CLAIM_ROOT_FILE = ".crabline-private-mutation.claim";
 const PRIVATE_MUTATION_CLAIM_OWNER_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/u;
 const PRIVATE_MUTATION_CLAIM_METADATA_MAX_BYTES = 4096;
 const PRIVATE_MUTATION_RESERVED_BASENAME_PATTERN = /^\.crabline-private-mutation(?:\.|$)/iu;
+const PRIVATE_MUTATION_CLAIM_WAIT_TIMEOUT_MS = 60_000;
+const PRIVATE_MUTATION_CLAIM_RETRY_DELAY_MS = 50;
+
+function preparePrivateMutationClaimWait(
+  options: PrivateMutationClaimWaitOptions,
+): PreparedPrivateMutationClaimWait {
+  const timeoutMs = options.timeoutMs ?? PRIVATE_MUTATION_CLAIM_WAIT_TIMEOUT_MS;
+  const retryDelayMs = options.retryDelayMs ?? PRIVATE_MUTATION_CLAIM_RETRY_DELAY_MS;
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 0) {
+    throw new Error("Private mutation claim wait timeout must be a non-negative safe integer.");
+  }
+  if (!Number.isSafeInteger(retryDelayMs) || retryDelayMs <= 0) {
+    throw new Error("Private mutation claim retry delay must be a positive safe integer.");
+  }
+  const now = options.now ?? performance.now.bind(performance);
+  const sleep =
+    options.sleep ??
+    ((delayMs: number, signal?: AbortSignal) => delay(delayMs, undefined, { signal }));
+  if (typeof now !== "function" || typeof sleep !== "function") {
+    throw new Error("Private mutation claim wait callbacks must be functions.");
+  }
+  if (options.signal !== undefined && typeof options.signal.throwIfAborted !== "function") {
+    throw new Error("Private mutation claim wait signal is invalid.");
+  }
+  options.signal?.throwIfAborted();
+  if (!Number.isFinite(now())) {
+    throw new Error("Private mutation claim wait clock is invalid.");
+  }
+  return {
+    now,
+    retryDelayMs,
+    ...(options.signal ? { signal: options.signal } : {}),
+    sleep,
+    timeoutMs,
+  };
+}
 
 function assertNotReservedPrivateMutationPath(targetPath: string): void {
   if (PRIVATE_MUTATION_RESERVED_BASENAME_PATTERN.test(path.basename(targetPath))) {
@@ -1622,6 +1675,12 @@ class UnsupportedPrivateMutationHardLinkError extends Error {
   }
 }
 
+class ActivePrivateMutationClaimError extends Error {
+  constructor(cause: unknown) {
+    super("Private path mutation is already claimed.", { cause });
+  }
+}
+
 function isUnsupportedHardLinkError(error: unknown): boolean {
   const code = (error as NodeJS.ErrnoException).code;
   return code === "EPERM" || code === "ENOTSUP" || code === "EOPNOTSUPP" || code === "ENOSYS";
@@ -1718,14 +1777,14 @@ async function acquireHardLinkPrivateMutationClaim(
             observed.owner.pid === runtime.pid &&
             observed.owner.processStartedAtMs === runtime.processStartedAtMs
           ) {
-            throw new Error("Private path mutation is already claimed.", { cause: error });
+            throw new ActivePrivateMutationClaimError(error);
           } else if (observed.owner.pid !== runtime.pid) {
             if (observed.owner.processIdentity === undefined) {
-              throw new Error("Private path mutation is already claimed.", { cause: error });
+              throw new ActivePrivateMutationClaimError(error);
             }
             const actualIdentity = runtime.getProcessIdentity(observed.owner.pid);
             if (actualIdentity === null || actualIdentity === observed.owner.processIdentity) {
-              throw new Error("Private path mutation is already claimed.", { cause: error });
+              throw new ActivePrivateMutationClaimError(error);
             }
           }
         }
@@ -2143,7 +2202,7 @@ async function acquireDirectoryPrivateMutationClaim(
           throw error;
         }
         if (privateMutationClaimOwnerIsActive(observed.metadata.owner, runtime)) {
-          throw new Error("Private path mutation is already claimed.", { cause: error });
+          throw new ActivePrivateMutationClaimError(error);
         }
         await parent.assertIdentityAt();
         const revalidated = await readPrivateMutationDirectoryClaim(claimPath);
@@ -2543,9 +2602,8 @@ async function acquirePrivateMutationClaimChain(
 ): Promise<PrivateMutationClaim> {
   const platform = options.platform ?? process.platform;
   const ancestry = await ownerOnlyPrivateClaimAncestry(leaf, platform);
-  const highestClaimDirectory = ancestry.at(-1)!;
   const outerBoundary = await captureSafePrivateDirectoryMutationParent(
-    highestClaimDirectory.directoryPath,
+    ancestry.at(-1)!.directoryPath,
     platform,
   );
   const claims: PrivateMutationClaim[] = [];
@@ -2657,6 +2715,68 @@ async function acquirePrivateMutationClaimChain(
   };
 }
 
+function privateMutationClaimTimeoutError(timeoutMs: number, cause: unknown): Error {
+  return Object.assign(
+    new Error(`Timed out after ${timeoutMs}ms waiting for a private mutation claim.`, { cause }),
+    { code: "ETIMEDOUT" },
+  );
+}
+
+async function releaseClaimAfterWaitFailure(
+  claim: PrivateMutationClaim,
+  error: unknown,
+): Promise<never> {
+  try {
+    await claim.release();
+  } catch (releaseError) {
+    const aggregateError = new AggregateError(
+      [error, releaseError],
+      "Private mutation claim wait failed and its acquired claim could not be released.",
+    );
+    aggregateError.cause = error;
+    throw aggregateError;
+  }
+  throw error;
+}
+
+async function acquirePrivateMutationClaimWithWait(
+  acquire: () => Promise<PrivateMutationClaim>,
+  wait?: PreparedPrivateMutationClaimWait,
+): Promise<PrivateMutationClaim> {
+  if (wait === undefined) {
+    return await acquire();
+  }
+  const deadlineMs = wait.now() + wait.timeoutMs;
+  let lastContentionError: ActivePrivateMutationClaimError | undefined;
+  for (;;) {
+    wait.signal?.throwIfAborted();
+    let claim: PrivateMutationClaim;
+    try {
+      claim = await acquire();
+    } catch (error) {
+      if (!(error instanceof ActivePrivateMutationClaimError) || wait.timeoutMs === 0) {
+        throw error;
+      }
+      lastContentionError = error;
+      const remainingMs = deadlineMs - wait.now();
+      if (remainingMs <= 0) {
+        throw privateMutationClaimTimeoutError(wait.timeoutMs, error);
+      }
+      await wait.sleep(Math.min(wait.retryDelayMs, remainingMs), wait.signal);
+      continue;
+    }
+    try {
+      wait.signal?.throwIfAborted();
+      if (lastContentionError && wait.now() >= deadlineMs) {
+        throw privateMutationClaimTimeoutError(wait.timeoutMs, lastContentionError);
+      }
+    } catch (error) {
+      return await releaseClaimAfterWaitFailure(claim, error);
+    }
+    return claim;
+  }
+}
+
 async function secureOwnerOnlyMutationParent(
   directoryPath: string,
 ): Promise<SecuredPrivateDirectory> {
@@ -2674,6 +2794,7 @@ export async function publishPrivateFileAtomically(
     beforeCommitRename?: (temporaryPath: string) => Promise<void>;
     beforeRename?: (temporaryPath: string) => Promise<void>;
     claimRuntime?: PrivateMutationClaimRuntime;
+    claimWait?: PrivateMutationClaimWaitOptions;
     createWindowsFile?: (temporaryPath: string) => Promise<FileIdentity>;
     createWindowsDirectories?: (directoryPath: string) => Promise<string | undefined>;
     platform?: NodeJS.Platform;
@@ -2683,6 +2804,7 @@ export async function publishPrivateFileAtomically(
   } = {},
 ): Promise<void> {
   assertNotReservedPrivateMutationPath(filePath);
+  const claimWait = preparePrivateMutationClaimWait(options.claimWait ?? {});
   const temporaryPath = path.join(
     path.dirname(filePath),
     `.${path.basename(filePath)}.${process.pid}.${randomUUID()}.tmp`,
@@ -2730,11 +2852,17 @@ export async function publishPrivateFileAtomically(
   await migrationBoundary?.assertIdentityAt();
   const parent = await secureOwnerOnlyMutationParent(parentDirectory);
   await migrationBoundary?.assertIdentityAt();
-  const claim = await acquirePrivateMutationClaimChain(parent, {
+  const claimOptions = {
     ...(options.claimRuntime ? { runtime: options.claimRuntime } : {}),
     ...(options.createWindowsFile ? { createWindowsFile: options.createWindowsFile } : {}),
     ...(options.platform ? { platform: options.platform } : {}),
-  });
+  };
+  // The full ancestry fence stays held for the temporary file's lifetime so supported removals
+  // cannot quarantine a secret. Active publishers wait here without serializing their whole flow.
+  const claim = await acquirePrivateMutationClaimWithWait(
+    () => acquirePrivateMutationClaimChain(parent, claimOptions),
+    claimWait,
+  );
   let handle: FileHandle | undefined;
   let identity: FileIdentity | undefined;
   let publicationFailed = false;

--- a/test/openclaw-private-file.test.ts
+++ b/test/openclaw-private-file.test.ts
@@ -61,6 +61,25 @@ async function writeOwnerOnlyClaimDirectory(
   await writeOwnerOnlyClaimFile(path.join(directoryPath, "owner.json"), contents);
 }
 
+function createForeignLiveClaimRuntimes() {
+  const identities = new Map([
+    [111, "test:holder-owner"],
+    [222, "test:waiter-owner"],
+  ]);
+  const createRuntime = (ownerId: string, pid: number) => ({
+    getProcessIdentity: vi.fn((candidatePid: number) => identities.get(candidatePid) ?? null),
+    isProcessAlive: (candidatePid: number) => identities.has(candidatePid),
+    ownerId,
+    pid,
+    processIdentity: identities.get(pid)!,
+    processStartedAtMs: pid,
+  });
+  return {
+    holder: createRuntime("holder-owner", 111),
+    waiter: createRuntime("waiter-owner", 222),
+  };
+}
+
 describe("OpenClaw private file publication", () => {
   it.skipIf(process.platform === "win32")(
     "replaces permissive POSIX files with mode 0600",
@@ -168,6 +187,41 @@ describe("OpenClaw private file publication", () => {
       }
     },
   );
+
+  it("rejects invalid claim waits before creating the publication parent", async () => {
+    const directory = await createTempDir();
+    const parent = path.join(directory, "invalid-wait");
+    try {
+      await expect(
+        publishPrivateFileAtomically(path.join(parent, "manifest.json"), "private\n", {
+          claimWait: { timeoutMs: -1 },
+        }),
+      ).rejects.toThrow("Private mutation claim wait timeout must be a non-negative safe integer.");
+
+      await expect(fs.stat(parent)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await disposeTempDir(directory);
+    }
+  });
+
+  it("rejects an already-aborted claim wait before creating the publication parent", async () => {
+    const directory = await createTempDir();
+    const parent = path.join(directory, "aborted-wait");
+    const controller = new AbortController();
+    const cancellation = new Error("cancel before publication setup");
+    controller.abort(cancellation);
+    try {
+      await expect(
+        publishPrivateFileAtomically(path.join(parent, "manifest.json"), "private\n", {
+          claimWait: { signal: controller.signal },
+        }),
+      ).rejects.toBe(cancellation);
+
+      await expect(fs.stat(parent)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await disposeTempDir(directory);
+    }
+  });
 
   it.skipIf(
     process.platform === "win32" ||
@@ -600,6 +654,58 @@ describe("OpenClaw private file publication", () => {
     }
   });
 
+  it("holds publication ancestry claims through temporary-file failure cleanup", async () => {
+    const directory = await createTempDir();
+    const securedAncestor = await securePrivateDirectory(directory);
+    const outputDirectory = path.join(directory, "telegram");
+    await fs.mkdir(outputDirectory);
+    const publicationError = new Error("publication failed after removal attempt");
+    let removalRenameReached = false;
+    let removalRecursiveReached = false;
+    let temporaryPath: string | undefined;
+    try {
+      await expect(
+        publishPrivateFileAtomically(
+          path.join(outputDirectory, "manifest.json"),
+          "private credential\n",
+          {
+            beforeRename: async (candidatePath) => {
+              temporaryPath = candidatePath;
+              await expect(
+                removeSecuredPrivateDirectory(securedAncestor, undefined, "suite-root", {
+                  beforeRecursiveRemove: async () => {
+                    removalRecursiveReached = true;
+                    throw new Error("removal aborted after quarantine rename");
+                  },
+                  beforeRename: async () => {
+                    removalRenameReached = true;
+                  },
+                }),
+              ).rejects.toThrow("Private path mutation is already claimed.");
+              throw publicationError;
+            },
+          },
+        ),
+      ).rejects.toBe(publicationError);
+
+      expect(removalRenameReached).toBe(false);
+      expect(removalRecursiveReached).toBe(false);
+      expect(temporaryPath).toBeDefined();
+      await expect(fs.stat(temporaryPath!)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.stat(outputDirectory)).resolves.toBeDefined();
+      await expect(fs.stat(path.join(outputDirectory, "manifest.json"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      expect(
+        (await fs.readdir(directory, { recursive: true })).filter(
+          (entry) => entry.includes(".tmp") || entry.includes(".remove"),
+        ),
+      ).toEqual([]);
+    } finally {
+      await disposeTempDir(directory);
+    }
+  });
+
   it("preserves undefined and null publication rejection reasons", async () => {
     const directory = await createTempDir();
     try {
@@ -707,9 +813,19 @@ describe("OpenClaw private file publication", () => {
       const reachedCommit = new Promise<void>((resolve) => {
         commitReached = resolve;
       });
+      let allowRetry!: () => void;
+      const retryAllowed = new Promise<void>((resolve) => {
+        allowRetry = resolve;
+      });
+      let retryReached!: () => void;
+      const reachedRetry = new Promise<void>((resolve) => {
+        retryReached = resolve;
+      });
+      let firstPublication: Promise<void> | undefined;
+      let secondPublication: Promise<void> | undefined;
       try {
         const filePath = path.join(directory, "manifest.json");
-        const firstPublication = publishPrivateFileAtomically(filePath, "first\n", {
+        firstPublication = publishPrivateFileAtomically(filePath, "first\n", {
           beforeCommitRename: async () => {
             const claimName = (await fs.readdir(directory)).find((entry) =>
               entry.endsWith(".claim"),
@@ -724,25 +840,276 @@ describe("OpenClaw private file publication", () => {
         });
         await reachedCommit;
 
-        await expect(publishPrivateFileAtomically(filePath, "second\n")).rejects.toThrow(
-          "Private path mutation is already claimed.",
-        );
+        secondPublication = publishPrivateFileAtomically(filePath, "second\n", {
+          claimWait: {
+            sleep: async () => {
+              retryReached();
+              await retryAllowed;
+            },
+          },
+        });
+        await reachedRetry;
 
         releaseCommit();
         await firstPublication;
-        await expect(fs.readFile(filePath, "utf8")).resolves.toBe("first\n");
+        allowRetry();
+        await secondPublication;
+        await expect(fs.readFile(filePath, "utf8")).resolves.toBe("second\n");
         expect((await fs.readdir(directory)).filter((entry) => entry.endsWith(".claim"))).toEqual(
           [],
         );
       } finally {
         releaseCommit();
+        allowRetry();
+        await firstPublication?.catch(() => undefined);
+        await secondPublication?.catch(() => undefined);
         await disposeTempDir(directory);
       }
     },
   );
 
+  it("waits for a sibling Windows publication claim at their shared ancestor", async () => {
+    const directory = await createTempDir();
+    const { holder, waiter } = createForeignLiveClaimRuntimes();
+    const firstDirectory = path.join(directory, "telegram");
+    const secondDirectory = path.join(directory, "matrix");
+    await fs.mkdir(firstDirectory);
+    await fs.mkdir(secondDirectory);
+    let releaseCommit!: () => void;
+    const commitReleased = new Promise<void>((resolve) => {
+      releaseCommit = resolve;
+    });
+    let commitReached!: () => void;
+    const reachedCommit = new Promise<void>((resolve) => {
+      commitReached = resolve;
+    });
+    let allowRetry!: () => void;
+    const retryAllowed = new Promise<void>((resolve) => {
+      allowRetry = resolve;
+    });
+    let retryReached!: () => void;
+    const reachedRetry = new Promise<void>((resolve) => {
+      retryReached = resolve;
+    });
+    let firstPublication: Promise<void> | undefined;
+    let secondPublication: Promise<void> | undefined;
+    try {
+      firstPublication = publishPrivateFileAtomically(
+        path.join(firstDirectory, "manifest.json"),
+        "telegram\n",
+        {
+          beforeCommitRename: async () => {
+            commitReached();
+            await commitReleased;
+          },
+          claimRuntime: holder,
+          platform: "win32",
+          secureWindowsFile: async () => undefined,
+        },
+      );
+      await reachedCommit;
+
+      secondPublication = publishPrivateFileAtomically(
+        path.join(secondDirectory, "manifest.json"),
+        "matrix\n",
+        {
+          claimRuntime: waiter,
+          claimWait: {
+            sleep: async () => {
+              retryReached();
+              await retryAllowed;
+            },
+          },
+          platform: "win32",
+          secureWindowsFile: async () => undefined,
+        },
+      );
+      await reachedRetry;
+      await expect(fs.readdir(secondDirectory)).resolves.toEqual([]);
+
+      releaseCommit();
+      await firstPublication;
+      allowRetry();
+      await secondPublication;
+
+      await expect(fs.readFile(path.join(firstDirectory, "manifest.json"), "utf8")).resolves.toBe(
+        "telegram\n",
+      );
+      await expect(fs.readFile(path.join(secondDirectory, "manifest.json"), "utf8")).resolves.toBe(
+        "matrix\n",
+      );
+      expect(waiter.getProcessIdentity).toHaveBeenCalledWith(holder.pid);
+    } finally {
+      releaseCommit();
+      allowRetry();
+      await firstPublication?.catch(() => undefined);
+      await secondPublication?.catch(() => undefined);
+      await disposeTempDir(directory);
+    }
+  });
+
+  it("aborts a waiting sibling publication and removes its prepared file", async () => {
+    const directory = await createTempDir();
+    const firstDirectory = path.join(directory, "telegram");
+    const secondDirectory = path.join(directory, "matrix");
+    await fs.mkdir(firstDirectory);
+    await fs.mkdir(secondDirectory);
+    const controller = new AbortController();
+    const cancellation = new Error("cancel sibling publication");
+    const actualLink = fs.link.bind(fs);
+    let abortOnSuccessfulLink = false;
+    const linkSpy = vi.spyOn(fs, "link").mockImplementation(async (...args) => {
+      await actualLink(...args);
+      if (abortOnSuccessfulLink) {
+        controller.abort(cancellation);
+      }
+    });
+    let releaseCommit!: () => void;
+    const commitReleased = new Promise<void>((resolve) => {
+      releaseCommit = resolve;
+    });
+    let commitReached!: () => void;
+    const reachedCommit = new Promise<void>((resolve) => {
+      commitReached = resolve;
+    });
+    let waitReached!: () => void;
+    const reachedWait = new Promise<void>((resolve) => {
+      waitReached = resolve;
+    });
+    let allowRetry!: () => void;
+    const retryAllowed = new Promise<void>((resolve) => {
+      allowRetry = resolve;
+    });
+    let firstPublication: Promise<void> | undefined;
+    let secondPublication: Promise<void> | undefined;
+    try {
+      firstPublication = publishPrivateFileAtomically(
+        path.join(firstDirectory, "manifest.json"),
+        "telegram\n",
+        {
+          beforeCommitRename: async () => {
+            commitReached();
+            await commitReleased;
+          },
+          platform: "win32",
+          secureWindowsFile: async () => undefined,
+        },
+      );
+      await reachedCommit;
+
+      secondPublication = publishPrivateFileAtomically(
+        path.join(secondDirectory, "manifest.json"),
+        "matrix\n",
+        {
+          claimWait: {
+            signal: controller.signal,
+            sleep: async () => {
+              waitReached();
+              await retryAllowed;
+            },
+          },
+          platform: "win32",
+          secureWindowsFile: async () => undefined,
+        },
+      );
+      await reachedWait;
+      abortOnSuccessfulLink = true;
+      releaseCommit();
+      await firstPublication;
+      allowRetry();
+
+      await expect(secondPublication).rejects.toBe(cancellation);
+      await expect(fs.readdir(secondDirectory)).resolves.toEqual([]);
+
+      expect(
+        (await fs.readdir(directory, { recursive: true })).filter((entry) =>
+          entry.includes(".crabline-private-mutation"),
+        ),
+      ).toEqual([]);
+    } finally {
+      controller.abort(cancellation);
+      releaseCommit();
+      allowRetry();
+      await firstPublication?.catch(() => undefined);
+      await secondPublication?.catch(() => undefined);
+      linkSpy.mockRestore();
+      await disposeTempDir(directory);
+    }
+  });
+
+  it("times out a waiting sibling publication with bounded non-spinning retries", async () => {
+    const directory = await createTempDir();
+    const firstDirectory = path.join(directory, "telegram");
+    const secondDirectory = path.join(directory, "matrix");
+    await fs.mkdir(firstDirectory);
+    await fs.mkdir(secondDirectory);
+    let releaseCommit!: () => void;
+    const commitReleased = new Promise<void>((resolve) => {
+      releaseCommit = resolve;
+    });
+    let commitReached!: () => void;
+    const reachedCommit = new Promise<void>((resolve) => {
+      commitReached = resolve;
+    });
+    let firstPublication: Promise<void> | undefined;
+    let nowMs = 0;
+    const sleepDelays: number[] = [];
+    try {
+      firstPublication = publishPrivateFileAtomically(
+        path.join(firstDirectory, "manifest.json"),
+        "telegram\n",
+        {
+          beforeCommitRename: async () => {
+            commitReached();
+            await commitReleased;
+          },
+          platform: "win32",
+          secureWindowsFile: async () => undefined,
+        },
+      );
+      await reachedCommit;
+
+      const failure = await publishPrivateFileAtomically(
+        path.join(secondDirectory, "manifest.json"),
+        "matrix\n",
+        {
+          claimWait: {
+            now: () => nowMs,
+            retryDelayMs: 40,
+            sleep: async (delayMs) => {
+              sleepDelays.push(delayMs);
+              nowMs += delayMs;
+              if (nowMs === 100) {
+                releaseCommit();
+                await firstPublication;
+              }
+            },
+            timeoutMs: 100,
+          },
+          platform: "win32",
+          secureWindowsFile: async () => undefined,
+        },
+      ).catch((error: unknown) => error);
+
+      expect(failure).toMatchObject({
+        code: "ETIMEDOUT",
+        message: "Timed out after 100ms waiting for a private mutation claim.",
+      });
+      expect(sleepDelays).toEqual([40, 40, 20]);
+      await expect(fs.readdir(secondDirectory)).resolves.toEqual([]);
+      await expect(fs.readFile(path.join(firstDirectory, "manifest.json"), "utf8")).resolves.toBe(
+        "telegram\n",
+      );
+    } finally {
+      releaseCommit();
+      await firstPublication?.catch(() => undefined);
+      await disposeTempDir(directory);
+    }
+  });
+
   it("falls back to an atomically renamed claim directory without hard-link support", async () => {
     const directory = await createTempDir();
+    const { holder, waiter } = createForeignLiveClaimRuntimes();
     const linkSpy = vi
       .spyOn(fs, "link")
       .mockRejectedValue(Object.assign(new Error("hard links unsupported"), { code: "ENOTSUP" }));
@@ -754,7 +1121,16 @@ describe("OpenClaw private file publication", () => {
     const reachedCommit = new Promise<void>((resolve) => {
       commitReached = resolve;
     });
+    let allowRetry!: () => void;
+    const retryAllowed = new Promise<void>((resolve) => {
+      allowRetry = resolve;
+    });
+    let retryReached!: () => void;
+    const reachedRetry = new Promise<void>((resolve) => {
+      retryReached = resolve;
+    });
     let firstPublication: Promise<void> | undefined;
+    let secondPublication: Promise<void> | undefined;
     try {
       const filePath = path.join(directory, "manifest.json");
       firstPublication = publishPrivateFileAtomically(filePath, "private\n", {
@@ -762,16 +1138,27 @@ describe("OpenClaw private file publication", () => {
           commitReached();
           await commitReleased;
         },
+        claimRuntime: holder,
       });
       await reachedCommit;
 
-      await expect(publishPrivateFileAtomically(filePath, "second\n")).rejects.toThrow(
-        "Private path mutation is already claimed.",
-      );
+      secondPublication = publishPrivateFileAtomically(filePath, "second\n", {
+        claimRuntime: waiter,
+        claimWait: {
+          sleep: async () => {
+            retryReached();
+            await retryAllowed;
+          },
+        },
+      });
+      await reachedRetry;
 
       releaseCommit();
       await firstPublication;
-      await expect(fs.readFile(filePath, "utf8")).resolves.toBe("private\n");
+      allowRetry();
+      await secondPublication;
+      await expect(fs.readFile(filePath, "utf8")).resolves.toBe("second\n");
+      expect(waiter.getProcessIdentity).toHaveBeenCalledWith(holder.pid);
       expect(
         (await fs.readdir(directory)).filter((entry) =>
           entry.startsWith(".crabline-private-mutation"),
@@ -779,7 +1166,9 @@ describe("OpenClaw private file publication", () => {
       ).toEqual([]);
     } finally {
       releaseCommit();
+      allowRetry();
       await firstPublication?.catch(() => undefined);
+      await secondPublication?.catch(() => undefined);
       linkSpy.mockRestore();
       await disposeTempDir(directory);
     }
@@ -787,6 +1176,7 @@ describe("OpenClaw private file publication", () => {
 
   it("recovers a stale directory claim on filesystems without hard-link support", async () => {
     const directory = await createTempDir();
+    const sleep = vi.fn(async () => undefined);
     try {
       const claimPath = path.join(directory, ".crabline-private-mutation.claim");
       await writeOwnerOnlyClaimDirectory(
@@ -808,6 +1198,7 @@ describe("OpenClaw private file publication", () => {
           processIdentity: "test:replacement-owner",
           processStartedAtMs: 200,
         },
+        claimWait: { sleep },
       });
 
       await expect(fs.readFile(path.join(directory, "manifest.json"), "utf8")).resolves.toBe(
@@ -818,6 +1209,7 @@ describe("OpenClaw private file publication", () => {
           entry.startsWith(".crabline-private-mutation"),
         ),
       ).toEqual([]);
+      expect(sleep).not.toHaveBeenCalled();
     } finally {
       await disposeTempDir(directory);
     }
@@ -925,6 +1317,7 @@ describe("OpenClaw private file publication", () => {
               processIdentity: "test:replacement-owner",
               processStartedAtMs: 200,
             },
+            claimWait: { timeoutMs: 0 },
           }),
         ).rejects.toThrow("Private path mutation is already claimed.");
 
@@ -1022,6 +1415,7 @@ describe("OpenClaw private file publication", () => {
             processIdentity: "test:replacement-owner",
             processStartedAtMs: 200,
           },
+          claimWait: { timeoutMs: 0 },
         }),
       ).rejects.toThrow("Private path mutation is already claimed.");
 
@@ -1083,6 +1477,7 @@ describe("OpenClaw private file publication", () => {
             processIdentity: "test:replacement-owner",
             processStartedAtMs: 200,
           },
+          claimWait: { timeoutMs: 0 },
         }),
       ).rejects.toThrow("Private path mutation is already claimed.");
 
@@ -1228,7 +1623,9 @@ describe("OpenClaw private file publication", () => {
       await reachedCommit;
 
       await expect(
-        publishPrivateFileAtomically(path.join(directory, "MANIFEST.JSON"), "second\n"),
+        publishPrivateFileAtomically(path.join(directory, "MANIFEST.JSON"), "second\n", {
+          claimWait: { timeoutMs: 0 },
+        }),
       ).rejects.toThrow("Private path mutation is already claimed.");
 
       releaseCommit();
@@ -1685,6 +2082,7 @@ describe("OpenClaw private file publication", () => {
             processIdentity: "test:second-owner",
             processStartedAtMs: 200,
           },
+          claimWait: { timeoutMs: 0 },
         }),
       ).rejects.toThrow("Private path mutation is already claimed.");
 


### PR DESCRIPTION
Closes #263

Related: https://github.com/openclaw/openclaw/pull/118008

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Concurrent Crabline readiness runs for sibling channel outputs can fail on Windows with `Private path mutation is already claimed.` The output-local readiness locks are independent, but Windows private-file publications correctly claim their shared owner-only ancestry. A verified live owner was treated as a terminal error, so OpenClaw had to serialize entire provider-readiness flows and cap concurrency.

## Why This Change Was Made

`publishPrivateFileAtomically` is the architectural owner of the full ancestry fence. It now validates wait controls before any directory, ACL, or temporary-file mutation and retries only claims classified as verified active owners. Retries use a 50 ms delay, a 60 second monotonic deadline, and optional cancellation; partial or newly acquired claims are released on failure, timeout, and abort. Malformed or unsafe claims still fail closed, stale owners still recover, and directory removal remains fail-fast.

The existing full ancestry claim stays held from before secret temporary-file creation through rename, sync, failure cleanup, and release. A narrower leaf/commit split was evaluated and rejected because ancestor quarantine could orphan the secret temp. The critical section is therefore one small atomic file publication, not adapter startup, provider probing, recorder work, capability generation, or a whole readiness flow.

Production delta: +136/-8 (net +128). The added code is limited to wait-option preflight, verified-active classification, bounded abort/deadline retry with acquired-claim rollback, and publication wiring at the existing security owner.

## User Impact

Windows users can run sibling Crabline channel readiness flows concurrently without transient private-publication claim failures. After a release containing this fix is adopted, OpenClaw can remove the shared `crabline-provider-readiness` whole-flow scheduler key and Crabline-specific `maxConcurrency` mitigation from openclaw/openclaw#118008; Crabline will serialize only each private-file publication.

## Evidence

- Targeted contention/security cases: 9/9 passed. Covers same-target serialization, sibling Windows outputs, foreign-live holder/waiter identity, hard-link and directory fallback, stale recovery, abort, exact-deadline timeout, pre-mutation validation, and ancestor-removal orphan prevention.
- Complete private-file suite excluding one exact-base macOS ACL failure: 86/86 passed, 8 skipped. Unfiltered result: 86 passed, 7 skipped, and only `rejects inherited macOS ACL risk without mutating the existing ancestor` failed; the same test fails unchanged on clean base `858a21c9`.
- Sibling artifact generation, provider-readiness lock, and OpenClaw bridge suites: 205/205 passed.
- `pnpm lint`, `pnpm typecheck`, `pnpm build`, formatting, and `git diff --check`: passed.
- Full coverage run reached 1830 passed and 36 skipped; 7 unrelated high-parallelism timeout/environment cases failed. Focused reruns of all touched and owning sibling surfaces are green.
- `pnpm test:autoreview`: its 3 Vitest tooling tests passed; the Python harness could not run because this host only has Python 3.9 and the harness requires 3.10+.
- Fresh structured autoreview: `patch is correct`, confidence 0.87, no accepted/actionable findings.