### PR TITLE
test: stabilize Slack arrival and full-frame boundary checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Separate Slack correlation-test setup from live-arrival deadlines and compare full-size WhatsApp frames without per-byte matcher overhead, retaining product waits and boundary coverage.
 - Refresh the Rolldown bundler used by package compatibility checks and the Go workflow-validation toolchain, align Dependabot version updates with the seven-day cooldown, and retain Node 22 declarations for supported runtimes.
 - Initialize native recorder ownership before timed loopback integration checks so macOS process discovery does not consume the fixture's one-second message budget.
 

--- a/test/slack-provider.test.ts
+++ b/test/slack-provider.test.ts
@@ -1,8 +1,9 @@
 import { createHmac } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { ProviderConfig } from "../src/config/schema.js";
+import { initializeProcessOwnedLockIdentity } from "../src/platform/process-owned-lock.js";
 import {
   handleSlackWebhookPayload,
   normalizeSlackEventsPayload,
@@ -114,6 +115,11 @@ function slackSignature(signingSecret: string, timestamp: string, body: string):
 }
 
 describe("slack provider", () => {
+  beforeAll(() => {
+    // Native recorder identity discovery is startup work, outside individual test budgets.
+    initializeProcessOwnedLockIdentity();
+  });
+
   it("requires request signatures for externally reachable event endpoints", async () => {
     const config = await createSlackConfig(0);
     config.slack!.webhook.host = "0.0.0.0";
@@ -304,17 +310,8 @@ describe("slack provider", () => {
       context.fixture.inboundMatch = { author: "user", nonce: "contains", strategy: "contains" };
       const endpoint = endpointFromDetails((await provider.probe(context)).details);
       const nonce = `direct-${userId}`;
-      const waiting = provider.waitForInbound({
-        ...context,
-        nonce,
-        since: new Date(Date.now() - 1000).toISOString(),
-        timeoutMs: 500,
-      });
-
-      for (const [channel, eventUser] of [
-        ["D9999999999", "U9999999999"],
-        ["D1234567890", userId],
-      ]) {
+      const since = new Date(Date.now() - 1000).toISOString();
+      const postEvent = async (channel: string, eventUser: string) => {
         const response = await fetch(endpoint, {
           body: JSON.stringify({
             event: {
@@ -330,7 +327,17 @@ describe("slack provider", () => {
           method: "POST",
         });
         expect(response.status).toBe(200);
-      }
+      };
+
+      // Persist the distractor and initialize the recorder before the live-arrival budget.
+      await postEvent("D9999999999", "U9999999999");
+      const waiting = provider.waitForInbound({
+        ...context,
+        nonce,
+        since,
+        timeoutMs: 500,
+      });
+      await postEvent("D1234567890", userId);
 
       await expect(waiting).resolves.toMatchObject({
         author: "user",
@@ -355,17 +362,8 @@ describe("slack provider", () => {
       context.fixture.inboundMatch = { author: "user", nonce: "contains", strategy: "contains" };
       const endpoint = endpointFromDetails((await provider.probe(context)).details);
       const nonce = `threaded-direct-${userId}`;
-      const waiting = provider.waitForInbound({
-        ...context,
-        nonce,
-        since: new Date(Date.now() - 1000).toISOString(),
-        timeoutMs: 500,
-      });
-
-      for (const [eventId, candidateThreadTs] of [
-        ["EvWRONGTHREAD1", "1700000000.000101"],
-        ["EvRIGHTTHREAD1", threadTs],
-      ]) {
+      const since = new Date(Date.now() - 1000).toISOString();
+      const postEvent = async (eventId: string, candidateThreadTs: string) => {
         const response = await fetch(endpoint, {
           body: JSON.stringify({
             event: {
@@ -383,7 +381,17 @@ describe("slack provider", () => {
           method: "POST",
         });
         expect(response.status).toBe(200);
-      }
+      };
+
+      // The wrong-thread setup must finish before the matching event's arrival budget.
+      await postEvent("EvWRONGTHREAD1", "1700000000.000101");
+      const waiting = provider.waitForInbound({
+        ...context,
+        nonce,
+        since,
+        timeoutMs: 500,
+      });
+      await postEvent("EvRIGHTTHREAD1", threadTs);
 
       await expect(waiting).resolves.toMatchObject({
         author: "user",

--- a/test/whatsapp-wire.test.ts
+++ b/test/whatsapp-wire.test.ts
@@ -1,3 +1,4 @@
+import { deepStrictEqual } from "node:assert";
 import { deflateSync } from "node:zlib";
 import { Curve as BaileysCurve, encodeBinaryNode as encodeBaileysNode, proto } from "baileys";
 import { describe, expect, it, vi } from "vitest";
@@ -700,7 +701,10 @@ describe("WhatsApp binary nodes", () => {
     const encoded = encodeBinaryNode(largest);
 
     expect(encoded).toHaveLength(WHATSAPP_BINARY_NODE_MAX_FRAME_BYTES);
-    await expect(decodeBinaryNode(encoded)).resolves.toEqual(largest);
+    const { content, ...decoded } = await decodeBinaryNode(encoded);
+    expect(decoded).toEqual({ attrs: largest.attrs, tag: largest.tag });
+    // Compare every byte without enumerating millions of buffer properties in the matcher.
+    deepStrictEqual(content, largest.content, "largest frame payload must round trip exactly");
     expect(() => encodeBinaryNode({ ...largest, content: Buffer.alloc(payloadBytes + 1) })).toThrow(
       `exceeds ${WHATSAPP_BINARY_NODE_MAX_FRAME_BYTES} bytes`,
     );


### PR DESCRIPTION
The two failures in [main CI](https://github.com/openclaw/crabline/actions/runs/33856275754) come from test setup and assertion cost. Slack starts its 500 ms arrival wait before two serial HTTP ingresses, and the full-frame wire test spends almost all its time in Vitest's deep comparison of an 8 MiB buffer.

Persist the unrelated or wrong-thread Slack event before starting the wait, then deliver the matching event through real HTTP while waiting. Capture `since` before setup so the distractor still tests correlation. Initialize real native recorder identity in `beforeAll`, following the existing loopback test, so cold process discovery is outside individual test budgets. The actual 500 ms wait and default 200 ms polling remain unchanged.

For the wire boundary, keep the existing metadata comparison and use Node's strict deep assertion for the complete buffer. On Node 22.13.0, the old assertion alone took 18.77 seconds; encode/decode took 116 ms / under 1 ms. The corrected boundary test took 157 ms. Exact maximum frame length, one-byte-overflow rejection, and the 60-second test timeout remain intact. Production code, supported Node floor, runtime dependencies and limits are unchanged.

Validation:

- Controlled first-ingress delay of 650 ms, with identical real native identity initialization: all four old-ordering direct/threaded cases fail with `null`; all four corrected cases pass. The diagnostic delay is outside the committed tests.
- Final Node 22.13.0 focused suites: 83/83 tests pass. Formatting, typecheck/type-aware lint, autoreview-tooling tests and build pass.
- Built-code proof round-trips an 8,388,609-byte frame, rejects encoder and decoder max+1 inputs, and detects mutations at the first, middle and last payload bytes. Strict buffer comparison took 1.58 ms.
- Full staged P0–P2 Codex review: scoped-clean, no accepted/actionable findings.

Local validation covers the changed suites and built boundary behavior. The exact PR CI will run the complete `pnpm verify` gate and coverage thresholds; no complete macOS suite rerun is claimed for this test-only follow-up.

<details>
<summary>Captured Node 22.13.0 execution evidence</summary>

Local paths are redacted below; test names, counts, durations and outcomes are retained from the saved output.

Final candidate command:

```text
pnpm exec vitest run test/slack-provider.test.ts test/whatsapp-wire.test.ts --maxWorkers=1 --reporter=default --reporter=json --outputFile=[local evidence]/focused-candidate.json
RUN  v4.1.11 [task checkout]

 ✓ test/slack-provider.test.ts (26 tests) 7730ms
     ✓ correlates native D-channel events to direct target U1234567890  379ms
     ✓ correlates native D-channel events to direct target W1234567890  703ms
     ✓ extracts native block and attachment fallback text  317ms
     ✓ records message-shaped app mentions  322ms
     ✓ keeps watched Slack threads scoped to their channel  536ms
 ✓ test/whatsapp-wire.test.ts (57 tests) 2941ms
     ✓ enforces the compressed payload limit after the frame flag  2162ms

 Test Files  2 passed (2)
      Tests  83 passed (83)
   Start at  02:37:00
   Duration  13.09s (transform 811ms, setup 0ms, import 1.99s, tests 10.67s, environment 0ms)

JSON report written to [local evidence]/focused-candidate.json
```

Controlled old/new ordering uses the same 650 ms delay before forwarding the unrelated request through the original real `fetch`, with real native identity initialization on both versions. Each case retains the actual 500 ms product wait. The baseline reports four `expected null to match object` failures; only setup ordering differs in the corrected run.

```text
Old ordering with identical initialization:
Test Files  1 failed (1)
      Tests  4 failed | 22 skipped (26)
   Start at  02:36:25
   Duration  5.12s (transform 238ms, setup 0ms, import 315ms, tests 4.61s, environment 0ms)

Corrected ordering with identical initialization:
Test Files  1 passed (1)
      Tests  4 passed | 22 skipped (26)
   Start at  02:36:30
   Duration  4.87s (transform 205ms, setup 0ms, import 253ms, tests 4.51s, environment 0ms)
```

Built-code probe output (the probe imports the compiled wire encoder/decoder, checks exact frame length and metadata, strict-compares the full payload, and requires assertion failures for mutations at all three listed offsets):

```json
{
  "node": "v22.13.0",
  "encodedBytes": 8388609,
  "payloadBytes": 8388592,
  "encodeMs": 136.203125,
  "decodeMs": 0.6842919999999992,
  "strictEqualityMs": 1.5832499999999925,
  "rejectedMutatedOffsets": [
    0,
    4194296,
    8388591
  ],
  "rejectsEncoderMaxPlusOne": true,
  "rejectsDecoderMaxPlusOne": true
}
```

[Exact-candidate full CI](https://github.com/openclaw/crabline/actions/runs/33859350378) passed on its first attempt: 1,891 tests passed, 69 existing platform/conditional skips, and all coverage thresholds passed. The maximum-frame test completed in 311 ms. [CodeQL](https://github.com/openclaw/crabline/actions/runs/33859413748) passed both analyses on this candidate. CodeQL's test-only path filter required running the existing workflow explicitly; no workflow or source configuration changed.

</details>
