### PR TITLE
fix(deps): prevent unsafe PostCSS source-map reads

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1372,8 +1372,8 @@ packages:
     resolution: {integrity: sha512-RyOSq98kuVfXB1emJ+NjBF0av8Ph3oBuqNy+Z5sFFfLhjYrkBQEB53V8u+U0RNTVwNo20WoPUwNkfKwZfrOqmQ==}
     engines: {node: '>=18'}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2635,7 +2635,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   obug@2.1.3: {}
 
@@ -2740,7 +2740,7 @@ snapshots:
 
   postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  postcss: 8.5.18
+  postcss: 8.5.26
   vite: 8.0.16
 
 importers:
@@ -1372,8 +1372,8 @@ packages:
     resolution: {integrity: sha512-RyOSq98kuVfXB1emJ+NjBF0av8Ph3oBuqNy+Z5sFFfLhjYrkBQEB53V8u+U0RNTVwNo20WoPUwNkfKwZfrOqmQ==}
     engines: {node: '>=18'}
 
-  nanoid@3.3.15:
-    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1451,8 +1451,8 @@ packages:
     resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
     hasBin: true
 
-  postcss@8.5.18:
-    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   process-warning@5.1.0:
@@ -2635,7 +2635,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  nanoid@3.3.15: {}
+  nanoid@3.3.17: {}
 
   obug@2.1.3: {}
 
@@ -2738,9 +2738,9 @@ snapshots:
       sonic-boom: 4.2.1
       thread-stream: 3.2.0
 
-  postcss@8.5.18:
+  postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.15
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -2929,7 +2929,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
-      postcss: 8.5.18
+      postcss: 8.5.26
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,7 @@ minimumReleaseAgeExclude:
 nodeLinker: hoisted
 blockExoticSubdeps: true
 overrides:
-  postcss: 8.5.18
+  postcss: 8.5.26
   vite: 8.0.16
 allowBuilds:
   baileys: false


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where Crabline's development dependency graph pins a PostCSS version affected by [GHSA-fxqj-rqcc-2cmp](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp): attacker-controlled CSS can cause external source-map reads when the caller omits `from`.

Addresses [Dependabot alert 3](https://github.com/openclaw/crabline/security/dependabot/3).

## Why This Change Was Made

Raise the existing PostCSS override from 8.5.18 to 8.5.26 and regenerate the corresponding lockfile entries, including Nano ID 3.3.18, the first patched 3.x version for [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8). PostCSS 8.5.23 is the first fix for the source-map advisory; 8.5.26 additionally resolves symlinks before containment checks. It remains within Vite 8.0.16's accepted PostCSS range.

Vite, Vitest, every other dependency resolution, and all dependency safety policies remain unchanged. No application-code refactor or policy exception is needed.

## User Impact

No production CLI or provider behavior change is intended. PostCSS is reachable only through development Vitest/coverage dependencies and Vite. The repository has no CSS processing pipeline, and Vite's normal PostCSS caller sets `from`; this removes a known-vulnerable toolchain dependency rather than claiming a demonstrated Crabline runtime exploit.

## Evidence

- Integrity-checked upstream PostCSS packages passed 27 isolated assertions using synthetic map files. Versions 8.5.23 and 8.5.26 block the no-`from` read; only 8.5.26 also blocks the tested symlink escape. Legitimate in-tree, inline, and explicit previous maps remain supported.
- The diff changes only the PostCSS override and matching lockfile graph, including Nano ID. Whitespace validation passed.
- Independent Codex autoreview completed with no accepted/actionable findings.
- Dependency Review rejected the initial Nano ID 3.3.17 resolution; this revision uses patched 3.3.18 rather than suppressing the advisory or changing the check.
- Frozen installation succeeded. The full local gate is being rerun against the corrected lockfile after an unchanged timing-sensitive test passed on focused retry. Existing GitHub CI remains unchanged; final-head results will be checked before merge.
