### PR TITLE
fix(openclaw): tolerate released mutation claims

### DIFF
--- a/src/openclaw/private-file.ts
+++ b/src/openclaw/private-file.ts
@@ -1533,23 +1533,34 @@ function parsePrivateMutationClaimOwner(contents: string): PrivateMutationClaimO
   return owner as PrivateMutationClaimOwner;
 }
 
+async function claimPathHasIdentity(
+  claimPath: string,
+  expected: FileIdentity,
+  expectedLinkCount?: bigint,
+): Promise<boolean> {
+  try {
+    const stats = await fs.lstat(claimPath, { bigint: true });
+    return (
+      stats.isFile() &&
+      (expectedLinkCount === undefined ? stats.nlink >= 1n : stats.nlink === expectedLinkCount) &&
+      stats.dev === expected.device &&
+      stats.ino === expected.inode
+    );
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+    throw new Error("Private path mutation claim identity changed.", { cause: error });
+  }
+}
+
 async function assertClaimPathIdentity(
   claimPath: string,
   expected: FileIdentity,
   expectedLinkCount?: bigint,
 ): Promise<void> {
-  try {
-    const stats = await fs.lstat(claimPath, { bigint: true });
-    if (
-      stats.isFile() &&
-      (expectedLinkCount === undefined ? stats.nlink >= 1n : stats.nlink === expectedLinkCount) &&
-      stats.dev === expected.device &&
-      stats.ino === expected.inode
-    ) {
-      return;
-    }
-  } catch (error) {
-    throw new Error("Private path mutation claim identity changed.", { cause: error });
+  if (await claimPathHasIdentity(claimPath, expected, expectedLinkCount)) {
+    return;
   }
   throw new Error("Private path mutation claim identity changed.");
 }
@@ -1621,7 +1632,11 @@ async function readPrivateMutationClaim(
     }
     const contents = buffer.toString("utf8");
     const owner = parsePrivateMutationClaimOwner(contents);
-    await assertClaimPathIdentity(claimPath, identity);
+    // A live owner may release or replace this pathname after our handle opens.
+    // The open handle is safe, but its metadata is no longer the active claim.
+    if (!(await claimPathHasIdentity(claimPath, identity))) {
+      return null;
+    }
     return { contents, identity, owner };
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {

--- a/test/openclaw-private-file.test.ts
+++ b/test/openclaw-private-file.test.ts
@@ -1731,6 +1731,73 @@ describe("OpenClaw private file publication", () => {
     }
   });
 
+  it("retries when an active claim is released after its metadata is opened", async () => {
+    const directory = await createTempDir();
+    let releaseCommit!: () => void;
+    const commitReleased = new Promise<void>((resolve) => {
+      releaseCommit = resolve;
+    });
+    let commitReached!: () => void;
+    const reachedCommit = new Promise<void>((resolve) => {
+      commitReached = resolve;
+    });
+    let firstPublication: Promise<void> | undefined;
+    let claimOpened = false;
+    let releasedAfterOpen = false;
+    const claimPath = path.join(directory, ".crabline-private-mutation.claim");
+    const actualOpen = fs.open.bind(fs);
+    const actualLstat = fs.lstat.bind(fs);
+    try {
+      const filePath = path.join(directory, "manifest.json");
+      firstPublication = publishPrivateFileAtomically(filePath, "first\n", {
+        beforeCommitRename: async () => {
+          commitReached();
+          await commitReleased;
+        },
+      });
+      await reachedCommit;
+
+      const openSpy = vi.spyOn(fs, "open").mockImplementation(async (openedPath, flags, mode) => {
+        const handle =
+          mode === undefined
+            ? await actualOpen(openedPath, flags)
+            : await actualOpen(openedPath, flags, mode);
+        if (openedPath === claimPath && (flags === "r" || typeof flags === "number")) {
+          claimOpened = true;
+        }
+        return handle;
+      });
+      const lstatSpy = vi.spyOn(fs, "lstat").mockImplementation(async (openedPath, options) => {
+        if (!releasedAfterOpen && claimOpened && openedPath === claimPath) {
+          releasedAfterOpen = true;
+          releaseCommit();
+          await firstPublication;
+        }
+        return options === undefined
+          ? await actualLstat(openedPath)
+          : await actualLstat(openedPath, options);
+      });
+      try {
+        await publishPrivateFileAtomically(filePath, "second\n");
+      } finally {
+        openSpy.mockRestore();
+        lstatSpy.mockRestore();
+      }
+
+      expect(releasedAfterOpen).toBe(true);
+      await expect(fs.readFile(filePath, "utf8")).resolves.toBe("second\n");
+      expect(
+        (await fs.readdir(directory)).filter((entry) =>
+          entry.startsWith(".crabline-private-mutation"),
+        ),
+      ).toEqual([]);
+    } finally {
+      releaseCommit();
+      await firstPublication?.catch(() => undefined);
+      await disposeTempDir(directory);
+    }
+  });
+
   it("retries the root claim when its owner releases after stale classification", async () => {
     const directory = await createTempDir();
     let releaseCommit!: () => void;


### PR DESCRIPTION
## Summary

- treat a released or replaced mutation-claim pathname as a stale observation during claim acquisition
- keep owned-claim identity assertions strict
- add a deterministic release-after-open regression with residue cleanup proof

## Root cause

A waiter could open and safely read an active claim while its owner released that pathname. The final pathname identity check wrapped the resulting ENOENT as fatal corruption, so the waiter never reached the existing retry path. Concurrent nested Crabline readiness generations exposed this in OpenClaw QA smoke CI.

## Validation

- focused release-after-open regression: pass
- artifact generation and provider readiness lock suites: 101 passed
- pnpm lint: pass
- pnpm build: pass
- concurrent parent plus four descendant readiness stress: 11 iterations, zero failures after the fix; published 0.1.16 reproduced the failure before the fix
- autoreview: clean