### PR TITLE
fix: keep Crabline crypto available in bundled consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## 0.1.20 - Unreleased
+## 0.1.20 - 2026-09-02
+
+- Fix bundled consumers failing to load the WhatsApp crypto dependency under isolated dependency layouts; preserve native and JavaScript crypto behavior.
+- Refresh compatible dependencies and expand WhatsApp recorder cancellation coverage.
 
 ## 0.1.19 - 2026-08-28
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ The source checkout does not link its own `crabline` bin into
 `pnpm exec crabline`. An installed package exposes the `crabline` command used
 in the examples below.
 
+Node.js consumers can bundle the package with its dependencies, including under
+pnpm's isolated linker. WhatsApp's crypto dependency uses static imports so it
+remains available when the bundle runs outside the original installation.
+
 ## Quality Gate
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/crabline",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "Standalone CLI for deterministic messaging provider E2E tests",
   "homepage": "https://github.com/openclaw/crabline#readme",
   "bugs": {
@@ -72,6 +72,7 @@
     "oxfmt": "^0.65.0",
     "oxlint": "^1.80.0",
     "oxlint-tsgolint": "^7.0.2001",
+    "rolldown": "1.2.5",
     "tsx": "^4.23.12",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vitest": "^4.1.11"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,6 +70,9 @@ importers:
       oxlint-tsgolint:
         specifier: ^7.0.2001
         version: 7.0.2001
+      rolldown:
+        specifier: 1.2.5
+        version: 1.2.5
       tsx:
         specifier: ^4.23.12
         version: 4.23.12

--- a/src/servers/whatsapp-wire/crypto.ts
+++ b/src/servers/whatsapp-wire/crypto.ts
@@ -10,17 +10,7 @@ import {
   hkdfSync,
   randomBytes,
 } from "node:crypto";
-import { createRequire } from "node:module";
-
-const require = createRequire(import.meta.url);
-
-type Curve25519Module = {
-  generateKeyPair(seed: Uint8Array): { private: Uint8Array; public: Uint8Array };
-  sharedKey(privateKey: Uint8Array, publicKey: Uint8Array): Uint8Array;
-  sign(privateKey: Uint8Array, message: Uint8Array, random: Uint8Array): Uint8Array;
-};
-
-const curve25519 = require("curve25519-js") as Curve25519Module;
+import * as curve25519 from "curve25519-js";
 
 const AES_GCM_TAG_LENGTH = 16;
 const PRIVATE_KEY_DER_PREFIX = Buffer.from([

--- a/test/package-production.test.ts
+++ b/test/package-production.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
+import { build } from "rolldown";
 import { describe, expect, expectTypeOf, it } from "vitest";
 import { parse } from "yaml";
 import type {
@@ -408,6 +409,69 @@ describe("production package", () => {
     );
   }, 120_000);
 
+  it("runs relocated bundles from a packed isolated-pnpm install", async () => {
+    const root = process.cwd();
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-bundled-consumer-"));
+    const consumerDirectory = path.join(tempRoot, "consumer");
+    const outputDirectory = path.join(tempRoot, "relocated");
+    try {
+      await fs.mkdir(consumerDirectory);
+      const packed = await npmPack(root, tempRoot);
+      await fs.writeFile(
+        path.join(consumerDirectory, "package.json"),
+        JSON.stringify({ name: "crabline-bundled-consumer", private: true, type: "module" }),
+      );
+      await fs.writeFile(
+        path.join(consumerDirectory, "pnpm-workspace.yaml"),
+        "packages: ['.']\nnodeLinker: isolated\nhoist: false\n",
+      );
+      await execPackageManager(
+        "pnpm",
+        ["add", "--ignore-scripts", "--prod", path.join(tempRoot, packed.filename)],
+        { cwd: consumerDirectory, maxBuffer: 10 * 1024 * 1024 },
+      );
+      await expect(
+        fs.stat(path.join(consumerDirectory, "node_modules", "curve25519-js")),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+      const installedRoot = path.join(consumerDirectory, "node_modules", "@openclaw", "crabline");
+      await build({
+        input: {
+          index: path.join(installedRoot, "dist/src/index.js"),
+          crypto: path.join(installedRoot, "dist/src/servers/whatsapp-wire/crypto.js"),
+        },
+        platform: "node",
+        output: { dir: outputDirectory, format: "esm", entryFileNames: "[name].mjs" },
+      });
+      await fs.rm(consumerDirectory, { recursive: true, force: true });
+      const { stdout } = await execFileAsync(
+        process.execPath,
+        [
+          "--input-type=module",
+          "--eval",
+          [
+            'import assert from "node:assert/strict";',
+            'import * as pkg from "./index.mjs";',
+            'import { Curve, createCurve } from "./crypto.mjs";',
+            'const privateKey = Buffer.from("77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a", "hex");',
+            'const publicKey = Buffer.from("de9edb7d7b7dc1b4d35b61c2ece435373f8343c85b78674dadfc7e146f882b4f", "hex");',
+            'const unsupported = () => { throw Object.assign(new Error("unsupported"), { code: "ERR_OSSL_EVP_UNSUPPORTED" }); };',
+            "const fallback = createCurve({ generateKeyPair: unsupported, sharedKey: unsupported });",
+            "for (const curve of [Curve, fallback]) {",
+            '  assert.equal(curve.sharedKey(privateKey, publicKey).toString("hex"), "4a5d9d5ba4ce2de1728e3bf480350f25e07e21c947d19e3376f09b3c1e161742");',
+            "  assert.equal(curve.generateKeyPair().public.length, 32);",
+            '  assert.equal(curve.sign(privateKey, Buffer.from("bundled consumer")).length, 64);',
+            "}",
+            "console.log(JSON.stringify(Object.keys(pkg).sort()));",
+          ].join("\n"),
+        ],
+        { cwd: outputDirectory, env: { ...process.env, NODE_PATH: "" } },
+      );
+      expect(JSON.parse(stdout) as string[]).toEqual(PUBLIC_RUNTIME_EXPORTS);
+    } finally {
+      await fs.rm(tempRoot, { recursive: true, force: true });
+    }
+  }, 120_000);
+
   it("uses portable cleanup scripts", async () => {
     const root = process.cwd();
     const pkg = JSON.parse(await fs.readFile(path.join(root, "package.json"), "utf8")) as {
@@ -576,22 +640,30 @@ async function execNpm(
   args: string[],
   options: Parameters<typeof execFileAsync>[2],
 ): Promise<{ stderr: string; stdout: string }> {
+  return execPackageManager("npm", args, options);
+}
+
+async function execPackageManager(
+  command: "npm" | "pnpm",
+  args: string[],
+  options: Parameters<typeof execFileAsync>[2],
+): Promise<{ stderr: string; stdout: string }> {
   const result =
     process.platform === "win32"
       ? await execFileAsync(
           process.env.ComSpec ?? "cmd.exe",
-          ["/d", "/s", "/c", buildWindowsNpmCommand(args)],
+          ["/d", "/s", "/c", buildWindowsNpmCommand(args, command)],
           { ...options, windowsVerbatimArguments: true },
         )
-      : await execFileAsync("npm", args, options);
+      : await execFileAsync(command, args, options);
   return {
     stderr: String(result.stderr),
     stdout: String(result.stdout),
   };
 }
 
-function buildWindowsNpmCommand(args: string[]): string {
-  return `"${["npm.cmd", ...args].map(quoteCmdArgument).join(" ")}"`;
+function buildWindowsNpmCommand(args: string[], command = "npm"): string {
+  return `"${[`${command}.cmd`, ...args].map(quoteCmdArgument).join(" ")}"`;
 }
 
 function quoteCmdArgument(value: string): string {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where developers bundling Crabline would get `Cannot find module 'curve25519-js'` when running the output outside Crabline's installation, including consumers using pnpm's isolated linker. This was exposed while validating openclaw/openclaw#135728.

## Why This Change Was Made

Replace the package-relative `createRequire(import.meta.url)` loader with a static namespace import and use the dependency's shipped types. This lets the bundler retain the dependency without relying on hoisting. The native X25519 backend, JavaScript fallback, randomized signatures, and public API stay unchanged. The runtime change removes ten net lines; no new runtime dependency or crypto implementation is introduced.

Extend the existing production-package suite with a packed isolated-pnpm consumer (`hoist: false`), bundle the public entry and crypto module using Rolldown, delete the installation, then execute the relocated output. Rolldown is now an explicit test dependency at the exact version already present through Vite; no transitive snapshots change for that declaration.

Prepare the explicitly requested patch release, 0.1.20, with finalized release notes covering this fix and the compatible dependency/recorder-test changes already on main. No next-release placeholder is added.

## User Impact

Node consumers can bundle Crabline without adding its private crypto dependency to their own root dependencies or preserving a Crabline-specific externalization workaround.

## Evidence

- The new packed-consumer regression fails on the original loader with `Cannot find module 'curve25519-js'` from the relocated output.
- After the fix, the package/WhatsApp wire suites pass: 2 files, 70 tests. Coverage includes RFC 7748 agreement, native and forced JavaScript fallback, randomized XEdDSA signatures, installed CLI/public declarations, and relocated public exports.
- Inspected curve25519-js 0.0.4's CommonJS exports and shipped declarations; its namespace exports match the existing calls. No other source createRequire loader remains.
- Codex autoreview found no accepted/actionable P0 findings; this was a P0-scoped review, not an all-priority audit.
- Exact-head Linux CI passed `pnpm verify`: **71 files passed, 1 platform skip; 1,891 tests passed, 69 skipped**, with coverage thresholds satisfied. [CI run 33605894453](https://github.com/openclaw/crabline/actions/runs/33605894453). CodeQL and dependency review also pass.

### Captured packaged-consumer behavior

The following is actual terminal output at `cea22bf7a27aeabb88ab28e0f221d4c292a0f728`, not a planned command. The relocated-bundle test executes native Node after deleting the installed dependency tree, so success requires both the public bundle and native/JavaScript crypto assertions to run.

```sh
# Bash 5 on PATH, matching the release workflow shell; no global shell changes.
RAYON_NUM_THREADS=4 GOMAXPROCS=4 VITEST_MAX_WORKERS=1 node node_modules/vitest/vitest.mjs run test/package-production.test.ts test/release-workflow.test.ts -t 'relocated bundles|release workflow' --reporter=verbose
```

```text
 ✓ test/release-workflow.test.ts > release workflow > only accepts stable tags and checks out the exact tag ref 423ms
 ✓ test/package-production.test.ts > production package > runs relocated bundles from a packed isolated-pnpm install 9227ms
 Test Files  2 passed (2)
      Tests  13 passed | 12 skipped (25)
   Duration  26.99s (transform 103ms, setup 0ms, import 721ms, tests 25.40s, environment 0ms)
```

The original loader produced `Cannot find module 'curve25519-js'` from `relocated/crypto.mjs` in this same packaged setup. The dependency's `exports.sharedKey`, `exports.sign`, and `exports.generateKeyPair` implementations and its shipped declarations were inspected directly; the new namespace import uses those existing exports. This closes the review's requested runtime evidence and dependency-shape gaps.

### Local full-suite limitations

The broader macOS run did not pass: 40 failures included filesystem/provider deadline failures, missed short recorder waits, and a shell mismatch. A focused rerun still hit the 1,000-audio-request/recorder stress deadline and short provider waits. The release-script rejection test was reproduced as macOS Bash 3.2's errexit behavior after a regex condition, and all 12 release-workflow tests pass under installed Bash 5 without changing assertions or the release script. These local failures are not counted as passing proof; the unchanged complete Linux CI suite is green. Follow-up: make the macOS release-test shell prerequisite explicit and isolate recorder/fsync throughput from the audio-queue retention test. No timeout increase or skipped assertion was used for this release.
