### PR TITLE
fix: complete recorder shutdown across callback and transport failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
-## Unreleased
+## 0.1.18 - 2026-08-28
 
+- Complete recorder shutdown for Telegram/Baileys observer self-close, repeated close calls, failed WebSocket teardown, and asynchronous lock-acquisition cleanup (#285).
+- Fix private artifact creation under restrictive macOS ACLs (#280).
 - Initialize provider recorder ownership before readiness and drain admitted persistence on shutdown without waiting for event observers (#283).
 - Refresh WebSocket and Matrix client dependencies, pnpm/npm, lint/test tooling, Go workflow tooling dependencies, and CodeQL pins; retain Node 22 typings for compatibility.
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,9 @@ Provider servers initialize recorder ownership before reporting readiness,
 without creating recorder files or emitting synthetic events. Closing a server
 stops new recorder admissions and waits for admitted persistence to finish.
 Shutdown does not wait for event observers, which may themselves call `close()`.
+Concurrent and repeated close calls share the same shutdown. All transports are
+closed even if one fails, and the persistence drain includes asynchronous cleanup
+after a failed recorder lock acquisition.
 
 Recorder files should normally have one filesystem name. If multiple processes
 cannot share the same OS account home, the home is read-only, or they write

--- a/docs/channel-setup.md
+++ b/docs/channel-setup.md
@@ -236,6 +236,8 @@ readiness, without creating recorder artifacts or invoking `onEvent`.
 Server `close()` stops new recorder admissions and drains admitted persistence
 before it succeeds. Event observers are not part of this drain, so an observer
 may call `close()`; stalled handlers still use the bounded transport shutdown.
+Repeated close calls share that shutdown, including failed-transport cleanup and
+any pending recorder lock removal.
 
 Commands in this section use the installed-package form. In a source checkout,
 replace `crabline` with `pnpm dev`; `pnpm exec crabline` is not available.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/crabline",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Standalone CLI for deterministic messaging provider E2E tests",
   "homepage": "https://github.com/openclaw/crabline#readme",
   "bugs": {

--- a/src/servers/discord.ts
+++ b/src/servers/discord.ts
@@ -5,6 +5,7 @@ import type { Duplex } from "node:stream";
 import { WebSocket, WebSocketServer, type RawData } from "ws";
 import {
   adminAuthError,
+  createServerClose,
   constantTimeTokenEqual,
   hasAdminToken,
   InvalidJsonBodyError,
@@ -1057,12 +1058,17 @@ export async function startDiscordServer(
   state.gatewayUrl = `${httpServer.baseUrl.replace(/^http/u, "ws")}/gateway`;
   const closeGateway = attachGatewayServer({ server: httpServer.server, state });
   return {
-    async close() {
-      await closeGateway();
-      await httpServer.close();
-      await state.recorder.close();
-      state.sessions.clear();
-    },
+    close: createServerClose(
+      state.recorder,
+      async () => {
+        try {
+          await closeGateway();
+        } finally {
+          state.sessions.clear();
+        }
+      },
+      () => httpServer.close(),
+    ),
     manifest: {
       adminToken: state.adminToken,
       applicationId: state.applicationId,

--- a/src/servers/http.ts
+++ b/src/servers/http.ts
@@ -407,6 +407,28 @@ export async function writeResponse(
   }
 }
 
+export function createServerClose(
+  recorder: { close(): Promise<void> },
+  ...closeResources: Array<() => void | Promise<void>>
+): () => Promise<void> {
+  let closing: Promise<void> | undefined;
+  return () =>
+    (closing ??= (async () => {
+      const results = await Promise.allSettled(closeResources.map(async (close) => await close()));
+      // Let native polling responses finish during transport grace, then fence late writes.
+      results.push(...(await Promise.allSettled([recorder.close()])));
+      const errors = results.flatMap((result) =>
+        result.status === "rejected" ? [result.reason] : [],
+      );
+      if (errors.length === 1) {
+        throw errors[0];
+      }
+      if (errors.length > 1) {
+        throw new AggregateError(errors, "Server shutdown failed.");
+      }
+    })());
+}
+
 export function closeServer(
   server: Server,
   graceMs = DEFAULT_SERVER_SHUTDOWN_GRACE_MS,

--- a/src/servers/matrix.ts
+++ b/src/servers/matrix.ts
@@ -9,6 +9,7 @@ import {
 } from "../matrix-ids.js";
 import {
   adminAuthError,
+  createServerClose,
   constantTimeTokenEqual,
   DEFAULT_MAX_RESPONSE_BODY_BYTES,
   hasAdminToken,
@@ -1218,7 +1219,7 @@ export async function startMatrixServer(
 
   const clientApiRoot = `${server.baseUrl}/_matrix/client/v3`;
   return {
-    async close() {
+    close: createServerClose(state.recorder, async () => {
       for (const room of state.rooms.values()) {
         for (const timer of room.typingTimeouts.values()) {
           clearTimeout(timer);
@@ -1226,8 +1227,7 @@ export async function startMatrixServer(
         room.typingTimeouts.clear();
       }
       await server.close();
-      await state.recorder.close();
-    },
+    }),
     manifest: {
       accessToken: state.accessToken,
       adminToken: state.adminToken,

--- a/src/servers/mattermost.ts
+++ b/src/servers/mattermost.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { WebSocket, WebSocketServer, type RawData } from "ws";
 import {
   adminAuthError,
+  createServerClose,
   constantTimeTokenEqual,
   drainRequestBody,
   hasAdminToken,
@@ -1252,11 +1253,9 @@ export async function startMattermostServer(
     state,
   });
   return {
-    async close() {
-      await closeMattermostWebSocketServer();
-      await httpServer.close();
-      await state.recorder.close();
-    },
+    close: createServerClose(state.recorder, closeMattermostWebSocketServer, () =>
+      httpServer.close(),
+    ),
     manifest: {
       adminToken: state.adminToken,
       baseUrl: httpServer.baseUrl,

--- a/src/servers/recorder.ts
+++ b/src/servers/recorder.ts
@@ -1,4 +1,4 @@
-import { constants as fsConstants } from "node:fs";
+import { constants as fsConstants, type PathLike } from "node:fs";
 import { createHash } from "node:crypto";
 import { chmod, lstat, mkdir, open, readlink, realpath, stat as statPath } from "node:fs/promises";
 import { userInfo } from "node:os";
@@ -934,10 +934,25 @@ async function acquireSingleRecorderLock(filePath: string): Promise<AcquiredReco
       }
     },
   });
+  // proper-lockfile reports a failed initial mtime probe before its rmdir settles.
+  const trackedFileSystem = Object.create(lockFileSystem) as typeof lockFileSystem;
+  const removeDirectory = lockFileSystem.rmdir.bind(lockFileSystem);
+  let pendingRemoval: Promise<void> | undefined;
+  trackedFileSystem.rmdir = ((
+    directory: PathLike,
+    callback: (error: NodeJS.ErrnoException | null) => void,
+  ) => {
+    pendingRemoval = new Promise<void>((resolve) => {
+      removeDirectory(directory, (error) => {
+        callback(error);
+        resolve();
+      });
+    });
+  }) as typeof lockFileSystem.rmdir;
   for (;;) {
     try {
       const release = await lock(filePath, {
-        fs: lockFileSystem,
+        fs: trackedFileSystem,
         realpath: false,
         retries: 0,
         stale: RECORDER_LOCK_STALE_MS,
@@ -945,6 +960,7 @@ async function acquireSingleRecorderLock(filePath: string): Promise<AcquiredReco
       });
       return { artifactIdentity, release };
     } catch (error) {
+      await pendingRemoval;
       if (!isRecorderLockContention(error)) {
         throw error;
       }

--- a/src/servers/signal.ts
+++ b/src/servers/signal.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import {
   adminAuthError,
   closeServer,
+  createServerClose,
   drainRequestBody,
   formatUrlHost,
   hasAdminToken,
@@ -1065,14 +1066,13 @@ export async function startSignalServer(
     normalizedHost === "0.0.0.0" ? "127.0.0.1" : normalizedHost === "::" ? "::1" : host;
   const baseUrl = `http://${formatUrlHost(advertisedHost)}:${address.port}`;
   return {
-    async close() {
+    close: createServerClose(state.recorder, async () => {
       clearInterval(keepalive);
       for (const client of state.clients) {
         client.end();
       }
       await closeServer(server);
-      await state.recorder.close();
-    },
+    }),
     manifest: {
       account: state.account,
       adminToken: state.adminToken,

--- a/src/servers/slack.ts
+++ b/src/servers/slack.ts
@@ -3,6 +3,7 @@ import { createHmac, randomBytes, randomInt, timingSafeEqual } from "node:crypto
 import path from "node:path";
 import {
   adminAuthError,
+  createServerClose,
   hasAdminToken,
   InvalidJsonBodyError,
   isJsonObject,
@@ -1404,13 +1405,12 @@ export async function startSlackServer(
   const baseUrl = httpServer.baseUrl;
   const apiRoot = `${baseUrl}/api/`;
   return {
-    async close() {
+    close: createServerClose(state.recorder, async () => {
       state.closing = true;
       state.deliveryAbortController.abort();
       await Promise.allSettled(state.activeEventDeliveries);
       await httpServer.close();
-      await state.recorder.close();
-    },
+    }),
     manifest: {
       adminToken: state.adminToken,
       baseUrl,

--- a/src/servers/telegram.ts
+++ b/src/servers/telegram.ts
@@ -6,6 +6,7 @@ import { CrablineError } from "../core/errors.js";
 import {
   adminAuthError,
   closeServer,
+  createServerClose,
   drainRequestBody,
   formatUrlHost,
   hasAdminToken,
@@ -2704,7 +2705,7 @@ export async function startTelegramServer(
   }
   const baseUrl = `http://${formatUrlHost(host)}:${address.port}`;
   return {
-    async close() {
+    close: createServerClose(state.recorder, async () => {
       state.closing = true;
       finishTelegramUpdatePoll(state, "shutdown");
       clearTelegramWebhookRetry(state);
@@ -2716,10 +2717,8 @@ export async function startTelegramServer(
       }
       await state.webhookDelivery;
       await state.webhookAdmission;
-      await state.inboundAdmission;
       await closeServer(server);
-      await state.recorder.close();
-    },
+    }),
     manifest: {
       adminToken: state.adminToken,
       baseUrl,

--- a/src/servers/whatsapp-baileys-websocket.ts
+++ b/src/servers/whatsapp-baileys-websocket.ts
@@ -1261,7 +1261,7 @@ class WhatsAppBaileysWebSocketSession {
   }
 
   async #handleNode(node: BinaryNode): Promise<void> {
-    await this.#recordNode(node);
+    await awaitWithAbort(this.#recordNode(node), this.#acceptanceAbort.signal);
     if (node.tag === "iq") {
       await this.#sendNode(this.#createIqResult(node));
       return;

--- a/src/servers/whatsapp.ts
+++ b/src/servers/whatsapp.ts
@@ -3,6 +3,7 @@ import { createCipheriv, createHash, createHmac, hkdfSync, randomBytes } from "n
 import path from "node:path";
 import {
   adminAuthError,
+  createServerClose,
   constantTimeTokenEqual,
   drainRequestBody,
   hasAdminToken,
@@ -1035,24 +1036,18 @@ export async function startWhatsAppServer(
   }
   state.prepareInboundMessage = (message) => baileysWebSocketServer.prepareInboundMessage(message);
   return {
-    async close() {
-      const results = await Promise.allSettled([
-        baileysWebSocketServer.close(),
-        httpServer.close(),
-      ]);
-      await state.recorder.close();
-      const errors = results.flatMap((result) =>
-        result.status === "rejected" ? [result.reason] : [],
-      );
-      state.mediaByPath.clear();
-      state.mediaBytes = 0;
-      if (errors.length === 1) {
-        throw errors[0];
-      }
-      if (errors.length > 1) {
-        throw new AggregateError(errors, "WhatsApp server shutdown failed.");
-      }
-    },
+    close: createServerClose(
+      state.recorder,
+      async () => {
+        try {
+          await baileysWebSocketServer.close();
+        } finally {
+          state.mediaByPath.clear();
+          state.mediaBytes = 0;
+        }
+      },
+      () => httpServer.close(),
+    ),
     manifest: {
       accessToken: state.accessToken,
       adminToken: state.adminToken,

--- a/src/servers/zalo.ts
+++ b/src/servers/zalo.ts
@@ -8,6 +8,7 @@ import {
 import path from "node:path";
 import {
   adminAuthError,
+  createServerClose,
   drainRequestBody,
   hasAdminToken,
   InvalidJsonBodyError,
@@ -1049,7 +1050,7 @@ export async function startZaloServer(
     version: 1,
   };
   return {
-    async close() {
+    close: createServerClose(state.recorder, async () => {
       state.closing = true;
       for (const request of state.activeWebhookRequests) {
         request.destroy(new Error("Zalo server is shutting down."));
@@ -1061,8 +1062,7 @@ export async function startZaloServer(
         settlePendingUpdate(state, state.pendingRequest, { kind: "shutdown" });
       }
       await httpServer.close();
-      await state.recorder.close();
-    },
+    }),
     manifest,
   };
 }

--- a/test/server-recorder-lifecycle.test.ts
+++ b/test/server-recorder-lifecycle.test.ts
@@ -1,0 +1,377 @@
+import { request, type IncomingMessage } from "node:http";
+import { subscribe, unsubscribe } from "node:diagnostics_channel";
+import fs from "node:fs";
+import { readFile, stat } from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { WebSocket, WebSocketServer } from "ws";
+import {
+  CRABLINE_SERVER_CHANNELS,
+  startCrablineServer,
+  type StartedCrablineServer,
+} from "../src/index.js";
+import { createTempDir, disposeTempDir } from "./test-helpers.js";
+
+const io = vi.hoisted(() => ({
+  path: "",
+  entered: () => {},
+  blocked: Promise.resolve(),
+}));
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...actual,
+    realpath: async (...args: Parameters<typeof actual.realpath>) => {
+      if (args[0] === io.path) {
+        io.entered();
+        await io.blocked;
+      }
+      return await actual.realpath(...args);
+    },
+  };
+});
+
+function gate() {
+  let release!: () => void;
+  const pending = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return { pending, release };
+}
+
+describe("server recorder lifecycle", () => {
+  it("fences a Telegram admin handler queued behind an observer after close", async () => {
+    const directory = await createTempDir();
+    const recorderPath = path.join(directory, "events.jsonl");
+    const firstEntered = gate();
+    const releaseFirst = gate();
+    const secondObserved = gate();
+    let observations = 0;
+    const server = await startCrablineServer({
+      channel: "telegram",
+      recorderPath,
+      async onEvent() {
+        if (++observations === 1) {
+          firstEntered.release();
+          await releaseFirst.pending;
+        } else {
+          secondObserved.release();
+        }
+      },
+    });
+    const requests: ReturnType<typeof request>[] = [];
+    const send = () => {
+      const pending = request(server.manifest.endpoints.adminInboundUrl, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-crabline-admin-token": server.manifest.adminToken,
+        },
+      });
+      pending.on("error", () => {});
+      pending.end(JSON.stringify({ chatId: "123456", text: "queued inbound" }));
+      requests.push(pending);
+    };
+    let secondRequest: IncomingMessage | undefined;
+    const port = Number(new URL(server.manifest.baseUrl).port);
+    const onRequest = (message: unknown) => {
+      const candidate = (message as { request: IncomingMessage }).request;
+      if (candidate.socket.localPort === port) {
+        secondRequest = candidate;
+      }
+    };
+    let lateIo = 0;
+    let closing: Promise<void> | undefined;
+    try {
+      send();
+      await firstEntered.pending;
+      subscribe("http.server.request.start", onRequest);
+      send();
+      await expect.poll(() => secondRequest?.readableEnded).toBe(true);
+      closing = server.close();
+      expect(await closeWithinGrace(closing)).toBe("closed");
+      await disposeTempDir(directory);
+      io.path = recorderPath;
+      io.entered = () => {
+        lateIo++;
+      };
+      io.blocked = Promise.resolve();
+      releaseFirst.release();
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(lateIo).toBe(0);
+      expect(observations).toBe(1);
+      await expect(stat(directory)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      unsubscribe("http.server.request.start", onRequest);
+      releaseFirst.release();
+      for (const pending of requests) {
+        pending.destroy();
+      }
+      if (lateIo > 0) {
+        await secondObserved.pending;
+      }
+      io.path = "";
+      await closing;
+      await server.close().catch(() => {});
+      await disposeTempDir(directory);
+    }
+  }, 20_000);
+
+  it.each(CRABLINE_SERVER_CHANNELS)(
+    "%s allows an observer to await concurrent and repeated close",
+    async (channel) => {
+      const directory = await createTempDir();
+      const recorderPath = path.join(directory, "events.jsonl");
+      const entered = gate();
+      const releaseObserver = gate();
+      let closing: Promise<void> | undefined;
+      const server = await startCrablineServer({
+        channel,
+        recorderPath,
+        async onEvent() {
+          closing = Promise.all([server.close(), server.close()]).then(() => {});
+          entered.release();
+          await Promise.race([closing, releaseObserver.pending]);
+        },
+      });
+      const pendingRequest = apiRequest(server);
+      pendingRequest.on("error", () => {});
+      try {
+        pendingRequest.end();
+        await entered.pending;
+        expect(await closeWithinGrace(closing!)).toBe("closed");
+        await server.close();
+        expect((await readFile(recorderPath, "utf8")).trim().split("\n")).toHaveLength(1);
+      } finally {
+        releaseObserver.release();
+        pendingRequest.destroy();
+        await closing?.catch(() => {});
+        await server.close().catch(() => {});
+        await disposeTempDir(directory);
+      }
+    },
+    20_000,
+  );
+
+  it("joins lock cleanup after an initial mtime-probe failure", async () => {
+    const directory = await createTempDir();
+    const recorderPath = path.join(directory, "events.jsonl");
+    const lockPath = `${recorderPath}.lock`;
+    const server = await startCrablineServer({ channel: "telegram", recorderPath });
+    const entered = gate();
+    const release = gate();
+    const removed = gate();
+    const utimes = fs.utimes.bind(fs);
+    const rename = fs.rename.bind(fs);
+    const utimesSpy = vi
+      .spyOn(fs, "utimes")
+      .mockImplementation((target, atime, mtime, callback) => {
+        if (String(target) === lockPath) {
+          callback(Object.assign(new Error("synthetic mtime-probe failure"), { code: "EIO" }));
+          return;
+        }
+        utimes(target, atime, mtime, callback);
+      });
+    const renameSpy = vi.spyOn(fs, "rename").mockImplementation((source, target, callback) => {
+      if (String(source) === lockPath) {
+        entered.release();
+        void release.pending.then(() =>
+          rename(source, target, (error) => {
+            callback(error);
+            removed.release();
+          }),
+        );
+        return;
+      }
+      rename(source, target, callback);
+    });
+    const pendingRequest = apiRequest(server);
+    pendingRequest.on("error", () => {});
+    let closing: Promise<void> | undefined;
+    let closed = false;
+    try {
+      pendingRequest.end();
+      await entered.pending;
+      pendingRequest.destroy();
+      closing = server.close().then(() => {
+        closed = true;
+      });
+      await new Promise((resolve) => setTimeout(resolve, 350));
+      expect(closed).toBe(false);
+      expect((await stat(lockPath)).isDirectory()).toBe(true);
+      release.release();
+      await closing;
+      await removed.pending;
+      await expect(stat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      release.release();
+      pendingRequest.destroy();
+      await removed.pending;
+      await (closing ?? server.close());
+      utimesSpy.mockRestore();
+      renameSpy.mockRestore();
+      await disposeTempDir(directory);
+    }
+  }, 20_000);
+
+  it("allows Telegram admin observers to close without waiting on their own admission", async () => {
+    const directory = await createTempDir();
+    const entered = gate();
+    const releaseObserver = gate();
+    let closing: Promise<void> | undefined;
+    const server = await startCrablineServer({
+      channel: "telegram",
+      recorderPath: path.join(directory, "events.jsonl"),
+      async onEvent() {
+        closing = server.close();
+        entered.release();
+        await Promise.race([closing, releaseObserver.pending]);
+      },
+    });
+    const pendingRequest = request(server.manifest.endpoints.adminInboundUrl, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-crabline-admin-token": server.manifest.adminToken,
+      },
+    });
+    pendingRequest.on("error", () => {});
+    try {
+      pendingRequest.end(JSON.stringify({ chatId: "123456", text: "synthetic inbound" }));
+      await entered.pending;
+      expect(await closeWithinGrace(closing!)).toBe("closed");
+      await server.close();
+    } finally {
+      releaseObserver.release();
+      pendingRequest.destroy();
+      await closing?.catch(() => {});
+      await server.close().catch(() => {});
+      await disposeTempDir(directory);
+    }
+  }, 20_000);
+
+  it("allows Discord Gateway observers to close and callers to repeat close", async () => {
+    const directory = await createTempDir();
+    const entered = gate();
+    const releaseObserver = gate();
+    let closing: Promise<void> | undefined;
+    const server = await startCrablineServer({
+      channel: "discord",
+      recorderPath: path.join(directory, "events.jsonl"),
+      async onEvent() {
+        closing = server.close();
+        entered.release();
+        await Promise.race([closing, releaseObserver.pending]);
+      },
+    });
+    const socket = new WebSocket(server.manifest.endpoints.gatewayUrl);
+    socket.on("error", () => {});
+    socket.once("open", () => socket.send(JSON.stringify({ op: 1, d: null })));
+    try {
+      await entered.pending;
+      expect(await closeWithinGrace(closing!)).toBe("closed");
+      await server.close();
+    } finally {
+      releaseObserver.release();
+      socket.terminate();
+      await closing?.catch(() => {});
+      await server.close().catch(() => {});
+      await disposeTempDir(directory);
+    }
+  }, 20_000);
+
+  it.each(["discord", "mattermost"] as const)(
+    "%s drains persistence and closes HTTP when WebSocket close fails",
+    async (channel) => {
+      const directory = await createTempDir();
+      const entered = gate();
+      const release = gate();
+      const observed = gate();
+      const recorderPath = path.join(directory, "events.jsonl");
+      io.path = recorderPath;
+      io.entered = entered.release;
+      io.blocked = release.pending;
+      const server = await startCrablineServer({
+        channel,
+        recorderPath,
+        onEvent: observed.release,
+      });
+      const port = Number(new URL(server.manifest.baseUrl).port);
+      const pendingRequest = apiRequest(server);
+      pendingRequest.on("error", () => {});
+      let closeSpy: ReturnType<typeof vi.spyOn> | undefined;
+      let closing: Promise<unknown> | undefined;
+      let replacement: StartedCrablineServer | undefined;
+      let settled = false;
+      try {
+        pendingRequest.end();
+        await entered.pending;
+        closeSpy = vi
+          .spyOn(WebSocketServer.prototype, "close")
+          .mockImplementationOnce((callback) =>
+            callback?.(new Error("synthetic WebSocket close failure")),
+          );
+        closing = server
+          .close()
+          .catch((error: unknown) => error)
+          .finally(() => {
+            settled = true;
+          });
+        await new Promise((resolve) => setTimeout(resolve, 350));
+        expect.soft(settled).toBe(false);
+        release.release();
+        expect(await closing).toMatchObject({ message: "synthetic WebSocket close failure" });
+        replacement = await startCrablineServer({ channel, port, recorderPath });
+      } finally {
+        release.release();
+        closeSpy?.mockRestore();
+        pendingRequest.destroy();
+        await observed.pending;
+        await closing;
+        await server.close().catch(() => {});
+        await replacement?.close();
+        io.path = "";
+        await disposeTempDir(directory);
+      }
+    },
+    20_000,
+  );
+});
+
+function apiRequest(server: StartedCrablineServer) {
+  const m = server.manifest;
+  const apiPath =
+    m.provider === "telegram" || m.provider === "zalo"
+      ? `/bot${m.botToken}/getMe`
+      : m.provider === "whatsapp"
+        ? `/${m.graphVersion}/${m.phoneNumberId}`
+        : {
+            discord: "/api/v10/users/@me",
+            mattermost: "/api/v4/users/me",
+            matrix: "/_matrix/client/versions",
+            signal: "/api/v1/check",
+            slack: "/api/auth.test",
+          }[m.provider];
+  const token = "botToken" in m ? m.botToken : "accessToken" in m ? m.accessToken : "";
+  return request(`${m.baseUrl}${apiPath}`, {
+    headers: { authorization: `${m.provider === "discord" ? "Bot" : "Bearer"} ${token}` },
+  });
+}
+
+async function closeWithinGrace(closing: Promise<void>): Promise<string> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      closing.then(
+        () => "closed",
+        () => "rejected",
+      ),
+      new Promise<string>((resolve) => {
+        timer = setTimeout(() => resolve("blocked"), 1000);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/test/server-shutdown.test.ts
+++ b/test/server-shutdown.test.ts
@@ -71,7 +71,8 @@ describe("provider server shutdown", () => {
     expect(Date.now() - startedAt).toBeLessThan(1_000);
     expect(mattermostSocket.destroyed).toBe(true);
     expect(whatsappSocket.destroyed).toBe(true);
-  });
+    // Native recorder identity is initialized during startup; the shutdown bound above stays 1 s.
+  }, 20_000);
 });
 
 async function openRawWebSocket(websocketUrl: string): Promise<Socket> {

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -48,6 +48,21 @@ const servers: StartedWhatsAppServer[] = [];
 const directories: string[] = [];
 const silentLogger = createSilentLogger();
 
+const recorderIo = vi.hoisted(() => ({ path: "", entered: () => {}, blocked: Promise.resolve() }));
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...actual,
+    realpath: async (...args: Parameters<typeof actual.realpath>) => {
+      if (args[0] === recorderIo.path) {
+        recorderIo.entered();
+        await recorderIo.blocked;
+      }
+      return await actual.realpath(...args);
+    },
+  };
+});
+
 type BaileysUpsertMessage = {
   key?: {
     fromMe?: boolean | null | undefined;
@@ -374,16 +389,12 @@ describe("whatsapp local provider server", () => {
     const recorderStarted = new Promise<void>((resolve) => {
       markRecorderStarted = resolve;
     });
-    let blockNextWebSocketEvent = true;
+    const recorderPath = path.join(directory, "whatsapp-shutdown.jsonl");
+    recorderIo.path = recorderPath;
+    recorderIo.entered = markRecorderStarted;
+    recorderIo.blocked = recorderBlocked;
     const server = await startWhatsAppServer({
-      onEvent: async (event) => {
-        if (blockNextWebSocketEvent && event.method === "WEBSOCKET") {
-          blockNextWebSocketEvent = false;
-          markRecorderStarted();
-          await recorderBlocked;
-        }
-      },
-      recorderPath: path.join(directory, "whatsapp-shutdown.jsonl"),
+      recorderPath,
     });
     const socket = createBaileysTestSocket(server);
     let closePromise: Promise<void> | undefined;
@@ -396,6 +407,7 @@ describe("whatsapp local provider server", () => {
       });
       await new Promise((resolve) => setTimeout(resolve, 50));
       expect(closeSettled).toBe(false);
+      await expect(fs.stat(recorderPath)).rejects.toMatchObject({ code: "ENOENT" });
 
       releaseRecorder();
       await closePromise;
@@ -403,8 +415,48 @@ describe("whatsapp local provider server", () => {
       releaseRecorder();
       socket.end(undefined);
       await closePromise?.catch(() => undefined);
+      recorderIo.path = "";
     }
-  });
+    // This real-I/O case includes cold identity setup, separate from the blocked-write assertion.
+  }, 20_000);
+
+  it("allows a Baileys observer to close its own server", async () => {
+    const directory = await createTempDir();
+    directories.push(directory);
+    let markEntered!: () => void;
+    const entered = new Promise<void>((resolve) => {
+      markEntered = resolve;
+    });
+    let releaseObserver!: () => void;
+    const released = new Promise<void>((resolve) => {
+      releaseObserver = resolve;
+    });
+    let closing: Promise<void> | undefined;
+    let closed = false;
+    const server = await startWhatsAppServer({
+      recorderPath: path.join(directory, "observer-close.jsonl"),
+      async onEvent(event) {
+        if (event.method === "WEBSOCKET") {
+          closing = server.close().then(() => {
+            closed = true;
+          });
+          markEntered();
+          await Promise.race([closing, released]);
+        }
+      },
+    });
+    const socket = createBaileysTestSocket(server);
+    try {
+      await entered;
+      await expect.poll(() => closed, { timeout: 1000 }).toBe(true);
+      await server.close();
+    } finally {
+      releaseObserver();
+      socket.end(undefined);
+      await closing?.catch(() => {});
+      await server.close().catch(() => {});
+    }
+  }, 20_000);
 
   it("closes the owning socket and bounds shutdown when acceptance never settles", async () => {
     let markAcceptanceStarted!: () => void;


### PR DESCRIPTION
Follow-up to #284; related to #283. The readiness and basic persistence-drain foundation is already on `main` and is preserved here.

## What Problem This Solves

Resolves remaining local-provider shutdown paths that can deadlock when an observer closes its own server, reject concurrent/repeated close calls, or leave HTTP/recorder cleanup unfinished after a WebSocket failure or failed lock acquisition.

## Why This Change Was Made

Provider close calls now share one shutdown promise and attempt all transport cleanup before draining the existing recorder owner. Telegram no longer joins the inbound admission held by its own observer. Baileys raw-node observation uses its existing session abort mechanism, while the recorder continues to retain actual persistence. Failed initial lock acquisition waits for proper-lockfile's asynchronous directory removal before settling.

Main's immutable identity implementation, named `ServerRecorder` interface, `record`/`recordCommitted` methods, factory/global-function reuse, and both recorder startup/shutdown suites are unchanged. The earlier duplicate initialization/basic-drain coverage, API rewrite and Matrix waiter changes were removed.

Production: **+85/-48 (net +37)**, for shared close orchestration and per-acquisition cleanup tracking, offset by provider cleanup simplification. Tests: **+441/-11**. No dependency, configuration, persisted format, identity policy, public API signature, provider-probe deadline or transport-grace change.

## User Impact

Observers can close their server without waiting on themselves, and callers can safely repeat or share close. Cleanup attempts continue after one transport fails, and admitted lock-removal work cannot race artifact deletion. Failures are still reported after cleanup attempts.

The existing arbitrary stalled-handler shutdown assertion stays below one second, the transport grace remains 250 ms, and provider readiness still has its five-second deadline. Native startup setup budgets do not relax those measured limits. Arbitrary application callback continuations remain caller-owned rather than part of the persistence drain.

## Evidence

Current-main red proof reproduced the callback/repeated-close failures, premature lock-cleanup completion, and failed-WebSocket cleanup paths. The strengthened transport fault also proved the original HTTP port remained occupied on main. All red probes terminated normally with cleanup gates; no killed process is counted as completed proof.

Resolved main-based focused proof: **86 passed, zero skips**, with no CLI/global timeout override:

```bash
pnpm test test/server-recorder-startup.test.ts test/server-recorder-shutdown.test.ts test/server-recorder-lifecycle.test.ts test/http-server.test.ts test/server-shutdown.test.ts --exclude '**/.claude/**'
```

Selected real Baileys, Telegram and Zalo lifecycle proof: **8 passed, 167 unselected**. This is not a full provider-suite result; the Slack filter matched no case, and Slack is instead covered by the all-provider focused recorder tests.

```bash
pnpm test test/whatsapp-server.test.ts test/telegram-server.test.ts test/slack-server.test.ts test/zalo-server.test.ts --exclude '**/.claude/**' -t 'waits for admitted Baileys recorder|allows a Baileys observer|closes the owning socket and bounds shutdown|releases pending long polls when the server closes|does not register a long poll after shutdown starts|does not rewind message IDs when an inbound observer fails during an API send|survives a client disconnect while preparing a response|cancels pending Events API retries|closes active webhook requests during server shutdown'
```

`pnpm lint` (including typecheck), `pnpm build`, and staged diff checks passed. An uninstrumented rebuilt macOS public-API smoke completed readiness in 974 ms and its first request in 88 ms with HTTP 200 under the unchanged 5,000 ms deadline; lazy artifacts, concurrent/repeated close, one durable record, and immediate artifact removal passed. It used synthetic loopback traffic only, with no real credentials, caller warmup or dispatcher changes.

### Review and validation scope

The conflicts and deletion of main's new suites reported by the initial review are resolved. Both main recorder suites and the process-owned-lock implementation are retained byte-for-byte. The PR is now only the distinct shutdown/lock-cleanup follow-up.

The old 467-pass/18-failure Mac diagnostic and baseline attribution applied to the original pre-rebase candidate, not this resolved tree. They are preserved as historical evidence, not relabeled green or claimed all fixed. The revised tree has the focused/native proof above; full clean-checkout exact-head CI remains required before merge. The local exclusion only avoids unrelated nested worktrees and does not change repository test configuration.

The maintainer-approved `0.1.18` release metadata is included so CI validates the exact version before tagging. The manifest change is version-only; no dependency specification changed. The release notes also include the already-landed macOS ACL repair and dependency/tooling updates since `0.1.17`. Publication will use the existing provenance-verifying release workflow only after verification.

AI-assisted repair. Fresh isolated Codex autoreview of the resolved runtime/test delta reported no actionable findings in its P0 scope.

Exact-head verification for `e2d444a520127869412f7712a04102e49dbf66cf` is green: [CI run 33161556578](https://github.com/openclaw/crabline/actions/runs/33161556578) completed successfully with **1,888 tests passed and 69 platform/selection skips** in the coverage suite, plus the separate autoreview-tooling tests. `pnpm verify` included formatting, typecheck, type-aware lint, tooling tests, build, and coverage. CodeQL checks also passed. No CI rerun or timeout override was needed.
