### PR TITLE
fix(deps): restore Zod compatibility with seven-day cooldowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.21 - 2026-09-02
+
+- Restore compatibility with Zod 4.4.3 so consumers can retain their seven-day dependency cooldown without a Zod exception; align the source checkout's release-age policy to seven days.
+
 ## 0.1.20 - 2026-09-02
 
 - Fix bundled consumers failing to load the WhatsApp crypto dependency under isolated dependency layouts; preserve native and JavaScript crypto behavior.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ pnpm build
 pnpm verify
 ```
 
+Dependency updates observe a seven-day release-age policy. Runtime dependency
+minimums must remain compatible with consumers using the same cooldown.
+
 Run locally:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/crabline",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "Standalone CLI for deterministic messaging provider E2E tests",
   "homepage": "https://github.com/openclaw/crabline#readme",
   "bugs": {
@@ -60,7 +60,7 @@
     "re2js": "2.8.6",
     "ws": "^8.21.3",
     "yaml": "^2.9.0",
-    "zod": "^4.5.2"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/proper-lockfile": "4.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ importers:
         specifier: ^2.9.0
         version: 2.9.0
       zod:
-        specifier: ^4.5.2
-        version: 4.5.2
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/proper-lockfile':
         specifier: 4.1.4
@@ -453,8 +453,8 @@ packages:
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
 
-  '@jridgewell/sourcemap-codec@1.6.0':
-    resolution: {integrity: sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==}
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
@@ -468,8 +468,8 @@ packages:
   '@keyv/serialize@1.1.1':
     resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
 
-  '@matrix-org/matrix-sdk-crypto-wasm@18.7.0':
-    resolution: {integrity: sha512-IiO8YrahwBN23iii4OBS6AUIEDZePa72bK7WN/DBjOXPc6g/wt891vn0vxmlopTahqFFOz/LErcHisdmzKVTsg==}
+  '@matrix-org/matrix-sdk-crypto-wasm@18.6.0':
+    resolution: {integrity: sha512-P3v8849O/1+c1CYDQ1X6L1p6UpakYAav1L4wTNvwLA54n9wNpadpw8sLZoxhaG4ftlmNzxFztjRYwDvx56d11w==}
     engines: {node: '>= 18'}
 
   '@oxc-project/types@0.146.0':
@@ -1436,8 +1436,8 @@ packages:
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
-  protobufjs@7.6.6:
-    resolution: {integrity: sha512-dYDWdjSl5RNb7SgPxGQcRU+GtvP7s2fpkrY0r432PcOIaZ0/rBcxEZnQN67iJhFuQiVw754JDoPruPCNdGsbjg==}
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
     engines: {node: '>=12.0.0'}
 
   qified@0.10.1:
@@ -1678,8 +1678,8 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
-  zod@4.5.2:
-    resolution: {integrity: sha512-XkYXCol10+ba/6F/cueWV+TezUeOqXW0hdeJt5CdXjTYeAgAQg5N03RQdJ80mhfFE72+pblvYMW4wy2Qp4Qbrg==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -1917,12 +1917,12 @@ snapshots:
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
-  '@jridgewell/sourcemap-codec@1.6.0': {}
+  '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.31':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.6.0
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@keyv/bigmap@1.3.1(keyv@5.6.0)':
     dependencies:
@@ -1932,7 +1932,7 @@ snapshots:
 
   '@keyv/serialize@1.1.1': {}
 
-  '@matrix-org/matrix-sdk-crypto-wasm@18.7.0': {}
+  '@matrix-org/matrix-sdk-crypto-wasm@18.6.0': {}
 
   '@oxc-project/types@0.146.0': {}
 
@@ -2318,7 +2318,7 @@ snapshots:
       music-metadata: 11.15.0(supports-color@7.2.0)
       p-queue: 9.3.3
       pino: 9.14.0
-      protobufjs: 7.6.6
+      protobufjs: 7.6.5
       sharp: 0.35.2
       whatsapp-rust-bridge: 0.5.4
       ws: 8.21.3
@@ -2456,7 +2456,7 @@ snapshots:
   libsignal@6.0.0:
     dependencies:
       curve25519-js: 0.0.4
-      protobufjs: 7.6.6
+      protobufjs: 7.6.5
 
   lightningcss-android-arm64@1.33.0:
     optional: true
@@ -2515,7 +2515,7 @@ snapshots:
 
   magic-string@0.30.21:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.6.0
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   magicast@0.5.4:
     dependencies:
@@ -2532,7 +2532,7 @@ snapshots:
   matrix-js-sdk@42.2.0:
     dependencies:
       '@babel/runtime': 8.0.0
-      '@matrix-org/matrix-sdk-crypto-wasm': 18.7.0
+      '@matrix-org/matrix-sdk-crypto-wasm': 18.6.0
       another-json: 0.2.0
       bs58: 6.0.0
       content-type: 2.1.0
@@ -2680,7 +2680,7 @@ snapshots:
       retry: 0.12.0
       signal-exit: 3.0.7
 
-  protobufjs@7.6.6:
+  protobufjs@7.6.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
@@ -2906,4 +2906,4 @@ snapshots:
 
   yaml@2.9.0: {}
 
-  zod@4.5.2: {}
+  zod@4.4.3: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,7 @@
 packages:
   - "."
 
-minimumReleaseAge: 2880
+minimumReleaseAge: 10080
 
 minimumReleaseAgeExclude:
   - "@typescript/native*"

--- a/test/package-production.test.ts
+++ b/test/package-production.test.ts
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
+import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -409,7 +410,7 @@ describe("production package", () => {
     );
   }, 120_000);
 
-  it("runs relocated bundles from a packed isolated-pnpm install", async () => {
+  it("runs relocated isolated-pnpm bundles with the supported Zod floor and seven-day cooldown", async () => {
     const root = process.cwd();
     const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "crabline-bundled-consumer-"));
     const consumerDirectory = path.join(tempRoot, "consumer");
@@ -419,11 +420,16 @@ describe("production package", () => {
       const packed = await npmPack(root, tempRoot);
       await fs.writeFile(
         path.join(consumerDirectory, "package.json"),
-        JSON.stringify({ name: "crabline-bundled-consumer", private: true, type: "module" }),
+        JSON.stringify({
+          name: "crabline-bundled-consumer",
+          private: true,
+          type: "module",
+          dependencies: { zod: "4.4.3" },
+        }),
       );
       await fs.writeFile(
         path.join(consumerDirectory, "pnpm-workspace.yaml"),
-        "packages: ['.']\nnodeLinker: isolated\nhoist: false\n",
+        "packages: ['.']\nnodeLinker: isolated\nhoist: false\nminimumReleaseAge: 10080\n",
       );
       await execPackageManager(
         "pnpm",
@@ -434,6 +440,14 @@ describe("production package", () => {
         fs.stat(path.join(consumerDirectory, "node_modules", "curve25519-js")),
       ).rejects.toMatchObject({ code: "ENOENT" });
       const installedRoot = path.join(consumerDirectory, "node_modules", "@openclaw", "crabline");
+      const requireCrabline = createRequire(path.join(installedRoot, "package.json"));
+      const installedZod = JSON.parse(
+        await fs.readFile(requireCrabline.resolve("zod/package.json"), "utf8"),
+      ) as { version: string };
+      expect(installedZod.version).toBe("4.4.3");
+      const exampleManifest = parse(
+        await fs.readFile(path.join(root, "fixtures/examples/crabline.example.yaml"), "utf8"),
+      );
       await build({
         input: {
           index: path.join(installedRoot, "dist/src/index.js"),
@@ -452,6 +466,7 @@ describe("production package", () => {
             'import assert from "node:assert/strict";',
             'import * as pkg from "./index.mjs";',
             'import { Curve, createCurve } from "./crypto.mjs";',
+            `pkg.ManifestSchema.parse(${JSON.stringify(exampleManifest)});`,
             'const privateKey = Buffer.from("77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a", "hex");',
             'const publicKey = Buffer.from("de9edb7d7b7dc1b4d35b61c2ece435373f8343c85b78674dadfc7e146f882b4f", "hex");',
             'const unsupported = () => { throw Object.assign(new Error("unsupported"), { code: "ERR_OSSL_EVP_UNSUPPORTED" }); };',


### PR DESCRIPTION
## What Problem This Solves

Fixes Crabline 0.1.20 requiring a Zod version that consumers using a seven-day release-age policy cannot yet install. The bundle-safe crypto fix does not require Zod 4.5 APIs.

## Why This Change Was Made

Restore the supported Zod floor and locked version to 4.4.3, and align Crabline's own cooldown from 48 hours to seven days. The same earlier dependency-refresh PR (#288) introduced three other currently ineligible transitive versions; restore their prior locks too: sourcemap-codec 1.5.5, Matrix crypto WASM 18.6.0, and protobufjs 7.6.5. The frozen lockfile passes all 306 supply-chain-policy checks. No new exclusion or override is added; existing unrelated TypeScript exceptions stay unchanged.

Prepare corrective patch release 0.1.21. Keep the 0.1.20 static crypto import and every runtime/public API unchanged. The older dependency floor belongs in Crabline, allowing OpenClaw to remove its Zod cooldown exception without a dependency override.

## User Impact

Consumers can retain their seven-day policy and use mature Zod 4.4.3 while preserving bundle-safe WhatsApp crypto. Source dependency updates now follow the same seven-day rule.

## Evidence

- Before: installing the published 0.1.20 tarball in an isolated consumer with `minimumReleaseAge: 10080` fails with `ERR_PNPM_NO_MATURE_MATCHING_VERSION`, specifically naming Zod 4.5.2 published August 29.
- The extended existing packed-consumer regression fails with the former Zod floor. After correction it installs without any cooldown exception, verifies Crabline actually resolves Zod 4.4.3, bundles public/schema/crypto code, removes the entire consumer installation, parses the real example manifest and executes native/JavaScript crypto vectors from the relocated bundles.
- `pnpm install --frozen-lockfile`: passes all 306 supply-chain-policy checks and builds successfully.
- `pnpm exec vitest run test/config.test.ts test/package-production.test.ts --maxWorkers=1`: 82 tests pass across 2 files.
- `pnpm lint`: formatting, typecheck and type-aware lint pass.
- Fresh Codex autoreview is scoped-clean at the requested P0 threshold; this is not an all-priority audit.
- Full exact-head [CI 33659821509](https://github.com/openclaw/crabline/actions/runs/33659821509), CodeQL and dependency review pass. The existing trusted-publishing release workflow follows merge. No test timeout, coverage threshold, or assertion is weakened.
- `pnpm audit --prod --json` reports zero known vulnerabilities across the 25 production dependencies.
