### PR TITLE
fix(servers): initialize and drain recorder persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Initialize provider recorder ownership before readiness and drain admitted persistence on shutdown without waiting for event observers (#283).
 - Refresh WebSocket and Matrix client dependencies, pnpm/npm, lint/test tooling, Go workflow tooling dependencies, and CodeQL pins; retain Node 22 typings for compatibility.
 
 ## 0.1.17 - 2026-08-14

--- a/README.md
+++ b/README.md
@@ -187,6 +187,11 @@ provider server, or `startOpenClawCrablineAdapter`. Crabline awaits the callback
 after appending each API/admin event to `recorderPath`, so callers can react in
 process while retaining the JSONL artifact as durable evidence.
 
+Provider servers initialize recorder ownership before reporting readiness,
+without creating recorder files or emitting synthetic events. Closing a server
+stops new recorder admissions and waits for admitted persistence to finish.
+Shutdown does not wait for event observers, which may themselves call `close()`.
+
 Recorder files should normally have one filesystem name. If multiple processes
 cannot share the same OS account home, the home is read-only, or they write
 through hardlinks to the same recorder inode, set

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -231,6 +231,12 @@ credentials unless the corresponding credential is supplied.
 WhatsApp is loopback-only because its HTTP and WebSocket endpoints carry bearer
 credentials over cleartext and the built-in server does not terminate TLS.
 
+Every public server starter initializes recorder ownership before reporting
+readiness, without creating recorder artifacts or invoking `onEvent`.
+Server `close()` stops new recorder admissions and drains admitted persistence
+before it succeeds. Event observers are not part of this drain, so an observer
+may call `close()`; stalled handlers still use the bounded transport shutdown.
+
 Commands in this section use the installed-package form. In a source checkout,
 replace `crabline` with `pnpm dev`; `pnpm exec crabline` is not available.
 

--- a/src/platform/process-owned-lock.ts
+++ b/src/platform/process-owned-lock.ts
@@ -965,36 +965,14 @@ function isRecoverableUnknownOwner(
   );
 }
 
-export function createProcessOwnedLockFileSystem(
-  options: {
-    beforeDirectoryRemoval?: (directoryPath: string) => void;
-    machineIdentityReader?: () => string | null;
-    onDirectoryOwned?: (directoryPath: string, identity: { dev: bigint; ino: bigint }) => void;
-    processIdentityReader?: (pid: number) => string | null;
-  } = {},
-): typeof fs {
-  if (
-    process.platform !== "linux" &&
-    process.platform !== "darwin" &&
-    process.platform !== "win32"
-  ) {
-    return fs;
-  }
-  const token = randomUUID();
-  const removeLockDirectorySync = (
-    directoryPath: fs.PathLike,
-    expectedIdentity: DirectoryIdentity,
-    expectedMtimeMs?: bigint,
-    afterClaim?: (directoryPath: string) => void,
-  ): void => {
-    removeVerifiedLockDirectorySync(
-      directoryPath,
-      expectedIdentity,
-      expectedMtimeMs,
-      options.beforeDirectoryRemoval,
-      afterClaim,
-    );
-  };
+type ProcessOwnedLockOptions = {
+  beforeDirectoryRemoval?: (directoryPath: string) => void;
+  machineIdentityReader?: () => string | null;
+  onDirectoryOwned?: (directoryPath: string, identity: { dev: bigint; ino: bigint }) => void;
+  processIdentityReader?: (pid: number) => string | null;
+};
+
+function readCurrentLockOwner(options: ProcessOwnedLockOptions) {
   const identityReader = options.processIdentityReader ?? readProcessIdentity;
   let currentProcessIdentity: string | null;
   if (options.processIdentityReader) {
@@ -1034,6 +1012,41 @@ export function createProcessOwnedLockFileSystem(
   if (process.platform === "linux" && currentProcessNamespace === null) {
     throw new Error("Recorder lock process namespace is unavailable.");
   }
+  return { currentProcessIdentity, currentMachineIdentity, currentProcessNamespace };
+}
+
+export function initializeProcessOwnedLockIdentity(): void {
+  if (["linux", "darwin", "win32"].includes(process.platform)) {
+    readCurrentLockOwner({});
+  }
+}
+
+export function createProcessOwnedLockFileSystem(options: ProcessOwnedLockOptions = {}): typeof fs {
+  if (
+    process.platform !== "linux" &&
+    process.platform !== "darwin" &&
+    process.platform !== "win32"
+  ) {
+    return fs;
+  }
+  const { currentProcessIdentity, currentMachineIdentity, currentProcessNamespace } =
+    readCurrentLockOwner(options);
+  const identityReader = options.processIdentityReader ?? readProcessIdentity;
+  const token = randomUUID();
+  const removeLockDirectorySync = (
+    directoryPath: fs.PathLike,
+    expectedIdentity: DirectoryIdentity,
+    expectedMtimeMs?: bigint,
+    afterClaim?: (directoryPath: string) => void,
+  ): void => {
+    removeVerifiedLockDirectorySync(
+      directoryPath,
+      expectedIdentity,
+      expectedMtimeMs,
+      options.beforeDirectoryRemoval,
+      afterClaim,
+    );
+  };
   const ownedDirectories = new Map<string, DirectoryIdentity>();
   const interruptedPublicationIdentities = new Map<string, DirectoryIdentity>();
   let cachedForeignIdentity:

--- a/src/servers/discord.ts
+++ b/src/servers/discord.ts
@@ -17,11 +17,7 @@ import {
   startHttpJsonServer,
   type ServerRequestEvent,
 } from "./http.js";
-import {
-  recordCommittedServerEvent,
-  recordServerEvent,
-  type ServerEventObserver,
-} from "./recorder.js";
+import { createServerRecorder, type ServerRecorder, type ServerEventObserver } from "./recorder.js";
 import { closeWebSocketServer } from "./websocket.js";
 
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 45_000;
@@ -109,8 +105,7 @@ type DiscordServerState = {
   maxGatewayPayloadBytes: number;
   messages: Map<string, DiscordMessage[]>;
   nextSequence: number;
-  onEvent: ServerEventObserver | undefined;
-  pendingRecorderEvents: Set<Promise<void>>;
+  recorder: ServerRecorder;
   recorderPath: string;
   sessions: Map<string, GatewaySession>;
 };
@@ -471,24 +466,15 @@ function dispatchGatewayEvent(state: DiscordServerState, type: string, data: unk
 }
 
 function recordGatewayEvent(state: DiscordServerState, body: unknown, accepted: boolean): void {
-  const pending = recordCommittedServerEvent({
-    event: {
-      accepted,
-      at: new Date().toISOString(),
-      body,
-      method: "WS",
-      path: "/gateway",
-      query: {},
-      type: "api",
-    } as DiscordRecorderEvent,
-    onEvent: state.onEvent,
-    recorderPath: state.recorderPath,
-  });
-  state.pendingRecorderEvents.add(pending);
-  void pending.then(
-    () => state.pendingRecorderEvents.delete(pending),
-    () => state.pendingRecorderEvents.delete(pending),
-  );
+  void state.recorder.recordCommitted({
+    accepted,
+    at: new Date().toISOString(),
+    body,
+    method: "WS",
+    path: "/gateway",
+    query: {},
+    type: "api",
+  } as DiscordRecorderEvent);
 }
 
 function readyPayload(state: DiscordServerState, sessionId: string) {
@@ -970,11 +956,7 @@ async function handleRequest(params: {
     };
     const response = await handleAdminInbound({ body, state: params.state });
     event.accepted = response.ok;
-    await recordCommittedServerEvent({
-      event,
-      onEvent: params.state.onEvent,
-      recorderPath: params.state.recorderPath,
-    });
+    await params.state.recorder.recordCommitted(event);
     return response;
   }
   const authError =
@@ -1002,11 +984,9 @@ async function handleRequest(params: {
     state: params.state,
   });
   event.accepted = response.ok;
-  await (response.ok ? recordCommittedServerEvent : recordServerEvent)({
-    event,
-    onEvent: params.state.onEvent,
-    recorderPath: params.state.recorderPath,
-  });
+  await (response.ok
+    ? params.state.recorder.recordCommitted(event)
+    : params.state.recorder.record(event));
   return response;
 }
 
@@ -1020,6 +1000,7 @@ export async function startDiscordServer(
   requireSnowflake(botUserId, "botUserId");
   const encodedApplicationId = Buffer.from(applicationId, "utf8").toString("base64url");
   const externallyBound = !isLoopbackHost(host);
+  const recorderPath = params.recorderPath ?? path.resolve(".crabline", "servers", "discord.jsonl");
   const state: DiscordServerState = {
     adminToken: params.adminToken ?? randomBytes(24).toString("base64url"),
     applicationId,
@@ -1051,9 +1032,8 @@ export async function startDiscordServer(
     ),
     messages: new Map(),
     nextSequence: 1,
-    onEvent: params.onEvent,
-    pendingRecorderEvents: new Set(),
-    recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "discord.jsonl"),
+    recorder: createServerRecorder({ recorderPath, onEvent: params.onEvent }),
+    recorderPath,
     sessions: new Map(),
   };
   const httpServer = await startHttpJsonServer({
@@ -1080,7 +1060,7 @@ export async function startDiscordServer(
     async close() {
       await closeGateway();
       await httpServer.close();
-      await Promise.all([...state.pendingRecorderEvents]);
+      await state.recorder.close();
       state.sessions.clear();
     },
     manifest: {

--- a/src/servers/matrix.ts
+++ b/src/servers/matrix.ts
@@ -23,11 +23,7 @@ import {
   startHttpJsonServer,
   type ServerRequestEvent,
 } from "./http.js";
-import {
-  recordCommittedServerEvent,
-  recordServerEvent,
-  type ServerEventObserver,
-} from "./recorder.js";
+import { createServerRecorder, type ServerRecorder, type ServerEventObserver } from "./recorder.js";
 
 type MatrixEvent = {
   content: Record<string, unknown>;
@@ -78,7 +74,7 @@ type MatrixServerState = {
   nextEvent: number;
   nextFilter: number;
   nextSequence: number;
-  onEvent: ServerEventObserver | undefined;
+  recorder: ServerRecorder;
   profiles: Map<string, { avatar_url?: string; display_name?: string }>;
   recorderPath: string;
   rooms: Map<string, MatrixRoom>;
@@ -160,8 +156,7 @@ async function appendEvent(
   event: ServerRequestEvent,
   committed = false,
 ): Promise<void> {
-  const params = { event, onEvent: state.onEvent, recorderPath: state.recorderPath };
-  await (committed ? recordCommittedServerEvent(params) : recordServerEvent(params));
+  await (committed ? state.recorder.recordCommitted(event) : state.recorder.record(event));
 }
 
 function authorized(request: IncomingMessage, token: string): boolean {
@@ -1084,6 +1079,7 @@ export async function startMatrixServer(
   if (!isMatrixUserId(botUserId)) {
     throw new Error("botUserId must be a canonical Matrix user ID.");
   }
+  const recorderPath = params.recorderPath ?? path.resolve("artifacts/crabline/matrix.jsonl");
   const state: MatrixServerState = {
     accessToken: params.accessToken ?? `syt_crabline_${randomBytes(12).toString("hex")}`,
     adminToken: params.adminToken ?? randomBytes(24).toString("hex"),
@@ -1111,9 +1107,9 @@ export async function startMatrixServer(
     nextEvent: 1,
     nextFilter: 1,
     nextSequence: 1,
-    onEvent: params.onEvent,
+    recorder: createServerRecorder({ recorderPath, onEvent: params.onEvent }),
     profiles: new Map([[botUserId, { display_name: "OpenClaw QA" }]]),
-    recorderPath: params.recorderPath ?? path.resolve("artifacts/crabline/matrix.jsonl"),
+    recorderPath,
     rooms: new Map(),
     serverName,
     syncWaiters: new Set(),
@@ -1230,6 +1226,7 @@ export async function startMatrixServer(
         room.typingTimeouts.clear();
       }
       await server.close();
+      await state.recorder.close();
     },
     manifest: {
       accessToken: state.accessToken,

--- a/src/servers/mattermost.ts
+++ b/src/servers/mattermost.ts
@@ -18,11 +18,7 @@ import {
   startHttpJsonServer,
   type ServerRequestEvent,
 } from "./http.js";
-import {
-  recordCommittedServerEvent,
-  recordServerEvent,
-  type ServerEventObserver,
-} from "./recorder.js";
+import { createServerRecorder, type ServerRecorder, type ServerEventObserver } from "./recorder.js";
 import { resolveMaxPendingInboundEvents } from "./pending-events.js";
 import { closeWebSocketServer } from "./websocket.js";
 
@@ -106,7 +102,7 @@ type MattermostServerState = {
   maxPendingInboundEvents: number;
   maxWebSocketBufferedBytes: number;
   nextPost: number;
-  onEvent: ServerEventObserver | undefined;
+  recorder: ServerRecorder;
   pendingEventBytes: number;
   pendingEvents: MattermostWebSocketEvent[];
   posts: Map<string, MattermostPost>;
@@ -174,8 +170,7 @@ async function appendEvent(
   event: ServerRequestEvent,
   committed = false,
 ): Promise<void> {
-  const params = { event, onEvent: state.onEvent, recorderPath: state.recorderPath };
-  await (committed ? recordCommittedServerEvent(params) : recordServerEvent(params));
+  await (committed ? state.recorder.recordCommitted(event) : state.recorder.record(event));
 }
 
 function authorized(request: IncomingMessage, token: string): boolean {
@@ -1185,6 +1180,8 @@ export async function startMattermostServer(
   if (initialCommittedStateBytes > maxCommittedStateBytes) {
     throw new Error("maxCommittedStateBytes cannot retain the configured bot user.");
   }
+  const recorderPath =
+    params.recorderPath ?? path.resolve(".crabline", "servers", "mattermost.jsonl");
   const state: MattermostServerState = {
     adminToken: params.adminToken ?? randomBytes(24).toString("base64url"),
     botToken:
@@ -1222,11 +1219,11 @@ export async function startMattermostServer(
       DEFAULT_MAX_WEBSOCKET_BUFFERED_BYTES,
     ),
     nextPost: 1,
-    onEvent: params.onEvent,
+    recorder: createServerRecorder({ recorderPath, onEvent: params.onEvent }),
     pendingEventBytes: 0,
     pendingEvents: [],
     posts: new Map(),
-    recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "mattermost.jsonl"),
+    recorderPath,
     userIdsByUsername: new Map([[botUsername, botUserId]]),
     users: new Map([[botUserId, botUser]]),
     websocketClients: new Map(),
@@ -1258,6 +1255,7 @@ export async function startMattermostServer(
     async close() {
       await closeMattermostWebSocketServer();
       await httpServer.close();
+      await state.recorder.close();
     },
     manifest: {
       adminToken: state.adminToken,

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -4,7 +4,10 @@ import { chmod, lstat, mkdir, open, readlink, realpath, stat as statPath } from 
 import { userInfo } from "node:os";
 import path from "node:path";
 import { lock } from "proper-lockfile";
-import { createProcessOwnedLockFileSystem } from "../platform/process-owned-lock.js";
+import {
+  createProcessOwnedLockFileSystem,
+  initializeProcessOwnedLockIdentity,
+} from "../platform/process-owned-lock.js";
 import {
   createOwnerOnlyWindowsDirectory,
   readWindowsDirectoryNamespaceSecuritySnapshot,
@@ -1531,7 +1534,7 @@ async function appendJsonLine(params: {
   line: string;
   onEvent: ServerEventObserver | undefined;
   recorderPath: string;
-}): Promise<void> {
+}): Promise<RecorderAppendResult> {
   const logicalPath = path.resolve(params.recorderPath);
   const previous = pendingAdmissions.get(logicalPath) ?? Promise.resolve();
   const current = previous
@@ -1566,7 +1569,7 @@ async function appendJsonLine(params: {
       pendingAdmissions.delete(logicalPath);
     }
   }
-  await result.observation;
+  return result;
 }
 
 function snapshotServerEvent(event: ServerRequestEvent): {
@@ -1583,32 +1586,75 @@ function snapshotServerEvent(event: ServerRequestEvent): {
   };
 }
 
-export async function recordServerEvent(params: {
+type ServerRecorderWrite = {
   event: ServerRequestEvent;
   onEvent: ServerEventObserver | undefined;
   recorderPath: string;
-}): Promise<void> {
+};
+
+export async function recordServerEvent(
+  params: ServerRecorderWrite,
+  pending?: Set<Promise<RecorderAppendResult>>,
+): Promise<void> {
   const snapshot = snapshotServerEvent(params.event);
-  await appendJsonLine({
+  const persistence = appendJsonLine({
     ...snapshot,
     onEvent: params.onEvent,
     recorderPath: params.recorderPath,
   });
+  pending?.add(persistence);
+  let result: RecorderAppendResult;
+  try {
+    result = await persistence;
+  } finally {
+    pending?.delete(persistence);
+  }
+  await result.observation;
 }
 
-export async function recordCommittedServerEvent(params: {
-  event: ServerRequestEvent;
-  onEvent: ServerEventObserver | undefined;
-  recorderPath: string;
-}): Promise<void> {
+export async function recordCommittedServerEvent(
+  params: ServerRecorderWrite,
+  pending?: Set<Promise<RecorderAppendResult>>,
+): Promise<void> {
   try {
-    const snapshot = snapshotServerEvent(params.event);
-    await appendJsonLine({
-      ...snapshot,
-      onEvent: params.onEvent,
-      recorderPath: params.recorderPath,
-    });
+    await recordServerEvent(params, pending);
   } catch {
     // The provider mutation already committed, so telemetry failure cannot change its response.
   }
+}
+
+export type ServerRecorder = {
+  record(event: ServerRequestEvent): Promise<void>;
+  recordCommitted(event: ServerRequestEvent): Promise<void>;
+  close(): Promise<void>;
+};
+
+export function createServerRecorder(params: {
+  recorderPath: string;
+  onEvent: ServerEventObserver | undefined;
+}): ServerRecorder {
+  initializeProcessOwnedLockIdentity();
+  const pending = new Set<Promise<RecorderAppendResult>>();
+  let closing = false;
+  const record = async (event: ServerRequestEvent, committed: boolean) => {
+    if (closing) {
+      if (committed) {
+        return;
+      }
+      throw new Error("Server recorder is closed.");
+    }
+    await (committed ? recordCommittedServerEvent : recordServerEvent)(
+      { ...params, event },
+      pending,
+    );
+  };
+  return {
+    record: (event) => record(event, false),
+    recordCommitted: (event) => record(event, true),
+    async close() {
+      closing = true;
+      // Observers can call close themselves; only persistence owns recorder artifacts.
+      await Promise.allSettled(pending);
+    },
+  };
 }

--- a/src/servers/signal.ts
+++ b/src/servers/signal.ts
@@ -20,8 +20,8 @@ import {
   writeResponse,
 } from "./http.js";
 import {
-  recordCommittedServerEvent,
-  recordServerEvent,
+  createServerRecorder,
+  type ServerRecorder,
   ServerRecorderCommittedError,
   type ServerEventObserver,
 } from "./recorder.js";
@@ -37,7 +37,7 @@ type SignalServerState = {
   lastCommittedTimestamp: number | undefined;
   nextEventSequence: number;
   nextTimestamp: number;
-  onEvent: ServerEventObserver | undefined;
+  recorder: ServerRecorder;
   pendingEventBytes: number;
   pendingEvents: SignalSseChunk[];
   pendingTimestampCommits: Promise<void>;
@@ -116,8 +116,7 @@ async function appendEvent(
   event: SignalRecorderEvent,
   committed = false,
 ): Promise<void> {
-  const params = { event, onEvent: state.onEvent, recorderPath: state.recorderPath };
-  await (committed ? recordCommittedServerEvent(params) : recordServerEvent(params));
+  await (committed ? state.recorder.recordCommitted(event) : state.recorder.record(event));
 }
 
 function rpcResponse(id: unknown, result: unknown): Response {
@@ -980,6 +979,7 @@ export async function startSignalServer(
   if (!account) {
     throw new Error("account must be an E.164 telephone number.");
   }
+  const recorderPath = params.recorderPath ?? path.resolve(".crabline", "servers", "signal.jsonl");
   const state: SignalServerState = {
     account,
     adminToken: params.adminToken ?? randomBytes(24).toString("base64url"),
@@ -993,12 +993,12 @@ export async function startSignalServer(
         : DEFAULT_MAX_SIGNAL_SSE_CLIENTS,
     nextEventSequence: 1,
     nextTimestamp: Date.now(),
-    onEvent: params.onEvent,
+    recorder: createServerRecorder({ recorderPath, onEvent: params.onEvent }),
     pendingEventBytes: 0,
     pendingEvents: [],
     pendingTimestampCommits: Promise.resolve(),
     pendingSseClients: 0,
-    recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "signal.jsonl"),
+    recorderPath,
   };
   const host = params.host ?? "127.0.0.1";
   const normalizedHost = normalizeSignalHost(host);
@@ -1071,6 +1071,7 @@ export async function startSignalServer(
         client.end();
       }
       await closeServer(server);
+      await state.recorder.close();
     },
     manifest: {
       account: state.account,

--- a/src/servers/slack.ts
+++ b/src/servers/slack.ts
@@ -23,11 +23,7 @@ import {
   SLACK_TS_RULE,
   SLACK_USER_ID_RULE,
 } from "../providers/slack-ids.js";
-import {
-  recordCommittedServerEvent,
-  recordServerEvent,
-  type ServerEventObserver,
-} from "./recorder.js";
+import { createServerRecorder, type ServerRecorder, type ServerEventObserver } from "./recorder.js";
 import {
   postWebhookRequestWithResponse,
   validateWebhookTarget,
@@ -76,7 +72,7 @@ type SlackServerState = {
   nextDmIndex: number;
   nextMpimIndex: number;
   nextTsIndex: number;
-  onEvent: ServerEventObserver | undefined;
+  recorder: ServerRecorder;
   recorderPath: string;
   restrictEventTargets: boolean;
   signingSecret: string;
@@ -565,8 +561,7 @@ function slackConversationType(conversation: Record<string, unknown>): string {
 }
 
 async function appendEvent(state: SlackServerState, event: ServerRequestEvent, committed = false) {
-  const params = { event, onEvent: state.onEvent, recorderPath: state.recorderPath };
-  await (committed ? recordCommittedServerEvent(params) : recordServerEvent(params));
+  await (committed ? state.recorder.recordCommitted(event) : state.recorder.record(event));
 }
 
 function redactSlackAuthFields(value: Record<string, unknown>): Record<string, unknown> {
@@ -1360,6 +1355,7 @@ export async function startSlackServer(
 ): Promise<StartedSlackServer> {
   const host = params.host ?? "127.0.0.1";
   const externallyBound = !isLoopbackHost(host);
+  const recorderPath = params.recorderPath ?? path.resolve(".crabline", "servers", "slack.jsonl");
   const state: SlackServerState = {
     activeEventDeliveries: new Set(),
     adminToken: params.adminToken ?? randomBytes(24).toString("base64url"),
@@ -1374,8 +1370,8 @@ export async function startSlackServer(
     nextDmIndex: 1,
     nextMpimIndex: 1,
     nextTsIndex: 100,
-    onEvent: params.onEvent,
-    recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "slack.jsonl"),
+    recorder: createServerRecorder({ recorderPath, onEvent: params.onEvent }),
+    recorderPath,
     restrictEventTargets: true,
     signingSecret: params.signingSecret ?? "crabline-slack-signing-secret",
     userDmChannels: new Map(),
@@ -1413,6 +1409,7 @@ export async function startSlackServer(
       state.deliveryAbortController.abort();
       await Promise.allSettled(state.activeEventDeliveries);
       await httpServer.close();
+      await state.recorder.close();
     },
     manifest: {
       adminToken: state.adminToken,

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -19,7 +19,7 @@ import {
   RequestBodyTooLargeError,
   writeResponse,
 } from "./http.js";
-import { recordServerEvent, type ServerEventObserver } from "./recorder.js";
+import { createServerRecorder, type ServerEventObserver, type ServerRecorder } from "./recorder.js";
 import { resolveMaxPendingInboundEvents } from "./pending-events.js";
 import {
   postWebhookRequest,
@@ -149,7 +149,7 @@ type TelegramServerState = {
   maxPendingInboundEvents: number;
   nextMessageIds: Map<string, number>;
   nextUpdateId: number;
-  onEvent: ServerEventObserver | undefined;
+  recorder: ServerRecorder;
   recorderPath: string;
   restrictWebhookTargets: boolean;
   updates: TelegramUpdate[];
@@ -869,7 +869,7 @@ function telegramStoredChatId(value: unknown): number | undefined {
 }
 
 async function appendEvent(state: TelegramServerState, event: TelegramServerEvent) {
-  await recordServerEvent({ event, onEvent: state.onEvent, recorderPath: state.recorderPath });
+  await state.recorder.record(event);
 }
 
 function isTelegramMultipartFile(value: unknown): value is TelegramMultipartFile {
@@ -2651,6 +2651,8 @@ export async function startTelegramServer(
   if (!TELEGRAM_BOT_USERNAME_PATTERN.test(`@${botUsername}`)) {
     throw new Error("botUsername must be a valid 5-32 character Telegram username.");
   }
+  const recorderPath =
+    params.recorderPath ?? path.resolve(".crabline", "servers", "telegram.jsonl");
   const state: TelegramServerState = {
     activeUpdatePoll: undefined,
     activeWebhookDeliveries: new Set(),
@@ -2671,8 +2673,8 @@ export async function startTelegramServer(
     maxPendingInboundEvents: resolveMaxPendingInboundEvents(params.maxPendingInboundEvents),
     nextMessageIds: new Map(),
     nextUpdateId: 1,
-    onEvent: params.onEvent,
-    recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "telegram.jsonl"),
+    recorder: createServerRecorder({ recorderPath, onEvent: params.onEvent }),
+    recorderPath,
     restrictWebhookTargets: true,
     closing: false,
     updates: [],
@@ -2716,6 +2718,7 @@ export async function startTelegramServer(
       await state.webhookAdmission;
       await state.inboundAdmission;
       await closeServer(server);
+      await state.recorder.close();
     },
     manifest: {
       adminToken: state.adminToken,

--- a/src/servers/whatsapp.ts
+++ b/src/servers/whatsapp.ts
@@ -18,7 +18,8 @@ import {
   type ServerRequestEvent,
 } from "./http.js";
 import {
-  recordServerEvent,
+  createServerRecorder,
+  type ServerRecorder,
   ServerRecorderCommittedError,
   type ServerEventObserver,
 } from "./recorder.js";
@@ -67,7 +68,7 @@ type WhatsAppServerState = {
   pendingMessageIds: Set<string>;
   recentMessageIds: Map<string, true>;
   nextMessageId: bigint;
-  onEvent: ServerEventObserver | undefined;
+  recorder: ServerRecorder;
   phoneNumberId: string;
   recorderPath: string;
   selfJid: string;
@@ -178,7 +179,7 @@ function graphAuthError(): Response {
 }
 
 async function appendEvent(state: WhatsAppServerState, event: WhatsAppRecorderEvent) {
-  await recordServerEvent({ event, onEvent: state.onEvent, recorderPath: state.recorderPath });
+  await state.recorder.record(event);
 }
 
 function requireWhatsAppChatJid(value: unknown): string | Response {
@@ -955,6 +956,8 @@ export async function startWhatsAppServer(
   if (!selfJid) {
     throw new Error("WhatsApp selfJid must be a WhatsApp user JID.");
   }
+  const recorderPath =
+    params.recorderPath ?? path.resolve(".crabline", "servers", "whatsapp.jsonl");
   const state: WhatsAppServerState = {
     accessToken: params.accessToken ?? createDefaultAccessToken(),
     adminToken: params.adminToken ?? randomBytes(24).toString("hex"),
@@ -968,9 +971,9 @@ export async function startWhatsAppServer(
     pendingMessageIds: new Set(),
     recentMessageIds: new Map(),
     nextMessageId: 1n,
-    onEvent: params.onEvent,
+    recorder: createServerRecorder({ recorderPath, onEvent: params.onEvent }),
     phoneNumberId,
-    recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "whatsapp.jsonl"),
+    recorderPath,
     selfJid,
   };
   const httpServer = await startHttpJsonServer({
@@ -1037,6 +1040,7 @@ export async function startWhatsAppServer(
         baileysWebSocketServer.close(),
         httpServer.close(),
       ]);
+      await state.recorder.close();
       const errors = results.flatMap((result) =>
         result.status === "rejected" ? [result.reason] : [],
       );

--- a/src/servers/zalo.ts
+++ b/src/servers/zalo.ts
@@ -22,7 +22,7 @@ import {
   type HttpJsonHandlerResult,
   type ServerRequestEvent,
 } from "./http.js";
-import { recordServerEvent, type ServerEventObserver } from "./recorder.js";
+import { createServerRecorder, type ServerEventObserver, type ServerRecorder } from "./recorder.js";
 import { resolveMaxPendingInboundEvents } from "./pending-events.js";
 import {
   postWebhookRequest,
@@ -88,7 +88,7 @@ type ZaloServerState = {
   maxPendingInboundEvents: number;
   nextMessage: number;
   nextUpdateOrder: number;
-  onEvent: ServerEventObserver | undefined;
+  recorder: ServerRecorder;
   pendingInboundAdmissions: number;
   pendingRequest: PendingUpdateRequest | undefined;
   recorderPath: string;
@@ -142,7 +142,7 @@ export type StartZaloServerParams = {
 };
 
 async function appendEvent(state: ZaloServerState, event: ZaloServerEvent): Promise<void> {
-  await recordServerEvent({ event, onEvent: state.onEvent, recorderPath: state.recorderPath });
+  await state.recorder.record(event);
 }
 
 function zaloOk(result?: unknown): Response {
@@ -970,6 +970,7 @@ export async function startZaloServer(
   params: StartZaloServerParams = {},
 ): Promise<StartedZaloServer> {
   const host = params.host ?? "127.0.0.1";
+  const recorderPath = params.recorderPath ?? path.resolve(".crabline", "servers", "zalo.jsonl");
   const state: ZaloServerState = {
     activeWebhookRequests: new Set(),
     activeWebhookValidations: new Set(),
@@ -986,10 +987,10 @@ export async function startZaloServer(
     maxPendingInboundEvents: resolveMaxPendingInboundEvents(params.maxPendingInboundEvents),
     nextMessage: 1,
     nextUpdateOrder: 1,
-    onEvent: params.onEvent,
+    recorder: createServerRecorder({ recorderPath, onEvent: params.onEvent }),
     pendingInboundAdmissions: 0,
     pendingRequest: undefined,
-    recorderPath: params.recorderPath ?? path.resolve(".crabline", "servers", "zalo.jsonl"),
+    recorderPath,
     retainedUpdateBytes: 0,
     retainedUpdateCount: 0,
     reservedUpdateOrders: new Set(),
@@ -1060,6 +1061,7 @@ export async function startZaloServer(
         settlePendingUpdate(state, state.pendingRequest, { kind: "shutdown" });
       }
       await httpServer.close();
+      await state.recorder.close();
     },
     manifest,
   };

--- a/test/server-recorder-shutdown.test.ts
+++ b/test/server-recorder-shutdown.test.ts
@@ -1,0 +1,210 @@
+import { mkdtemp, readFile, realpath, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { afterEach, expect, it, vi } from "vitest";
+import {
+  startCrablineServer,
+  startTelegramServer,
+  type StartedCrablineServer,
+} from "../src/index.js";
+import { createServerRecorder } from "../src/servers/recorder.js";
+
+const persistence = vi.hoisted(() => ({
+  filePath: "",
+  beforeSync: undefined as (() => Promise<void>) | undefined,
+}));
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...actual,
+    open: async (...args: Parameters<typeof actual.open>) => {
+      const file = await actual.open(...args);
+      if (String(args[0]) === persistence.filePath) {
+        const sync = file.sync.bind(file);
+        file.sync = async () => {
+          await persistence.beforeSync?.();
+          await sync();
+        };
+      }
+      return file;
+    },
+  };
+});
+afterEach(() => {
+  persistence.filePath = "";
+  persistence.beforeSync = undefined;
+});
+
+it.each([
+  "discord",
+  "mattermost",
+  "matrix",
+  "signal",
+  "slack",
+  "telegram",
+  "whatsapp",
+  "zalo",
+] as const)(
+  "%s drains persistence from an aborted request before successful close",
+  async (channel) => {
+    const directory = await realpath(
+      await mkdtemp(path.join(os.tmpdir(), "crabline-recorder-drain-")),
+    );
+    persistence.filePath = path.join(directory, "events.jsonl");
+    const entered = deferred();
+    const release = deferred();
+    const observed = deferred();
+    persistence.beforeSync = async () => {
+      entered.resolve();
+      await release.promise;
+    };
+    const server = await startCrablineServer({
+      channel,
+      onEvent: () => observed.resolve(),
+      recorderPath: persistence.filePath,
+    });
+    const controller = new AbortController();
+    const probe = nativeProbe(server);
+    const response = fetch(probe.url, {
+      ...probe.init,
+      signal: controller.signal,
+    }).catch(() => undefined);
+    let closed = false;
+    let closing: Promise<void> | undefined;
+    try {
+      await Promise.race([
+        entered.promise,
+        response.then(() => {
+          throw new Error("Probe ended before reaching persistence.");
+        }),
+      ]);
+      controller.abort();
+      await response;
+      closing = server.close().then(() => {
+        closed = true;
+      });
+      await delay(350);
+      expect(closed).toBe(false);
+      release.resolve();
+      await closing;
+      expect((await readFile(persistence.filePath, "utf8")).trim().split("\n")).toHaveLength(1);
+    } finally {
+      release.resolve();
+      await Promise.race([observed.promise, delay(1000)]);
+      await (closing ?? server.close());
+      await rm(directory, { recursive: true, force: true });
+    }
+  },
+  20_000,
+);
+
+it.each(["reentrant", "stalled"] as const)(
+  "closes with a %s event observer",
+  async (mode) => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "crabline-observer-close-"));
+    const entered = deferred();
+    const release = deferred();
+    let closing: Promise<void> | undefined;
+    const server = await startTelegramServer({
+      recorderPath: path.join(directory, "events.jsonl"),
+      async onEvent() {
+        entered.resolve();
+        if (mode === "reentrant") {
+          closing = server.close();
+          await closing;
+        } else {
+          await release.promise;
+        }
+      },
+    });
+    const response = fetch(`${server.manifest.baseUrl}/bot${server.manifest.botToken}/getMe`).catch(
+      () => undefined,
+    );
+    try {
+      await entered.promise;
+      const started = performance.now();
+      await (closing ??= server.close());
+      expect(performance.now() - started).toBeLessThan(1000);
+    } finally {
+      release.resolve();
+      await response;
+      await (closing ?? server.close());
+      await rm(directory, { recursive: true, force: true });
+    }
+  },
+  20_000,
+);
+
+it("rejects late recorder admissions without recreating artifacts after close", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "crabline-recorder-closed-"));
+  const recorder = createServerRecorder({
+    recorderPath: path.join(directory, "missing", "events.jsonl"),
+    onEvent: undefined,
+  });
+  await recorder.close();
+  await rm(directory, { recursive: true, force: true });
+  await expect(
+    recorder.record({
+      at: new Date().toISOString(),
+      method: "GET",
+      path: "/late",
+      query: {},
+      type: "api",
+    }),
+  ).rejects.toThrow("Server recorder is closed");
+  await expect(readFile(path.join(directory, "missing", "events.jsonl"))).rejects.toMatchObject({
+    code: "ENOENT",
+  });
+});
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function nativeProbe(server: StartedCrablineServer): { url: string; init?: RequestInit } {
+  const manifest = server.manifest;
+  switch (manifest.provider) {
+    case "discord":
+      return {
+        url: `${manifest.endpoints.apiRoot}/v10/users/@me`,
+        init: { headers: { authorization: `Bot ${manifest.botToken}` } },
+      };
+    case "mattermost":
+      return {
+        url: `${manifest.endpoints.apiRoot}/users/me`,
+        init: { headers: { authorization: `Bearer ${manifest.botToken}` } },
+      };
+    case "matrix":
+      return {
+        url: `${manifest.endpoints.clientApiRoot}/account/whoami`,
+        init: { headers: { authorization: `Bearer ${manifest.accessToken}` } },
+      };
+    case "signal":
+      return {
+        url: manifest.endpoints.rpcUrl,
+        init: {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "version" }),
+        },
+      };
+    case "slack":
+      return {
+        url: `${manifest.endpoints.apiRoot}auth.test`,
+        init: { headers: { authorization: `Bearer ${manifest.botToken}` } },
+      };
+    case "telegram":
+    case "zalo":
+      return { url: `${manifest.baseUrl}/bot${manifest.botToken}/getMe` };
+    case "whatsapp":
+      return {
+        url: manifest.endpoints.phoneNumberUrl,
+        init: { headers: { authorization: `Bearer ${manifest.accessToken}` } },
+      };
+  }
+}

--- a/test/server-recorder-startup.test.ts
+++ b/test/server-recorder-startup.test.ts
@@ -1,0 +1,62 @@
+import { mkdtemp, readdir, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+
+const native = vi.hoisted(() => ({ commands: [] as string[] }));
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    spawnSync(command: string) {
+      native.commands.push(command);
+      const stdout =
+        command === "/usr/sbin/sysctl"
+          ? "{ sec = 1000, usec = 0 }"
+          : command === "/usr/bin/vmmap"
+            ? "Launch Time: 2026-08-28 00:00:00.000000 +0000"
+            : command === "/usr/sbin/ioreg"
+              ? '"IOPlatformUUID" = "test-machine"'
+              : "";
+      return { status: 0, stdout, stderr: "" };
+    },
+  };
+});
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+  native.commands.length = 0;
+});
+afterEach(() => vi.restoreAllMocks());
+
+it.each([
+  "startDiscordServer",
+  "startMattermostServer",
+  "startMatrixServer",
+  "startSignalServer",
+  "startSlackServer",
+  "startTelegramServer",
+  "startWhatsAppServer",
+  "startZaloServer",
+] as const)(
+  "%s initializes recorder ownership before readiness without artifacts",
+  async (name) => {
+    const api = await import("../src/index.js");
+    const directory = await mkdtemp(path.join(os.tmpdir(), "crabline-cold-recorder-"));
+    const observer = vi.fn();
+    const server = await api[name]({
+      onEvent: observer,
+      recorderPath: path.join(directory, "missing", "events.jsonl"),
+    });
+    try {
+      expect(native.commands).toContain("/usr/bin/vmmap");
+      expect(native.commands).toContain("/usr/sbin/ioreg");
+      expect(await readdir(directory)).toEqual([]);
+      expect(observer).not.toHaveBeenCalled();
+    } finally {
+      await server.close();
+      await rm(directory, { recursive: true, force: true });
+    }
+  },
+);


### PR DESCRIPTION
Cold provider probes currently pay for recorder ownership initialization on their first recorded request. On macOS, the native process inspection can consume the five-second readiness probe budget even though the HTTP server is already listening. Socket shutdown also does not wait for an aborted request's admitted recorder write, allowing persistence to race artifact cleanup.

Each public provider server now owns a recorder lifecycle. Startup reads and validates the existing process and machine ownership facts before reporting readiness, without creating recorder artifacts or synthetic events. Shutdown preserves each provider's transport and polling behavior, then seals recorder admission and drains persistence. Observers remain outside that drain; standalone and server-owned writes share the same persistence implementation. Discord's separate recorder promise collection is replaced by the shared lifecycle.

No provider protocol, probe timeout, process-identity validation, or test deadline is relaxed. README, channel setup, and the changelog describe the lifecycle.

Validation:

- Reproduced on main: all eight public starters advertised readiness before ownership initialization; an aborted Telegram request's `close()` completed while file persistence was deliberately blocked.
- Added 19 regressions covering all eight starters without artifacts, all eight providers draining an aborted request, reentrant/stalled observers, and rejected admissions after close.
- Real macOS timing capture: native `vmmap` moved from the request phase to startup. The observed first request changed from 4,728 ms to 1,555 ms; this is an illustrative cold run, not a throughput benchmark.
- Source-blind validation of the rebuilt CLI: readiness created no recorder artifact; authenticated `getMe` returned HTTP 200 with `ok:true` in 529 ms under the unchanged 5,000 ms timeout; wrong-token access returned 404; one event was recorded; SIGTERM exited 0 and one cleanup attempt succeeded.
- Final macOS focused run: 21 lifecycle/shutdown tests passed across three files.
- Full Linux/Node 22 gate passed with original deadlines and one worker: 1,872 tests passed, 70 skipped; coverage 86.85% statements, 81.02% branches, 93.90% functions, 86.91% lines. Formatting, typecheck, lint, 226 Python tests (3 skipped), build, CLI smoke checks, packaging dry-run, and workflow validation passed.
- An earlier two-worker Linux run timed out in three existing OpenClaw bridge/private-file tests; all passed in the complete one-worker rerun. The broader macOS run also encountered native-inspection/timing failures and is not claimed green.
- Codex autoreview reported no actionable P0 findings under the canonical helper's configured default threshold.

Fixes #283
