### PR TITLE
docs: prepare 0.1.22 patch notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## Unreleased
 
+**Highlights:** WhatsApp sessions stay connected through reactions and follow-up encrypted messages.
+
 - Keep WhatsApp sessions connected when Baileys sends reactions or established-session encrypted messages by recognizing their standard wire tokens.
-- Separate Slack correlation-test setup from live-arrival deadlines and compare full-size WhatsApp frames without per-byte matcher overhead, retaining product waits and boundary coverage.
+- Refresh Zod to 4.5.4 and the development runner to tsx 4.23.13 while preserving the Zod 4.4.3 consumer minimum and seven-day dependency cooldown.
 - Refresh the Rolldown bundler used by package compatibility checks and the Go workflow-validation toolchain, align Dependabot version updates with the seven-day cooldown, and retain Node 22 declarations for supported runtimes.
-- Initialize native recorder ownership before timed loopback integration checks so macOS process discovery does not consume the fixture's one-second message budget.
+- Stabilize Slack arrival, WhatsApp frame-boundary, and macOS recorder tests without changing product waits or boundary coverage.
 
 ## 0.1.21 - 2026-09-02
 


### PR DESCRIPTION
The next patch includes the WhatsApp session fix already merged in #294 and the compatible dependency updates in #295 and #296. Lead Unreleased with the WhatsApp behavior, retain the consumer Zod minimum and seven-day cooldown in the dependency notes, and consolidate the existing test-maintenance entries.

Merge after #295 and #296. This is the single changelog PR for that batch; the dependency PRs remain independent of main and do not edit release notes. Suggested next version: 0.1.22. This PR does not bump, tag, or publish a release.

Validation: formatting and independent Codex autoreview through P2 passed. Built CLI loopback and Telegram HTTP roundtrips passed. The built WhatsApp server accepted a text message, reaction, and encrypted follow-up from a real Baileys client with one connection and no unexpected disconnects. Exact-head CI and final validation are recorded in the proof comment.
