### PR TITLE
fix: private artifacts fail under restrictive macOS ACLs

### DIFF
--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -773,7 +773,12 @@ Publication rollback removes them when possible, and the next lock-owning
 publisher prunes any leftovers before staging a new generation. Post-commit
 cleanup retains only the current and previous pointer generations.
 
-POSIX generation directories use mode `0700` and files use mode `0600`. Windows
+POSIX generation directories use mode `0700` and files use mode `0600`. On macOS,
+private directories must be ACL-free. Ancestors may retain fully understood,
+deny-only ACLs that do not propagate to children, including entries marked as
+inherited. Allowing, mixed, propagating, or unverifiable ancestor ACLs abort
+publication. Crabline never removes external ancestor ACLs; their denials can
+still cause filesystem operations to fail. Windows
 hosts require `powershell.exe` with `Set-Acl`; Crabline resolves it from the
 absolute local `SystemRoot` and applies a protected, inheritable DACL containing
 only the current user SID to an empty generation directory before creating

--- a/src/openclaw/private-file.ts
+++ b/src/openclaw/private-file.ts
@@ -849,28 +849,94 @@ async function syncPathAncestry(
   }
 }
 
-async function darwinDirectoryHasExtendedAcl(directoryPath: string): Promise<boolean> {
+type DarwinDirectoryAcl = "none" | "nonpropagating-deny" | "unsafe";
+
+// Directory rights from chmod(1); inheritance flags are deliberately not rights.
+const DARWIN_DIRECTORY_ACL_RIGHTS = new Set([
+  "list",
+  "add_file",
+  "search",
+  "delete",
+  "add_subdirectory",
+  "delete_child",
+  "readattr",
+  "writeattr",
+  "readextattr",
+  "writeextattr",
+  "readsecurity",
+  "writesecurity",
+  "chown",
+]);
+
+async function readDarwinDirectoryAcl(directoryPath: string): Promise<DarwinDirectoryAcl> {
   if (process.platform !== "darwin") {
-    return false;
+    return "none";
   }
+  const directory = await captureDirectoryIdentity(directoryPath);
   let output: string;
   try {
-    const result = await execFileAsync("/bin/ls", ["-lde", directoryPath], {
+    // A literal basename prevents newline-containing paths from impersonating ACEs.
+    const result = await execFileAsync("/bin/ls", ["-lde", "."], {
+      cwd: directoryPath,
       encoding: "utf8",
       env: { ...process.env, LC_ALL: "C" },
       maxBuffer: 64 * 1024,
     });
+    if (result.stderr.length > 0) {
+      throw new Error("macOS ACL inspection reported a diagnostic.");
+    }
     output = result.stdout;
   } catch (error) {
     throw new Error("Could not verify the private directory macOS ACL.", { cause: error });
   }
-  const mode = output.trimStart().split(/\s+/u, 1)[0] ?? "";
-  return mode.includes("+");
+  await directory.assertIdentityAt();
+  for (const character of output) {
+    const code = character.charCodeAt(0);
+    if ((code < 32 && character !== "\n") || (code >= 127 && code <= 159)) {
+      return "unsafe";
+    }
+  }
+  const [header, ...entries] = output.slice(0, -1).split("\n");
+  const mode = header?.match(
+    /^d[r-][w-][xsS-][r-][w-][xsS-][r-][w-][xtT-]([+@]?) +[1-9]\d* +\S+ +\S+ +\d+ +[A-Z][a-z]{2} +\d{1,2} +(?:\d{2}:\d{2}|\d{4}) +\.$/u,
+  );
+  if (!output.endsWith("\n") || !mode) {
+    return "unsafe";
+  }
+  // Extended attributes take precedence over '+' in ls, even when an ACL exists.
+  if (entries.length === 0) {
+    return mode[1] === "+" ? "unsafe" : "none";
+  }
+  if (mode[1] === "") {
+    return "unsafe";
+  }
+  for (const [index, entry] of entries.entries()) {
+    // 'inherited' records origin; unlike *_inherit flags it does not propagate.
+    const ace = entry.match(
+      /^ +(\d+): (?:user|group):\S+ (?:inherited )?deny ([a-z_]+(?:,[a-z_]+)*)$/u,
+    );
+    if (
+      !ace ||
+      ace[1] !== String(index) ||
+      !ace[2]!.split(",").every((right) => DARWIN_DIRECTORY_ACL_RIGHTS.has(right))
+    ) {
+      return "unsafe";
+    }
+  }
+  return "nonpropagating-deny";
 }
 
-async function assertDarwinDirectoryHasNoExtendedAcl(directoryPath: string): Promise<void> {
-  if (await darwinDirectoryHasExtendedAcl(directoryPath)) {
-    throw new Error("Private directory must not have a macOS extended ACL.");
+async function assertDarwinDirectoryAcl(
+  directoryPath: string,
+  scope: "private" | "ancestor",
+): Promise<void> {
+  const acl = await readDarwinDirectoryAcl(directoryPath);
+  if (acl === "unsafe" || (scope === "private" && acl !== "none")) {
+    throw new Error(
+      scope === "private"
+        ? "Private directory must not have a macOS extended ACL."
+        : "Private mutation ancestry has an unsafe or unverifiable macOS ACL.",
+    );
   }
 }
 
@@ -935,7 +1001,7 @@ async function assertDarwinCreatedAncestryHasNoExtendedAcl(
     currentPath = parentPath;
   }
   for (const createdPath of createdPaths.reverse()) {
-    await assertDarwinDirectoryHasNoExtendedAcl(createdPath);
+    await assertDarwinDirectoryAcl(createdPath, "private");
   }
 }
 
@@ -953,6 +1019,7 @@ async function captureSingleSafePrivateMutationBoundary(
   if (currentUserId === undefined || !Number.isSafeInteger(currentUserId) || currentUserId < 0) {
     throw new Error("Could not resolve the current POSIX user for private mutation.");
   }
+  const boundary = await captureDirectoryIdentity(directoryPath);
   const stats = await fs.lstat(directoryPath, { bigint: true });
   if (!stats.isDirectory()) {
     throw new Error("Private mutation boundary is not a directory.");
@@ -967,8 +1034,9 @@ async function captureSingleSafePrivateMutationBoundary(
   if (writableByAnotherPrincipal && !protectedByStickyOwnership) {
     throw new Error("Private mutation boundary is writable by another POSIX principal.");
   }
-  await assertDarwinDirectoryHasNoExtendedAcl(directoryPath);
-  return await captureDirectoryIdentity(directoryPath);
+  await assertDarwinDirectoryAcl(directoryPath, "ancestor");
+  await boundary.assertIdentityAt();
+  return boundary;
 }
 
 async function captureSafePrivateMutationBoundary(
@@ -1182,7 +1250,7 @@ export async function securePrivateDirectory(
       }
     }
     if (!existed) {
-      await assertDarwinDirectoryHasNoExtendedAcl(path.dirname(directoryPath));
+      await assertDarwinDirectoryAcl(path.dirname(directoryPath), "ancestor");
     }
     try {
       await fs.mkdir(directoryPath, { mode: 0o700 });
@@ -1251,7 +1319,7 @@ export async function securePrivateDirectory(
       const mutationRootMode =
         options.markMutationRoot === false ? currentStats.mode & 0o1000n : 0o1000n;
       await handle.chmod(Number(0o700n | mutationRootMode));
-      await assertDarwinDirectoryHasNoExtendedAcl(directoryPath);
+      await assertDarwinDirectoryAcl(directoryPath, "private");
       await (options.syncDirectory ?? (() => handle.sync()))();
     }
     await secured.assertIdentityAt();
@@ -1711,17 +1779,6 @@ async function acquireHardLinkPrivateMutationClaim(
 ): Promise<PrivateMutationClaim> {
   const platform = options.platform ?? process.platform;
   const runtime = options.runtime ?? defaultPrivateMutationClaimRuntime();
-  if (
-    !Number.isSafeInteger(runtime.pid) ||
-    runtime.pid <= 0 ||
-    !PRIVATE_MUTATION_CLAIM_OWNER_ID_PATTERN.test(runtime.ownerId) ||
-    !Number.isSafeInteger(runtime.processStartedAtMs) ||
-    runtime.processStartedAtMs <= 0 ||
-    (runtime.processIdentity !== undefined &&
-      (runtime.processIdentity.length === 0 || runtime.processIdentity.length > 256))
-  ) {
-    throw new Error("Private path mutation claim runtime is invalid.");
-  }
   if (
     !Number.isSafeInteger(runtime.pid) ||
     runtime.pid <= 0 ||
@@ -2561,6 +2618,7 @@ async function captureOwnerOnlyPrivateClaimAncestor(
   if (currentUserId === undefined || !Number.isSafeInteger(currentUserId) || currentUserId < 0) {
     throw new Error("Could not resolve the current POSIX user for private mutation claims.");
   }
+  const directory = await captureDirectoryIdentity(directoryPath);
   const stats = await fs.lstat(directoryPath, { bigint: true });
   if (!stats.isDirectory()) {
     throw new Error("Private mutation claim ancestry contains a non-directory entry.");
@@ -2568,12 +2626,13 @@ async function captureOwnerOnlyPrivateClaimAncestor(
   if (
     stats.uid !== BigInt(currentUserId) ||
     (stats.mode & 0o022n) !== 0n ||
-    (await darwinDirectoryHasExtendedAcl(directoryPath))
+    (await readDarwinDirectoryAcl(directoryPath)) === "unsafe"
   ) {
     return null;
   }
+  await directory.assertIdentityAt();
   return {
-    directory: await captureDirectoryIdentity(directoryPath),
+    directory,
     mutationRoot: (stats.mode & 0o1000n) !== 0n,
   };
 }

--- a/test/openclaw-artifact-generation.test.ts
+++ b/test/openclaw-artifact-generation.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -67,7 +68,10 @@ function createLock(): OpenClawCrablineProviderReadinessLock & {
   };
 }
 
-function publishParams(outputDir: string, lock = createLock()) {
+function publishParams(
+  outputDir: string,
+  lock: OpenClawCrablineProviderReadinessLock = createLock(),
+) {
   return {
     capabilityReport: { result: { selectedChannel: "telegram" } },
     lock,
@@ -1295,6 +1299,61 @@ describe("OpenClaw artifact generation publication", () => {
       await disposeTempDir(outputDir);
     }
   });
+
+  it.skipIf(process.platform !== "darwin")(
+    "publishes and rolls back beneath a deny-only macOS ancestor with a real lock",
+    async () => {
+      const ancestor = await createTempDir();
+      const outputDir = path.join(ancestor, "output");
+      await fs.mkdir(outputDir, { mode: 0o700 });
+      execFileSync("/bin/chmod", ["+a", "everyone deny delete", ancestor]);
+      const aclBefore = execFileSync("/bin/ls", ["-lde", "."], { cwd: ancestor, encoding: "utf8" });
+      const { dev, ino, mode } = await fs.lstat(ancestor);
+      const publish = async (
+        dependencies: Parameters<typeof publishOpenClawCrablineArtifactGeneration>[1],
+      ) => {
+        const lock = await acquireOpenClawCrablineProviderReadinessLock({
+          channel: "telegram",
+          outputDir,
+        });
+        try {
+          return await publishOpenClawCrablineArtifactGeneration(
+            publishParams(outputDir, lock),
+            dependencies,
+          );
+        } finally {
+          await lock.release();
+        }
+      };
+      try {
+        const publicationFailure = new Error("crash before pointer switch");
+        await expect(
+          publish({
+            beforePointerSwitch: async () => {
+              throw publicationFailure;
+            },
+          }),
+        ).rejects.toBe(publicationFailure);
+        const storePath = path.join(outputDir, OPENCLAW_CRABLINE_ARTIFACT_STORE_DIRECTORY);
+        await expect(fs.readdir(storePath)).resolves.toEqual([]);
+        await expect(readOpenClawCrablineArtifactPointer(outputDir)).resolves.toBeNull();
+        const result = await publish({});
+        expect((await readOpenClawCrablineArtifactPointer(outputDir))?.generation).toBe(
+          result.generation,
+        );
+        expect((await fs.readdir(storePath)).sort()).toEqual(
+          ["current.json", result.generation].sort(),
+        );
+        expect(execFileSync("/bin/ls", ["-lde", "."], { cwd: ancestor, encoding: "utf8" })).toBe(
+          aclBefore,
+        );
+        expect(await fs.lstat(ancestor)).toMatchObject({ dev, ino, mode });
+      } finally {
+        execFileSync("/bin/chmod", ["-N", ancestor]);
+        await disposeTempDir(ancestor);
+      }
+    },
+  );
 
   it("reclaims interrupted artifact removal tombstones", async () => {
     const outputDir = await createTempDir();

--- a/test/openclaw-private-file-acl.test.ts
+++ b/test/openclaw-private-file-acl.test.ts
@@ -1,0 +1,231 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  publishPrivateFileAtomically,
+  removeSecuredPrivateDirectory,
+  securePrivateDirectory,
+} from "../src/openclaw/private-file.js";
+import { createTempDir, disposeTempDir } from "./test-helpers.js";
+
+const { inspectCommand } = vi.hoisted(() => ({ inspectCommand: vi.fn() }));
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  const { promisify } = await import("node:util");
+  const run = promisify(actual.execFile);
+  return {
+    ...actual,
+    execFile: Object.assign(
+      (...args: Parameters<typeof actual.execFile>) => actual.execFile(...args),
+      {
+        [promisify.custom]: async (...args: Parameters<typeof run>) =>
+          (await inspectCommand(...args)) ?? (await run(...args)),
+      },
+    ),
+  };
+});
+
+function directoryAcl(directory: string): string[] {
+  return execFileSync("/bin/ls", ["-lde", "."], {
+    cwd: directory,
+    encoding: "utf8",
+    env: { ...process.env, LC_ALL: "C" },
+  })
+    .split("\n")
+    .slice(1)
+    .filter(Boolean);
+}
+
+async function directoryState(directory: string) {
+  const { dev, ino, mode, uid } = await fs.lstat(directory);
+  return { acl: directoryAcl(directory), dev, ino, mode, uid };
+}
+
+describe.skipIf(process.platform !== "darwin")("macOS private ancestry ACLs", () => {
+  afterEach(() => inspectCommand.mockReset());
+
+  it.each([
+    { mode: 0o755, inherited: false, acl: true, xattr: false },
+    { mode: 0o755, inherited: true, acl: true, xattr: true },
+    { mode: 0o1777, inherited: false, acl: true, xattr: false },
+    { mode: 0o755, inherited: false, acl: false, xattr: true },
+  ])(
+    "preserves safe ancestry ($mode, ACL=$acl, inherited=$inherited, xattr=$xattr) across all mutations",
+    async ({ mode, inherited, acl, xattr }) => {
+      const root = await createTempDir();
+      const ancestor = path.join(root, "ancestor\n 0: group:everyone allow add_file");
+      await fs.mkdir(ancestor);
+      try {
+        await fs.chmod(ancestor, mode);
+        if (acl) {
+          execFileSync("/bin/chmod", [
+            inherited ? "+ai" : "+a",
+            "group:everyone deny delete",
+            ancestor,
+          ]);
+          execFileSync("/bin/chmod", ["+a", "group:staff deny chown", ancestor]);
+        }
+        if (xattr) {
+          execFileSync("/usr/bin/xattr", ["-w", "com.crabline.acl-test", "fixture", ancestor]);
+        }
+        const before = await directoryState(ancestor);
+        const existing = path.join(ancestor, "existing");
+        const nested = path.join(ancestor, "nested", "deep");
+        await fs.mkdir(existing, { mode: 0o700 });
+        for (const directory of [existing, nested]) {
+          const file = path.join(directory, "private.json");
+          await publishPrivateFileAtomically(file, "private\n");
+          expect((await fs.stat(file)).mode & 0o777).toBe(0o600);
+          expect(
+            execFileSync("/bin/ls", ["-lde", "private.json"], { cwd: directory, encoding: "utf8" })
+              .split("\n")
+              .filter(Boolean),
+          ).toHaveLength(1);
+          expect((await fs.stat(directory)).mode & 0o777).toBe(0o700);
+          expect(directoryAcl(directory)).toEqual([]);
+          await removeSecuredPrivateDirectory(await securePrivateDirectory(directory));
+          await expect(fs.lstat(directory)).rejects.toMatchObject({ code: "ENOENT" });
+        }
+        expect(directoryAcl(path.dirname(nested))).toEqual([]);
+        expect((await fs.stat(path.dirname(nested))).mode & 0o777).toBe(0o700);
+        const direct = await securePrivateDirectory(path.join(ancestor, "direct"));
+        expect(directoryAcl(direct.directoryPath)).toEqual([]);
+        await removeSecuredPrivateDirectory(direct);
+        expect(await directoryState(ancestor)).toEqual(before);
+      } finally {
+        execFileSync("/bin/chmod", ["-N", ancestor]);
+        await disposeTempDir(root);
+      }
+    },
+  );
+
+  it("rejects an allowing ACL even when extended attributes hide the plus marker", async () => {
+    const root = await createTempDir();
+    const ancestor = path.join(root, "ancestor\n 0: group:everyone deny delete");
+    await fs.mkdir(ancestor, { mode: 0o700 });
+    try {
+      execFileSync("/bin/chmod", ["+a", "everyone allow add_file", ancestor]);
+      execFileSync("/usr/bin/xattr", ["-w", "com.crabline.acl-test", "fixture", ancestor]);
+      const before = await directoryState(ancestor);
+      await expect(securePrivateDirectory(path.join(ancestor, "private"))).rejects.toThrow(
+        /macOS.*ACL/u,
+      );
+      await expect(fs.readdir(ancestor)).resolves.toEqual([]);
+      expect(await directoryState(ancestor)).toEqual(before);
+    } finally {
+      execFileSync("/bin/chmod", ["-N", ancestor]);
+      await disposeTempDir(root);
+    }
+  });
+
+  it.each([0o777, 0o770])(
+    "does not use deny entries to excuse writable POSIX mode %i",
+    async (mode) => {
+      const ancestor = await createTempDir();
+      try {
+        await fs.chmod(ancestor, mode);
+        execFileSync("/bin/chmod", ["+a", "everyone deny delete", ancestor]);
+        const before = await directoryState(ancestor);
+        await expect(
+          publishPrivateFileAtomically(path.join(ancestor, "nested", "private.json"), "private"),
+        ).rejects.toThrow("writable by another POSIX principal");
+        expect(await directoryState(ancestor)).toEqual(before);
+      } finally {
+        execFileSync("/bin/chmod", ["-N", ancestor]);
+        await disposeTempDir(ancestor);
+      }
+    },
+  );
+
+  it("preserves actual permission failures from a restrictive ancestor", async () => {
+    const ancestor = await createTempDir();
+    try {
+      execFileSync("/bin/chmod", ["+a", "everyone deny add_subdirectory", ancestor]);
+      const before = await directoryState(ancestor);
+      const failure = await securePrivateDirectory(path.join(ancestor, "private")).catch(
+        (error: unknown) => error,
+      );
+      expect(failure).toMatchObject({ code: expect.stringMatching(/^(?:EACCES|EPERM)$/u) });
+      expect(await directoryState(ancestor)).toEqual(before);
+    } finally {
+      execFileSync("/bin/chmod", ["-N", ancestor]);
+      await disposeTempDir(ancestor);
+    }
+  });
+
+  const header = "drwx------  2 owner group 64 Aug 27 12:00 .\n";
+  const aclHeader = header.replace("------ ", "------+ ");
+  it.each([
+    ["empty", ""],
+    ["non-directory", header.replace(/^d/u, "-")],
+    ["control character", header.replace("owner", "own\0er")],
+    ["missing entries", aclHeader],
+    ["missing marker", `${header} 0: group:everyone deny delete\n`],
+    ["truncated", `${aclHeader} 0: group:everyone deny`],
+    ["unknown right", `${aclHeader} 0: group:everyone deny future_right\n`],
+    ["unknown flag", `${aclHeader} 0: group:everyone future_flag deny delete\n`],
+    ["skipped index", `${aclHeader} 1: group:everyone deny delete\n`],
+    [
+      "duplicate index",
+      `${aclHeader} 0: group:everyone deny delete\n 0: group:staff deny delete\n`,
+    ],
+    ["trailing garbage", `${aclHeader} 0: group:everyone deny delete\nunrecognized\n`],
+    ["missing principal", `${aclHeader} 0: deny delete\n`],
+    ["wrong header name", header.replace(" .\n", " something\n")],
+    ["command warning", header],
+    ["command failure", header],
+  ])("fails closed for %s inspection output before creation", async (label, stdout) => {
+    const directory = await createTempDir();
+    try {
+      inspectCommand.mockImplementation((command: string) => {
+        if (command !== "/bin/ls") {
+          return undefined;
+        }
+        if (label === "command failure") {
+          throw new Error("inspection unavailable");
+        }
+        return { stdout, stderr: label === "command warning" ? "ls: ACL unavailable" : "" };
+      });
+      await expect(securePrivateDirectory(path.join(directory, "private"))).rejects.toThrow(
+        /macOS.*ACL/u,
+      );
+      await expect(fs.readdir(directory)).resolves.toEqual([]);
+    } finally {
+      await disposeTempDir(directory);
+    }
+  });
+
+  it("rejects replacement of the inspected ancestor before capturing its identity", async () => {
+    const root = await createTempDir();
+    const ancestor = path.join(root, "ancestor");
+    const displaced = path.join(root, "displaced");
+    await fs.mkdir(ancestor, { mode: 0o700 });
+    let replaced = false;
+    try {
+      inspectCommand.mockImplementation(
+        async (command: string, args: string[], options: { cwd?: string }) => {
+          if (
+            command !== "/bin/ls" ||
+            replaced ||
+            (options.cwd !== ancestor && !args.includes(ancestor))
+          ) {
+            return undefined;
+          }
+          replaced = true;
+          await fs.rename(ancestor, displaced);
+          await fs.mkdir(ancestor, { mode: 0o777 });
+          await fs.chmod(ancestor, 0o777);
+          return { stdout: header, stderr: "" };
+        },
+      );
+      await expect(
+        publishPrivateFileAtomically(path.join(ancestor, "nested", "private.json"), "private"),
+      ).rejects.toThrow(/identity changed/u);
+      expect(replaced).toBe(true);
+      await expect(fs.readdir(ancestor)).resolves.toEqual([]);
+    } finally {
+      await disposeTempDir(root);
+    }
+  });
+});

--- a/test/openclaw-private-file.test.ts
+++ b/test/openclaw-private-file.test.ts
@@ -19,6 +19,15 @@ import {
 import { createTempDir, disposeTempDir } from "./test-helpers.js";
 
 const currentEffectiveUserId = process.geteuid?.();
+const claimAclCases = [
+  { acl: false, fallback: false },
+  ...(process.platform === "darwin"
+    ? [
+        { acl: true, fallback: false },
+        { acl: true, fallback: true },
+      ]
+    : []),
+];
 
 function expectedAncestrySyncPaths(filePath: string, syncThroughPath?: string): string[] {
   const paths: string[] = [];
@@ -654,57 +663,97 @@ describe("OpenClaw private file publication", () => {
     }
   });
 
-  it("holds publication ancestry claims through temporary-file failure cleanup", async () => {
-    const directory = await createTempDir();
-    const securedAncestor = await securePrivateDirectory(directory);
-    const outputDirectory = path.join(directory, "telegram");
-    await fs.mkdir(outputDirectory);
-    const publicationError = new Error("publication failed after removal attempt");
-    let removalRenameReached = false;
-    let removalRecursiveReached = false;
-    let temporaryPath: string | undefined;
-    try {
-      await expect(
-        publishPrivateFileAtomically(
-          path.join(outputDirectory, "manifest.json"),
-          "private credential\n",
-          {
-            beforeRename: async (candidatePath) => {
-              temporaryPath = candidatePath;
-              await expect(
-                removeSecuredPrivateDirectory(securedAncestor, undefined, "suite-root", {
-                  beforeRecursiveRemove: async () => {
-                    removalRecursiveReached = true;
-                    throw new Error("removal aborted after quarantine rename");
-                  },
-                  beforeRename: async () => {
-                    removalRenameReached = true;
-                  },
-                }),
-              ).rejects.toThrow("Private path mutation is already claimed.");
-              throw publicationError;
+  it.each(claimAclCases)(
+    "holds publication ancestry claims through temporary-file failure cleanup (ACL=$acl, fallback=$fallback)",
+    async ({ acl, fallback }) => {
+      const fixture = await createTempDir();
+      const directory = path.join(fixture, "root");
+      await fs.mkdir(directory);
+      const securedAncestor = await securePrivateDirectory(directory);
+      const outputDirectory = path.join(directory, "telegram");
+      await fs.mkdir(outputDirectory);
+      const legacyPath = path.join(directory, "legacy");
+      if (acl) {
+        await fs.mkdir(legacyPath, { mode: 0o755 });
+        await fs.chmod(legacyPath, 0o755);
+        execFileSync("/bin/chmod", ["+a", "everyone deny chown", legacyPath]);
+        await fs.rename(outputDirectory, path.join(legacyPath, "telegram"));
+      }
+      const publicationDirectory = acl ? path.join(legacyPath, "telegram") : outputDirectory;
+      const linkSpy = fallback
+        ? vi
+            .spyOn(fs, "link")
+            .mockRejectedValue(Object.assign(new Error("unsupported"), { code: "ENOTSUP" }))
+        : undefined;
+      let cleanupChecked = false;
+      const publicationError = new Error("publication failed after removal attempt");
+      let removalRenameReached = false;
+      let removalRecursiveReached = false;
+      let temporaryPath: string | undefined;
+      try {
+        await expect(
+          publishPrivateFileAtomically(
+            path.join(publicationDirectory, "manifest.json"),
+            "private credential\n",
+            {
+              removeTemporaryFile: async (candidate) => {
+                cleanupChecked = true;
+                await expect(removeSecuredPrivateDirectory(securedAncestor)).rejects.toThrow(
+                  "Private path mutation is already claimed.",
+                );
+                await fs.rm(candidate, { force: true });
+              },
+              beforeRename: async (candidatePath) => {
+                temporaryPath = candidatePath;
+                await expect(
+                  removeSecuredPrivateDirectory(securedAncestor, undefined, "suite-root", {
+                    beforeRecursiveRemove: async () => {
+                      removalRecursiveReached = true;
+                      throw new Error("removal aborted after quarantine rename");
+                    },
+                    beforeRename: async () => {
+                      removalRenameReached = true;
+                    },
+                  }),
+                ).rejects.toThrow("Private path mutation is already claimed.");
+                throw publicationError;
+              },
             },
-          },
-        ),
-      ).rejects.toBe(publicationError);
+          ),
+        ).rejects.toBe(publicationError);
 
-      expect(removalRenameReached).toBe(false);
-      expect(removalRecursiveReached).toBe(false);
-      expect(temporaryPath).toBeDefined();
-      await expect(fs.stat(temporaryPath!)).rejects.toMatchObject({ code: "ENOENT" });
-      await expect(fs.stat(outputDirectory)).resolves.toBeDefined();
-      await expect(fs.stat(path.join(outputDirectory, "manifest.json"))).rejects.toMatchObject({
-        code: "ENOENT",
-      });
-      expect(
-        (await fs.readdir(directory, { recursive: true })).filter(
-          (entry) => entry.includes(".tmp") || entry.includes(".remove"),
-        ),
-      ).toEqual([]);
-    } finally {
-      await disposeTempDir(directory);
-    }
-  });
+        expect(cleanupChecked).toBe(true);
+        expect(removalRenameReached).toBe(false);
+        expect(removalRecursiveReached).toBe(false);
+        expect(temporaryPath).toBeDefined();
+        await expect(fs.stat(temporaryPath!)).rejects.toMatchObject({ code: "ENOENT" });
+        await expect(fs.stat(publicationDirectory)).resolves.toBeDefined();
+        await expect(
+          fs.stat(path.join(publicationDirectory, "manifest.json")),
+        ).rejects.toMatchObject({
+          code: "ENOENT",
+        });
+        expect(
+          (await fs.readdir(directory, { recursive: true })).filter(
+            (entry) => entry.includes(".tmp") || entry.includes(".remove"),
+          ),
+        ).toEqual([]);
+        const remainingAcl = acl
+          ? execFileSync("/bin/ls", ["-lde", "."], { cwd: legacyPath, encoding: "utf8" })
+              .split("\n")
+              .slice(1)
+              .filter(Boolean)
+          : [];
+        expect(remainingAcl).toEqual(acl ? [" 0: group:everyone deny chown"] : []);
+        await removeSecuredPrivateDirectory(securedAncestor);
+        await expect(fs.stat(directory)).rejects.toMatchObject({ code: "ENOENT" });
+      } finally {
+        linkSpy?.mockRestore();
+        // Includes any quarantine relocated beside the mutation root.
+        await disposeTempDir(fixture);
+      }
+    },
+  );
 
   it("preserves undefined and null publication rejection reasons", async () => {
     const directory = await createTempDir();
@@ -1636,9 +1685,9 @@ describe("OpenClaw private file publication", () => {
     }
   });
 
-  it.skipIf(process.platform === "win32")(
-    "serializes recursive removal across an owned legacy 0755 descendant",
-    async () => {
+  it.skipIf(process.platform === "win32").each(claimAclCases)(
+    "serializes recursive removal across an owned legacy 0755 descendant (ACL=$acl, fallback=$fallback)",
+    async ({ acl, fallback }) => {
       const directory = await createTempDir();
       let releaseCommit!: () => void;
       const commitReleased = new Promise<void>((resolve) => {
@@ -1649,12 +1698,21 @@ describe("OpenClaw private file publication", () => {
         commitReached = resolve;
       });
       let publication: Promise<void> | undefined;
+      const linkSpy = fallback
+        ? vi
+            .spyOn(fs, "link")
+            .mockRejectedValue(Object.assign(new Error("unsupported"), { code: "ENOTSUP" }))
+        : undefined;
       try {
         const generationPath = path.join(directory, "generation");
         const secured = await securePrivateDirectory(generationPath, { platform: "linux" });
         const legacyPath = path.join(generationPath, "legacy");
         await fs.mkdir(legacyPath, { mode: 0o755 });
         await fs.chmod(legacyPath, 0o755);
+        if (acl) {
+          execFileSync("/bin/chmod", ["+a", "everyone deny chown", legacyPath]);
+        }
+        await fs.mkdir(path.join(legacyPath, "nested"), { mode: 0o700 });
         const filePath = path.join(legacyPath, "nested", "manifest.json");
         publication = publishPrivateFileAtomically(filePath, "private\n", {
           beforeCommitRename: async () => {
@@ -1662,7 +1720,7 @@ describe("OpenClaw private file publication", () => {
             await commitReleased;
           },
         });
-        await reachedCommit;
+        await Promise.race([reachedCommit, publication]);
 
         await expect(
           removeSecuredPrivateDirectory(secured, undefined, undefined, {
@@ -1673,9 +1731,17 @@ describe("OpenClaw private file publication", () => {
         releaseCommit();
         await publication;
         await expect(fs.readFile(filePath, "utf8")).resolves.toBe("private\n");
+        expect(
+          (await fs.readdir(generationPath, { recursive: true })).filter((entry) =>
+            entry.includes(".crabline-private-mutation"),
+          ),
+        ).toEqual([]);
+        await removeSecuredPrivateDirectory(secured);
+        await expect(fs.stat(generationPath)).rejects.toMatchObject({ code: "ENOENT" });
       } finally {
         releaseCommit();
         await publication?.catch(() => undefined);
+        linkSpy?.mockRestore();
         await disposeTempDir(directory);
       }
     },
@@ -2309,34 +2375,41 @@ describe("OpenClaw private file publication", () => {
     },
   );
 
-  it.skipIf(process.platform !== "darwin")(
-    "rejects inherited macOS ACL risk without mutating the existing ancestor",
-    async () => {
-      const directory = await createTempDir();
-      try {
-        execFileSync(
-          "/bin/chmod",
-          ["+a", "everyone allow add_file,delete_child,file_inherit,directory_inherit", directory],
-          { stdio: "ignore" },
-        );
-        const filePath = path.join(directory, "nested", "manifest.json");
-
-        await expect(publishPrivateFileAtomically(filePath, "private\n")).rejects.toThrow(
-          "Private directory must not have a macOS extended ACL.",
-        );
-
-        expect(
-          execFileSync("/bin/ls", ["-lde", directory], { encoding: "utf8" })
-            .trimStart()
-            .split(/\s+/u, 1)[0],
-        ).toContain("+");
-        await expect(fs.stat(filePath)).rejects.toMatchObject({ code: "ENOENT" });
-      } finally {
-        execFileSync("/bin/chmod", ["-RN", directory], { stdio: "ignore" });
-        await disposeTempDir(directory);
+  it
+    .skipIf(process.platform !== "darwin")
+    .each([
+      ["everyone allow add_file,delete_child,file_inherit,directory_inherit"],
+      ["everyone allow add_file"],
+      ["everyone deny delete", "group:staff allow add_file"],
+      ...["file_inherit", "directory_inherit", "limit_inherit", "only_inherit"].map((flag) => [
+        `everyone deny delete,${flag}`,
+      ]),
+    ])("rejects unsafe macOS ACL %j without mutating the existing ancestor", async (...entries) => {
+    const directory = await createTempDir();
+    try {
+      for (const entry of entries) {
+        execFileSync("/bin/chmod", ["+a", entry, directory]);
       }
-    },
-  );
+      const aclBefore = execFileSync("/bin/ls", ["-lde", "."], { cwd: directory, encoding: "utf8" })
+        .split("\n")
+        .slice(1);
+      const filePath = path.join(directory, "nested", "manifest.json");
+
+      await expect(publishPrivateFileAtomically(filePath, "private\n")).rejects.toThrow(
+        /macOS.*ACL/u,
+      );
+
+      expect(
+        execFileSync("/bin/ls", ["-lde", "."], { cwd: directory, encoding: "utf8" })
+          .split("\n")
+          .slice(1),
+      ).toEqual(aclBefore);
+      await expect(fs.stat(filePath)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      execFileSync("/bin/chmod", ["-RN", directory], { stdio: "ignore" });
+      await disposeTempDir(directory);
+    }
+  });
 
   it.skipIf(process.platform !== "darwin")(
     "migrates an existing macOS publication parent with a legacy ACL",

--- a/test/openclaw.test.ts
+++ b/test/openclaw.test.ts
@@ -1,7 +1,6 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { once } from "node:events";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -43,6 +42,7 @@ import {
   runOpenClawCrablineProviderProbe,
   type OpenClawCrablineProviderAdapter,
 } from "../src/openclaw/shared.js";
+import { createTempDir } from "./test-helpers.js";
 
 type ProviderReadinessTestDependencies = {
   acquireLock?: () => Promise<{
@@ -1541,7 +1541,7 @@ describe("OpenClaw local provider bridge", () => {
   });
 
   it("keeps Telegram username identity consistent across the bridge and provider server", async () => {
-    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-telegram-identity-"));
+    const outputDir = await createTempDir();
     const adapter = await startOpenClawCrablineAdapter({
       channel: "telegram",
       recorderPath: path.join(outputDir, "telegram.jsonl"),
@@ -3563,7 +3563,7 @@ describe("OpenClaw local provider bridge", () => {
   });
 
   it("accepts exact provider API route evidence without claiming OpenClaw execution", async () => {
-    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-provider-readiness-"));
+    const outputDir = await createTempDir();
     try {
       const unmanagedManifestPath = path.join(outputDir, OPENCLAW_CRABLINE_MANIFEST_PATH);
       await fs.writeFile(unmanagedManifestPath, "permissive unmanaged manifest\n", { mode: 0o666 });
@@ -3737,7 +3737,7 @@ describe("OpenClaw local provider bridge", () => {
   it.each(["committed", "failed"] as const)(
     "syncs the recorder directory after the final %s temporary unlink",
     async (outcome) => {
-      const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-recorder-unlink-"));
+      const outputDir = await createTempDir();
       const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
       const probeFailure = new Error("probe failed");
       let recorderPath: string | undefined;
@@ -3782,7 +3782,7 @@ describe("OpenClaw local provider bridge", () => {
   );
 
   it("closes readiness adapters before returning an unsettled probe failure", async () => {
-    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-probe-drain-"));
+    const outputDir = await createTempDir();
     const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
     const controller = new AbortController();
     const timeoutMock = vi.spyOn(AbortSignal, "timeout").mockReturnValue(controller.signal);
@@ -3845,7 +3845,7 @@ describe("OpenClaw local provider bridge", () => {
   }, 5_000);
 
   it("fails closed when a successful probe produces no recorder evidence", async () => {
-    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-recorder-missing-"));
+    const outputDir = await createTempDir();
     const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
     const close = vi.fn(async () => undefined);
     const publishGeneration = vi.fn<typeof publishOpenClawCrablineArtifactGeneration>();
@@ -3897,7 +3897,7 @@ describe("OpenClaw local provider bridge", () => {
     ["wrong API route", recorderProbeLine({ path: "/bot<redacted>/sendMessage" })],
     ["valid event followed by malformed JSON", `${recorderProbeLine()}not-json\n`],
   ])("fails closed on %s readiness recorder evidence", async (_label, recorderContents) => {
-    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-recorder-invalid-"));
+    const outputDir = await createTempDir();
     const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
     const close = vi.fn(async () => undefined);
     const publishGeneration = vi.fn<typeof publishOpenClawCrablineArtifactGeneration>();
@@ -3938,7 +3938,7 @@ describe("OpenClaw local provider bridge", () => {
   });
 
   it("keeps readiness recorder snapshots immutable across later generations", async () => {
-    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-recorder-snapshots-"));
+    const outputDir = await createTempDir();
     const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
     let run = 0;
     const startAdapter = async (params: Parameters<typeof startOpenClawCrablineAdapter>[0]) => {
@@ -3989,10 +3989,8 @@ describe("OpenClaw local provider bridge", () => {
       if (process.platform === "win32") {
         return;
       }
-      const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-recorder-symlink-"));
-      const externalDirectory = await fs.mkdtemp(
-        path.join(os.tmpdir(), "crabline-recorder-external-"),
-      );
+      const outputDir = await createTempDir();
+      const externalDirectory = await createTempDir();
       const staleName = ".telegram-provider-server.11111111-1111-4111-8111-111111111111.jsonl.tmp";
       const sentinelPath = path.join(externalDirectory, staleName);
       const startAdapter = vi.fn<typeof startOpenClawCrablineAdapter>();
@@ -4026,7 +4024,7 @@ describe("OpenClaw local provider bridge", () => {
   );
 
   it("reclaims only exact stale readiness recorder temporaries", async () => {
-    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-recorder-recovery-"));
+    const outputDir = await createTempDir();
     const recorderDirectory = path.join(outputDir, "artifacts", "crabline");
     const staleTelegram =
       ".telegram-provider-server.11111111-1111-4111-8111-111111111111.jsonl.tmp";
@@ -4099,7 +4097,7 @@ describe("OpenClaw local provider bridge", () => {
   });
 
   it("reclaims recorder lock tombstones after interrupted removal", async () => {
-    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-recorder-lock-retry-"));
+    const outputDir = await createTempDir();
     const recorderDirectory = path.join(outputDir, "artifacts", "crabline");
     const lockName =
       ".telegram-provider-server.55555555-5555-4555-8555-555555555555.jsonl.tmp.lock";
@@ -4158,7 +4156,7 @@ describe("OpenClaw local provider bridge", () => {
   it.skipIf(process.platform === "win32")(
     "preserves exact recorder temporary lock symlinks without following them",
     async () => {
-      const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-recorder-lock-symlink-"));
+      const outputDir = await createTempDir();
       const recorderDirectory = path.join(outputDir, "artifacts", "crabline");
       const targetDirectory = path.join(outputDir, "external-lock-target");
       const lockName =
@@ -4199,7 +4197,7 @@ describe("OpenClaw local provider bridge", () => {
   );
 
   it("owns complete artifact publication and releases only after the generation is installed", async () => {
-    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-openclaw-artifacts-"));
+    const outputDir = await createTempDir();
     const telegram = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
     const slack = resolveOpenClawCrablineChannelDriverSelection({ channel: "slack" });
     let resumePublication: (() => void) | undefined;
@@ -4264,7 +4262,7 @@ describe("OpenClaw local provider bridge", () => {
   });
 
   it("returns the committed generation when post-commit lock cleanup fails", async () => {
-    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-openclaw-release-"));
+    const outputDir = await createTempDir();
     const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
     const cleanupFailure = new Error("lock release retries exhausted");
     let pointerAtCleanup: Awaited<ReturnType<typeof readOpenClawCrablineArtifactPointer>> = null;
@@ -4308,7 +4306,7 @@ describe("OpenClaw local provider bridge", () => {
   });
 
   it("preserves the primary readiness failure when lock cleanup also fails", async () => {
-    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-openclaw-errors-"));
+    const outputDir = await createTempDir();
     const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
     const primaryFailure = new Error("probe failed");
     const cleanupFailure = new Error("lock release retries exhausted");
@@ -4339,9 +4337,7 @@ describe("OpenClaw local provider bridge", () => {
   });
 
   it("preserves a frozen readiness failure when lock cleanup also fails", async () => {
-    const outputDir = await fs.mkdtemp(
-      path.join(os.tmpdir(), "crabline-openclaw-frozen-readiness-"),
-    );
+    const outputDir = await createTempDir();
     const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
     const primaryFailure = Object.freeze(new Error("frozen readiness failure"));
     try {
@@ -4370,7 +4366,7 @@ describe("OpenClaw local provider bridge", () => {
   });
 
   it("preserves the primary provider probe failure when adapter cleanup also fails", async () => {
-    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-openclaw-probe-errors-"));
+    const outputDir = await createTempDir();
     const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
     const primaryFailure = new Error("probe failed");
     const cleanupFailure = new Error("adapter close failed");
@@ -4402,7 +4398,7 @@ describe("OpenClaw local provider bridge", () => {
   });
 
   it("preserves a frozen provider probe failure when adapter cleanup also fails", async () => {
-    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-openclaw-frozen-error-"));
+    const outputDir = await createTempDir();
     const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
     const primaryFailure = Object.freeze(new Error("frozen probe failure"));
     try {
@@ -4434,7 +4430,7 @@ describe("OpenClaw local provider bridge", () => {
   it.each(["setup", "probe", "cleanup"] as const)(
     "preserves the complete prior artifact generation on %s failure",
     async (failureStage) => {
-      const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-openclaw-failure-"));
+      const outputDir = await createTempDir();
       const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
       try {
         const prior = await runOpenClawCrablineProviderReadiness({ outputDir, selection });
@@ -4481,7 +4477,7 @@ describe("OpenClaw local provider bridge", () => {
   );
 
   it("rolls back the complete artifact generation when publication fails", async () => {
-    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-openclaw-rollback-"));
+    const outputDir = await createTempDir();
     const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
     try {
       const prior = await runOpenClawCrablineProviderReadiness({ outputDir, selection });
@@ -4512,7 +4508,7 @@ describe("OpenClaw local provider bridge", () => {
   });
 
   it("rolls back publication when heartbeat ownership cannot be sealed", async () => {
-    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-openclaw-heartbeat-"));
+    const outputDir = await createTempDir();
     const selection = resolveOpenClawCrablineChannelDriverSelection({ channel: "telegram" });
     const failure = new Error("heartbeat renewal failed");
     const release = vi.fn<() => Promise<void>>(async () => undefined);
@@ -4546,7 +4542,7 @@ describe("OpenClaw local provider bridge", () => {
   });
 
   it("rejects concurrent provider-readiness runs that share an output artifact set", async () => {
-    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-openclaw-overlap-"));
+    const outputDir = await createTempDir();
     const holder = startProviderReadinessLockHolder(outputDir, "telegram");
     try {
       await waitForProviderReadinessLock(holder);
@@ -4582,7 +4578,7 @@ describe("OpenClaw local provider bridge", () => {
   });
 
   it("recovers a provider readiness lock abandoned by a terminated process", async () => {
-    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-openclaw-stale-lock-"));
+    const outputDir = await createTempDir();
     const holder = startProviderReadinessLockHolder(outputDir, "telegram");
     try {
       await waitForProviderReadinessLock(holder);

--- a/test/test-helpers.test.ts
+++ b/test/test-helpers.test.ts
@@ -1,9 +1,25 @@
 import { EventEmitter } from "node:events";
+import { realpath } from "node:fs/promises";
 import type { ClientRequest, IncomingMessage, request as httpRequest } from "node:http";
 import { describe, expect, it, vi } from "vitest";
-import { captureWrites, requestHttp, settleCleanup } from "./test-helpers.js";
+import {
+  captureWrites,
+  createTempDir,
+  disposeTempDir,
+  requestHttp,
+  settleCleanup,
+} from "./test-helpers.js";
 
 describe("test helpers", () => {
+  it("creates canonical temporary directories for filesystem boundary tests", async () => {
+    const directory = await createTempDir();
+    try {
+      expect(directory).toBe(await realpath(directory));
+    } finally {
+      await disposeTempDir(directory);
+    }
+  });
+
   it("rejects incomplete HTTP responses", async () => {
     const response = Object.assign(new EventEmitter(), {
       complete: false,

--- a/test/test-helpers.ts
+++ b/test/test-helpers.ts
@@ -1,10 +1,12 @@
 import { AsyncLocalStorage } from "node:async_hooks";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
 import { request as httpRequest } from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-export const createTempDir = async (): Promise<string> => mkdtemp(path.join(tmpdir(), "crabline-"));
+// macOS temp roots can be aliases; boundary tests need the physical directory ancestry.
+export const createTempDir = async (): Promise<string> =>
+  realpath(await mkdtemp(path.join(tmpdir(), "crabline-")));
 
 export const disposeTempDir = async (directory: string): Promise<void> => {
   await rm(directory, { force: true, recursive: true });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where macOS users running Crabline QA under a restrictive ancestor ACL could finish the provider flow but fail private-artifact publication and rollback cleanup. A normal non-inheriting `group:everyone deny delete` entry was rejected just like an ACL granting another principal permission to modify the tree.

The reproduced error was: `Private directory must not have a macOS extended ACL. OpenClaw Crabline artifact rollback cleanup also failed.` This is an upstream Crabline repair; it does not modify OpenClaw or override its installed dependency.

## Why This Change Was Made

Replace the mode-marker boolean with one bounded native ACL classification: no ACL, completely understood non-propagating deny-only ACL, or unsafe/unverifiable ACL. Private artifact directories remain ACL-free. Namespace validation and mutation-claim traversal use the same safe-ancestry policy, so an accepted restrictive intermediate cannot split a publisher from the ancestor-removal claim that must exclude it.

Inspection handles extended-attribute output, consumes complete ACL entries, avoids filename/ACL-text ambiguity, and is bound to directory identity. POSIX ownership, writable/sticky checks, full ancestry validation, quarantine, claim metadata and release ordering remain intact. External ancestor ACLs are never stripped; genuine operation-denying permissions still fail normally. The duplicate claim-runtime validation block is removed.

Native proof also exposed temporary test roots returned through macOS `/tmp` or `/var` aliases. The shared fixture producer now returns physical paths, and readiness tests reuse it instead of maintaining separate allocation paths. The fixture consolidation preserves all assertions. No test deadlines or permission guards are weakened, and no dependencies, versions, or release workflows change.

Production LOC: +85/-26 (net +59). Tests and test support: +489/-112 (net +377). Docs: +6/-1. The production growth implements complete ACL classification and identity-bound inspection that the previous boolean marker check could not express.

## User Impact

Private QA artifacts can be published, rolled back, and retained beneath safe restrictive macOS ACLs without changing a user's home-directory ACL. Allowing, mixed, propagating, malformed, or unverifiable ancestor ACLs still fail closed, including when extended attributes affect the listing marker.

This PR does not release a package or update OpenClaw's dependency. Those remain separate actions.

## Evidence

Native macOS 27/arm64 proof used a frozen source snapshot on an existing low-load Mac over SSH, with task-owned fixture directories, isolated test homes, and no live Gateway or external provider account. Snapshot transport SHA-256 matched at both ends. Home ACLs were checked unchanged and disposable behavioral fixtures were removed.

- Original production with canonical fixtures: **133 passed, 7 Windows-only skips** across the private-file and artifact-generation suites.
- New focused regressions against original production: **4 expected failures, 2 passes**; failures reproduced restrictive-ancestor rejection, exact artifact rollback aggregation, and ACL inspection with extended attributes. These cases pass with the repair.
- Repaired owner and sibling suites: **236 passed, 7 Windows-only skips** with default test deadlines:
  ```bash
  pnpm test test/test-helpers.test.ts test/openclaw-private-file-acl.test.ts test/openclaw-private-file.test.ts test/openclaw-artifact-generation.test.ts test/openclaw-provider-readiness-lock.test.ts --maxWorkers=1
  ```
- Readiness fixture follow-through: **111 passed**:
  ```bash
  pnpm test test/openclaw.test.ts --maxWorkers=1
  ```
- Source-blind public API behavior contract: **all 6 clauses passed**, including eight real generated artifact generations, channel changes, retention, restrictive ancestry, newline filenames, extended attributes, unsafe ACL/POSIX rejection, private file modes, and unchanged external ACLs. The unchanged baseline failed the relevant ACL clauses without readiness timeouts on the same host.
- Isolated Codex autoreview completed with no actionable findings for the production repair and the fixture-only follow-through.
- Final full native validation passed: formatting/typecheck/lint, autoreview tooling tests, build, and **68 test files / 1,892 passed / 35 platform-specific skips**. Coverage: **87.12% lines, 81.29% branches, 93.93% functions**, above the unchanged thresholds. The verification sequence was:
  ```bash
  pnpm lint && pnpm test:autoreview && pnpm build && pnpm test:coverage --maxWorkers=1
  ```
- Exact-head GitHub [CI verification](https://github.com/openclaw/crabline/actions/runs/33132423968) passed on `96d1084d0da5f03ae579d3604a5f1ac59cf95564`.
- Exact-head [CodeQL TypeScript and Actions analyses](https://github.com/openclaw/crabline/actions/runs/33132482281) passed.

The first local runs were affected by severe host oversubscription. Native validation was moved to the existing low-load Mac rather than increasing timeouts. The first full native pass identified the readiness fixtures still using alias paths; those were consolidated, their entire suite passed, and the subsequent full native coverage run passed. The 35 native skips are platform-specific tests, not newly disabled failures.
