### PR TITLE
fix: contain recorder rejections during WhatsApp shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## 0.1.19 - Unreleased
+## 0.1.19 - 2026-08-28
+
+- Observe late recorder rejections when WhatsApp shutdown interrupts compressed-frame decoding, preserving prompt cancellation and observer-safe shutdown.
 
 ## 0.1.18 - 2026-08-28
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/crabline",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Standalone CLI for deterministic messaging provider E2E tests",
   "homepage": "https://github.com/openclaw/crabline#readme",
   "bugs": {

--- a/src/servers/whatsapp-baileys-websocket.ts
+++ b/src/servers/whatsapp-baileys-websocket.ts
@@ -184,10 +184,9 @@ async function awaitWithAbort<T>(operation: Promise<T>, signal?: AbortSignal): P
   if (!signal) {
     return await operation;
   }
-  signal.throwIfAborted();
   return await new Promise<T>((resolve, reject) => {
     const abort = () => reject(signal.reason);
-    signal.addEventListener("abort", abort, { once: true });
+    // The operation already started; even pre-aborted waits must observe its rejection.
     void operation.then(
       (value) => {
         signal.removeEventListener("abort", abort);
@@ -198,6 +197,8 @@ async function awaitWithAbort<T>(operation: Promise<T>, signal?: AbortSignal): P
         reject(error);
       },
     );
+    signal.throwIfAborted();
+    signal.addEventListener("abort", abort, { once: true });
   });
 }
 

--- a/test/whatsapp-server.test.ts
+++ b/test/whatsapp-server.test.ts
@@ -1,8 +1,10 @@
 import fs from "node:fs/promises";
 import { createHash, createHmac, hkdfSync } from "node:crypto";
-import { Agent } from "node:http";
+import { Agent, createServer } from "node:http";
 import { createServer as createNetServer } from "node:net";
 import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
+import { deflateSync } from "node:zlib";
 import {
   downloadMediaMessage,
   initAuthCreds,
@@ -28,8 +30,9 @@ import {
   type StartedWhatsAppServer,
 } from "../src/index.js";
 import { WHATSAPP_OPENCLAW_CRABLINE_PROVIDER_BRIDGE } from "../src/openclaw/bridges/whatsapp.js";
-import { ADMIN_TOKEN_HEADER } from "../src/servers/http.js";
+import { ADMIN_TOKEN_HEADER, closeServer } from "../src/servers/http.js";
 import {
+  attachWhatsAppBaileysWebSocketServer,
   MAX_WHATSAPP_WEBSOCKET_FRAGMENTS,
   persistAcceptedBaileysMessage,
   signalBundleIdentityKey,
@@ -40,9 +43,9 @@ import {
   canonicalizeWhatsAppUserJid,
 } from "../src/servers/whatsapp-jid.js";
 import { isWhatsAppMessageIdInUse } from "../src/servers/whatsapp.js";
-import type { BinaryNode } from "../src/servers/whatsapp-wire/binary-node.js";
+import { encodeBinaryNode, type BinaryNode } from "../src/servers/whatsapp-wire/binary-node.js";
 import { Curve, ensureSignalPublicKey, type KeyPair } from "../src/servers/whatsapp-wire/crypto.js";
-import { createTempDir, disposeTempDir, requestHttp } from "./test-helpers.js";
+import { createTempDir, disposeTempDir, requestHttp, settleCleanup } from "./test-helpers.js";
 
 const servers: StartedWhatsAppServer[] = [];
 const directories: string[] = [];
@@ -59,6 +62,30 @@ vi.mock("node:fs/promises", async (importOriginal) => {
         await recorderIo.blocked;
       }
       return await actual.realpath(...args);
+    },
+  };
+});
+
+const compressedFrameIo = vi.hoisted(() => ({
+  input: undefined as Buffer | undefined,
+  entered: () => {},
+  blocked: Promise.resolve(),
+}));
+vi.mock("node:zlib", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:zlib")>();
+  return {
+    ...actual,
+    inflate: (...args: Parameters<typeof actual.inflate>) => {
+      if (
+        compressedFrameIo.input &&
+        Buffer.isBuffer(args[0]) &&
+        args[0].equals(compressedFrameIo.input)
+      ) {
+        compressedFrameIo.entered();
+        void compressedFrameIo.blocked.then(() => actual.inflate(...args));
+        return;
+      }
+      actual.inflate(...args);
     },
   };
 });
@@ -198,7 +225,7 @@ function padSignalMessage(message: Buffer): Buffer {
 }
 
 function createBaileysTestSocket(
-  server: StartedWhatsAppServer,
+  server: { manifest: { endpoints: { baileysWebSocketUrl: string } } },
   options: { fireInitQueries?: boolean } = {},
 ) {
   const creds: AuthenticationCreds = {
@@ -457,6 +484,90 @@ describe("whatsapp local provider server", () => {
       await server.close().catch(() => {});
     }
   }, 20_000);
+
+  it("contains late recorder rejection when shutdown interrupts compressed decoding", async () => {
+    const gate = () => {
+      let resolve!: () => void;
+      const promise = new Promise<void>((done) => {
+        resolve = done;
+      });
+      return { promise, resolve };
+    };
+    const decodeEntered = gate();
+    const releaseDecode = gate();
+    const releaseAppend = gate();
+    const node: BinaryNode = { attrs: { id: "cancelled-compressed" }, tag: "presence" };
+    const compressed = deflateSync(encodeBinaryNode(node).subarray(1));
+    const recorderError = new Error("late recorder failure after compressed decode");
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => unhandled.push(reason);
+    const httpServer = createServer();
+    const server = attachWhatsAppBaileysWebSocketServer({
+      accessToken: "recorder-cancellation",
+      async appendEvent(event) {
+        if (isDeepStrictEqual(event.body, node)) {
+          await releaseAppend.promise;
+          throw recorderError;
+        }
+      },
+      httpServer,
+      path: "/ws/chat",
+      selfJid: "15550000001:0@s.whatsapp.net",
+    });
+    let socket: ReturnType<typeof createBaileysTestSocket> | undefined;
+    let closing: Promise<void> | undefined;
+    process.on("unhandledRejection", onUnhandled);
+    try {
+      await new Promise<void>((resolve, reject) => {
+        httpServer.once("error", reject);
+        httpServer.listen(0, "127.0.0.1", () => {
+          httpServer.off("error", reject);
+          resolve();
+        });
+      });
+      const address = httpServer.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Missing loopback WhatsApp test address.");
+      }
+      socket = createBaileysTestSocket({
+        manifest: {
+          endpoints: {
+            baileysWebSocketUrl: `ws://127.0.0.1:${address.port}/ws/chat?access_token=recorder-cancellation`,
+          },
+        },
+      });
+      await socket.waitForConnectionUpdate(async ({ connection }) => connection === "open");
+      compressedFrameIo.input = compressed;
+      compressedFrameIo.entered = decodeEntered.resolve;
+      compressedFrameIo.blocked = releaseDecode.promise;
+      await socket.sendRawMessage(Buffer.concat([Buffer.from([2]), compressed]));
+      await decodeEntered.promise;
+
+      // Cancellation must win without abandoning recorder work started when decode resumes.
+      closing = server.close();
+      releaseDecode.resolve();
+      await closing;
+      releaseAppend.resolve();
+      // Node reports orphaned rejections at the turn boundary, not during promise settlement.
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(unhandled).toEqual([]);
+    } finally {
+      releaseDecode.resolve();
+      releaseAppend.resolve();
+      try {
+        await settleCleanup([
+          socket?.end(undefined) ?? Promise.resolve(),
+          closing ?? server.close(),
+          httpServer.listening ? closeServer(httpServer) : Promise.resolve(),
+        ]);
+      } finally {
+        process.off("unhandledRejection", onUnhandled);
+        compressedFrameIo.input = undefined;
+        compressedFrameIo.entered = () => {};
+        compressedFrameIo.blocked = Promise.resolve();
+      }
+    }
+  });
 
   it("closes the owning socket and bounds shutdown when acceptance never settles", async () => {
     let markAcceptanceStarted!: () => void;


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/131883 (blocked Crabline adoption in QA safety work)

## What Problem This Solves

Fixes an issue where callers shutting down a local WhatsApp server during compressed-frame decoding could receive an unhandled rejection if the recorder or event observer subsequently failed. This regression in the 0.1.18 recorder-shutdown change blocks safe adoption of that release, including its macOS artifact ACL repair.

## Why This Change Was Made

The existing cancellation waiter now registers settlement handlers on its already-started operation before checking for pre-abortion. Pre-aborted callers still reject promptly without adding an abort listener, while later operation failures remain observed.

This repairs the shared owner rather than adding an OpenClaw catch or changing individual callers. Persistence-only draining, observer-safe shutdown, cancellation precedence, timeouts, and public APIs remain unchanged. No new export, dependency, fallback, or production test seam is introduced. The package version and dated changelog prepare the explicitly authorized corrective 0.1.19 release.

## User Impact

Closing a WhatsApp mock server while a compressed frame is pending no longer abandons a later recorder rejection. Shutdown remains prompt even when the observer has not settled. The existing restrictive macOS ancestor-ACL fix remains included in the corrective release.

Production source delta: +3/-2, net +1 solely for the ordering-invariant comment; executable LOC is neutral. Tests: +116/-5, reusing the existing Baileys client helper with an endpoint-only input type. Release metadata is counted separately.

## Evidence

- The new `contains late recorder rejection when shutdown interrupts compressed decoding` case uses a real Baileys Noise-encrypted frame, the existing public `attachWhatsAppBaileysWebSocketServer` API, a matching-input zlib gate, and an in-memory append operation. It starts public shutdown while decoding is pending, resumes decoding, permits shutdown before the append settles, and then rejects that append.
- Pre-fix source: the exact case failed in 65ms with the expected recorder error in the unhandled-rejection collection (1 failed, 55 skipped), not a timeout.
- Fixed source: the same case passed (1 passed, 55 skipped). The grouped cancellation/acceptance run passed 9 tests; the complete pure-wire suite passed 57 tests.
- `pnpm lint` passed formatting, TypeScript, and type-aware lint; `pnpm build` passed.
- Fresh Codex autoreview of the complete four-file change reported no accepted/actionable findings at its default P0 scope.
- Baileys 7.0.0-rc14 source/types were checked: `sendRawMessage` encrypts the supplied bytes through Noise and sends them to the configured WebSocket URL.

Focused commands, from the repository root:

```bash
pnpm test test/whatsapp-server.test.ts -t 'contains late recorder rejection when shutdown interrupts compressed decoding'
```

```bash
pnpm test test/whatsapp-server.test.ts -t 'contains late recorder rejection|does not invoke acceptance work for an already-aborted owner signal|times out stalled acceptance|preserves the acceptance timeout|fences duplicate persistence|fences recorder persistence after the owning socket aborts|fences late Signal mutation|shares a pending false acceptance|shares a pending rejection'
```

```bash
pnpm test test/whatsapp-wire.test.ts
```

```bash
pnpm lint
```

```bash
pnpm build
```

Proof limits: local tests use only ephemeral loopback sockets and in-memory recorder injection, not real WhatsApp, a Gateway, credentials, or the operator's recorder cache. Full recorder/filesystem and package coverage is left to the repository's secretless hosted CI and release verification. No host permissions or live state were changed.

Provenance: the new `#recordNode` cancellation call was introduced by https://github.com/openclaw/crabline/pull/285 (`2c07cda31293f9743b36fecc1702716b925354e6`, authored by Peter Steinberger and squash-committed by GitHub). The helper existed earlier; this change repairs its promise-observation contract for all callers.

AI-assisted implementation and independent review.
