### PR TITLE
chore(deps): refresh compatible tooling and align update policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,16 @@ updates:
       time: "09:00"
       timezone: America/Los_Angeles
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+      exclude:
+        - "@typescript/native*"
+        - "@typescript/typescript-*"
+        - "typescript"
+    ignore:
+      # Keep declarations aligned with the supported Node 22 runtime.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
     groups:
       production-minor-and-patch:
         dependency-type: production
@@ -18,6 +28,8 @@ updates:
 
   - package-ecosystem: github-actions
     directory: /
+    cooldown:
+      default-days: 7
     schedule:
       interval: weekly
       day: monday
@@ -30,6 +42,8 @@ updates:
 
   - package-ecosystem: gomod
     directory: /tools
+    cooldown:
+      default-days: 7
     schedule:
       interval: weekly
       day: monday

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Refresh the Rolldown bundler used by package compatibility checks and the Go workflow-validation toolchain, align Dependabot version updates with the seven-day cooldown, and retain Node 22 declarations for supported runtimes.
+
 ## 0.1.21 - 2026-09-02
 
 - Restore compatibility with Zod 4.4.3 so consumers can retain their seven-day dependency cooldown without a Zod exception; align the source checkout's release-age policy to seven days.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Refresh the Rolldown bundler used by package compatibility checks and the Go workflow-validation toolchain, align Dependabot version updates with the seven-day cooldown, and retain Node 22 declarations for supported runtimes.
+- Initialize native recorder ownership before timed loopback integration checks so macOS process discovery does not consume the fixture's one-second message budget.
 
 ## 0.1.21 - 2026-09-02
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ pnpm verify
 
 Dependency updates observe a seven-day release-age policy. Runtime dependency
 minimums must remain compatible with consumers using the same cooldown.
+Dependabot applies the same cooldown to version updates, preserving the
+TypeScript exceptions in `pnpm-workspace.yaml`. Node declarations stay on
+Node 22 while that runtime remains supported.
 
 Run locally:
 

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "oxfmt": "^0.65.0",
     "oxlint": "^1.80.0",
     "oxlint-tsgolint": "^7.0.2001",
-    "rolldown": "1.2.5",
+    "rolldown": "1.2.6",
     "tsx": "^4.23.12",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "vitest": "^4.1.11"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,8 +71,8 @@ importers:
         specifier: ^7.0.2001
         version: 7.0.2001
       rolldown:
-        specifier: 1.2.5
-        version: 1.2.5
+        specifier: 1.2.6
+        version: 1.2.6
       tsx:
         specifier: ^4.23.12
         version: 4.23.12
@@ -475,6 +475,9 @@ packages:
   '@oxc-project/types@0.146.0':
     resolution: {integrity: sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA==}
 
+  '@oxc-project/types@0.147.0':
+    resolution: {integrity: sha512-IJ3s6ltHLp45S0bh7phkX+gJO7A1Wuz2EaqpAhb8WjqDwbzMiWKHhyyT42tskaWjEYXtHtVCPpnBJVT9+dcRLg==}
+
   '@oxfmt/binding-android-arm-eabi@0.65.0':
     resolution: {integrity: sha512-M10Gs1SSpTNI6ahGx3M/OlIdUF4hkaP6OgUb+MS79t/Pgflk3r1nW5gPFqsZGUAXg0H1AfANT9AvLdBSTIhZKg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -785,8 +788,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@rolldown/binding-android-arm-eabi@1.2.6':
+    resolution: {integrity: sha512-b+jTcARdTiFLI6jB4a5XjTm0RWd6KcRfQj/I2356fxUZemiho9zQLxo0RtCuMDAyKcLo6cEltkgbQp6d1+sjjQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
   '@rolldown/binding-android-arm64@1.2.5':
     resolution: {integrity: sha512-zXcwKlQApYAOELHd8PwKDFkagYF9Wy4e0RJ+0qnzl9Pjnpj75TEG8ufv40p2J7kCEfwZAsNiuzRIyNNMWT38ig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-android-arm64@1.2.6':
+    resolution: {integrity: sha512-lkWU8ZJaRk9q3CIEY1Tc7vIFALp3Xw5NfGJo2hQg5oIqNgxWi1zI+IiDEK3r70BF5Dzol1tcXsnzsRc8NLhG+Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
@@ -797,8 +812,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rolldown/binding-darwin-arm64@1.2.6':
+    resolution: {integrity: sha512-dgR56NYnvAszm7Ob1B2/Vn0e8bUQYZH2UjVaMMtMVOCKFSfjhfLmuA/9+O+F+ajUdG6B/bSssrKW6JJYASa8jA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rolldown/binding-darwin-x64@1.2.5':
     resolution: {integrity: sha512-fqSALaUu1Wjd1nK2uW2kJDWdLCc8lx1IcY+MTY26Aurfdx19anlzhqXOgCFbBFQnlFDTn4TC1/7Nz4Bl2mLP3A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.2.6':
+    resolution: {integrity: sha512-vpVxFvUCFioJqug7OTvqptkc4yb8UX0AwfDmJpaR/0sWz+BUmqSVAf7c8JkUgnN8YLspb4a/N6NhTyMAmdyQ7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
@@ -809,14 +836,33 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@rolldown/binding-freebsd-x64@1.2.6':
+    resolution: {integrity: sha512-h1wG6Y6K3JlRswxsI64qQJqBAy4vrLuHgRbc8CZMGSWTOFRY6ghMApM1NKzB2I0n5xV1fjkE18SuVl2QpLeNpA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
   '@rolldown/binding-linux-arm-gnueabihf@1.2.5':
     resolution: {integrity: sha512-abk0NLA519LxRCszmbE0jYKuQ9YPocOXTiOXOo6Yr+YAT95VH+PtqYAjOJvGKt3viEd/x4qzabAlwd5bHOOARg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.6':
+    resolution: {integrity: sha512-tbCiqub0q2MVWJKgF5PoAlNWCtQydiOYSLIkd8sByqK/6MMYLJRcSXSYodqYtd0O+Fw7QaVmKKlS4oL94YRZ0w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@rolldown/binding-linux-arm64-gnu@1.2.5':
     resolution: {integrity: sha512-Y7eALiJ8lr0M2HH103Js+g7V34wf6snlpZLAsHI90uLhr3PVlNsbFVAXJC9d/V6BnPyKtpSwI+NcB/RLxsQxuA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.6':
+    resolution: {integrity: sha512-oxK9+baEBPhZG5HB4URY+uU04zJWeZlH6Tb9rB5DK4DF9XR1uXNLXt5Q5ZsugTKayNCNLhkcwz/ye74hRI98dg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -829,8 +875,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rolldown/binding-linux-arm64-musl@1.2.6':
+    resolution: {integrity: sha512-muWCk27FVBEZtv0MsK8gnfSmgczA8KQ0uRVJbTABKhkRfQc38aUrcb7fhi3BNiyseFmgcRsoMfQsSNJ+DbZdSw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@rolldown/binding-linux-ppc64-gnu@1.2.5':
     resolution: {integrity: sha512-GRjeqTUDHTo5GwntsLaAMcBahG3nlpjftXWZLN73HiYQlhwEowvarFgQnRnQZtIp4keXX7quXFbG38uPZBa2EA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.6':
+    resolution: {integrity: sha512-eWDoSfU7Co2qj3vgB3Dt4lj1mG6CoWbcJQkRMP3XJplyCMtuaq3LHvPFjS9QIPvMGWVadJC04Xiy0IdcVPtnwQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -843,8 +903,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@rolldown/binding-linux-s390x-gnu@1.2.6':
+    resolution: {integrity: sha512-2bWNjRSIayvupRKxXUY2tWG9fYdoUlTqWywHRvE8Eq3GvuQ+f2HeIkve697fIt+IQs/PV8yFsdWuhp1aJ1PdnA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@rolldown/binding-linux-x64-gnu@1.2.5':
     resolution: {integrity: sha512-Mgj59/HTuYeK9Gz2MA+mBWKnHsAgkBSec15ZMb1st3oIfFbX7gCjOae7GydHhzcyQi9Z/7M1QuN9bR3oFqF0jQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.2.6':
+    resolution: {integrity: sha512-KekI0gS0wLxe1UBSQSjenBVwou/JkcQPDzBPICGZjxUv9k3RteHDPBQaiOicZUFKRIH2wKEimGwVpnJsbPzu7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -857,8 +931,21 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rolldown/binding-linux-x64-musl@1.2.6':
+    resolution: {integrity: sha512-TvtPnfVr+HtyGiDmPK4VWmlNm7QhNNAcK5Q9A7aOXsI8545yCyaoMaicXrFZ72JzeYjaUVk7yT243zT0jzjFKQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@rolldown/binding-openharmony-arm64@1.2.5':
     resolution: {integrity: sha512-8SLssA2oweAxyRgDp789ACfRb/3P+zNRJpzZxSizxF9m8NUDQ4+3xjo8ttjhVGGw6Qxb70oZiEtIjaKikCO7Yw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-openharmony-arm64@1.2.6':
+    resolution: {integrity: sha512-iOo0VEay2XFhaCcH0sps5XIimkSuOnNaZrf6+ZkoSOQBJPKNU48RkmJv0/lSpipexu5P+ouFgafe5IGr/DiQfg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -869,8 +956,20 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@rolldown/binding-win32-arm64-msvc@1.2.6':
+    resolution: {integrity: sha512-y5NTmmasMS455JlOCO4ZM9krIchv3Mvm1crL1iUPGOPgEzSkves9n0SdC5Sjz6+qWDFhd8/JpfWMH8NSWNHe+A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
   '@rolldown/binding-win32-x64-msvc@1.2.5':
     resolution: {integrity: sha512-e/SXpgISz+IoqVcSSI0rx/d/he8zqLex+/rCWpnHpmVfmPIUjag9H6P7zotf0gJHwPUhQxZ/mF8tr6acebT9yw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.2.6':
+    resolution: {integrity: sha512-np8iZSLfXlAD4kWhiyq/u0Yt8oZDtRQ8lGhQaCXo2rl37KNjeU0GjJuwr4P3oeZ++ROfofsKNBqR5LTO8aXyWQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -1464,6 +1563,11 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  rolldown@1.2.6:
+    resolution: {integrity: sha512-vMM4q3aixf46GiF1Kok8jDPFsEpXgFWGjUHXNkNHNm+Y2adXAG2dbX91jkti3i0ZRsOlcmbuzAz1poObSHCmUA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
@@ -1936,6 +2040,8 @@ snapshots:
 
   '@oxc-project/types@0.146.0': {}
 
+  '@oxc-project/types@0.147.0': {}
+
   '@oxfmt/binding-android-arm-eabi@0.65.0':
     optional: true
 
@@ -2093,46 +2199,91 @@ snapshots:
   '@rolldown/binding-android-arm-eabi@1.2.5':
     optional: true
 
+  '@rolldown/binding-android-arm-eabi@1.2.6':
+    optional: true
+
   '@rolldown/binding-android-arm64@1.2.5':
+    optional: true
+
+  '@rolldown/binding-android-arm64@1.2.6':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.2.5':
     optional: true
 
+  '@rolldown/binding-darwin-arm64@1.2.6':
+    optional: true
+
   '@rolldown/binding-darwin-x64@1.2.5':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.2.6':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.2.5':
     optional: true
 
+  '@rolldown/binding-freebsd-x64@1.2.6':
+    optional: true
+
   '@rolldown/binding-linux-arm-gnueabihf@1.2.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.6':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.2.5':
     optional: true
 
+  '@rolldown/binding-linux-arm64-gnu@1.2.6':
+    optional: true
+
   '@rolldown/binding-linux-arm64-musl@1.2.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.2.6':
     optional: true
 
   '@rolldown/binding-linux-ppc64-gnu@1.2.5':
     optional: true
 
+  '@rolldown/binding-linux-ppc64-gnu@1.2.6':
+    optional: true
+
   '@rolldown/binding-linux-s390x-gnu@1.2.5':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.6':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.2.5':
     optional: true
 
+  '@rolldown/binding-linux-x64-gnu@1.2.6':
+    optional: true
+
   '@rolldown/binding-linux-x64-musl@1.2.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.2.6':
     optional: true
 
   '@rolldown/binding-openharmony-arm64@1.2.5':
     optional: true
 
+  '@rolldown/binding-openharmony-arm64@1.2.6':
+    optional: true
+
   '@rolldown/binding-win32-arm64-msvc@1.2.5':
     optional: true
 
+  '@rolldown/binding-win32-arm64-msvc@1.2.6':
+    optional: true
+
   '@rolldown/binding-win32-x64-msvc@1.2.5':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.2.6':
     optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
@@ -2726,6 +2877,27 @@ snapshots:
       '@rolldown/binding-openharmony-arm64': 1.2.5
       '@rolldown/binding-win32-arm64-msvc': 1.2.5
       '@rolldown/binding-win32-x64-msvc': 1.2.5
+
+  rolldown@1.2.6:
+    dependencies:
+      '@oxc-project/types': 0.147.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm-eabi': 1.2.6
+      '@rolldown/binding-android-arm64': 1.2.6
+      '@rolldown/binding-darwin-arm64': 1.2.6
+      '@rolldown/binding-darwin-x64': 1.2.6
+      '@rolldown/binding-freebsd-x64': 1.2.6
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.6
+      '@rolldown/binding-linux-arm64-gnu': 1.2.6
+      '@rolldown/binding-linux-arm64-musl': 1.2.6
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.6
+      '@rolldown/binding-linux-s390x-gnu': 1.2.6
+      '@rolldown/binding-linux-x64-gnu': 1.2.6
+      '@rolldown/binding-linux-x64-musl': 1.2.6
+      '@rolldown/binding-openharmony-arm64': 1.2.6
+      '@rolldown/binding-win32-arm64-msvc': 1.2.6
+      '@rolldown/binding-win32-x64-msvc': 1.2.6
 
   safe-stable-stringify@2.5.0: {}
 

--- a/test/run.e2e.test.ts
+++ b/test/run.e2e.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { runFixtureCommand } from "../src/core/run.js";
 import { createRegistry } from "../src/providers/registry.js";
 import type { ManifestDefinition } from "../src/config/schema.js";
+import { initializeProcessOwnedLockIdentity } from "../src/platform/process-owned-lock.js";
 
 const manifest: ManifestDefinition = {
   configVersion: 1,
@@ -48,6 +49,11 @@ const manifest: ManifestDefinition = {
 };
 
 describe("loopback e2e", () => {
+  beforeAll(() => {
+    // Native identity discovery is startup work outside the one-second fixture budget.
+    initializeProcessOwnedLockIdentity();
+  });
+
   it("completes a roundtrip", async () => {
     const result = await runFixtureCommand({
       fixtureId: "loopback-roundtrip",
@@ -56,7 +62,7 @@ describe("loopback e2e", () => {
       registry: createRegistry(manifest, "/tmp/crabline.yaml"),
     });
 
-    expect(result.ok).toBe(true);
+    expect(result).toMatchObject({ ok: true });
   });
 
   it("completes an agent flow", async () => {
@@ -67,6 +73,6 @@ describe("loopback e2e", () => {
       registry: createRegistry(manifest, "/tmp/crabline.yaml"),
     });
 
-    expect(result.ok).toBe(true);
+    expect(result).toMatchObject({ ok: true });
   });
 });

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,6 +2,8 @@ module github.com/openclaw/crabline/tools
 
 go 1.25.0
 
+toolchain go1.25.14
+
 require github.com/rhysd/actionlint v1.7.12
 
 require (


### PR DESCRIPTION
## What Problem This Solves

Dependabot proposes Node 26 declarations even though Crabline supports and verifies Node 22. The proposed upgrade in #289 fails compilation because `node:crypto.JsonWebKey` is no longer exported. Automated version updates also need to follow the repository's existing seven-day dependency cooldown.

## Why This Change Was Made

Keep Node declarations on the supported major and apply the seven-day cooldown to Dependabot version updates, preserving the existing TypeScript exceptions. Refresh the Rolldown bundler used by package compatibility checks from 1.2.5 to 1.2.6, which is past the cooldown. Select Go 1.25.14 for workflow validation via the toolchain directive, retaining the Go 1.25.0 language minimum; setup-go otherwise installs the original 1.25.0 release.

The Node 22.13.0 comparison also exposed a preexisting loopback test setup problem: lazy native recorder ownership discovery runs inside the fixture's one-second send budget. On macOS, its process discovery alone measured roughly 550–590ms. Initialize that real ownership state in `beforeAll`; the fixture deadlines and success assertions remain intact. No sleeps, fake identities, production timeout changes, coverage reductions, or runtime-policy changes were added.

## User Impact

Maintenance updates preserve Node 22 compatibility and the consumer cooldown contract. Package compatibility checks exercise a newer compatible bundler. Runtime dependencies, runtime floors, and the package manager remain unchanged.

## Evidence

Node 22.13.0 and pnpm 11.24.0 were used for a serial, one-worker comparison of base `a5efe39dd509b125f3f9fc98a094e326d3a3f0f1` and original candidate `81b1a90b33cee186becee068f15e7af137ed3786`, with separately frozen installs. All 18 previously failing tests passed unchanged on both. Base passed the complete gate (1,929 tests); the original candidate had only the separate cold loopback failure. The setup correction passes both loopback cases and packed/relocated package execution.

The latest complete macOS gate passed lint, tooling tests and build, then reported 1,926 passed, three deadline failures, and the same 35 platform/conditional skips. Those three cases are unchanged: Matrix's 1,000-message retention case and two release-workflow shell fixtures. All three then reproduced on unchanged base under current host conditions; both release fixtures passed on the corrected candidate. This is a remaining host-sensitive test limitation, not a passing local broad gate. The historical stacks identify deadline expiration, but do not identify every underlying stalled operation.

Captured focused execution output on Node 22.13.0:

```text
$ pnpm exec vitest run test/run.e2e.test.ts test/package-production.test.ts --maxWorkers=1 --reporter=verbose
✓ test/run.e2e.test.ts > loopback e2e > completes a roundtrip 78ms
✓ test/run.e2e.test.ts > loopback e2e > completes an agent flow 22ms
✓ test/package-production.test.ts > production package > ships its public entry points and CLI without dev-only dependencies 5585ms
✓ test/package-production.test.ts > production package > runs relocated isolated-pnpm bundles with the supported Zod floor and seven-day cooldown 2165ms
Test Files  2 passed (2)
Tests  15 passed (15)
```

The relocated test imports Rolldown 1.2.6 directly, installs the packed package into an isolated pnpm consumer, bundles its public and crypto entries, removes the installation, and executes the relocated output. The subsequent full Node 22.13.0 run also passed these package tests and both loopback cases.

Captured workflow tooling output (`GOTOOLCHAIN=go1.25.14`, from `tools`):

```text
$ go version
go version go1.25.14 darwin/arm64
exit: 0
$ go run github.com/rhysd/actionlint/cmd/actionlint -config-file ../.github/actionlint.yaml -ignore 'unexpected key "queue" for "concurrency" section' ../.github/workflows/*.yml
exit: 0
$ go mod verify
all modules verified
exit: 0
```

Built CLI fixture discovery and a real Telegram HTTP smoke also passed on Node 22.13.0: getMe, sendMessage, authenticated admin ingress, getUpdates, recorder persistence, and SIGTERM cleanup. The npm audit reported zero vulnerabilities. Codex autoreview of the complete PR plus test correction found no actionable P0–P2 findings.

Exact-head checks on `8875e2e2ba429ef5692b319230876bac71565796` passed on their first attempts: [CI](https://github.com/openclaw/crabline/actions/runs/33854561877), [CodeQL](https://github.com/openclaw/crabline/actions/runs/33854561865), and [Dependency Review](https://github.com/openclaw/crabline/actions/runs/33854561749). CI used Node 22.23.2 and Go 1.25.14, passed the complete verify gate (71 test files passed, one platform-skipped file), and passed all coverage thresholds. The separate quiet Linux attempt pinned to Node 22.13.0 could not obtain capacity and was cancelled with its lease confirmed released; its script never ran. A fully green corrected-candidate macOS Node 22.13.0 broad gate is therefore still not established, despite the original failures passing the controlled comparison and the later failures reproducing on base.

Related: #289. No merge, release, or closure is part of this preparation.
