### PR TITLE
chore: refresh compatible dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "re2js": "2.8.6",
     "ws": "^8.21.3",
     "yaml": "^2.9.0",
-    "zod": "^4.4.3"
+    "zod": "^4.5.2"
   },
   "devDependencies": {
     "@types/proper-lockfile": "4.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ importers:
         specifier: ^2.9.0
         version: 2.9.0
       zod:
-        specifier: ^4.4.3
-        version: 4.4.3
+        specifier: ^4.5.2
+        version: 4.5.2
     devDependencies:
       '@types/proper-lockfile':
         specifier: 4.1.4
@@ -450,8 +450,8 @@ packages:
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
 
-  '@jridgewell/sourcemap-codec@1.5.5':
-    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+  '@jridgewell/sourcemap-codec@1.6.0':
+    resolution: {integrity: sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==}
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
@@ -465,8 +465,8 @@ packages:
   '@keyv/serialize@1.1.1':
     resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
 
-  '@matrix-org/matrix-sdk-crypto-wasm@18.6.0':
-    resolution: {integrity: sha512-P3v8849O/1+c1CYDQ1X6L1p6UpakYAav1L4wTNvwLA54n9wNpadpw8sLZoxhaG4ftlmNzxFztjRYwDvx56d11w==}
+  '@matrix-org/matrix-sdk-crypto-wasm@18.7.0':
+    resolution: {integrity: sha512-IiO8YrahwBN23iii4OBS6AUIEDZePa72bK7WN/DBjOXPc6g/wt891vn0vxmlopTahqFFOz/LErcHisdmzKVTsg==}
     engines: {node: '>= 18'}
 
   '@oxc-project/types@0.146.0':
@@ -1433,8 +1433,8 @@ packages:
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
-  protobufjs@7.6.5:
-    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
+  protobufjs@7.6.6:
+    resolution: {integrity: sha512-dYDWdjSl5RNb7SgPxGQcRU+GtvP7s2fpkrY0r432PcOIaZ0/rBcxEZnQN67iJhFuQiVw754JDoPruPCNdGsbjg==}
     engines: {node: '>=12.0.0'}
 
   qified@0.10.1:
@@ -1675,8 +1675,8 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
-  zod@4.4.3:
-    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+  zod@4.5.2:
+    resolution: {integrity: sha512-XkYXCol10+ba/6F/cueWV+TezUeOqXW0hdeJt5CdXjTYeAgAQg5N03RQdJ80mhfFE72+pblvYMW4wy2Qp4Qbrg==}
 
 snapshots:
 
@@ -1914,12 +1914,12 @@ snapshots:
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
-  '@jridgewell/sourcemap-codec@1.5.5': {}
+  '@jridgewell/sourcemap-codec@1.6.0': {}
 
   '@jridgewell/trace-mapping@0.3.31':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/sourcemap-codec': 1.6.0
 
   '@keyv/bigmap@1.3.1(keyv@5.6.0)':
     dependencies:
@@ -1929,7 +1929,7 @@ snapshots:
 
   '@keyv/serialize@1.1.1': {}
 
-  '@matrix-org/matrix-sdk-crypto-wasm@18.6.0': {}
+  '@matrix-org/matrix-sdk-crypto-wasm@18.7.0': {}
 
   '@oxc-project/types@0.146.0': {}
 
@@ -2315,7 +2315,7 @@ snapshots:
       music-metadata: 11.15.0(supports-color@7.2.0)
       p-queue: 9.3.3
       pino: 9.14.0
-      protobufjs: 7.6.5
+      protobufjs: 7.6.6
       sharp: 0.35.2
       whatsapp-rust-bridge: 0.5.4
       ws: 8.21.3
@@ -2453,7 +2453,7 @@ snapshots:
   libsignal@6.0.0:
     dependencies:
       curve25519-js: 0.0.4
-      protobufjs: 7.6.5
+      protobufjs: 7.6.6
 
   lightningcss-android-arm64@1.33.0:
     optional: true
@@ -2512,7 +2512,7 @@ snapshots:
 
   magic-string@0.30.21:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/sourcemap-codec': 1.6.0
 
   magicast@0.5.4:
     dependencies:
@@ -2529,7 +2529,7 @@ snapshots:
   matrix-js-sdk@42.2.0:
     dependencies:
       '@babel/runtime': 8.0.0
-      '@matrix-org/matrix-sdk-crypto-wasm': 18.6.0
+      '@matrix-org/matrix-sdk-crypto-wasm': 18.7.0
       another-json: 0.2.0
       bs58: 6.0.0
       content-type: 2.1.0
@@ -2677,7 +2677,7 @@ snapshots:
       retry: 0.12.0
       signal-exit: 3.0.7
 
-  protobufjs@7.6.5:
+  protobufjs@7.6.6:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
@@ -2903,4 +2903,4 @@ snapshots:
 
   yaml@2.9.0: {}
 
-  zod@4.4.3: {}
+  zod@4.5.2: {}


### PR DESCRIPTION
## What Problem This Solves

Refresh the dependency graph to the newest compatible versions eligible under the repository's existing 48-hour release-age policy.

## Why This Change Was Made

| Dependency | Before | After |
| --- | --- | --- |
| zod | 4.4.3 | 4.5.2 |
| @jridgewell/sourcemap-codec (transitive) | 1.5.5 | 1.6.0 |
| @matrix-org/matrix-sdk-crypto-wasm (transitive) | 18.6.0 | 18.7.0 |
| protobufjs (transitive) | 7.6.5 | 7.6.6 |

Regenerated the lockfile with `pnpm update`, preserving the existing pnpm version, overrides, release-age checks, and build-script policy. All GitHub Actions pins, pnpm 11.24.0, npm 12.0.2, and actionlint 1.7.12 were checked against upstream releases and are current.

No major upgrades were taken. `@types/node` stays at the latest Node 22 version (22.20.1) to match the supported runtime and CI; moving to Node 26 types should accompany an explicit runtime-support decision. Zod 4.5.4 and tsx 4.23.13 remain inside the existing 48-hour quarantine (eligible after 2026-08-31 17:55:43 UTC and 2026-09-01 00:46:17 UTC, respectively).

The Go module was also checked. Trying `go get -u github.com/rhysd/actionlint/cmd/actionlint` selected YAML v4.0.0-rc.6, but workflow validation failed to compile:

```text
te.Errors[0].Error undefined (type string has no field or method Error)
e.Err undefined (type string has no field or method Err)
e.Line undefined (type string has no field or method Line)
e.Column undefined (type string has no field or method Column)
undefined: yaml.ParserError
```

Restored YAML rc.3 with `go get go.yaml.in/yaml/v4@v4.0.0-rc.3` and `go mod tidy`; there is no Go diff. Recommend waiting for an actionlint release compatible with the changed YAML API. The newer x/net and goldmark entries reported by `go list -m -u all` are unused graph entries (`go mod why -m` reports that this module does not need them), so they were not promoted to new requirements.

## User Impact

No intended CLI, provider protocol, configuration, or runtime-support changes. No changelog entry is needed for this maintenance-only refresh.

## Evidence

Verified commit: `7e214355927905ad7a6f8fd905ef5c0ce948cf85`. The full gate passed locally with Node 22.23.2 and pnpm 11.24.0 in the existing OrbStack Linux runtime. The test runner used two workers with the original timeouts, assertions, and coverage thresholds.

```text
$ pnpm verify --maxWorkers=2
Ran 28 tests in 0.274s
OK
Ran 198 tests in 10.253s
OK (skipped=3)
 Test Files  71 passed | 1 skipped (72)
      Tests  1889 passed | 70 skipped (1959)
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
All files          |   86.82 |       81 |   93.88 |   86.88 |                   
```

The skips are existing platform/environment conditions. Native macOS attempts hit five-second filesystem-heavy test timeouts under shared-host load. An initial Linux run passed 1,872 tests but timed out in 17 Matrix cases: Matrix's default recorder was still writing `artifacts/crabline/matrix.jsonl` onto the slow host mount. The successful run placed generated artifacts, recorder state, temporary files, and lock caches in memory-backed filesystems. Unrelated `.claude/` agent scratch was hidden from the container, leaving those host files untouched. All 36 Matrix tests then passed. No repository tests or workflow settings were changed to obtain this result.

<details>
<summary>Exact local Linux verification command</summary>

The checkout is bind-mounted directly. Temporary mounts and the container are removed after execution; build outputs remain in the checkout for cleanup. The cached image digest is `node@sha256:8a34c4ab3ea2c5cd194f07e317b2a8f09461d3c8b05c4e34c8ccd56d56024c4d`.

```sh
mkdir -p .crabline/deps-refresh-20260830/pnpm-store
cat > .crabline/deps-refresh-20260830/linux-verify-memory.sh <<'EOF'
#!/bin/sh
set -eu
node --version
python3 --version
git --version
npm install --global pnpm@11.24.0
pnpm --version
git config --global --add safe.directory /workspace
pnpm install --frozen-lockfile --store-dir /pnpm-store
pnpm verify --maxWorkers=2
node dist/src/bin/crabline.js --json roundtrip loopback-roundtrip --config fixtures/examples/crabline.example.yaml
EOF
docker run --rm --name crabline-deps-refresh-20260830 --cpus=2 \
  --mount "type=bind,source=$PWD,target=/workspace" \
  --mount "type=bind,source=$PWD/.crabline/deps-refresh-20260830,target=/proof,readonly" \
  --mount "type=bind,source=$PWD/.crabline/deps-refresh-20260830/pnpm-store,target=/pnpm-store" \
  --tmpfs /workspace/node_modules:rw,exec,size=1073741824 \
  --tmpfs /workspace/.crabline:rw,exec,size=1073741824 \
  --tmpfs /workspace/.claude:rw,exec \
  --tmpfs /workspace/artifacts:rw,exec,mode=0755,size=1073741824 \
  --tmpfs /tmp:rw,exec,mode=1777,size=2147483648 \
  --tmpfs /root/.cache:rw,exec,mode=0755,size=1073741824 \
  --workdir /workspace node:22-bookworm sh /proof/linux-verify-memory.sh
```

</details>

Workflow lint and module checks:

```sh
(cd tools && go run github.com/rhysd/actionlint/cmd/actionlint -config-file ../.github/actionlint.yaml -ignore 'unexpected key "queue" for "concurrency" section' ../.github/workflows/*.yml)
(cd tools && go mod verify)
```

```text
# Workflow lint: exit 0, no diagnostics; existing queue-schema exception unchanged.
all modules verified
```

Built CLI on the real example manifest:

```sh
node dist/src/bin/crabline.js --json roundtrip loopback-roundtrip --config fixtures/examples/crabline.example.yaml
```

```json
{
  "diagnostics": [
    "accepted message loopback-mock-mtgwgfzu-0g1nnt",
    "matched inbound loopback-mock-mtgwgfzu-0g1nnt-reply"
  ],
  "fixtureId": "loopback-roundtrip",
  "mode": "roundtrip",
  "nonce": "mp-loopback-roundtrip-mtgwgfy5-06f071a7",
  "ok": true,
  "providerId": "local"
}
```

<details>
<summary>Built library: live native Telegram HTTP roundtrip</summary>

The temporary proof script below starts an actual local server from `dist`, exercises HTTP identity, admin ingress, polling, and reply delivery, and verifies recorder persistence after shutdown. Generated credentials stay in memory and are never printed. Only synthetic fixture data is used.

```sh
mkdir -p .crabline/deps-refresh-20260830
cat > .crabline/deps-refresh-20260830/live-http.mjs <<'EOF'
import assert from 'node:assert/strict';
import { mkdtemp, readFile, rm } from 'node:fs/promises';
import { startTelegramServer } from '../../dist/src/index.js';

const dir = await mkdtemp('.crabline/deps-refresh-20260830/http-');
const server = await startTelegramServer({ recorderPath: `${dir}/telegram.jsonl` });
try {
  const { manifest } = server;
  const api = `${manifest.baseUrl}/bot${manifest.botToken}`;
  const request = async (label, url, body, extraHeaders = {}) => {
    const response = await fetch(url, {
      method: body ? 'POST' : 'GET',
      headers: { 'content-type': 'application/json', ...extraHeaders },
      body: body ? JSON.stringify(body) : undefined,
    });
    assert.equal(response.status, 200);
    const json = await response.json();
    console.log(`${label}: HTTP ${response.status}`);
    return json;
  };
  const identity = await request('getMe', `${api}/getMe`);
  assert.equal(identity.result.is_bot, true);
  await request('admin inbound', manifest.endpoints.adminInboundUrl,
    { chatId: '100000001', fromId: 100000002, text: 'deps-refresh-inbound' },
    { 'x-crabline-admin-token': manifest.adminToken });
  const updates = await request('getUpdates', `${api}/getUpdates`, { timeout: 0 });
  assert.equal(updates.result.length, 1);
  assert.equal(updates.result[0].message.text, 'deps-refresh-inbound');
  const sent = await request('sendMessage', `${api}/sendMessage`,
    { chat_id: '100000001', text: 'deps-refresh-reply' });
  assert.equal(sent.result.text, 'deps-refresh-reply');
  await server.close();
  const records = (await readFile(manifest.recorderPath, 'utf8')).trim().split('\n').map(JSON.parse);
  assert.ok(records.some(record => record.accepted === true || record.body?.text === 'deps-refresh-reply'));
  console.log(`PASS: native inbound/outbound HTTP roundtrip; ${records.length} persisted recorder events`);
} finally {
  await server.close();
  await rm(dir, { recursive: true, force: true });
}
EOF
node .crabline/deps-refresh-20260830/live-http.mjs
```

```text
getMe: HTTP 200
admin inbound: HTTP 200
getUpdates: HTTP 200
sendMessage: HTTP 200
PASS: native inbound/outbound HTTP roundtrip; 4 persisted recorder events
```

</details>

Codex autoreview (`.agents/skills/autoreview/scripts/autoreview --engine codex --mode local`, with task-scoped review context) completed cleanly: `autoreview clean: no accepted/actionable findings reported`. No findings were accepted or rejected.

### CI reasoning

Default-branch build/test CI was already green at the starting commit: https://github.com/openclaw/crabline/actions/runs/33204310227. This PR preserves every existing gate and assertion. `CI` runs formatting, typecheck, lint, autoreview tooling tests, build, coverage, and workflow lint. CodeQL and Dependency Review are security checks; Stale and ClawSweeper Dispatch are operational automation, not build/test proof. Release is publication-only and was not run.

PR build/test CI passed on its first run: https://github.com/openclaw/crabline/actions/runs/33365320415. After marking the PR ready, both security workflows passed: [CodeQL](https://github.com/openclaw/crabline/actions/runs/33367396172) and [Dependency Review](https://github.com/openclaw/crabline/actions/runs/33367396139). Their initial draft-only skips are superseded by these successful runs.

This PR is for maintainer review and is not merged.
