### PR TITLE
test(whatsapp): cover native recorder cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ Provider servers initialize recorder ownership before reporting readiness,
 without creating recorder files or emitting synthetic events. Closing a server
 stops new recorder admissions and waits for admitted persistence to finish.
 Shutdown does not wait for event observers, which may themselves call `close()`.
+Baileys recorder rejections remain handled when shutdown interrupts compressed
+frame decoding and an event observer subsequently fails.
 Concurrent and repeated close calls share the same shutdown. All transports are
 closed even if one fails, and the persistence drain includes asynchronous cleanup
 after a failed recorder lock acquisition.

--- a/test/fixtures/whatsapp-recorder-abort.ts
+++ b/test/fixtures/whatsapp-recorder-abort.ts
@@ -1,0 +1,387 @@
+import assert from "node:assert/strict";
+import { createHook } from "node:async_hooks";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { setImmediate as checkpoint } from "node:timers/promises";
+import { inspect } from "node:util";
+import { deflateSync, Inflate } from "node:zlib";
+import {
+  encodeBinaryNode,
+  initAuthCreds,
+  makeWASocket,
+  type SignalDataTypeMap,
+  type SignalKeyStore,
+} from "baileys";
+import { startWhatsAppServer, type StartedWhatsAppServer } from "../../src/servers/whatsapp.js";
+import type { ServerRequestEvent } from "../../src/servers/http.js";
+import { WHATSAPP_BINARY_NODE_MAX_DECOMPRESSED_BYTES } from "../../src/servers/whatsapp-wire/binary-node.js";
+import { createTempDir, disposeTempDir } from "../test-helpers.js";
+
+function fence<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((complete) => {
+    resolve = complete;
+  });
+  return { promise, resolve };
+}
+
+async function within<T>(promise: Promise<T>, label: string, ms = 2_000): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`Missing milestone: ${label}`)), ms);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function memoryKeys(): SignalKeyStore {
+  const values = new Map<string, unknown>();
+  return {
+    async get(type, ids) {
+      const result: Record<string, unknown> = {};
+      for (const id of ids) {
+        const value = values.get(`${type}.${id}`);
+        if (value !== undefined) {
+          result[id] = value;
+        }
+      }
+      return result as { [id: string]: SignalDataTypeMap[typeof type] };
+    },
+    async set(data) {
+      for (const [type, entries] of Object.entries(data)) {
+        for (const [id, value] of Object.entries(entries ?? {})) {
+          if (value === null) {
+            values.delete(`${type}.${id}`);
+          } else {
+            values.set(`${type}.${id}`, value);
+          }
+        }
+      }
+    },
+  };
+}
+
+const logger = {
+  child: () => logger,
+  debug: () => undefined,
+  error: () => undefined,
+  info: () => undefined,
+  level: "silent",
+  trace: () => undefined,
+  warn: () => undefined,
+};
+const marker = {
+  attrs: { id: "pre-aborted-recorder-marker", to: "s.whatsapp.net", type: "get", xmlns: "w:p" },
+  content: [{ attrs: {}, tag: "ping" }],
+  tag: "iq",
+};
+const encoded = encodeBinaryNode(marker);
+const compressed = deflateSync(encoded.subarray(1));
+const observerSentinel = new Error("pre-aborted-recorder-observer-sentinel");
+const milestones: string[] = [];
+const unhandled: unknown[] = [];
+process.on("unhandledRejection", (reason) => {
+  unhandled.push(reason);
+  process.exitCode = 1;
+  process.stderr.write(`UNHANDLED ${inspect(reason, { depth: 5 })}\n`);
+});
+
+function milestone(name: string) {
+  milestones.push(name);
+  process.stdout.write(`milestone: ${name}\n`);
+}
+
+function isMarker(event: ServerRequestEvent): boolean {
+  const body = event.body as { attrs?: { id?: string } } | undefined;
+  return event.method === "WEBSOCKET" && body?.attrs?.id === marker.attrs.id;
+}
+
+type InflateResult = { buffer: Buffer; engine: Inflate };
+type InflateCallback = (error: Error | null, result?: InflateResult) => void;
+type NativeInflate = Inflate & {
+  cb: InflateCallback;
+  _info: boolean;
+  _maxOutputLength: number;
+};
+
+// Observe construction, then gate only this instance's real completion delivery.
+// Node's native owner/callback shape is deliberately checked, never mocked globally.
+function holdNativeInflate() {
+  const delivered = fence();
+  const failed = fence<Error>();
+  let armed = true;
+  let captures = 0;
+  let callbacks = 0;
+  let invocations = 0;
+  let input: Buffer | undefined;
+  let engine: NativeInflate | undefined;
+  let original: InflateCallback | undefined;
+  let held: Parameters<InflateCallback> | undefined;
+  let failure: Error | undefined;
+  const fail = (error: Error) => {
+    failure = error;
+    failed.resolve(error);
+  };
+  const hook = createHook({
+    init(_id, type, _trigger, resource: object) {
+      if (!armed || type !== "ZLIB") {
+        return;
+      }
+      queueMicrotask(() => {
+        if (!armed) {
+          return;
+        }
+        try {
+          const handle = resource as { buffer?: unknown; [key: symbol]: unknown };
+          assert(Buffer.isBuffer(handle.buffer), "Native ZLIB resource has no input Buffer");
+          if (!handle.buffer.equals(compressed)) {
+            return;
+          }
+          const owners = Object.getOwnPropertySymbols(handle).filter(
+            (symbol) => symbol.description === "owner_symbol",
+          );
+          assert.equal(owners.length, 1, "Native ZLIB owner_symbol shape changed");
+          const owner = handle[owners[0]!];
+          assert(owner instanceof Inflate, "Matching native ZLIB owner is not Inflate");
+          const candidate = owner as NativeInflate;
+          const { _info: info, _maxOutputLength: maxOutputLength } = candidate;
+          assert.equal(info, true, "Native Inflate info option changed");
+          assert.equal(maxOutputLength, WHATSAPP_BINARY_NODE_MAX_DECOMPRESSED_BYTES);
+          assert.equal(typeof candidate.cb, "function", "Native Inflate cb shape changed");
+          assert.equal(++captures, 1, "More than one matching native Inflate instance");
+          input = Buffer.from(handle.buffer);
+          engine = candidate;
+          original = candidate.cb;
+          candidate.cb = (...args) => {
+            callbacks += 1;
+            if (held) {
+              fail(new Error("Native Inflate delivered more than one callback"));
+              return;
+            }
+            held = args;
+            delivered.resolve();
+          };
+        } catch (error) {
+          fail(new Error("Native Inflate instance seam failed", { cause: error }));
+        }
+      });
+    },
+  }).enable();
+  return {
+    ready: Promise.race([
+      delivered.promise,
+      failed.promise.then((error) => {
+        throw error;
+      }),
+    ]),
+    verify() {
+      assert.equal(failure, undefined, failure?.stack);
+      assert.equal(captures, 1);
+      assert.equal(callbacks, 1);
+      assert.deepEqual(input, compressed);
+      assert(held, "Native Inflate completion was not captured");
+      assert.equal(held[0], null, "Actual native Inflate failed");
+      assert(held[1], "Actual native Inflate did not return info");
+      assert.equal(held[1].engine, engine);
+      assert.equal(engine?.bytesWritten, compressed.length);
+      assert.deepEqual(held[1].buffer, encoded.subarray(1));
+    },
+    release() {
+      if (engine && original) {
+        engine.cb = original;
+        if (held && invocations === 0) {
+          invocations += 1;
+          original.apply(engine, held);
+        }
+      }
+    },
+    stop() {
+      armed = false;
+      hook.disable();
+      this.release();
+    },
+    proof() {
+      this.verify();
+      assert.equal(invocations, 1);
+      assert.equal(engine?.cb, original, "Native Inflate callback was not restored");
+      return {
+        captures,
+        callbacks,
+        invocations,
+        inputBytes: input?.length,
+        bytesWritten: engine?.bytesWritten,
+      };
+    },
+  };
+}
+
+async function run() {
+  const directory = await createTempDir();
+  const recorderPath = path.join(directory, "pre-aborted.jsonl");
+  const observerEntered = fence();
+  const observerRelease = fence();
+  const observerSettled = fence<unknown>();
+  const clientClosed = fence();
+  let observerStarted = false;
+  let observerReleased = false;
+  let server: StartedWhatsAppServer | undefined;
+  let socket: ReturnType<typeof makeWASocket> | undefined;
+  let inflate: ReturnType<typeof holdNativeInflate> | undefined;
+  let closeMs: number | undefined;
+  let durableRecords = 0;
+  try {
+    server = await startWhatsAppServer({
+      recorderPath,
+      onEvent(event) {
+        if (!isMarker(event)) {
+          return;
+        }
+        assert.equal(observerStarted, false, "Marker observer entered twice");
+        observerStarted = true;
+        observerEntered.resolve();
+        const observation = (async () => {
+          await observerRelease.promise;
+          throw observerSentinel;
+        })();
+        // This fence observes only our callback, never the escaped outer recorder promise.
+        void observation.then(observerSettled.resolve, observerSettled.resolve);
+        return observation;
+      },
+    });
+    socket = makeWASocket({
+      auth: {
+        creds: {
+          ...initAuthCreds(),
+          me: { id: "15550000001:0@s.whatsapp.net", name: "Crabline Test Bot" },
+        },
+        keys: memoryKeys(),
+      },
+      browser: ["crabline", "test", "1.0"],
+      connectTimeoutMs: 2_000,
+      defaultQueryTimeoutMs: 750,
+      fireInitQueries: false,
+      keepAliveIntervalMs: 10_000,
+      logger,
+      markOnlineOnConnect: false,
+      printQRInTerminal: false,
+      syncFullHistory: false,
+      waWebSocketUrl: server.manifest.endpoints.baileysWebSocketUrl,
+      version: [2, 3000, 1035194821],
+    });
+    const clientOpen = fence();
+    socket.ev.on("connection.update", (update) => {
+      if (update.connection === "open") {
+        clientOpen.resolve();
+      }
+      if (update.connection === "close") {
+        clientClosed.resolve();
+      }
+    });
+    await within(clientOpen.promise, "Baileys connection ready");
+    milestone("client-ready");
+    const barrier = await within(
+      socket.query({ ...marker, attrs: { ...marker.attrs, id: "pre-abort-iq-barrier" } }),
+      "IQ readiness barrier",
+    );
+    assert.equal(barrier?.attrs.id, "pre-abort-iq-barrier");
+    assert.equal(barrier.attrs.type, "result");
+    milestone("iq-barrier");
+
+    inflate = holdNativeInflate();
+    await Promise.all([
+      within(
+        socket.sendRawMessage(Buffer.concat([Buffer.from([2]), compressed])),
+        "encrypted compressed send",
+      ),
+      within(inflate.ready, "actual native Inflate completion held"),
+    ]);
+    inflate.verify();
+    assert.equal(observerStarted, false);
+    milestone("native-inflate-held");
+
+    const started = performance.now();
+    const closing = server.close();
+    const closeBound = within(closing, "close while observer held (1000ms)", 1_000);
+    const concurrent = server.close();
+    assert.equal(concurrent, closing);
+    milestone("close-started-before-decode-release");
+    inflate.release();
+    milestone("native-decode-released");
+    await Promise.all([closeBound, within(observerEntered.promise, "marker observer entered")]);
+    closeMs = performance.now() - started;
+    assert(closeMs < 1_000, `Close exceeded lifecycle bound: ${closeMs}ms`);
+    assert.equal(observerReleased, false);
+    milestone("closed-with-observer-held");
+    await within(server.close(), "repeated close", 1_000);
+    milestone("repeated-close");
+    const events = (await readFile(recorderPath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as ServerRequestEvent);
+    const matches = events.filter(isMarker);
+    durableRecords = matches.length;
+    assert.equal(durableRecords, 1);
+    assert.deepEqual(matches[0]?.body, marker);
+    milestone("one-durable-marker");
+
+    observerReleased = true;
+    observerRelease.resolve();
+    assert.equal(
+      await within(observerSettled.promise, "observer rejection settlement"),
+      observerSentinel,
+    );
+    milestone("observer-rejected-and-settled");
+  } finally {
+    inflate?.stop();
+    observerRelease.resolve();
+    // Unstick both gates before joining owned work or removing its recorder directory.
+    const cleanup = await Promise.allSettled([
+      ...(server ? [within(server.close(), "cleanup server close", 1_000)] : []),
+      ...(socket
+        ? [
+            within(
+              (async () => {
+                await socket.end(undefined);
+                await clientClosed.promise;
+              })(),
+              "owned Baileys teardown",
+            ),
+          ]
+        : []),
+      ...(observerStarted ? [within(observerSettled.promise, "cleanup observer settlement")] : []),
+    ]);
+    const errors = cleanup.flatMap((result) =>
+      result.status === "rejected" ? [result.reason] : [],
+    );
+    assert.equal(errors.length, 0, `Cleanup did not settle: ${inspect(errors)}`);
+    if (observerStarted) {
+      await within(observerSettled.promise, "observer settlement after serialized handler drain");
+    }
+    milestone("owned-work-settled");
+    await checkpoint();
+    milestone("event-loop-checkpoint");
+    await disposeTempDir(directory);
+    milestone("temporary-directory-removed");
+  }
+  const native = inflate?.proof();
+  process.stdout.write(
+    `proof: ${JSON.stringify({ node: process.version, execPath: process.execPath, milestones, native, closeMs, durableRecords, unhandledRejections: unhandled.length })}\n`,
+  );
+  assert.equal(
+    unhandled.length,
+    0,
+    `Expected zero TOTAL unhandledRejection events; received ${inspect(unhandled)}`,
+  );
+}
+
+process.stdout.write(`runtime: ${process.execPath} ${process.version}\n`);
+await run().catch((error: unknown) => {
+  process.stderr.write(`${inspect(error, { depth: 5 })}\n`);
+  process.stderr.write(`Completed milestones: ${milestones.join(", ")}\n`);
+  process.exitCode = 1;
+});

--- a/test/whatsapp-recorder-abort.test.ts
+++ b/test/whatsapp-recorder-abort.test.ts
@@ -1,0 +1,79 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { expect, it } from "vitest";
+
+it("observes recorder rejection when shutdown aborts during native Baileys inflation", async () => {
+  const child = spawn(
+    process.execPath,
+    [
+      "--import",
+      "tsx",
+      "--input-type=module",
+      "--eval",
+      `console.log("child-started", process.execPath, process.version); await import(${JSON.stringify(new URL("./fixtures/whatsapp-recorder-abort.ts", import.meta.url).href)});`,
+    ],
+    { stdio: ["ignore", "pipe", "pipe"] },
+  );
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => {
+    stdout += chunk;
+  });
+  child.stderr.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+  const exited = once(child, "close");
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    const [code, signal] = await Promise.race([
+      exited,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`Child did not exit; stdout: ${stdout}\nstderr: ${stderr}`)),
+          // Use the recorder subprocess bound, reserving one second for forced teardown.
+          30_000 - 1_000,
+        );
+      }),
+    ]);
+    process.stdout.write(stdout);
+    expect({ code, signal }, `stdout: ${stdout}\nstderr: ${stderr}`).toEqual({
+      code: 0,
+      signal: null,
+    });
+    const line = stdout.split("\n").find((value) => value.startsWith("proof: "));
+    expect(line).toBeDefined();
+    const proof = JSON.parse(line!.slice("proof: ".length));
+    expect(proof).toMatchObject({
+      node: process.version,
+      execPath: process.execPath,
+      durableRecords: 1,
+      native: { captures: 1, callbacks: 1, invocations: 1 },
+      unhandledRejections: 0,
+      milestones: [
+        "client-ready",
+        "iq-barrier",
+        "native-inflate-held",
+        "close-started-before-decode-release",
+        "native-decode-released",
+        "closed-with-observer-held",
+        "repeated-close",
+        "one-durable-marker",
+        "observer-rejected-and-settled",
+        "owned-work-settled",
+        "event-loop-checkpoint",
+        "temporary-directory-removed",
+      ],
+    });
+    expect(proof.native.inputBytes).toBeGreaterThan(0);
+    expect(proof.native.bytesWritten).toBe(proof.native.inputBytes);
+    expect(proof.closeMs).toBeLessThan(1_000);
+  } finally {
+    clearTimeout(timer);
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill("SIGKILL");
+      await exited;
+    }
+  }
+}, 30_000);


### PR DESCRIPTION
## Summary

Follow-up coverage for https://github.com/openclaw/crabline/pull/286. The production repair is already merged; this PR keeps that helper, release metadata, dependencies, and policy unchanged.

The new subprocess regression exercises the complete `startWhatsAppServer` → real Baileys Noise transport → native compressed-frame inflation → real recorder → rejecting `onEvent` path. It gates only the exact-input-matched native Inflate instance's completion callback, rather than replacing the zlib module or adding a production seam.

The test closes the server before releasing decode, keeps the observer pending while shutdown finishes, verifies exactly one durable marker, then rejects the observer. It asserts the unchanged 1,000 ms close bound, exact native input/output and callback counts, callback restoration, explicit cleanup/settlement fences, zero total unhandled rejections through child exit, and normal exit. README documents the already-landed lifecycle behavior.

## Validation

- Historical negative proof on pre-fix source `6c4baf2193f4f355d38cfbf3a16ee312e9d059de`: the real compressed-WebSocket case completed its lifecycle milestones and failed with the escaped `ServerRecorderCommittedError` caused by the observer sentinel. This is not an extracted-helper probe.
- Against the canonical merged helper: the native regression passed on Node 22.23.2 and Node 26.7.0, with zero unhandled rejections and shutdown below the existing one-second bound.
- The nine selected cancellation/acceptance cases and all 57 wire tests passed.
- `pnpm lint` and `pnpm build` passed. Fresh scoped Codex review reported no actionable findings at the default P0 scope.
- Full repository verification and coverage must pass in hosted CI on this PR's exact head before merge; the earlier green run for #286 is not substituted for this PR's checks.

Focused commands use pnpm 11.24.0:

```bash
TSX_DISABLE_CACHE=1 pnpm test --no-cache --configLoader native test/whatsapp-recorder-abort.test.ts
```

```bash
TSX_DISABLE_CACHE=1 pnpm test --no-cache --configLoader native test/whatsapp-wire.test.ts
```

Earlier local attempts failed during startup/readiness before reaching the native gate; those failures are not reclassified as passing proof. During preparation, Vitest also discovered an archived prototype copy. Only the archive's filename was changed, preserving its bytes, and the clean Node 22 command was rerun successfully. No assertions, lifecycle deadlines, or coverage thresholds were relaxed.

This is local mock-provider coverage, not live WhatsApp or Gateway coverage. Native Inflate internals are checked explicitly and fail clearly if their shape changes. No package release, version bump, OpenClaw pin change, or release-age exemption is part of this PR.

AI-assisted implementation and independent scoped review.
